### PR TITLE
refactor: Move ChatRuntime history mutation out of Task.Run callback

### DIFF
--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -125,6 +125,9 @@ public sealed class ChatRuntime
             CancellationToken = runToken,
         };
 
+        // Collect history mutations from the background thread; apply on caller context after task completes.
+        var pendingHistoryMessages = new List<ChatMessage>();
+
         var runTask = Task.Run(async () =>
         {
             var wroteOutput = false;
@@ -134,11 +137,13 @@ public sealed class ChatRuntime
                 {
                     if (runContext.Terminate) return;
 
-                    _history.Add(ChatMessage.User(runContext.UserMessage));
+                    var userMsg = ChatMessage.User(runContext.UserMessage);
+                    pendingHistoryMessages.Add(userMsg);
                     var baseRequest = ApplyRequestIdentity(_requestBuilder(), requestId, metadata);
                     var provider = _providerFactory();
                     runContext.Items["gen_ai.provider.name"] = provider.Name;
-                    var messages = _history.BuildMessages(baseRequest.Messages.FirstOrDefault(m => m.Role == "system")?.Content);
+                    // Build messages from a local snapshot + pending user message instead of mutating _history.
+                    var messages = BuildMessagesWithPending(baseRequest, userMsg);
 
                     var request = new LLMRequest
                     {
@@ -212,7 +217,7 @@ public sealed class ChatRuntime
 
                     if (!string.IsNullOrEmpty(streamedContent) || streamedToolCalls is { Count: > 0 })
                     {
-                        _history.Add(new ChatMessage
+                        pendingHistoryMessages.Add(new ChatMessage
                         {
                             Role = "assistant",
                             Content = streamedContent,
@@ -247,7 +252,26 @@ public sealed class ChatRuntime
         {
             linkedCts.Cancel();
             try { await runTask.ConfigureAwait(false); } catch { /* best-effort */ }
+
+            // Apply collected history mutations on the caller context after the background task completes.
+            foreach (var msg in pendingHistoryMessages)
+                _history.Add(msg);
         }
+    }
+
+    /// <summary>
+    /// Build the LLM messages list from the current history snapshot plus a pending user message,
+    /// without mutating <see cref="_history"/>. Used by the streaming path to avoid cross-thread mutation.
+    /// </summary>
+    private List<ChatMessage> BuildMessagesWithPending(LLMRequest baseRequest, ChatMessage pendingUserMessage)
+    {
+        var systemPrompt = baseRequest.Messages.FirstOrDefault(m => m.Role == "system")?.Content;
+        var messages = new List<ChatMessage>();
+        if (!string.IsNullOrEmpty(systemPrompt))
+            messages.Add(ChatMessage.System(systemPrompt));
+        messages.AddRange(_history.Messages);
+        messages.Add(pendingUserMessage);
+        return messages;
     }
 
     private static LLMRequest ApplyRequestIdentity(


### PR DESCRIPTION
## Issue

[HIGH] ChatRuntime.ChatStreamAsync mutates _history from Task.Run background thread, violating actor callback rule.

## Fix Summary

- Collected pending history messages in a local list inside Task.Run instead of mutating _history directly
- Applied collected messages to _history in the finally block on the caller context
- Added `BuildMessagesWithPending` helper to build LLM messages from a snapshot + pending, avoiding cross-thread mutation

## Referenced CLAUDE.md Rules

> 回调只发信号：Task.Run/Timer/线程池回调不直接读写运行态或推进业务
> 单线程事实源：运行态只在事件处理主线程修改

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team