### PR TITLE
Apply LLM middleware and hooks to final ToolCallLoop call

### DIFF
--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -50,32 +50,9 @@ public sealed class ToolCallLoop
                 MaxTokens = baseRequest.MaxTokens,
             };
 
-            // ─── Hook: LLM Request Start ───
-            var llmCtx = new AIGAgentExecutionHookContext { LLMRequest = request };
-            if (_hooks != null) await _hooks.RunLLMRequestStartAsync(llmCtx, ct);
+            var (response, terminated) = await InvokeLlmAsync(provider, request, ct);
 
-            var llmCallContext = new LLMCallContext
-            {
-                Request = request,
-                Provider = provider,
-                CancellationToken = ct,
-                IsStreaming = false,
-            };
-
-            await MiddlewarePipeline.RunLLMCallAsync(_llmMiddlewares, llmCallContext, async () =>
-            {
-                if (llmCallContext.Terminate) return;
-                llmCallContext.Response = await provider.ChatAsync(llmCallContext.Request, ct);
-            });
-
-            var response = llmCallContext.Response
-                ?? new LLMResponse { Content = null, ToolCalls = null };
-            llmCtx.LLMResponse = response;
-
-            // ─── Hook: LLM Request End ───
-            if (_hooks != null) await _hooks.RunLLMRequestEndAsync(llmCtx, ct);
-
-            if (llmCallContext.Terminate || !response.HasToolCalls)
+            if (terminated || !response.HasToolCalls)
             {
                 if (response.Content != null)
                     messages.Add(ChatMessage.Assistant(response.Content));
@@ -132,7 +109,52 @@ public sealed class ToolCallLoop
             }
         }
 
-        return messages.LastOrDefault(m => m.Role == "assistant")?.Content;
+        // maxRounds exhausted — tool results from the last round are already in messages.
+        // Make one final LLM call WITHOUT tools so the model must produce a text response.
+        var finalRequest = new LLMRequest
+        {
+            Messages = [..messages], Tools = null,
+            Model = baseRequest.Model, Temperature = baseRequest.Temperature,
+            MaxTokens = baseRequest.MaxTokens,
+        };
+        var (finalResponse, _) = await InvokeLlmAsync(provider, finalRequest, ct);
+        var finalContent = finalResponse?.Content;
+        if (finalContent != null)
+            messages.Add(ChatMessage.Assistant(finalContent));
+        return finalContent;
+    }
+
+    private async Task<(LLMResponse Response, bool Terminated)> InvokeLlmAsync(
+        ILLMProvider provider,
+        LLMRequest request,
+        CancellationToken ct)
+    {
+        // ─── Hook: LLM Request Start ───
+        var llmCtx = new AIGAgentExecutionHookContext { LLMRequest = request };
+        if (_hooks != null) await _hooks.RunLLMRequestStartAsync(llmCtx, ct);
+
+        var llmCallContext = new LLMCallContext
+        {
+            Request = request,
+            Provider = provider,
+            CancellationToken = ct,
+            IsStreaming = false,
+        };
+
+        await MiddlewarePipeline.RunLLMCallAsync(_llmMiddlewares, llmCallContext, async () =>
+        {
+            if (llmCallContext.Terminate) return;
+            llmCallContext.Response = await provider.ChatAsync(llmCallContext.Request, ct);
+        });
+
+        var response = llmCallContext.Response
+            ?? new LLMResponse { Content = null, ToolCalls = null };
+        llmCtx.LLMResponse = response;
+
+        // ─── Hook: LLM Request End ───
+        if (_hooks != null) await _hooks.RunLLMRequestEndAsync(llmCtx, ct);
+
+        return (response, llmCallContext.Terminate);
     }
 
     private sealed class NullAgentTool(string name) : IAgentTool

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -131,7 +131,18 @@ public class ToolCallLoopTests
         ]);
         var tools = new ToolManager();
         tools.Register(new DelegateTool("echo", _ => "{}"));
-        var loop = new ToolCallLoop(tools);
+        var hook = new RecordingHook();
+        var llmMiddlewareCalls = 0;
+        var llmMiddleware = new DelegateLlmCallMiddleware(async (_, next) =>
+        {
+            llmMiddlewareCalls++;
+            await next();
+        });
+        var loop = new ToolCallLoop(
+            tools,
+            hooks: new AgentHookPipeline([hook]),
+            toolMiddlewares: [],
+            llmMiddlewares: [llmMiddleware]);
         var messages = new List<ChatMessage> { ChatMessage.User("hello") };
         var request = new LLMRequest { Messages = [], Tools = null };
 
@@ -140,6 +151,12 @@ public class ToolCallLoopTests
         result.Should().BeNull();
         messages.Count(m => m.Role == "assistant" && m.ToolCalls?.Count == 1).Should().Be(1);
         messages.Should().ContainSingle(m => m.Role == "tool");
+        // Final call should have been made without tools
+        provider.Requests.Should().HaveCount(2);
+        provider.Requests[1].Tools.Should().BeNull();
+        llmMiddlewareCalls.Should().Be(2);
+        hook.LlmStartCount.Should().Be(2);
+        hook.LlmEndCount.Should().Be(2);
     }
 
     [Fact]
@@ -262,6 +279,12 @@ public class ToolCallLoopTests
         Func<ToolCallContext, Func<Task>, Task> handler) : IToolCallMiddleware
     {
         public Task InvokeAsync(ToolCallContext context, Func<Task> next) => handler(context, next);
+    }
+
+    private sealed class DelegateLlmCallMiddleware(
+        Func<LLMCallContext, Func<Task>, Task> handler) : ILLMCallMiddleware
+    {
+        public Task InvokeAsync(LLMCallContext context, Func<Task> next) => handler(context, next);
     }
 
     private sealed class RecordingHook : IAIGAgentExecutionHook


### PR DESCRIPTION
This pull request refactors the LLM invocation logic in `ToolCallLoop` to improve code reuse and clarity, and updates the loop's behavior when the maximum number of tool call rounds is reached. It also enhances test coverage to ensure the new logic is properly exercised. The most important changes are grouped below.

### Refactoring and Code Reuse

* Extracted the LLM invocation logic (including hooks and middleware) from the main loop into a new private method `InvokeLlmAsync` in `ToolCallLoop`, reducing duplication and improving maintainability. (`src/Aevatar.AI.Core/Tools/ToolCallLoop.cs` [[1]](diffhunk://#diff-b782b96bdde09caba1ab2bbad5b5111637c4c87755613a9afa15226ec2a2cf27L53-R55) [[2]](diffhunk://#diff-b782b96bdde09caba1ab2bbad5b5111637c4c87755613a9afa15226ec2a2cf27L135-R157)

### Behavior Change: Final LLM Call

* When the maximum number of tool call rounds is exhausted, the loop now makes a final LLM call without tools to ensure a textual response is produced, and appends it to the messages if present. (`src/Aevatar.AI.Core/Tools/ToolCallLoop.cs` [src/Aevatar.AI.Core/Tools/ToolCallLoop.csL135-R157](diffhunk://#diff-b782b96bdde09caba1ab2bbad5b5111637c4c87755613a9afa15226ec2a2cf27L135-R157))

### Testing and Middleware

* Updated the test `ExecuteAsync_WhenMaxRoundsReachedWithoutTerminalContent_Should` to verify that the final LLM call is made without tools, and that hooks and middleware are invoked the correct number of times. (`test/Aevatar.AI.Tests/ToolCallLoopTests.cs` [[1]](diffhunk://#diff-1d46e902a1d7408d57e8753495338a07850ebb866e30ba1199a6c6a9afa29e24L134-R145) [[2]](diffhunk://#diff-1d46e902a1d7408d57e8753495338a07850ebb866e30ba1199a6c6a9afa29e24R154-R159)
* Added a `DelegateLlmCallMiddleware` helper class to facilitate testing of LLM call middleware. (`test/Aevatar.AI.Tests/ToolCallLoopTests.cs` [test/Aevatar.AI.Tests/ToolCallLoopTests.csR284-R289](diffhunk://#diff-1d46e902a1d7408d57e8753495338a07850ebb866e30ba1199a6c6a9afa29e24R284-R289))