### PR TITLE
refactor: Replace lock-based state with lock-free patterns in MCP tool providers

### DIFF
--- a/src/Aevatar.AI.ToolProviders.MCP/MCPAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPAgentToolSource.cs
@@ -10,58 +10,42 @@ namespace Aevatar.AI.ToolProviders.MCP;
 /// </summary>
 public sealed class MCPAgentToolSource : IAgentToolSource
 {
-    private readonly MCPToolsOptions _options;
-    private readonly MCPClientManager _clientManager;
-    private readonly ILogger _logger;
-    private readonly SemaphoreSlim _lock = new(1, 1);
-    private IReadOnlyList<IAgentTool>? _cachedTools;
+    private readonly Lazy<Task<IReadOnlyList<IAgentTool>>> _cachedTools;
 
     public MCPAgentToolSource(
         MCPToolsOptions options,
         MCPClientManager clientManager,
         ILogger<MCPAgentToolSource>? logger = null)
     {
-        _options = options;
-        _clientManager = clientManager;
-        _logger = logger ?? NullLogger<MCPAgentToolSource>.Instance;
+        var log = logger ?? NullLogger<MCPAgentToolSource>.Instance;
+        _cachedTools = new Lazy<Task<IReadOnlyList<IAgentTool>>>(() => DiscoverAllAsync(options, clientManager, log));
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
+        => _cachedTools.Value;
+
+    private static async Task<IReadOnlyList<IAgentTool>> DiscoverAllAsync(
+        MCPToolsOptions options, MCPClientManager clientManager, ILogger logger)
     {
-        if (_cachedTools != null) return _cachedTools;
+        if (options.Servers.Count == 0)
+            return [];
 
-        await _lock.WaitAsync(ct);
-        try
+        var tools = new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase);
+        foreach (var server in options.Servers)
         {
-            if (_cachedTools != null) return _cachedTools;
-            if (_options.Servers.Count == 0)
+            try
             {
-                _cachedTools = [];
-                return _cachedTools;
+                var discovered = await clientManager.ConnectAndDiscoverAsync(server);
+                foreach (var tool in discovered)
+                    tools[tool.Name] = tool;
             }
-
-            var tools = new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase);
-            foreach (var server in _options.Servers)
+            catch (Exception ex)
             {
-                try
-                {
-                    var discovered = await _clientManager.ConnectAndDiscoverAsync(server, ct);
-                    foreach (var tool in discovered)
-                        tools[tool.Name] = tool;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "MCP tool discovery failed for server {ServerName}", server.Name);
-                }
+                logger.LogWarning(ex, "MCP tool discovery failed for server {ServerName}", server.Name);
             }
+        }
 
-            _cachedTools = tools.Values.ToList();
-            return _cachedTools;
-        }
-        finally
-        {
-            _lock.Release();
-        }
+        return tools.Values.ToList();
     }
 }

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPAgentToolSource.cs
@@ -10,23 +10,33 @@ namespace Aevatar.AI.ToolProviders.MCP;
 /// </summary>
 public sealed class MCPAgentToolSource : IAgentToolSource
 {
-    private readonly Lazy<Task<IReadOnlyList<IAgentTool>>> _cachedTools;
+    private readonly MCPToolsOptions _options;
+    private readonly MCPClientManager _clientManager;
+    private readonly ILogger _logger;
+    private volatile Task<IReadOnlyList<IAgentTool>>? _cachedTools;
 
     public MCPAgentToolSource(
         MCPToolsOptions options,
         MCPClientManager clientManager,
         ILogger<MCPAgentToolSource>? logger = null)
     {
-        var log = logger ?? NullLogger<MCPAgentToolSource>.Instance;
-        _cachedTools = new Lazy<Task<IReadOnlyList<IAgentTool>>>(() => DiscoverAllAsync(options, clientManager, log));
+        _options = options;
+        _clientManager = clientManager;
+        _logger = logger ?? NullLogger<MCPAgentToolSource>.Instance;
     }
 
     /// <inheritdoc />
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
-        => _cachedTools.Value;
+    {
+        var current = _cachedTools;
+        if (current is { IsFaulted: false }) return current;
+        var task = DiscoverAllAsync(_options, _clientManager, _logger, ct);
+        var winner = Interlocked.CompareExchange(ref _cachedTools, task, current);
+        return winner ?? task;
+    }
 
     private static async Task<IReadOnlyList<IAgentTool>> DiscoverAllAsync(
-        MCPToolsOptions options, MCPClientManager clientManager, ILogger logger)
+        MCPToolsOptions options, MCPClientManager clientManager, ILogger logger, CancellationToken ct)
     {
         if (options.Servers.Count == 0)
             return [];
@@ -36,7 +46,7 @@ public sealed class MCPAgentToolSource : IAgentToolSource
         {
             try
             {
-                var discovered = await clientManager.ConnectAndDiscoverAsync(server);
+                var discovered = await clientManager.ConnectAndDiscoverAsync(server, ct);
                 foreach (var tool in discovered)
                     tools[tool.Name] = tool;
             }

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPAgentToolSource.cs
@@ -29,10 +29,10 @@ public sealed class MCPAgentToolSource : IAgentToolSource
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
         var current = _cachedTools;
-        if (current is { IsFaulted: false }) return current;
+        if (current is { IsCompletedSuccessfully: true }) return current;
         var task = DiscoverAllAsync(_options, _clientManager, _logger, ct);
         var winner = Interlocked.CompareExchange(ref _cachedTools, task, current);
-        return winner ?? task;
+        return ReferenceEquals(winner, current) ? task : winner!;
     }
 
     private static async Task<IReadOnlyList<IAgentTool>> DiscoverAllAsync(

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPClientManager.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPClientManager.cs
@@ -3,6 +3,7 @@
 // 自动连接、发现工具、适配为 IAgentTool
 // ─────────────────────────────────────────────────────────────
 
+using System.Collections.Immutable;
 using Aevatar.AI.Abstractions.ToolProviders;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -13,10 +14,12 @@ namespace Aevatar.AI.ToolProviders.MCP;
 
 /// <summary>
 /// 管理 MCP Server 连接。连接后自动发现工具并适配为 IAgentTool。
+/// Clients are tracked via an immutable list for thread-safe append;
+/// disposal iterates a snapshot and is intended to be called once at shutdown.
 /// </summary>
 public sealed class MCPClientManager : IAsyncDisposable
 {
-    private readonly List<McpClient> _clients = [];
+    private ImmutableList<McpClient> _clients = ImmutableList<McpClient>.Empty;
     private readonly ILogger _logger;
 
     public MCPClientManager(ILogger? logger = null) =>
@@ -47,7 +50,7 @@ public sealed class MCPClientManager : IAsyncDisposable
         };
 
         var client = await McpClient.CreateAsync(transport, options, cancellationToken: ct);
-        _clients.Add(client);
+        ImmutableInterlocked.Update(ref _clients, list => list.Add(client));
 
         // 发现工具
         var tools = await client.ListToolsAsync(cancellationToken: ct);
@@ -72,8 +75,8 @@ public sealed class MCPClientManager : IAsyncDisposable
     /// <summary>释放所有 MCP 连接。</summary>
     public async ValueTask DisposeAsync()
     {
-        foreach (var client in _clients)
+        var snapshot = Interlocked.Exchange(ref _clients, ImmutableList<McpClient>.Empty);
+        foreach (var client in snapshot)
             await client.DisposeAsync();
-        _clients.Clear();
     }
 }

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Diagnostics;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -18,10 +19,8 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
     private readonly string? _defaultTool;
     private readonly HashSet<string> _allowedTools;
     private readonly HashSet<string> _allowedInputKeys;
-    private readonly SemaphoreSlim _initLock = new(1, 1);
-    private readonly Dictionary<string, IAgentTool> _tools = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>> _tools;
     private readonly ILogger _logger;
-    private volatile bool _initialized;
 
     public MCPConnector(
         string name,
@@ -40,6 +39,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         _allowedInputKeys = new HashSet<string>(allowedInputKeys ?? [], StringComparer.OrdinalIgnoreCase);
         _clientManager = clientManager ?? new MCPClientManager(logger);
         _logger = logger ?? NullLogger.Instance;
+        _tools = new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(ConnectAndIndexToolsAsync);
     }
 
     /// <inheritdoc />
@@ -54,7 +54,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         var sw = Stopwatch.StartNew();
         try
         {
-            await EnsureConnectedAsync(ct);
+            var tools = await _tools.Value;
 
             var toolName = ResolveToolName(request);
             if (string.IsNullOrWhiteSpace(toolName))
@@ -75,7 +75,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
                 };
             }
 
-            if (!_tools.TryGetValue(toolName, out var tool))
+            if (!tools.TryGetValue(toolName, out var tool))
             {
                 return new ConnectorResponse
                 {
@@ -133,26 +133,10 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         return _defaultTool ?? "";
     }
 
-    private async Task EnsureConnectedAsync(CancellationToken ct)
+    private async Task<IReadOnlyDictionary<string, IAgentTool>> ConnectAndIndexToolsAsync()
     {
-        if (_initialized) return;
-
-        await _initLock.WaitAsync(ct);
-        try
-        {
-            if (_initialized) return;
-
-            var tools = await _clientManager.ConnectAndDiscoverAsync(_serverConfig, ct);
-            _tools.Clear();
-            foreach (var tool in tools)
-                _tools[tool.Name] = tool;
-
-            _initialized = true;
-        }
-        finally
-        {
-            _initLock.Release();
-        }
+        var discovered = await _clientManager.ConnectAndDiscoverAsync(_serverConfig);
+        return discovered.ToFrozenDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
@@ -135,10 +135,10 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
     private Task<IReadOnlyDictionary<string, IAgentTool>> GetOrConnectAsync(CancellationToken ct)
     {
         var current = _tools;
-        if (current is { IsFaulted: false }) return current;
+        if (current is { IsCompletedSuccessfully: true }) return current;
         var task = ConnectAndIndexToolsAsync(ct);
         var winner = Interlocked.CompareExchange(ref _tools, task, current);
-        return winner ?? task;
+        return ReferenceEquals(winner, current) ? task : winner!;
     }
 
     private async Task<IReadOnlyDictionary<string, IAgentTool>> ConnectAndIndexToolsAsync(CancellationToken ct)

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
@@ -19,7 +19,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
     private readonly string? _defaultTool;
     private readonly HashSet<string> _allowedTools;
     private readonly HashSet<string> _allowedInputKeys;
-    private readonly Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>> _tools;
+    private volatile Task<IReadOnlyDictionary<string, IAgentTool>>? _tools;
     private readonly ILogger _logger;
 
     public MCPConnector(
@@ -39,7 +39,6 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         _allowedInputKeys = new HashSet<string>(allowedInputKeys ?? [], StringComparer.OrdinalIgnoreCase);
         _clientManager = clientManager ?? new MCPClientManager(logger);
         _logger = logger ?? NullLogger.Instance;
-        _tools = new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(ConnectAndIndexToolsAsync);
     }
 
     /// <inheritdoc />
@@ -54,7 +53,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         var sw = Stopwatch.StartNew();
         try
         {
-            var tools = await _tools.Value;
+            var tools = await GetOrConnectAsync(ct);
 
             var toolName = ResolveToolName(request);
             if (string.IsNullOrWhiteSpace(toolName))
@@ -133,9 +132,18 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         return _defaultTool ?? "";
     }
 
-    private async Task<IReadOnlyDictionary<string, IAgentTool>> ConnectAndIndexToolsAsync()
+    private Task<IReadOnlyDictionary<string, IAgentTool>> GetOrConnectAsync(CancellationToken ct)
     {
-        var discovered = await _clientManager.ConnectAndDiscoverAsync(_serverConfig);
+        var current = _tools;
+        if (current is { IsFaulted: false }) return current;
+        var task = ConnectAndIndexToolsAsync(ct);
+        var winner = Interlocked.CompareExchange(ref _tools, task, current);
+        return winner ?? task;
+    }
+
+    private async Task<IReadOnlyDictionary<string, IAgentTool>> ConnectAndIndexToolsAsync(CancellationToken ct)
+    {
+        var discovered = await _clientManager.ConnectAndDiscoverAsync(_serverConfig, ct);
         return discovered.ToFrozenDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -102,10 +102,10 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
     private Task<IReadOnlyDictionary<string, IAgentTool>> GetOrDiscoverAsync(CancellationToken ct)
     {
         var current = _toolIndex;
-        if (current is { IsFaulted: false }) return current;
+        if (current is { IsCompletedSuccessfully: true }) return current;
         var task = DiscoverAllToolsAsync(_toolSources, _logger, ct);
         var winner = Interlocked.CompareExchange(ref _toolIndex, task, current);
-        return winner ?? task;
+        return ReferenceEquals(winner, current) ? task : winner!;
     }
 
     private static async Task<IReadOnlyDictionary<string, IAgentTool>> DiscoverAllToolsAsync(

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ToolCallModule.cs
@@ -14,14 +14,16 @@ namespace Aevatar.Workflow.Core.Modules;
 /// <summary>工具调用模块。处理 type=tool_call 的步骤。</summary>
 public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
 {
-    private readonly Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>> _toolIndex;
+    private readonly IEnumerable<IAgentToolSource> _toolSources;
+    private readonly ILogger _logger;
+    private volatile Task<IReadOnlyDictionary<string, IAgentTool>>? _toolIndex;
 
     public ToolCallModule(
         IEnumerable<IAgentToolSource> toolSources,
         ILogger<ToolCallModule> logger)
     {
-        _toolIndex = new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
-            () => DiscoverAllToolsAsync(toolSources, logger));
+        _toolSources = toolSources;
+        _logger = logger;
     }
 
     public string Name => "tool_call";
@@ -63,7 +65,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             CallId = request.StepId,
         }, TopologyAudience.Self, ct);
 
-        var toolIndex = await _toolIndex.Value;
+        var toolIndex = await GetOrDiscoverAsync(ct);
         if (!toolIndex.TryGetValue(toolName, out var tool))
         {
             const string notFound = "tool not found or no tool sources configured";
@@ -97,9 +99,19 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
         }
     }
 
+    private Task<IReadOnlyDictionary<string, IAgentTool>> GetOrDiscoverAsync(CancellationToken ct)
+    {
+        var current = _toolIndex;
+        if (current is { IsFaulted: false }) return current;
+        var task = DiscoverAllToolsAsync(_toolSources, _logger, ct);
+        var winner = Interlocked.CompareExchange(ref _toolIndex, task, current);
+        return winner ?? task;
+    }
+
     private static async Task<IReadOnlyDictionary<string, IAgentTool>> DiscoverAllToolsAsync(
         IEnumerable<IAgentToolSource> toolSources,
-        ILogger logger)
+        ILogger logger,
+        CancellationToken ct)
     {
         var index = new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase);
         foreach (var source in toolSources)
@@ -107,7 +119,7 @@ public sealed class ToolCallModule : IEventModule<IWorkflowExecutionContext>
             IReadOnlyList<IAgentTool> tools;
             try
             {
-                tools = await source.DiscoverToolsAsync();
+                tools = await source.DiscoverToolsAsync(ct);
             }
             catch (Exception ex)
             {

--- a/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Runtime.CompilerServices;
 using System.Reflection;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -599,9 +600,10 @@ public class AIComponentCoverageTests
             allowedTools: ["tool-a"],
             allowedInputKeys: ["q"]);
 
-        SetPrivateField(connector, "_initialized", true);
-        var tools = GetPrivateField<Dictionary<string, IAgentTool>>(connector, "_tools");
-        tools["tool-a"] = new StubTool("tool-a");
+        SetPrivateField(connector, "_tools",
+            new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
+                Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
+                    new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase) { ["tool-a"] = new StubTool("tool-a") })));
 
         var success = await connector.ExecuteAsync(new Aevatar.Foundation.Abstractions.Connectors.ConnectorRequest
         {
@@ -630,7 +632,10 @@ public class AIComponentCoverageTests
             serverConfig: new MCPServerConfig { Name = "server-2", Command = "missing-cmd" },
             allowedTools: [],
             allowedInputKeys: []);
-        SetPrivateField(discoveredMiss, "_initialized", true);
+        SetPrivateField(discoveredMiss, "_tools",
+            new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
+                Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
+                    new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase))));
 
         var notDiscovered = await discoveredMiss.ExecuteAsync(new Aevatar.Foundation.Abstractions.Connectors.ConnectorRequest
         {
@@ -643,8 +648,10 @@ public class AIComponentCoverageTests
             name: "mcp-3",
             serverConfig: new MCPServerConfig { Name = "server-3", Command = "missing-cmd" },
             defaultTool: "tool-x");
-        SetPrivateField(throwingConnector, "_initialized", true);
-        GetPrivateField<Dictionary<string, IAgentTool>>(throwingConnector, "_tools")["tool-x"] = new ThrowingTool("tool-x");
+        SetPrivateField(throwingConnector, "_tools",
+            new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
+                Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
+                    new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase) { ["tool-x"] = new ThrowingTool("tool-x") })));
 
         var caught = await throwingConnector.ExecuteAsync(new Aevatar.Foundation.Abstractions.Connectors.ConnectorRequest
         {

--- a/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
@@ -601,9 +601,8 @@ public class AIComponentCoverageTests
             allowedInputKeys: ["q"]);
 
         SetPrivateField(connector, "_tools",
-            new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
-                Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
-                    new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase) { ["tool-a"] = new StubTool("tool-a") })));
+            Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
+                new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase) { ["tool-a"] = new StubTool("tool-a") }));
 
         var success = await connector.ExecuteAsync(new Aevatar.Foundation.Abstractions.Connectors.ConnectorRequest
         {
@@ -633,9 +632,8 @@ public class AIComponentCoverageTests
             allowedTools: [],
             allowedInputKeys: []);
         SetPrivateField(discoveredMiss, "_tools",
-            new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
-                Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
-                    new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase))));
+            Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
+                new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase)));
 
         var notDiscovered = await discoveredMiss.ExecuteAsync(new Aevatar.Foundation.Abstractions.Connectors.ConnectorRequest
         {
@@ -649,9 +647,8 @@ public class AIComponentCoverageTests
             serverConfig: new MCPServerConfig { Name = "server-3", Command = "missing-cmd" },
             defaultTool: "tool-x");
         SetPrivateField(throwingConnector, "_tools",
-            new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
-                Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
-                    new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase) { ["tool-x"] = new ThrowingTool("tool-x") })));
+            Task.FromResult<IReadOnlyDictionary<string, IAgentTool>>(
+                new Dictionary<string, IAgentTool>(StringComparer.OrdinalIgnoreCase) { ["tool-x"] = new ThrowingTool("tool-x") }));
 
         var caught = await throwingConnector.ExecuteAsync(new Aevatar.Foundation.Abstractions.Connectors.ConnectorRequest
         {


### PR DESCRIPTION
## Issue

[MEDIUM] MCPConnector, MCPAgentToolSource, MCPClientManager use SemaphoreSlim/lock + mutable Dictionary/List as singleton state.

## Fix Summary

- MCPConnector: `SemaphoreSlim + Dictionary + volatile bool` → `volatile Task<T>` with `Interlocked.CompareExchange`, FrozenDictionary result
- MCPAgentToolSource: `SemaphoreSlim + nullable cached list` → same CAS pattern
- MCPClientManager: `List<McpClient>` → `ImmutableList` with `ImmutableInterlocked.Update`
- ToolCallModule: Updated `DiscoverToolsAsync` to forward CancellationToken
- CancellationToken now forwarded to connection/discovery phase
- Faulted/cancelled tasks retry on next call (checks `IsCompletedSuccessfully`)
- CAS return value correctly uses new task on successful swap

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| arch-reviewer | Opus | R1: APPROVED, R2: CHANGES_REQUESTED (CAS bug + cancelled cache) |
| arch-reviewer | Sonnet | R1: CHANGES_REQUESTED (CancellationToken) |
| quality-reviewer | Opus | R1: CHANGES_REQUESTED (faulted Lazy), R2: CHANGES_REQUESTED (CAS bug) |
| quality-reviewer | Sonnet | R1: CHANGES_REQUESTED (CancellationToken + faulted Lazy) |
| ci-guard-runner | Sonnet | R1: PASSED, R2: PASSED |

**Review rounds:** 3/3 (R1 feedback fixed in R2, R2 feedback fixed in R3)

## Referenced CLAUDE.md Rules

> 无锁优先：需加锁 → 先判定为"破坏 Actor 边界"
> 禁止中间层维护 ID → 上下文/事实状态的进程内映射

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team