### PR TITLE
refactor: Add production guard for InMemory actor runtime backends

### DIFF
--- a/src/Aevatar.Foundation.Runtime.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -65,6 +65,8 @@ public static class ServiceCollectionExtensions
             options.EventSourcingRetainedEventsAfterSnapshot = eventSourcingRetainedEvents;
         configure?.Invoke(options);
 
+        EnforceActorRuntimeInMemoryPolicy(configuration, options);
+
         services.Replace(ServiceDescriptor.Singleton(options));
 
         if (string.Equals(options.Provider, AevatarActorRuntimeOptions.ProviderInMemory, StringComparison.OrdinalIgnoreCase))
@@ -126,6 +128,69 @@ public static class ServiceCollectionExtensions
             eventSourcingOptions.EnableEventCompaction = options.EventSourcingEnableEventCompaction;
             eventSourcingOptions.RetainedEventsAfterSnapshot = options.EventSourcingRetainedEventsAfterSnapshot;
         });
+    }
+
+    private static void EnforceActorRuntimeInMemoryPolicy(
+        IConfiguration configuration,
+        AevatarActorRuntimeOptions options)
+    {
+        var sectionPrefix = $"{AevatarActorRuntimeOptions.SectionName}:Policies";
+        var denyInMemory = ResolveOptionalBool(
+            configuration[$"{sectionPrefix}:DenyInMemoryBackends"],
+            fallbackValue: false);
+        var environment = ResolveRuntimeEnvironment(configuration[$"{sectionPrefix}:Environment"]);
+        var production = IsProductionEnvironment(environment);
+
+        if (!denyInMemory && !production)
+            return;
+
+        var inMemoryBackends = new List<string>();
+
+        if (string.Equals(options.Provider, AevatarActorRuntimeOptions.ProviderInMemory, StringComparison.OrdinalIgnoreCase))
+            inMemoryBackends.Add("Provider");
+
+        if (string.Equals(options.OrleansStreamBackend, AevatarActorRuntimeOptions.OrleansStreamBackendInMemory, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(options.Provider, AevatarActorRuntimeOptions.ProviderOrleans, StringComparison.OrdinalIgnoreCase))
+            inMemoryBackends.Add("OrleansStreamBackend");
+
+        if (string.Equals(options.OrleansPersistenceBackend, AevatarActorRuntimeOptions.OrleansPersistenceBackendInMemory, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(options.Provider, AevatarActorRuntimeOptions.ProviderOrleans, StringComparison.OrdinalIgnoreCase))
+            inMemoryBackends.Add("OrleansPersistenceBackend");
+
+        if (inMemoryBackends.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"InMemory actor runtime backends are not allowed in production. " +
+                $"The following backends are set to InMemory: {string.Join(", ", inMemoryBackends)}. " +
+                $"Configure durable backends or set ActorRuntime:Policies:DenyInMemoryBackends to false for non-production use.");
+        }
+    }
+
+    private static string ResolveRuntimeEnvironment(string? configuredEnvironment)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredEnvironment))
+            return configuredEnvironment.Trim();
+
+        var dotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        if (!string.IsNullOrWhiteSpace(dotnetEnvironment))
+            return dotnetEnvironment.Trim();
+
+        var aspnetEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        return aspnetEnvironment?.Trim() ?? "";
+    }
+
+    private static bool IsProductionEnvironment(string environment) =>
+        string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
+
+    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue))
+            return fallbackValue;
+
+        if (!bool.TryParse(rawValue, out var parsed))
+            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
+
+        return parsed;
     }
 
     private static void ConfigureMassTransitTransport(

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/AevatarActorRuntimeServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/AevatarActorRuntimeServiceCollectionExtensionsTests.cs
@@ -321,6 +321,99 @@ public class AevatarActorRuntimeServiceCollectionExtensionsTests
             .WithMessage("*Garnet connection string is required*");
     }
 
+    [Fact]
+    public void AddAevatarActorRuntime_WhenProductionAndProviderIsInMemory_ShouldThrow()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:Policies:Environment"] = "Production",
+        });
+
+        var act = () => services.AddAevatarActorRuntime(configuration);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*InMemory actor runtime backends are not allowed in production*")
+            .WithMessage("*Provider*");
+    }
+
+    [Fact]
+    public void AddAevatarActorRuntime_WhenProductionAndOrleansWithInMemoryBackends_ShouldThrow()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:Provider"] = AevatarActorRuntimeOptions.ProviderOrleans,
+            [$"{AevatarActorRuntimeOptions.SectionName}:OrleansStreamBackend"] = AevatarActorRuntimeOptions.OrleansStreamBackendInMemory,
+            [$"{AevatarActorRuntimeOptions.SectionName}:OrleansPersistenceBackend"] = AevatarActorRuntimeOptions.OrleansPersistenceBackendInMemory,
+            [$"{AevatarActorRuntimeOptions.SectionName}:Policies:Environment"] = "Production",
+        });
+
+        var act = () => services.AddAevatarActorRuntime(configuration);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*InMemory actor runtime backends are not allowed in production*")
+            .WithMessage("*OrleansStreamBackend*")
+            .WithMessage("*OrleansPersistenceBackend*");
+    }
+
+    [Fact]
+    public void AddAevatarActorRuntime_WhenDenyInMemoryAndProviderIsInMemory_ShouldThrow()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:Policies:DenyInMemoryBackends"] = "true",
+        });
+
+        var act = () => services.AddAevatarActorRuntime(configuration);
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*InMemory actor runtime backends are not allowed in production*")
+            .WithMessage("*Provider*");
+    }
+
+    [Fact]
+    public void AddAevatarActorRuntime_WhenProductionAndOrleansDurableBackends_ShouldSucceed()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:Provider"] = AevatarActorRuntimeOptions.ProviderOrleans,
+            [$"{AevatarActorRuntimeOptions.SectionName}:OrleansStreamBackend"] = AevatarActorRuntimeOptions.OrleansStreamBackendMassTransitAdapter,
+            [$"{AevatarActorRuntimeOptions.SectionName}:OrleansPersistenceBackend"] = AevatarActorRuntimeOptions.OrleansPersistenceBackendGarnet,
+            [$"{AevatarActorRuntimeOptions.SectionName}:OrleansGarnetConnectionString"] = "garnet.local:6379",
+            [$"{AevatarActorRuntimeOptions.SectionName}:MassTransitTransportBackend"] = AevatarActorRuntimeOptions.MassTransitTransportBackendKafka,
+            [$"{AevatarActorRuntimeOptions.SectionName}:MassTransitKafkaBootstrapServers"] = "kafka.local:9092",
+            [$"{AevatarActorRuntimeOptions.SectionName}:MassTransitKafkaTopicName"] = "events",
+            [$"{AevatarActorRuntimeOptions.SectionName}:MassTransitKafkaConsumerGroup"] = "group",
+            [$"{AevatarActorRuntimeOptions.SectionName}:Policies:Environment"] = "Production",
+        });
+
+        var act = () => services.AddAevatarActorRuntime(configuration);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddAevatarActorRuntime_WhenNonProductionEnvironment_ShouldAllowInMemory()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:Policies:Environment"] = "Development",
+        });
+
+        services.AddAevatarActorRuntime(configuration);
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<AevatarActorRuntimeOptions>().Provider
+            .Should().Be(AevatarActorRuntimeOptions.ProviderInMemory);
+    }
+
     private static IConfiguration BuildConfiguration(Dictionary<string, string?>? values = null)
     {
         var builder = new ConfigurationBuilder();


### PR DESCRIPTION
## Issue

AevatarActorRuntimeOptions defaults Provider, OrleansStreamBackend, and OrleansPersistenceBackend to "InMemory". The projection provider layer has production guards (EnforceDocumentProviderPolicy/EnforceGraphProviderPolicy), but the actor runtime hosting layer had none — a production deployment omitting configuration would silently lose all data on restart.

## Fix Summary

- Added `EnforceActorRuntimeInMemoryPolicy` guard following the established projection provider pattern
- Checks `ActorRuntime:Policies:Environment` (with DOTNET_ENVIRONMENT/ASPNETCORE_ENVIRONMENT fallback)
- Checks `ActorRuntime:Policies:DenyInMemoryBackends` for explicit denial
- Throws InvalidOperationException listing offending backends when InMemory is used in production
- Orleans sub-backends only checked when Provider is Orleans
- 5 new tests covering production throw, Orleans sub-backends, explicit deny, durable success, and dev allowed

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| arch-reviewer | Opus | APPROVED |
| arch-reviewer | Sonnet | CHANGES_REQUESTED (false negative — read wrong file version) |
| quality-reviewer | Opus | APPROVED |
| quality-reviewer | Sonnet | APPROVED |
| ci-guard-runner | Sonnet | PASSED |

**Review rounds:** 1/3
**Non-blocking notes:**
- Error message says "in production" even when triggered by DenyInMemoryBackends flag (minor wording)
- Helper methods (ResolveRuntimeEnvironment etc.) duplicated across guard files (pre-existing pattern)

## Referenced CLAUDE.md Rules

- "InMemory 实现仅限开发/测试，不外溢到中间层业务语义"
- "渐进演进：开发期可用本地/内存实现，但生产语义必须能无缝迁移到分布式与持久化"

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team