### PR TITLE
Refactor Orleans State Management and Introduce Runtime Actor State S…

### DIFF
--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/DependencyInjection/ServiceCollectionExtensions.cs
@@ -22,8 +22,9 @@ public static class ServiceCollectionExtensions
         services.Replace(ServiceDescriptor.Singleton(options));
 
         services.Replace(ServiceDescriptor.Singleton<IActorRuntime, OrleansActorRuntime>());
-
-        services.TryAddSingleton(typeof(IStateStore<>), typeof(InMemoryStateStore<>));
+        services.RemoveAll(typeof(IStateStore<>));
+        services.TryAddSingleton<IRuntimeActorStateBindingAccessor, AsyncLocalRuntimeActorStateBindingAccessor>();
+        services.TryAddTransient(typeof(IStateStore<>), typeof(RuntimeActorGrainStateStore<>));
         services.TryAddSingleton<IEventStore, InMemoryEventStore>();
         services.TryAddSingleton<IAgentManifestStore, InMemoryManifestStore>();
         services.TryAddSingleton<IEventDeduplicator, MemoryCacheDeduplicator>();

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/AsyncLocalRuntimeActorStateBindingAccessor.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/AsyncLocalRuntimeActorStateBindingAccessor.cs
@@ -1,0 +1,39 @@
+using Orleans.Runtime;
+
+namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
+
+internal sealed class AsyncLocalRuntimeActorStateBindingAccessor : IRuntimeActorStateBindingAccessor
+{
+    private static readonly AsyncLocal<IPersistentState<RuntimeActorGrainState>?> CurrentState = new();
+
+    public IPersistentState<RuntimeActorGrainState>? Current => CurrentState.Value;
+
+    public IDisposable Bind(IPersistentState<RuntimeActorGrainState> runtimeState)
+    {
+        ArgumentNullException.ThrowIfNull(runtimeState);
+
+        var previous = CurrentState.Value;
+        CurrentState.Value = runtimeState;
+        return new RestoreScope(previous);
+    }
+
+    private sealed class RestoreScope : IDisposable
+    {
+        private readonly IPersistentState<RuntimeActorGrainState>? _previous;
+        private bool _disposed;
+
+        public RestoreScope(IPersistentState<RuntimeActorGrainState>? previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            CurrentState.Value = _previous;
+            _disposed = true;
+        }
+    }
+}

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/IRuntimeActorStateBindingAccessor.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/IRuntimeActorStateBindingAccessor.cs
@@ -1,0 +1,10 @@
+using Orleans.Runtime;
+
+namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
+
+public interface IRuntimeActorStateBindingAccessor
+{
+    IPersistentState<RuntimeActorGrainState>? Current { get; }
+
+    IDisposable Bind(IPersistentState<RuntimeActorGrainState> runtimeState);
+}

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeActorGrain.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeActorGrain.cs
@@ -11,6 +11,7 @@ namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 public sealed class RuntimeActorGrain : Grain, IRuntimeActorGrain
 {
     private readonly IPersistentState<RuntimeActorGrainState> _state;
+    private readonly IRuntimeActorStateBindingAccessor _stateBindingAccessor;
     private IAgent? _agent;
     private IEventDeduplicator? _deduplicator;
     private IEnvelopePropagationPolicy _propagationPolicy =
@@ -22,9 +23,11 @@ public sealed class RuntimeActorGrain : Grain, IRuntimeActorGrain
 
     public RuntimeActorGrain(
         [PersistentState("agent", OrleansRuntimeConstants.GrainStateStorageName)]
-        IPersistentState<RuntimeActorGrainState> state)
+        IPersistentState<RuntimeActorGrainState> state,
+        IRuntimeActorStateBindingAccessor stateBindingAccessor)
     {
         _state = state;
+        _stateBindingAccessor = stateBindingAccessor;
     }
 
     public override async Task OnActivateAsync(CancellationToken cancellationToken)
@@ -197,6 +200,8 @@ public sealed class RuntimeActorGrain : Grain, IRuntimeActorGrain
         _state.State.AgentTypeName = null;
         _state.State.ParentId = null;
         _state.State.Children.Clear();
+        _state.State.AgentStateTypeName = null;
+        _state.State.AgentStateSnapshot = null;
         await _state.WriteStateAsync();
     }
 
@@ -278,6 +283,7 @@ public sealed class RuntimeActorGrain : Grain, IRuntimeActorGrain
             {
                 var stateType = type.GetGenericArguments()[0];
                 var stateStoreType = typeof(IStateStore<>).MakeGenericType(stateType);
+                using var binding = _stateBindingAccessor.Bind(_state);
                 var stateStore = ServiceProvider.GetService(stateStoreType);
                 if (stateStore != null)
                     type.GetProperty("StateStore")?.SetValue(agent, stateStore);

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeActorGrainState.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeActorGrainState.cs
@@ -14,4 +14,10 @@ public sealed class RuntimeActorGrainState
 
     [Id(3)]
     public List<string> Children { get; set; } = [];
+
+    [Id(4)]
+    public string? AgentStateTypeName { get; set; }
+
+    [Id(5)]
+    public byte[]? AgentStateSnapshot { get; set; }
 }

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeActorGrainStateStore.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeActorGrainStateStore.cs
@@ -1,0 +1,68 @@
+using Orleans.Runtime;
+
+namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
+
+/// <summary>
+/// Uses RuntimeActorGrain's persistent state as the backing store for agent state snapshots.
+/// </summary>
+internal sealed class RuntimeActorGrainStateStore<TState>
+    : IStateStore<TState>
+    where TState : class, IMessage<TState>, new()
+{
+    private static readonly string StateTypeName = typeof(TState).FullName ?? typeof(TState).Name;
+
+    private readonly IPersistentState<RuntimeActorGrainState> _runtimeState;
+
+    public RuntimeActorGrainStateStore(IPersistentState<RuntimeActorGrainState> runtimeState)
+    {
+        _runtimeState = runtimeState;
+    }
+
+    public RuntimeActorGrainStateStore(IRuntimeActorStateBindingAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+        _runtimeState = accessor.Current
+                        ?? throw new InvalidOperationException(
+                            "Runtime actor state is not bound. " +
+                            "Resolve IStateStore<TState> only within RuntimeActorGrain binding context.");
+    }
+
+    public Task<TState?> LoadAsync(string agentId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ct.ThrowIfCancellationRequested();
+
+        var snapshot = _runtimeState.State.AgentStateSnapshot;
+        if (snapshot == null || snapshot.Length == 0)
+            return Task.FromResult<TState?>(null);
+
+        // Snapshot belongs to another state type (e.g. actor type migrated).
+        if (!string.Equals(_runtimeState.State.AgentStateTypeName, StateTypeName, StringComparison.Ordinal))
+            return Task.FromResult<TState?>(null);
+
+        var state = new TState();
+        state.MergeFrom(snapshot);
+        return Task.FromResult<TState?>(state);
+    }
+
+    public Task SaveAsync(string agentId, TState state, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentNullException.ThrowIfNull(state);
+        ct.ThrowIfCancellationRequested();
+
+        _runtimeState.State.AgentStateTypeName = StateTypeName;
+        _runtimeState.State.AgentStateSnapshot = state.ToByteArray();
+        return _runtimeState.WriteStateAsync();
+    }
+
+    public Task DeleteAsync(string agentId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ct.ThrowIfCancellationRequested();
+
+        _runtimeState.State.AgentStateTypeName = null;
+        _runtimeState.State.AgentStateSnapshot = null;
+        return _runtimeState.WriteStateAsync();
+    }
+}

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/AevatarActorRuntimeServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/AevatarActorRuntimeServiceCollectionExtensionsTests.cs
@@ -1,8 +1,10 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Runtime.Hosting;
 using Aevatar.Foundation.Runtime.Hosting.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Actors;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
 using Aevatar.Foundation.Runtime.Streaming.Implementations.MassTransit;
@@ -222,6 +224,22 @@ public class AevatarActorRuntimeServiceCollectionExtensionsTests
         var options = provider.GetRequiredService<AevatarActorRuntimeOptions>();
         options.OrleansPersistenceBackend.Should().Be(AevatarActorRuntimeOptions.OrleansPersistenceBackendGarnet);
         options.OrleansGarnetConnectionString.Should().Be("garnet.local:6379,abortConnect=false");
+    }
+
+    [Fact]
+    public void AddAevatarActorRuntime_WhenProviderIsOrleans_ShouldReplaceOpenGenericIStateStoreWithRuntimeActorStateStore()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:Provider"] = AevatarActorRuntimeOptions.ProviderOrleans,
+        });
+
+        services.AddAevatarActorRuntime(configuration);
+
+        var descriptor = services.LastOrDefault(x => x.ServiceType == typeof(IStateStore<>));
+        descriptor.Should().NotBeNull();
+        descriptor!.ImplementationType.Should().Be(typeof(RuntimeActorGrainStateStore<>));
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDistributedCoverageTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDistributedCoverageTests.cs
@@ -6,6 +6,7 @@ using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming.Topology;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Orleans.Runtime;
@@ -341,7 +342,7 @@ public sealed class OrleansDistributedCoverageTests
     {
         var state = DispatchProxy.Create<IPersistentState<RuntimeActorGrainState>, RuntimeActorPersistentStateProxy>();
         var stateProxy = (RuntimeActorPersistentStateProxy)(object)state;
-        var grain = new RuntimeActorGrain(state);
+        var grain = new RuntimeActorGrain(state, new AsyncLocalRuntimeActorStateBindingAccessor());
 
         (await grain.IsInitializedAsync()).Should().BeFalse();
         stateProxy.State.AgentTypeName = "Known.Type";
@@ -364,11 +365,15 @@ public sealed class OrleansDistributedCoverageTests
         await grain.ClearParentAsync();
 
         stateProxy.State.AgentId = "actor-1";
+        stateProxy.State.AgentStateTypeName = typeof(EventEnvelope).FullName;
+        stateProxy.State.AgentStateSnapshot = new EventEnvelope { Id = "snapshot" }.ToByteArray();
         await grain.PurgeAsync();
         stateProxy.State.AgentId.Should().BeEmpty();
         stateProxy.State.AgentTypeName.Should().BeNull();
         stateProxy.State.ParentId.Should().BeNull();
         stateProxy.State.Children.Should().BeEmpty();
+        stateProxy.State.AgentStateTypeName.Should().BeNull();
+        stateProxy.State.AgentStateSnapshot.Should().BeNull();
         stateProxy.WriteCount.Should().BeGreaterThan(0);
     }
 
@@ -376,7 +381,7 @@ public sealed class OrleansDistributedCoverageTests
     public async Task RuntimeActorGrain_ShouldCoverExceptionalBranches()
     {
         var state = DispatchProxy.Create<IPersistentState<RuntimeActorGrainState>, RuntimeActorPersistentStateProxy>();
-        var grain = new RuntimeActorGrain(state);
+        var grain = new RuntimeActorGrain(state, new AsyncLocalRuntimeActorStateBindingAccessor());
 
         var envelopeAct = () => grain.HandleEnvelopeAsync(new byte[] { 1, 2, 3 });
         await envelopeAct.Should().ThrowAsync<InvalidOperationException>()

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansGarnetPersistenceIntegrationTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansGarnetPersistenceIntegrationTests.cs
@@ -1,10 +1,12 @@
 using System.Net;
 using System.Net.Sockets;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Orleans;
@@ -69,6 +71,67 @@ public sealed class OrleansGarnetPersistenceIntegrationTests
             (await grain.IsInitializedAsync()).Should().BeTrue();
             (await grain.GetParentAsync()).Should().Be("parent-garnet");
             (await grain.GetChildrenAsync()).Should().BeEquivalentTo("child-garnet-1", "child-garnet-2");
+
+            await grain.PurgeAsync();
+            (await grain.IsInitializedAsync()).Should().BeFalse();
+        }
+        finally
+        {
+            await secondHost.StopAsync();
+            secondHost.Dispose();
+        }
+    }
+
+    [GarnetIntegrationFact]
+    public async Task StatefulAgentSnapshot_ShouldPersistAcrossSiloRestart_WhenUsingGarnetStorage()
+    {
+        var garnetConnectionString = RequireGarnetConnectionString();
+        var actorId = $"stateful-actor-{Guid.NewGuid():N}";
+        var serviceId = $"aevatar-orleans-garnet-stateful-service-{Guid.NewGuid():N}";
+        var clusterId = $"aevatar-orleans-garnet-stateful-cluster-{Guid.NewGuid():N}";
+        var agentTypeName = typeof(RecordingGarnetStatefulAgent).AssemblyQualifiedName!;
+
+        var firstSiloPort = ReserveTcpPort();
+        var firstGatewayPort = ReserveTcpPort();
+        var firstHost = await StartSiloHostAsync(
+            garnetConnectionString,
+            clusterId,
+            serviceId,
+            firstSiloPort,
+            firstGatewayPort);
+
+        try
+        {
+            var grainFactory = firstHost.Services.GetRequiredService<IGrainFactory>();
+            var grain = grainFactory.GetGrain<IRuntimeActorGrain>(actorId);
+
+            (await grain.InitializeAgentAsync(agentTypeName)).Should().BeTrue();
+            (await grain.GetDescriptionAsync()).Should().Be("activation-count:1");
+
+            await grain.DeactivateAsync();
+        }
+        finally
+        {
+            await firstHost.StopAsync();
+            firstHost.Dispose();
+        }
+
+        var secondSiloPort = ReserveTcpPort();
+        var secondGatewayPort = ReserveTcpPort();
+        var secondHost = await StartSiloHostAsync(
+            garnetConnectionString,
+            clusterId,
+            serviceId,
+            secondSiloPort,
+            secondGatewayPort);
+
+        try
+        {
+            var grainFactory = secondHost.Services.GetRequiredService<IGrainFactory>();
+            var grain = grainFactory.GetGrain<IRuntimeActorGrain>(actorId);
+
+            (await grain.IsInitializedAsync()).Should().BeTrue();
+            (await grain.GetDescriptionAsync()).Should().Be("activation-count:2");
 
             await grain.PurgeAsync();
             (await grain.IsInitializedAsync()).Should().BeFalse();
@@ -147,5 +210,17 @@ public sealed class OrleansGarnetPersistenceIntegrationTests
             ct.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class RecordingGarnetStatefulAgent : GAgentBase<Int32Value>
+    {
+        protected override Task OnActivateAsync(CancellationToken ct)
+        {
+            State.Value += 1;
+            return Task.CompletedTask;
+        }
+
+        public override Task<string> GetDescriptionAsync() =>
+            Task.FromResult($"activation-count:{State.Value}");
     }
 }

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansRuntimeActorStateStoreIntegrationTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansRuntimeActorStateStoreIntegrationTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Sockets;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Hosting;
+
+namespace Aevatar.Foundation.Runtime.Hosting.Tests;
+
+public sealed class OrleansRuntimeActorStateStoreIntegrationTests
+{
+    [Fact]
+    public async Task RuntimeActorGrain_ShouldRestoreStatefulAgentSnapshot_WhenReinitialized()
+    {
+        var actorId = $"actor-{Guid.NewGuid():N}";
+        var siloPort = ReserveTcpPort();
+        var gatewayPort = ReserveTcpPort();
+        var host = await StartSiloHostAsync(siloPort, gatewayPort);
+
+        try
+        {
+            var grainFactory = host.Services.GetRequiredService<IGrainFactory>();
+            var grain = grainFactory.GetGrain<IRuntimeActorGrain>(actorId);
+            var agentType = typeof(StateStoreAwareActivationAgent).AssemblyQualifiedName!;
+
+            (await grain.InitializeAgentAsync(agentType)).Should().BeTrue();
+            (await grain.GetDescriptionAsync()).Should().Be("activation-count:1");
+
+            await grain.DeactivateAsync();
+
+            (await grain.InitializeAgentAsync(agentType)).Should().BeTrue();
+            (await grain.GetDescriptionAsync()).Should().Be("activation-count:2");
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    private static async Task<IHost> StartSiloHostAsync(int siloPort, int gatewayPort)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .UseOrleans(siloBuilder =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: siloPort,
+                    gatewayPort: gatewayPort,
+                    serviceId: $"aevatar-orleans-state-store-it-service-{Guid.NewGuid():N}",
+                    clusterId: $"aevatar-orleans-state-store-it-cluster-{Guid.NewGuid():N}");
+                siloBuilder.AddAevatarFoundationRuntimeOrleans(options =>
+                {
+                    options.StreamBackend = AevatarOrleansRuntimeOptions.StreamBackendInMemory;
+                    options.PersistenceBackend = AevatarOrleansRuntimeOptions.PersistenceBackendInMemory;
+                });
+            })
+            .Build();
+
+        await host.StartAsync();
+        return host;
+    }
+
+    private static int ReserveTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    public sealed class StateStoreAwareActivationAgent : GAgentBase<Int32Value>
+    {
+        protected override Task OnActivateAsync(CancellationToken ct)
+        {
+            State.Value += 1;
+            return Task.CompletedTask;
+        }
+
+        public override Task<string> GetDescriptionAsync() =>
+            Task.FromResult($"activation-count:{State.Value}");
+    }
+}

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansRuntimeServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansRuntimeServiceCollectionExtensionsTests.cs
@@ -1,5 +1,7 @@
 using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using Aevatar.Foundation.Abstractions.Persistence;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -55,6 +57,17 @@ public sealed class OrleansRuntimeServiceCollectionExtensionsTests
         var options = provider.GetRequiredService<AevatarOrleansRuntimeOptions>();
         options.PersistenceBackend.Should().Be(AevatarOrleansRuntimeOptions.PersistenceBackendGarnet);
         options.GarnetConnectionString.Should().Be("garnet.internal:6379,abortConnect=false");
+    }
+
+    [Fact]
+    public void AddAevatarFoundationRuntimeOrleans_ServiceCollection_ShouldRegisterRuntimeActorStateStoreAsOpenGenericIStateStore()
+    {
+        var services = new ServiceCollection();
+        services.AddAevatarFoundationRuntimeOrleans();
+
+        var descriptor = services.LastOrDefault(x => x.ServiceType == typeof(IStateStore<>));
+        descriptor.Should().NotBeNull();
+        descriptor!.ImplementationType.Should().Be(typeof(RuntimeActorGrainStateStore<>));
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeActorGrainStateStoreTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeActorGrainStateStoreTests.cs
@@ -1,0 +1,175 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
+using FluentAssertions;
+using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+
+namespace Aevatar.Foundation.Runtime.Hosting.Tests;
+
+public sealed class RuntimeActorGrainStateStoreTests
+{
+    [Fact]
+    public async Task RuntimeActorGrainStateStore_ShouldRoundtripProtobufState()
+    {
+        var runtimeState = DispatchProxy.Create<IPersistentState<RuntimeActorGrainState>, RuntimeActorPersistentStateProxy>();
+        var stateProxy = (RuntimeActorPersistentStateProxy)(object)runtimeState;
+        var store = new RuntimeActorGrainStateStore<EventEnvelope>(runtimeState);
+        var state = new EventEnvelope
+        {
+            Id = "evt-1",
+            PublisherId = "publisher-1",
+            Direction = EventDirection.Both,
+        };
+        state.Metadata["k"] = "v";
+
+        await store.SaveAsync("actor-1", state);
+        var loaded = await store.LoadAsync("actor-1");
+
+        loaded.Should().NotBeNull();
+        loaded!.Id.Should().Be("evt-1");
+        loaded.PublisherId.Should().Be("publisher-1");
+        loaded.Direction.Should().Be(EventDirection.Both);
+        loaded.Metadata.Should().ContainKey("k").WhoseValue.Should().Be("v");
+        stateProxy.State.AgentStateTypeName.Should().Be(typeof(EventEnvelope).FullName);
+        stateProxy.State.AgentStateSnapshot.Should().NotBeNull();
+        stateProxy.WriteCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RuntimeActorGrainStateStore_WhenSnapshotTypeIsDifferent_ShouldReturnNull()
+    {
+        var runtimeState = DispatchProxy.Create<IPersistentState<RuntimeActorGrainState>, RuntimeActorPersistentStateProxy>();
+        var stateProxy = (RuntimeActorPersistentStateProxy)(object)runtimeState;
+        var stored = new EventEnvelope
+        {
+            Id = "evt-snapshot",
+        };
+        stateProxy.State.AgentStateTypeName = typeof(EventEnvelope).FullName;
+        stateProxy.State.AgentStateSnapshot = stored.ToByteArray();
+        var store = new RuntimeActorGrainStateStore<ParentChangedEvent>(runtimeState);
+
+        var loaded = await store.LoadAsync("actor-1");
+
+        loaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RuntimeActorGrainStateStore_Delete_ShouldClearSnapshot()
+    {
+        var runtimeState = DispatchProxy.Create<IPersistentState<RuntimeActorGrainState>, RuntimeActorPersistentStateProxy>();
+        var stateProxy = (RuntimeActorPersistentStateProxy)(object)runtimeState;
+        stateProxy.State.AgentStateTypeName = typeof(EventEnvelope).FullName;
+        stateProxy.State.AgentStateSnapshot = new EventEnvelope
+        {
+            Id = "evt-to-delete",
+        }.ToByteArray();
+        var store = new RuntimeActorGrainStateStore<EventEnvelope>(runtimeState);
+
+        await store.DeleteAsync("actor-1");
+
+        stateProxy.State.AgentStateTypeName.Should().BeNull();
+        stateProxy.State.AgentStateSnapshot.Should().BeNull();
+        stateProxy.WriteCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task IStateStoreResolution_WithBoundRuntimeState_ShouldUseRuntimeActorStateStore()
+    {
+        var runtimeState = DispatchProxy.Create<IPersistentState<RuntimeActorGrainState>, RuntimeActorPersistentStateProxy>();
+        var stateProxy = (RuntimeActorPersistentStateProxy)(object)runtimeState;
+        var services = new ServiceCollection();
+        services.AddAevatarFoundationRuntimeOrleans();
+        using var provider = services.BuildServiceProvider();
+        var accessor = provider.GetRequiredService<IRuntimeActorStateBindingAccessor>();
+
+        IStateStore<EventEnvelope> store;
+        using (accessor.Bind(runtimeState))
+        {
+            store = provider.GetRequiredService<IStateStore<EventEnvelope>>();
+            await store.SaveAsync("actor-1", new EventEnvelope { Id = "evt-created-by-di" });
+        }
+
+        stateProxy.State.AgentStateTypeName.Should().Be(typeof(EventEnvelope).FullName);
+        stateProxy.State.AgentStateSnapshot.Should().NotBeNull();
+        stateProxy.WriteCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void IStateStoreResolution_WithoutBoundRuntimeState_ShouldThrow()
+    {
+        var services = new ServiceCollection();
+        services.AddAevatarFoundationRuntimeOrleans();
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStateStore<EventEnvelope>>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Runtime actor state is not bound*");
+    }
+
+    [Fact]
+    public void AddAevatarFoundationRuntimeOrleans_ShouldRegisterRuntimeActorStateStoreAsOpenGenericIStateStore()
+    {
+        var services = new ServiceCollection();
+        services.AddAevatarFoundationRuntimeOrleans();
+
+        var descriptor = services.LastOrDefault(x => x.ServiceType == typeof(IStateStore<>));
+        descriptor.Should().NotBeNull();
+        descriptor!.ImplementationType.Should().Be(typeof(RuntimeActorGrainStateStore<>));
+
+        var accessorDescriptor = services.LastOrDefault(x => x.ServiceType == typeof(IRuntimeActorStateBindingAccessor));
+        accessorDescriptor.Should().NotBeNull();
+        accessorDescriptor!.ImplementationType.Should().Be(typeof(AsyncLocalRuntimeActorStateBindingAccessor));
+    }
+
+    private class RuntimeActorPersistentStateProxy : DispatchProxy
+    {
+        public RuntimeActorGrainState State { get; set; } = new();
+
+        public int WriteCount { get; private set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            var name = targetMethod?.Name;
+            if (name == "get_State")
+                return State;
+            if (name == "set_State")
+            {
+                State = args?[0] as RuntimeActorGrainState ?? new RuntimeActorGrainState();
+                return null;
+            }
+
+            if (name == "WriteStateAsync")
+            {
+                WriteCount++;
+                return Task.CompletedTask;
+            }
+
+            if (name == "ReadStateAsync" || name == "ClearStateAsync")
+                return Task.CompletedTask;
+
+            if (name == "get_RecordExists")
+                return true;
+
+            if (name == "get_Etag")
+                return string.Empty;
+
+            if (name == "set_Etag")
+                return null;
+
+            return GetDefault(targetMethod?.ReturnType);
+        }
+
+        private static object? GetDefault(Type? type)
+        {
+            if (type == null || type == typeof(void))
+                return null;
+
+            return type.IsValueType ? Activator.CreateInstance(type) : null;
+        }
+    }
+}


### PR DESCRIPTION
…tore

- Removed the existing InMemoryStateStore and replaced it with RuntimeActorGrainStateStore for better state management.
- Added AsyncLocalRuntimeActorStateBindingAccessor to manage actor state binding context.
- Updated RuntimeActorGrain to utilize the new state binding accessor and handle state snapshots.
- Enhanced RuntimeActorGrainState to include new properties for agent state type and snapshot.
- Implemented tests to validate the new state store functionality and ensure proper state restoration across silo restarts.