### PR TITLE
refactor: Replace ToolCallModule lock+Dictionary with Lazy<Task> lock-free init

### DIFF
--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -7,7 +7,6 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Abstractions.EventModules;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Core.Modules;
@@ -15,9 +14,15 @@ namespace Aevatar.Workflow.Core.Modules;
 /// <summary>工具调用模块。处理 type=tool_call 的步骤。</summary>
 public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 {
-    private readonly Dictionary<string, IAgentTool> _toolIndex = new(StringComparer.OrdinalIgnoreCase);
-    private readonly SemaphoreSlim _toolIndexLock = new(1, 1);
-    private bool _toolIndexInitialized;
+    private readonly Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>> _toolIndex;
+
+    public ToolCallModule(
+        IEnumerable<IAgentToolSource> toolSources,
+        ILogger<ToolCallModule> logger)
+    {
+        _toolIndex = new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
+            () => DiscoverAllToolsAsync(toolSources, logger));
+    }
 
     public string Name => "tool_call";
     public int Priority => 10;
@@ -58,8 +63,8 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             CallId = request.StepId,
         }, TopologyAudience.Self, ct);
 
-        var tool = await ResolveToolAsync(toolName, ctx, ct);
-        if (tool == null)
+        var toolIndex = await _toolIndex.Value;
+        if (!toolIndex.TryGetValue(toolName, out var tool))
         {
             const string notFound = "tool not found or no tool sources configured";
             await PublishToolFailureAsync(ctx, request, toolName, notFound, ct);
@@ -92,46 +97,29 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         }
     }
 
-    private async Task<IAgentTool?> ResolveToolAsync(string toolName, IWorkflowExecutionContext ctx, CancellationToken ct)
+    private static async Task<IReadOnlyDictionary<string, IAgentTool>> DiscoverAllToolsAsync(
+        IEnumerable<IAgentToolSource> toolSources,
+        ILogger logger)
     {
-        if (_toolIndex.TryGetValue(toolName, out var cached))
-            return cached;
-
-        await _toolIndexLock.WaitAsync(ct);
-        try
+        var index = new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase);
+        foreach (var source in toolSources)
         {
-            if (_toolIndex.TryGetValue(toolName, out cached))
-                return cached;
-
-            if (!_toolIndexInitialized)
+            IReadOnlyList<IAgentTool> tools;
+            try
             {
-                var sources = ctx.Services.GetServices<IAgentToolSource>().ToList();
-                foreach (var source in sources)
-                {
-                    IReadOnlyList<IAgentTool> tools;
-                    try
-                    {
-                        tools = await source.DiscoverToolsAsync(ct);
-                    }
-                    catch (Exception ex)
-                    {
-                        ctx.Logger.LogWarning(ex, "Tool source discovery failed: {Source}", source.GetType().Name);
-                        continue;
-                    }
-
-                    foreach (var tool in tools)
-                        _toolIndex[tool.Name] = tool;
-                }
-
-                _toolIndexInitialized = true;
+                tools = await source.DiscoverToolsAsync();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Tool source discovery failed: {Source}", source.GetType().Name);
+                continue;
             }
 
-            return _toolIndex.GetValueOrDefault(toolName);
+            foreach (var tool in tools)
+                index[tool.Name] = tool;
         }
-        finally
-        {
-            _toolIndexLock.Release();
-        }
+
+        return index;
     }
 
     private static async Task PublishToolFailureAsync(

--- a/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowCoreModulesCoverageTests.cs
@@ -20,7 +20,7 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_MissingToolParameter_ShouldPublishFailedStepCompleted()
     {
-        var module = new ToolCallModule();
+        var module = new ToolCallModule([], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
         var request = new StepRequestEvent
         {
@@ -42,7 +42,7 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_ToolNotFound_ShouldPublishToolFailureEvents()
     {
-        var module = new ToolCallModule();
+        var module = new ToolCallModule([], NullLogger<ToolCallModule>.Instance);
         var ctx = CreateContext();
         var request = new StepRequestEvent
         {
@@ -72,16 +72,13 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_WhenDiscoveryFailsThenToolFound_ShouldStillExecuteSuccessfully()
     {
-        var module = new ToolCallModule();
         var source = new CountingToolSource(
             [
                 new FakeAgentTool("echo", args => args),
             ]);
-        var services = new ServiceCollection()
-            .AddSingleton<IAgentToolSource>(new ThrowingToolSource())
-            .AddSingleton<IAgentToolSource>(source)
-            .BuildServiceProvider();
-        var ctx = CreateContext(services);
+        IAgentToolSource[] toolSources = [new ThrowingToolSource(), source];
+        var module = new ToolCallModule(toolSources, NullLogger<ToolCallModule>.Instance);
+        var ctx = CreateContext();
         var request = new StepRequestEvent
         {
             StepId = "step-3",
@@ -101,15 +98,12 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_ShouldCacheDiscoveredToolsAcrossCalls()
     {
-        var module = new ToolCallModule();
         var source = new CountingToolSource(
             [
                 new FakeAgentTool("cached_echo", args => args),
             ]);
-        var services = new ServiceCollection()
-            .AddSingleton<IAgentToolSource>(source)
-            .BuildServiceProvider();
-        var ctx = CreateContext(services);
+        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var ctx = CreateContext();
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -140,15 +134,12 @@ public sealed class WorkflowCoreModulesCoverageTests
     [Fact]
     public async Task ToolCallModule_WhenToolThrows_ShouldPublishFailedStepCompleted()
     {
-        var module = new ToolCallModule();
         var source = new CountingToolSource(
             [
                 new FakeAgentTool("explode", _ => throw new InvalidOperationException("boom")),
             ]);
-        var services = new ServiceCollection()
-            .AddSingleton<IAgentToolSource>(source)
-            .BuildServiceProvider();
-        var ctx = CreateContext(services);
+        var module = new ToolCallModule([source], NullLogger<ToolCallModule>.Instance);
+        var ctx = CreateContext();
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent

--- a/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowIntegrationTests.cs
@@ -27,6 +27,7 @@ using Aevatar.Workflow.Core.Validation;
 using Aevatar.Foundation.Runtime.Implementations.Local.DependencyInjection;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Integration.Tests;
 
@@ -479,6 +480,7 @@ public class WorkflowIntegrationTests
     public void Scenario7_AllCoreModules()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddAevatarWorkflow();
         using var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IEventModuleFactory<IWorkflowExecutionContext>>();


### PR DESCRIPTION
## Issue

[HIGH] ToolCallModule maintains Dictionary + SemaphoreSlim as singleton service-level state, violating lock-free and middle-layer state constraints.

## Fix Summary

- Replaced mutable `Dictionary<string, IAgentTool>` + `SemaphoreSlim` + `bool _toolIndexInitialized` with `Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>`
- Constructor injection of `IEnumerable<IAgentToolSource>` and `ILogger` via DI, removing service-locator anti-pattern (`ctx.Services.GetServices`)
- Tool discovery runs once (lock-free), result is immutable

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| arch-reviewer | Opus | APPROVED |
| arch-reviewer | Sonnet | APPROVED |
| quality-reviewer | Opus | APPROVED |
| quality-reviewer | Sonnet | APPROVED |
| ci-guard-runner | Sonnet | PASSED (1887 tests, 0 failed) |

**Review rounds:** 1/3
**Non-blocking notes:** CancellationToken not forwarded to DiscoverToolsAsync (LOW, acceptable for one-time init)

## Referenced CLAUDE.md Rules

> 无锁优先：需加锁 → 先判定为"破坏 Actor 边界" → 重构为事件化串行模型
> 禁止中间层维护 entity/actor/workflow-run/session 等 ID → 上下文/事实状态的进程内映射

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team