### PR TITLE
Refactor workflow execution lifecycle and align MessageId semantics

### DIFF
--- a/demos/Aevatar.Demos.Maker/MakerRunRecorder.cs
+++ b/demos/Aevatar.Demos.Maker/MakerRunRecorder.cs
@@ -170,12 +170,12 @@ internal sealed class MakerRunRecorder
                 AddTimeline(
                     now,
                     "llm.start",
-                    $"agent={evt.AgentId}, session={evt.SessionId}",
+                    $"agent={evt.AgentId}, message={evt.MessageId}",
                     envelope.PublisherId,
                     null,
                     null,
                     typeUrl,
-                    new Dictionary<string, string> { ["session_id"] = evt.SessionId, ["agent_id"] = evt.AgentId });
+                    new Dictionary<string, string> { ["message_id"] = evt.MessageId, ["agent_id"] = evt.AgentId });
                 return;
             }
 
@@ -190,7 +190,7 @@ internal sealed class MakerRunRecorder
                     {
                         Timestamp = now,
                         RoleId = publisher,
-                        SessionId = evt.SessionId ?? "",
+                        MessageId = evt.MessageId ?? "",
                         Content = evt.Content ?? "",
                         ContentLength = (evt.Content ?? "").Length,
                     });
@@ -204,7 +204,7 @@ internal sealed class MakerRunRecorder
                     null,
                     null,
                     typeUrl,
-                    new Dictionary<string, string> { ["session_id"] = evt.SessionId ?? "" });
+                    new Dictionary<string, string> { ["message_id"] = evt.MessageId ?? "" });
                 return;
             }
 
@@ -480,7 +480,7 @@ internal static class MakerRunReportWriter
             foreach (var reply in report.RoleReplies)
             {
                 sb.AppendLine("<details>");
-                sb.AppendLine($"<summary><code>{E(reply.RoleId)}</code> session={E(reply.SessionId)} chars={reply.ContentLength} time={E(reply.Timestamp.ToString("HH:mm:ss.fff"))}</summary>");
+                sb.AppendLine($"<summary><code>{E(reply.RoleId)}</code> message={E(reply.MessageId)} chars={reply.ContentLength} time={E(reply.Timestamp.ToString("HH:mm:ss.fff"))}</summary>");
                 sb.AppendLine($"<pre>{E(reply.Content)}</pre>");
                 sb.AppendLine("</details>");
             }
@@ -583,7 +583,7 @@ internal sealed class MakerRoleReply
 {
     public DateTimeOffset Timestamp { get; set; }
     public string RoleId { get; set; } = "";
-    public string SessionId { get; set; } = "";
+    public string MessageId { get; set; } = "";
     public string Content { get; set; } = "";
     public int ContentLength { get; set; }
 }

--- a/demos/Aevatar.Demos.Maker/Program.cs
+++ b/demos/Aevatar.Demos.Maker/Program.cs
@@ -212,9 +212,9 @@ await using var sub = await stream.SubscribeAsync<EventEnvelope>(envelope =>
     if (payload.Is(TextMessageStartEvent.Descriptor))
     {
         var evt = payload.Unpack<TextMessageStartEvent>();
-        logger.LogInformation("Role stream started: agent={AgentId}, session={SessionId}",
+        logger.LogInformation("Role stream started: agent={AgentId}, message={MessageId}",
             string.IsNullOrWhiteSpace(evt.AgentId) ? envelope.PublisherId : evt.AgentId,
-            evt.SessionId);
+            evt.MessageId);
     }
 
     if (payload.Is(TextMessageEndEvent.Descriptor))
@@ -281,7 +281,7 @@ logger.LogInformation("Input: {Len} chars", inputText.Length);
 // ─── Send request ───
 
 var runStartedAt = DateTimeOffset.UtcNow;
-var chatEvt = new ChatRequestEvent { Prompt = inputText, SessionId = "maker-demo" };
+var chatEvt = new ChatRequestEvent { Prompt = inputText, MessageId = "maker-demo" };
 var envelope = new EventEnvelope
 {
     Id = Guid.NewGuid().ToString("N"),

--- a/docs/IDENTIFIER_RELATIONSHIPS.md
+++ b/docs/IDENTIFIER_RELATIONSHIPS.md
@@ -1,4 +1,4 @@
-# 标识符关系（EventEnvelope.Id / RunId / SessionId / ActorId）
+# 标识符关系（EventEnvelope.Id / RunId / MessageId / ActorId）
 
 本文说明当前实现中几个常见标识符的职责边界与流转关系。
 
@@ -7,22 +7,26 @@
 | 标识符 | 作用域 | 谁生成 | 主要用途 |
 |---|---|---|---|
 | `EventEnvelope.Id` | 单条事件 | 事件发布方 | 去重、追踪单条消息 |
-| `RunId` | 一次 workflow 执行 | `WorkflowExecutionProjectionService` | 关联同一次运行的多条事件与读模型 |
-| `SessionId` | 一次 LLM 会话（或步骤会话） | 服务端内部 | 给 AI 消息链路分段，不等于 run |
+| `RunId` | 一次 workflow 执行 | `WorkflowChatRunApplicationService` | 关联同一次运行的多条事件与读模型 |
+| `MessageId` | 一次 AI 消息链路（或步骤消息链路） | 服务端内部 | 给 AI 消息链路分段，不等于 run |
 | `ActorId` | 一个 Actor 实例 | Runtime | 订阅粒度、线程/会话归属（`threadId`） |
 
 ## 生成点（代码）
 
-- `RunId`：`src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionService.cs`
-  - `StartAsync(...)` 中调用 `IProjectionRunIdGenerator.NextRunId()`
+- `RunId` 生成：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs`
+  - `GenerateRunId()` 生成 runId，并用于创建 `WorkflowExecutionGAgent`（`executionActorId = runId`）
+- `RunId` 注入投影会话：`src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionService.cs`
+  - `StartAsync(..., runId)` 接收应用层传入的 runId
 - `RunId` 注入请求：
   - `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs`
   - 写入 `ChatRequestEvent.Metadata["run_id"]`
-- `WorkflowGAgent` 取 `RunId`：
-  - `src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs` 的 `ResolveRunId(...)`
-- `SessionId`：
+- `WorkflowExecutionGAgent`：
+  - `src/workflow/Aevatar.Workflow.Core/WorkflowExecutionGAgent.cs`
+  - `BindWorkflowAgentId(...)` 显式绑定长期 `WorkflowGAgent`
+  - `ConfigureWorkflow(...)` 注入运行期 workflow 快照
+- `MessageId`：
   - 请求入口会生成内部会话：`chat-{guid}`
-  - 步骤级会话常用 `runId:stepId`（见 `src/Aevatar.AI.Abstractions/ChatSessionKeys.cs`）
+  - 步骤级会话常用 `runId:stepId`（`:attempt` 预留，见 `src/Aevatar.AI.Abstractions/ChatMessageKeys.cs`）
 
 ## 流程图（执行链路）
 
@@ -31,15 +35,21 @@ sequenceDiagram
     participant Client
     participant Api as HostApi
     participant App as WorkflowApp
+    participant Workflow as WorkflowGAgent
+    participant Execution as WorkflowExecutionGAgent
     participant Projection as WorkflowExecutionProjectionService
-    participant Agent as WorkflowGAgent
 
     Client->>Api: POST /api/chat
     Api->>App: ExecuteAsync(prompt, workflow, agentId)
-    App->>Projection: StartAsync(actorId, workflowName, input)
-    Projection-->>App: RunId
-    App->>Agent: ChatRequestEvent(metadata.run_id = RunId)
-    Agent->>Agent: 发布 StartWorkflowEvent(runId)
+    App->>Workflow: ResolveOrCreate(workflow agent)
+    App->>App: Generate RunId
+    App->>Execution: Create(actorId = RunId)
+    App->>Execution: BindWorkflowAgentId(workflowAgentId)
+    App->>Execution: ConfigureWorkflow(workflowYaml, workflowName)
+    App->>Workflow: LinkAsync(workflowAgentId, executionActorId)
+    App->>Projection: StartAsync(rootActorId = RunId, runId = RunId)
+    App->>Execution: ChatRequestEvent(metadata.run_id = RunId)
+    Execution->>Execution: 发布 StartWorkflowEvent(runId)
 ```
 
 ## 流程图（投影识别 run）
@@ -62,5 +72,5 @@ flowchart LR
 ## 客户端契约（当前）
 
 - 客户端只传：`prompt`、`workflow`、`agentId?`。
-- `RunId` 与内部 `SessionId` 都由服务端生成和管理。
-- 查询读模型用 `runId`（`GET /api/runs/{runId}`）；实时流输出携带 `threadId=ActorId` 与 `runId`。
+- `RunId` 与内部 `MessageId` 都由服务端生成和管理。
+- 查询读模型用 `runId`（`GET /api/runs/{runId}`）；实时流输出统一 `threadId=executionActorId=runId`。

--- a/docs/WORKFLOW_EXECUTION_DESTROY_RACE_MEMO.md
+++ b/docs/WORKFLOW_EXECUTION_DESTROY_RACE_MEMO.md
@@ -1,0 +1,95 @@
+# Workflow Execution 销毁竞态备忘（Bug 6）
+
+## 目的
+
+记录当前 `WorkflowExecutionGAgent` 销毁时序中的竞态风险、影响面和后续可选方案，作为后续评审与实现的上下文基线。
+
+这份文档是备忘，不是最终改造方案。
+
+## 问题一句话
+
+当前链路在 run 收尾后会立即 `DestroyExecutionActor`。大多数场景是安全的，但在极端时序下，仍存在“非投影消费方的尾部事件尚在路上，执行 actor 已销毁”的理论窗口。
+
+## 当前收尾链路（代码语义）
+
+`WorkflowChatRunApplicationService.ExecuteAsync(...)` 的主流程是：
+
+1. 启动 `processingTask = ProcessEnvelopeAsync(...)`。
+2. `StreamAsync(...)` 从 `IWorkflowRunEventSink` 读事件，直到 `RUN_FINISHED` 或 `RUN_ERROR`。
+3. `FinalizeAsync(...)` 等待投影完成状态并产出报告。
+4. `JoinProcessingTaskAsync(...)` 等待请求处理任务退出。
+5. 结束阶段：
+   - 正常分支：`DisposeSinkSafeAsync(...)`
+   - 异常分支：`AbortCoreAsync(...)`（内部也会 `JoinProcessingTaskAsync` + `DisposeSinkSafeAsync`）
+6. `finally` 中无条件 `DestroyExecutionActorSafeAsync(executionActorId)`。
+
+关键点在第 6 步：销毁是“当前应用层链路完成后立即发生”，没有额外 grace period。
+
+## 竞态窗口定义
+
+这里的“销毁竞态”不是指主流程内明显漏 await，而是指跨组件时序：
+
+- 我们等待的是“投影完成信号”和“本地处理任务结束”。
+- 但系统里可能存在不受这两个信号严格约束的异步消费方（例如某些实时推送或外部订阅扩展）。
+- 如果这些消费方仍依赖 execution actor 存活，立即销毁就有机会把尾部事件截断。
+
+换句话说：当前链路对“投影闭环”已经有等待，但对“所有潜在旁路消费者都完成”没有全局确认。
+
+## 影响面（如果竞态触发）
+
+- 终态推送偶发缺尾（例如最后一帧或结束信号迟到）。
+- 个别观察端看到 run 已结束，但补充事件未到齐。
+- 排障时会出现“报告已完成但实时流尾部不完整”的不一致体感。
+
+目前没有证据显示这是高频问题，更接近低概率时序缺口。
+
+## 为什么当前优先级可以放 P3
+
+现有实现已经有几层保护，实际风险被压低：
+
+- `WorkflowExecutionRunOrchestrator.FinalizeAsync(...)` 先等投影完成，超时后还有一次 grace wait。
+- `WorkflowChatRunApplicationService` 在销毁前会 `JoinProcessingTaskAsync(...)`。
+- sink 在结束时 `Complete + Dispose`，避免无限写入。
+- `DestroyExecutionActorSafeAsync(...)` 做了异常兜底，不会反向拖垮主流程。
+
+所以它不是“当前链路必现 bug”，更像“高负载或复杂订阅拓扑下的稳健性增强点”。
+
+## 后续可选方案（按侵入性从低到高）
+
+### 方案 A：固定 grace period 后再销毁
+
+- 做法：`finally` 里先 `Task.Delay(xxx)` 再 `DestroyAsync`。
+- 优点：实现最简单，改动小。
+- 缺点：拍脑袋参数，不同负载下效果不稳定。
+
+### 方案 B：soft-destroy（标记回收）+ 延迟清理
+
+- 做法：先把 execution actor 标记为“待回收”，短窗口后统一清理。
+- 优点：语义清晰，可观察性好，便于灰度。
+- 缺点：需要 runtime/生命周期扩展，改动面较大。
+
+### 方案 C：显式 ack 的收口协议
+
+- 做法：以 run 终态事件为边界，等待关键消费者 ack 后再销毁。
+- 优点：语义最严格，可证明“不会截尾”。
+- 缺点：实现复杂，需要定义 ack 协议与超时策略。
+
+## 建议的落地顺序
+
+1. 先补观测：统计“run 完成到 actor 销毁”的耗时、销毁失败率、尾帧缺失率。
+2. 如果观测到真实尾部缺失，再优先尝试方案 A 做低风险缓解。
+3. 若 A 仍不足，再评估方案 B（soft-destroy）作为正式收口方案。
+
+## 建议补充的回归用例
+
+- 人工注入慢消费（延迟投递/延迟推送）后，验证是否仍稳定拿到终态帧。
+- 高并发 run 下，检查 `RUN_FINISHED` 与最后 `TEXT_MESSAGE_END` 的到达完整率。
+- 销毁时机压测：缩短/拉长 grace window，对比尾帧完整率和资源占用。
+
+## 代码锚点
+
+- `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs`
+- `src/workflow/Aevatar.Workflow.Application/Orchestration/WorkflowExecutionRunOrchestrator.cs`
+- `src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunEventContracts.cs`
+- `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunOutputStreamer.cs`
+- `src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowExecutionAGUIEventProjector.cs`

--- a/docs/WORKFLOW_RUN_LIFECYCLE.md
+++ b/docs/WORKFLOW_RUN_LIFECYCLE.md
@@ -1,0 +1,195 @@
+# Workflow Run Lifecycle（重构汇报稿）
+
+## 执行摘要
+
+这次重构的目标，是把“长期编排职责”和“单次执行职责”拆开，解决当前一个 `WorkflowGAgent` 同时承担模板管理、运行执行、并发隔离带来的复杂度问题。
+
+目标方案是：
+
+- `WorkflowGAgent` 作为长期编排实例，负责 workflow 定义、策略和入口。
+- `WorkflowExecutionGAgent` 作为一次 run 的执行实例，`AgentId` 与 `RunId` 同值。
+- `MessageId` 保留为 AI 消息链路标识，不与 `RunId` 合并。
+
+这套模型的核心收益是：执行隔离更清晰、查询主键统一、并发场景更稳，且与现有 CQRS 投影链路兼容。
+
+## 1. 背景与重构目标
+
+### 1.1 当前痛点
+
+- 同一个编排实例承载多次执行，运行态与编排态边界不清。
+- `RunId`、`ActorId`、`MessageId` 在语义上容易被混用，讨论成本高。
+- 并发执行时，步骤回包关联和排障依赖更多约定，维护成本上升。
+
+### 1.2 重构目标
+
+1. 每次执行具备独立 actor 身份，执行边界与生命周期清晰。
+2. `RunId` 成为唯一执行主键，查询和追踪统一。
+3. 保留 `MessageId` 的消息链路能力，避免流式与投影能力回退。
+
+## 2. 目标架构
+
+### 2.1 角色分工
+
+- `WorkflowGAgent`（long-lived）
+  - 保存 workflow 定义与配置。
+  - 接收入口请求并选择/创建执行实例。
+  - 不承载单次 run 的可变执行状态。
+- `WorkflowExecutionGAgent`（per-run）
+  - 处理本次 run 的步骤推进、事件发布、回包关联。
+  - run 结束后销毁或回收。
+
+```mermaid
+flowchart TB
+    workflowAgent["WorkflowGAgent (long-lived)"]
+    executionA["WorkflowExecutionGAgent (runA)"]
+    executionB["WorkflowExecutionGAgent (runB)"]
+    runId["RunId = ExecutionActorId"]
+    sessionKey["MessageId (message chain key)"]
+
+    workflowAgent --> executionA
+    workflowAgent --> executionB
+    executionA --> runId
+    executionA --> sessionKey
+```
+
+### 2.2 标识符职责边界
+
+| 标识符 | 作用域 | 主用途 | 结论 |
+|---|---|---|---|
+| `WorkflowGAgent.AgentId` | 长期编排主体 | 入口与编排身份 | 不等于 `RunId` |
+| `RunId` | 单次执行 | 执行主键、查询主键 | 等于 `ExecutionActorId` |
+| `WorkflowExecutionGAgent.AgentId` | 单次执行 actor | 运行隔离与线程标识 | 与 `RunId` 同值 |
+| `MessageId` | AI 消息链路 | 流式消息聚合、回包匹配 | 不能删除 |
+
+## 3. 关键设计：Execution 如何定位长期 Workflow
+
+核心原则：**执行实例不做运行时搜索，编排层在创建时显式绑定 owner。**
+
+标准流程：
+
+1. 入口先定位长期 `WorkflowGAgent`（`agentId` 命中则复用，否则创建并配置）。
+2. 生成 `RunId`。
+3. 创建 `WorkflowExecutionGAgent`，并强制 `executionActorId = runId`。
+4. 调用 `BindWorkflowAgentId(workflowAgentId)` 显式绑定 owner。
+5. 调用 `ConfigureWorkflow(workflowYaml, workflowName)` 完成 execution 初始化。
+6. 建立父子关系：`LinkAsync(workflowAgentId, executionActorId)`。
+7. 执行阶段若需回调编排实例，直接 `SendToAsync(workflowAgentId, evt)`。
+
+设计约束：
+
+- 禁止按 `workflowName` 扫描 owner。
+- `workflowAgentId` 在 run 生命周期内不可变。
+- owner 丢失时快速失败，输出明确错误事件。
+
+## 4. 一次请求的调用链与参数赋值
+
+```mermaid
+sequenceDiagram
+    participant client as Client
+    participant api as HostApi
+    participant app as WorkflowApplication
+    participant resolver as RunActorResolver
+    participant execution as WorkflowExecutionGAgent
+    participant role as RoleGAgent
+    participant projection as ProjectionPipeline
+
+    client->>api: "/api/chat(prompt, workflow, agentId?)"
+    api->>app: "ExecuteAsync(request)"
+    app->>resolver: "ResolveOrCreate(workflowAgent)"
+    app->>app: "Generate runId"
+    app->>execution: "Create(actorId = runId)"
+    app->>execution: "BindWorkflowAgentId(workflowAgentId)"
+    app->>execution: "ConfigureWorkflow(workflowYaml, workflowName)"
+    app->>resolver: "LinkAsync(workflowAgentId, executionActorId)"
+    app->>execution: "Dispatch run events"
+    execution->>role: "ChatRequestEvent(messageId = runId:stepId)"
+    role-->>execution: "TextMessageStart/Content/End(messageId)"
+    execution-->>projection: "Events(runId, messageId)"
+    projection-->>api: "Run report + stream frames"
+```
+
+参数赋值表：
+
+| 参数 | 来源 | 赋值规则 | 消费方 |
+|---|---|---|---|
+| `prompt` | 请求体 | `ChatInput.Prompt` 原样传递 | `ChatRequestEvent.Prompt` |
+| `workflowName` | 请求体 | 为空走默认 workflow | workflow 加载/解析 |
+| `agentId` | 请求体 | 定位长期 `WorkflowGAgent` | actor resolver |
+| `runId` | 服务端生成 | 每次 run 生成一次 | 执行事件、投影、查询 |
+| `executionActorId` | 服务端派生 | `executionActorId = runId` | runtime、routing、thread |
+| `workflowAgentId` | 服务端解析 | owner id，创建 execution 时写入 | execution 回调编排主体 |
+| `threadId` | 服务端派生 | 对外输出使用 `executionActorId` | SSE/WS 输出 |
+| `messageId` | 服务端生成 | 入口 `chat-{guid}`；步骤 `runId:stepId`（`:attempt` 预留） | LLM 回包关联、消息聚合 |
+
+## 5. 为什么 `MessageId` 不能删
+
+`RunId` 和 `MessageId` 不是同一层标识。`RunId` 管执行实例，`MessageId` 管消息会话链路。
+
+删除 `MessageId` 后会直接影响：
+
+1. 步骤回包匹配失效  
+   - `LLMCallModule` 依赖 `messageId` 关联 `_pending` 请求。
+2. AI 事件 run 归属能力下降  
+   - `AIChatMessageRunIdResolver` 通过 `messageId` 反解 `runId`。
+3. 流式消息聚合受损  
+   - AGUI 侧 `msg:{messageId}` 无法稳定归并 start/content/end。
+4. 读模型可观测性下降  
+   - role reply 与 timeline 的 `message_id` 维度丢失。
+
+结论：`MessageId` 必须保留，但它不是执行主键。
+
+## 6. 落地步骤（建议汇报用）
+
+### 阶段 1：模型落地
+
+- 新增 `WorkflowExecutionGAgent`，定义 owner 绑定字段（`workflowAgentId`）。
+- 调整 run 启动流程，改为“先定位 workflow agent，再创建 execution agent”。
+- 强制 `executionActorId = runId`。
+
+### 阶段 2：链路切换
+
+- 执行事件改为由 `WorkflowExecutionGAgent` 产生。
+- 输出 `threadId` 统一切到 execution actor id。
+- pending/关联键检查并统一为 run 作用域。
+
+### 阶段 3：验证与收口
+
+- 并发 run 压测（同一 `WorkflowGAgent` 多 run）。
+- 回包匹配与流式聚合验证（`MessageId` 维度）。
+- 读模型查询一致性验证（`/api/runs/{runId}`）。
+
+## 7. 风险与控制
+
+| 风险 | 表现 | 控制策略 |
+|---|---|---|
+| owner 绑定遗漏 | execution 无法回调 workflow | 创建时强制校验 `workflowAgentId` |
+| run/thread 标识不一致 | 前端线程展示混乱 | 统一 `threadId = executionActorId` |
+| session 格式不统一 | 回包匹配或聚合异常 | 固化规范：`chat-{guid}` 与 `runId:stepId`（`:attempt` 预留） |
+| 迁移阶段行为漂移 | 新旧链路结果不一致 | 灰度开关 + 双链路对比 |
+
+## 8. 验收标准
+
+1. 一次 run 只对应一个 `WorkflowExecutionGAgent`，且 `AgentId == RunId`。
+2. 同一 `WorkflowGAgent` 并发多 run 时无串线。
+3. SSE/WS 全链路可用，`RUN_STARTED/RUN_FINISHED` 标识稳定。
+4. 查询侧按 `runId` 可稳定获取完整报告。
+5. 删除 `MessageId` 的回归测试明确失败（作为保护性用例）。
+
+## 9. 代码锚点（便于评审）
+
+- 入口解析：`src/Aevatar.Host.Api/Endpoints/ChatEndpoints.cs`
+- WS 入口：`src/Aevatar.Host.Api/Endpoints/ChatWebSocketRunCoordinator.cs`
+- 编排入口：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs`
+- 编排主体定位：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs`
+- 运行编排：`src/workflow/Aevatar.Workflow.Application/Orchestration/WorkflowExecutionRunOrchestrator.cs`
+- 执行实例：`src/workflow/Aevatar.Workflow.Core/WorkflowExecutionGAgent.cs`
+- 工作流快照：`src/workflow/Aevatar.Workflow.Core/WorkflowDefinitionSnapshot.cs`
+- `RunId` 生成：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs`
+- `RunId` 注入：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs`
+- `RunId` 提取：`src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs`
+- `MessageId` 规范：`src/Aevatar.AI.Abstractions/ChatMessageKeys.cs`
+- 会话关联：`src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs`
+
+---
+
+相关文档：`docs/IDENTIFIER_RELATIONSHIPS.md`

--- a/src/Aevatar.AI.Abstractions/ChatSessionKeys.cs
+++ b/src/Aevatar.AI.Abstractions/ChatSessionKeys.cs
@@ -1,11 +1,11 @@
 namespace Aevatar.AI.Abstractions;
 
 /// <summary>
-/// Canonical helpers for chat session identifiers used across workflow modules and projections.
+/// Canonical helpers for chat message identifiers used across workflow modules and projections.
 /// </summary>
-public static class ChatSessionKeys
+public static class ChatMessageKeys
 {
-    public static string CreateWorkflowStepSessionId(string runId, string stepId)
+    public static string CreateWorkflowStepMessageId(string runId, string stepId)
     {
         if (string.IsNullOrWhiteSpace(runId))
             throw new ArgumentException("RunId is required.", nameof(runId));
@@ -15,17 +15,17 @@ public static class ChatSessionKeys
         return $"{runId}:{stepId}";
     }
 
-    public static bool TryParseWorkflowRunId(string? sessionId, out string? runId)
+    public static bool TryParseWorkflowRunId(string? messageId, out string? runId)
     {
         runId = null;
-        if (string.IsNullOrWhiteSpace(sessionId))
+        if (string.IsNullOrWhiteSpace(messageId))
             return false;
 
-        var separatorIndex = sessionId.IndexOf(':');
+        var separatorIndex = messageId.IndexOf(':');
         if (separatorIndex <= 0)
             return false;
 
-        runId = sessionId[..separatorIndex];
+        runId = messageId[..separatorIndex];
         return !string.IsNullOrWhiteSpace(runId);
     }
 }

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -2,12 +2,12 @@ syntax = "proto3";
 package aevatar.ai;
 option csharp_namespace = "Aevatar.AI.Abstractions";
 
-message ChatRequestEvent  { string prompt = 1; string session_id = 2; map<string, string> metadata = 3; }
-message ChatResponseEvent { string content = 1; string session_id = 2; }
+message ChatRequestEvent  { string prompt = 1; string message_id = 2; map<string, string> metadata = 3; }
+message ChatResponseEvent { string content = 1; string message_id = 2; }
 
-message TextMessageStartEvent   { string session_id = 1; string agent_id = 2; }
-message TextMessageContentEvent { string delta = 1; string session_id = 2; }
-message TextMessageEndEvent     { string content = 1; string session_id = 2; }
+message TextMessageStartEvent   { string message_id = 1; string agent_id = 2; }
+message TextMessageContentEvent { string delta = 1; string message_id = 2; }
+message TextMessageEndEvent     { string content = 1; string message_id = 2; }
 
 message ToolCallEvent   { string tool_name = 1; string arguments_json = 2; string call_id = 3; }
 message ToolResultEvent { string call_id = 1; string result_json = 2; bool success = 3; string error = 4; }

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -59,7 +59,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
         // ─── AG-UI: TEXT_MESSAGE_START ───
         await PublishAsync(new TextMessageStartEvent
         {
-            SessionId = request.SessionId,
+            MessageId = request.MessageId,
             AgentId = Id,
         }, EventDirection.Up);
 
@@ -71,7 +71,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
             await PublishAsync(new TextMessageContentEvent
             {
                 Delta = chunk,
-                SessionId = request.SessionId,
+                MessageId = request.MessageId,
             }, EventDirection.Up);
         }
 
@@ -86,7 +86,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
         await PublishAsync(new TextMessageEndEvent
         {
             Content = response,
-            SessionId = request.SessionId,
+            MessageId = request.MessageId,
         }, EventDirection.Up);
     }
 }

--- a/src/Aevatar.Configuration/AevatarSecretsStore.cs
+++ b/src/Aevatar.Configuration/AevatarSecretsStore.cs
@@ -30,11 +30,13 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
     private const string KeychainAccount = "aevatar-masterkey";
 
     private readonly string _filePath;
+    private readonly bool _enableEncryption;
     private Dictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase);
 
-    public AevatarSecretsStore(string? filePath = null)
+    public AevatarSecretsStore(string? filePath = null, bool enableEncryption = true)
     {
         _filePath = filePath ?? AevatarPaths.SecretsJson;
+        _enableEncryption = enableEncryption;
         Load();
     }
 
@@ -103,8 +105,8 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
 
         if (string.IsNullOrWhiteSpace(json)) return;
 
-        // Try encrypted format first
-        if (TryLoadEncrypted(json))
+        // Try encrypted format first (unless encryption is explicitly disabled).
+        if (_enableEncryption && TryLoadEncrypted(json))
             return;
 
         // Fallback: plaintext JSON
@@ -152,6 +154,12 @@ public sealed class AevatarSecretsStore : IAevatarSecretsStore
 
     private void Save()
     {
+        if (!_enableEncryption)
+        {
+            SavePlaintext();
+            return;
+        }
+
         var masterKey = TryGetMasterKey();
         if (masterKey != null && TrySaveEncrypted(masterKey))
             return;

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionProjectionPort.cs
@@ -14,6 +14,7 @@ public interface IWorkflowExecutionProjectionPort
         string workflowName,
         string input,
         IWorkflowRunEventSink sink,
+        string? runId = null,
         CancellationToken ct = default);
 
     Task<WorkflowProjectionCompletionStatus> WaitForRunProjectionCompletionStatusAsync(

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowExecutionQueryModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowExecutionQueryModels.cs
@@ -97,7 +97,7 @@ public sealed class WorkflowRunRoleReply
 {
     public DateTimeOffset Timestamp { get; set; }
     public string RoleId { get; set; } = string.Empty;
-    public string SessionId { get; set; } = string.Empty;
+    public string MessageId { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public int ContentLength { get; set; }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Orchestration/IWorkflowExecutionRunOrchestrator.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Orchestration/IWorkflowExecutionRunOrchestrator.cs
@@ -12,6 +12,7 @@ public interface IWorkflowExecutionRunOrchestrator
         string workflowName,
         string prompt,
         IWorkflowRunEventSink sink,
+        string? runId = null,
         CancellationToken ct = default);
 
     Task<WorkflowProjectionFinalizeResult> FinalizeAsync(

--- a/src/workflow/Aevatar.Workflow.Application/Orchestration/WorkflowExecutionRunOrchestrator.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Orchestration/WorkflowExecutionRunOrchestrator.cs
@@ -30,9 +30,10 @@ public sealed class WorkflowExecutionRunOrchestrator : IWorkflowExecutionRunOrch
         string workflowName,
         string prompt,
         IWorkflowRunEventSink sink,
+        string? runId = null,
         CancellationToken ct = default)
     {
-        var session = await _projectionPort.StartAsync(actorId, workflowName, prompt, sink, ct);
+        var session = await _projectionPort.StartAsync(actorId, workflowName, prompt, sink, runId, ct);
         return new WorkflowProjectionRun(session);
     }
 

--- a/src/workflow/Aevatar.Workflow.Application/Runs/IWorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/IWorkflowRunActorResolver.cs
@@ -11,6 +11,7 @@ public interface IWorkflowRunActorResolver
 }
 
 public sealed record WorkflowActorResolutionResult(
-    IActor? Actor,
+    IActor? WorkflowActor,
     string WorkflowNameForRun,
+    string WorkflowYamlForRun,
     WorkflowChatRunStartError Error);

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs
@@ -11,7 +11,7 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : IWorkflowChatRequestE
         var chatRequest = new ChatRequestEvent
         {
             Prompt = prompt,
-            SessionId = CreateInternalChatSessionId(),
+            MessageId = CreateInternalChatMessageId(),
         };
         chatRequest.Metadata[ChatRequestMetadataKeys.RunId] = runId;
 
@@ -25,5 +25,5 @@ internal sealed class WorkflowChatRequestEnvelopeFactory : IWorkflowChatRequestE
         };
     }
 
-    private static string CreateInternalChatSessionId() => $"chat-{Guid.NewGuid():N}";
+    private static string CreateInternalChatMessageId() => $"chat-{Guid.NewGuid():N}";
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs
@@ -3,6 +3,7 @@ using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Orchestration;
+using Aevatar.Workflow.Core;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -72,7 +73,7 @@ public sealed class WorkflowChatRunApplicationService : IWorkflowChatRunApplicat
             var finalizeResult = await _runOrchestrator.FinalizeAsync(
                 runContext.ProjectionRun,
                 _runtime,
-                runContext.ActorId,
+                runContext.ExecutionActorId,
                 ct);
             finalized = true;
 
@@ -93,20 +94,27 @@ public sealed class WorkflowChatRunApplicationService : IWorkflowChatRunApplicat
         }
         finally
         {
-            if (finalized)
+            try
             {
-                await DisposeSinkSafeAsync(runContext.Sink);
+                if (finalized)
+                {
+                    await DisposeSinkSafeAsync(runContext.Sink);
+                }
+                else
+                {
+                    try
+                    {
+                        await AbortCoreAsync(runContext, processingTask);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Abort workflow projection run failed during cleanup.");
+                    }
+                }
             }
-            else
+            finally
             {
-                try
-                {
-                    await AbortCoreAsync(runContext, processingTask);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Abort workflow projection run failed during cleanup.");
-                }
+                await DestroyExecutionActorSafeAsync(runContext.ExecutionActorId, CancellationToken.None);
             }
         }
     }
@@ -116,31 +124,46 @@ public sealed class WorkflowChatRunApplicationService : IWorkflowChatRunApplicat
         CancellationToken ct)
     {
         var actorResolution = await _actorResolver.ResolveOrCreateAsync(request, ct);
-        if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Actor == null)
+        if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.WorkflowActor == null)
             return new WorkflowRunContextCreateResult(actorResolution.Error, null);
 
-        var actor = actorResolution.Actor;
+        var workflowActor = actorResolution.WorkflowActor;
         var workflowNameForRun = actorResolution.WorkflowNameForRun;
+        var workflowYamlForRun = actorResolution.WorkflowYamlForRun;
         var sink = new WorkflowRunEventChannel();
+        var runId = GenerateRunId();
+        IActor? executionActor = null;
 
         WorkflowProjectionRun projectionRun;
         try
         {
+            executionActor = await _runtime.CreateAsync<WorkflowExecutionGAgent>(runId, ct);
+            if (executionActor.Agent is not WorkflowExecutionGAgent executionAgent)
+                throw new InvalidOperationException("Created execution actor is not WorkflowExecutionGAgent.");
+
+            executionAgent.BindWorkflowAgentId(workflowActor.Id);
+            executionAgent.ConfigureWorkflow(workflowYamlForRun, workflowNameForRun);
+            await _runtime.LinkAsync(workflowActor.Id, executionActor.Id, ct);
+
             projectionRun = await _runOrchestrator.StartAsync(
-                actor.Id,
+                executionActor.Id,
                 workflowNameForRun,
                 request.Prompt,
                 sink,
+                runId,
                 ct);
         }
         catch
         {
+            if (executionActor != null)
+                await DestroyExecutionActorSafeAsync(executionActor.Id, CancellationToken.None);
             await sink.DisposeAsync();
             throw;
         }
 
         if (!projectionRun.Session.Enabled)
         {
+            await DestroyExecutionActorSafeAsync(runId, CancellationToken.None);
             await sink.DisposeAsync();
             return new WorkflowRunContextCreateResult(
                 WorkflowChatRunStartError.ProjectionDisabled,
@@ -151,7 +174,8 @@ public sealed class WorkflowChatRunApplicationService : IWorkflowChatRunApplicat
             WorkflowChatRunStartError.None,
             new WorkflowRunContext
             {
-                Actor = actor,
+                WorkflowActor = workflowActor,
+                ExecutionActor = executionActor!,
                 WorkflowName = workflowNameForRun,
                 ProjectionRun = projectionRun,
                 Sink = sink,
@@ -163,8 +187,8 @@ public sealed class WorkflowChatRunApplicationService : IWorkflowChatRunApplicat
         EventEnvelope requestEnvelope,
         CancellationToken ct) =>
         _requestExecutor.ExecuteAsync(
-            runContext.Actor,
-            runContext.ActorId,
+            runContext.ExecutionActor,
+            runContext.ExecutionActorId,
             runContext.RunId,
             requestEnvelope,
             runContext.Sink,
@@ -218,5 +242,22 @@ public sealed class WorkflowChatRunApplicationService : IWorkflowChatRunApplicat
     {
         sink.Complete();
         await sink.DisposeAsync();
+    }
+
+    private static string GenerateRunId() => Guid.NewGuid().ToString("N");
+
+    private async Task DestroyExecutionActorSafeAsync(string executionActorId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(executionActorId))
+            return;
+
+        try
+        {
+            await _runtime.DestroyAsync(executionActorId, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Destroy execution actor failed: {ExecutionActorId}", executionActorId);
+        }
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
@@ -22,28 +22,47 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
         WorkflowChatRunRequest request,
         CancellationToken ct = default)
     {
-        var workflowNameForRun = string.IsNullOrWhiteSpace(request.WorkflowName) ? "direct" : request.WorkflowName;
+        var requestedWorkflowName = string.IsNullOrWhiteSpace(request.WorkflowName) ? "direct" : request.WorkflowName;
 
         if (!string.IsNullOrWhiteSpace(request.ActorId))
         {
             var existing = await _runtime.GetAsync(request.ActorId);
             if (existing == null)
-                return new WorkflowActorResolutionResult(null, workflowNameForRun, WorkflowChatRunStartError.AgentNotFound);
+                return new WorkflowActorResolutionResult(null, requestedWorkflowName, string.Empty, WorkflowChatRunStartError.AgentNotFound);
 
-            if (existing.Agent is not WorkflowGAgent)
-                return new WorkflowActorResolutionResult(null, workflowNameForRun, WorkflowChatRunStartError.AgentTypeNotSupported);
+            if (existing.Agent is not WorkflowGAgent workflowAgent)
+                return new WorkflowActorResolutionResult(null, requestedWorkflowName, string.Empty, WorkflowChatRunStartError.AgentTypeNotSupported);
 
-            return new WorkflowActorResolutionResult(existing, workflowNameForRun, WorkflowChatRunStartError.None);
+            var snapshot = workflowAgent.GetWorkflowDefinitionSnapshot();
+            var resolvedWorkflowNameForRun = string.IsNullOrWhiteSpace(snapshot.WorkflowName)
+                ? requestedWorkflowName
+                : snapshot.WorkflowName;
+
+            if (string.IsNullOrWhiteSpace(snapshot.WorkflowYaml))
+            {
+                return new WorkflowActorResolutionResult(
+                    null,
+                    resolvedWorkflowNameForRun,
+                    string.Empty,
+                    WorkflowChatRunStartError.WorkflowNotFound);
+            }
+
+            return new WorkflowActorResolutionResult(
+                existing,
+                resolvedWorkflowNameForRun,
+                snapshot.WorkflowYaml,
+                WorkflowChatRunStartError.None);
         }
 
+        var workflowNameForRun = requestedWorkflowName;
         var yaml = _workflowRegistry.GetYaml(workflowNameForRun);
         if (yaml == null)
-            return new WorkflowActorResolutionResult(null, workflowNameForRun, WorkflowChatRunStartError.WorkflowNotFound);
+            return new WorkflowActorResolutionResult(null, workflowNameForRun, string.Empty, WorkflowChatRunStartError.WorkflowNotFound);
 
         var actor = await _runtime.CreateAsync<WorkflowGAgent>(ct: ct);
-        if (actor.Agent is WorkflowGAgent workflowAgent)
-            workflowAgent.ConfigureWorkflow(yaml, workflowNameForRun);
+        if (actor.Agent is WorkflowGAgent createdWorkflowAgent)
+            createdWorkflowAgent.ConfigureWorkflow(yaml, workflowNameForRun);
 
-        return new WorkflowActorResolutionResult(actor, workflowNameForRun, WorkflowChatRunStartError.None);
+        return new WorkflowActorResolutionResult(actor, workflowNameForRun, yaml, WorkflowChatRunStartError.None);
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunContext.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunContext.cs
@@ -6,7 +6,9 @@ namespace Aevatar.Workflow.Application.Runs;
 
 internal sealed class WorkflowRunContext
 {
-    public required IActor Actor { get; init; }
+    public required IActor WorkflowActor { get; init; }
+
+    public required IActor ExecutionActor { get; init; }
 
     public required string WorkflowName { get; init; }
 
@@ -14,11 +16,13 @@ internal sealed class WorkflowRunContext
 
     public required IWorkflowRunEventSink Sink { get; init; }
 
-    public string ActorId => Actor.Id;
+    public string WorkflowActorId => WorkflowActor.Id;
+
+    public string ExecutionActorId => ExecutionActor.Id;
 
     public string RunId => ProjectionRun.RunId;
 
-    public WorkflowChatRunStarted ToStarted() => new(ActorId, WorkflowName, RunId);
+    public WorkflowChatRunStarted ToStarted() => new(ExecutionActorId, WorkflowName, RunId);
 }
 
 internal sealed record WorkflowRunContextCreateResult(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -55,9 +55,9 @@ public sealed class LLMCallModule : IEventModule
                 prompt = prefix.TrimEnd() + "\n\n" + prompt;
             }
 
-            // Use per-step session id to avoid collisions across concurrent llm_call steps.
-            var chatSessionId = ChatSessionKeys.CreateWorkflowStepSessionId(request.RunId, request.StepId);
-            _pending[chatSessionId] = request;
+            // Use per-step message id to avoid collisions across concurrent llm_call steps.
+            var chatMessageId = ChatMessageKeys.CreateWorkflowStepMessageId(request.RunId, request.StepId);
+            _pending[chatMessageId] = request;
 
             var targetRole = request.TargetRole;
             var promptPreview = prompt.Length > 200 ? prompt[..200] + "..." : prompt;
@@ -69,7 +69,7 @@ public sealed class LLMCallModule : IEventModule
                     "LLMCallModule: step={StepId} → SendTo role={Role} prompt=({Len} chars) {Preview}",
                     request.StepId, targetRole, prompt.Length, promptPreview);
 
-                var chatEvt = new ChatRequestEvent { Prompt = prompt, SessionId = chatSessionId };
+                var chatEvt = new ChatRequestEvent { Prompt = prompt, MessageId = chatMessageId };
                 await gab.EventPublisher.SendToAsync(targetRole, chatEvt, ct);
             }
             else
@@ -81,7 +81,7 @@ public sealed class LLMCallModule : IEventModule
 
                 await ctx.PublishAsync(new ChatRequestEvent
                 {
-                    Prompt = prompt, SessionId = chatSessionId,
+                    Prompt = prompt, MessageId = chatMessageId,
                 }, EventDirection.Self, ct);
             }
             return;
@@ -91,10 +91,10 @@ public sealed class LLMCallModule : IEventModule
         if (payload.Is(TextMessageEndEvent.Descriptor))
         {
             var evt = payload.Unpack<TextMessageEndEvent>();
-            var sessionId = evt.SessionId;
-            if (string.IsNullOrEmpty(sessionId)) return;
-            if (!_pending.TryGetValue(sessionId, out var pending)) return;
-            _pending.Remove(sessionId);
+            var messageId = evt.MessageId;
+            if (string.IsNullOrEmpty(messageId)) return;
+            if (!_pending.TryGetValue(messageId, out var pending)) return;
+            _pending.Remove(messageId);
 
             var outputPreview = (evt.Content ?? "").Length > 300 ? evt.Content![..300] + "..." : evt.Content ?? "";
             ctx.Logger.LogInformation(
@@ -114,10 +114,10 @@ public sealed class LLMCallModule : IEventModule
         if (payload.Is(ChatResponseEvent.Descriptor))
         {
             var evt = payload.Unpack<ChatResponseEvent>();
-            var sessionId = evt.SessionId;
-            if (string.IsNullOrEmpty(sessionId)) return;
-            if (!_pending.TryGetValue(sessionId, out var pending)) return;
-            _pending.Remove(sessionId);
+            var messageId = evt.MessageId;
+            if (string.IsNullOrEmpty(messageId)) return;
+            if (!_pending.TryGetValue(messageId, out var pending)) return;
+            _pending.Remove(messageId);
 
             var nsPreview = (evt.Content ?? "").Length > 300 ? evt.Content![..300] + "..." : evt.Content ?? "";
             ctx.Logger.LogInformation(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/WorkflowLoopModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/WorkflowLoopModule.cs
@@ -132,7 +132,18 @@ public sealed class WorkflowLoopModule : IEventModule
         ctx.Logger.LogInformation("workflow_loop: dispatch step={StepId} type={Type} role={Role} input=({Len} chars) {Preview}",
             step.Id, step.Type, step.TargetRole ?? "(none)", input.Length, inputPreview);
 
-        var req = new StepRequestEvent { StepId = step.Id, StepType = step.Type, RunId = runId, Input = input, TargetRole = step.TargetRole ?? "" };
+        var resolvedTargetRole = step.TargetRole ?? "";
+        if (!string.IsNullOrWhiteSpace(resolvedTargetRole) && ctx.Agent is WorkflowGAgent workflowAgent)
+            resolvedTargetRole = workflowAgent.ResolveTargetRoleActorId(resolvedTargetRole);
+
+        var req = new StepRequestEvent
+        {
+            StepId = step.Id,
+            StepType = step.Type,
+            RunId = runId,
+            Input = input,
+            TargetRole = resolvedTargetRole,
+        };
         foreach (var (k, v) in step.Parameters) req.Parameters[k] = v;
 
         // 当步骤指定了 TargetRole 且该角色配置了 connectors 允许列表时，注入 allowed_connectors 供 ConnectorCallModule 校验

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowDefinitionSnapshot.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowDefinitionSnapshot.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.Workflow.Core;
+
+/// <summary>
+/// Immutable snapshot of workflow definition content for bootstrapping execution agents.
+/// </summary>
+public sealed record WorkflowDefinitionSnapshot(
+    string WorkflowYaml,
+    string WorkflowName);

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowExecutionGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowExecutionGAgent.cs
@@ -1,0 +1,97 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Workflow.Core.Composition;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Workflow.Core;
+
+/// <summary>
+/// Per-run workflow execution actor.
+/// AgentId is bound to runId and owner workflow agent is explicitly injected.
+/// </summary>
+public sealed class WorkflowExecutionGAgent : WorkflowGAgent
+{
+    private string _workflowAgentId = string.Empty;
+
+    public WorkflowExecutionGAgent(
+        IActorRuntime runtime,
+        IRoleAgentTypeResolver roleAgentTypeResolver,
+        IEnumerable<IEventModuleFactory> eventModuleFactories,
+        IEnumerable<IWorkflowModuleDependencyExpander> moduleDependencyExpanders,
+        IEnumerable<IWorkflowModuleConfigurator> moduleConfigurators)
+        : base(
+            runtime,
+            roleAgentTypeResolver,
+            eventModuleFactories,
+            moduleDependencyExpanders,
+            moduleConfigurators)
+    {
+    }
+
+    /// <summary>
+    /// Long-lived workflow owner actor ID.
+    /// </summary>
+    public string WorkflowAgentId => _workflowAgentId;
+
+    /// <summary>
+    /// Binds owner workflow agent. Can only be set once per execution actor.
+    /// </summary>
+    public void BindWorkflowAgentId(string workflowAgentId)
+    {
+        if (string.IsNullOrWhiteSpace(workflowAgentId))
+            throw new ArgumentException("WorkflowAgentId is required.", nameof(workflowAgentId));
+
+        if (!string.IsNullOrWhiteSpace(_workflowAgentId) &&
+            !string.Equals(_workflowAgentId, workflowAgentId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"WorkflowExecutionGAgent owner already bound: '{_workflowAgentId}'.");
+        }
+
+        _workflowAgentId = workflowAgentId;
+    }
+
+    /// <inheritdoc />
+    public override Task<string> GetDescriptionAsync() =>
+        Task.FromResult($"WorkflowExecutionGAgent[owner={_workflowAgentId}, run={Id}]");
+
+    /// <inheritdoc />
+    protected override string ResolveRoleActorId(string roleId) => $"{Id}:{roleId}";
+
+    /// <inheritdoc />
+    protected override string ResolveRunId(ChatRequestEvent request) => Id;
+
+    /// <inheritdoc />
+    protected override bool ValidateBeforeRun(ChatRequestEvent request, out string? validationError)
+    {
+        if (string.IsNullOrWhiteSpace(_workflowAgentId))
+        {
+            validationError = "执行实例未绑定长期工作流 Actor。";
+            return false;
+        }
+
+        if (request.Metadata.TryGetValue(ChatRequestMetadataKeys.RunId, out var runIdFromMetadata) &&
+            !string.IsNullOrWhiteSpace(runIdFromMetadata) &&
+            !string.Equals(runIdFromMetadata, Id, StringComparison.Ordinal))
+        {
+            validationError = $"执行实例 run_id 与 actorId 不一致: run_id={runIdFromMetadata}, actorId={Id}";
+            return false;
+        }
+
+        return base.ValidateBeforeRun(request, out validationError);
+    }
+
+    /// <inheritdoc />
+    [EventHandler]
+    public override async Task HandleWorkflowCompleted(WorkflowCompletedEvent evt)
+    {
+        Logger.LogInformation("执行实例 {RunId} 完成: {Success}", evt.RunId, evt.Success);
+        await PublishAsync(new TextMessageEndEvent
+        {
+            Content = evt.Success ? evt.Output : $"工作流执行失败: {evt.Error}",
+            MessageId = evt.RunId,
+        }, EventDirection.Up);
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs
@@ -36,6 +36,7 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
     private WorkflowDefinition? _compiledWorkflow;
     private readonly WorkflowParser _parser = new();
     private readonly List<string> _childAgentIds = [];
+    private readonly Dictionary<string, string> _roleActorIdsByRoleId = new(StringComparer.OrdinalIgnoreCase);
     private readonly IActorRuntime _runtime;
     private readonly IRoleAgentTypeResolver _roleAgentTypeResolver;
     private readonly IReadOnlyList<IEventModuleFactory> _eventModuleFactories;
@@ -81,6 +82,7 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
             State.WorkflowName = workflowName;
 
         _childAgentIds.Clear();
+        _roleActorIdsByRoleId.Clear();
 
         if (string.IsNullOrWhiteSpace(State.WorkflowYaml))
         {
@@ -109,13 +111,30 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
     [EventHandler]
     public async Task HandleChatRequest(ChatRequestEvent request)
     {
+        if (!ValidateBeforeRun(request, out var validationError))
+        {
+            await PublishAsync(new ChatResponseEvent
+            {
+                Content = validationError ?? "工作流执行校验失败",
+                MessageId = request.MessageId,
+            }, EventDirection.Up);
+            return;
+        }
+
         if (_compiledWorkflow == null)
         {
             await PublishAsync(new ChatResponseEvent
             {
-                Content = "工作流未编译或未配置", SessionId = request.SessionId,
+                Content = "工作流未编译或未配置", MessageId = request.MessageId,
             }, EventDirection.Up);
             return;
+        }
+
+        if (GetType() == typeof(WorkflowGAgent))
+        {
+            Logger.LogWarning(
+                "WorkflowGAgent {ActorId} is handling ChatRequestEvent directly. This path is kept for compatibility and will be deprecated; prefer per-run WorkflowExecutionGAgent.",
+                Id);
         }
 
         await EnsureAgentTreeAsync();
@@ -133,7 +152,7 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
 
     /// <summary>处理工作流完成事件：汇总结果，更新统计。</summary>
     [EventHandler]
-    public async Task HandleWorkflowCompleted(WorkflowCompletedEvent evt)
+    public virtual async Task HandleWorkflowCompleted(WorkflowCompletedEvent evt)
     {
         Logger.LogInformation("工作流 {Name} 完成: {Success}", evt.WorkflowName, evt.Success);
         State.TotalExecutions++;
@@ -144,6 +163,7 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
         await PublishAsync(new TextMessageEndEvent
         {
             Content = evt.Success ? evt.Output : $"工作流执行失败: {evt.Error}",
+            MessageId = evt.RunId,
         }, EventDirection.Up);
     }
 
@@ -158,7 +178,8 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
 
         foreach (var role in _compiledWorkflow.Roles)
         {
-            var actor = await _runtime.CreateAsync(roleAgentType, role.Id);
+            var roleActorId = ResolveRoleActorId(role.Id);
+            var actor = await _runtime.CreateAsync(roleAgentType, roleActorId);
             if (actor.Agent is IRoleAgent roleAgent)
             {
                 roleAgent.SetRoleName(role.Name);
@@ -177,6 +198,7 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
 
             await _runtime.LinkAsync(Id, actor.Id);
             _childAgentIds.Add(actor.Id);
+            _roleActorIdsByRoleId[role.Id] = actor.Id;
         }
         Logger.LogInformation("Agent 树创建完成: {Count} 个 role agents", _childAgentIds.Count);
     }
@@ -223,7 +245,42 @@ public class WorkflowGAgent : GAgentBase<WorkflowState>
             configurator.Configure(module, _compiledWorkflow);
     }
 
-    private static string ResolveRunId(ChatRequestEvent request)
+    /// <summary>
+    /// Allows subclasses to inject pre-run validation.
+    /// </summary>
+    protected virtual bool ValidateBeforeRun(ChatRequestEvent request, out string? validationError)
+    {
+        validationError = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves the physical actor ID for a logical workflow role ID.
+    /// </summary>
+    /// <param name="roleId">Logical role ID in workflow definition.</param>
+    /// <returns>Physical actor ID used by runtime routing.</returns>
+    public string ResolveTargetRoleActorId(string roleId)
+    {
+        if (string.IsNullOrWhiteSpace(roleId))
+            return roleId;
+
+        return _roleActorIdsByRoleId.TryGetValue(roleId, out var actorId)
+            ? actorId
+            : roleId;
+    }
+
+    /// <summary>
+    /// Returns current workflow definition snapshot for execution-agent bootstrap.
+    /// </summary>
+    public WorkflowDefinitionSnapshot GetWorkflowDefinitionSnapshot() =>
+        new(State.WorkflowYaml, State.WorkflowName);
+
+    /// <summary>
+    /// Allows subclasses to customize physical actor IDs for role agents.
+    /// </summary>
+    protected virtual string ResolveRoleActorId(string roleId) => roleId;
+
+    protected virtual string ResolveRunId(ChatRequestEvent request)
     {
         if (request.Metadata.TryGetValue(ChatRequestMetadataKeys.RunId, out var runIdFromMetadata) &&
             !string.IsNullOrWhiteSpace(runIdFromMetadata))

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Reporting/WorkflowExecutionReportWriter.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Reporting/WorkflowExecutionReportWriter.cs
@@ -127,7 +127,7 @@ public static class WorkflowExecutionReportWriter
             foreach (var reply in report.RoleReplies)
             {
                 sb.AppendLine("<details>");
-                sb.AppendLine($"<summary><code>{E(reply.RoleId)}</code> session={E(reply.SessionId)} chars={reply.ContentLength} time={E(reply.Timestamp.ToString("HH:mm:ss.fff"))}</summary>");
+                sb.AppendLine($"<summary><code>{E(reply.RoleId)}</code> message={E(reply.MessageId)} chars={reply.ContentLength} time={E(reply.Timestamp.ToString("HH:mm:ss.fff"))}</summary>");
                 sb.AppendLine($"<pre>{E(reply.Content)}</pre>");
                 sb.AppendLine("</details>");
             }

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToAGUIEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToAGUIEventMapper.cs
@@ -141,7 +141,7 @@ public sealed class AITextStreamAGUIEventEnvelopeMappingHandler : IAGUIEventEnve
         if (payload.Is(AIEvents.TextMessageStartEvent.Descriptor))
         {
             var evt = payload.Unpack<AIEvents.TextMessageStartEvent>();
-            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.SessionId, envelope.Id);
+            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.MessageId, envelope.Id);
             events =
             [
                 new AGUI.TextMessageStartEvent
@@ -157,7 +157,7 @@ public sealed class AITextStreamAGUIEventEnvelopeMappingHandler : IAGUIEventEnve
         if (payload.Is(AIEvents.TextMessageContentEvent.Descriptor))
         {
             var evt = payload.Unpack<AIEvents.TextMessageContentEvent>();
-            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.SessionId, envelope.Id);
+            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.MessageId, envelope.Id);
             events =
             [
                 new AGUI.TextMessageContentEvent
@@ -173,7 +173,7 @@ public sealed class AITextStreamAGUIEventEnvelopeMappingHandler : IAGUIEventEnve
         if (payload.Is(AIEvents.TextMessageEndEvent.Descriptor))
         {
             var evt = payload.Unpack<AIEvents.TextMessageEndEvent>();
-            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.SessionId, envelope.Id);
+            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.MessageId, envelope.Id);
             events =
             [
                 new AGUI.TextMessageEndEvent
@@ -188,7 +188,7 @@ public sealed class AITextStreamAGUIEventEnvelopeMappingHandler : IAGUIEventEnve
         if (payload.Is(AIEvents.ChatResponseEvent.Descriptor))
         {
             var evt = payload.Unpack<AIEvents.ChatResponseEvent>();
-            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.SessionId, envelope.Id);
+            var msgId = AGUIEventEnvelopeMappingHelpers.ResolveMessageId(evt.MessageId, envelope.Id);
             events =
             [
                 new AGUI.TextMessageStartEvent
@@ -324,10 +324,10 @@ internal static class AGUIEventEnvelopeMappingHelpers
             : envelope.PublisherId;
     }
 
-    public static string ResolveMessageId(string? sessionId, string? envelopeId)
+    public static string ResolveMessageId(string? messageId, string? envelopeId)
     {
-        if (!string.IsNullOrWhiteSpace(sessionId))
-            return $"msg:{sessionId}";
+        if (!string.IsNullOrWhiteSpace(messageId))
+            return $"msg:{messageId}";
 
         return $"msg:{envelopeId}";
     }

--- a/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IWorkflowExecutionProjectionContextFactory, DefaultWorkflowExecutionProjectionContextFactory>();
         services.TryAddSingleton<WorkflowExecutionReadModelMapper>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowExecutionRunIdResolver, WorkflowCoreRunIdResolver>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowExecutionRunIdResolver, AIChatSessionRunIdResolver>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IWorkflowExecutionRunIdResolver, AIChatMessageRunIdResolver>());
         RegisterFromAssembly(services, typeof(ServiceCollectionExtensions).Assembly);
         services.TryAddSingleton<IProjectionCoordinator<WorkflowExecutionProjectionContext, IReadOnlyList<WorkflowExecutionTopologyEdge>>, ProjectionCoordinator<WorkflowExecutionProjectionContext, IReadOnlyList<WorkflowExecutionTopologyEdge>>>();
         services.TryAddSingleton<IProjectionCompletionDetector<WorkflowExecutionProjectionContext>, WorkflowCompletedEventProjectionCompletionDetector<WorkflowExecutionProjectionContext>>();

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionService.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionService.cs
@@ -49,29 +49,30 @@ public sealed class WorkflowExecutionProjectionService : IWorkflowExecutionProje
         string workflowName,
         string input,
         IWorkflowRunEventSink sink,
+        string? runId = null,
         CancellationToken ct = default)
     {
-        var runId = _runIdGenerator.NextRunId();
+        var resolvedRunId = string.IsNullOrWhiteSpace(runId) ? _runIdGenerator.NextRunId() : runId;
         var startedAt = _clock.UtcNow;
 
         if (!ProjectionEnabled)
         {
             return new WorkflowProjectionSession
             {
-                RunId = runId,
+                RunId = resolvedRunId,
                 StartedAt = startedAt,
                 Enabled = false,
             };
         }
 
-        var context = _contextFactory.Create(runId, rootActorId, workflowName, input, startedAt);
+        var context = _contextFactory.Create(resolvedRunId, rootActorId, workflowName, input, startedAt);
         context.SetRunEventSink(sink);
         await _lifecycle.StartAsync(context, ct);
-        _contexts[runId] = context;
+        _contexts[resolvedRunId] = context;
 
         return new WorkflowProjectionSession
         {
-            RunId = runId,
+            RunId = resolvedRunId,
             StartedAt = startedAt,
             Enabled = true,
         };

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModel.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModel.cs
@@ -81,7 +81,7 @@ public sealed class WorkflowExecutionRoleReply
 {
     public DateTimeOffset Timestamp { get; set; }
     public string RoleId { get; set; } = "";
-    public string SessionId { get; set; } = "";
+    public string MessageId { get; set; } = "";
     public string Content { get; set; } = "";
     public int ContentLength { get; set; }
 }

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowExecutionReadModelMapper.cs
@@ -62,7 +62,7 @@ public sealed class WorkflowExecutionReadModelMapper
                 {
                     Timestamp = x.Timestamp,
                     RoleId = x.RoleId,
-                    SessionId = x.SessionId,
+                    MessageId = x.MessageId,
                     Content = x.Content,
                     ContentLength = x.ContentLength,
                 })

--- a/src/workflow/Aevatar.Workflow.Projection/Reducers/TextMessageEndEventReducer.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Reducers/TextMessageEndEventReducer.cs
@@ -21,7 +21,7 @@ public sealed class TextMessageEndEventReducer : WorkflowExecutionEventReducerBa
             {
                 Timestamp = now,
                 RoleId = publisher,
-                SessionId = evt.SessionId ?? "",
+                MessageId = evt.MessageId ?? "",
                 Content = evt.Content ?? "",
                 ContentLength = (evt.Content ?? "").Length,
             });
@@ -38,7 +38,7 @@ public sealed class TextMessageEndEventReducer : WorkflowExecutionEventReducerBa
             envelope.Payload?.TypeUrl ?? "",
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["session_id"] = evt.SessionId ?? "",
+                ["message_id"] = evt.MessageId ?? "",
             });
     }
 }

--- a/src/workflow/Aevatar.Workflow.Projection/RunIdResolvers/AIChatSessionRunIdResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/RunIdResolvers/AIChatSessionRunIdResolver.cs
@@ -3,7 +3,7 @@ using AIEvents = Aevatar.AI.Abstractions;
 
 namespace Aevatar.Workflow.Projection.RunIdResolvers;
 
-public sealed class AIChatSessionRunIdResolver : IWorkflowExecutionRunIdResolver
+public sealed class AIChatMessageRunIdResolver : IWorkflowExecutionRunIdResolver
 {
     public int Order => 100;
 
@@ -15,16 +15,16 @@ public sealed class AIChatSessionRunIdResolver : IWorkflowExecutionRunIdResolver
             return false;
 
         if (payload.Is(AIEvents.TextMessageStartEvent.Descriptor))
-            return ChatSessionKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.TextMessageStartEvent>().SessionId, out runId);
+            return ChatMessageKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.TextMessageStartEvent>().MessageId, out runId);
 
         if (payload.Is(AIEvents.TextMessageContentEvent.Descriptor))
-            return ChatSessionKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.TextMessageContentEvent>().SessionId, out runId);
+            return ChatMessageKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.TextMessageContentEvent>().MessageId, out runId);
 
         if (payload.Is(AIEvents.TextMessageEndEvent.Descriptor))
-            return ChatSessionKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.TextMessageEndEvent>().SessionId, out runId);
+            return ChatMessageKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.TextMessageEndEvent>().MessageId, out runId);
 
         if (payload.Is(AIEvents.ChatResponseEvent.Descriptor))
-            return ChatSessionKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.ChatResponseEvent>().SessionId, out runId);
+            return ChatMessageKeys.TryParseWorkflowRunId(payload.Unpack<AIEvents.ChatResponseEvent>().MessageId, out runId);
 
         return false;
     }

--- a/src/workflow/Aevatar.Workflow.Projection/Stores/InMemoryWorkflowExecutionReadModelStore.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Stores/InMemoryWorkflowExecutionReadModelStore.cs
@@ -103,7 +103,7 @@ public sealed class InMemoryWorkflowExecutionReadModelStore
     {
         Timestamp = source.Timestamp,
         RoleId = source.RoleId,
-        SessionId = source.SessionId,
+        MessageId = source.MessageId,
         Content = source.Content,
         ContentLength = source.ContentLength,
     };

--- a/test/Aevatar.Host.Api.Tests/AIChatMessageRunIdResolverTests.cs
+++ b/test/Aevatar.Host.Api.Tests/AIChatMessageRunIdResolverTests.cs
@@ -1,0 +1,54 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Workflow.Projection.RunIdResolvers;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Host.Api.Tests;
+
+public class AIChatMessageRunIdResolverTests
+{
+    [Fact]
+    public void TryResolve_ForMessageEvents_ShouldExtractRunId()
+    {
+        var resolver = new AIChatMessageRunIdResolver();
+        const string expectedRunId = "run-42";
+        const string messageId = "run-42:step-a";
+
+        resolver.TryResolve(Wrap(new TextMessageStartEvent { MessageId = messageId }), out var fromStart)
+            .Should().BeTrue();
+        fromStart.Should().Be(expectedRunId);
+
+        resolver.TryResolve(Wrap(new TextMessageContentEvent { MessageId = messageId, Delta = "x" }), out var fromContent)
+            .Should().BeTrue();
+        fromContent.Should().Be(expectedRunId);
+
+        resolver.TryResolve(Wrap(new TextMessageEndEvent { MessageId = messageId, Content = "done" }), out var fromEnd)
+            .Should().BeTrue();
+        fromEnd.Should().Be(expectedRunId);
+
+        resolver.TryResolve(Wrap(new ChatResponseEvent { MessageId = messageId, Content = "done" }), out var fromResponse)
+            .Should().BeTrue();
+        fromResponse.Should().Be(expectedRunId);
+    }
+
+    [Fact]
+    public void TryResolve_WithInvalidMessageId_ShouldReturnFalse()
+    {
+        var resolver = new AIChatMessageRunIdResolver();
+        var envelope = Wrap(new TextMessageStartEvent { MessageId = "invalid-id" });
+
+        resolver.TryResolve(envelope, out var runId).Should().BeFalse();
+        runId.Should().BeNull();
+    }
+
+    private static EventEnvelope Wrap<T>(T evt) where T : class, Google.Protobuf.IMessage<T> =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(evt),
+            PublisherId = "test",
+            Direction = EventDirection.Down,
+        };
+}

--- a/test/Aevatar.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -75,7 +75,7 @@ public class EventEnvelopeToAGUIEventMapperTests
     {
         var envelope = Wrap(new ChatResponseEvent
         {
-            Content = "分析结果如下...", SessionId = "s1",
+            Content = "分析结果如下...", MessageId = "s1",
         });
 
         var events = CreateMapper().Map(envelope);
@@ -94,13 +94,44 @@ public class EventEnvelopeToAGUIEventMapperTests
     {
         var envelope = Wrap(new Aevatar.AI.Abstractions.TextMessageContentEvent
         {
-            Delta = "部分", SessionId = "s1",
+            Delta = "部分", MessageId = "s1",
         });
 
         var events = CreateMapper().Map(envelope);
 
         events.Should().HaveCount(1);
         events[0].Should().BeOfType<Aevatar.Presentation.AGUI.TextMessageContentEvent>();
+    }
+
+    [Fact]
+    public void TextMessageStreamEvents_ShouldKeepSameMessageId()
+    {
+        const string messageId = "run-1:s1";
+        var mapper = CreateMapper();
+
+        var start = mapper.Map(Wrap(new Aevatar.AI.Abstractions.TextMessageStartEvent
+        {
+            MessageId = messageId,
+            AgentId = "assistant",
+        }));
+        var content = mapper.Map(Wrap(new Aevatar.AI.Abstractions.TextMessageContentEvent
+        {
+            MessageId = messageId,
+            Delta = "abc",
+        }));
+        var end = mapper.Map(Wrap(new Aevatar.AI.Abstractions.TextMessageEndEvent
+        {
+            MessageId = messageId,
+            Content = "abc",
+        }));
+
+        var startEvent = start.Should().ContainSingle().Subject.Should().BeOfType<Aevatar.Presentation.AGUI.TextMessageStartEvent>().Subject;
+        var contentEvent = content.Should().ContainSingle().Subject.Should().BeOfType<Aevatar.Presentation.AGUI.TextMessageContentEvent>().Subject;
+        var endEvent = end.Should().ContainSingle().Subject.Should().BeOfType<Aevatar.Presentation.AGUI.TextMessageEndEvent>().Subject;
+
+        startEvent.MessageId.Should().Be("msg:run-1:s1");
+        contentEvent.MessageId.Should().Be(startEvent.MessageId);
+        endEvent.MessageId.Should().Be(startEvent.MessageId);
     }
 
     [Fact]

--- a/test/Aevatar.Host.Api.Tests/WorkflowExecutionReadModelProjectorTests.cs
+++ b/test/Aevatar.Host.Api.Tests/WorkflowExecutionReadModelProjectorTests.cs
@@ -78,7 +78,7 @@ public class WorkflowExecutionReadModelProjectorTests
         }));
         await coordinator.ProjectAsync(context, Wrap(new AIEvents.TextMessageEndEvent
         {
-            SessionId = "wf-run-1:s1",
+            MessageId = "wf-run-1:s1",
             Content = "analysis result",
         }, "assistant"));
         await coordinator.ProjectAsync(context, Wrap(new WorkflowCompletedEvent

--- a/test/Aevatar.Host.Api.Tests/WorkflowExecutionReportWriterTests.cs
+++ b/test/Aevatar.Host.Api.Tests/WorkflowExecutionReportWriterTests.cs
@@ -139,7 +139,7 @@ public class WorkflowExecutionReportWriterTests
                     {
                         Timestamp = started.AddMilliseconds(700),
                         RoleId = "role-a",
-                        SessionId = "s-1",
+                        MessageId = "s-1",
                         Content = "reply",
                         ContentLength = 5,
                     },

--- a/test/Aevatar.Integration.Tests/ConnectorCallIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallIntegrationTests.cs
@@ -214,7 +214,7 @@ public class ConnectorCallIntegrationTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-            Payload = Any.Pack(new ChatRequestEvent { Prompt = input, SessionId = "test-session" }),
+            Payload = Any.Pack(new ChatRequestEvent { Prompt = input, MessageId = "test-session" }),
             PublisherId = "test",
             Direction = EventDirection.Self,
         });

--- a/test/Aevatar.Integration.Tests/MakerRecursiveRegressionTests.cs
+++ b/test/Aevatar.Integration.Tests/MakerRecursiveRegressionTests.cs
@@ -119,7 +119,7 @@ public class MakerRecursiveRegressionTests
         {
             Id = Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-            Payload = Any.Pack(new ChatRequestEvent { Prompt = input, SessionId = "maker-regression" }),
+            Payload = Any.Pack(new ChatRequestEvent { Prompt = input, MessageId = "maker-regression" }),
             PublisherId = "test",
             Direction = EventDirection.Self,
         });

--- a/test/Aevatar.Integration.Tests/SecretsStoreTests.cs
+++ b/test/Aevatar.Integration.Tests/SecretsStoreTests.cs
@@ -43,12 +43,12 @@ public class SecretsStoreTests
 
         try
         {
-            var store = new AevatarSecretsStore(path);
+            var store = new AevatarSecretsStore(path, enableEncryption: false);
             store.Set("K1", "V1");
             store.Set("K2", "V2");
             store.Remove("K1");
 
-            var reloaded = new AevatarSecretsStore(path);
+            var reloaded = new AevatarSecretsStore(path, enableEncryption: false);
             reloaded.Get("K1").Should().BeNull();
             reloaded.Get("K2").Should().Be("V2");
 

--- a/test/Aevatar.Integration.Tests/WorkflowExecutionOwnerBindingTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowExecutionOwnerBindingTests.cs
@@ -1,0 +1,281 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.Agents;
+using Aevatar.AI.Core.Agents;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Runtime.DependencyInjection;
+using Aevatar.Workflow.Core;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Integration.Tests;
+
+[Trait("Category", "Integration")]
+public class WorkflowExecutionOwnerBindingTests
+{
+    private const string MinimalWorkflowYaml = """
+        name: runid-check
+        description: minimal workflow for execution tests
+        roles: []
+        steps:
+          - id: step-1
+            type: passthrough
+        """;
+
+    [Fact]
+    public async Task WorkflowExecutionGAgent_ShouldBindOwnerId_Once()
+    {
+        using var provider = BuildProvider();
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+        var executionActor = await runtime.CreateAsync<WorkflowExecutionGAgent>("run-bind");
+        var execution = executionActor.Agent.Should().BeOfType<WorkflowExecutionGAgent>().Subject;
+
+        execution.BindWorkflowAgentId("owner-a");
+        execution.WorkflowAgentId.Should().Be("owner-a");
+
+        var bindSameOwner = () => execution.BindWorkflowAgentId("owner-a");
+        bindSameOwner.Should().NotThrow();
+
+        var bindDifferentOwner = () => execution.BindWorkflowAgentId("owner-b");
+        bindDifferentOwner.Should().Throw<InvalidOperationException>();
+
+        await runtime.DestroyAsync(executionActor.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowExecutionGAgent_WithoutOwnerBinding_ShouldFailFast()
+    {
+        using var provider = BuildProvider();
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+        var streams = provider.GetRequiredService<IStreamProvider>();
+        var ownerActor = await runtime.CreateAsync<WorkflowGAgent>("owner-1");
+        var executionActor = await runtime.CreateAsync<WorkflowExecutionGAgent>("run-no-owner");
+        await runtime.LinkAsync(ownerActor.Id, executionActor.Id);
+
+        var ownerStream = streams.GetStream(ownerActor.Id);
+        var errorResponse = new TaskCompletionSource<ChatResponseEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var sub = await ownerStream.SubscribeAsync<EventEnvelope>(envelope =>
+        {
+            if (envelope.Payload?.Is(ChatResponseEvent.Descriptor) == true)
+                errorResponse.TrySetResult(envelope.Payload.Unpack<ChatResponseEvent>());
+
+            return Task.CompletedTask;
+        });
+
+        await executionActor.HandleEventAsync(new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new ChatRequestEvent
+            {
+                Prompt = "hello",
+                MessageId = "run-no-owner:s1",
+            }),
+            PublisherId = "test",
+            Direction = EventDirection.Self,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var response = await errorResponse.Task.WaitAsync(timeout.Token);
+        response.Content.Should().Contain("未绑定长期工作流 Actor");
+        response.MessageId.Should().Be("run-no-owner:s1");
+
+        await runtime.DestroyAsync(executionActor.Id);
+        await runtime.DestroyAsync(ownerActor.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowExecutionGAgent_DirectChatRequest_ShouldUseActorIdAsRunId()
+    {
+        using var provider = BuildProvider();
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+        var streams = provider.GetRequiredService<IStreamProvider>();
+        var executionActor = await runtime.CreateAsync<WorkflowExecutionGAgent>("run-direct");
+        var execution = executionActor.Agent.Should().BeOfType<WorkflowExecutionGAgent>().Subject;
+        execution.BindWorkflowAgentId("owner-direct");
+        execution.ConfigureWorkflow(MinimalWorkflowYaml, "runid-check");
+
+        var executionStream = streams.GetStream(executionActor.Id);
+        var started = new TaskCompletionSource<StartWorkflowEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var sub = await executionStream.SubscribeAsync<EventEnvelope>(envelope =>
+        {
+            if (envelope.Payload?.Is(StartWorkflowEvent.Descriptor) == true)
+                started.TrySetResult(envelope.Payload.Unpack<StartWorkflowEvent>());
+
+            return Task.CompletedTask;
+        });
+
+        await executionActor.HandleEventAsync(new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new ChatRequestEvent
+            {
+                Prompt = "hello",
+                MessageId = "run-direct:s1",
+            }),
+            PublisherId = "test",
+            Direction = EventDirection.Self,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var startEvent = await started.Task.WaitAsync(timeout.Token);
+        startEvent.RunId.Should().Be(executionActor.Id);
+
+        await runtime.DestroyAsync(executionActor.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowExecutionGAgent_MetadataRunIdMismatch_ShouldFailFast()
+    {
+        using var provider = BuildProvider();
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+        var streams = provider.GetRequiredService<IStreamProvider>();
+        var ownerActor = await runtime.CreateAsync<WorkflowGAgent>("owner-mismatch");
+        var executionActor = await runtime.CreateAsync<WorkflowExecutionGAgent>("run-mismatch");
+        var execution = executionActor.Agent.Should().BeOfType<WorkflowExecutionGAgent>().Subject;
+        execution.BindWorkflowAgentId(ownerActor.Id);
+        await runtime.LinkAsync(ownerActor.Id, executionActor.Id);
+
+        var ownerStream = streams.GetStream(ownerActor.Id);
+        var errorResponse = new TaskCompletionSource<ChatResponseEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var sub = await ownerStream.SubscribeAsync<EventEnvelope>(envelope =>
+        {
+            if (envelope.Payload?.Is(ChatResponseEvent.Descriptor) == true)
+                errorResponse.TrySetResult(envelope.Payload.Unpack<ChatResponseEvent>());
+
+            return Task.CompletedTask;
+        });
+
+        var request = new ChatRequestEvent
+        {
+            Prompt = "hello",
+            MessageId = "run-mismatch:s1",
+        };
+        request.Metadata[ChatRequestMetadataKeys.RunId] = "run-from-metadata";
+
+        await executionActor.HandleEventAsync(new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(request),
+            PublisherId = "test",
+            Direction = EventDirection.Self,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var response = await errorResponse.Task.WaitAsync(timeout.Token);
+        response.Content.Should().Contain("run_id 与 actorId 不一致");
+        response.MessageId.Should().Be("run-mismatch:s1");
+
+        await runtime.DestroyAsync(executionActor.Id);
+        await runtime.DestroyAsync(ownerActor.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowGAgent_WorkflowCompleted_ShouldPublishTextEndWithMessageId_AndAccumulateStats()
+    {
+        using var provider = BuildProvider();
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+        var streams = provider.GetRequiredService<IStreamProvider>();
+        var ownerActor = await runtime.CreateAsync<WorkflowGAgent>("owner-completed");
+        var workflowActor = await runtime.CreateAsync<WorkflowGAgent>("workflow-completed");
+        var workflow = workflowActor.Agent.Should().BeOfType<WorkflowGAgent>().Subject;
+        await runtime.LinkAsync(ownerActor.Id, workflowActor.Id);
+
+        var ownerStream = streams.GetStream(ownerActor.Id);
+        var messageEnd = new TaskCompletionSource<TextMessageEndEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var sub = await ownerStream.SubscribeAsync<EventEnvelope>(envelope =>
+        {
+            if (envelope.Payload?.Is(TextMessageEndEvent.Descriptor) == true)
+                messageEnd.TrySetResult(envelope.Payload.Unpack<TextMessageEndEvent>());
+
+            return Task.CompletedTask;
+        });
+
+        await workflowActor.HandleEventAsync(new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new WorkflowCompletedEvent
+            {
+                WorkflowName = "wf",
+                RunId = "run-1",
+                Success = true,
+                Output = "done",
+            }),
+            PublisherId = "test",
+            Direction = EventDirection.Self,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var end = await messageEnd.Task.WaitAsync(timeout.Token);
+        end.MessageId.Should().Be("run-1");
+        end.Content.Should().Be("done");
+
+        workflow.State.TotalExecutions.Should().Be(1);
+        workflow.State.SuccessfulExecutions.Should().Be(1);
+        workflow.State.FailedExecutions.Should().Be(0);
+
+        await runtime.DestroyAsync(workflowActor.Id);
+        await runtime.DestroyAsync(ownerActor.Id);
+    }
+
+    [Fact]
+    public async Task WorkflowExecutionGAgent_WorkflowCompleted_ShouldPublishTextEndWithMessageId_WithoutAccumulatingStats()
+    {
+        using var provider = BuildProvider();
+        var runtime = provider.GetRequiredService<IActorRuntime>();
+        var streams = provider.GetRequiredService<IStreamProvider>();
+        var ownerActor = await runtime.CreateAsync<WorkflowGAgent>("owner-exec-completed");
+        var executionActor = await runtime.CreateAsync<WorkflowExecutionGAgent>("run-exec-completed");
+        var execution = executionActor.Agent.Should().BeOfType<WorkflowExecutionGAgent>().Subject;
+        execution.BindWorkflowAgentId(ownerActor.Id);
+        await runtime.LinkAsync(ownerActor.Id, executionActor.Id);
+
+        var ownerStream = streams.GetStream(ownerActor.Id);
+        var messageEnd = new TaskCompletionSource<TextMessageEndEvent>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var sub = await ownerStream.SubscribeAsync<EventEnvelope>(envelope =>
+        {
+            if (envelope.Payload?.Is(TextMessageEndEvent.Descriptor) == true)
+                messageEnd.TrySetResult(envelope.Payload.Unpack<TextMessageEndEvent>());
+
+            return Task.CompletedTask;
+        });
+
+        await executionActor.HandleEventAsync(new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new WorkflowCompletedEvent
+            {
+                WorkflowName = "wf",
+                RunId = executionActor.Id,
+                Success = false,
+                Error = "boom",
+            }),
+            PublisherId = "test",
+            Direction = EventDirection.Self,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var end = await messageEnd.Task.WaitAsync(timeout.Token);
+        end.MessageId.Should().Be(executionActor.Id);
+        end.Content.Should().Contain("工作流执行失败");
+
+        execution.State.TotalExecutions.Should().Be(0);
+        execution.State.SuccessfulExecutions.Should().Be(0);
+        execution.State.FailedExecutions.Should().Be(0);
+
+        await runtime.DestroyAsync(executionActor.Id);
+        await runtime.DestroyAsync(ownerActor.Id);
+    }
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddAevatarRuntime();
+        services.AddSingleton<IRoleAgentTypeResolver, RoleGAgentTypeResolver>();
+        return services.BuildServiceProvider();
+    }
+}

--- a/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
@@ -167,7 +167,7 @@ public class WorkflowIntegrationTests
             Payload = Google.Protobuf.WellKnownTypes.Any.Pack(new ChatRequestEvent
             {
                 Prompt = "分析量子纠缠的最新进展",
-                SessionId = "test-session",
+                MessageId = "test-session",
             }),
             PublisherId = "test",
             Direction = EventDirection.Self,
@@ -299,7 +299,7 @@ public class WorkflowIntegrationTests
             Payload = Google.Protobuf.WellKnownTypes.Any.Pack(new ChatRequestEvent
             {
                 Prompt = "分析量子纠缠",
-                SessionId = "test",
+                MessageId = "test",
             }),
             PublisherId = "test",
             Direction = EventDirection.Down,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -1,4 +1,6 @@
+using Aevatar.AI.Abstractions.Agents;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
@@ -8,6 +10,8 @@ using Aevatar.Workflow.Application.Orchestration;
 using Aevatar.Workflow.Application.Queries;
 using Aevatar.Workflow.Application.Runs;
 using Aevatar.Workflow.Application.Workflows;
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Core.Composition;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -40,6 +44,33 @@ public class WorkflowChatRunApplicationServiceTests
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
         result.Started.Should().BeNull();
         orchestrator.StartCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_WhenExistingWorkflowActorHasNoYaml_ShouldFailFast()
+    {
+        var resolverRuntime = new FakeActorRuntime(
+        [
+            new FakeActor(
+                "workflow-a",
+                null,
+                new WorkflowGAgent(
+                    new FakeActorRuntime([]),
+                    new FakeRoleAgentTypeResolver(),
+                    Array.Empty<IEventModuleFactory>(),
+                    Array.Empty<IWorkflowModuleDependencyExpander>(),
+                    Array.Empty<IWorkflowModuleConfigurator>())),
+        ]);
+        var registry = new WorkflowDefinitionRegistry();
+        var resolver = new WorkflowRunActorResolver(resolverRuntime, registry);
+
+        var result = await resolver.ResolveOrCreateAsync(
+            new WorkflowChatRunRequest("hello", null, "workflow-a"),
+            CancellationToken.None);
+
+        result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
+        result.WorkflowActor.Should().BeNull();
+        result.WorkflowYamlForRun.Should().BeEmpty();
     }
 }
 
@@ -136,10 +167,11 @@ internal sealed class FakeProjectionService : IWorkflowExecutionProjectionPort
         string workflowName,
         string input,
         IWorkflowRunEventSink sink,
+        string? runId = null,
         CancellationToken ct = default) =>
         Task.FromResult(new WorkflowProjectionSession
         {
-            RunId = Guid.NewGuid().ToString("N"),
+            RunId = runId ?? Guid.NewGuid().ToString("N"),
             StartedAt = DateTimeOffset.UtcNow,
             Enabled = ProjectionEnabled,
         });
@@ -170,7 +202,7 @@ internal sealed class SpyRunOrchestrator : IWorkflowExecutionRunOrchestrator
 {
     public bool StartCalled { get; private set; }
 
-    public Task<WorkflowProjectionRun> StartAsync(string actorId, string workflowName, string prompt, IWorkflowRunEventSink sink, CancellationToken ct = default)
+    public Task<WorkflowProjectionRun> StartAsync(string actorId, string workflowName, string prompt, IWorkflowRunEventSink sink, string? runId = null, CancellationToken ct = default)
     {
         StartCalled = true;
         throw new InvalidOperationException("StartAsync should not be called in this test.");
@@ -202,6 +234,11 @@ internal sealed class NoopReportSink : IWorkflowExecutionReportArtifactSink
 {
     public Task PersistAsync(WorkflowRunReport report, CancellationToken ct = default) =>
         Task.CompletedTask;
+}
+
+internal sealed class FakeRoleAgentTypeResolver : IRoleAgentTypeResolver
+{
+    public Type ResolveRoleAgentType() => typeof(FakeAgent);
 }
 
 internal sealed class FakeActorRuntime : IActorRuntime


### PR DESCRIPTION
# Workflow Run Lifecycle（重构汇报稿）

## 执行摘要

这次重构的目标，是把“长期编排职责”和“单次执行职责”拆开，解决当前一个 `WorkflowGAgent` 同时承担模板管理、运行执行、并发隔离带来的复杂度问题。

目标方案是：

- `WorkflowGAgent` 作为长期编排实例，负责 workflow 定义、策略和入口。
- `WorkflowExecutionGAgent` 作为一次 run 的执行实例，`AgentId` 与 `RunId` 同值。
- `MessageId` 保留为 AI 消息链路标识，不与 `RunId` 合并。

这套模型的核心收益是：执行隔离更清晰、查询主键统一、并发场景更稳，且与现有 CQRS 投影链路兼容。

## 1. 背景与重构目标

### 1.1 当前痛点

- 同一个编排实例承载多次执行，运行态与编排态边界不清。
- `RunId`、`ActorId`、`MessageId` 在语义上容易被混用，讨论成本高。
- 并发执行时，步骤回包关联和排障依赖更多约定，维护成本上升。

### 1.2 重构目标

1. 每次执行具备独立 actor 身份，执行边界与生命周期清晰。
2. `RunId` 成为唯一执行主键，查询和追踪统一。
3. 保留 `MessageId` 的消息链路能力，避免流式与投影能力回退。

## 2. 目标架构

### 2.1 角色分工

- `WorkflowGAgent`（long-lived）
  - 保存 workflow 定义与配置。
  - 接收入口请求并选择/创建执行实例。
  - 不承载单次 run 的可变执行状态。
- `WorkflowExecutionGAgent`（per-run）
  - 处理本次 run 的步骤推进、事件发布、回包关联。
  - run 结束后销毁或回收。

```mermaid
flowchart TB
    workflowAgent["WorkflowGAgent (long-lived)"]
    executionA["WorkflowExecutionGAgent (runA)"]
    executionB["WorkflowExecutionGAgent (runB)"]
    runId["RunId = ExecutionActorId"]
    sessionKey["MessageId (message chain key)"]

    workflowAgent --> executionA
    workflowAgent --> executionB
    executionA --> runId
    executionA --> sessionKey
```

### 2.2 标识符职责边界

| 标识符 | 作用域 | 主用途 | 结论 |
|---|---|---|---|
| `WorkflowGAgent.AgentId` | 长期编排主体 | 入口与编排身份 | 不等于 `RunId` |
| `RunId` | 单次执行 | 执行主键、查询主键 | 等于 `ExecutionActorId` |
| `WorkflowExecutionGAgent.AgentId` | 单次执行 actor | 运行隔离与线程标识 | 与 `RunId` 同值 |
| `MessageId` | AI 消息链路 | 流式消息聚合、回包匹配 | 不能删除 |

## 3. 关键设计：Execution 如何定位长期 Workflow

核心原则：**执行实例不做运行时搜索，编排层在创建时显式绑定 owner。**

标准流程：

1. 入口先定位长期 `WorkflowGAgent`（`agentId` 命中则复用，否则创建并配置）。
2. 生成 `RunId`。
3. 创建 `WorkflowExecutionGAgent`，并强制 `executionActorId = runId`。
4. 调用 `BindWorkflowAgentId(workflowAgentId)` 显式绑定 owner。
5. 调用 `ConfigureWorkflow(workflowYaml, workflowName)` 完成 execution 初始化。
6. 建立父子关系：`LinkAsync(workflowAgentId, executionActorId)`。
7. 执行阶段若需回调编排实例，直接 `SendToAsync(workflowAgentId, evt)`。

设计约束：

- 禁止按 `workflowName` 扫描 owner。
- `workflowAgentId` 在 run 生命周期内不可变。
- owner 丢失时快速失败，输出明确错误事件。

## 4. 一次请求的调用链与参数赋值

```mermaid
sequenceDiagram
    participant client as Client
    participant api as HostApi
    participant app as WorkflowApplication
    participant resolver as RunActorResolver
    participant execution as WorkflowExecutionGAgent
    participant role as RoleGAgent
    participant projection as ProjectionPipeline

    client->>api: "/api/chat(prompt, workflow, agentId?)"
    api->>app: "ExecuteAsync(request)"
    app->>resolver: "ResolveOrCreate(workflowAgent)"
    app->>app: "Generate runId"
    app->>execution: "Create(actorId = runId)"
    app->>execution: "BindWorkflowAgentId(workflowAgentId)"
    app->>execution: "ConfigureWorkflow(workflowYaml, workflowName)"
    app->>resolver: "LinkAsync(workflowAgentId, executionActorId)"
    app->>execution: "Dispatch run events"
    execution->>role: "ChatRequestEvent(messageId = runId:stepId)"
    role-->>execution: "TextMessageStart/Content/End(messageId)"
    execution-->>projection: "Events(runId, messageId)"
    projection-->>api: "Run report + stream frames"
```

参数赋值表：

| 参数 | 来源 | 赋值规则 | 消费方 |
|---|---|---|---|
| `prompt` | 请求体 | `ChatInput.Prompt` 原样传递 | `ChatRequestEvent.Prompt` |
| `workflowName` | 请求体 | 为空走默认 workflow | workflow 加载/解析 |
| `agentId` | 请求体 | 定位长期 `WorkflowGAgent` | actor resolver |
| `runId` | 服务端生成 | 每次 run 生成一次 | 执行事件、投影、查询 |
| `executionActorId` | 服务端派生 | `executionActorId = runId` | runtime、routing、thread |
| `workflowAgentId` | 服务端解析 | owner id，创建 execution 时写入 | execution 回调编排主体 |
| `threadId` | 服务端派生 | 对外输出使用 `executionActorId` | SSE/WS 输出 |
| `messageId` | 服务端生成 | 入口 `chat-{guid}`；步骤 `runId:stepId`（`:attempt` 预留） | LLM 回包关联、消息聚合 |

## 5. 为什么 `MessageId` 不能删

`RunId` 和 `MessageId` 不是同一层标识。`RunId` 管执行实例，`MessageId` 管消息会话链路。

删除 `MessageId` 后会直接影响：

1. 步骤回包匹配失效  
   - `LLMCallModule` 依赖 `messageId` 关联 `_pending` 请求。
2. AI 事件 run 归属能力下降  
   - `AIChatMessageRunIdResolver` 通过 `messageId` 反解 `runId`。
3. 流式消息聚合受损  
   - AGUI 侧 `msg:{messageId}` 无法稳定归并 start/content/end。
4. 读模型可观测性下降  
   - role reply 与 timeline 的 `message_id` 维度丢失。

结论：`MessageId` 必须保留，但它不是执行主键。

## 6. 落地步骤（建议汇报用）

### 阶段 1：模型落地

- 新增 `WorkflowExecutionGAgent`，定义 owner 绑定字段（`workflowAgentId`）。
- 调整 run 启动流程，改为“先定位 workflow agent，再创建 execution agent”。
- 强制 `executionActorId = runId`。

### 阶段 2：链路切换

- 执行事件改为由 `WorkflowExecutionGAgent` 产生。
- 输出 `threadId` 统一切到 execution actor id。
- pending/关联键检查并统一为 run 作用域。

### 阶段 3：验证与收口

- 并发 run 压测（同一 `WorkflowGAgent` 多 run）。
- 回包匹配与流式聚合验证（`MessageId` 维度）。
- 读模型查询一致性验证（`/api/runs/{runId}`）。

## 7. 风险与控制

| 风险 | 表现 | 控制策略 |
|---|---|---|
| owner 绑定遗漏 | execution 无法回调 workflow | 创建时强制校验 `workflowAgentId` |
| run/thread 标识不一致 | 前端线程展示混乱 | 统一 `threadId = executionActorId` |
| session 格式不统一 | 回包匹配或聚合异常 | 固化规范：`chat-{guid}` 与 `runId:stepId`（`:attempt` 预留） |
| 迁移阶段行为漂移 | 新旧链路结果不一致 | 灰度开关 + 双链路对比 |

## 8. 验收标准

1. 一次 run 只对应一个 `WorkflowExecutionGAgent`，且 `AgentId == RunId`。
2. 同一 `WorkflowGAgent` 并发多 run 时无串线。
3. SSE/WS 全链路可用，`RUN_STARTED/RUN_FINISHED` 标识稳定。
4. 查询侧按 `runId` 可稳定获取完整报告。
5. 删除 `MessageId` 的回归测试明确失败（作为保护性用例）。

## 9. 代码锚点（便于评审）

- 入口解析：`src/Aevatar.Host.Api/Endpoints/ChatEndpoints.cs`
- WS 入口：`src/Aevatar.Host.Api/Endpoints/ChatWebSocketRunCoordinator.cs`
- 编排入口：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs`
- 编排主体定位：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs`
- 运行编排：`src/workflow/Aevatar.Workflow.Application/Orchestration/WorkflowExecutionRunOrchestrator.cs`
- 执行实例：`src/workflow/Aevatar.Workflow.Core/WorkflowExecutionGAgent.cs`
- 工作流快照：`src/workflow/Aevatar.Workflow.Core/WorkflowDefinitionSnapshot.cs`
- `RunId` 生成：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRunApplicationService.cs`
- `RunId` 注入：`src/workflow/Aevatar.Workflow.Application/Runs/WorkflowChatRequestEnvelopeFactory.cs`
- `RunId` 提取：`src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs`
- `MessageId` 规范：`src/Aevatar.AI.Abstractions/ChatMessageKeys.cs`
- 会话关联：`src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs`

---

相关文档：`docs/IDENTIFIER_RELATIONSHIPS.md`