### PR TITLE
refactor: Replace lock with atomic snapshot swap in ReloadableLLMProviderFactory

### DIFF
--- a/src/Aevatar.Bootstrap.Extensions.AI/ReloadableLLMProviderFactory.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ReloadableLLMProviderFactory.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -6,17 +7,21 @@ namespace Aevatar.Bootstrap.Extensions.AI;
 
 /// <summary>
 /// A lightweight wrapper that rebuilds the inner factory when config version changes.
+/// Uses an immutable snapshot swapped atomically to avoid locks on the fast path.
 /// </summary>
 public sealed class ReloadableLLMProviderFactory : ILLMProviderFactory
 {
+    private sealed record Snapshot(ILLMProviderFactory Factory, long Version, long LastFailedVersion);
+
     private readonly Func<ILLMProviderFactory> _factoryBuilder;
     private readonly Func<long> _versionProvider;
     private readonly ILogger _logger;
-    private readonly object _sync = new();
 
-    private ILLMProviderFactory _currentFactory;
-    private long _currentVersion;
-    private long _lastFailedVersion = long.MinValue;
+    /// <summary>
+    /// Immutable snapshot holding the current factory, version, and last-failed version.
+    /// All mutations go through <see cref="Interlocked.CompareExchange{T}"/>.
+    /// </summary>
+    private Snapshot _snapshot;
 
     public ReloadableLLMProviderFactory(
         Func<ILLMProviderFactory> factoryBuilder,
@@ -27,8 +32,9 @@ public sealed class ReloadableLLMProviderFactory : ILLMProviderFactory
         _versionProvider = versionProvider ?? throw new ArgumentNullException(nameof(versionProvider));
         _logger = logger ?? NullLogger.Instance;
 
-        _currentFactory = _factoryBuilder();
-        _currentVersion = _versionProvider();
+        var factory = _factoryBuilder();
+        var version = _versionProvider();
+        _snapshot = new Snapshot(factory, version, long.MinValue);
     }
 
     public ILLMProvider GetProvider(string name) =>
@@ -42,31 +48,52 @@ public sealed class ReloadableLLMProviderFactory : ILLMProviderFactory
 
     private ILLMProviderFactory GetCurrentFactory()
     {
-        lock (_sync)
+        var current = Volatile.Read(ref _snapshot);
+        var observedVersion = _versionProvider();
+
+        // Fast path: version unchanged, no lock needed.
+        if (observedVersion == current.Version)
+            return current.Factory;
+
+        // Slow path: version changed, attempt to rebuild.
+        return RebuildFactory(current, observedVersion);
+    }
+
+    private ILLMProviderFactory RebuildFactory(Snapshot before, long observedVersion)
+    {
+        // Re-read to see if another thread already rebuilt for this version.
+        var current = Volatile.Read(ref _snapshot);
+        if (observedVersion == current.Version)
+            return current.Factory;
+
+        try
         {
-            var observedVersion = _versionProvider();
-            if (observedVersion == _currentVersion)
-                return _currentFactory;
+            var newFactory = _factoryBuilder();
+            var desired = new Snapshot(newFactory, observedVersion, long.MinValue);
 
-            try
+            // Atomically swap only if no other thread has updated since we read.
+            var original = Interlocked.CompareExchange(ref _snapshot, desired, current);
+            if (ReferenceEquals(original, current))
+                return newFactory;
+
+            // Another thread won the race; use whatever is current now.
+            return Volatile.Read(ref _snapshot).Factory;
+        }
+        catch (Exception ex)
+        {
+            // On failure, update LastFailedVersion to suppress repeated logging.
+            if (observedVersion != current.LastFailedVersion)
             {
-                _currentFactory = _factoryBuilder();
-                _currentVersion = observedVersion;
-                _lastFailedVersion = long.MinValue;
-            }
-            catch (Exception ex)
-            {
-                if (observedVersion != _lastFailedVersion)
-                {
-                    _lastFailedVersion = observedVersion;
-                    _logger.LogWarning(
-                        ex,
-                        "Reloadable LLM provider factory failed to reload for version {Version}; keep previous snapshot.",
-                        observedVersion);
-                }
+                var failed = current with { LastFailedVersion = observedVersion };
+                Interlocked.CompareExchange(ref _snapshot, failed, current);
+
+                _logger.LogWarning(
+                    ex,
+                    "Reloadable LLM provider factory failed to reload for version {Version}; keep previous snapshot.",
+                    observedVersion);
             }
 
-            return _currentFactory;
+            return current.Factory;
         }
     }
 }


### PR DESCRIPTION
## Issue

[HIGH] ReloadableLLMProviderFactory uses lock on every LLM request hot path.

## Fix Summary

- Replaced `lock(_sync)` with immutable `record Snapshot` swapped via `Interlocked.CompareExchange`
- Fast path: `Volatile.Read` version check with zero contention
- Slow path: atomic snapshot swap on version change

## Referenced CLAUDE.md Rules

> 无锁优先：需加锁 → 先判定为"破坏 Actor 边界" → 重构为事件化串行模型

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team