### PR TITLE
fix(ci): add grep fallback for distributed smoke health check

### DIFF
--- a/tools/ci/distributed_smoke_common.sh
+++ b/tools/ci/distributed_smoke_common.sh
@@ -223,8 +223,15 @@ wait_elasticsearch_health() {
   local try=0
 
   while (( try < attempts )); do
+    local health_payload
     local status
-    status="$(curl --max-time 2 -s "${endpoint}/_cluster/health" | rg -o "\"status\":\"[^\"]+\"" || true)"
+    health_payload="$(curl --max-time 2 -s "${endpoint}/_cluster/health" || true)"
+    if command -v rg >/dev/null 2>&1; then
+      status="$(printf '%s' "${health_payload}" | rg -o "\"status\":\"[^\"]+\"" || true)"
+    else
+      status="$(printf '%s' "${health_payload}" | grep -E -o "\"status\":\"[^\"]+\"" || true)"
+    fi
+
     if [[ "${status}" == "\"status\":\"green\"" || "${status}" == "\"status\":\"yellow\"" ]]; then
       echo "Elasticsearch is ready: ${status}"
       return 0


### PR DESCRIPTION
## Summary
- make the distributed smoke Elasticsearch health check work when `rg` is not installed
- keep the existing `rg` path but fall back to `grep -E -o` on runners without ripgrep
- fix the remote `distributed-3node-smoke` and `distributed-mixed-version-smoke` failures caused by `tools/ci/distributed_smoke_common.sh: rg: command not found`

## Validation
- `bash -n tools/ci/distributed_smoke_common.sh`
- simulated the health check against a temporary local HTTP endpoint with `PATH` restricted so `rg` was unavailable; the fallback matched `"status":"yellow"` successfully

## Notes
- local `dev` was reset back to `origin/dev`
- untracked files `TODOS.md` and `docs/superpowers/` were left untouched