### PR TITLE
refactor: Replace ConcurrentDictionary with ImmutableDictionary in LLM provider factories

### DIFF
--- a/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProviderFactory.cs
+++ b/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProviderFactory.cs
@@ -5,7 +5,7 @@
 // 按名字选择。每个 provider 由一个 IChatClient 支撑。
 // ─────────────────────────────────────────────────────────────
 
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -16,10 +16,13 @@ namespace Aevatar.AI.LLMProviders.MEAI;
 /// <summary>
 /// 基于 MEAI 的 LLM Provider 工厂。
 /// 支持注册多个命名 provider，按名字获取。
+/// Startup-initialized, read-heavy: uses ImmutableDictionary for lock-free reads.
 /// </summary>
 public sealed class MEAILLMProviderFactory : ILLMProviderFactory, IMEAILLMProviderRegistry
 {
-    private readonly ConcurrentDictionary<string, MEAILLMProvider> _providers = new(StringComparer.OrdinalIgnoreCase);
+    private ImmutableDictionary<string, MEAILLMProvider> _providers =
+        ImmutableDictionary<string, MEAILLMProvider>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+
     private string _defaultName = "openai";
 
     /// <summary>
@@ -30,24 +33,26 @@ public sealed class MEAILLMProviderFactory : ILLMProviderFactory, IMEAILLMProvid
     /// <param name="logger">日志记录器。</param>
     public IMEAILLMProviderRegistry Register(string name, IChatClient client, ILogger? logger = null)
     {
-        _providers[name] = new MEAILLMProvider(name, client, logger);
+        var provider = new MEAILLMProvider(name, client, logger);
+        ImmutableInterlocked.AddOrUpdate(ref _providers, name, provider, (_, _) => provider);
         return this;
     }
 
     /// <summary>设置默认 provider 名称。</summary>
     public IMEAILLMProviderRegistry SetDefault(string name)
     {
-        _defaultName = name;
+        Volatile.Write(ref _defaultName, name);
         return this;
     }
 
     /// <inheritdoc />
     public ILLMProvider GetProvider(string name) =>
-        _providers.GetValueOrDefault(name)
-        ?? throw new InvalidOperationException($"LLM Provider '{name}' 未注册。可用: {string.Join(", ", _providers.Keys)}");
+        _providers.TryGetValue(name, out var provider)
+        ? provider
+        : throw new InvalidOperationException($"LLM Provider '{name}' 未注册。可用: {string.Join(", ", _providers.Keys)}");
 
     /// <inheritdoc />
-    public ILLMProvider GetDefault() => GetProvider(_defaultName);
+    public ILLMProvider GetDefault() => GetProvider(Volatile.Read(ref _defaultName));
 
     /// <inheritdoc />
     public IReadOnlyList<string> GetAvailableProviders() => _providers.Keys.ToList();

--- a/src/Aevatar.AI.LLMProviders.Tornado/TornadoLLMProviderFactory.cs
+++ b/src/Aevatar.AI.LLMProviders.Tornado/TornadoLLMProviderFactory.cs
@@ -3,7 +3,7 @@
 // 支持注册多个 provider（openai / anthropic / google 等）
 // ─────────────────────────────────────────────────────────────
 
-using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using Aevatar.AI.Abstractions.LLMProviders;
 using LlmTornado;
 using LlmTornado.Code;
@@ -15,10 +15,13 @@ namespace Aevatar.AI.LLMProviders.Tornado;
 /// <summary>
 /// 基于 LlmTornado 的 LLM Provider 工厂。
 /// 支持注册多个命名 provider。
+/// Startup-initialized, read-heavy: uses ImmutableDictionary for lock-free reads.
 /// </summary>
 public sealed class TornadoLLMProviderFactory : ILLMProviderFactory, ITornadoLLMProviderRegistry
 {
-    private readonly ConcurrentDictionary<string, TornadoLLMProvider> _providers = new(StringComparer.OrdinalIgnoreCase);
+    private ImmutableDictionary<string, TornadoLLMProvider> _providers =
+        ImmutableDictionary<string, TornadoLLMProvider>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+
     private string _defaultName = "";
 
     /// <summary>
@@ -33,8 +36,9 @@ public sealed class TornadoLLMProviderFactory : ILLMProviderFactory, ITornadoLLM
         string name, LLmProviders providerType, string apiKey, string model, ILogger? logger = null)
     {
         var api = new TornadoApi(providerType, apiKey);
-        _providers[name] = new TornadoLLMProvider(name, api, model, logger);
-        if (string.IsNullOrEmpty(_defaultName)) _defaultName = name;
+        var provider = new TornadoLLMProvider(name, api, model, logger);
+        ImmutableInterlocked.AddOrUpdate(ref _providers, name, provider, (_, _) => provider);
+        if (string.IsNullOrEmpty(Volatile.Read(ref _defaultName))) Volatile.Write(ref _defaultName, name);
         return this;
     }
 
@@ -55,21 +59,23 @@ public sealed class TornadoLLMProviderFactory : ILLMProviderFactory, ITornadoLLM
             api = new TornadoApi(LLmProviders.OpenAi, apiKey);
         }
 
-        _providers[name] = new TornadoLLMProvider(name, api, model, logger);
-        if (string.IsNullOrEmpty(_defaultName)) _defaultName = name;
+        var provider = new TornadoLLMProvider(name, api, model, logger);
+        ImmutableInterlocked.AddOrUpdate(ref _providers, name, provider, (_, _) => provider);
+        if (string.IsNullOrEmpty(Volatile.Read(ref _defaultName))) Volatile.Write(ref _defaultName, name);
         return this;
     }
 
     /// <summary>设置默认 provider。</summary>
-    public ITornadoLLMProviderRegistry SetDefault(string name) { _defaultName = name; return this; }
+    public ITornadoLLMProviderRegistry SetDefault(string name) { Volatile.Write(ref _defaultName, name); return this; }
 
     /// <inheritdoc />
     public ILLMProvider GetProvider(string name) =>
-        _providers.GetValueOrDefault(name)
-        ?? throw new InvalidOperationException($"Tornado Provider '{name}' 未注册");
+        _providers.TryGetValue(name, out var provider)
+        ? provider
+        : throw new InvalidOperationException($"Tornado Provider '{name}' 未注册");
 
     /// <inheritdoc />
-    public ILLMProvider GetDefault() => GetProvider(_defaultName);
+    public ILLMProvider GetDefault() => GetProvider(Volatile.Read(ref _defaultName));
 
     /// <inheritdoc />
     public IReadOnlyList<string> GetAvailableProviders() => _providers.Keys.ToList();


### PR DESCRIPTION
## Issue

[HIGH] TornadoLLMProviderFactory and MEAILLMProviderFactory use ConcurrentDictionary + unsynchronized _defaultName as singleton mutable state.

## Fix Summary

- Replaced `ConcurrentDictionary` with `ImmutableDictionary` + `ImmutableInterlocked.AddOrUpdate` in both factories
- `_defaultName` now uses `Volatile.Read`/`Volatile.Write` for cross-thread visibility
- Lock-free, startup-initialized, read-heavy pattern

## Referenced CLAUDE.md Rules

> 禁止中间层维护 entity/actor/workflow-run/session 等 ID → 上下文/事实状态的进程内映射
> 事实源唯一

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team