### PR TITLE
refactor: Make ChatRuntime stream history handoff explicit via Task result

### DIFF
--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -125,11 +125,12 @@ public sealed class ChatRuntime
             CancellationToken = runToken,
         };
 
-        // Collect history mutations from the background thread; apply on caller context after task completes.
-        var pendingHistoryMessages = new List<ChatMessage>();
-
+        // The background task collects history mutations and returns them as its result.
+        // The caller applies them to _history after awaiting, making the producer-consumer
+        // contract explicit through the Task<List<ChatMessage>> return type.
         var runTask = Task.Run(async () =>
         {
+            var pendingHistoryMessages = new List<ChatMessage>();
             var wroteOutput = false;
             try
             {
@@ -236,10 +237,12 @@ public sealed class ChatRuntime
                 }
 
                 channel.Writer.TryComplete();
+                return pendingHistoryMessages;
             }
             catch (Exception ex)
             {
                 channel.Writer.TryComplete(ex);
+                return pendingHistoryMessages;
             }
         });
 
@@ -251,11 +254,19 @@ public sealed class ChatRuntime
         finally
         {
             linkedCts.Cancel();
-            try { await runTask.ConfigureAwait(false); } catch { /* best-effort */ }
+            List<ChatMessage>? collectedHistory = null;
+            try
+            {
+                collectedHistory = await runTask.ConfigureAwait(false);
+            }
+            catch { /* best-effort — errors already surfaced via channel */ }
 
             // Apply collected history mutations on the caller context after the background task completes.
-            foreach (var msg in pendingHistoryMessages)
-                _history.Add(msg);
+            if (collectedHistory != null)
+            {
+                foreach (var msg in collectedHistory)
+                    _history.Add(msg);
+            }
         }
     }
 


### PR DESCRIPTION
## Issue

ChatRuntime.ChatStreamAsync used Task.Run with pendingHistoryMessages as a closure-captured shared variable between background thread and caller. While technically correct (task completion is a synchronization barrier), the pattern is fragile and violates the spirit of "回调只发信号" rule.

## Fix Summary

- Moved `pendingHistoryMessages` from closure-captured variable to task-local variable
- Background task returns `List<ChatMessage>` as `Task<List<ChatMessage>>` result
- Caller reads history from `await runTask` in finally block, then applies to `_history`
- Producer-consumer contract now explicit through type system instead of implicit closure sharing

## Review Record

| Reviewer | Model | Verdict |
|----------|-------|---------|
| arch-reviewer | Opus | APPROVED |
| arch-reviewer | Sonnet | APPROVED |
| quality-reviewer | Opus | APPROVED |
| quality-reviewer | Sonnet | APPROVED |
| ci-guard-runner | Sonnet | PASSED |

**Review rounds:** 1/3

## Referenced CLAUDE.md Rules

- "回调只发信号：Task.Run/Timer/线程池回调不直接读写运行态或推进业务"

🤖 Generated with [Claude Code](https://claude.com/claude-code) Refactoring Team