### PR TITLE
Feat/2026 04 09 console web ai teams

### DIFF
--- a/apps/aevatar-console-web/config/routes.ts
+++ b/apps/aevatar-console-web/config/routes.ts
@@ -10,8 +10,6 @@
  * @param icon 配置路由的图标，取值参考 https://ant.design/components/icon-cn， 注意去除风格后缀和大小写，如想要配置图标为 <StepBackwardOutlined /> 则取值应为 stepBackward 或 StepBackward，如想要配置图标为 <UserOutlined /> 则取值应为 user 或者 User
  * @doc https://umijs.org/docs/guides/routes
  */
-const HOME_REDIRECT = '/teams';
-
 export default [
   {
     path: "/login",
@@ -25,73 +23,63 @@ export default [
   },
   {
     path: "/overview",
-    redirect: HOME_REDIRECT,
+    redirect: "/teams",
     hideInMenu: true,
   },
   {
     path: "/teams",
-    name: "Teams",
-    component: "./teams",
-    menuGroupKey: "home",
-    hideInMenu: false,
+    name: "我的团队",
+    component: "./scopes/overview",
+    menuGroupKey: "teams",
+  },
+  {
+    path: "/teams/new",
+    name: "组建团队",
+    component: "./teams/new",
+    menuGroupKey: "teams",
   },
   {
     path: "/teams/:scopeId",
-    component: "./teams/detail",
+    name: "团队详情",
+    component: "./teams",
     hideInMenu: true,
     parentKeys: ["/teams"],
   },
   {
     path: "/scopes/assets",
-    name: "Assets",
     component: "./scopes/assets",
-    // postMenuData in app.tsx regroups flat routes into lifecycle menu sections.
-    menuGroupKey: "build",
-    menuBadgeKey: "build.assets",
     hideInMenu: true,
   },
   {
     path: "/studio",
-    name: "Studio",
     component: "./studio",
-    menuGroupKey: "build",
     hideInMenu: true,
   },
   {
     path: "/runtime/workflows",
-    name: "Workflows",
     component: "./workflows",
-    menuGroupKey: "build",
     hideInMenu: true,
   },
   {
     path: "/runtime/primitives",
-    name: "Capabilities",
+    name: "连接器",
     component: "./primitives",
-    menuGroupKey: "build",
     hideInMenu: true,
   },
   {
     path: "/chat",
-    name: "Chat",
     component: "./chat",
-    menuGroupKey: "chat",
     hideInMenu: true,
   },
   {
     path: "/scopes/invoke",
-    name: "Invoke Lab",
     component: "./scopes/invoke",
-    menuGroupKey: "live",
-    menuBadgeKey: "live.invoke",
     hideInMenu: true,
   },
   {
     path: "/runtime/runs",
-    name: "Runs",
+    name: "事件流",
     component: "./runs",
-    menuGroupKey: "platform",
-    menuBadgeKey: "live.runs",
     hideInMenu: true,
   },
   {
@@ -99,21 +87,17 @@ export default [
     name: "Mission Control",
     component: "./MissionControl",
     hideInMenu: true,
-    menuGroupKey: "live",
-    menuBadgeKey: "live.attention",
   },
   {
     path: "/runtime/explorer",
     name: "Topology",
     component: "./actors",
     menuGroupKey: "platform",
-    menuBadgeKey: "live.topology",
   },
   {
     path: "/runtime/gagents",
-    name: "Member Runtime",
+    name: "成员",
     component: "./gagents",
-    menuGroupKey: "live",
     hideInMenu: true,
   },
   {
@@ -121,7 +105,6 @@ export default [
     name: "Services",
     component: "./services",
     menuGroupKey: "platform",
-    menuBadgeKey: "governance.services",
   },
   {
     path: "/services/:serviceId",
@@ -134,14 +117,12 @@ export default [
     name: "Deployments",
     component: "./Deployments",
     menuGroupKey: "platform",
-    menuBadgeKey: "governance.deployments",
   },
   {
     path: "/governance",
     name: "Governance",
     component: "./governance",
     menuGroupKey: "platform",
-    menuBadgeKey: "governance.audit",
   },
   {
     path: "/governance/policies",
@@ -169,20 +150,28 @@ export default [
   },
   {
     path: "/scopes/overview",
-    name: "Team Overview",
-    component: "./scopes/overview",
-    menuGroupKey: "settings",
+    redirect: "/teams",
     hideInMenu: true,
   },
   {
     path: "/settings",
-    name: "Settings",
+    name: "设置",
     component: "./settings/account",
     menuGroupKey: "settings",
   },
   {
     path: "/scopes",
-    redirect: HOME_REDIRECT,
+    redirect: "/teams",
+    hideInMenu: true,
+  },
+  {
+    path: "/scopes/workflows",
+    component: "./scopes/workflows",
+    hideInMenu: true,
+  },
+  {
+    path: "/scopes/scripts",
+    component: "./scopes/scripts",
     hideInMenu: true,
   },
   {
@@ -191,8 +180,38 @@ export default [
     hideInMenu: true,
   },
   {
+    path: "/workflows",
+    redirect: "/runtime/workflows",
+    hideInMenu: true,
+  },
+  {
+    path: "/primitives",
+    redirect: "/runtime/primitives",
+    hideInMenu: true,
+  },
+  {
+    path: "/runs",
+    redirect: "/runtime/runs",
+    hideInMenu: true,
+  },
+  {
+    path: "/actors",
+    redirect: "/runtime/explorer",
+    hideInMenu: true,
+  },
+  {
+    path: "/gagents",
+    redirect: "/runtime/gagents",
+    hideInMenu: true,
+  },
+  {
+    path: "/mission-control",
+    redirect: "/runtime/mission-control",
+    hideInMenu: true,
+  },
+  {
     path: "/",
-    redirect: HOME_REDIRECT,
+    redirect: "/teams",
   },
   {
     component: "404",

--- a/apps/aevatar-console-web/config/routes.ts
+++ b/apps/aevatar-console-web/config/routes.ts
@@ -166,12 +166,12 @@ export default [
   },
   {
     path: "/scopes/workflows",
-    component: "./scopes/workflows",
+    redirect: "/runtime/workflows",
     hideInMenu: true,
   },
   {
     path: "/scopes/scripts",
-    component: "./scopes/scripts",
+    redirect: "/studio?tab=scripts",
     hideInMenu: true,
   },
   {

--- a/apps/aevatar-console-web/src/app.tsx
+++ b/apps/aevatar-console-web/src/app.tsx
@@ -4,6 +4,8 @@ import {
   ProConfigProvider,
 } from "@ant-design/pro-components";
 import {
+  AppstoreOutlined,
+  DashboardOutlined,
   DownOutlined,
   LogoutOutlined,
   SettingOutlined,
@@ -23,7 +25,6 @@ import {
   ensureActiveAuthSession,
   hasRestorableAuthSession,
 } from "./shared/auth/client";
-import { isTeamFirstEnabled } from "@/shared/config/consoleFeatures";
 import { getNyxIDRuntimeConfig } from "./shared/auth/config";
 import {
   buildAuthInitialState,
@@ -39,7 +40,6 @@ import { readMissionControlRouteContext } from "@/pages/MissionControl/services/
 import { loadRecentRuns } from "@/shared/runs/recentRuns";
 import { queryClient } from "./shared/query/queryClient";
 import { aevatarThemeConfig } from "@/shared/ui/aevatarWorkbench";
-import { getNavigationGroupOrder } from "@/shared/navigation/navigationGroups";
 
 const PUBLIC_ROUTES = new Set(["/login", "/auth/callback"]);
 const DEFAULT_PROTECTED_ROUTE = CONSOLE_HOME_ROUTE;
@@ -105,6 +105,13 @@ type NavigationMenuItem = {
   [key: string]: unknown;
 };
 
+type NavigationGroup = {
+  flattenSingleItem?: boolean;
+  icon: React.ReactNode;
+  key: string;
+  label: string;
+};
+
 type AuthSessionBootstrapProps = {
   pathname: string;
   children: React.ReactNode;
@@ -114,6 +121,24 @@ const LIVE_OPS_ATTENTION_BADGE_KEY = "live.attention";
 const LIVE_OPS_ATTENTION_MAX_CANDIDATES = 6;
 const LIVE_OPS_ATTENTION_MAX_AGE_MS = 12 * 60 * 60 * 1000;
 const LIVE_OPS_ATTENTION_REFRESH_MS = 30_000;
+const NAVIGATION_GROUP_ORDER: readonly NavigationGroup[] = [
+  {
+    icon: <AppstoreOutlined />,
+    key: "teams",
+    label: "Teams",
+  },
+  {
+    icon: <DashboardOutlined />,
+    key: "platform",
+    label: "Platform",
+  },
+  {
+    flattenSingleItem: true,
+    icon: <SettingOutlined />,
+    key: "settings",
+    label: "Settings",
+  },
+] as const;
 const LIVE_OPS_DEFAULT_ATTENTION_SNAPSHOT: LiveOpsAttentionSnapshot = {
   hasPendingAttention: false,
   pendingCount: 0,
@@ -441,8 +466,7 @@ function groupNavigationMenuItems(items: NavigationMenuItem[]): NavigationMenuIt
     grouped.set(groupKey, [item]);
   }
 
-  const navigationGroupOrder = getNavigationGroupOrder();
-  const menuGroups = navigationGroupOrder.flatMap((group) => {
+  const menuGroups = NAVIGATION_GROUP_ORDER.flatMap((group) => {
     const children = grouped.get(group.key);
     if (!children || children.length === 0) {
       return [];

--- a/apps/aevatar-console-web/src/pages/gagents/index.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.tsx
@@ -257,7 +257,7 @@ function createBindingEndpointDraft(
     requestTypeUrl:
       overrides?.requestTypeUrl ?? DEFAULT_GAGENT_REQUEST_TYPE_URL,
     responseTypeUrl: overrides?.responseTypeUrl ?? '',
-    description: overrides?.description ?? 'Run the published team entry.',
+    description: overrides?.description ?? 'Run the published GAgent.',
   };
 }
 
@@ -626,18 +626,18 @@ const GAgentsPage: React.FC = () => {
 
   const bindingImpactMessage = useMemo(() => {
     if (!selectedType) {
-      return 'Select a discovered member type to prepare a published binding.';
+      return 'Select a discovered GAgent type to prepare a published binding.';
     }
 
     if (!bindingQuery.data?.available || !currentBindingRevision) {
-      return 'This will create the first published default service for the current team.';
+      return 'This will create the first published default service for the current scope.';
     }
 
     if (currentBindingMatchesSelectedType) {
-      return 'This will publish a new revision for the current team entry without changing the product surface.';
+      return 'This will publish a new revision for the current GAgent service without changing the product surface.';
     }
 
-    return `This will replace the current default service (${formatRuntimeGAgentBindingImplementationKind(currentBindingRevision.implementationKind)} · ${describeRuntimeGAgentBindingRevisionTarget(currentBindingRevision)}) with the selected member type.`;
+    return `This will replace the current default service (${formatRuntimeGAgentBindingImplementationKind(currentBindingRevision.implementationKind)} · ${describeRuntimeGAgentBindingRevisionTarget(currentBindingRevision)}) with the selected GAgent type.`;
   }, [
     bindingQuery.data?.available,
     currentBindingMatchesSelectedType,
@@ -812,7 +812,7 @@ const GAgentsPage: React.FC = () => {
       setRegistryNotice({
         type: 'error',
         message:
-          'Select a team, choose a member type, and enter an actor id before saving.',
+          'Select a scope, choose a GAgent type, and enter an actor id before saving.',
       });
       return;
     }
@@ -862,7 +862,7 @@ const GAgentsPage: React.FC = () => {
     if (!normalizedScopeId) {
       setRegistryNotice({
         type: 'error',
-        message: 'Team context is required before removing a saved actor.',
+        message: 'Scope is required before removing a saved actor.',
       });
       return;
     }
@@ -1023,7 +1023,7 @@ const GAgentsPage: React.FC = () => {
       setBindingNotice({
         type: 'error',
         message:
-          'Resolve the current team before publishing a binding.',
+          'Resolve the current scope before publishing a GAgent binding.',
       });
       return;
     }
@@ -1031,7 +1031,7 @@ const GAgentsPage: React.FC = () => {
     if (!actorTypeName) {
       setBindingNotice({
         type: 'error',
-        message: 'Choose a discovered member type before publishing a binding.',
+        message: 'Choose a discovered GAgent type before publishing a binding.',
       });
       return;
     }
@@ -1041,7 +1041,7 @@ const GAgentsPage: React.FC = () => {
       setBindingNotice({
         type: 'error',
         message:
-          'Add at least one published endpoint before binding the selected member type.',
+          'Add at least one published endpoint before binding the selected GAgent.',
       });
       return;
     }
@@ -1128,7 +1128,7 @@ const GAgentsPage: React.FC = () => {
       setIsRevisionDrawerOpen(true);
       setBindingNotice({
         type: 'success',
-        message: `Team ${result.scopeId} is now serving revision ${result.revisionId}.`,
+        message: `Scope ${result.scopeId} is now serving revision ${result.revisionId}.`,
       });
     } catch (error) {
       setBindingNotice({
@@ -1181,7 +1181,7 @@ const GAgentsPage: React.FC = () => {
     if (!normalizedScopeId || !normalizedActorTypeName || !normalizedPrompt) {
       setRunState((current) => ({
         ...current,
-        error: 'Team, member type, and prompt are required before running.',
+        error: 'Scope, GAgent type, and prompt are required before running.',
         status: 'error',
       }));
       return;
@@ -1357,17 +1357,17 @@ const GAgentsPage: React.FC = () => {
   const rail = (
     <div style={cliRailShellStyle}>
       <div style={cliRailSectionStyle}>
-        <div style={cliCardLabelStyle}>Team Context</div>
+        <div style={cliCardLabelStyle}>Scope Context</div>
         <Input
-          aria-label="Team ID"
+          aria-label="Scope ID"
           onChange={(event) => setScopeId(event.target.value)}
-          placeholder="Team ID"
+          placeholder="Scope ID"
           value={scopeId}
         />
         <Typography.Text type="secondary">
           {resolvedScope?.scopeId
-            ? `NyxID resolved team: ${resolvedScope.scopeId}`
-            : 'No team was resolved from the current session.'}
+            ? `NyxID resolved scope: ${resolvedScope.scopeId}`
+            : 'No scope was resolved from the current session.'}
         </Typography.Text>
         {bindingQuery.data?.available ? (
           <div
@@ -1418,7 +1418,7 @@ const GAgentsPage: React.FC = () => {
               justifyContent: 'space-between',
             }}
           >
-            <div style={cliCardLabelStyle}>Member Types</div>
+            <div style={cliCardLabelStyle}>GAgent Types</div>
             <Button
               icon={<ReloadOutlined />}
               onClick={() => void gAgentTypesQuery.refetch()}
@@ -1429,9 +1429,9 @@ const GAgentsPage: React.FC = () => {
             </Button>
           </div>
           <Input
-            aria-label="Filter member types"
+            aria-label="Filter GAgent types"
             onChange={(event) => setTypeFilter(event.target.value)}
-            placeholder="Filter member types"
+            placeholder="Filter GAgent types"
             value={typeFilter}
           />
           {gAgentTypesQuery.error ? (
@@ -1448,8 +1448,8 @@ const GAgentsPage: React.FC = () => {
             <Empty
               description={
                 gAgentTypesQuery.isLoading
-                  ? 'Loading runtime member types.'
-                  : 'No member types matched the current filter.'
+                  ? 'Loading runtime GAgent types.'
+                  : 'No GAgent types matched the current filter.'
               }
               image={Empty.PRESENTED_IMAGE_SIMPLE}
             />
@@ -1532,7 +1532,7 @@ const GAgentsPage: React.FC = () => {
 
   const selectedTypePanel = (
     <WorkbenchCard
-      description="Current member type selection that drives both draft runs and published bindings."
+      description="Current type selection that drives both draft runs and published bindings."
       eyebrow="Selected Type"
       extra={
         <Space size={[8, 8]} wrap>
@@ -1597,7 +1597,7 @@ const GAgentsPage: React.FC = () => {
           </div>
         </div>
       ) : (
-        <AevatarInspectorEmpty description="Choose a discovered member type from the left rail to prepare draft runs or published bindings." />
+        <AevatarInspectorEmpty description="Choose a discovered GAgent type from the left rail to prepare draft runs or published bindings." />
       )}
     </WorkbenchCard>
   );
@@ -1691,7 +1691,7 @@ const GAgentsPage: React.FC = () => {
                 {runState.assistantText}
               </Typography.Paragraph>
             ) : (
-              <AevatarInspectorEmpty description="Run a draft prompt to watch the streamed member response here." />
+              <AevatarInspectorEmpty description="Run a draft prompt to watch the streamed GAgent response here." />
             ),
           },
           {
@@ -1740,8 +1740,8 @@ const GAgentsPage: React.FC = () => {
     <WorkbenchCard
       description={
         selectedType
-          ? `Reusable actor ids saved for ${selectedType.typeName} in this team.`
-          : 'Reusable actor ids saved for this team.'
+          ? `Reusable actor ids saved for ${selectedType.typeName} in this scope.`
+          : 'Reusable actor ids saved for this scope.'
       }
       eyebrow="Actor Registry"
       extra={
@@ -1774,7 +1774,7 @@ const GAgentsPage: React.FC = () => {
           placeholder={
             selectedType
               ? `Save actor id for ${selectedType.typeName}`
-              : 'Select a member type before saving an actor'
+              : 'Select a GAgent type before saving an actor'
           }
           value={registryActorIdInput}
         />
@@ -1794,7 +1794,7 @@ const GAgentsPage: React.FC = () => {
           <Typography.Text type="secondary">
             {selectedType
               ? `Saving under ${selectedType.fullName}.`
-              : 'Saved actors follow the currently selected member type.'}
+              : 'Saved actors follow the currently selected GAgent type.'}
           </Typography.Text>
         </Space>
 
@@ -1809,7 +1809,7 @@ const GAgentsPage: React.FC = () => {
             description={
               gAgentActorsQuery.isLoading
                 ? 'Loading actor registry.'
-                : 'No saved actors were found for this team.'
+                : 'No saved actors were found for this scope.'
             }
             image={Empty.PRESENTED_IMAGE_SIMPLE}
           />
@@ -1938,8 +1938,8 @@ const GAgentsPage: React.FC = () => {
 
   const currentBindingPanel = (
     <WorkbenchCard
-      description="Current default service for this team."
-      eyebrow="Current Team Binding"
+      description="Current default service for this scope."
+      eyebrow="Current Scope Binding"
       extra={
         <Space size={[8, 8]} wrap>
           <Button
@@ -1975,7 +1975,7 @@ const GAgentsPage: React.FC = () => {
         ) : bindingQuery.isLoading ? (
           <AevatarInspectorEmpty description="Loading the current published binding." />
         ) : !bindingQuery.data?.available ? (
-          <AevatarInspectorEmpty description="No default team service has been published yet." />
+          <AevatarInspectorEmpty description="No default scope service has been published yet." />
         ) : (
           <>
             <div
@@ -2067,8 +2067,8 @@ const GAgentsPage: React.FC = () => {
 
   const publishBindingPanel = (
     <WorkbenchCard
-      description="Publish the selected member type as this team's default service."
-      eyebrow="Publish Team Binding"
+      description="Publish the selected GAgent type as this scope's default service."
+      eyebrow="Publish Binding"
       extra={
         <Button
           disabled={!selectedType}
@@ -2081,12 +2081,12 @@ const GAgentsPage: React.FC = () => {
       title={
         selectedType
           ? `Publish ${selectedType.typeName}`
-          : 'Publish Team Binding'
+          : 'Publish GAgent Binding'
       }
     >
       <Space direction="vertical" size={16} style={{ width: '100%' }}>
         {!selectedType ? (
-          <AevatarInspectorEmpty description="Choose a discovered member type before configuring a published binding." />
+          <AevatarInspectorEmpty description="Choose a discovered GAgent type before configuring a published binding." />
         ) : (
           <>
             <Tabs
@@ -2387,14 +2387,14 @@ const GAgentsPage: React.FC = () => {
               showIcon
               type={bindingQuery.data?.available ? 'warning' : 'info'}
               title={bindingImpactMessage}
-              description="Type = template. Binding = published team entry. Actor = runtime instance created by activation or invocation."
+              description="Type = template. Binding = published default service. Actor = runtime instance created by activation or invocation."
             />
 
             <Checkbox
               checked={publishAcknowledged}
               onChange={(event) => setPublishAcknowledged(event.target.checked)}
             >
-              I understand this changes the team's published default service.
+              I understand this changes the scope's published default service.
             </Checkbox>
 
             <Space size={[8, 8]} wrap>
@@ -2452,7 +2452,7 @@ const GAgentsPage: React.FC = () => {
           <AevatarInspectorEmpty description="Loading binding revisions." />
         ) : !bindingQuery.data?.available ||
           bindingQuery.data.revisions.length === 0 ? (
-          <AevatarInspectorEmpty description="Publish the selected member type to create the first revision." />
+          <AevatarInspectorEmpty description="Publish the selected GAgent to create the first revision." />
         ) : (
           <div style={compactListStyle}>
             {bindingQuery.data.revisions.map((revision) => {
@@ -2586,7 +2586,7 @@ const GAgentsPage: React.FC = () => {
 
   const draftRunPanel = (
     <WorkbenchCard
-      description="Test the selected member type before publishing."
+      description="Test the selected GAgent type before publishing."
       eyebrow="Draft Run"
       extra={
         <Space size={[8, 8]} wrap>
@@ -2594,7 +2594,7 @@ const GAgentsPage: React.FC = () => {
           {runState.runId ? <Tag>{runState.runId}</Tag> : null}
         </Space>
       }
-      title={selectedType ? selectedType.typeName : 'Member Draft Run'}
+      title={selectedType ? selectedType.typeName : 'GAgent Draft Run'}
     >
       <Space direction="vertical" size={16} style={{ width: '100%' }}>
         {selectedType ? (
@@ -2625,7 +2625,7 @@ const GAgentsPage: React.FC = () => {
             </div>
           </div>
         ) : (
-          <AevatarInspectorEmpty description="Select a discovered member type before drafting a direct run." />
+          <AevatarInspectorEmpty description="Select a discovered GAgent type before drafting a direct run." />
         )}
 
         <Select
@@ -2688,7 +2688,7 @@ const GAgentsPage: React.FC = () => {
           aria-label="Draft prompt"
           autoSize={{ minRows: 4, maxRows: 8 }}
           onChange={(event) => setPrompt(event.target.value)}
-          placeholder="Enter a direct prompt for the selected member type"
+          placeholder="Enter a direct prompt for the selected GAgent type"
           value={prompt}
         />
 
@@ -2789,14 +2789,14 @@ const GAgentsPage: React.FC = () => {
       layoutMode="document"
       extra={
         <Space size={[8, 8]} wrap>
-          <Typography.Text type="secondary">Team</Typography.Text>
+          <Typography.Text type="secondary">Scope</Typography.Text>
           <Typography.Text style={{ maxWidth: 320 }} strong>
             {normalizedScopeId || resolvedScope?.scopeId || 'Not resolved'}
           </Typography.Text>
         </Space>
       }
-      title="Member Runtime"
-      titleHelp="Discover runtime member types, publish team bindings, reuse actors, and verify draft and serving paths from one workbench."
+      title="团队成员"
+      titleHelp="这里保留原有 GAgent runtime 能力，但统一对外表述为团队成员管理与绑定工作台。"
     >
       <AevatarWorkbenchLayout
         layoutMode="document"
@@ -2807,7 +2807,7 @@ const GAgentsPage: React.FC = () => {
       <AevatarContextDrawer
         onClose={() => setIsActorRegistryDrawerOpen(false)}
         open={isActorRegistryDrawerOpen}
-        title="Actor Registry"
+        title="成员注册表"
         width={screens.xl ? 680 : 520}
       >
         {actorRegistryPanel}
@@ -2820,7 +2820,7 @@ const GAgentsPage: React.FC = () => {
             ? describeRuntimeGAgentBindingRevisionTarget(selectedRevision)
             : undefined
         }
-        title="Revision Details"
+        title="版本详情"
         width={screens.xl ? 620 : 480}
       >
         {selectedRevisionPanel}

--- a/apps/aevatar-console-web/src/pages/primitives/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/primitives/index.test.tsx
@@ -34,15 +34,15 @@ describe("PrimitivesPage", () => {
       React.createElement(PrimitivesPage),
     );
 
-    expect(container.textContent).toContain("Primitive Library");
+    expect(container.textContent).toContain("连接器目录");
     expect(
       screen.queryByText(
         "Primitive definitions are now managed as a runtime library workbench. The main stage stays dedicated to discovery while parameter contracts and example workflows live in the inspector.",
       ),
     ).toBeNull();
     expect(screen.getAllByRole("button", { name: "Show help" }).length).toBeGreaterThan(0);
-    expect(container.textContent).toContain("Runtime Primitives");
-    expect(container.textContent).toContain("Filter Library");
+    expect(container.textContent).toContain("可用连接器");
+    expect(container.textContent).toContain("筛选连接器");
     expect(container.textContent).not.toContain("Legacy draft");
     expect(container.textContent).not.toContain("Studio");
 
@@ -56,7 +56,7 @@ describe("PrimitivesPage", () => {
       React.createElement(PrimitivesPage),
     );
 
-    expect(await screen.findByText("Library Digest")).toBeTruthy();
+    expect(await screen.findByText("目录摘要")).toBeTruthy();
     expect(container.querySelector(".ant-select")).toHaveStyle({ width: "100%" });
   });
 
@@ -64,13 +64,13 @@ describe("PrimitivesPage", () => {
     renderWithQueryClient(React.createElement(PrimitivesPage));
 
     expect(await screen.findByText("Ready")).toBeTruthy();
-    expect(screen.getByText("Category")).toBeTruthy();
-    expect(screen.getByText("Parameters")).toBeTruthy();
-    expect(screen.getByText("Examples")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Inspect" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Example workflow" })).toBeTruthy();
+    expect(screen.getByText("分类")).toBeTruthy();
+    expect(screen.getByText("参数")).toBeTruthy();
+    expect(screen.getByText("示例")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "查看" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "示例行为定义" })).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Inspect primitive human_input" }),
+      screen.getByRole("button", { name: "查看连接器 human_input" }),
     ).toHaveStyle({
       width: "100%",
     });
@@ -80,9 +80,9 @@ describe("PrimitivesPage", () => {
     renderWithQueryClient(React.createElement(PrimitivesPage));
 
     fireEvent.click(
-      await screen.findByRole("button", { name: "Inspect primitive human_input" }),
+      await screen.findByRole("button", { name: "查看连接器 human_input" }),
     );
 
-    expect(await screen.findByText("Primitive contract")).toBeTruthy();
+    expect(await screen.findByText("连接器契约")).toBeTruthy();
   });
 });

--- a/apps/aevatar-console-web/src/pages/primitives/index.tsx
+++ b/apps/aevatar-console-web/src/pages/primitives/index.tsx
@@ -48,8 +48,8 @@ function buildPrimitiveSummary(primitive: WorkflowPrimitiveDescriptor): string {
   }
 
   return primitive.aliases.length > 0
-    ? `Aliases: ${primitive.aliases.join(", ")}`
-    : "Ready to inspect parameter contracts and example workflow coverage.";
+    ? `别名：${primitive.aliases.join(", ")}`
+    : "已就绪，可继续查看参数契约和示例行为定义。";
 }
 
 const PrimitiveSummaryMetric: React.FC<{
@@ -72,7 +72,7 @@ const PrimitiveCatalogCard: React.FC<{
 
   return (
     <div
-      aria-label={`Inspect primitive ${primitive.name}`}
+      aria-label={`查看连接器 ${primitive.name}`}
       onClick={onInspect}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
@@ -138,30 +138,30 @@ const PrimitiveCatalogCard: React.FC<{
           width: "100%",
         }}
       >
-        <PrimitiveSummaryMetric label="Category" value={primitive.category} />
+        <PrimitiveSummaryMetric label="分类" value={primitive.category} />
         <PrimitiveSummaryMetric
-          label="Parameters"
-          value={`${primitive.parameters.length} defined`}
+          label="参数"
+          value={`${primitive.parameters.length} 个`}
         />
         <PrimitiveSummaryMetric
-          label="Examples"
-          value={`${primitive.exampleWorkflows.length} linked`}
+          label="示例"
+          value={`${primitive.exampleWorkflows.length} 个`}
         />
       </div>
 
       <div style={cardListActionStyle}>
         <Button
-          aria-label="Inspect"
+          aria-label="查看"
           icon={<EyeOutlined />}
           onClick={(event) => {
             event.stopPropagation();
             onInspect();
           }}
         >
-          Inspect
+          查看
         </Button>
         <Button
-          aria-label="Example workflow"
+          aria-label="示例行为定义"
           disabled={!hasExampleWorkflow}
           icon={<BuildOutlined />}
           onClick={(event) => {
@@ -172,7 +172,7 @@ const PrimitiveCatalogCard: React.FC<{
           }}
           type="primary"
         >
-          Example workflow
+          示例行为定义
         </Button>
       </div>
     </div>
@@ -237,8 +237,8 @@ const PrimitivesPage: React.FC = () => {
   return (
     <AevatarPageShell
       layoutMode="document"
-      title="Primitive Library"
-      titleHelp="Primitive definitions are now managed as a runtime library workbench. The main stage stays dedicated to discovery while parameter contracts and example workflows live in the inspector."
+      title="连接器目录"
+      titleHelp="这里继续复用 runtime primitive 数据，但对外展示成团队可复用的连接器能力目录。"
     >
       <AevatarWorkbenchLayout
         layoutMode="document"
@@ -246,8 +246,8 @@ const PrimitivesPage: React.FC = () => {
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <AevatarPanel
               layoutMode="document"
-              title="Filter Library"
-              titleHelp="Filter by category or keyword without leaving the viewport."
+              title="筛选连接器"
+              titleHelp="按分类或关键字过滤连接器能力，不离开当前视口。"
             >
               <div
                 style={{
@@ -259,7 +259,7 @@ const PrimitivesPage: React.FC = () => {
               >
                 <Input
                   onChange={(event) => setKeyword(event.target.value)}
-                  placeholder="Search primitive, category, or alias"
+                  placeholder="搜索连接器、分类或别名"
                   style={{ width: "100%" }}
                   value={keyword}
                 />
@@ -267,7 +267,7 @@ const PrimitivesPage: React.FC = () => {
                   mode="multiple"
                   onChange={setSelectedCategories}
                   options={categoryOptions}
-                  placeholder="Filter categories"
+                  placeholder="筛选分类"
                   style={{ width: "100%" }}
                   value={selectedCategories}
                 />
@@ -278,23 +278,23 @@ const PrimitivesPage: React.FC = () => {
                     setSelectedPrimitiveName("");
                   }}
                 >
-                  Reset filters
+                  重置筛选
                 </Button>
               </div>
             </AevatarPanel>
 
-            <AevatarPanel layoutMode="document" title="Library Digest">
+            <AevatarPanel layoutMode="document" title="目录摘要">
               <Space direction="vertical" size={6}>
                 <Typography.Text strong>
-                  {filteredRows.length} primitives in view
+                  {filteredRows.length} 个连接器能力
                 </Typography.Text>
                 <Typography.Text type="secondary">
-                  {categoryOptions.length} categories ·{" "}
+                  {categoryOptions.length} 个分类 ·{" "}
                   {filteredRows.reduce(
                     (count, primitive) => count + primitive.parameters.length,
                     0,
                   )}{" "}
-                  parameters surfaced
+                  个已暴露参数
                 </Typography.Text>
               </Space>
             </AevatarPanel>
@@ -303,8 +303,8 @@ const PrimitivesPage: React.FC = () => {
         stage={
           <AevatarPanel
             layoutMode="document"
-            title="Runtime Primitives"
-            titleHelp="A card-flow library lets you scan categories and examples without collapsing into parameter tables."
+            title="可用连接器"
+            titleHelp="卡片流目录帮助你快速浏览能力分类、参数契约和示例行为定义。"
           >
             <ProList<WorkflowPrimitiveDescriptor>
               dataSource={filteredRows}
@@ -312,7 +312,7 @@ const PrimitivesPage: React.FC = () => {
               locale={{
                 emptyText: (
                   <Empty
-                    description="No primitives matched the current filter."
+                    description="当前筛选条件下没有匹配的连接器。"
                     image={Empty.PRESENTED_IMAGE_SIMPLE}
                   />
                 ),
@@ -343,16 +343,16 @@ const PrimitivesPage: React.FC = () => {
       <AevatarContextDrawer
         onClose={() => setSelectedPrimitiveName("")}
         open={Boolean(selectedPrimitiveName)}
-        subtitle="Primitive contract"
-        title={selectedPrimitive?.name || selectedPrimitiveName || "Primitive"}
+        subtitle="连接器契约"
+        title={selectedPrimitive?.name || selectedPrimitiveName || "连接器"}
       >
         {!selectedPrimitive ? (
-          <AevatarInspectorEmpty description="Choose a primitive to inspect its parameter contract and example workflow coverage." />
+          <AevatarInspectorEmpty description="选择一个连接器以查看它的参数契约和示例行为定义。" />
         ) : (
           <>
             <AevatarPanel
-              title="Definition"
-              titleHelp="Primitive description and aliases remain concise so the drawer stays decision-oriented."
+              title="定义"
+              titleHelp="连接器描述和别名保持精简，方便快速决策。"
             >
               <Space direction="vertical" size={8}>
                 <Space wrap size={[8, 8]}>
@@ -362,20 +362,20 @@ const PrimitivesPage: React.FC = () => {
                   </Typography.Text>
                 </Space>
                 <Typography.Text>
-                  {selectedPrimitive.description || "No primitive description."}
+                  {selectedPrimitive.description || "当前连接器还没有描述。"}
                 </Typography.Text>
                 <Typography.Text type="secondary">
-                  Aliases:{" "}
+                  别名：
                   {selectedPrimitive.aliases.length > 0
                     ? selectedPrimitive.aliases.join(", ")
-                    : "None"}
+                    : "无"}
                 </Typography.Text>
               </Space>
             </AevatarPanel>
 
             <AevatarPanel
-              title="Parameters"
-              titleHelp="Parameter contracts move here so the library stage can stay lightweight."
+              title="参数"
+              titleHelp="参数契约收进右侧抽屉，保持主目录轻量。"
             >
               {selectedPrimitive.parameters.length > 0 ? (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -395,7 +395,7 @@ const PrimitivesPage: React.FC = () => {
                         <Typography.Text strong>{parameter.name}</Typography.Text>
                         <AevatarStatusTag
                           domain="governance"
-                          label={parameter.required ? "Required" : "Optional"}
+                          label={parameter.required ? "必填" : "可选"}
                           status={parameter.required ? "ready" : "draft"}
                         />
                         <Typography.Text type="secondary">
@@ -403,25 +403,25 @@ const PrimitivesPage: React.FC = () => {
                         </Typography.Text>
                       </Space>
                       <Typography.Text type="secondary">
-                        {parameter.description || "No parameter description."}
+                        {parameter.description || "当前参数还没有描述。"}
                       </Typography.Text>
                       <Typography.Text type="secondary">
-                        Default: {parameter.default || "n/a"}
+                        默认值：{parameter.default || "n/a"}
                       </Typography.Text>
                     </div>
                   ))}
                 </div>
               ) : (
                 <Empty
-                  description="This primitive does not declare parameters."
+                  description="当前连接器没有声明参数。"
                   image={Empty.PRESENTED_IMAGE_SIMPLE}
                 />
               )}
             </AevatarPanel>
 
             <AevatarPanel
-              title="Example Coverage"
-              titleHelp="Examples form the bridge from primitive library to workflow design."
+              title="示例覆盖"
+              titleHelp="示例行为定义会把连接器目录和行为设计串起来。"
             >
               {selectedPrimitive.exampleWorkflows.length > 0 ? (
                 <Space direction="vertical" size={8} style={{ width: "100%" }}>
@@ -447,14 +447,14 @@ const PrimitivesPage: React.FC = () => {
                           )
                         }
                       >
-                        Open workflow
+                        打开行为定义
                       </Button>
                     </div>
                   ))}
                 </Space>
               ) : (
                 <Empty
-                  description="No example workflows were attached."
+                  description="当前还没有关联示例行为定义。"
                   image={Empty.PRESENTED_IMAGE_SIMPLE}
                 />
               )}

--- a/apps/aevatar-console-web/src/pages/runs/components/RunsTracePane.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/components/RunsTracePane.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import RunsTracePane from "./RunsTracePane";
 
@@ -30,5 +30,38 @@ describe("RunsTracePane", () => {
       minHeight: "0",
       overflow: "hidden",
     });
+  });
+
+  it("shows only the active trace pane when switching tabs", () => {
+    const Harness = () => {
+      const [view, setView] = React.useState<"timeline" | "messages" | "events">(
+        "timeline"
+      );
+
+      return (
+        <RunsTracePane
+          consoleView={view}
+          eventConsoleView={<div>events panel</div>}
+          eventCount={3}
+          hasPendingInteraction={false}
+          messageConsoleView={<div>messages panel</div>}
+          messageCount={2}
+          onConsoleViewChange={(key) => setView(key)}
+          timelineView={<div>timeline panel</div>}
+        />
+      );
+    };
+
+    const { queryByText } = render(<Harness />);
+
+    expect(screen.getByText("timeline panel")).toBeTruthy();
+    expect(queryByText("messages panel")).toBeNull();
+    expect(queryByText("events panel")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Messages" }));
+
+    expect(screen.getByText("messages panel")).toBeTruthy();
+    expect(queryByText("timeline panel")).toBeNull();
+    expect(queryByText("events panel")).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/pages/runs/components/RunsTracePane.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/components/RunsTracePane.tsx
@@ -77,6 +77,7 @@ const RunsTracePane: React.FC<RunsTracePaneProps> = ({
       <Tabs
         activeKey={consoleView}
         className={runsTraceTabsClassName}
+        destroyOnHidden
         style={workbenchTraceTabsStyle}
         items={[
           {

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -9,6 +9,7 @@ import {
 import { saveRecentRun } from "@/shared/runs/recentRuns";
 import { runtimeCatalogApi } from "@/shared/api/runtimeCatalogApi";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
+import { parseBackendSSEStream } from "@/shared/agui/sseFrameNormalizer";
 import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
 import RunsPage from "./index";
 
@@ -82,21 +83,6 @@ jest.mock("@/shared/api/runtimeRunsApi", () => ({
   },
 }));
 
-function getButtonByText(label: string): HTMLButtonElement {
-  const button = screen
-    .getAllByText((_, element) => element?.textContent?.trim() === label)
-    .map((element) =>
-      element instanceof HTMLButtonElement ? element : element.closest("button")
-    )
-    .find((element): element is HTMLButtonElement => element instanceof HTMLButtonElement);
-
-  if (!button) {
-    throw new Error(`Unable to find button with text '${label}'.`);
-  }
-
-  return button;
-}
-
 describe("RunsPage", () => {
   const mockedRuntimeCatalogApi = runtimeCatalogApi as unknown as {
     listWorkflowCatalog: jest.Mock;
@@ -109,6 +95,7 @@ describe("RunsPage", () => {
     signal: jest.Mock;
     stop: jest.Mock;
   };
+  const mockedParseBackendSSEStream = parseBackendSSEStream as jest.Mock;
 
   beforeEach(() => {
     window.history.replaceState({}, "", "/runtime/runs");
@@ -136,21 +123,74 @@ describe("RunsPage", () => {
     });
     mockedRuntimeRunsApi.streamDraftRun.mockResolvedValue({});
     mockedRuntimeCatalogApi.listWorkflowCatalog.mockResolvedValue([]);
+    mockedParseBackendSSEStream.mockImplementation(
+      () => (async function* () {})()
+    );
   });
 
   it("renders the runtime run console header and navigation actions", async () => {
     const { container } = renderWithQueryClient(React.createElement(RunsPage));
 
     expect(container.textContent).toContain("Runtime endpoint console");
-    expect(screen.getByLabelText("Open runtime console guide")).toBeTruthy();
-    expect(screen.getByText("Catalog")).toBeTruthy();
-    expect(screen.getByText("Explorer")).toBeTruthy();
-    expect(screen.queryByLabelText("Open observability hub")).toBeNull();
-    expect(screen.getByText("Inspector")).toBeTruthy();
-    expect(screen.getByLabelText("Scope ID")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Open runtime console guide" })
+    );
+    expect(
+      screen.getByRole("button", { name: "Catalog" })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "返回团队高级编辑" })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Explorer" })
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Open observability hub" })
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Inspector" })).toBeTruthy();
+    expect(
+      screen.getByPlaceholderText("Describe the task to run.")
+    ).toBeTruthy();
     expect(container.textContent).toContain("Launch rail");
     expect(container.textContent).toContain("Run trace");
     expect(container.textContent).toContain("Inspector");
+  });
+
+  it("navigates back to the team advanced tab from the runs console", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/runtime/runs?scopeId=scope-1"
+    );
+
+    renderWithQueryClient(React.createElement(RunsPage));
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "返回团队高级编辑" })
+    );
+
+    expect(window.location.pathname).toBe("/teams/scope-1");
+    expect(new URLSearchParams(window.location.search).get("tab")).toBe(
+      "advanced"
+    );
+  });
+
+  it("keeps the trace workspace viewport stretchable so the inner console can scroll", async () => {
+    const { container } = renderWithQueryClient(React.createElement(RunsPage));
+
+    const tabs = container.querySelectorAll(".ant-tabs");
+    expect(tabs[0]).toHaveStyle({
+      flex: "1",
+      minHeight: "0",
+    });
+
+    const contentHolder = tabs[0]?.querySelector(".ant-tabs-content-holder");
+    expect(contentHolder).not.toBeNull();
+    expect(contentHolder).toHaveStyle({
+      flex: "1",
+      minHeight: "0",
+      overflow: "hidden",
+    });
   });
 
   it("uses the generic invoke path for prepared service invocation drafts", async () => {
@@ -168,13 +208,8 @@ describe("RunsPage", () => {
 
     renderWithQueryClient(React.createElement(RunsPage));
 
-    const promptInput = await screen.findByDisplayValue("script payload");
-    // ProForm's custom submitter buttons don't render in jsdom; submit via the
-    // form element which exercises the same onFinish path as the button's
-    // onClick={() => props.form?.submit?.()) wiring.
-    const form = promptInput.closest("form");
-    expect(form).toBeTruthy();
-    fireEvent.submit(form!);
+    await screen.findByDisplayValue("script payload");
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
 
     await waitFor(() => {
       expect(mockedRuntimeRunsApi.invokeEndpoint).toHaveBeenCalledWith(
@@ -235,6 +270,120 @@ describe("RunsPage", () => {
 
     expect(new URLSearchParams(window.location.search).get("draftKey")).toBeNull();
     expect(loadDraftRunPayload(draftKey)).toBeNull();
+  });
+
+  it("retries chat runs against the scope default binding when a stale service id is missing", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/runtime/runs?scopeId=scope-1&route=hello-chat&serviceOverrideId=scope-1:default:default:hello-chat&prompt=%E4%BD%A0%E5%A5%BD%EF%BC%8C%E8%AF%B7%E5%81%9A%E4%B8%AA%E8%87%AA%E6%88%91%E4%BB%8B%E7%BB%8D"
+    );
+
+    mockedRuntimeRunsApi.streamChat
+      .mockRejectedValueOnce(
+        new Error(
+          "Service 'scope-1:default:default:hello-chat' was not found."
+        )
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {},
+      });
+
+    renderWithQueryClient(React.createElement(RunsPage));
+
+    await screen.findByDisplayValue("scope-1");
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(mockedRuntimeRunsApi.streamChat).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockedRuntimeRunsApi.streamChat).toHaveBeenNthCalledWith(
+      1,
+      "scope-1",
+      expect.objectContaining({
+        prompt: "你好，请做个自我介绍",
+      }),
+      expect.any(AbortSignal),
+      {
+        serviceId: "scope-1:default:default:hello-chat",
+      }
+    );
+
+    expect(mockedRuntimeRunsApi.streamChat).toHaveBeenNthCalledWith(
+      2,
+      "scope-1",
+      expect.objectContaining({
+        prompt: "你好，请做个自我介绍",
+      }),
+      expect.any(AbortSignal),
+      {
+        serviceId: undefined,
+      }
+    );
+  });
+
+  it("retries streamed chat runs against the scope default binding when the stream reports a missing service", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/runtime/runs?scopeId=scope-1&route=hello-chat&serviceOverrideId=scope-1:default:default:hello-chat&prompt=%E4%BD%A0%E5%A5%BD%EF%BC%8C%E8%AF%B7%E5%81%9A%E4%B8%AA%E8%87%AA%E6%88%91%E4%BB%8B%E7%BB%8D"
+    );
+
+    mockedRuntimeRunsApi.streamChat
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {},
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {},
+      });
+    mockedParseBackendSSEStream
+      .mockImplementationOnce(
+        () =>
+          (async function* () {
+            yield {
+              type: "RUN_ERROR",
+              message: "Service 'scope-1:default:default:hello-chat' was not found.",
+            };
+          })()
+      )
+      .mockImplementationOnce(() => (async function* () {})());
+
+    renderWithQueryClient(React.createElement(RunsPage));
+
+    await screen.findByDisplayValue("scope-1");
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
+
+    await waitFor(() => {
+      expect(mockedRuntimeRunsApi.streamChat).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockedRuntimeRunsApi.streamChat).toHaveBeenNthCalledWith(
+      1,
+      "scope-1",
+      expect.objectContaining({
+        prompt: "你好，请做个自我介绍",
+      }),
+      expect.any(AbortSignal),
+      {
+        serviceId: "scope-1:default:default:hello-chat",
+      }
+    );
+
+    expect(mockedRuntimeRunsApi.streamChat).toHaveBeenNthCalledWith(
+      2,
+      "scope-1",
+      expect.objectContaining({
+        prompt: "你好，请做个自我介绍",
+      }),
+      expect.any(AbortSignal),
+      {
+        serviceId: undefined,
+      }
+    );
   });
 
   it("hydrates observed run sessions without starting a new invoke", async () => {
@@ -336,8 +485,7 @@ describe("RunsPage", () => {
     mockDispatch.mockClear();
     mockReset.mockClear();
 
-    fireEvent.click(screen.getByText("Recent (1)"));
-    fireEvent.click(getButtonByText("Restore"));
+    fireEvent.click(screen.getAllByRole("button", { name: "Restore" })[0]);
 
     await waitFor(() => {
       expect(mockReset).toHaveBeenCalled();
@@ -389,13 +537,8 @@ describe("RunsPage", () => {
 
     renderWithQueryClient(React.createElement(RunsPage));
 
-    const promptInput = await screen.findByDisplayValue("Run it");
-    // ProForm's custom submitter buttons don't render in jsdom; submit via the
-    // form element which exercises the same onFinish path as the button's
-    // onClick={() => props.form?.submit?.()) wiring.
-    const form = promptInput.closest("form");
-    expect(form).toBeTruthy();
-    fireEvent.submit(form!);
+    await screen.findByDisplayValue("Run it");
+    fireEvent.click(screen.getByRole("button", { name: "Start run" }));
 
     await waitFor(() => {
       expect(mockedRuntimeRunsApi.streamChat).toHaveBeenCalledWith(

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -175,6 +175,31 @@ describe("RunsPage", () => {
     );
   });
 
+  it("returns to the originating studio route when a return target is provided", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/runtime/runs?scopeId=scope-1&returnTo=%2Fstudio%3FscopeId%3Dscope-1%26tab%3Dstudio%26template%3Dhello-chat"
+    );
+
+    renderWithQueryClient(React.createElement(RunsPage));
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "返回团队高级编辑" })
+    );
+
+    expect(window.location.pathname).toBe("/studio");
+    expect(new URLSearchParams(window.location.search).get("scopeId")).toBe(
+      "scope-1"
+    );
+    expect(new URLSearchParams(window.location.search).get("tab")).toBe(
+      "studio"
+    );
+    expect(new URLSearchParams(window.location.search).get("template")).toBe(
+      "hello-chat"
+    );
+  });
+
   it("keeps the trace workspace viewport stretchable so the inner console can scroll", async () => {
     const { container } = renderWithQueryClient(React.createElement(RunsPage));
 

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "@ant-design/pro-components";
 import { useQuery } from "@tanstack/react-query";
 import { history } from "@/shared/navigation/history";
+import { buildTeamDetailHref } from "@/shared/navigation/teamRoutes";
 import {
   buildRuntimeExplorerHref,
   buildRuntimeWorkflowsHref,
@@ -90,6 +91,7 @@ import RunsTimelineView from "./components/RunsTimelineView";
 import {
   buildTimelineGroups,
   buildEventRows,
+  resolveRunMessageFallback,
   isHumanApprovalSuspension,
   type RunEventRow,
   type RunTimelineGroup,
@@ -130,6 +132,8 @@ import {
   workbenchEventRowStyle,
   workbenchMessageListStyle,
   workbenchOverviewGridStyle,
+  workbenchTraceTabsStyle,
+  workbenchTraceTabsStyles,
 } from "./runWorkbenchConfig";
 
 const runsWorkbenchHeaderBarStyle: React.CSSProperties = {
@@ -159,6 +163,25 @@ const runsWorkbenchHeaderActionStyle: React.CSSProperties = {
   justifyContent: "flex-end",
 };
 
+const runsWorkspaceTabsClassName = "runs-workspace-tabs";
+const runsWorkspaceTabsCss = `
+.${runsWorkspaceTabsClassName} {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.${runsWorkspaceTabsClassName} .ant-tabs-content-holder,
+.${runsWorkspaceTabsClassName} .ant-tabs-content,
+.${runsWorkspaceTabsClassName} .ant-tabs-tabpane-active {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+`;
+
 function resolveRequestedServiceId(
   request: Pick<
     RunFormValues,
@@ -181,6 +204,15 @@ function resolveRequestedServiceId(
   }
 
   return normalizedServiceOverrideId || trimOptional(request.routeName) || "";
+}
+
+function extractMissingServiceId(messageText: string): string {
+  const match = messageText.match(/Service '([^']+)' was not found/i);
+  return match?.[1]?.trim() ?? "";
+}
+
+function isMissingScopeServiceError(messageText: string): boolean {
+  return extractMissingServiceId(messageText).length > 0;
 }
 
 const RunsPage: React.FC = () => {
@@ -430,145 +462,224 @@ const RunsPage: React.FC = () => {
       scopeId: string,
       request: RunFormValues
     ) => {
-      const normalizedScopeId = scopeId.trim();
-      const normalizedEndpointKind = normalizeRunEndpointKind(
-        request.endpointKind,
-        request.endpointId
-      );
-      const normalizedEndpointId = resolveStoredRunEndpointId(
-        normalizedEndpointKind,
-        request.endpointId
-      );
-      const resolvedServiceId = resolveRequestedServiceId(
-        request,
-        Boolean(scopeDraftPayload)
-      );
-      const requestedPayloadTypeUrl = request.payloadTypeUrl?.trim() ?? "";
-      const requestedPayloadBase64 = request.payloadBase64?.trim() ?? "";
-      if (!normalizedScopeId) {
-        throw new Error("Scope ID is required.");
-      }
-      if (normalizedEndpointKind === "command" && !normalizedEndpointId) {
-        throw new Error("Endpoint ID is required for command invokes.");
-      }
-      if (
-        requestedPayloadTypeUrl &&
-        !requestedPayloadBase64 &&
-        !isAutoEncodableTextPayloadTypeUrl(requestedPayloadTypeUrl)
-      ) {
-        throw new Error(
-          `payloadBase64 is required for payloadTypeUrl '${requestedPayloadTypeUrl}'.`
+      const runAttempt = async (
+        requestedRun: RunFormValues,
+        allowMissingServiceRecovery: boolean
+      ): Promise<void> => {
+        const normalizedScopeId = scopeId.trim();
+        const normalizedEndpointKind = normalizeRunEndpointKind(
+          requestedRun.endpointKind,
+          requestedRun.endpointId
         );
-      }
+        const normalizedEndpointId = resolveStoredRunEndpointId(
+          normalizedEndpointKind,
+          requestedRun.endpointId
+        );
+        const resolvedServiceId = resolveRequestedServiceId(
+          requestedRun,
+          Boolean(scopeDraftPayload)
+        );
+        const requestedPayloadTypeUrl =
+          requestedRun.payloadTypeUrl?.trim() ?? "";
+        const requestedPayloadBase64 =
+          requestedRun.payloadBase64?.trim() ?? "";
 
-      abortRun();
-      reset();
-      setTransportIssue(undefined);
-      setActiveTransport(request.transport);
-      setActiveScopeId(normalizedScopeId);
-      setActiveServiceOverrideId(resolvedServiceId);
-      setActiveEndpointKind(normalizedEndpointKind);
-      setActiveEndpointId(normalizedEndpointId);
-      setRunStartedAtMs(Date.now());
-      setStreaming(true);
+        if (!normalizedScopeId) {
+          throw new Error("Scope ID is required.");
+        }
+        if (normalizedEndpointKind === "command" && !normalizedEndpointId) {
+          throw new Error("Endpoint ID is required for command invokes.");
+        }
+        if (
+          requestedPayloadTypeUrl &&
+          !requestedPayloadBase64 &&
+          !isAutoEncodableTextPayloadTypeUrl(requestedPayloadTypeUrl)
+        ) {
+          throw new Error(
+            `payloadBase64 is required for payloadTypeUrl '${requestedPayloadTypeUrl}'.`
+          );
+        }
 
-      try {
-        const controller = new AbortController();
-        stopActiveRunRef.current = () => controller.abort();
+        abortRun();
+        reset();
+        setTransportIssue(undefined);
+        setActiveTransport(requestedRun.transport);
+        setActiveScopeId(normalizedScopeId);
+        setActiveServiceOverrideId(resolvedServiceId);
+        setActiveEndpointKind(normalizedEndpointKind);
+        setActiveEndpointId(normalizedEndpointId);
+        setRunStartedAtMs(Date.now());
+        setStreaming(true);
 
-        const response = scopeDraftPayload
-          ? await runtimeRunsApi.streamDraftRun(
-              normalizedScopeId,
-              {
-                prompt: request.prompt,
-                workflowYamls: scopeDraftPayload.bundleYamls,
-              },
-              controller.signal
-            )
-          : normalizedEndpointKind === "chat" &&
-              !request.payloadTypeUrl?.trim() &&
-              !request.payloadBase64?.trim()
-            ? await runtimeRunsApi.streamChat(
+        try {
+          const controller = new AbortController();
+          stopActiveRunRef.current = () => controller.abort();
+
+          const response = scopeDraftPayload
+            ? await runtimeRunsApi.streamDraftRun(
                 normalizedScopeId,
                 {
-                  prompt: request.prompt,
-                  metadata: undefined,
+                  prompt: requestedRun.prompt,
+                  workflowYamls: scopeDraftPayload.bundleYamls,
                 },
-                controller.signal,
-                {
-                  serviceId: resolvedServiceId || undefined,
-                }
+                controller.signal
               )
-            : null;
+            : normalizedEndpointKind === "chat" &&
+                !requestedRun.payloadTypeUrl?.trim() &&
+                !requestedRun.payloadBase64?.trim()
+              ? await runtimeRunsApi.streamChat(
+                  normalizedScopeId,
+                  {
+                    prompt: requestedRun.prompt,
+                    metadata: undefined,
+                  },
+                  controller.signal,
+                  {
+                    serviceId: resolvedServiceId || undefined,
+                  }
+                )
+              : null;
 
-        if (response) {
-          for await (const event of parseBackendSSEStream(response, {
-            signal: controller.signal,
-          })) {
-            if (controller.signal.aborted) {
-              break;
-            }
+          if (response) {
+            for await (const event of parseBackendSSEStream(response, {
+              signal: controller.signal,
+            })) {
+              if (controller.signal.aborted) {
+                break;
+              }
 
-            dispatch(event);
-          }
-        } else {
-          const receipt = await runtimeRunsApi.invokeEndpoint(
-            normalizedScopeId,
-            {
-              endpointId: normalizedEndpointId,
-              prompt: request.prompt,
-              commandId: undefined,
-              payloadTypeUrl: request.payloadTypeUrl || undefined,
-              payloadBase64: request.payloadBase64 || undefined,
-            },
-            {
-              serviceId: resolvedServiceId || undefined,
+              if (
+                allowMissingServiceRecovery &&
+                normalizedEndpointKind === "chat" &&
+                resolvedServiceId &&
+                event.type === AGUIEventType.RUN_ERROR &&
+                isMissingScopeServiceError(event.message ?? "")
+              ) {
+                composerFormRef.current?.setFieldsValue({
+                  routeName: undefined,
+                  serviceOverrideId: undefined,
+                });
+                setSelectedRouteName("");
+                setActiveServiceOverrideId("");
+                messageApi.warning(
+                  `Selected service '${extractMissingServiceId(
+                    event.message ?? ""
+                  )}' is no longer available. Retrying with the scope default binding.`
+                );
+                await runAttempt(
+                  {
+                    ...requestedRun,
+                    routeName: undefined,
+                    serviceOverrideId: undefined,
+                  },
+                  false
+                );
+                return;
+              }
+
+              dispatch(event);
             }
-          );
-          const receiptRunId =
-            String(receipt.request_id ?? receipt.requestId ?? receipt.commandId ?? "").trim() ||
-            `${normalizedEndpointId}-${Date.now().toString(36)}`;
-          const receiptActorId =
-            String(
-              receipt.target_actor_id ?? receipt.targetActorId ?? receipt.actorId ?? ""
+          } else {
+            const receipt = await runtimeRunsApi.invokeEndpoint(
+              normalizedScopeId,
+              {
+                endpointId: normalizedEndpointId,
+                prompt: requestedRun.prompt,
+                commandId: undefined,
+                payloadTypeUrl: requestedRun.payloadTypeUrl || undefined,
+                payloadBase64: requestedRun.payloadBase64 || undefined,
+              },
+              {
+                serviceId: resolvedServiceId || undefined,
+              }
+            );
+            const receiptRunId =
+              String(
+                receipt.request_id ??
+                  receipt.requestId ??
+                  receipt.commandId ??
+                  ""
+              ).trim() || `${normalizedEndpointId}-${Date.now().toString(36)}`;
+            const receiptActorId = String(
+              receipt.target_actor_id ??
+                receipt.targetActorId ??
+                receipt.actorId ??
+                ""
             ).trim();
-          const receiptCorrelationId =
-            String(receipt.correlation_id ?? receipt.correlationId ?? receiptRunId).trim() ||
-            receiptRunId;
+            const receiptCorrelationId =
+              String(
+                receipt.correlation_id ??
+                  receipt.correlationId ??
+                  receiptRunId
+              ).trim() || receiptRunId;
 
-          dispatch({
-            type: AGUIEventType.RUN_STARTED,
-            threadId: receiptCorrelationId,
-            runId: receiptRunId,
-          });
-          dispatch({
-            type: AGUIEventType.CUSTOM,
-            name: CustomEventName.RunContext,
-            value: {
-              actorId: receiptActorId || undefined,
-              workflowName: normalizedEndpointId,
-              commandId:
-                String(receipt.command_id ?? receipt.commandId ?? "").trim() || undefined,
-            },
-          });
-          messageApi.success(
-            `Endpoint ${normalizedEndpointId} accepted with request ${receiptRunId}.`
-          );
-        }
-      } catch (error) {
-        if (error instanceof Error && error.name === "AbortError") {
-          return;
-        }
+            dispatch({
+              type: AGUIEventType.RUN_STARTED,
+              threadId: receiptCorrelationId,
+              runId: receiptRunId,
+            });
+            dispatch({
+              type: AGUIEventType.CUSTOM,
+              name: CustomEventName.RunContext,
+              value: {
+                actorId: receiptActorId || undefined,
+                workflowName: normalizedEndpointId,
+                commandId:
+                  String(
+                    receipt.command_id ?? receipt.commandId ?? ""
+                  ).trim() || undefined,
+              },
+            });
+            messageApi.success(
+              `Endpoint ${normalizedEndpointId} accepted with request ${receiptRunId}.`
+            );
+          }
+        } catch (error) {
+          if (error instanceof Error && error.name === "AbortError") {
+            return;
+          }
 
-        const text = error instanceof Error ? error.message : String(error);
-        reportTransportError(text);
-      } finally {
-        stopActiveRunRef.current = undefined;
-        setStreaming(false);
-      }
+          const text = error instanceof Error ? error.message : String(error);
+          if (
+            allowMissingServiceRecovery &&
+            normalizedEndpointKind === "chat" &&
+            resolvedServiceId &&
+            isMissingScopeServiceError(text)
+          ) {
+            composerFormRef.current?.setFieldsValue({
+              routeName: undefined,
+              serviceOverrideId: undefined,
+            });
+            setSelectedRouteName("");
+            setActiveServiceOverrideId("");
+            messageApi.warning(
+              `Selected service '${extractMissingServiceId(
+                text
+              )}' is no longer available. Retrying with the scope default binding.`
+            );
+            await runAttempt(
+              {
+                ...requestedRun,
+                routeName: undefined,
+                serviceOverrideId: undefined,
+              },
+              false
+            );
+            return;
+          }
+
+          reportTransportError(text);
+        } finally {
+          stopActiveRunRef.current = undefined;
+          setStreaming(false);
+        }
+      };
+
+      await runAttempt(request, true);
     },
     [
       abortRun,
+      composerFormRef,
       dispatch,
       messageApi,
       reportTransportError,
@@ -584,6 +695,19 @@ const RunsPage: React.FC = () => {
       ""
     );
   }, [activeScopeId]);
+
+  const teamAdvancedHref = useMemo(() => {
+    const scopeId = resolveRunScopeId();
+    if (!scopeId) {
+      return "";
+    }
+
+    return buildTeamDetailHref({
+      scopeId,
+      tab: "advanced",
+      runId: session.runId || undefined,
+    });
+  }, [resolveRunScopeId, session.runId]);
 
   const resolveRunServiceOverrideId = useCallback(() => {
     return (
@@ -946,12 +1070,56 @@ const RunsPage: React.FC = () => {
     return builtInPresets.filter((preset) => available.has(preset.routeName));
   }, [workflowCatalogQuery.data]);
 
+  const snapshotMessageFallback = useMemo(() => {
+    const snapshot = actorSnapshotQuery.data;
+    if (!snapshot || session.status !== "finished") {
+      return "";
+    }
+
+    const snapshotCommandId = snapshot.lastCommandId?.trim() ?? "";
+    if (commandId && snapshotCommandId && snapshotCommandId !== commandId) {
+      return "";
+    }
+
+    return snapshot.lastOutput?.trim() ?? "";
+  }, [actorSnapshotQuery.data, commandId, session.status]);
+
+  const displayedMessages = useMemo(() => {
+    if (session.messages.length > 0) {
+      return session.messages;
+    }
+
+    const fallbackContent = resolveRunMessageFallback(
+      session.events,
+      snapshotMessageFallback
+    );
+    if (!fallbackContent) {
+      return session.messages;
+    }
+
+    return [
+      {
+        messageId: `final-output:${session.runId || commandId || actorId || "latest"}`,
+        role: "assistant",
+        content: fallbackContent,
+        complete: true,
+      },
+    ] as typeof session.messages;
+  }, [
+    actorId,
+    commandId,
+    session.events,
+    session.messages,
+    session.runId,
+    snapshotMessageFallback,
+  ]);
+
   const latestMessagePreview = useMemo(() => {
-    const lastWithContent = [...session.messages]
+    const lastWithContent = [...displayedMessages]
       .reverse()
       .find((item) => item.content?.trim());
     return lastWithContent?.content?.trim() ?? "";
-  }, [session.messages]);
+  }, [displayedMessages]);
 
   const recentRunRows = useMemo<RecentRunTableRow[]>(
     () =>
@@ -1256,7 +1424,7 @@ const RunsPage: React.FC = () => {
       focusStatus: runFocus.status,
       focusLabel: runFocus.label,
       lastEventAt,
-      messageCount: session.messages.length,
+      messageCount: displayedMessages.length,
       eventCount: session.events.length,
       activeSteps: [...session.activeSteps],
     }),
@@ -1269,7 +1437,7 @@ const RunsPage: React.FC = () => {
       runFocus.status,
       session.activeSteps,
       session.events.length,
-      session.messages.length,
+      displayedMessages.length,
       session.runId,
       session.status,
       endpointKind,
@@ -1398,9 +1566,9 @@ const RunsPage: React.FC = () => {
         Message stream
       </div>
       <div style={workbenchConsoleScrollStyle}>
-        {session.messages.length > 0 ? (
+        {displayedMessages.length > 0 ? (
           <div style={workbenchMessageListStyle}>
-            {session.messages.map((record) => (
+            {displayedMessages.map((record) => (
               <div
                 key={record.messageId}
                 style={{
@@ -1574,6 +1742,14 @@ const RunsPage: React.FC = () => {
             </Popover>
           </div>
           <div style={runsWorkbenchHeaderActionStyle}>
+            {teamAdvancedHref ? (
+              <Button
+                size="small"
+                onClick={() => history.push(teamAdvancedHref)}
+              >
+                返回团队高级编辑
+              </Button>
+            ) : null}
             <Button
               size="small"
               onClick={() => history.push(buildRuntimeWorkflowsHref())}
@@ -1603,7 +1779,7 @@ const RunsPage: React.FC = () => {
           eventCount={session.events.length}
           hasPendingInteraction={hasPendingInteraction}
           isRunLive={isRunLive}
-          messageCount={session.messages.length}
+          messageCount={displayedMessages.length}
           onAbort={handleAbortRun}
           onOpenInspector={() => setIsInspectorDrawerOpen(true)}
           runId={session.runId || commandId || "Not started"}
@@ -1723,8 +1899,11 @@ const RunsPage: React.FC = () => {
           </button>
           <div style={runsWorkbenchMonitorStyle}>
             <div style={workbenchOverviewGridStyle}>
+              <style>{runsWorkspaceTabsCss}</style>
               <Tabs
                 activeKey="trace-layout"
+                className={runsWorkspaceTabsClassName}
+                style={workbenchTraceTabsStyle}
                 items={[
                   {
                     key: "trace-layout",
@@ -1737,7 +1916,7 @@ const RunsPage: React.FC = () => {
                           eventCount={eventRows.length}
                           hasPendingInteraction={hasPendingInteraction}
                           messageConsoleView={messageConsoleView}
-                          messageCount={session.messages.length}
+                          messageCount={displayedMessages.length}
                           onConsoleViewChange={setConsoleView}
                           timelineView={
                             <RunsTimelineView
@@ -1754,6 +1933,7 @@ const RunsPage: React.FC = () => {
                     ),
                   },
                 ]}
+                styles={workbenchTraceTabsStyles}
               />
             </div>
           </div>

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "@ant-design/pro-components";
 import { useQuery } from "@tanstack/react-query";
 import { history } from "@/shared/navigation/history";
+import { sanitizeReturnTo } from "@/shared/auth/session";
 import { buildTeamDetailHref } from "@/shared/navigation/teamRoutes";
 import {
   buildRuntimeExplorerHref,
@@ -224,6 +225,14 @@ const RunsPage: React.FC = () => {
     }
 
     return new URLSearchParams(window.location.search).get("draftKey") ?? "";
+  }, []);
+  const requestedReturnTo = useMemo(() => {
+    if (typeof window === "undefined") {
+      return "";
+    }
+
+    const returnTo = new URLSearchParams(window.location.search).get("returnTo");
+    return returnTo ? sanitizeReturnTo(returnTo) : "";
   }, []);
   const draftRunPayload = useMemo(
     () => loadQueuedDraftRunPayload(draftRunKey),
@@ -697,6 +706,10 @@ const RunsPage: React.FC = () => {
   }, [activeScopeId]);
 
   const teamAdvancedHref = useMemo(() => {
+    if (requestedReturnTo) {
+      return requestedReturnTo;
+    }
+
     const scopeId = resolveRunScopeId();
     if (!scopeId) {
       return "";
@@ -707,7 +720,7 @@ const RunsPage: React.FC = () => {
       tab: "advanced",
       runId: session.runId || undefined,
     });
-  }, [resolveRunScopeId, session.runId]);
+  }, [requestedReturnTo, resolveRunScopeId, session.runId]);
 
   const resolveRunServiceOverrideId = useCallback(() => {
     return (

--- a/apps/aevatar-console-web/src/pages/runs/runEventPresentation.test.ts
+++ b/apps/aevatar-console-web/src/pages/runs/runEventPresentation.test.ts
@@ -6,7 +6,9 @@ import {
 import {
   buildTimelineGroups,
   buildEventRows,
+  extractRunFinishedOutput,
   filterEventRows,
+  resolveRunMessageFallback,
   type EventFilterValues,
 } from './runEventPresentation';
 
@@ -148,5 +150,36 @@ describe('runEventPresentation', () => {
     expect(groups[0].label).toBe('Step · triage');
     expect(groups[2].label).toBe('Step · triage');
     expect(groups[0].key).not.toBe(groups[2].key);
+  });
+
+  it('extracts final output from the run finished result payload', () => {
+    const events: AGUIEvent[] = [
+      {
+        type: AGUIEventType.RUN_FINISHED,
+        threadId: 'actor-1',
+        runId: 'run-1',
+        result: {
+          '@type':
+            'type.googleapis.com/aevatar.workflow.application.abstractions.runs.WorkflowRunResultPayload',
+          output: '你好，我是 hello-chat。',
+        },
+      },
+    ];
+
+    expect(extractRunFinishedOutput(events)).toBe('你好，我是 hello-chat。');
+  });
+
+  it('falls back to snapshot output when no message frames were emitted', () => {
+    const events: AGUIEvent[] = [
+      {
+        type: AGUIEventType.RUN_FINISHED,
+        threadId: 'actor-1',
+        runId: 'run-1',
+      },
+    ];
+
+    expect(resolveRunMessageFallback(events, '最终输出来自 snapshot')).toBe(
+      '最终输出来自 snapshot',
+    );
   });
 });

--- a/apps/aevatar-console-web/src/pages/runs/runEventPresentation.ts
+++ b/apps/aevatar-console-web/src/pages/runs/runEventPresentation.ts
@@ -58,6 +58,8 @@ export type RunTimelineGroup = {
 
 const PAYLOAD_PREVIEW_LIMIT = 180;
 
+type JsonRecord = Record<string, unknown>;
+
 export const eventStatusValueEnum = {
   processing: { text: 'Processing', status: 'Processing' },
   success: { text: 'Completed', status: 'Success' },
@@ -124,6 +126,60 @@ function getEventDisplayType(event: AGUIEvent): string {
 function readOptionalEventString(event: AGUIEvent, key: string): string {
   const candidate = (event as unknown as Record<string, unknown>)[key];
   return typeof candidate === 'string' ? candidate : '';
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as JsonRecord;
+}
+
+function readOptionalRecordString(
+  record: JsonRecord | undefined,
+  key: string,
+): string {
+  if (!record) {
+    return '';
+  }
+
+  const candidate = record[key];
+  return typeof candidate === 'string' ? candidate : '';
+}
+
+export function extractRunFinishedOutput(events: AGUIEvent[]): string {
+  const latestRunFinished = [...events]
+    .reverse()
+    .find((event) => event.type === AGUIEventType.RUN_FINISHED);
+
+  if (!latestRunFinished) {
+    return '';
+  }
+
+  const result = asRecord(
+    (latestRunFinished as unknown as Record<string, unknown>).result,
+  );
+
+  return (
+    readOptionalRecordString(result, 'output') ||
+    readOptionalRecordString(result, 'Output') ||
+    ''
+  );
+}
+
+export function resolveRunMessageFallback(
+  events: AGUIEvent[],
+  snapshotLastOutput?: string | null,
+): string {
+  const runFinishedOutput = extractRunFinishedOutput(events).trim();
+  if (runFinishedOutput) {
+    return runFinishedOutput;
+  }
+
+  return typeof snapshotLastOutput === 'string'
+    ? snapshotLastOutput.trim()
+    : '';
 }
 
 function mergeTimelineStatus(

--- a/apps/aevatar-console-web/src/pages/runs/runWorkbenchConfig.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/runWorkbenchConfig.tsx
@@ -462,8 +462,11 @@ export const workbenchHudBodyStyle = {
 } as const;
 
 export const workbenchOverviewGridStyle = {
+  display: "flex",
   flex: 1,
+  flexDirection: "column",
   minHeight: 0,
+  overflow: "hidden",
 } as const;
 
 export const workbenchOverviewCardStyle = {

--- a/apps/aevatar-console-web/src/pages/scopes/components/ScopeQueryCard.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/components/ScopeQueryCard.tsx
@@ -5,10 +5,12 @@ import { moduleCardProps } from '@/shared/ui/proComponents';
 import type { ScopeQueryDraft } from './scopeQuery';
 
 type ScopeQueryCardProps = {
+  activeScopeId?: string | null;
   draft: ScopeQueryDraft;
   onChange: (draft: ScopeQueryDraft) => void;
   onLoad: () => void;
   onReset?: () => void;
+  resetDisabled?: boolean;
   loadLabel?: string;
   resolvedScopeId?: string | null;
   resolvedScopeSource?: string | null;
@@ -16,21 +18,32 @@ type ScopeQueryCardProps = {
 };
 
 const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
+  activeScopeId,
   draft,
   onChange,
   onLoad,
   onReset,
-  loadLabel = 'Load team',
+  resetDisabled,
+  loadLabel = 'Load scope',
   resolvedScopeId,
   resolvedScopeSource,
   onUseResolvedScope,
 }) => {
+  const normalizedDraftScopeId = draft.scopeId.trim();
+  const normalizedActiveScopeId = activeScopeId?.trim() ?? '';
   const normalizedResolvedScopeId = resolvedScopeId?.trim() ?? '';
   const normalizedResolvedScopeSource = resolvedScopeSource?.trim() ?? '';
   const canUseResolvedScope =
     normalizedResolvedScopeId.length > 0 &&
-    draft.scopeId.trim() !== normalizedResolvedScopeId &&
+    normalizedDraftScopeId !== normalizedResolvedScopeId &&
     onUseResolvedScope;
+  const loadIsNoOp =
+    normalizedDraftScopeId.length > 0 &&
+    normalizedDraftScopeId === normalizedActiveScopeId;
+  const computedResetDisabled =
+    normalizedDraftScopeId === normalizedResolvedScopeId &&
+    normalizedActiveScopeId === normalizedResolvedScopeId;
+  const resetIsNoOp = (resetDisabled ?? computedResetDisabled) === true;
   const { token } = theme.useToken();
   const helperLabelStyle = {
     color: token.colorTextSecondary,
@@ -68,7 +81,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
       >
         <Input
           allowClear
-          placeholder="Enter team ID"
+          placeholder="输入团队 scopeId"
           style={{ flex: '1 1 240px', minWidth: 0, width: '100%' }}
           value={draft.scopeId}
           onChange={(event) =>
@@ -78,10 +91,14 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
           }
           onPressEnter={onLoad}
         />
-        <Button type="primary" onClick={onLoad}>
+        <Button disabled={!normalizedDraftScopeId || loadIsNoOp} type="primary" onClick={onLoad}>
           {loadLabel}
         </Button>
-        {onReset ? <Button onClick={onReset}>Reset</Button> : null}
+        {onReset ? (
+          <Button disabled={resetDisabled ?? computedResetDisabled} onClick={onReset}>
+            重置
+          </Button>
+        ) : null}
       </div>
       <div
         style={{
@@ -94,7 +111,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
         {normalizedResolvedScopeId ? (
           <>
             <Typography.Text style={helperLabelStyle}>
-              Resolved team
+              已解析团队
             </Typography.Text>
             <Typography.Paragraph
               copyable={{ text: normalizedResolvedScopeId }}
@@ -113,13 +130,23 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
                   wordBreak: 'break-word',
                 }}
               >
-                Resolved from the current session via {normalizedResolvedScopeSource}
+                当前会话已通过 {normalizedResolvedScopeSource} 解析出这个团队
+              </Typography.Text>
+            ) : null}
+            {loadIsNoOp ? (
+              <Typography.Text style={helperCopyStyle}>
+                当前已加载这个团队，所以“{loadLabel}”不会再触发变化。
+              </Typography.Text>
+            ) : null}
+            {resetIsNoOp ? (
+              <Typography.Text style={helperCopyStyle}>
+                当前已经回到会话解析出的团队，所以“重置”不会再触发变化。
               </Typography.Text>
             ) : null}
             {canUseResolvedScope ? (
               <div>
                 <Button size="small" onClick={onUseResolvedScope}>
-                  Use resolved team
+                  使用会话团队
                 </Button>
               </div>
             ) : null}
@@ -135,9 +162,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
               wordBreak: 'break-word',
             }}
           >
-            No team context was resolved from the current session. Enter a
-            team ID manually. tenantId and appId stay platform-managed and
-            hidden in this flow.
+            当前会话里没有自动解析出团队。请手动输入一个 scopeId。
           </Typography.Text>
         )}
       </div>

--- a/apps/aevatar-console-web/src/pages/scopes/invoke.test.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/invoke.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { loadDraftRunPayload } from '@/shared/runs/draftRunSession';
 import { renderWithQueryClient } from '../../../tests/reactQueryTestUtils';
-import ScopeInvokePage from './invoke';
+import ScopeInvokePage, { buildServiceOptions } from './invoke';
 
 jest.mock('@ant-design/pro-components', () => {
   const mockReact = require('react');
@@ -408,6 +408,80 @@ describe('ScopeInvokePage', () => {
     });
   });
 
+  it('deduplicates repeated service ids before building picker options', () => {
+    expect(
+      buildServiceOptions(
+        [
+          {
+            serviceKey: 'scope-a:default:default:hello-chat:older',
+            tenantId: 'scope-a',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'hello-chat',
+            displayName: 'hello-chat',
+            defaultServingRevisionId: 'rev-1',
+            activeServingRevisionId: 'rev-1',
+            deploymentId: 'deploy-1',
+            primaryActorId: 'actor://scope-a/hello-chat/1',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'chat',
+                displayName: 'chat',
+                kind: 'chat',
+                requestTypeUrl: 'type.googleapis.com/aevatar.ChatRequestEvent',
+                responseTypeUrl: 'type.googleapis.com/aevatar.ChatResponseEvent',
+                description: 'Chat endpoint.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-04-09T09:00:00Z',
+          },
+          {
+            serviceKey: 'scope-a:default:default:hello-chat:newer',
+            tenantId: 'scope-a',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'hello-chat',
+            displayName: 'hello-chat',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'deploy-2',
+            primaryActorId: 'actor://scope-a/hello-chat/2',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'chat',
+                displayName: 'chat',
+                kind: 'chat',
+                requestTypeUrl: 'type.googleapis.com/aevatar.ChatRequestEvent',
+                responseTypeUrl: 'type.googleapis.com/aevatar.ChatResponseEvent',
+                description: 'Chat endpoint.',
+              },
+              {
+                endpointId: 'health',
+                displayName: 'health',
+                kind: 'command',
+                requestTypeUrl: 'type.googleapis.com/google.protobuf.Empty',
+                responseTypeUrl: 'type.googleapis.com/google.protobuf.StringValue',
+                description: 'Health endpoint.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-04-09T09:30:00Z',
+          },
+        ],
+        'hello-chat',
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        serviceId: 'hello-chat',
+        serviceKey: 'scope-a:default:default:hello-chat:newer',
+        activeServingRevisionId: 'rev-2',
+      }),
+    ]);
+  });
+
   it('invokes a non-chat endpoint for the selected scope service', async () => {
     (servicesApi.listServices as jest.Mock).mockResolvedValue([
       {
@@ -623,6 +697,57 @@ describe('ScopeInvokePage', () => {
         ],
       }),
     );
+  });
+
+  it('keeps the invoke lab workspace constrained so the chat composer stays visible', async () => {
+    (servicesApi.listServices as jest.Mock).mockResolvedValue([
+      {
+        serviceKey: 'scope-a:default:default:default',
+        tenantId: 'scope-a',
+        appId: 'default',
+        namespace: 'default',
+        serviceId: 'default',
+        displayName: 'Workspace Demo',
+        defaultServingRevisionId: 'rev-2',
+        activeServingRevisionId: 'rev-2',
+        deploymentId: 'deploy-2',
+        primaryActorId: 'actor://scope-a/default',
+        deploymentStatus: 'Active',
+        endpoints: [
+          {
+            endpointId: 'chat',
+            displayName: 'chat',
+            kind: 'chat',
+            requestTypeUrl: 'type.googleapis.com/aevatar.ChatRequestEvent',
+            responseTypeUrl: 'type.googleapis.com/aevatar.ChatResponseEvent',
+            description: 'Chat with the published scope service.',
+          },
+        ],
+        policyIds: [],
+        updatedAt: '2026-03-26T08:00:00Z',
+      },
+    ]);
+
+    renderWithQueryClient(React.createElement(ScopeInvokePage));
+
+    const viewport = await screen.findByTestId('invoke-lab-workspace-viewport');
+    const grid = await screen.findByTestId('invoke-lab-workspace-grid');
+
+    expect(viewport).toHaveStyle({
+      flex: '1 1 auto',
+      minHeight: '0',
+      overflow: 'hidden',
+    });
+    expect(grid).toHaveStyle({
+      alignItems: 'stretch',
+      height: '100%',
+      minHeight: '0',
+    });
+    expect(
+      await screen.findByPlaceholderText(
+        'Describe the task, ask a question, or paste the next operator instruction.',
+      ),
+    ).toBeTruthy();
   });
 
   it('renders semantic chat output for reasoning, steps, and tool activity', async () => {

--- a/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/invoke.tsx
@@ -144,15 +144,16 @@ const pageHeaderStyle: React.CSSProperties = {
 };
 const workspaceViewportStyle: React.CSSProperties = {
   display: 'flex',
-  flex: '1 0 auto',
+  flex: '1 1 auto',
   minHeight: 0,
-  overflow: 'visible',
+  overflow: 'hidden',
 };
 const workspaceGridStyle: React.CSSProperties = {
-  alignItems: 'start',
+  alignItems: 'stretch',
   display: 'grid',
   gap: 12,
   gridTemplateColumns: '250px minmax(0, 1fr) 300px',
+  height: '100%',
   minHeight: 0,
   minWidth: 0,
   width: '100%',
@@ -282,7 +283,7 @@ const playgroundChatComposerStyle: React.CSSProperties = {
   background: '#ffffff',
   borderTop: '1px solid #e7e5e4',
   flexShrink: 0,
-  padding: '14px 20px',
+  padding: '14px 20px 18px',
 };
 const consoleShellStyle: React.CSSProperties = {
   background: 'var(--ant-color-bg-container)',
@@ -329,20 +330,63 @@ function createClientId(): string {
     : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function buildServiceOptions(
+function compareServicePriority(
+  left: ServiceCatalogSnapshot,
+  right: ServiceCatalogSnapshot,
+  defaultServiceId?: string,
+): number {
+  const leftIsDefault = left.serviceId === defaultServiceId ? 1 : 0;
+  const rightIsDefault = right.serviceId === defaultServiceId ? 1 : 0;
+
+  if (leftIsDefault !== rightIsDefault) {
+    return rightIsDefault - leftIsDefault;
+  }
+
+  const endpointDelta = right.endpoints.length - left.endpoints.length;
+  if (endpointDelta !== 0) {
+    return endpointDelta;
+  }
+
+  const leftHasDisplayName = left.displayName.trim() ? 1 : 0;
+  const rightHasDisplayName = right.displayName.trim() ? 1 : 0;
+  if (leftHasDisplayName !== rightHasDisplayName) {
+    return rightHasDisplayName - leftHasDisplayName;
+  }
+
+  const updatedAtDelta = right.updatedAt.localeCompare(left.updatedAt);
+  if (updatedAtDelta !== 0) {
+    return updatedAtDelta;
+  }
+
+  const serviceIdDelta = left.serviceId.localeCompare(right.serviceId);
+  if (serviceIdDelta !== 0) {
+    return serviceIdDelta;
+  }
+
+  return left.serviceKey.localeCompare(right.serviceKey);
+}
+
+export function buildServiceOptions(
   services: readonly ServiceCatalogSnapshot[],
   defaultServiceId?: string,
 ): ServiceCatalogSnapshot[] {
-  return [...services].sort((left, right) => {
-    const leftIsDefault = left.serviceId === defaultServiceId ? 1 : 0;
-    const rightIsDefault = right.serviceId === defaultServiceId ? 1 : 0;
+  const deduped = new Map<string, ServiceCatalogSnapshot>();
 
-    if (leftIsDefault !== rightIsDefault) {
-      return rightIsDefault - leftIsDefault;
+  services.forEach((service) => {
+    const current = deduped.get(service.serviceId);
+    if (!current) {
+      deduped.set(service.serviceId, service);
+      return;
     }
 
-    return left.serviceId.localeCompare(right.serviceId);
+    if (compareServicePriority(service, current, defaultServiceId) < 0) {
+      deduped.set(service.serviceId, service);
+    }
   });
+
+  return [...deduped.values()].sort((left, right) =>
+    compareServicePriority(left, right, defaultServiceId),
+  );
 }
 
 function isChatEndpoint(
@@ -1106,8 +1150,8 @@ const ScopeInvokePage: React.FC = () => {
           </Space>
         </div>
 
-        <div style={workspaceViewportStyle}>
-          <div style={workspaceGridStyle}>
+        <div data-testid="invoke-lab-workspace-viewport" style={workspaceViewportStyle}>
+          <div data-testid="invoke-lab-workspace-grid" style={workspaceGridStyle}>
             <div style={columnStyle}>
               <ProCard
                 bodyStyle={viewportCardBodyStyle}

--- a/apps/aevatar-console-web/src/pages/scopes/overview.test.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/overview.test.tsx
@@ -173,30 +173,30 @@ describe('ScopeOverviewPage', () => {
   it('renders the scope status board and asset summaries', async () => {
     renderWithQueryClient(React.createElement(ScopeOverviewPage));
 
-    expect(await screen.findByText('Team Status Board')).toBeTruthy();
+    expect(await screen.findByText('团队状态')).toBeTruthy();
     expect(
       screen.queryByText(
-        'Team Overview keeps binding posture, asset surface, and next-step actions on one deep-link board.',
+        'Project Overview is now a true scope-level status board: binding posture, asset surface, and next-step actions all live on one stage.',
       ),
     ).toBeNull();
     expect(screen.getAllByRole('button', { name: 'Show help' }).length).toBeGreaterThan(0);
-    expect(await screen.findByText('Current Team Binding')).toBeTruthy();
-    expect(await screen.findByText('Revision Rollout')).toBeTruthy();
-    expect(screen.getByText('Revision Rollout')).toBeTruthy();
+    expect(await screen.findByText('当前默认成员')).toBeTruthy();
+    expect(await screen.findByText('版本发布')).toBeTruthy();
+    expect(screen.getByText('版本发布')).toBeTruthy();
     expect(await screen.findByText('Workflow Alpha')).toBeTruthy();
     expect(await screen.findByText('script-alpha')).toBeTruthy();
     expect(
-      screen.getByRole('button', { name: 'Open Workflow Builder' })
+      screen.getByRole('button', { name: '打开行为定义' })
     ).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Open team assets' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Open Invoke Lab' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '打开团队资产' })).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: '打开测试入口' }).length).toBeGreaterThan(0);
     expect(screen.queryByRole('button', { name: 'Invoke Services' })).toBeNull();
   });
 
   it('activates a historical revision from the overview page', async () => {
     renderWithQueryClient(React.createElement(ScopeOverviewPage));
 
-    expect(await screen.findByText('Revision Rollout')).toBeTruthy();
+    expect(await screen.findByText('版本发布')).toBeTruthy();
     const activateButtons = await screen.findAllByRole('button', {
       name: 'Activate',
     });
@@ -213,7 +213,7 @@ describe('ScopeOverviewPage', () => {
   it('retires a historical revision from the overview page', async () => {
     renderWithQueryClient(React.createElement(ScopeOverviewPage));
 
-    expect(await screen.findByText('Revision Rollout')).toBeTruthy();
+    expect(await screen.findByText('版本发布')).toBeTruthy();
     const retireButtons = await screen.findAllByRole('button', {
       name: 'Retire',
     });

--- a/apps/aevatar-console-web/src/pages/scopes/overview.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/overview.tsx
@@ -3,6 +3,8 @@ import {
   EyeOutlined,
   RocketOutlined,
 } from "@ant-design/icons";
+import type { ProListMetas } from "@ant-design/pro-components";
+import { ProList } from "@ant-design/pro-components";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Alert, Button, Empty, Space, Typography } from "antd";
 import React, { useEffect, useMemo, useState } from "react";
@@ -10,6 +12,7 @@ import { scopesApi } from "@/shared/api/scopesApi";
 import { servicesApi } from "@/shared/api/servicesApi";
 import { formatDateTime } from "@/shared/datetime/dateTime";
 import { history } from "@/shared/navigation/history";
+import { buildTeamDetailHref } from "@/shared/navigation/teamRoutes";
 import {
   buildRuntimeGAgentsHref,
   buildRuntimeRunsHref,
@@ -43,7 +46,6 @@ import { resolveStudioScopeContext } from "./components/resolvedScope";
 import ScopeQueryCard from "./components/ScopeQueryCard";
 import {
   buildScopeHref,
-  buildScopeOverviewHref,
   normalizeScopeDraft,
   readScopeQueryDraft,
   type ScopeQueryDraft,
@@ -90,42 +92,6 @@ function buildScopedServiceHref(scopeId: string, serviceId: string): string {
   params.set("serviceId", serviceId.trim());
   return `/services?${params.toString()}`;
 }
-
-type AssetCardProps = {
-  actions: React.ReactNode;
-  description: React.ReactNode;
-  subtitle: React.ReactNode;
-  title: React.ReactNode;
-};
-
-const assetCardStyle: React.CSSProperties = {
-  border: "1px solid var(--ant-color-border-secondary)",
-  borderRadius: 12,
-  display: "flex",
-  flexDirection: "column",
-  gap: 12,
-  padding: 16,
-};
-
-const AssetCard: React.FC<AssetCardProps> = ({
-  actions,
-  description,
-  subtitle,
-  title,
-}) => (
-  <div style={assetCardStyle}>
-    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      <Typography.Title level={5} style={{ margin: 0 }}>
-        {title}
-      </Typography.Title>
-      <div>{subtitle}</div>
-      <Typography.Paragraph style={{ margin: 0 }} type="secondary">
-        {description}
-      </Typography.Paragraph>
-    </div>
-    <Space wrap>{actions}</Space>
-  </div>
-);
 
 const ScopeOverviewPage: React.FC = () => {
   const queryClient = useQueryClient();
@@ -223,7 +189,7 @@ const ScopeOverviewPage: React.FC = () => {
 
   useEffect(() => {
     history.replace(
-      buildScopeOverviewHref(activeDraft, {
+      buildScopeHref("/teams", activeDraft, {
         revisionId: focus?.kind === "revision" ? focus.id : "",
         workflowId: focus?.kind === "workflow" ? focus.id : "",
         scriptId: focus?.kind === "script" ? focus.id : "",
@@ -248,11 +214,121 @@ const ScopeOverviewPage: React.FC = () => {
     scopeServicesQuery.data?.find((service) => service.serviceId === binding?.serviceId) ??
     null;
 
+  const workflowMetas = useMemo<ProListMetas<ScopeWorkflowSummary>>(
+    () => ({
+      actions: {
+        render: (_, workflow) => [
+          <Button
+            icon={<EyeOutlined />}
+            key={`${workflow.workflowId}-inspect`}
+            onClick={() => setFocus({ kind: "workflow", id: workflow.workflowId })}
+            type="link"
+          >
+            查看
+          </Button>,
+          <Button
+            icon={<RocketOutlined />}
+            key={`${workflow.workflowId}-runs`}
+            onClick={() =>
+              history.push(
+                buildRuntimeRunsHref({
+                  scopeId,
+                }),
+              )
+            }
+            type="link"
+          >
+            事件流
+          </Button>,
+        ],
+      },
+      description: {
+        render: (_, workflow) =>
+          workflow.serviceKey
+            ? `入口 ${workflow.serviceKey}`
+            : "该行为定义还没有发布为团队默认入口。",
+      },
+      subTitle: {
+        render: (_, workflow) => (
+          <Space wrap size={[8, 8]}>
+            <AevatarStatusTag
+              domain="asset"
+              status={workflow.activeRevisionId ? "active" : "draft"}
+            />
+            <AevatarStatusTag
+              domain="governance"
+              status={workflow.deploymentStatus || "draft"}
+            />
+          </Space>
+        ),
+      },
+      title: {
+        render: (_, workflow) => workflow.displayName || workflow.workflowId,
+      },
+    }),
+    [scopeId],
+  );
+  const scriptMetas = useMemo<ProListMetas<ScopeScriptSummary>>(
+    () => ({
+      actions: {
+        render: (_, script) => [
+          <Button
+            icon={<EyeOutlined />}
+            key={`${script.scriptId}-inspect`}
+            onClick={() => setFocus({ kind: "script", id: script.scriptId })}
+            type="link"
+          >
+            查看
+          </Button>,
+          <Button
+            icon={<CodeOutlined />}
+            key={`${script.scriptId}-studio`}
+            onClick={() =>
+              history.push(
+                buildStudioScriptsWorkspaceRoute({
+                  scopeId,
+                  scopeLabel: scopeId,
+                  scriptId: script.scriptId,
+                }),
+              )
+            }
+            type="link"
+          >
+            打开脚本行为
+          </Button>,
+        ],
+      },
+      description: {
+        render: (_, script) =>
+          script.activeSourceHash
+            ? `源码哈希 ${script.activeSourceHash}`
+            : "该脚本行为正在等待已提交的源码哈希。",
+      },
+      subTitle: {
+        render: (_, script) => (
+          <Space wrap size={[8, 8]}>
+            <AevatarStatusTag
+              domain="asset"
+              status={script.activeRevision ? "active" : "draft"}
+            />
+            <Typography.Text type="secondary">
+              Revision {script.activeRevision || "n/a"}
+            </Typography.Text>
+          </Space>
+        ),
+      },
+      title: {
+        render: (_, script) => script.scriptId,
+      },
+    }),
+    [],
+  );
+
   return (
     <AevatarPageShell
       layoutMode="document"
-      title="Team Overview"
-      titleHelp="Team Overview keeps binding posture, asset surface, and next-step actions on one deep-link board."
+      title="我的团队"
+      titleHelp="当前团队首页继续复用 scope 级状态板，但会用 Team 语义组织默认绑定、成员资产和下一步动作。"
     >
       <AevatarWorkbenchLayout
         layoutMode="document"
@@ -260,12 +336,13 @@ const ScopeOverviewPage: React.FC = () => {
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <AevatarPanel
               layoutMode="document"
-              title="Team Context"
-              titleHelp="Everything downstream stays team-scoped once you load a team."
+              title="团队范围"
+              titleHelp="这里先锁定当前 Team（Scope），后续成员、事件流和高级编辑都会沿用这个上下文。"
             >
               <ScopeQueryCard
+                activeScopeId={scopeId}
                 draft={draft}
-                loadLabel="Load team overview"
+                loadLabel="加载团队状态"
                 onChange={setDraft}
                 onLoad={() => {
                   const nextDraft = normalizeScopeDraft(draft);
@@ -280,6 +357,12 @@ const ScopeOverviewPage: React.FC = () => {
                   setActiveDraft(nextDraft);
                   setFocus(null);
                 }}
+                resetDisabled={
+                  normalizeScopeDraft(draft).scopeId ===
+                    (resolvedScope?.scopeId?.trim() ?? "") &&
+                  scopeId === (resolvedScope?.scopeId?.trim() ?? "") &&
+                  focus == null
+                }
                 onUseResolvedScope={() => {
                   if (!resolvedScope?.scopeId) {
                     return;
@@ -296,15 +379,45 @@ const ScopeOverviewPage: React.FC = () => {
               />
             </AevatarPanel>
 
-            <AevatarPanel title="Team Lanes">
-              <Space orientation="vertical" size={8} style={{ width: "100%" }}>
+            <AevatarPanel title="团队操作">
+              <Space direction="vertical" size={8} style={{ width: "100%" }}>
+                <Button
+                  disabled={!scopeId}
+                  onClick={() =>
+                    history.push(
+                      scopeId
+                        ? buildTeamDetailHref({
+                            scopeId,
+                          })
+                        : "/teams",
+                    )
+                  }
+                  type="primary"
+                >
+                  打开团队详情
+                </Button>
+                <Button
+                  disabled={!scopeId}
+                  onClick={() =>
+                    history.push(
+                      scopeId
+                        ? buildTeamDetailHref({
+                            scopeId,
+                            tab: "advanced",
+                          })
+                        : "/teams",
+                    )
+                  }
+                >
+                  打开高级编辑
+                </Button>
                 <Button onClick={() => history.push(buildScopeHref("/scopes/assets", activeDraft))}>
-                  Open team assets
+                  打开团队资产
                 </Button>
                 <Button onClick={() => history.push(buildScopeHref("/scopes/invoke", activeDraft, {
                   serviceId: binding?.serviceId ?? "",
                 }))}>
-                  Open Invoke Lab
+                  打开测试入口
                 </Button>
                 <Button
                   onClick={() =>
@@ -317,14 +430,19 @@ const ScopeOverviewPage: React.FC = () => {
                     )
                   }
                 >
-                  Open Member Runtime
+                  管理成员
                 </Button>
                 <Button
                   onClick={() =>
-                    history.push(buildStudioWorkflowWorkspaceRoute())
+                    history.push(
+                      buildStudioWorkflowWorkspaceRoute({
+                        scopeId,
+                        scopeLabel: scopeId,
+                      }),
+                    )
                   }
                 >
-                  Open Workflow Builder
+                  打开行为定义
                 </Button>
                 <Button
                   onClick={() =>
@@ -335,7 +453,7 @@ const ScopeOverviewPage: React.FC = () => {
                     )
                   }
                 >
-                  Open Services
+                  打开平台服务
                 </Button>
               </Space>
             </AevatarPanel>
@@ -345,7 +463,7 @@ const ScopeOverviewPage: React.FC = () => {
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {!scopeId ? (
               <Alert
-                title="Select a team to inspect its current binding, active revisions, and owned assets."
+                title="选择一个团队以查看当前默认成员、版本发布和已拥有资产。"
                 showIcon
                 type="info"
               />
@@ -354,8 +472,8 @@ const ScopeOverviewPage: React.FC = () => {
             {scopeId ? (
               <>
                 <AevatarPanel
-                  title="Team Status Board"
-                  titleHelp="The command surface users actually care about: whether the team is bound, serving, and ready to invoke."
+                  title="团队状态"
+                  titleHelp="团队首页会把默认入口、成员资产和是否可测试集中展示，不再暴露 project 术语。"
                 >
                   <div
                     style={{
@@ -364,44 +482,44 @@ const ScopeOverviewPage: React.FC = () => {
                       gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
                     }}
                   >
-                    <MetricCard label="Team" value={scopeId} />
+                    <MetricCard label="团队" value={scopeId} />
                     <MetricCard
-                      label="Binding"
+                      label="默认成员"
                       value={binding?.available ? binding.displayName || binding.serviceId : "Not bound"}
                     />
                     <MetricCard
-                      label="Binding target"
+                      label="绑定目标"
                       value={currentBindingTarget}
                     />
                     <MetricCard
-                      label="Binding kind"
+                      label="实现类型"
                       value={formatStudioScopeBindingImplementationKind(
                         activeRevision?.implementationKind,
                       )}
                     />
                     <MetricCard
-                      label="Workflows"
+                      label="行为定义"
                       value={workflowsQuery.data?.length ?? 0}
                     />
-                    <MetricCard label="Scripts" value={scriptsQuery.data?.length ?? 0} />
+                    <MetricCard label="脚本行为" value={scriptsQuery.data?.length ?? 0} />
                     <MetricCard
-                      label="Services"
+                      label="成员服务"
                       value={scopeServicesQuery.data?.length ?? 0}
                     />
                     <MetricCard
-                      label="Serving"
+                      label="发布状态"
                       value={binding?.deploymentStatus || "draft"}
                     />
                   </div>
                 </AevatarPanel>
 
                 <AevatarPanel
-                  title="Current Team Binding"
-                  titleHelp="The current team binding should be legible without leaving the overview page."
+                  title="当前默认成员"
+                  titleHelp="这里展示当前团队默认服务绑定到的成员实现，便于继续进入事件流或高级编辑。"
                 >
                   {!binding?.available || !activeRevision ? (
                     <Alert
-                      title="No published default binding is active for this team yet."
+                      title="当前团队还没有可用的默认成员绑定。"
                       showIcon
                       type="info"
                     />
@@ -414,24 +532,24 @@ const ScopeOverviewPage: React.FC = () => {
                           gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
                         }}
                       >
-                        <MetricCard label="Service" value={binding.displayName || binding.serviceId} />
-                        <MetricCard label="Target" value={currentBindingTarget} />
+                        <MetricCard label="成员" value={binding.displayName || binding.serviceId} />
+                        <MetricCard label="目标" value={currentBindingTarget} />
                         <MetricCard
-                          label="Revision"
+                          label="版本"
                           value={activeRevision.revisionId}
                         />
                         <MetricCard
-                          label="Actor"
+                          label="实例"
                           value={currentBindingActor || "n/a"}
                         />
                       </div>
                       {currentBindingContext ? (
-                        <Alert
-                          description={currentBindingContext}
-                          showIcon
-                          title="Binding detail"
-                          type="info"
-                        />
+                      <Alert
+                        description={currentBindingContext}
+                        showIcon
+                        title="绑定详情"
+                        type="info"
+                      />
                       ) : null}
                       <Space wrap>
                         <Button
@@ -447,7 +565,7 @@ const ScopeOverviewPage: React.FC = () => {
                             )
                           }
                         >
-                          Open Member Runtime
+                          在成员页查看
                         </Button>
                         <Button
                           onClick={() =>
@@ -459,7 +577,7 @@ const ScopeOverviewPage: React.FC = () => {
                           }
                           type="primary"
                         >
-                          Test in Invoke Lab
+                          打开测试入口
                         </Button>
                       </Space>
                     </>
@@ -467,8 +585,8 @@ const ScopeOverviewPage: React.FC = () => {
                 </AevatarPanel>
 
                 <AevatarPanel
-                  title="Revision Rollout"
-                  titleHelp="Binding revisions are treated as the team's runtime posture, not hidden on a secondary page."
+                  title="版本发布"
+                  titleHelp="团队默认入口的历史版本仍然保留在这里，方便继续切换或退役。"
                 >
                   {revisions.length > 0 ? (
                     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -503,7 +621,7 @@ const ScopeOverviewPage: React.FC = () => {
                     </div>
                   ) : (
                     <Empty
-                      description="No binding revisions are available yet."
+                      description="当前团队还没有可切换的版本。"
                       image={Empty.PRESENTED_IMAGE_SIMPLE}
                     />
                   )}
@@ -517,8 +635,8 @@ const ScopeOverviewPage: React.FC = () => {
                   }}
                 >
                   <AevatarPanel
-                    title="Published Services"
-                    titleHelp="Published services are the runtime surfaces users can actually invoke from this team."
+                    title="已发布成员"
+                    titleHelp="当前团队下已发布的 service 会在这里展示，并作为成员列表和连接器聚合的基础。"
                   >
                     {scopeServicesQuery.error ? (
                       <Alert
@@ -526,12 +644,12 @@ const ScopeOverviewPage: React.FC = () => {
                         title={
                           scopeServicesQuery.error instanceof Error
                             ? scopeServicesQuery.error.message
-                            : "Failed to load published services."
+                            : "加载已发布成员失败。"
                         }
                         type="error"
                       />
                     ) : scopeServicesQuery.isLoading ? (
-                      <AevatarInspectorEmpty description="Loading published services." />
+                      <AevatarInspectorEmpty description="正在加载已发布成员。" />
                     ) : scopeServicesQuery.data && scopeServicesQuery.data.length > 0 ? (
                       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                         {scopeServicesQuery.data.map((service) => (
@@ -555,139 +673,56 @@ const ScopeOverviewPage: React.FC = () => {
                       </div>
                     ) : (
                       <Empty
-                        description="No published services were found for this team."
+                        description="当前团队还没有已发布成员。"
                         image={Empty.PRESENTED_IMAGE_SIMPLE}
                       />
                     )}
                   </AevatarPanel>
 
-                  <AevatarPanel title="Workflow Assets">
-                    {workflowsQuery.isLoading ? (
-                      <AevatarInspectorEmpty description="Loading workflow assets." />
-                    ) : workflowsQuery.data && workflowsQuery.data.length > 0 ? (
-                      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                        {workflowsQuery.data.map((workflow) => (
-                          <AssetCard
-                            key={workflow.workflowId}
-                            actions={
-                              <>
-                                <Button
-                                  icon={<EyeOutlined />}
-                                  key={`${workflow.workflowId}-inspect`}
-                                  onClick={() =>
-                                    setFocus({ kind: "workflow", id: workflow.workflowId })
-                                  }
-                                  type="link"
-                                >
-                                  Inspect
-                                </Button>
-                                <Button
-                                  icon={<RocketOutlined />}
-                                  key={`${workflow.workflowId}-runs`}
-                                  onClick={() =>
-                                    history.push(
-                                      buildRuntimeRunsHref({
-                                        scopeId,
-                                      }),
-                                    )
-                                  }
-                                  type="link"
-                                >
-                                  Runs
-                                </Button>
-                              </>
-                            }
-                            description={
-                              workflow.serviceKey
-                                ? `Entrypoint ${workflow.serviceKey}`
-                                : "Workflow asset is not yet published as a team entrypoint."
-                            }
-                            subtitle={
-                              <Space wrap size={[8, 8]}>
-                                <AevatarStatusTag
-                                  domain="asset"
-                                  status={workflow.activeRevisionId ? "active" : "draft"}
-                                />
-                                <AevatarStatusTag
-                                  domain="governance"
-                                  status={workflow.deploymentStatus || "draft"}
-                                />
-                              </Space>
-                            }
-                            title={workflow.displayName || workflow.workflowId}
+                  <AevatarPanel title="行为定义资产">
+                    <ProList<ScopeWorkflowSummary>
+                      dataSource={workflowsQuery.data ?? []}
+                      grid={{ gutter: 16, column: 1 }}
+                      itemCardProps={{
+                        bodyStyle: { padding: 16 },
+                        style: { borderRadius: 12 },
+                      }}
+                      locale={{
+                        emptyText: (
+                          <Empty
+                            description="当前团队还没有行为定义资产。"
+                            image={Empty.PRESENTED_IMAGE_SIMPLE}
                           />
-                        ))}
-                      </div>
-                    ) : (
-                      <Empty
-                        description="No workflow assets were found for this team."
-                        image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      />
-                    )}
+                        ),
+                      }}
+                      metas={workflowMetas}
+                      pagination={false}
+                      rowKey="workflowId"
+                      split={false}
+                    />
                   </AevatarPanel>
 
-                  <AevatarPanel title="Script Assets">
-                    {scriptsQuery.isLoading ? (
-                      <AevatarInspectorEmpty description="Loading script assets." />
-                    ) : scriptsQuery.data && scriptsQuery.data.length > 0 ? (
-                      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                        {scriptsQuery.data.map((script) => (
-                          <AssetCard
-                            key={script.scriptId}
-                            actions={
-                              <>
-                                <Button
-                                  icon={<EyeOutlined />}
-                                  key={`${script.scriptId}-inspect`}
-                                  onClick={() =>
-                                    setFocus({ kind: "script", id: script.scriptId })
-                                  }
-                                  type="link"
-                                >
-                                  Inspect
-                                </Button>
-                                <Button
-                                  icon={<CodeOutlined />}
-                                  key={`${script.scriptId}-studio`}
-                                  onClick={() =>
-                                    history.push(
-                                      buildStudioScriptsWorkspaceRoute({
-                                        scriptId: script.scriptId,
-                                      }),
-                                    )
-                                  }
-                                  type="link"
-                                >
-                                  Open scripts workspace
-                                </Button>
-                              </>
-                            }
-                            description={
-                              script.activeSourceHash
-                                ? `Source hash ${script.activeSourceHash}`
-                                : "Script asset is waiting for a committed source hash."
-                            }
-                            subtitle={
-                              <Space wrap size={[8, 8]}>
-                                <AevatarStatusTag
-                                  domain="asset"
-                                  status={script.activeRevision ? "active" : "draft"}
-                                />
-                                <Typography.Text type="secondary">
-                                  Revision {script.activeRevision || "n/a"}
-                                </Typography.Text>
-                              </Space>
-                            }
-                            title={script.scriptId}
+                  <AevatarPanel title="脚本行为资产">
+                    <ProList<ScopeScriptSummary>
+                      dataSource={scriptsQuery.data ?? []}
+                      grid={{ gutter: 16, column: 1 }}
+                      itemCardProps={{
+                        bodyStyle: { padding: 16 },
+                        style: { borderRadius: 12 },
+                      }}
+                      locale={{
+                        emptyText: (
+                          <Empty
+                            description="当前团队还没有脚本行为资产。"
+                            image={Empty.PRESENTED_IMAGE_SIMPLE}
                           />
-                        ))}
-                      </div>
-                    ) : (
-                      <Empty
-                        description="No script assets were found for this team."
-                        image={Empty.PRESENTED_IMAGE_SIMPLE}
-                      />
-                    )}
+                        ),
+                      }}
+                      metas={scriptMetas}
+                      pagination={false}
+                      rowKey="scriptId"
+                      split={false}
+                    />
                   </AevatarPanel>
                 </div>
               </>
@@ -699,18 +734,18 @@ const ScopeOverviewPage: React.FC = () => {
       <AevatarContextDrawer
         onClose={() => setFocus(null)}
         open={Boolean(focus)}
-        subtitle="Overview inspector"
+        subtitle="团队检查器"
         title={
           focus?.kind === "revision"
-            ? focusedRevision?.revisionId || focus?.id || "Revision"
-            : focus?.id || "Team detail"
+            ? focusedRevision?.revisionId || focus?.id || "版本"
+            : focus?.id || "团队详情"
         }
       >
         {!focus ? (
-          <AevatarInspectorEmpty description="Choose a revision, workflow, or script to inspect its role in the current team." />
+          <AevatarInspectorEmpty description="选择一个版本、行为定义或脚本行为来查看它在当前团队中的作用。" />
         ) : focus.kind === "revision" && focusedRevision ? (
           <AevatarPanel
-            title="Revision Snapshot"
+            title="版本快照"
             titleHelp="Revision posture, rollout identity, and activation affordance stay in one place."
           >
             <div
@@ -720,20 +755,20 @@ const ScopeOverviewPage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
               }}
             >
-              <MetricCard label="Revision" value={focusedRevision.revisionId} />
+              <MetricCard label="版本" value={focusedRevision.revisionId} />
               <MetricCard
-                label="Implementation"
+                label="实现类型"
                 value={formatStudioScopeBindingImplementationKind(
                   focusedRevision.implementationKind,
                 )}
               />
               <MetricCard
-                label="Target"
+                label="目标"
                 value={describeStudioScopeBindingRevisionTarget(focusedRevision)}
               />
-              <MetricCard label="Serving state" value={focusedRevision.servingState || focusedRevision.status} />
+              <MetricCard label="发布状态" value={focusedRevision.servingState || focusedRevision.status} />
               <MetricCard
-                label="Actor"
+                label="实例"
                 value={focusedRevision.primaryActorId || "n/a"}
               />
             </div>
@@ -743,7 +778,7 @@ const ScopeOverviewPage: React.FC = () => {
                   focusedRevision,
                 )}
                 showIcon
-                title="Binding detail"
+                title="绑定详情"
                 type="info"
               />
             ) : null}
@@ -780,15 +815,15 @@ const ScopeOverviewPage: React.FC = () => {
                   )
                 }
               >
-                Open Member Runtime
+                在成员页查看
               </Button>
             </Space>
           </AevatarPanel>
         ) : focus.kind === "workflow" ? (
           workflowDetailQuery.data?.available && workflowDetailQuery.data.workflow ? (
             <>
-              <AevatarPanel title="Workflow Asset">
-                <Space orientation="vertical" size={8}>
+              <AevatarPanel title="行为定义资产">
+                <Space direction="vertical" size={8}>
                   <Space wrap size={[8, 8]}>
                     <AevatarStatusTag
                       domain="asset"
@@ -803,24 +838,24 @@ const ScopeOverviewPage: React.FC = () => {
                     {workflowDetailQuery.data.workflow.displayName || workflowDetailQuery.data.workflow.workflowId}
                   </Typography.Text>
                   <Typography.Text type="secondary">
-                    {workflowDetailQuery.data.workflow.serviceKey || "No published entrypoint"}
+                    {workflowDetailQuery.data.workflow.serviceKey || "当前还没有已发布入口"}
                   </Typography.Text>
                 </Space>
               </AevatarPanel>
-              <AevatarPanel title="Workflow Source">
+              <AevatarPanel title="行为定义源码">
                 <pre style={codeBlockStyle}>
-                  {workflowDetailQuery.data.source?.workflowYaml || "No workflow YAML available."}
+                  {workflowDetailQuery.data.source?.workflowYaml || "当前还没有可查看的行为定义 YAML。"}
                 </pre>
               </AevatarPanel>
             </>
           ) : (
-            <AevatarInspectorEmpty description="Workflow detail is not available yet." />
+            <AevatarInspectorEmpty description="当前还没有可查看的行为定义详情。" />
           )
         ) : focus.kind === "script" ? (
           scriptDetailQuery.data?.available && scriptDetailQuery.data.script ? (
             <>
-              <AevatarPanel title="Script Asset">
-                <Space orientation="vertical" size={8}>
+              <AevatarPanel title="脚本行为资产">
+                <Space direction="vertical" size={8}>
                   <AevatarStatusTag
                     domain="asset"
                     status={scriptDetailQuery.data.script.activeRevision ? "active" : "draft"}
@@ -829,22 +864,22 @@ const ScopeOverviewPage: React.FC = () => {
                     {scriptDetailQuery.data.script.scriptId}
                   </Typography.Text>
                   <Typography.Text type="secondary">
-                    Revision {scriptDetailQuery.data.script.activeRevision || "n/a"} · Hash{" "}
+                    版本 {scriptDetailQuery.data.script.activeRevision || "n/a"} · 哈希{" "}
                     {scriptDetailQuery.data.script.activeSourceHash || "n/a"}
                   </Typography.Text>
                 </Space>
               </AevatarPanel>
-              <AevatarPanel title="Source Snapshot">
+              <AevatarPanel title="源码快照">
                 <pre style={codeBlockStyle}>
-                  {scriptDetailQuery.data.source?.sourceText || "No script source available."}
+                  {scriptDetailQuery.data.source?.sourceText || "当前还没有可查看的脚本源码。"}
                 </pre>
               </AevatarPanel>
             </>
           ) : (
-            <AevatarInspectorEmpty description="Script detail is not available yet." />
+            <AevatarInspectorEmpty description="当前还没有可查看的脚本行为详情。" />
           )
         ) : (
-          <AevatarInspectorEmpty description="No team detail is available." />
+          <AevatarInspectorEmpty description="当前还没有可查看的团队详情。" />
         )}
       </AevatarContextDrawer>
     </AevatarPageShell>
@@ -913,19 +948,19 @@ const ScopeServiceCard: React.FC<{
       />
     </Space>
     <Typography.Text type="secondary">
-      {service.endpoints.length} endpoints · Revision{" "}
+      {service.endpoints.length} 个端点 · 版本{" "}
       {service.activeServingRevisionId ||
         service.defaultServingRevisionId ||
         "n/a"}
     </Typography.Text>
     <Typography.Text type="secondary">
-      Actor {service.primaryActorId || "n/a"} · Updated {formatDateTime(service.updatedAt)}
+      实例 {service.primaryActorId || "n/a"} · 更新时间 {formatDateTime(service.updatedAt)}
     </Typography.Text>
     <Space wrap>
       <Button onClick={onOpenInvoke} type="primary">
-        Open invoke
+        打开测试入口
       </Button>
-      <Button onClick={onOpenServices}>Open services</Button>
+      <Button onClick={onOpenServices}>打开平台服务</Button>
     </Space>
   </div>
 );
@@ -1017,12 +1052,12 @@ const RevisionCard: React.FC<{
         wordBreak: "break-word",
       }}
     >
-      Actor {revision.primaryActorId || "n/a"} · Deployment{" "}
+      实例 {revision.primaryActorId || "n/a"} · 部署{" "}
       {revision.deploymentId || "draft"}
     </Typography.Text>
     <Space wrap>
       <Button icon={<EyeOutlined />} onClick={onInspect}>
-        Inspect
+        查看
       </Button>
       <Button
         disabled={!canActivate}

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
@@ -38,7 +38,9 @@ describe("StudioShell", () => {
 
     expect(container.firstChild).toHaveStyle({
       flex: "1",
-      minHeight: "calc(100vh - 176px)",
+      height: "100%",
+      minHeight: "0",
+      overflow: "hidden",
     });
     expect(container.querySelector(".ant-row")).toHaveStyle({
       flex: "1",
@@ -74,5 +76,22 @@ describe("StudioShell", () => {
     expect(
       screen.getByRole("button", { name: "Collapse workbench" })
     ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("allows callers to hand scroll ownership to the page content", () => {
+    render(
+      React.createElement(StudioShell, {
+        contentOverflow: "hidden",
+        currentPage: "workflows",
+        navItems,
+        onSelectPage: jest.fn(),
+        pageTitle: "Studio page",
+        children: React.createElement("div", null, "Studio content"),
+      })
+    );
+
+    expect(screen.getByText("Studio content").parentElement).toHaveStyle({
+      overflowY: "hidden",
+    });
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.tsx
@@ -28,6 +28,7 @@ export type StudioShellNavItem = {
 
 type StudioShellProps = {
   readonly alerts?: React.ReactNode;
+  readonly contentOverflow?: 'auto' | 'hidden';
   readonly currentPage: StudioWorkspacePage;
   readonly navItems: readonly StudioShellNavItem[];
   readonly onSelectPage: (page: StudioWorkspacePage) => void;
@@ -121,7 +122,9 @@ const workbenchFooterStyle: React.CSSProperties = {
 const shellRootStyle: React.CSSProperties = {
   ...cardStackStyle,
   flex: 1,
-  minHeight: 'calc(100vh - 176px)',
+  height: '100%',
+  minHeight: 0,
+  overflow: 'hidden',
 };
 
 const shellRowStyle: React.CSSProperties = {
@@ -131,6 +134,7 @@ const shellRowStyle: React.CSSProperties = {
 
 const shellColumnStyle: React.CSSProperties = {
   ...stretchColumnStyle,
+  flexDirection: 'column',
   minHeight: 0,
 };
 
@@ -153,6 +157,7 @@ const navItemIconByKey: Record<StudioWorkspacePage, React.ReactNode> = {
 
 const StudioShell: React.FC<StudioShellProps> = ({
   alerts,
+  contentOverflow = 'auto',
   currentPage,
   navItems,
   onSelectPage,
@@ -297,7 +302,12 @@ const StudioShell: React.FC<StudioShellProps> = ({
           </aside>
         </Col>
         <Col flex="auto" style={{ ...shellColumnStyle, minWidth: 0 }}>
-          <div style={shellContentStyle}>
+          <div
+            style={{
+              ...shellContentStyle,
+              overflowY: contentOverflow,
+            }}
+          >
             {showPageHeader ? (
               <div
                 style={{

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -158,6 +158,70 @@ type StudioSelectedGraphEdge = {
   readonly implicit: boolean;
 };
 
+function readWorkflowSortTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function compareWorkflowSummaryPriority(
+  left: StudioWorkflowSummary,
+  right: StudioWorkflowSummary,
+  selectedWorkflowId = '',
+): number {
+  const leftSelected = left.workflowId === selectedWorkflowId;
+  const rightSelected = right.workflowId === selectedWorkflowId;
+  if (leftSelected !== rightSelected) {
+    return leftSelected ? -1 : 1;
+  }
+
+  const updatedDelta =
+    readWorkflowSortTimestamp(right.updatedAtUtc) -
+    readWorkflowSortTimestamp(left.updatedAtUtc);
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+
+  if (left.stepCount !== right.stepCount) {
+    return right.stepCount - left.stepCount;
+  }
+
+  const leftDescriptionLength = left.description.trim().length;
+  const rightDescriptionLength = right.description.trim().length;
+  if (leftDescriptionLength !== rightDescriptionLength) {
+    return rightDescriptionLength - leftDescriptionLength;
+  }
+
+  return left.workflowId.localeCompare(right.workflowId);
+}
+
+export function dedupeStudioWorkflowSummaries(
+  workflows: readonly StudioWorkflowSummary[],
+  selectedWorkflowId = '',
+): StudioWorkflowSummary[] {
+  const dedupedWorkflows = new Map<string, StudioWorkflowSummary>();
+
+  for (const workflow of workflows) {
+    const key =
+      workflow.name.trim().toLowerCase() ||
+      workflow.workflowId.trim().toLowerCase();
+    const current = dedupedWorkflows.get(key);
+    if (!current) {
+      dedupedWorkflows.set(key, workflow);
+      continue;
+    }
+
+    if (
+      compareWorkflowSummaryPriority(workflow, current, selectedWorkflowId) < 0
+    ) {
+      dedupedWorkflows.set(key, workflow);
+    }
+  }
+
+  return Array.from(dedupedWorkflows.values()).sort((left, right) =>
+    compareWorkflowSummaryPriority(left, right, selectedWorkflowId),
+  );
+}
+
 const DEFAULT_GAGENT_REQUEST_TYPE_URL =
   'type.googleapis.com/google.protobuf.StringValue';
 
@@ -1803,11 +1867,16 @@ export const StudioWorkflowsPage: React.FC<StudioWorkflowsPageProps> = ({
 }) => {
   const directories = workspaceSettings.data?.directories ?? [];
   const isScopeMode = workflowStorageMode === 'scope';
+  const visibleWorkflows = React.useMemo(
+    () =>
+      dedupeStudioWorkflowSummaries(workflows.data ?? [], selectedWorkflowId),
+    [selectedWorkflowId, workflows.data],
+  );
   const activeDirectory =
     directories.find((directory) => directory.directoryId === selectedDirectoryId) ||
     directories[0] ||
     null;
-  const filteredWorkflows = (workflows.data ?? []).filter((workflow) => {
+  const filteredWorkflows = visibleWorkflows.filter((workflow) => {
     const keyword = workflowSearch.trim().toLowerCase();
     if (!keyword) {
       return true;

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -282,6 +282,12 @@ const workflowSidebarStackStyle: React.CSSProperties = {
   minHeight: 0,
 };
 
+const workflowColumnStretchStyle: React.CSSProperties = {
+  ...stretchColumnStyle,
+  flexDirection: 'column',
+  minHeight: 0,
+};
+
 const workflowSectionShellStyle: React.CSSProperties = {
   border: '1px solid #E6E3DE',
   borderRadius: 32,
@@ -1890,6 +1896,23 @@ export const StudioWorkflowsPage: React.FC<StudioWorkflowsPageProps> = ({
     ].some((value) => value.toLowerCase().includes(keyword));
   });
   const workflowViewportMaxWidth = isScopeMode ? undefined : 1080;
+  const resolvedWorkspaceRowStyle: React.CSSProperties = isScopeMode
+    ? { width: '100%' }
+    : workflowWorkspaceRowStyle;
+  const resolvedWorkflowBrowserStyle: React.CSSProperties = isScopeMode
+    ? {
+        ...workflowBrowserStyle,
+        flex: '0 0 auto',
+        height: 'auto',
+      }
+    : workflowBrowserStyle;
+  const resolvedWorkflowResultsBodyStyle: React.CSSProperties = isScopeMode
+    ? {
+        ...workflowResultsBodyStyle,
+        flex: '0 0 auto',
+        overflowY: 'visible',
+      }
+    : workflowResultsBodyStyle;
 
   const scopeSummaryDescription = workspaceSettings.isLoading
     ? 'Resolving the current scope.'
@@ -1900,9 +1923,9 @@ export const StudioWorkflowsPage: React.FC<StudioWorkflowsPageProps> = ({
     activeWorkflowDescription || 'Open the selected workflow or start a blank draft.';
 
   return (
-    <Row gutter={[16, 16]} align="stretch" style={workflowWorkspaceRowStyle}>
+    <Row gutter={[16, 16]} align="stretch" style={resolvedWorkspaceRowStyle}>
       {!isScopeMode ? (
-        <Col xs={24} xl={8} xxl={7} style={stretchColumnStyle}>
+        <Col xs={24} xl={8} xxl={7} style={workflowColumnStretchStyle}>
           <div style={workflowSidebarStackStyle}>
             <section
               style={{
@@ -2095,9 +2118,9 @@ export const StudioWorkflowsPage: React.FC<StudioWorkflowsPageProps> = ({
         xs={24}
         xl={isScopeMode ? 24 : 16}
         xxl={isScopeMode ? 24 : 17}
-        style={stretchColumnStyle}
+        style={workflowColumnStretchStyle}
       >
-        <section style={workflowBrowserStyle}>
+        <section style={resolvedWorkflowBrowserStyle}>
           <input
             ref={workflowImportInputRef}
             hidden
@@ -2216,7 +2239,7 @@ export const StudioWorkflowsPage: React.FC<StudioWorkflowsPageProps> = ({
             </div>
           </div>
 
-          <div style={workflowResultsBodyStyle}>
+          <div style={resolvedWorkflowResultsBodyStyle}>
             {workflows.isLoading ? (
               <Typography.Text type="secondary">
                 Loading workflows...

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkflowsPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkflowsPage.test.tsx
@@ -1,6 +1,25 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { StudioWorkflowsPage } from './StudioWorkbenchSections';
+import {
+  dedupeStudioWorkflowSummaries,
+  StudioWorkflowsPage,
+} from './StudioWorkbenchSections';
+
+function createWorkflowSummary(overrides = {}) {
+  return {
+    workflowId: 'workflow-1',
+    name: 'workflow-demo',
+    description: '',
+    fileName: 'workflow-demo.yaml',
+    filePath: '/tmp/workflows/workflow-demo.yaml',
+    directoryId: 'scope:scope-1',
+    directoryLabel: 'scope-1',
+    stepCount: 0,
+    hasLayout: false,
+    updatedAtUtc: '2026-04-09T09:00:00Z',
+    ...overrides,
+  };
+}
 
 function createProps(overrides = {}) {
   return {
@@ -50,6 +69,27 @@ function createProps(overrides = {}) {
 }
 
 describe('StudioWorkflowsPage', () => {
+  it('deduplicates same-name workflows and keeps the selected item visible', () => {
+    const deduped = dedupeStudioWorkflowSummaries(
+      [
+        createWorkflowSummary({
+          workflowId: 'legacy-id',
+          name: 'hello-chat',
+          updatedAtUtc: '2026-04-09T09:00:00Z',
+        }),
+        createWorkflowSummary({
+          workflowId: 'hello-chat',
+          name: 'hello-chat',
+          updatedAtUtc: '2026-04-09T10:00:00Z',
+        }),
+      ],
+      'legacy-id',
+    );
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.workflowId).toBe('legacy-id');
+  });
+
   it('keeps the browser panel stretched and centers the empty state', () => {
     render(React.createElement(StudioWorkflowsPage, createProps()));
 
@@ -65,5 +105,34 @@ describe('StudioWorkflowsPage', () => {
     expect(emptyContainer).toHaveStyle('display: flex');
     expect(emptyContainer).toHaveStyle('justify-content: center');
     expect(emptyContainer).toHaveStyle('width: 100%');
+  });
+
+  it('renders only the newest workflow card when duplicate names are returned', () => {
+    render(
+      React.createElement(
+        StudioWorkflowsPage,
+        createProps({
+          workflows: {
+            isLoading: false,
+            isError: false,
+            error: null,
+            data: [
+              createWorkflowSummary({
+                workflowId: 'legacy-id',
+                name: 'hello-chat',
+                updatedAtUtc: '2026-04-09T09:00:00Z',
+              }),
+              createWorkflowSummary({
+                workflowId: 'hello-chat',
+                name: 'hello-chat',
+                updatedAtUtc: '2026-04-09T10:00:00Z',
+              }),
+            ],
+          },
+        }),
+      ),
+    );
+
+    expect(screen.getAllByText('hello-chat')).toHaveLength(1);
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -1,8 +1,7 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { savePlaygroundDraft } from "@/shared/playground/playgroundDraft";
 import { ensureActiveAuthSession } from "@/shared/auth/client";
-import { history } from "@/shared/navigation/history";
 import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
 import { runtimeQueryApi } from "@/shared/api/runtimeQueryApi";
 import { loadDraftRunPayload } from "@/shared/runs/draftRunSession";
@@ -906,13 +905,14 @@ jest.mock("./components/StudioBootstrapGate", () => ({
 
 jest.mock("./components/StudioShell", () => ({
   __esModule: true,
-  default: ({ children, navItems = [], onSelectPage }: any) => {
+  default: ({ alerts, children, navItems = [], onSelectPage }: any) => {
     const React = require("react");
     return React.createElement(
       "div",
       null,
       [
         React.createElement("div", { key: "workbench" }, "Workbench"),
+        alerts ? React.createElement("div", { key: "alerts" }, alerts) : null,
         ...navItems.map((item: any) =>
           React.createElement(
             "button",
@@ -1575,6 +1575,33 @@ describe("StudioPage", () => {
     });
   });
 
+  it("keeps team context visible and preserved in the Studio route", async () => {
+    renderStudioPage(
+      "/studio?scopeId=scope-a&scopeLabel=%E5%9B%A2%E9%98%9F+A&memberId=service-alpha&memberLabel=%E6%88%90%E5%91%98+Alpha&workflow=workflow-1&tab=studio"
+    );
+
+    expect(await screen.findByText("团队构建器上下文")).toBeTruthy();
+    expect(screen.getByText("团队 A / 成员 Alpha")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/studio");
+    });
+
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get("scopeId")).toBe("scope-a");
+    expect(searchParams.get("scopeLabel")).toBe("团队 A");
+    expect(searchParams.get("memberId")).toBe("service-alpha");
+    expect(searchParams.get("memberLabel")).toBe("成员 Alpha");
+    expect(searchParams.get("workflow")).toBe("workflow-1");
+    expect(searchParams.get("tab")).toBe("studio");
+
+    fireEvent.click(screen.getByRole("button", { name: "查看行为定义" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Workflows" })).toBeTruthy();
+    });
+  });
+
   it("hydrates an editable blank draft when a scope workflow has no YAML source yet", async () => {
     (studioApi.getAppContext as jest.Mock).mockResolvedValue({
       ...defaultStudioAppContext,
@@ -1741,7 +1768,7 @@ describe("StudioPage", () => {
     renderStudioPage("/studio?tab=scripts");
 
     await screen.findByLabelText("Script ID");
-    fireEvent.click(screen.getByRole("button", { name: "Workflows" }));
+    fireEvent.click(screen.getByRole("button", { name: "行为定义" }));
 
     expect(await screen.findByText("Leave Scripts Studio?")).toBeTruthy();
     expect(
@@ -1756,7 +1783,7 @@ describe("StudioPage", () => {
     });
     expect(screen.getByLabelText("Script ID")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Workflows" }));
+    fireEvent.click(screen.getByRole("button", { name: "行为定义" }));
     fireEvent.click(await screen.findByRole("button", { name: "Leave page" }));
 
     expect(await screen.findByText("Current draft")).toBeTruthy();
@@ -1792,6 +1819,37 @@ describe("StudioPage", () => {
     renderStudioPage("/studio?draft=new");
 
     expect(await screen.findByText("Blank Studio draft")).toBeTruthy();
+    expect(
+      (await screen.findByLabelText("Workflow name")) as HTMLInputElement
+    ).toHaveValue("draft");
+    expect(
+      (await screen.findByLabelText("Workflow YAML")) as HTMLTextAreaElement
+    ).toHaveValue("name: draft\nsteps: []\n");
+  });
+
+  it("recovers to a blank draft when the route points at a missing workflow", async () => {
+    (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
+      ...defaultStudioAppContext,
+      scopeId: "scope-1",
+      scopeResolved: true,
+      workflowStorageMode: "scope",
+    });
+    (studioApi.listWorkflows as jest.Mock).mockResolvedValueOnce([]);
+    (studioApi.getWorkflow as jest.Mock).mockRejectedValueOnce(
+      new Error("Not Found")
+    );
+
+    renderStudioPage("/studio?scopeId=scope-1&workflow=draft&tab=studio");
+
+    await waitFor(() => {
+      expect(studioApi.getWorkflow).toHaveBeenCalledWith("draft");
+    });
+
+    await waitFor(() => {
+      expect(window.location.search).toContain("draft=new");
+      expect(window.location.search).not.toContain("workflow=draft");
+    });
+
     expect(
       (await screen.findByLabelText("Workflow name")) as HTMLInputElement
     ).toHaveValue("draft");
@@ -1990,7 +2048,7 @@ describe("StudioPage", () => {
     });
   });
 
-  it("loads discovered GAgent types and the resolved scope binding", async () => {
+  it("loads discovered GAgent types for the resolved scope context", async () => {
     (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
       ...defaultStudioAppContext,
       scopeId: "scope-1",
@@ -2003,41 +2061,6 @@ describe("StudioPage", () => {
     });
     await waitFor(() => {
       expect(studioApi.getScopeBinding).toHaveBeenCalledWith("scope-1");
-    });
-  });
-
-  it("prefers the route scopeId over the app context scope when opening Studio", async () => {
-    (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
-      ...defaultStudioAppContext,
-      scopeId: "scope-app",
-      scopeResolved: true,
-    });
-    renderStudioPage("/studio?scopeId=scope-route&workflow=workflow-1&tab=studio");
-
-    await waitFor(() => {
-      expect(studioApi.getScopeBinding).toHaveBeenCalledWith("scope-route");
-    });
-  });
-
-  it("updates the scope context when the Studio route scopeId changes after mount", async () => {
-    (studioApi.getAppContext as jest.Mock).mockResolvedValue({
-      ...defaultStudioAppContext,
-      scopeId: "scope-app",
-      scopeResolved: true,
-    });
-
-    renderStudioPage("/studio?scopeId=scope-route-a&workflow=workflow-1&tab=studio");
-
-    await waitFor(() => {
-      expect(studioApi.getScopeBinding).toHaveBeenCalledWith("scope-route-a");
-    });
-
-    await act(async () => {
-      history.push("/studio?scopeId=scope-route-b&workflow=workflow-1&tab=studio");
-    });
-
-    await waitFor(() => {
-      expect(studioApi.getScopeBinding).toHaveBeenCalledWith("scope-route-b");
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -1,17 +1,20 @@
 import { PageContainer } from '@ant-design/pro-components';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { history } from '@/shared/navigation/history';
-import { buildTeamWorkspaceRoute } from '@/shared/navigation/scopeRoutes';
+import {
+  buildTeamDetailHref,
+  buildTeamsHref,
+} from '@/shared/navigation/teamRoutes';
 import {
   buildRuntimeRunsHref,
   buildRuntimeWorkflowsHref,
 } from '@/shared/navigation/runtimeRoutes';
 import type { Node } from '@xyflow/react';
 import {
+  Alert,
   Button,
   Modal,
   Space,
-  message,
 } from 'antd';
 import React, {
   useCallback,
@@ -98,6 +101,7 @@ import StudioShell, {
 } from './components/StudioShell';
 import ScriptsWorkbenchPage from '@/modules/studio/scripts/ScriptsWorkbenchPage';
 import {
+  dedupeStudioWorkflowSummaries,
   type StudioCatalogDraftMeta,
   type StudioConnectorCatalogItem,
   type StudioConnectorDraftItem,
@@ -115,6 +119,9 @@ import {
 
 type StudioRouteState = {
   scopeId: string;
+  scopeLabel: string;
+  memberId: string;
+  memberLabel: string;
   workflowId: string;
   scriptId: string;
   templateWorkflow: string;
@@ -804,12 +811,13 @@ function buildBlankDraftYaml(workflowName: string): string {
   return `name: ${normalizedName}\nsteps: []\n`;
 }
 
-function readInitialStudioRouteState(
-  search = typeof window === 'undefined' ? '' : window.location.search,
-): StudioRouteState {
-  if (typeof window === 'undefined' && !search) {
+function readInitialStudioRouteState(): StudioRouteState {
+  if (typeof window === 'undefined') {
     return {
       scopeId: '',
+      scopeLabel: '',
+      memberId: '',
+      memberLabel: '',
       workflowId: '',
       scriptId: '',
       templateWorkflow: '',
@@ -822,9 +830,12 @@ function readInitialStudioRouteState(
     };
   }
 
-  const params = new URLSearchParams(search);
+  const params = new URLSearchParams(window.location.search);
   return {
     scopeId: trimOptional(params.get('scopeId')),
+    scopeLabel: trimOptional(params.get('scopeLabel')),
+    memberId: trimOptional(params.get('memberId')),
+    memberLabel: trimOptional(params.get('memberLabel')),
     workflowId: trimOptional(params.get('workflow')),
     scriptId: trimOptional(params.get('script')),
     templateWorkflow: trimOptional(params.get('template')),
@@ -912,30 +923,18 @@ function readValidationSummary(
       };
 }
 
-const StudioPage: React.FC = () => {
-  const [messageApi, messageContextHolder] = message.useMessage();
-  const locationSearch = React.useSyncExternalStore(
-    (listener) => {
-      if (typeof window === 'undefined') {
-        return () => undefined;
-      }
+function isWorkflowNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
 
-      window.addEventListener('popstate', listener);
-      return () => {
-        window.removeEventListener('popstate', listener);
-      };
-    },
-    () => (typeof window === 'undefined' ? '' : window.location.search),
-    () => '',
-  );
-  const routeState = useMemo(
-    () => readInitialStudioRouteState(locationSearch),
-    [locationSearch],
-  );
-  const initialState = React.useRef(routeState).current;
+  return /not found/i.test(error.message);
+}
+
+const StudioPage: React.FC = () => {
+  const initialState = useMemo(() => readInitialStudioRouteState(), []);
   const nyxIdConfig = useMemo(() => getNyxIDRuntimeConfig(), []);
   const queryClient = useQueryClient();
-  const routeScopeId = routeState.scopeId;
   const [workspacePage, setWorkspacePage] = useState<StudioWorkspacePage>(
     readInitialWorkspacePage(initialState),
   );
@@ -1126,7 +1125,7 @@ const StudioPage: React.FC = () => {
     queryFn: () => studioApi.getAppContext(),
   });
   const resolvedStudioScopeId =
-    trimOptional(routeScopeId) ||
+    initialState.scopeId ||
     trimOptional(appContextQuery.data?.scopeId) ||
     trimOptional(authSessionQuery.data?.scopeId) ||
     '';
@@ -1197,11 +1196,19 @@ const StudioPage: React.FC = () => {
     retry: false,
     queryFn: () => runtimeQueryApi.listPrimitives(),
   });
+  const visibleWorkflowSummaries = useMemo(
+    () =>
+      dedupeStudioWorkflowSummaries(
+        workflowsQuery.data ?? [],
+        selectedWorkflowId,
+      ),
+    [selectedWorkflowId, workflowsQuery.data],
+  );
   const matchingWorkspaceWorkflow = useMemo(
     () =>
-      (workflowsQuery.data ?? []).find((item) => item.name === templateWorkflow) ??
+      visibleWorkflowSummaries.find((item) => item.name === templateWorkflow) ??
       null,
-    [templateWorkflow, workflowsQuery.data],
+    [templateWorkflow, visibleWorkflowSummaries],
   );
   const templateWorkflowQuery = useQuery({
     queryKey: ['studio-template-workflow', templateWorkflow],
@@ -1215,8 +1222,8 @@ const StudioPage: React.FC = () => {
   const activeWorkflowFile = selectedWorkflowQuery.data ?? null;
   const activeTemplate = templateWorkflowQuery.data ?? null;
   const workflowNames = useMemo(
-    () => (workflowsQuery.data ?? []).map((item) => item.name),
-    [workflowsQuery.data],
+    () => visibleWorkflowSummaries.map((item) => item.name),
+    [visibleWorkflowSummaries],
   );
   const availableStepTypes = useMemo(() => {
     const stepTypes = new Set<string>();
@@ -1317,13 +1324,51 @@ const StudioPage: React.FC = () => {
       selectedWorkflowId ||
       templateWorkflow ||
       draftMode === 'new' ||
-      (workflowsQuery.data?.length ?? 0) === 0
+      visibleWorkflowSummaries.length === 0
     ) {
       return;
     }
 
-    setSelectedWorkflowId(workflowsQuery.data?.[0]?.workflowId ?? '');
-  }, [draftMode, selectedWorkflowId, templateWorkflow, workflowsQuery.data]);
+    setSelectedWorkflowId(visibleWorkflowSummaries[0]?.workflowId ?? '');
+  }, [draftMode, selectedWorkflowId, templateWorkflow, visibleWorkflowSummaries]);
+
+  useEffect(() => {
+    if (
+      !selectedWorkflowId ||
+      !selectedWorkflowQuery.isError ||
+      !isWorkflowNotFoundError(selectedWorkflowQuery.error)
+    ) {
+      return;
+    }
+
+    const fallbackWorkflowId =
+      visibleWorkflowSummaries.find(
+        (workflow) => workflow.workflowId !== selectedWorkflowId,
+      )?.workflowId ?? '';
+
+    if (fallbackWorkflowId) {
+      setSelectedWorkflowId(fallbackWorkflowId);
+      setTemplateWorkflow('');
+      setDraftMode('');
+      setLegacySource('');
+      setSaveNotice(null);
+      return;
+    }
+
+    setSelectedWorkflowId('');
+    setTemplateWorkflow('');
+    setDraftMode('new');
+    setLegacySource('');
+    setDraftDirectoryId((current) => current || defaultDirectoryId);
+    setDraftWorkflowLayout(null);
+    setSaveNotice(null);
+  }, [
+    defaultDirectoryId,
+    selectedWorkflowId,
+    selectedWorkflowQuery.error,
+    selectedWorkflowQuery.isError,
+    visibleWorkflowSummaries,
+  ]);
 
   useEffect(() => {
     if (!templateWorkflow || selectedWorkflowId || !matchingWorkspaceWorkflow) {
@@ -1483,10 +1528,6 @@ const StudioPage: React.FC = () => {
       return;
     }
 
-    if (!window.location.pathname.startsWith('/studio')) {
-      return;
-    }
-
     const tab: StudioTab =
       workspacePage === 'studio'
         ? studioView === 'execution'
@@ -1495,7 +1536,10 @@ const StudioPage: React.FC = () => {
         : workspacePage;
 
     window.history.replaceState(null, '', buildStudioRoute({
-      scopeId: routeScopeId || undefined,
+      scopeId: resolvedStudioScopeId || undefined,
+      scopeLabel: initialState.scopeLabel || undefined,
+      memberId: initialState.memberId || undefined,
+      memberLabel: initialState.memberLabel || undefined,
       workflowId: selectedWorkflowId || undefined,
       scriptId: selectedScriptId || undefined,
       template: !selectedWorkflowId ? templateWorkflow || undefined : undefined,
@@ -1520,7 +1564,6 @@ const StudioPage: React.FC = () => {
     draftMode,
     legacySource,
     logsPopoutMode,
-    routeScopeId,
     selectedExecutionId,
     selectedScriptId,
     selectedWorkflowId,
@@ -1615,7 +1658,7 @@ const StudioPage: React.FC = () => {
       throw new Error('Workflow YAML is required.');
     }
 
-    const workspaceWorkflows = workflowsQuery.data ?? [];
+    const workspaceWorkflows = visibleWorkflowSummaries;
     const availableWorkflowNames = workspaceWorkflows.map((item) => item.name);
     const workflowIdsByName = new Map(
       workspaceWorkflows.map((item) => [item.name, item.workflowId]),
@@ -1689,7 +1732,7 @@ const StudioPage: React.FC = () => {
     availableStepTypes,
     draftWorkflowName,
     draftYaml,
-    workflowsQuery.data,
+    visibleWorkflowSummaries,
   ]);
   const recentPromptHistory = useMemo(
     () => promptHistory.slice(0, 3),
@@ -1936,7 +1979,7 @@ const StudioPage: React.FC = () => {
       return;
     }
 
-    const workspaceWorkflow = (workflowsQuery.data ?? []).find(
+    const workspaceWorkflow = visibleWorkflowSummaries.find(
       (item) => item.name === normalizedWorkflowName,
     );
     if (workspaceWorkflow) {
@@ -1982,7 +2025,7 @@ const StudioPage: React.FC = () => {
     }
 
     const fallbackWorkflowId =
-      selectedWorkflowId || workflowsQuery.data?.[0]?.workflowId || '';
+      selectedWorkflowId || visibleWorkflowSummaries[0]?.workflowId || '';
     if (fallbackWorkflowId) {
       setSelectedWorkflowId(fallbackWorkflowId);
       setTemplateWorkflow('');
@@ -2010,7 +2053,7 @@ const StudioPage: React.FC = () => {
     sourceWorkflowLayout,
     sourceWorkflowName,
     sourceYaml,
-    workflowsQuery.data,
+    visibleWorkflowSummaries,
   ]);
 
   const handleSwitchStudioView = useCallback(
@@ -4028,40 +4071,40 @@ const StudioPage: React.FC = () => {
   const navItems: StudioShellNavItem[] = [
     {
       key: 'workflows',
-      label: 'Workflows',
-      description: 'Browse workspace workflows and start new drafts.',
-      count: workflowsQuery.data?.length ?? 0,
+      label: '行为定义',
+      description: '浏览团队可用的行为定义并开始新的草稿。',
+      count: visibleWorkflowSummaries.length,
     },
     {
       key: 'studio',
-      label: 'Studio',
-      description: 'Edit the active draft and inspect execution runs.',
+      label: '成员编辑器',
+      description: '编辑当前成员草稿，并查看测试运行状态。',
       count: executionsQuery.data?.length ?? 0,
     },
     {
       key: 'roles',
-      label: 'Roles',
-      description: 'Edit, import, and save workflow role definitions.',
+      label: 'Agent 角色',
+      description: '编辑、导入并保存 Agent 角色定义。',
       count: rolesQuery.data?.roles.length ?? 0,
     },
     {
       key: 'connectors',
-      label: 'Connectors',
-      description: 'Edit, import, and save Studio connectors.',
+      label: '集成',
+      description: '编辑、导入并保存团队可用集成。',
       count: connectorsQuery.data?.connectors.length ?? 0,
     },
     {
       key: 'settings',
-      label: 'Workspace settings',
-      description: 'Manage AI providers and review runtime and workflow setup.',
+      label: '编辑器设置',
+      description: '管理 AI Provider，并检查运行时与行为定义配置。',
       count: workspaceSettingsQuery.data?.directories.length ?? 0,
     },
   ];
   if (appContextQuery.data?.features.scripts) {
     navItems.splice(2, 0, {
       key: 'scripts',
-      label: 'Scripts',
-      description: 'Author, validate, run, and promote scope-aware scripts.',
+      label: '脚本行为',
+      description: '编写、校验、测试并发布 scope 感知脚本。',
     });
   }
 
@@ -4086,18 +4129,18 @@ const StudioPage: React.FC = () => {
 
   const pageTitle =
     workspacePage === 'workflows'
-      ? 'Workflows'
+      ? '行为定义'
       : workspacePage === 'scripts'
-        ? 'Scripts Studio'
+        ? '脚本行为'
       : workspacePage === 'studio'
         ? studioView === 'execution'
-          ? 'Studio execution view'
-          : 'Studio editor'
+          ? '测试运行'
+          : '成员编辑器'
         : workspacePage === 'roles'
-          ? 'Role catalog'
+          ? 'Agent 角色'
           : workspacePage === 'connectors'
-            ? 'Connector catalog'
-            : 'Workspace settings';
+            ? '集成'
+            : '编辑器设置';
 
   const pageToolbar =
     workspacePage === 'studio' ? (
@@ -4106,33 +4149,80 @@ const StudioPage: React.FC = () => {
           type={studioView === 'editor' ? 'primary' : 'default'}
           onClick={() => handleSwitchStudioView('editor')}
         >
-          Edit
+          编辑画布
         </Button>
         <Button
           type={studioView === 'execution' ? 'primary' : 'default'}
           onClick={() => handleSwitchStudioView('execution')}
         >
-          Runs
+          测试运行
         </Button>
         <Button onClick={() => setWorkspacePage('workflows')}>
-          Workflow library
+          行为定义
         </Button>
       </Space>
     ) : workspacePage === 'scripts' ? (
       <Space wrap size={[8, 8]}>
         <Button onClick={() => setWorkspacePage('workflows')}>
-          Workflow library
+          行为定义
         </Button>
       </Space>
     ) : undefined;
 
+  const studioContextScopeLabel = initialState.scopeLabel || resolvedStudioScopeId;
+  const studioContextMemberLabel = initialState.memberLabel;
+  const studioContextAlert =
+    resolvedStudioScopeId || studioContextMemberLabel ? (
+      <Alert
+        action={
+          <Space wrap size={[8, 8]}>
+            {resolvedStudioScopeId ? (
+              <Button
+                onClick={() =>
+                  history.push(
+                    buildTeamDetailHref({
+                      scopeId: resolvedStudioScopeId,
+                      tab: 'advanced',
+                      serviceId: scopeBindingQuery.data?.serviceId || undefined,
+                    }),
+                  )
+                }
+                size="small"
+                type="link"
+              >
+                返回团队
+              </Button>
+            ) : null}
+            <Button
+              onClick={() => setWorkspacePage('workflows')}
+              size="small"
+              type="link"
+            >
+              查看行为定义
+            </Button>
+          </Space>
+        }
+        description={
+          studioContextMemberLabel
+            ? `${studioContextScopeLabel || '当前团队'} / ${studioContextMemberLabel}`
+            : `${studioContextScopeLabel || '当前团队'}`
+        }
+        message="团队构建器上下文"
+        showIcon
+        type="info"
+      />
+    ) : null;
+
   const workspaceAlerts = (
-    <StudioWorkspaceAlerts
-      authSession={authRecoveryPending ? null : authSessionQuery.data}
-      templateWorkflow={templateWorkflow}
-      draftMode={draftMode}
-      legacySource={legacySource}
-    />
+    <>
+      {studioContextAlert}
+      <StudioWorkspaceAlerts
+        authSession={authRecoveryPending ? null : authSessionQuery.data}
+        templateWorkflow={templateWorkflow}
+        draftMode={draftMode}
+        legacySource={legacySource}
+      />
+    </>
   );
 
   const inspectorContent = (
@@ -4201,7 +4291,12 @@ const StudioPage: React.FC = () => {
         }}
       >
         <StudioWorkflowsPage
-          workflows={workflowsQuery}
+          workflows={{
+            isLoading: workflowsQuery.isLoading,
+            isError: workflowsQuery.isError,
+            error: workflowsQuery.error,
+            data: visibleWorkflowSummaries,
+          }}
           workspaceSettings={workspaceSettingsQuery}
           workflowStorageMode={
             appContextQuery.data?.workflowStorageMode || 'workspace'
@@ -4436,7 +4531,15 @@ const StudioPage: React.FC = () => {
           onOpenWorkflowFromHistory={openWorkflowFromHistory}
           onStartExecution={() => void handleStartExecution()}
           onOpenProjectOverview={() => {
-            history.push(buildTeamWorkspaceRoute(resolvedStudioScopeId));
+            history.push(
+              resolvedStudioScopeId
+                ? buildTeamDetailHref({
+                    scopeId: resolvedStudioScopeId,
+                    tab: 'advanced',
+                    serviceId: scopeBindingQuery.data?.serviceId || undefined,
+                  })
+                : buildTeamsHref(),
+            );
           }}
           onOpenProjectInvoke={() => {
             history.push(

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -2233,6 +2233,7 @@ const StudioPage: React.FC = () => {
           route: workflowName,
           prompt,
           draftKey,
+          returnTo: currentStudioReturnTo || undefined,
         }),
       );
     } catch (error) {
@@ -2447,6 +2448,7 @@ const StudioPage: React.FC = () => {
               endpointId: launchEndpoint.endpointId,
               endpointKind: launchEndpointKind,
               prompt: input.prompt?.trim() || undefined,
+              returnTo: currentStudioReturnTo || undefined,
             }),
           );
         } else if (launchEndpoint) {
@@ -2468,6 +2470,7 @@ const StudioPage: React.FC = () => {
               endpointKind: launchEndpointKind,
               prompt: input.prompt?.trim() || undefined,
               draftKey,
+              returnTo: currentStudioReturnTo || undefined,
             }),
           );
         }
@@ -4171,6 +4174,12 @@ const StudioPage: React.FC = () => {
 
   const studioContextScopeLabel = initialState.scopeLabel || resolvedStudioScopeId;
   const studioContextMemberLabel = initialState.memberLabel;
+  const currentStudioReturnTo =
+    typeof window === 'undefined'
+      ? ''
+      : sanitizeReturnTo(
+          `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        );
   const studioContextAlert =
     resolvedStudioScopeId || studioContextMemberLabel ? (
       <Alert
@@ -4284,10 +4293,8 @@ const StudioPage: React.FC = () => {
         data-testid="studio-workflows-viewport"
         style={{
           display: 'flex',
-          flex: 1,
           flexDirection: 'column',
-          minHeight: 0,
-          overflow: 'hidden',
+          minWidth: 0,
         }}
       >
         <StudioWorkflowsPage
@@ -4508,6 +4515,7 @@ const StudioPage: React.FC = () => {
                   route: workflowName || undefined,
                   prompt: runPrompt || undefined,
                   draftKey,
+                  returnTo: currentStudioReturnTo || undefined,
                 }),
               );
             } catch {
@@ -4516,6 +4524,7 @@ const StudioPage: React.FC = () => {
                   scopeId: scopeId || undefined,
                   route: workflowName || undefined,
                   prompt: runPrompt || undefined,
+                  returnTo: currentStudioReturnTo || undefined,
                 }),
               );
             }

--- a/apps/aevatar-console-web/src/pages/teams/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/index.test.tsx
@@ -1,168 +1,251 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { history } from "@/shared/navigation/history";
 import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
-import TeamsIndexPage from "./index";
+import TeamDetailPage from "./index";
 
-jest.mock("@/shared/studio/api", () => ({
-  studioApi: {
-    getAuthSession: jest.fn(),
+jest.mock("@/shared/api/runtimeGAgentApi", () => ({
+  runtimeGAgentApi: {
+    getScopeBinding: jest.fn(),
+    listActors: jest.fn(),
   },
 }));
 
-jest.mock("./runtime/useTeamRuntimeLens", () => ({
-  useTeamRuntimeLens: jest.fn(),
+jest.mock("@/shared/api/servicesApi", () => ({
+  servicesApi: {
+    listServices: jest.fn(),
+  },
 }));
 
-import { studioApi } from "@/shared/studio/api";
-import { useTeamRuntimeLens } from "./runtime/useTeamRuntimeLens";
+jest.mock("@/shared/api/scopesApi", () => ({
+  scopesApi: {
+    listWorkflows: jest.fn(),
+    listScripts: jest.fn(),
+  },
+}));
 
-function createTeamLensResult(overrides?: Record<string, unknown>) {
-  return {
-    actorGraphQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    baselineRunAuditQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    bindingQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    currentRunAuditQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    lens: {
-      baselineRun: {
-        runId: "run-good",
+jest.mock("@/shared/api/runtimeActorsApi", () => ({
+  runtimeActorsApi: {
+    getActorGraphEnriched: jest.fn(),
+  },
+}));
+
+jest.mock("@/shared/api/scopeRuntimeApi", () => ({
+  scopeRuntimeApi: {
+    listServiceRuns: jest.fn(),
+    getServiceRunAudit: jest.fn(),
+    getServiceBindings: jest.fn(),
+  },
+}));
+
+jest.mock("@/shared/graphs/GraphCanvas", () => ({
+  __esModule: true,
+  default: () => {
+    const mockReact = require("react");
+    return mockReact.createElement("div", null, "GraphCanvas");
+  },
+}));
+
+import { runtimeActorsApi } from "@/shared/api/runtimeActorsApi";
+import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
+import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
+import { scopesApi } from "@/shared/api/scopesApi";
+import { servicesApi } from "@/shared/api/servicesApi";
+
+describe("TeamDetailPage", () => {
+  beforeEach(() => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-a?tab=advanced&serviceId=service-alpha&runId=run-1",
+    );
+    jest.clearAllMocks();
+
+    (runtimeGAgentApi.getScopeBinding as jest.Mock).mockResolvedValue({
+      available: true,
+      scopeId: "scope-a",
+      serviceId: "service-alpha",
+      displayName: "Alpha Team",
+      serviceKey: "scope-a/default",
+      defaultServingRevisionId: "rev-1",
+      activeServingRevisionId: "rev-1",
+      deploymentId: "deploy-1",
+      deploymentStatus: "Ready",
+      primaryActorId: "actor://team-alpha",
+      updatedAt: "2026-04-09T08:00:00Z",
+      revisions: [
+        {
+          revisionId: "rev-1",
+          implementationKind: "workflow",
+          status: "Ready",
+          artifactHash: "artifact-1",
+          failureReason: "",
+          isDefaultServing: true,
+          isActiveServing: true,
+          isServingTarget: true,
+          allocationWeight: 100,
+          servingState: "Ready",
+          deploymentId: "deploy-1",
+          primaryActorId: "actor://team-alpha",
+          createdAt: "2026-04-09T07:00:00Z",
+          preparedAt: "2026-04-09T07:05:00Z",
+          publishedAt: "2026-04-09T07:10:00Z",
+          retiredAt: null,
+          workflowName: "workflow-alpha",
+          workflowDefinitionActorId: "definition://workflow-alpha",
+          inlineWorkflowCount: 1,
+          scriptId: "",
+          scriptRevision: "",
+          scriptDefinitionActorId: "",
+          scriptSourceHash: "",
+          staticActorTypeName: "",
+        },
+      ],
+    });
+    (runtimeGAgentApi.listActors as jest.Mock).mockResolvedValue([
+      {
+        gAgentType: "Tests.WorkflowMember",
+        actorIds: ["actor://team-alpha", "actor://helper"],
       },
-      compare: {
-        summary: "Current run differs from the latest prior good run.",
+    ]);
+    (servicesApi.listServices as jest.Mock).mockResolvedValue([
+      {
+        serviceId: "service-alpha",
+        serviceKey: "scope-a/default",
+        displayName: "Alpha Assistant",
+        deploymentStatus: "Ready",
+        updatedAt: "2026-04-09T08:00:00Z",
+        endpoints: [{ endpointId: "chat" }],
+        primaryActorId: "actor://team-alpha",
+        activeServingRevisionId: "rev-1",
+        defaultServingRevisionId: "rev-1",
       },
-      currentBindingContext: "Serving revision rev-2 on default service.",
-      currentBindingTarget: "Workflow support-triage",
-      currentRun: {
-        completionStatus: "waiting_approval",
-        runId: "run-current",
+    ]);
+    (scopesApi.listWorkflows as jest.Mock).mockResolvedValue([
+      {
+        scopeId: "scope-a",
+        workflowId: "workflow-alpha",
+        displayName: "Alpha Workflow",
+        workflowName: "workflow-alpha",
+        serviceKey: "scope-a/default",
+        actorId: "actor://team-alpha",
+        activeRevisionId: "rev-1",
+        deploymentStatus: "Published",
+        deploymentId: "deploy-1",
+        updatedAt: "2026-04-09T08:00:00Z",
       },
-      graph: {
-        available: true,
-        focusActorId: "actor-intake",
-        focusReason: "The latest visible run is still centered on actor-intake.",
-        relationships: [
+    ]);
+    (scopesApi.listScripts as jest.Mock).mockResolvedValue([
+      {
+        scopeId: "scope-a",
+        scriptId: "script-alpha",
+        catalogActorId: "catalog://script-alpha",
+        definitionActorId: "definition://script-alpha",
+        activeRevision: "rev-1",
+        activeSourceHash: "hash-1",
+        updatedAt: "2026-04-09T08:00:00Z",
+      },
+    ]);
+    (runtimeActorsApi.getActorGraphEnriched as jest.Mock).mockResolvedValue({
+      snapshot: {
+        actorId: "actor://team-alpha",
+      },
+      subgraph: {
+        rootNodeId: "actor://team-alpha",
+        nodes: [
           {
-            fromActorId: "actor-intake",
-            toActorId: "actor-risk",
+            nodeId: "actor://team-alpha",
+            nodeType: "WorkflowRun",
+            properties: {
+              workflowName: "workflow-alpha",
+              stepId: "",
+              stepType: "",
+              targetRole: "",
+            },
+          },
+        ],
+        edges: [],
+      },
+    });
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValue({
+      runs: [
+        {
+          runId: "run-1",
+          actorId: "actor://team-alpha",
+          completionStatus: "Completed",
+        },
+      ],
+    });
+    (scopeRuntimeApi.getServiceRunAudit as jest.Mock).mockResolvedValue({
+      audit: {
+        summary: {
+          totalSteps: 3,
+          requestedSteps: 3,
+          completedSteps: 3,
+          roleReplyCount: 2,
+        },
+        timeline: [
+          {
+            timestamp: "2026-04-09T08:01:00Z",
+            eventType: "RunStarted",
+            agentId: "actor://team-alpha",
+            stepId: "step-1",
+            message: "Run started",
           },
         ],
       },
-      healthStatus: "blocked",
-      healthSummary: "The team is waiting on human approval.",
-      healthTone: "warning",
-      partialSignals: [],
-      playback: {
-        interactionLabel: "human_approval",
-        prompt: "Approve escalation",
-        summary: "Playback is centered on the current human gate.",
-      },
-      subtitle: "Support escalations with human approval when risk spikes.",
-      title: "Support Escalation Triage",
-    },
-    runsQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    scriptsQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    servicesQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    workflowsQuery: {
-      isError: false,
-      isLoading: false,
-    },
-    ...overrides,
-  };
-}
-
-describe("TeamsIndexPage", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    window.history.replaceState({}, "", "/teams");
-    (useTeamRuntimeLens as jest.Mock).mockReturnValue(createTeamLensResult());
+    });
+    (scopeRuntimeApi.getServiceBindings as jest.Mock).mockResolvedValue({
+      bindings: [
+        {
+          bindingId: "binding-1",
+          displayName: "Search Connector",
+          retired: false,
+          connectorRef: {
+            connectorType: "http",
+            connectorId: "search",
+          },
+          targetKind: "workflow",
+          targetName: "workflow-alpha",
+        },
+      ],
+    });
   });
 
-  it("renders the current team home instead of redirecting immediately", async () => {
-    (studioApi.getAuthSession as jest.Mock).mockResolvedValue({
-      enabled: true,
-      scopeId: "scope-team",
-      scopeSource: "claim:scope_id",
-    });
+  it("renders the team detail tabs and aggregated team content", async () => {
+    renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    renderWithQueryClient(React.createElement(TeamsIndexPage));
-
+    expect(await screen.findByText("高级编辑")).toBeTruthy();
+    expect(screen.getByText("团队构建器入口")).toBeTruthy();
     expect(
-      await screen.findByRole("button", { name: "Handle current blockage" }),
-    ).toBeTruthy();
-    expect(screen.getByText("Current collaboration snapshot")).toBeTruthy();
-    expect(screen.getByText("Support Escalation Triage")).toBeTruthy();
-    expect(window.location.pathname).toBe("/teams");
-  });
-
-  it("opens the current team workspace from the dynamic primary CTA", async () => {
-    (studioApi.getAuthSession as jest.Mock).mockResolvedValue({
-      enabled: true,
-      scopeId: "scope-team",
-      scopeSource: "claim:scope_id",
-    });
-
-    renderWithQueryClient(React.createElement(TeamsIndexPage));
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Handle current blockage" }),
-    );
+      screen.getAllByRole("button", { name: "打开团队构建器" }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "行为定义" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "脚本行为" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Agent 角色" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "集成" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "测试运行" })).toBeTruthy();
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/teams/scope-team");
-      expect(window.location.search).toBe("?scopeId=scope-team");
+      expect(runtimeGAgentApi.getScopeBinding).toHaveBeenCalledWith("scope-a");
+      expect(servicesApi.listServices).toHaveBeenCalled();
+      expect(scopeRuntimeApi.getServiceBindings).toHaveBeenCalledWith(
+        "scope-a",
+        "service-alpha",
+      );
     });
   });
 
-  it("shows Team Builder as the first action when no current team is available", async () => {
-    (studioApi.getAuthSession as jest.Mock).mockResolvedValue({
-      enabled: true,
-      scopeId: "",
-      scopeSource: "",
+  it("opens Studio workflow definitions with preserved team context", async () => {
+    const pushSpy = jest.spyOn(history, "push");
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    fireEvent.click(await screen.findByRole("button", { name: "行为定义" }));
+
+    await waitFor(() => {
+      expect(pushSpy).toHaveBeenCalledWith(
+        "/studio?scopeId=scope-a&scopeLabel=scope-a&tab=workflows",
+      );
     });
-
-    renderWithQueryClient(React.createElement(TeamsIndexPage));
-
-    expect(await screen.findByText("Team context unavailable")).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Build first team" }),
-    ).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open Settings" })).toBeTruthy();
-  });
-
-  it("does not leak raw session errors into the error state", async () => {
-    (studioApi.getAuthSession as jest.Mock).mockRejectedValue(
-      new Error("No stub for /api/auth/me"),
-    );
-
-    renderWithQueryClient(React.createElement(TeamsIndexPage));
-
-    expect(await screen.findByText("Team context unavailable")).toBeTruthy();
-    expect(
-      screen.getAllByText(
-        "The current session could not be refreshed into a usable team context. Retry, or open Settings while the team context is repaired.",
-      ).length,
-    ).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
-    expect(screen.queryByText("No stub for /api/auth/me")).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/index.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/index.tsx
@@ -1,455 +1,774 @@
 import {
+  ApiOutlined,
+  ApartmentOutlined,
   BranchesOutlined,
-  ClockCircleOutlined,
-  PauseCircleOutlined,
-  SafetyCertificateOutlined,
+  BuildOutlined,
+  DeploymentUnitOutlined,
+  EyeOutlined,
+  LinkOutlined,
+  RocketOutlined,
 } from "@ant-design/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Alert, Button, Empty, Skeleton, Space, Typography, theme } from "antd";
-import React, { useMemo } from "react";
-import { studioApi } from "@/shared/studio/api";
+import {
+  Alert,
+  Button,
+  Empty,
+  Select,
+  Space,
+  Table,
+  Tabs,
+  Typography,
+} from "antd";
+import type { Edge, Node } from "@xyflow/react";
+import React, { useEffect, useMemo, useState } from "react";
+import GraphCanvas from "@/shared/graphs/GraphCanvas";
 import { history } from "@/shared/navigation/history";
-import { buildTeamWorkspaceRoute, readScopeQueryDraft } from "@/shared/navigation/scopeRoutes";
-import { resolveStudioScopeContext } from "@/shared/scope/context";
 import {
+  buildTeamDetailHref,
+  buildTeamsHref,
+  type TeamDetailTab,
+} from "@/shared/navigation/teamRoutes";
+import {
+  buildStudioRoute,
+  buildStudioScriptsWorkspaceRoute,
   buildStudioWorkflowEditorRoute,
-  buildStudioWorkflowWorkspaceRoute,
 } from "@/shared/studio/navigation";
+import { formatDateTime } from "@/shared/datetime/dateTime";
+import { runtimeActorsApi } from "@/shared/api/runtimeActorsApi";
+import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
+import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
+import { scopesApi } from "@/shared/api/scopesApi";
+import { servicesApi } from "@/shared/api/servicesApi";
+import type { ScopeScriptSummary, ScopeWorkflowSummary } from "@/shared/models/scopes";
+import type {
+  WorkflowActorGraphEnrichedSnapshot,
+  WorkflowActorGraphNode,
+} from "@/shared/models/runtime/actors";
+import type {
+  ScopeServiceRunAuditTimelineEvent,
+  ScopeServiceRunSummary,
+} from "@/shared/models/runtime/scopeServices";
+import type { ServiceCatalogSnapshot } from "@/shared/models/services";
 import {
+  describeScopeServiceBindingTarget,
+} from "@/shared/models/runtime/scopeServices";
+import {
+  describeRuntimeGAgentBindingRevisionTarget,
+  formatRuntimeGAgentBindingImplementationKind,
+  getRuntimeGAgentCurrentBindingRevision,
+  type RuntimeGAgentBindingRevision,
+} from "@/shared/models/runtime/gagents";
+import {
+  AevatarInspectorEmpty,
   AevatarPageShell,
   AevatarPanel,
   AevatarStatusTag,
-  AevatarTwoPaneLayout,
 } from "@/shared/ui/aevatarPageShells";
-import {
-  buildAevatarMetricCardStyle,
-  resolveAevatarMetricVisual,
-  type AevatarSemanticTone,
-  type AevatarThemeSurfaceToken,
-} from "@/shared/ui/aevatarWorkbench";
-import { useTeamRuntimeLens } from "./runtime/useTeamRuntimeLens";
 
-type SummaryCardProps = {
-  caption?: React.ReactNode;
-  icon?: React.ReactNode;
-  label: React.ReactNode;
-  tone?: AevatarSemanticTone;
-  value: React.ReactNode;
+type TeamDetailRouteState = {
+  readonly runId: string;
+  readonly scopeId: string;
+  readonly serviceId: string;
+  readonly tab: TeamDetailTab;
 };
 
-function renderHealthLabel(status: string): string {
-  switch (status) {
-    case "human-overridden":
-      return "Human Override";
-    case "blocked":
-      return "Blocked";
-    case "degraded":
-      return "Degraded";
-    case "healthy":
-      return "Healthy";
+type TeamConnectorRow = {
+  readonly bindingId: string;
+  readonly connectorLabel: string;
+  readonly displayName: string;
+  readonly retired: boolean;
+  readonly serviceDisplayName: string;
+  readonly serviceId: string;
+  readonly targetLabel: string;
+};
+
+const scopeServiceAppId = "default";
+const scopeServiceNamespace = "default";
+
+function trimOptional(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function parseTeamTab(value: string | null): TeamDetailTab {
+  switch (trimOptional(value).toLowerCase()) {
+    case "topology":
+    case "events":
+    case "members":
+    case "connectors":
+    case "advanced":
+      return trimOptional(value).toLowerCase() as TeamDetailTab;
     default:
-      return "Attention";
+      return "overview";
   }
 }
 
-function summarizeOwner(
-  focusActorId?: string,
-  fallbackActorId?: string,
-): string {
-  const resolvedActorId = focusActorId?.trim() || fallbackActorId?.trim() || "";
-  if (!resolvedActorId) {
-    return "No current owner visible";
+function readInitialTeamRouteState(): TeamDetailRouteState {
+  if (typeof window === "undefined") {
+    return {
+      runId: "",
+      scopeId: "",
+      serviceId: "",
+      tab: "overview",
+    };
   }
 
-  return resolvedActorId;
+  const pathname = window.location.pathname.split("/").filter(Boolean);
+  const params = new URLSearchParams(window.location.search);
+  return {
+    runId: trimOptional(params.get("runId")),
+    scopeId: trimOptional(pathname[1]),
+    serviceId: trimOptional(params.get("serviceId")),
+    tab: parseTeamTab(params.get("tab")),
+  };
 }
 
-function summarizeLatestHandoff(
-  fromActorId?: string,
-  toActorId?: string,
-): string {
-  const from = fromActorId?.trim() || "";
-  const to = toActorId?.trim() || "";
-  if (!from || !to) {
-    return "No visible handoff yet";
+function buildScopedServiceHref(scopeId: string, serviceId: string): string {
+  const params = new URLSearchParams();
+  params.set("tenantId", scopeId.trim());
+  params.set("appId", scopeServiceAppId);
+  params.set("namespace", scopeServiceNamespace);
+  params.set("serviceId", serviceId.trim());
+  return `/services?${params.toString()}`;
+}
+
+function shortActorId(actorId: string): string {
+  const normalized = actorId.trim();
+  if (!normalized) {
+    return "n/a";
   }
 
-  return `${from} -> ${to}`;
+  if (normalized.length <= 24) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 10)}...${normalized.slice(-10)}`;
 }
 
-function SummaryCard({
-  caption,
-  icon,
-  label,
-  tone = "default",
-  value,
-}: SummaryCardProps) {
-  const { token } = theme.useToken();
-  const visual = resolveAevatarMetricVisual(
-    token as AevatarThemeSurfaceToken,
-    tone,
-  );
+function inferTeamNodeLabel(node: WorkflowActorGraphNode): {
+  readonly label: string;
+  readonly subtitle: string;
+} {
+  const workflowName = trimOptional(node.properties.workflowName);
+  const stepId = trimOptional(node.properties.stepId);
+  const stepType = trimOptional(node.properties.stepType);
+  const targetRole = trimOptional(node.properties.targetRole);
 
-  return (
-    <div
-      style={{
-        ...buildAevatarMetricCardStyle(token as AevatarThemeSurfaceToken, tone),
-        display: "flex",
-        flexDirection: "column",
-        gap: 10,
-        minHeight: 120,
-        padding: 16,
-      }}
-    >
-      <Space align="center" size={10}>
-        {icon ? (
-          <span
-            style={{
-              alignItems: "center",
-              color: visual.iconColor,
-              display: "inline-flex",
-              fontSize: 18,
-              justifyContent: "center",
-            }}
-          >
-            {icon}
-          </span>
-        ) : null}
-        <Typography.Text
-          style={{
-            color: visual.labelColor,
-          }}
-        >
-          {label}
-        </Typography.Text>
-      </Space>
-      <Typography.Title
-        level={4}
-        style={{
-          color: visual.valueColor,
-          margin: 0,
-        }}
-      >
-        {value}
-      </Typography.Title>
-      {caption ? (
-        <Typography.Text
-          style={{
-            color: visual.secondaryColor,
-          }}
-        >
-          {caption}
-        </Typography.Text>
-      ) : null}
-    </div>
-  );
+  switch (node.nodeType) {
+    case "WorkflowRun":
+      return {
+        label: workflowName || "Workflow Run",
+        subtitle: shortActorId(node.nodeId),
+      };
+    case "WorkflowStep":
+      return {
+        label: stepId || "Step",
+        subtitle: [stepType, targetRole].filter(Boolean).join(" · ") || shortActorId(node.nodeId),
+      };
+    default:
+      return {
+        label: workflowName || shortActorId(node.nodeId),
+        subtitle: node.nodeType || "Actor",
+      };
+  }
 }
 
-const TeamsIndexPage: React.FC = () => {
-  const requestedDraft = useMemo(() => readScopeQueryDraft(), []);
-  const authSessionQuery = useQuery({
-    queryKey: ["teams", "auth-session"],
-    queryFn: () => studioApi.getAuthSession(),
-    retry: false,
+function resolveNodeLevelMap(
+  graph: WorkflowActorGraphEnrichedSnapshot,
+): Map<string, number> {
+  const levels = new Map<string, number>();
+  const rootNodeId =
+    trimOptional(graph.subgraph.rootNodeId) ||
+    trimOptional(graph.snapshot.actorId) ||
+    trimOptional(graph.subgraph.nodes[0]?.nodeId);
+
+  if (!rootNodeId) {
+    return levels;
+  }
+
+  const queue = [rootNodeId];
+  levels.set(rootNodeId, 0);
+
+  while (queue.length > 0) {
+    const currentNodeId = queue.shift() ?? "";
+    const currentLevel = levels.get(currentNodeId) ?? 0;
+
+    graph.subgraph.edges
+      .filter((edge) => edge.fromNodeId === currentNodeId)
+      .forEach((edge) => {
+        if (levels.has(edge.toNodeId)) {
+          return;
+        }
+
+        levels.set(edge.toNodeId, currentLevel + 1);
+        queue.push(edge.toNodeId);
+      });
+  }
+
+  let fallbackLevel = Math.max(...Array.from(levels.values()), 0) + 1;
+  graph.subgraph.nodes.forEach((node) => {
+    if (!levels.has(node.nodeId)) {
+      levels.set(node.nodeId, fallbackLevel);
+      fallbackLevel += 1;
+    }
   });
 
-  const resolvedScopeId = useMemo(() => {
-    const requestedScopeId = requestedDraft.scopeId.trim();
-    if (requestedScopeId) {
-      return requestedScopeId;
+  return levels;
+}
+
+function buildTopologyGraph(
+  graph: WorkflowActorGraphEnrichedSnapshot | undefined,
+): {
+  readonly edges: Edge[];
+  readonly nodes: Node[];
+} {
+  if (!graph) {
+    return { edges: [], nodes: [] };
+  }
+
+  const levelMap = resolveNodeLevelMap(graph);
+  const rowsByLevel = new Map<number, number>();
+
+  const nodes = graph.subgraph.nodes.map((node) => {
+    const level = levelMap.get(node.nodeId) ?? 0;
+    const row = rowsByLevel.get(level) ?? 0;
+    rowsByLevel.set(level, row + 1);
+    const label = inferTeamNodeLabel(node);
+    const accentColor =
+      node.nodeType === "WorkflowRun"
+        ? "#7c3aed"
+        : node.nodeType === "WorkflowStep"
+          ? "#1677ff"
+          : "#16a34a";
+
+    return {
+      id: node.nodeId,
+      data: {
+        label: (
+          <div style={{ minWidth: 180 }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>{label.label}</div>
+            <div style={{ color: "var(--ant-color-text-tertiary)", fontSize: 11 }}>
+              {label.subtitle}
+            </div>
+          </div>
+        ),
+      },
+      position: {
+        x: level * 260,
+        y: row * 132,
+      },
+      style: {
+        background: "var(--ant-color-bg-container)",
+        border: `1px solid ${accentColor}`,
+        borderRadius: 16,
+        boxShadow: "0 12px 28px rgba(15, 23, 42, 0.08)",
+        padding: 12,
+      },
+    } satisfies Node;
+  });
+
+  const edges = graph.subgraph.edges.map((edge) => ({
+    id: edge.edgeId,
+    label: edge.edgeType,
+    source: edge.fromNodeId,
+    target: edge.toNodeId,
+    animated: edge.edgeType !== "CONTAINS_STEP",
+    style: {
+      stroke:
+        edge.edgeType === "CHILD_OF"
+          ? "#16a34a"
+          : edge.edgeType === "OWNS"
+            ? "#7c3aed"
+            : "#1677ff",
+      strokeDasharray: edge.edgeType === "CHILD_OF" ? "4 4" : undefined,
+      strokeWidth: edge.edgeType === "CONTAINS_STEP" ? 1.5 : 2,
+    },
+  })) satisfies Edge[];
+
+  return { edges, nodes };
+}
+
+function resolveMemberEditorHref(options: {
+  readonly memberLabel: string;
+  readonly scopeId: string;
+  readonly scopeLabel: string;
+  readonly scripts: readonly ScopeScriptSummary[];
+  readonly service: ServiceCatalogSnapshot | null | undefined;
+  readonly workflows: readonly ScopeWorkflowSummary[];
+  readonly preferredRevision?: RuntimeGAgentBindingRevision | null;
+}): string {
+  const {
+    memberLabel,
+    preferredRevision,
+    scopeId,
+    scopeLabel,
+    scripts,
+    service,
+    workflows,
+  } = options;
+  const memberId = service?.serviceId || "";
+  const workflowMatch =
+    workflows.find((item) => item.workflowId === memberId) ||
+    workflows.find((item) => item.workflowName === memberId) ||
+    workflows.find((item) => item.displayName === memberLabel) ||
+    workflows.find(
+      (item) =>
+        trimOptional(preferredRevision?.workflowName) &&
+        item.workflowName === trimOptional(preferredRevision?.workflowName),
+    ) ||
+    workflows.find(
+      (item) =>
+        trimOptional(preferredRevision?.workflowName) &&
+        item.displayName === trimOptional(preferredRevision?.workflowName),
+    ) ||
+    null;
+
+  if (workflowMatch) {
+    return buildStudioWorkflowEditorRoute({
+      memberId,
+      memberLabel,
+      scopeId,
+      scopeLabel,
+      workflowId: workflowMatch.workflowId,
+    });
+  }
+
+  const scriptMatch =
+    scripts.find((item) => item.scriptId === memberId) ||
+    scripts.find(
+      (item) =>
+        trimOptional(preferredRevision?.scriptId) &&
+        item.scriptId === trimOptional(preferredRevision?.scriptId),
+    ) ||
+    null;
+
+  if (scriptMatch) {
+    return buildStudioScriptsWorkspaceRoute({
+      memberId,
+      memberLabel,
+      scopeId,
+      scopeLabel,
+      scriptId: scriptMatch.scriptId,
+    });
+  }
+
+  return buildStudioRoute({
+    memberId,
+    memberLabel,
+    scopeId,
+    scopeLabel,
+    tab: "workflows",
+  });
+}
+
+const TeamMetricCard: React.FC<{
+  readonly label: string;
+  readonly value: React.ReactNode;
+}> = ({ label, value }) => (
+  <div
+    style={{
+      border: "1px solid var(--ant-color-border-secondary)",
+      borderRadius: 14,
+      display: "flex",
+      flexDirection: "column",
+      gap: 4,
+      minWidth: 0,
+      padding: 14,
+    }}
+  >
+    <Typography.Text type="secondary">{label}</Typography.Text>
+    <Typography.Text strong style={{ fontSize: 18 }}>
+      {value}
+    </Typography.Text>
+  </div>
+);
+
+const TeamDetailPage: React.FC = () => {
+  const initialState = useMemo(() => readInitialTeamRouteState(), []);
+  const [activeTab, setActiveTab] = useState<TeamDetailTab>(initialState.tab);
+  const [selectedServiceId, setSelectedServiceId] = useState(initialState.serviceId);
+  const [selectedRunId, setSelectedRunId] = useState(initialState.runId);
+
+  const scopeId = initialState.scopeId;
+
+  const bindingQuery = useQuery({
+    enabled: Boolean(scopeId),
+    queryKey: ["teams", "binding", scopeId],
+    queryFn: () => runtimeGAgentApi.getScopeBinding(scopeId),
+  });
+  const servicesQuery = useQuery({
+    enabled: Boolean(scopeId),
+    queryKey: ["teams", "services", scopeId],
+    queryFn: () =>
+      servicesApi.listServices({
+        tenantId: scopeId,
+        appId: scopeServiceAppId,
+        namespace: scopeServiceNamespace,
+      }),
+  });
+  const actorsQuery = useQuery({
+    enabled: Boolean(scopeId),
+    queryKey: ["teams", "actors", scopeId],
+    queryFn: () => runtimeGAgentApi.listActors(scopeId),
+  });
+  const workflowsQuery = useQuery({
+    enabled: Boolean(scopeId),
+    queryKey: ["teams", "workflows", scopeId],
+    queryFn: () => scopesApi.listWorkflows(scopeId),
+  });
+  const scriptsQuery = useQuery({
+    enabled: Boolean(scopeId),
+    queryKey: ["teams", "scripts", scopeId],
+    queryFn: () => scopesApi.listScripts(scopeId),
+  });
+
+  const currentBindingRevision = useMemo(
+    () => getRuntimeGAgentCurrentBindingRevision(bindingQuery.data),
+    [bindingQuery.data],
+  );
+  const services = servicesQuery.data ?? [];
+  const selectedService =
+    services.find((service) => service.serviceId === selectedServiceId) ?? null;
+  const teamLabel = scopeId || "团队";
+
+  useEffect(() => {
+    if (!selectedServiceId && services.length > 0) {
+      const nextServiceId =
+        trimOptional(bindingQuery.data?.serviceId) || services[0]?.serviceId || "";
+      setSelectedServiceId(nextServiceId);
+    }
+  }, [bindingQuery.data?.serviceId, selectedServiceId, services]);
+
+  const runsQuery = useQuery({
+    enabled: Boolean(scopeId && selectedService?.serviceId),
+    queryKey: ["teams", "runs", scopeId, selectedService?.serviceId],
+    queryFn: () =>
+      scopeRuntimeApi.listServiceRuns(scopeId, selectedService?.serviceId || "", {
+        take: 12,
+      }),
+  });
+  const recentRuns = runsQuery.data?.runs ?? [];
+
+  useEffect(() => {
+    if (!recentRuns.length) {
+      setSelectedRunId("");
+      return;
     }
 
-    return resolveStudioScopeContext(authSessionQuery.data)?.scopeId ?? "";
-  }, [authSessionQuery.data, requestedDraft.scopeId]);
+    if (selectedRunId && recentRuns.some((run) => run.runId === selectedRunId)) {
+      return;
+    }
 
-  const {
-    actorGraphQuery,
-    baselineRunAuditQuery,
-    bindingQuery,
-    currentRunAuditQuery,
-    lens,
-    runsQuery,
-    scriptsQuery,
-    servicesQuery,
-    workflowsQuery,
-  } = useTeamRuntimeLens(resolvedScopeId);
-  const lensLoading =
-    resolvedScopeId.length > 0 &&
-    (bindingQuery.isLoading ||
-      servicesQuery.isLoading ||
-      workflowsQuery.isLoading ||
-      scriptsQuery.isLoading);
-  const teamSignalIssues = [
-    bindingQuery.isError ? "Team binding could not be loaded." : null,
-    servicesQuery.isError ? "Published services could not be loaded." : null,
-    runsQuery.isError ? "Recent team activity could not be loaded." : null,
-    currentRunAuditQuery.isError ? "Current run audit could not be loaded." : null,
-    baselineRunAuditQuery.isError ? "Baseline run audit could not be loaded." : null,
-    actorGraphQuery.isError ? "Collaboration graph could not be loaded." : null,
-  ].filter((issue): issue is string => Boolean(issue));
+    setSelectedRunId(recentRuns[0]?.runId || "");
+  }, [recentRuns, selectedRunId]);
 
-  const teamResolutionDescription = authSessionQuery.isError
-    ? "The current session could not be refreshed into a usable team context. Retry, or open Settings while the team context is repaired."
-    : "No current team context is available.";
+  const selectedRun =
+    recentRuns.find((run) => run.runId === selectedRunId) ?? recentRuns[0] ?? null;
 
-  if (authSessionQuery.isLoading || lensLoading) {
-    return (
-      <AevatarPageShell
-        title="Teams"
-        content="Start from the current team workspace so the console tells one team story before it exposes deeper runtime controls."
-      >
-        <AevatarTwoPaneLayout
-          rail={
-            <AevatarPanel
-              extra={
-                <AevatarStatusTag
-                  domain="observation"
-                  label="Loading"
-                  status="delayed"
-                />
-              }
-              title="Recent activity summary"
-            >
-              <Skeleton active paragraph={{ rows: 6 }} title />
-            </AevatarPanel>
+  const selectedRunAuditQuery = useQuery({
+    enabled: Boolean(
+      scopeId &&
+        selectedService?.serviceId &&
+        selectedRun?.runId &&
+        selectedRun.actorId,
+    ),
+    queryKey: [
+      "teams",
+      "run-audit",
+      scopeId,
+      selectedService?.serviceId,
+      selectedRun?.runId,
+      selectedRun?.actorId,
+    ],
+    queryFn: () =>
+      scopeRuntimeApi.getServiceRunAudit(
+        scopeId,
+        selectedService?.serviceId || "",
+        selectedRun?.runId || "",
+        {
+          actorId: selectedRun?.actorId || undefined,
+        },
+      ),
+  });
+
+  const topologyQuery = useQuery({
+    enabled: Boolean(trimOptional(bindingQuery.data?.primaryActorId)),
+    queryKey: ["teams", "topology", trimOptional(bindingQuery.data?.primaryActorId)],
+    queryFn: () =>
+      runtimeActorsApi.getActorGraphEnriched(
+        trimOptional(bindingQuery.data?.primaryActorId),
+        {
+          depth: 4,
+          take: 120,
+          direction: "Both",
+        },
+      ),
+  });
+
+  const connectorBindingsQuery = useQuery({
+    enabled: Boolean(scopeId && services.length > 0),
+    queryKey: [
+      "teams",
+      "connectors",
+      scopeId,
+      services.map((service) => service.serviceId).join("|"),
+    ],
+    queryFn: async () => {
+      const results = await Promise.all(
+        services.map(async (service) => {
+          try {
+            const snapshot = await scopeRuntimeApi.getServiceBindings(
+              scopeId,
+              service.serviceId,
+            );
+            return snapshot.bindings
+              .filter((binding) => binding.connectorRef)
+              .map(
+                (binding) =>
+                  ({
+                    bindingId: binding.bindingId,
+                    connectorLabel: `${binding.connectorRef?.connectorType || ""}:${binding.connectorRef?.connectorId || ""}`,
+                    displayName: binding.displayName || binding.bindingId,
+                    retired: binding.retired,
+                    serviceDisplayName: service.displayName || service.serviceId,
+                    serviceId: service.serviceId,
+                    targetLabel: describeScopeServiceBindingTarget(binding),
+                  }) satisfies TeamConnectorRow,
+              );
+          } catch {
+            return [] as TeamConnectorRow[];
           }
-          railWidth={320}
-          stage={
-            <AevatarPanel
-              extra={
-                <AevatarStatusTag
-                  domain="observation"
-                  label="Loading"
-                  status="delayed"
-                />
-              }
-              title="Current collaboration snapshot"
-            >
-              <Skeleton active paragraph={{ rows: 8 }} title />
-            </AevatarPanel>
-          }
-        />
-      </AevatarPageShell>
+        }),
+      );
+
+      return results.flat();
+    },
+  });
+
+  useEffect(() => {
+    if (!scopeId) {
+      return;
+    }
+
+    history.replace(
+      buildTeamDetailHref({
+        scopeId,
+        tab: activeTab,
+        serviceId: selectedService?.serviceId || undefined,
+        runId: selectedRun?.runId || undefined,
+      }),
     );
-  }
+  }, [activeTab, scopeId, selectedRun?.runId, selectedService?.serviceId]);
 
-  if (!resolvedScopeId) {
-    return (
-      <AevatarPageShell
-        title="Teams"
-        content="Open a current team when one is available, or start the first team from Team Builder."
-      >
-        <AevatarPanel
-          extra={
-            <AevatarStatusTag
-              domain="observation"
-              label={authSessionQuery.isError ? "Unavailable" : "Empty"}
-              status={authSessionQuery.isError ? "unavailable" : "partial"}
-            />
-          }
-          title="Team context unavailable"
-        >
-          <Space orientation="vertical" size={16} style={{ width: "100%" }}>
-            <Typography.Paragraph style={{ margin: 0 }}>
-              The console could not resolve a current team from the active session.
-              Open Settings, retry, or start the first team from Team Builder.
-            </Typography.Paragraph>
-            {authSessionQuery.isError ? (
-              <Alert
-                description={teamResolutionDescription}
-                showIcon
-                type="warning"
-              />
-            ) : null}
-            <Empty description={teamResolutionDescription} />
-            <Space wrap>
-              {authSessionQuery.isError ? (
-                <Button
-                  onClick={() => void authSessionQuery.refetch()}
-                  type="primary"
-                >
-                  Retry
-                </Button>
-              ) : (
-                <Button
-                  onClick={() =>
-                    history.push(
-                      buildStudioWorkflowEditorRoute({
-                        draftMode: "new",
-                      }),
-                    )
-                  }
-                  type="primary"
-                >
-                  Build first team
-                </Button>
-              )}
-              {authSessionQuery.isError ? (
-                <Button
-                  onClick={() =>
-                    history.push(
-                      buildStudioWorkflowEditorRoute({
-                        draftMode: "new",
-                      }),
-                    )
-                  }
-                >
-                  Build first team
-                </Button>
-              ) : null}
-              <Button onClick={() => history.push("/settings")}>
-                Open Settings
-              </Button>
-            </Space>
-          </Space>
-        </AevatarPanel>
-      </AevatarPageShell>
-    );
-  }
+  const connectorRows = connectorBindingsQuery.data ?? [];
+  const actorCount = useMemo(
+    () =>
+      (actorsQuery.data ?? []).reduce(
+        (count, group) => count + group.actorIds.length,
+        0,
+      ),
+    [actorsQuery.data],
+  );
+  const topologyGraph = useMemo(
+    () => buildTopologyGraph(topologyQuery.data),
+    [topologyQuery.data],
+  );
+  const defaultEditorHref = resolveMemberEditorHref({
+    memberLabel: selectedService?.displayName || selectedService?.serviceId || teamLabel,
+    preferredRevision: currentBindingRevision,
+    scopeId,
+    scopeLabel: teamLabel,
+    scripts: scriptsQuery.data ?? [],
+    service: selectedService,
+    workflows: workflowsQuery.data ?? [],
+  });
 
-  const latestRelationship = lens.graph.relationships[0];
-  const currentRunSummary = lens.currentRun
-    ? `${lens.currentRun.runId} · ${lens.currentRun.completionStatus || "unknown"}`
-    : "No recent run is visible yet.";
-  const primaryActionLabel =
-    lens.healthStatus === "blocked" || lens.healthStatus === "human-overridden"
-      ? "Handle current blockage"
-      : lens.healthStatus === "degraded" || lens.healthStatus === "attention"
-        ? "Review current attention"
-        : "View current team";
-  const stageProvenance =
-    actorGraphQuery.isError
-      ? { label: "Unavailable", status: "unavailable" }
-      : lens.graph.available
-        ? { label: "Live", status: "live" }
-        : { label: "Partial", status: "partial" };
-  const activityProvenance =
-    runsQuery.isError || currentRunAuditQuery.isError
-      ? { label: "Unavailable", status: "unavailable" }
-      : lens.currentRun
-        ? { label: "Delayed", status: "delayed" }
-        : { label: "Partial", status: "partial" };
+  const eventTimeline = selectedRunAuditQuery.data?.audit.timeline ?? [];
+  const eventSummary = selectedRunAuditQuery.data?.audit.summary;
 
-  return (
-    <AevatarPageShell
-      content={`${lens.subtitle}. Teams Home keeps the first screen anchored on the current team so users see ownership, activity, and the next best action before they enter deeper runtime tools.`}
-      extra={
+  const memberColumns = [
+    {
+      dataIndex: "displayName",
+      key: "member",
+      render: (_: unknown, service: ServiceCatalogSnapshot) => (
+        <div>
+          <Typography.Text strong>
+            {service.displayName || service.serviceId}
+          </Typography.Text>
+          <div style={{ color: "var(--ant-color-text-tertiary)", fontSize: 12 }}>
+            {service.serviceKey}
+          </div>
+        </div>
+      ),
+      title: "成员",
+    },
+    {
+      dataIndex: "serviceId",
+      key: "serviceId",
+      render: (value: string) => (
+        <Typography.Text code>{value}</Typography.Text>
+      ),
+      title: "Service ID",
+    },
+    {
+      dataIndex: "primaryActorId",
+      key: "actorId",
+      render: (value: string) => (
+        <Typography.Text code>{shortActorId(value)}</Typography.Text>
+      ),
+      title: "Actor",
+    },
+    {
+      dataIndex: "deploymentStatus",
+      key: "status",
+      render: (value: string) => (
+        <AevatarStatusTag domain="governance" status={value || "draft"} />
+      ),
+      title: "状态",
+    },
+    {
+      dataIndex: "endpoints",
+      key: "endpoints",
+      render: (value: ServiceCatalogSnapshot["endpoints"]) => value.length,
+      title: "端点",
+    },
+    {
+      dataIndex: "updatedAt",
+      key: "updatedAt",
+      render: (value: string) => formatDateTime(value),
+      title: "更新时间",
+    },
+    {
+      key: "actions",
+      render: (_: unknown, service: ServiceCatalogSnapshot) => (
         <Space wrap>
           <Button
-            onClick={() => history.push(buildTeamWorkspaceRoute(resolvedScopeId))}
-            type="primary"
+            icon={<EyeOutlined />}
+            onClick={() => {
+              setSelectedServiceId(service.serviceId);
+              setActiveTab("events");
+            }}
           >
-            {primaryActionLabel}
+            查看事件流
           </Button>
           <Button
+            icon={<LinkOutlined />}
+            onClick={() =>
+              history.push(buildScopedServiceHref(scopeId, service.serviceId))
+            }
+          >
+            平台详情
+          </Button>
+          <Button
+            icon={<BuildOutlined />}
             onClick={() =>
               history.push(
-                buildStudioWorkflowWorkspaceRoute({
-                  scopeId: resolvedScopeId,
+                resolveMemberEditorHref({
+                  memberLabel: service.displayName || service.serviceId,
+                  scopeId,
+                  scopeLabel: teamLabel,
+                  scripts: scriptsQuery.data ?? [],
+                  service,
+                  workflows: workflowsQuery.data ?? [],
                 }),
               )
             }
+            type="primary"
           >
-            Open Team Builder
+            编辑
           </Button>
         </Space>
-      }
-      title={
-        <Space align="center" wrap size={12}>
-          <Typography.Text strong>Teams</Typography.Text>
-          <AevatarStatusTag
-            domain="run"
-            label={renderHealthLabel(lens.healthStatus)}
-            status={lens.healthStatus === "healthy" ? "completed" : lens.healthStatus}
-          />
-        </Space>
-      }
-      titleHelp="Teams Home is the current-team workbench. It should tell users who owns the flow, what just happened, and what to do next without sending them straight into a builder."
-    >
-      {teamSignalIssues.length > 0 ? (
-        <Alert
-          description={teamSignalIssues.join(" ")}
-          title="Some team signals are currently unavailable"
-          showIcon
-          type="warning"
-        />
-      ) : null}
-      <AevatarTwoPaneLayout
-        rail={
-          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <AevatarPanel
-              extra={
-                <AevatarStatusTag
-                  domain="observation"
-                  label={activityProvenance.label}
-                  status={activityProvenance.status}
-                />
-              }
-              title="Recent activity summary"
-              titleHelp="This rail stays secondary on purpose. It explains what changed recently without taking over the team story."
-            >
-              <Space orientation="vertical" size={12} style={{ width: "100%" }}>
-                <div>
-                  <Typography.Text strong>Current run</Typography.Text>
-                  <Typography.Paragraph style={{ marginBottom: 0, marginTop: 4 }}>
-                    {currentRunSummary}
-                  </Typography.Paragraph>
-                </div>
-                <div>
-                  <Typography.Text strong>Latest change</Typography.Text>
-                  <Typography.Paragraph style={{ marginBottom: 0, marginTop: 4 }}>
-                    {lens.compare.summary}
-                  </Typography.Paragraph>
-                </div>
-                <div>
-                  <Typography.Text strong>Current anomaly or risk</Typography.Text>
-                  <Typography.Paragraph style={{ marginBottom: 0, marginTop: 4 }}>
-                    {lens.playback.prompt || lens.healthSummary}
-                  </Typography.Paragraph>
-                </div>
-              </Space>
-            </AevatarPanel>
-            <AevatarPanel
-              extra={
-                <AevatarStatusTag
-                  domain="observation"
-                  label={lens.partialSignals.length > 0 ? "Partial" : "Live"}
-                  status={lens.partialSignals.length > 0 ? "partial" : "live"}
-                />
-              }
-              title="Current team identity"
-            >
-              <Space orientation="vertical" size={8} style={{ width: "100%" }}>
-                <Typography.Title level={4} style={{ margin: 0 }}>
-                  {lens.title}
-                </Typography.Title>
-                <Typography.Text type="secondary">{resolvedScopeId}</Typography.Text>
-                <Typography.Paragraph style={{ margin: 0 }}>
-                  {lens.currentBindingTarget}
-                </Typography.Paragraph>
-                {lens.currentBindingContext ? (
-                  <Alert
-                    description={lens.currentBindingContext}
-                    showIcon
-                    type="info"
-                  />
-                ) : null}
-              </Space>
-            </AevatarPanel>
+      ),
+      title: "操作",
+    },
+  ];
+
+  const connectorColumns = [
+    {
+      dataIndex: "displayName",
+      key: "displayName",
+      title: "连接器绑定",
+    },
+    {
+      dataIndex: "connectorLabel",
+      key: "connectorLabel",
+      render: (value: string) => <Typography.Text code>{value}</Typography.Text>,
+      title: "连接器",
+    },
+    {
+      dataIndex: "serviceDisplayName",
+      key: "serviceDisplayName",
+      render: (value: string, row: TeamConnectorRow) => (
+        <div>
+          <Typography.Text strong>{value}</Typography.Text>
+          <div style={{ color: "var(--ant-color-text-tertiary)", fontSize: 12 }}>
+            {row.serviceId}
           </div>
-        }
-        railWidth={340}
-        stage={
+        </div>
+      ),
+      title: "来源成员",
+    },
+    {
+      dataIndex: "targetLabel",
+      key: "targetLabel",
+      title: "目标",
+    },
+    {
+      dataIndex: "retired",
+      key: "retired",
+      render: (value: boolean) => (
+        <AevatarStatusTag
+          domain="governance"
+          status={value ? "retired" : "active"}
+        />
+      ),
+      title: "状态",
+    },
+  ];
+
+  const eventColumns = [
+    {
+      dataIndex: "timestamp",
+      key: "timestamp",
+      render: (value: string | null) => formatDateTime(value),
+      title: "时间",
+      width: 180,
+    },
+    {
+      dataIndex: "eventType",
+      key: "eventType",
+      title: "类型",
+      width: 220,
+    },
+    {
+      dataIndex: "agentId",
+      key: "agentId",
+      render: (value: string) => <Typography.Text code>{shortActorId(value)}</Typography.Text>,
+      title: "Actor",
+      width: 180,
+    },
+    {
+      dataIndex: "stepId",
+      key: "stepId",
+      render: (value: string) => value || "—",
+      title: "步骤",
+      width: 140,
+    },
+    {
+      dataIndex: "message",
+      key: "message",
+      title: "详情",
+    },
+  ];
+
+  const tabItems = [
+    {
+      key: "overview",
+      label: "概览",
+      children: (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <AevatarPanel
-            extra={
-              <AevatarStatusTag
-                domain="observation"
-                label={stageProvenance.label}
-                status={stageProvenance.status}
-              />
-            }
-            title="Current collaboration snapshot"
-            titleHelp="The first screen should answer who owns the flow, the latest visible handoff, and the current risk before the user decides where to click."
+            title="团队总览"
+            titleHelp="当前前端以 Scope = Team 的语义组织信息，团队详情把默认入口、成员规模和运行状态收敛到一个页面。"
           >
             <div
               style={{
@@ -458,69 +777,452 @@ const TeamsIndexPage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
               }}
             >
-              <SummaryCard
-                caption={lens.graph.focusReason}
-                icon={<BranchesOutlined />}
-                label="Current owner"
-                tone="info"
-                value={summarizeOwner(
-                  lens.graph.focusActorId,
-                  lens.currentRun?.actorId,
-                )}
+              <TeamMetricCard label="团队 ID" value={scopeId || "n/a"} />
+              <TeamMetricCard label="成员数" value={services.length} />
+              <TeamMetricCard label="Actor 实例" value={actorCount} />
+              <TeamMetricCard label="行为定义" value={workflowsQuery.data?.length ?? 0} />
+              <TeamMetricCard label="脚本行为" value={scriptsQuery.data?.length ?? 0} />
+              <TeamMetricCard label="连接器" value={connectorRows.length} />
+              <TeamMetricCard
+                label="默认入口"
+                value={bindingQuery.data?.displayName || bindingQuery.data?.serviceId || "未绑定"}
               />
-              <SummaryCard
-                caption={lens.graph.stageSummary}
-                icon={<ClockCircleOutlined />}
-                label="Latest handoff"
-                tone="default"
-                value={summarizeLatestHandoff(
-                  latestRelationship?.fromActorId,
-                  latestRelationship?.toActorId,
-                )}
+              <TeamMetricCard
+                label="部署状态"
+                value={bindingQuery.data?.deploymentStatus || "draft"}
               />
-              <SummaryCard
-                caption={lens.healthSummary}
-                icon={<PauseCircleOutlined />}
-                label="Current risk"
-                tone={lens.healthTone}
-                value={lens.playback.interactionLabel || renderHealthLabel(lens.healthStatus)}
-              />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-              <Alert
-                description={lens.playback.summary}
-                title="Current collaboration posture"
-                showIcon
-                type={lens.healthStatus === "healthy" ? "info" : "warning"}
-              />
-              <div>
-                <Typography.Text strong>Mission</Typography.Text>
-                <Typography.Paragraph style={{ marginBottom: 0, marginTop: 4 }}>
-                  {lens.subtitle}
-                </Typography.Paragraph>
-              </div>
-              <div>
-                <Typography.Text strong>Next best move</Typography.Text>
-                <Typography.Paragraph style={{ marginBottom: 0, marginTop: 4 }}>
-                  {primaryActionLabel === "View current team"
-                    ? "The team is stable enough to enter the team workspace."
-                    : "The team needs operator attention before more changes are introduced."}
-                </Typography.Paragraph>
-              </div>
-              {lens.partialSignals.length > 0 ? (
-                <Alert
-                  description={lens.partialSignals.join(" · ")}
-                  title="Partial team truth"
-                  showIcon
-                  type="info"
-                />
-              ) : null}
             </div>
           </AevatarPanel>
-        }
-      />
+
+          <AevatarPanel
+            title="当前默认成员"
+            titleHelp="这里展示当前 scope 默认服务绑定到的运行入口，也是事件拓扑和事件流的默认观察对象。"
+          >
+            {!bindingQuery.data?.available || !currentBindingRevision ? (
+              <Alert
+                showIcon
+                title="当前团队还没有可观察的默认成员绑定。"
+                type="info"
+              />
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <Space wrap size={[8, 8]}>
+                  <Typography.Text strong style={{ fontSize: 16 }}>
+                    {bindingQuery.data.displayName || bindingQuery.data.serviceId}
+                  </Typography.Text>
+                  <AevatarStatusTag
+                    domain="governance"
+                    status={bindingQuery.data.deploymentStatus || "draft"}
+                    label={formatRuntimeGAgentBindingImplementationKind(
+                      currentBindingRevision.implementationKind,
+                    )}
+                  />
+                </Space>
+                <Typography.Text type="secondary">
+                  {describeRuntimeGAgentBindingRevisionTarget(currentBindingRevision)}
+                </Typography.Text>
+                <Typography.Text type="secondary">
+                  Actor {currentBindingRevision.primaryActorId || "n/a"} · Revision{" "}
+                  {currentBindingRevision.revisionId}
+                </Typography.Text>
+              </div>
+            )}
+          </AevatarPanel>
+        </div>
+      ),
+    },
+    {
+      key: "topology",
+      label: "事件拓扑",
+      children: (
+        <AevatarPanel
+          title="EventEnvelope 事件拓扑"
+          titleHelp="这里复用现有 XYFlow 画布，把当前默认成员的 actor 子图直接展开成团队运行时拓扑。"
+        >
+          {topologyQuery.error ? (
+            <Alert
+              showIcon
+              title={
+                topologyQuery.error instanceof Error
+                  ? topologyQuery.error.message
+                  : "加载事件拓扑失败。"
+              }
+              type="error"
+            />
+          ) : topologyQuery.isLoading ? (
+            <AevatarInspectorEmpty description="正在加载团队事件拓扑。" />
+          ) : topologyGraph.nodes.length > 0 ? (
+            <GraphCanvas
+              edges={topologyGraph.edges}
+              nodes={topologyGraph.nodes}
+              height={520}
+            />
+          ) : (
+            <Empty
+              description="当前默认成员还没有可展示的运行时拓扑。"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          )}
+        </AevatarPanel>
+      ),
+    },
+    {
+      key: "events",
+      label: "事件流",
+      children: (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <AevatarPanel
+            title="运行选择"
+            titleHelp="事件流直接复用现有 service run audit，先选择成员，再查看最近一次运行的 EventEnvelope 时间线。"
+          >
+            <Space wrap size={[12, 12]}>
+              <Select
+                options={services.map((service) => ({
+                  label: service.displayName || service.serviceId,
+                  value: service.serviceId,
+                }))}
+                onChange={setSelectedServiceId}
+                placeholder="选择成员"
+                style={{ minWidth: 220 }}
+                value={selectedService?.serviceId || undefined}
+              />
+              <Select
+                disabled={!selectedService}
+                options={recentRuns.map((run) => ({
+                  label: `${run.runId} · ${run.completionStatus}`,
+                  value: run.runId,
+                }))}
+                onChange={setSelectedRunId}
+                placeholder="选择运行"
+                style={{ minWidth: 260 }}
+                value={selectedRun?.runId || undefined}
+              />
+              {selectedService ? (
+                <Button
+                  icon={<RocketOutlined />}
+                  onClick={() =>
+                    history.push(
+                      buildScopedServiceHref(scopeId, selectedService.serviceId),
+                    )
+                  }
+                >
+                  打开平台服务
+                </Button>
+              ) : null}
+            </Space>
+          </AevatarPanel>
+
+          {eventSummary ? (
+            <AevatarPanel title="运行摘要">
+              <div
+                style={{
+                  display: "grid",
+                  gap: 12,
+                  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+                }}
+              >
+                <TeamMetricCard label="总步骤" value={eventSummary.totalSteps} />
+                <TeamMetricCard
+                  label="已请求步骤"
+                  value={eventSummary.requestedSteps}
+                />
+                <TeamMetricCard
+                  label="已完成步骤"
+                  value={eventSummary.completedSteps}
+                />
+                <TeamMetricCard
+                  label="角色回复"
+                  value={eventSummary.roleReplyCount}
+                />
+              </div>
+            </AevatarPanel>
+          ) : null}
+
+          <AevatarPanel
+            title="事件时间线"
+            titleHelp="当前展示的是选中运行的审计时间线，用来还原消息进入、路由、工具调用和完成状态。"
+          >
+            {runsQuery.error ? (
+              <Alert
+                showIcon
+                title={
+                  runsQuery.error instanceof Error
+                    ? runsQuery.error.message
+                    : "加载运行列表失败。"
+                }
+                type="error"
+              />
+            ) : runsQuery.isLoading ? (
+              <AevatarInspectorEmpty description="正在加载成员运行列表。" />
+            ) : selectedRunAuditQuery.error ? (
+              <Alert
+                showIcon
+                title={
+                  selectedRunAuditQuery.error instanceof Error
+                    ? selectedRunAuditQuery.error.message
+                    : "加载运行审计失败。"
+                }
+                type="error"
+              />
+            ) : selectedRunAuditQuery.isLoading ? (
+              <AevatarInspectorEmpty description="正在加载事件流审计。" />
+            ) : eventTimeline.length > 0 ? (
+              <Table<ScopeServiceRunAuditTimelineEvent>
+                columns={eventColumns}
+                dataSource={eventTimeline}
+                pagination={{ pageSize: 8, showSizeChanger: false }}
+                rowKey={(row) =>
+                  `${row.timestamp || "ts"}:${row.eventType}:${row.agentId}:${row.stepId}`
+                }
+                size="small"
+              />
+            ) : (
+              <Empty
+                description="当前成员还没有可展示的事件流。"
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+              />
+            )}
+          </AevatarPanel>
+        </div>
+      ),
+    },
+    {
+      key: "members",
+      label: "成员",
+      children: (
+        <AevatarPanel
+          title="团队成员"
+          titleHelp="当前版本以 scope 下已发布 service 作为团队成员视图，并保留跳转到 Platform Services 和团队构建器的入口。"
+        >
+          {servicesQuery.error ? (
+            <Alert
+              showIcon
+              title={
+                servicesQuery.error instanceof Error
+                  ? servicesQuery.error.message
+                  : "加载团队成员失败。"
+              }
+              type="error"
+            />
+          ) : servicesQuery.isLoading ? (
+            <AevatarInspectorEmpty description="正在加载团队成员。" />
+          ) : services.length > 0 ? (
+            <Table<ServiceCatalogSnapshot>
+              columns={memberColumns}
+              dataSource={services}
+              pagination={{ pageSize: 8, showSizeChanger: false }}
+              rowKey="serviceKey"
+            />
+          ) : (
+            <Empty
+              description="当前团队还没有已发布成员。"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          )}
+        </AevatarPanel>
+      ),
+    },
+    {
+      key: "connectors",
+      label: "连接器",
+      children: (
+        <AevatarPanel
+          title="团队连接器"
+          titleHelp="连接器视图会聚合当前 scope 下各成员 service 绑定出的 connector 依赖，帮助你快速看到外部集成面。"
+        >
+          {connectorBindingsQuery.isLoading ? (
+            <AevatarInspectorEmpty description="正在汇总团队连接器。" />
+          ) : connectorRows.length > 0 ? (
+            <Table<TeamConnectorRow>
+              columns={connectorColumns}
+              dataSource={connectorRows}
+              pagination={{ pageSize: 8, showSizeChanger: false }}
+              rowKey={(row) => `${row.serviceId}:${row.bindingId}`}
+            />
+          ) : (
+            <Empty
+              description="当前团队还没有公开的连接器绑定。"
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          )}
+        </AevatarPanel>
+      ),
+    },
+    {
+      key: "advanced",
+      label: "高级编辑",
+      children: (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <AevatarPanel
+            title="团队构建器入口"
+            titleHelp="Studio 已经从一级导航移出，这里是当前团队进入行为定义、脚本行为、Agent 角色、集成和测试运行的统一入口。"
+          >
+            <div
+              style={{
+                display: "grid",
+                gap: 12,
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+              }}
+            >
+              <Button
+                block
+                icon={<BuildOutlined />}
+                onClick={() => history.push(defaultEditorHref)}
+                type="primary"
+              >
+                打开团队构建器
+              </Button>
+              <Button
+                block
+                icon={<BranchesOutlined />}
+                onClick={() =>
+                  history.push(
+                    buildStudioRoute({
+                      scopeId,
+                      scopeLabel: teamLabel,
+                      tab: "workflows",
+                    }),
+                  )
+                }
+              >
+                行为定义
+              </Button>
+              <Button
+                block
+                icon={<ApartmentOutlined />}
+                onClick={() =>
+                  history.push(
+                    buildStudioRoute({
+                      scopeId,
+                      scopeLabel: teamLabel,
+                      tab: "scripts",
+                    }),
+                  )
+                }
+              >
+                脚本行为
+              </Button>
+              <Button
+                block
+                icon={<DeploymentUnitOutlined />}
+                onClick={() =>
+                  history.push(
+                    buildStudioRoute({
+                      scopeId,
+                      scopeLabel: teamLabel,
+                      tab: "roles",
+                    }),
+                  )
+                }
+              >
+                Agent 角色
+              </Button>
+              <Button
+                block
+                icon={<ApiOutlined />}
+                onClick={() =>
+                  history.push(
+                    buildStudioRoute({
+                      scopeId,
+                      scopeLabel: teamLabel,
+                      tab: "connectors",
+                    }),
+                  )
+                }
+              >
+                集成
+              </Button>
+              <Button
+                block
+                icon={<RocketOutlined />}
+                onClick={() =>
+                  history.push(
+                    buildStudioRoute({
+                      scopeId,
+                      scopeLabel: teamLabel,
+                      tab: "executions",
+                    }),
+                  )
+                }
+              >
+                测试运行
+              </Button>
+            </div>
+          </AevatarPanel>
+
+          <AevatarPanel title="当前上下文">
+            <Space direction="vertical" size={8}>
+              <Typography.Text>
+                团队: <Typography.Text code>{scopeId || "n/a"}</Typography.Text>
+              </Typography.Text>
+              <Typography.Text>
+                默认成员:{" "}
+                <Typography.Text code>
+                  {selectedService?.serviceId || bindingQuery.data?.serviceId || "n/a"}
+                </Typography.Text>
+              </Typography.Text>
+              <Typography.Text type="secondary">
+                团队构建器会自动保留当前 scope，上下文按钮会优先尝试打开匹配的行为定义或脚本行为。
+              </Typography.Text>
+            </Space>
+          </AevatarPanel>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <AevatarPageShell
+      extra={
+        <Space wrap size={[8, 8]}>
+          <Button onClick={() => history.push(buildTeamsHref())}>返回我的团队</Button>
+          <Button
+            icon={<BuildOutlined />}
+            onClick={() => history.push(defaultEditorHref)}
+            type="primary"
+          >
+            打开团队构建器
+          </Button>
+        </Space>
+      }
+      layoutMode="document"
+      onBack={() => history.push(buildTeamsHref())}
+      title={teamLabel || "团队详情"}
+      titleHelp="团队详情页把 Scope 的运行语义重新包装成 Team 视图，并把事件拓扑、事件流、成员和高级编辑收敛到统一入口。"
+    >
+      {!scopeId ? (
+        <Alert
+          showIcon
+          title="缺少团队 ID，暂时无法加载团队详情。"
+          type="warning"
+        />
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <Space wrap size={[8, 8]}>
+            <AevatarStatusTag
+              domain="governance"
+              status={bindingQuery.data?.deploymentStatus || "draft"}
+            />
+            {selectedService ? (
+              <Typography.Text type="secondary">
+                默认成员 {selectedService.displayName || selectedService.serviceId}
+              </Typography.Text>
+            ) : null}
+            {selectedRun ? (
+              <Typography.Text type="secondary">
+                最近运行 {selectedRun.runId}
+              </Typography.Text>
+            ) : null}
+          </Space>
+          <Tabs
+            activeKey={activeTab}
+            items={tabItems}
+            onChange={(value) => setActiveTab(value as TeamDetailTab)}
+          />
+        </div>
+      )}
     </AevatarPageShell>
   );
 };
 
-export default TeamsIndexPage;
+export default TeamDetailPage;

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -1,0 +1,62 @@
+import { BuildOutlined, RocketOutlined } from "@ant-design/icons";
+import { Button, Space, Typography } from "antd";
+import React from "react";
+import { history } from "@/shared/navigation/history";
+import { buildTeamsHref } from "@/shared/navigation/teamRoutes";
+import { buildStudioRoute } from "@/shared/studio/navigation";
+import { AevatarPageShell, AevatarPanel } from "@/shared/ui/aevatarPageShells";
+
+const TeamCreatePage: React.FC = () => {
+  return (
+    <AevatarPageShell
+      extra={
+        <Button onClick={() => history.push(buildTeamsHref())}>返回我的团队</Button>
+      }
+      layoutMode="document"
+      onBack={() => history.push(buildTeamsHref())}
+      title="组建团队"
+      titleHelp="当前版本先复用已有 Studio 能力作为团队构建器入口，后续再承接模板化的组建流程。"
+    >
+      <AevatarPanel
+        title="开始构建"
+        titleHelp="Scope = Team，因此这里直接进入团队构建器创建行为定义、脚本行为、Agent 角色和集成。"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Typography.Paragraph style={{ marginBottom: 0 }}>
+            这一步不会引入新的后端流程，先复用现有 Studio 工作台完成团队搭建，再从团队详情页观察事件拓扑和事件流。
+          </Typography.Paragraph>
+          <Space wrap size={[8, 8]}>
+            <Button
+              icon={<BuildOutlined />}
+              onClick={() =>
+                history.push(
+                  buildStudioRoute({
+                    draftMode: "new",
+                    tab: "studio",
+                  }),
+                )
+              }
+              type="primary"
+            >
+              打开团队构建器
+            </Button>
+            <Button
+              icon={<RocketOutlined />}
+              onClick={() =>
+                history.push(
+                  buildStudioRoute({
+                    tab: "workflows",
+                  }),
+                )
+              }
+            >
+              查看行为定义
+            </Button>
+          </Space>
+        </div>
+      </AevatarPanel>
+    </AevatarPageShell>
+  );
+};
+
+export default TeamCreatePage;

--- a/apps/aevatar-console-web/src/shared/navigation/runtimeRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/runtimeRoutes.ts
@@ -57,6 +57,7 @@ export function buildRuntimeRunsHref(options?: {
   payloadBase64?: string;
   actorId?: string;
   draftKey?: string;
+  returnTo?: string;
 }): string {
   return buildHref(runtimePaths.runs, {
     route: options?.route ?? options?.workflow,
@@ -69,6 +70,7 @@ export function buildRuntimeRunsHref(options?: {
     payloadBase64: options?.payloadBase64,
     actorId: options?.actorId,
     draftKey: options?.draftKey,
+    returnTo: options?.returnTo,
   });
 }
 

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
@@ -1,0 +1,57 @@
+type TeamDetailTab =
+  | 'overview'
+  | 'topology'
+  | 'events'
+  | 'members'
+  | 'connectors'
+  | 'advanced';
+
+type QueryValue = string | undefined;
+
+function buildHref(
+  pathname: string,
+  query?: Record<string, QueryValue>,
+): string {
+  if (!query) {
+    return pathname;
+  }
+
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([key, value]) => {
+    const normalized = value?.trim();
+    if (normalized) {
+      params.set(key, normalized);
+    }
+  });
+
+  const search = params.toString();
+  return search ? `${pathname}?${search}` : pathname;
+}
+
+export function buildTeamsHref(): string {
+  return '/teams';
+}
+
+export function buildTeamCreateHref(): string {
+  return '/teams/new';
+}
+
+export function buildTeamDetailHref(options: {
+  scopeId: string;
+  tab?: TeamDetailTab;
+  serviceId?: string;
+  runId?: string;
+}): string {
+  const scopeId = options.scopeId.trim();
+  if (!scopeId) {
+    return buildTeamsHref();
+  }
+
+  return buildHref(`/teams/${encodeURIComponent(scopeId)}`, {
+    tab: options.tab,
+    serviceId: options.serviceId,
+    runId: options.runId,
+  });
+}
+
+export type { TeamDetailTab };

--- a/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
@@ -77,6 +77,16 @@ describe('buildStudioRoute', () => {
       '/studio?scopeId=scope-1&tab=workflows',
     );
     expect(
+      buildStudioWorkflowWorkspaceRoute({
+        scopeId: 'scope-a',
+        scopeLabel: '团队 A',
+        memberId: 'service-alpha',
+        memberLabel: '默认成员',
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-a&scopeLabel=%E5%9B%A2%E9%98%9F+A&memberId=service-alpha&memberLabel=%E9%BB%98%E8%AE%A4%E6%88%90%E5%91%98&tab=workflows',
+    );
+    expect(
       buildStudioWorkflowEditorRoute({
         scopeId: 'scope-1',
         workflowId: 'workflow-1',
@@ -104,5 +114,19 @@ describe('buildStudioRoute', () => {
         executionId: 'execution-1',
       }),
     ).toBe('/studio?tab=executions&execution=execution-1');
+  });
+
+  it('preserves team context query params when building Studio routes', () => {
+    expect(
+      buildStudioRoute({
+        scopeId: 'scope-a',
+        scopeLabel: '团队 A',
+        memberId: 'service-alpha',
+        memberLabel: '成员 Alpha',
+        workflowId: 'workflow-1',
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-a&scopeLabel=%E5%9B%A2%E9%98%9F+A&memberId=service-alpha&memberLabel=%E6%88%90%E5%91%98+Alpha&workflow=workflow-1&tab=studio',
+    );
   });
 });

--- a/apps/aevatar-console-web/src/shared/studio/navigation.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.ts
@@ -1,7 +1,6 @@
 export type StudioTab =
   | 'workflows'
   | 'studio'
-  | 'files'
   | 'scripts'
   | 'executions'
   | 'roles'
@@ -10,6 +9,9 @@ export type StudioTab =
 
 type StudioRouteOptions = {
   scopeId?: string;
+  scopeLabel?: string;
+  memberId?: string;
+  memberLabel?: string;
   workflowId?: string;
   scriptId?: string;
   template?: string;
@@ -52,6 +54,15 @@ export function buildStudioRoute(options?: StudioRouteOptions): string {
   if (options?.scopeId?.trim()) {
     params.set('scopeId', options.scopeId.trim());
   }
+  if (options?.scopeLabel?.trim()) {
+    params.set('scopeLabel', options.scopeLabel.trim());
+  }
+  if (options?.memberId?.trim()) {
+    params.set('memberId', options.memberId.trim());
+  }
+  if (options?.memberLabel?.trim()) {
+    params.set('memberLabel', options.memberLabel.trim());
+  }
   if (options?.workflowId?.trim()) {
     params.set('workflow', options.workflowId.trim());
   }
@@ -87,6 +98,9 @@ export function buildStudioRoute(options?: StudioRouteOptions): string {
 
 export function buildStudioWorkflowWorkspaceRoute(options?: {
   scopeId?: string;
+  scopeLabel?: string;
+  memberId?: string;
+  memberLabel?: string;
 }): string {
   return buildStudioRoute({
     ...options,
@@ -94,17 +108,11 @@ export function buildStudioWorkflowWorkspaceRoute(options?: {
   });
 }
 
-export function buildStudioFilesWorkspaceRoute(options?: {
-  scopeId?: string;
-}): string {
-  return buildStudioRoute({
-    ...options,
-    tab: 'files',
-  });
-}
-
 export function buildStudioWorkflowEditorRoute(options?: {
   scopeId?: string;
+  scopeLabel?: string;
+  memberId?: string;
+  memberLabel?: string;
   workflowId?: string;
   template?: string;
   draftMode?: 'new';
@@ -119,6 +127,9 @@ export function buildStudioWorkflowEditorRoute(options?: {
 
 export function buildStudioScriptsWorkspaceRoute(options?: {
   scopeId?: string;
+  scopeLabel?: string;
+  memberId?: string;
+  memberLabel?: string;
   scriptId?: string;
 }): string {
   return buildStudioRoute({

--- a/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
+++ b/apps/aevatar-console-web/src/shared/ui/aevatarPageShells.tsx
@@ -247,11 +247,7 @@ export const AevatarPageShell: React.FC<AevatarPageShellProps> = ({
           : pageContainerChildrenViewportStyle
       }
       content={content}
-      extra={
-        extra
-          ? [<React.Fragment key="aevatar-page-shell-extra">{extra}</React.Fragment>]
-          : undefined
-      }
+      extra={extra}
       onBack={onBack}
       pageHeaderRender={pageHeaderRender}
       style={
@@ -410,7 +406,7 @@ export const AevatarPanel: React.FC<AevatarPanelProps> = ({
         {title || description || extra ? (
           <div style={sectionHeaderStyle}>
             <Space
-              orientation="vertical"
+              direction="vertical"
               size={4}
               style={{ flex: 1, minWidth: 0 }}
             >
@@ -469,7 +465,7 @@ export const AevatarContextDrawer: React.FC<AevatarContextDrawerProps> = ({
       }
       styles={{ body: aevatarDrawerBodyStyle }}
       title={
-        <Space orientation="vertical" size={2}>
+        <Space direction="vertical" size={2}>
           <Typography.Text strong>{title}</Typography.Text>
           {subtitle ? (
             <Typography.Text style={{ color: token.colorTextSecondary }}>
@@ -515,7 +511,7 @@ export const AevatarInspectorEmpty: React.FC<{
   return (
     <Empty
       description={
-        <Space orientation="vertical" size={4}>
+        <Space direction="vertical" size={4}>
           <Typography.Text strong>{title}</Typography.Text>
           <Typography.Text style={{ color: token.colorTextSecondary }}>
             {description}

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Actors/OrleansActorRuntime.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Actors/OrleansActorRuntime.cs
@@ -56,6 +56,7 @@ public sealed class OrleansActorRuntime : IActorRuntime
     {
         ct.ThrowIfCancellationRequested();
         await _callbackScheduler.PurgeActorAsync(id, ct);
+        using var reentrancyScope = RequestContext.AllowCallChainReentrancy();
         var grain = _grainFactory.GetGrain<IRuntimeActorGrain>(id);
 
         var parentId = await grain.GetParentAsync();
@@ -113,6 +114,7 @@ public sealed class OrleansActorRuntime : IActorRuntime
     public async Task UnlinkAsync(string childId, CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
+        using var reentrancyScope = RequestContext.AllowCallChainReentrancy();
         var child = _grainFactory.GetGrain<IRuntimeActorGrain>(childId);
         var parentId = await child.GetParentAsync();
         if (!string.IsNullOrWhiteSpace(parentId))

--- a/src/Aevatar.Mainnet.Host.Api/README.md
+++ b/src/Aevatar.Mainnet.Host.Api/README.md
@@ -53,6 +53,31 @@ export AEVATAR_Orleans__SiloPort=11111
 export AEVATAR_Orleans__GatewayPort=30000
 ```
 
+## 本地持久化开发模式（Orleans + Garnet）
+
+如果只是想避免本地 scope workflow / actor state 因后端重启而完全丢失，而当前机器又没有 Kafka / Elasticsearch / Neo4j，可以先用仓库内置的 `PersistentLocal` 环境：
+
+```bash
+ASPNETCORE_ENVIRONMENT=PersistentLocal dotnet run --project src/Aevatar.Mainnet.Host.Api
+```
+
+该模式默认启用：
+
+- `ActorRuntime:Provider=Orleans`
+- `ActorRuntime:OrleansStreamBackend=InMemory`
+- `ActorRuntime:OrleansPersistenceBackend=Garnet`
+- `Projection:Document:Providers:InMemory:Enabled=true`
+- `Projection:Graph:Providers:InMemory:Enabled=true`
+
+前提：
+
+- 本机 `localhost:6379` 可用（Redis / Garnet 兼容连接）
+
+说明：
+
+- 该模式的目标是保住本地 actor 持久态与 workflow 存储回补能力，适合单机开发验证。
+- 它不是完整的 distributed / production profile；若需要 durable document / graph projection，仍应使用 `Distributed` 环境并启动 Kafka、Elasticsearch、Neo4j。
+
 ## 多机集群测试（Docker）
 
 仓库提供的集群启动脚本会拉起 3 节点 Mainnet + Kafka + Garnet + Elasticsearch + Neo4j。

--- a/src/Aevatar.Mainnet.Host.Api/appsettings.PersistentLocal.json
+++ b/src/Aevatar.Mainnet.Host.Api/appsettings.PersistentLocal.json
@@ -1,0 +1,50 @@
+{
+  "ActorRuntime": {
+    "Provider": "Orleans",
+    "OrleansStreamBackend": "InMemory",
+    "OrleansStreamProviderName": "AevatarOrleansStreamProvider",
+    "OrleansActorEventNamespace": "aevatar.actor.events",
+    "OrleansPersistenceBackend": "Garnet",
+    "OrleansGarnetConnectionString": "localhost:6379"
+  },
+  "Orleans": {
+    "ClusteringMode": "Localhost",
+    "ClusterId": "aevatar-mainnet-cluster",
+    "ServiceId": "aevatar-mainnet-host-api",
+    "SiloHost": "127.0.0.1",
+    "PrimarySiloEndpoint": "",
+    "SiloPort": 11111,
+    "GatewayPort": 30000,
+    "QueueCount": 8,
+    "QueueCacheSize": 4096
+  },
+  "Projection": {
+    "Document": {
+      "Providers": {
+        "Elasticsearch": {
+          "Enabled": false,
+          "Endpoints": []
+        },
+        "InMemory": {
+          "Enabled": true
+        }
+      }
+    },
+    "Graph": {
+      "Providers": {
+        "Neo4j": {
+          "Enabled": false,
+          "Uri": ""
+        },
+        "InMemory": {
+          "Enabled": true
+        }
+      }
+    },
+    "Policies": {
+      "Environment": "Development",
+      "DenyInMemoryDocumentReadStore": false,
+      "DenyInMemoryGraphFactStore": false
+    }
+  }
+}

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -162,17 +162,27 @@ public sealed class AppScopedWorkflowService
         ArgumentNullException.ThrowIfNull(request);
 
         var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var requestedWorkflowName = string.IsNullOrWhiteSpace(request.WorkflowName)
+            ? string.Empty
+            : request.WorkflowName.Trim();
         var normalizedYaml = NormalizeRequired(request.Yaml, nameof(request.Yaml));
+        if (!string.IsNullOrWhiteSpace(requestedWorkflowName))
+        {
+            normalizedYaml = AlignWorkflowYamlName(normalizedYaml, requestedWorkflowName);
+        }
+
         var parsed = _yamlDocumentService.Parse(normalizedYaml);
-        var workflowName = !string.IsNullOrWhiteSpace(parsed.Document?.Name)
+        var workflowName = !string.IsNullOrWhiteSpace(requestedWorkflowName)
+            ? requestedWorkflowName
+            : !string.IsNullOrWhiteSpace(parsed.Document?.Name)
             ? parsed.Document.Name.Trim()
             : NormalizeRequired(request.WorkflowName, nameof(request.WorkflowName));
         var workflowId = string.IsNullOrWhiteSpace(request.WorkflowId)
             ? StudioDocumentIdNormalizer.Normalize(workflowName, "workflow")
             : NormalizeRequired(request.WorkflowId, nameof(request.WorkflowId));
-        var displayName = string.IsNullOrWhiteSpace(request.WorkflowName)
+        var displayName = string.IsNullOrWhiteSpace(requestedWorkflowName)
             ? workflowId
-            : request.WorkflowName.Trim();
+            : requestedWorkflowName;
 
         ScopeWorkflowUpsertResult upsert;
         if (_workflowCommandPort != null)
@@ -220,6 +230,24 @@ public sealed class AppScopedWorkflowService
             normalizedYaml,
             request.Layout,
             parsed);
+    }
+
+    private string AlignWorkflowYamlName(string yaml, string workflowName)
+    {
+        if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
+            return yaml;
+
+        var parsed = _yamlDocumentService.Parse(yaml);
+        if (parsed.Document == null)
+            return yaml;
+
+        if (string.Equals(parsed.Document.Name?.Trim(), workflowName, StringComparison.Ordinal))
+            return yaml;
+
+        return _yamlDocumentService.Serialize(parsed.Document with
+        {
+            Name = workflowName,
+        });
     }
 
     public static WorkflowDirectorySummary CreateScopeDirectory(string scopeId) =>

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -64,10 +64,12 @@ public sealed class AppScopedWorkflowService
                 body: null,
                 ct) ?? [];
 
-        return workflows
+        var summaries = workflows
             .OrderByDescending(static item => item.UpdatedAt)
             .Select(workflow => ToWorkflowSummary(normalizedScopeId, workflow))
             .ToList();
+
+        return await MergeStoredWorkflowSummariesAsync(normalizedScopeId, summaries, ct);
     }
 
     public async Task<WorkflowFileResponse?> GetAsync(
@@ -81,59 +83,70 @@ public sealed class AppScopedWorkflowService
         if (_workflowQueryPort != null && _workflowActorBindingReader != null)
         {
             var workflow = await _workflowQueryPort.GetByWorkflowIdAsync(normalizedScopeId, normalizedWorkflowId, ct);
-            if (workflow == null)
-                return null;
-
-            var binding = string.IsNullOrWhiteSpace(workflow.ActorId)
-                ? null
-                : await _workflowActorBindingReader.GetAsync(workflow.ActorId, ct);
-
-            var yaml = binding?.WorkflowYaml ?? string.Empty;
-
-            // Fallback: if binding projection hasn't materialized the YAML yet,
-            // try the artifact store which is written synchronously during save.
-            if (string.IsNullOrWhiteSpace(yaml) &&
-                _artifactStore != null &&
-                !string.IsNullOrWhiteSpace(workflow.ServiceKey))
+            if (workflow != null)
             {
-                // Try with known revision ID.
-                if (!string.IsNullOrWhiteSpace(workflow.ActiveRevisionId))
-                {
-                    var artifact = await _artifactStore.GetAsync(workflow.ServiceKey, workflow.ActiveRevisionId, ct);
-                    yaml = artifact?.DeploymentPlan?.WorkflowPlan?.WorkflowYaml ?? string.Empty;
-                }
+                var binding = string.IsNullOrWhiteSpace(workflow.ActorId)
+                    ? null
+                    : await _workflowActorBindingReader.GetAsync(workflow.ActorId, ct);
 
-                // If revision ID is empty (deployment snapshot not ready yet),
-                // scan for the latest revision via the service lifecycle query.
+                var yaml = binding?.WorkflowYaml ?? string.Empty;
+
+                // Fallback: if binding projection hasn't materialized the YAML yet,
+                // try the artifact store which is written synchronously during save.
                 if (string.IsNullOrWhiteSpace(yaml) &&
-                    _workflowQueryPort != null &&
-                    _serviceLifecycleQueryPort != null)
+                    _artifactStore != null &&
+                    !string.IsNullOrWhiteSpace(workflow.ServiceKey))
                 {
-                    var identity = new ServiceIdentity
+                    // Try with known revision ID.
+                    if (!string.IsNullOrWhiteSpace(workflow.ActiveRevisionId))
                     {
-                        TenantId = normalizedScopeId,
-                        AppId = "default",
-                        Namespace = "default",
-                        ServiceId = normalizedWorkflowId,
-                    };
-                    var svc = await _serviceLifecycleQueryPort.GetServiceAsync(identity, ct);
-                    var revId = svc?.ActiveServingRevisionId;
-                    if (string.IsNullOrWhiteSpace(revId))
-                        revId = svc?.DefaultServingRevisionId;
-                    if (!string.IsNullOrWhiteSpace(revId))
-                    {
-                        var artifact = await _artifactStore.GetAsync(workflow.ServiceKey, revId, ct);
+                        var artifact = await _artifactStore.GetAsync(workflow.ServiceKey, workflow.ActiveRevisionId, ct);
                         yaml = artifact?.DeploymentPlan?.WorkflowPlan?.WorkflowYaml ?? string.Empty;
                     }
+
+                    // If revision ID is empty (deployment snapshot not ready yet),
+                    // scan for the latest revision via the service lifecycle query.
+                    if (string.IsNullOrWhiteSpace(yaml) &&
+                        _workflowQueryPort != null &&
+                        _serviceLifecycleQueryPort != null)
+                    {
+                        var identity = new ServiceIdentity
+                        {
+                            TenantId = normalizedScopeId,
+                            AppId = "default",
+                            Namespace = "default",
+                            ServiceId = normalizedWorkflowId,
+                        };
+                        var svc = await _serviceLifecycleQueryPort.GetServiceAsync(identity, ct);
+                        var revId = svc?.ActiveServingRevisionId;
+                        if (string.IsNullOrWhiteSpace(revId))
+                            revId = svc?.DefaultServingRevisionId;
+                        if (!string.IsNullOrWhiteSpace(revId))
+                        {
+                            var artifact = await _artifactStore.GetAsync(workflow.ServiceKey, revId, ct);
+                            yaml = artifact?.DeploymentPlan?.WorkflowPlan?.WorkflowYaml ?? string.Empty;
+                        }
+                    }
                 }
+
+                return ToWorkflowFileResponse(
+                    normalizedScopeId,
+                    workflow,
+                    yaml,
+                    layout: TryReadPersistedLayout(normalizedScopeId, normalizedWorkflowId),
+                    findingsFallbackMessage: "Workflow YAML is not available yet.");
             }
 
-            return ToWorkflowFileResponse(
-                normalizedScopeId,
-                workflow,
-                yaml,
-                layout: TryReadPersistedLayout(normalizedScopeId, normalizedWorkflowId),
-                findingsFallbackMessage: "Workflow YAML is not available yet.");
+            var storedWorkflow = await TryGetStoredWorkflowAsync(normalizedWorkflowId, ct);
+            if (storedWorkflow != null)
+            {
+                return ToStoredWorkflowFileResponse(
+                    normalizedScopeId,
+                    storedWorkflow,
+                    TryReadPersistedLayout(normalizedScopeId, normalizedWorkflowId));
+            }
+
+            return null;
         }
 
         var detail = await SendAsync<ScopeWorkflowDetail>(
@@ -144,7 +157,15 @@ public sealed class AppScopedWorkflowService
             allowNotFound: true);
 
         if (detail == null || detail.Workflow == null)
-            return null;
+        {
+            var storedWorkflow = await TryGetStoredWorkflowAsync(normalizedWorkflowId, ct);
+            return storedWorkflow == null
+                ? null
+                : ToStoredWorkflowFileResponse(
+                    normalizedScopeId,
+                    storedWorkflow,
+                    TryReadPersistedLayout(normalizedScopeId, normalizedWorkflowId));
+        }
 
         return ToWorkflowFileResponse(
             normalizedScopeId,
@@ -322,6 +343,111 @@ public sealed class AppScopedWorkflowService
             return workflow.WorkflowName;
 
         return workflow.WorkflowId;
+    }
+
+    private async Task<IReadOnlyList<WorkflowSummary>> MergeStoredWorkflowSummariesAsync(
+        string scopeId,
+        IReadOnlyList<WorkflowSummary> runtimeSummaries,
+        CancellationToken ct)
+    {
+        if (_workflowStoragePort == null)
+            return runtimeSummaries;
+
+        IReadOnlyList<StoredWorkflowYaml> storedWorkflows;
+        try
+        {
+            storedWorkflows = await _workflowStoragePort.ListWorkflowYamlsAsync(ct);
+        }
+        catch
+        {
+            return runtimeSummaries;
+        }
+
+        if (storedWorkflows.Count == 0)
+            return runtimeSummaries;
+
+        var merged = runtimeSummaries.ToDictionary(summary => summary.WorkflowId, StringComparer.Ordinal);
+        foreach (var storedWorkflow in storedWorkflows)
+        {
+            if (merged.ContainsKey(storedWorkflow.WorkflowId))
+                continue;
+
+            merged[storedWorkflow.WorkflowId] = ToStoredWorkflowSummary(scopeId, storedWorkflow);
+        }
+
+        return merged.Values
+            .OrderByDescending(static item => item.UpdatedAtUtc)
+            .ToList();
+    }
+
+    private async Task<StoredWorkflowYaml?> TryGetStoredWorkflowAsync(string workflowId, CancellationToken ct)
+    {
+        if (_workflowStoragePort == null)
+            return null;
+
+        try
+        {
+            return await _workflowStoragePort.GetWorkflowYamlAsync(workflowId, ct);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private WorkflowSummary ToStoredWorkflowSummary(
+        string scopeId,
+        StoredWorkflowYaml storedWorkflow)
+    {
+        var parse = _yamlDocumentService.Parse(storedWorkflow.Yaml);
+        var scopeDirectory = CreateScopeDirectory(scopeId);
+        return new WorkflowSummary(
+            storedWorkflow.WorkflowId,
+            ResolveStoredWorkflowName(storedWorkflow, parse),
+            parse.Document?.Description ?? string.Empty,
+            $"{storedWorkflow.WorkflowId}.yaml",
+            $"{scopeDirectory.Path}/{storedWorkflow.WorkflowId}.yaml",
+            scopeDirectory.DirectoryId,
+            scopeDirectory.Label,
+            parse.Document?.Steps.Count ?? 0,
+            TryReadPersistedLayout(scopeId, storedWorkflow.WorkflowId) != null,
+            storedWorkflow.UpdatedAtUtc ?? DateTimeOffset.UtcNow);
+    }
+
+    private WorkflowFileResponse ToStoredWorkflowFileResponse(
+        string scopeId,
+        StoredWorkflowYaml storedWorkflow,
+        WorkflowLayoutDocument? layout)
+    {
+        var parse = _yamlDocumentService.Parse(storedWorkflow.Yaml);
+        var scopeDirectory = CreateScopeDirectory(scopeId);
+        return new WorkflowFileResponse(
+            storedWorkflow.WorkflowId,
+            ResolveStoredWorkflowName(storedWorkflow, parse),
+            $"{storedWorkflow.WorkflowId}.yaml",
+            $"{scopeDirectory.Path}/{storedWorkflow.WorkflowId}.yaml",
+            scopeDirectory.DirectoryId,
+            scopeDirectory.Label,
+            storedWorkflow.Yaml,
+            parse.Document,
+            layout,
+            parse.Findings,
+            storedWorkflow.UpdatedAtUtc);
+    }
+
+    private static string ResolveStoredWorkflowName(
+        StoredWorkflowYaml storedWorkflow,
+        WorkflowParseResult parseResult)
+    {
+        var parsedName = parseResult.Document?.Name?.Trim();
+        if (!string.IsNullOrWhiteSpace(parsedName))
+            return parsedName;
+
+        var storedName = storedWorkflow.WorkflowName?.Trim();
+        if (!string.IsNullOrWhiteSpace(storedName))
+            return storedName;
+
+        return storedWorkflow.WorkflowId;
     }
 
     private async Task<T?> SendAsync<T>(

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkflowStoragePort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkflowStoragePort.cs
@@ -6,4 +6,14 @@ namespace Aevatar.Studio.Application.Studio.Abstractions;
 public interface IWorkflowStoragePort
 {
     Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct);
+
+    Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct);
+
+    Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct);
 }
+
+public sealed record StoredWorkflowYaml(
+    string WorkflowId,
+    string WorkflowName,
+    string Yaml,
+    DateTimeOffset? UpdatedAtUtc);

--- a/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
@@ -123,6 +123,7 @@ public sealed class WorkspaceService
         var normalizedName = string.IsNullOrWhiteSpace(request.WorkflowName)
             ? "workflow"
             : request.WorkflowName.Trim();
+        var normalizedYaml = AlignWorkflowYamlName(request.Yaml, normalizedName);
 
         var normalizedFileName = EnsureYamlExtension(string.IsNullOrWhiteSpace(request.FileName)
             ? normalizedName
@@ -140,12 +141,30 @@ public sealed class WorkspaceService
                 FilePath: filePath,
                 DirectoryId: directory.DirectoryId,
                 DirectoryLabel: directory.Label,
-                Yaml: request.Yaml,
+                Yaml: normalizedYaml,
                 Layout: request.Layout,
                 UpdatedAtUtc: DateTimeOffset.UtcNow),
             cancellationToken);
 
         return ToWorkflowFileResponse(stored);
+    }
+
+    private string AlignWorkflowYamlName(string yaml, string workflowName)
+    {
+        if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
+            return yaml;
+
+        var parsed = _yamlDocumentService.Parse(yaml);
+        if (parsed.Document == null)
+            return yaml;
+
+        if (string.Equals(parsed.Document.Name?.Trim(), workflowName, StringComparison.Ordinal))
+            return yaml;
+
+        return _yamlDocumentService.Serialize(parsed.Document with
+        {
+            Name = workflowName,
+        });
     }
 
     private WorkflowFileResponse ToWorkflowFileResponse(StoredWorkflowFile file)

--- a/src/Aevatar.Studio.Domain/Studio/Compatibility/WorkflowCompatibilityProfile.cs
+++ b/src/Aevatar.Studio.Domain/Studio/Compatibility/WorkflowCompatibilityProfile.cs
@@ -194,6 +194,9 @@ public sealed class WorkflowCompatibilityProfile
                 comparer,
                 new Dictionary<string, string>(comparer)
                 {
+                    ["llm"] = "llm_call",
+                    ["chat"] = "llm_call",
+                    ["task"] = "llm_call",
                     ["loop"] = "while",
                     ["sub_workflow"] = "workflow_call",
                     ["for_each"] = "foreach",

--- a/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateOrchestrator.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateOrchestrator.cs
@@ -41,6 +41,7 @@ internal sealed class WorkflowGenerateOrchestrator
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
     private static readonly string[] AuthoringSchemaRules =
     [
+        "Use canonical step types only. For a simple assistant/chat workflow, the step type must be llm_call (not llm, chat, or task).",
         "Use only these step-level fields: id, type, target_role (or role), parameters, next, branches, children, retry, on_error, timeout_ms.",
         "Do not put model, provider, temperature, max_tokens, max_history_messages, connectors, or system_prompt on steps. Those belong under roles[*].",
         "Do not use steps[*].messages.",

--- a/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateOrchestrator.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateOrchestrator.cs
@@ -39,6 +39,14 @@ internal sealed class WorkflowGenerateOrchestrator
     private static readonly Regex YamlFenceRegex = new(
         @"```(?:ya?ml)?\s*\n([\s\S]*?)```",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly string[] AuthoringSchemaRules =
+    [
+        "Use only these step-level fields: id, type, target_role (or role), parameters, next, branches, children, retry, on_error, timeout_ms.",
+        "Do not put model, provider, temperature, max_tokens, max_history_messages, connectors, or system_prompt on steps. Those belong under roles[*].",
+        "Do not use steps[*].messages.",
+        "Do not use steps[*].params. Put step options under steps[*].parameters.",
+        "If you need to shape LLM input, use steps[*].parameters.prompt_prefix.",
+    ];
 
     private readonly WorkflowEditorService _editorService;
 
@@ -106,7 +114,7 @@ internal sealed class WorkflowGenerateOrchestrator
                     ct);
             }
             var parse = _editorService.ParseYaml(new ParseYamlRequest(candidateYaml, request.AvailableWorkflowNames));
-            if (parse.Document == null || HasErrors(parse.Findings))
+            if (parse.Document == null)
             {
                 lastFindings = parse.Findings.Count > 0
                     ? parse.Findings
@@ -133,6 +141,25 @@ internal sealed class WorkflowGenerateOrchestrator
             var normalized = _editorService.Normalize(new NormalizeWorkflowRequest(
                 parse.Document,
                 request.AvailableWorkflowNames));
+            var blockingParseFindings = GetBlockingParseFindings(parse.Findings);
+            if (blockingParseFindings.Count > 0)
+            {
+                lastCandidate = string.IsNullOrWhiteSpace(normalized.Yaml)
+                    ? candidateYaml
+                    : normalized.Yaml;
+                lastFindings = blockingParseFindings;
+                if (onProgress != null && attempt < MaxAttempts)
+                {
+                    await onProgress(
+                        new WorkflowGenerateProgress(
+                            WorkflowGenerateProgressStage.RepairingDraft,
+                            attempt,
+                            BuildRepairStatusMessage(lastFindings, attempt)),
+                        ct);
+                }
+                continue;
+            }
+
             if (HasErrors(normalized.Findings))
             {
                 lastCandidate = normalized.Yaml;
@@ -210,6 +237,7 @@ internal sealed class WorkflowGenerateOrchestrator
         }
 
         parts.Add($"User request:\n{request}");
+        parts.Add(BuildAuthoringSchemaHintBlock());
         return string.Join("\n\n", parts);
     }
 
@@ -258,7 +286,28 @@ internal sealed class WorkflowGenerateOrchestrator
         }
 
         builder.AppendLine();
+        builder.AppendLine("Workflow authoring constraints:");
+        foreach (var rule in AuthoringSchemaRules)
+        {
+            builder.Append("- ");
+            builder.AppendLine(rule);
+        }
+
+        builder.AppendLine();
         builder.Append("Return workflow YAML only.");
+        return builder.ToString().Trim();
+    }
+
+    private static string BuildAuthoringSchemaHintBlock()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("Workflow authoring constraints:");
+        foreach (var rule in AuthoringSchemaRules)
+        {
+            builder.Append("- ");
+            builder.AppendLine(rule);
+        }
+
         return builder.ToString().Trim();
     }
 
@@ -279,5 +328,26 @@ internal sealed class WorkflowGenerateOrchestrator
 
         var firstFinding = findings[0];
         return $"{headline} {firstFinding.Path}: {firstFinding.Message}";
+    }
+
+    private static IReadOnlyList<ValidationFinding> GetBlockingParseFindings(
+        IReadOnlyList<ValidationFinding> findings) =>
+        findings
+            .Where(static finding => finding.Level == ValidationLevel.Error)
+            .Where(static finding => !IsSanitizableParseFinding(finding))
+            .ToList();
+
+    private static bool IsSanitizableParseFinding(ValidationFinding finding)
+    {
+        if (string.Equals(finding.Code, "unknown_field", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!string.Equals(finding.Code, "runtime_validation", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var message = finding.Message ?? string.Empty;
+        return message.Contains("Unknown field '", StringComparison.OrdinalIgnoreCase) ||
+               (message.Contains("Property '", StringComparison.OrdinalIgnoreCase) &&
+                message.Contains("not found on type", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Aevatar.Studio.Infrastructure/Storage/ChronoStorageWorkflowStoragePort.cs
+++ b/src/Aevatar.Studio.Infrastructure/Storage/ChronoStorageWorkflowStoragePort.cs
@@ -5,6 +5,8 @@ namespace Aevatar.Studio.Infrastructure.Storage;
 
 internal sealed class ChronoStorageWorkflowStoragePort : IWorkflowStoragePort
 {
+    private const string WorkflowDirectory = "workflows";
+
     private readonly ChronoStorageCatalogBlobClient _blobClient;
 
     public ChronoStorageWorkflowStoragePort(ChronoStorageCatalogBlobClient blobClient)
@@ -15,10 +17,86 @@ internal sealed class ChronoStorageWorkflowStoragePort : IWorkflowStoragePort
     public async Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct)
     {
         var yamlBytes = Encoding.UTF8.GetBytes(yaml);
-        var key = $"workflows/{workflowId}.yaml";
+        var key = $"{WorkflowDirectory}/{workflowId}.yaml";
         var context = _blobClient.TryResolveContext(string.Empty, key);
         if (context == null) return;
 
         await _blobClient.UploadAsync(context, yamlBytes, "text/yaml", ct);
+    }
+
+    public async Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct)
+    {
+        var directoryContext = ResolveWorkflowDirectoryContext();
+        if (directoryContext == null)
+            return [];
+
+        var objects = await _blobClient.ListObjectsAsync(directoryContext, WorkflowDirectory, ct);
+        if (objects.Objects.Count == 0)
+            return [];
+
+        var workflows = new List<StoredWorkflowYaml>(objects.Objects.Count);
+        foreach (var storageObject in objects.Objects)
+        {
+            var workflowId = TryResolveWorkflowId(storageObject.Key);
+            if (string.IsNullOrWhiteSpace(workflowId))
+                continue;
+
+            var stored = await GetWorkflowYamlAsync(workflowId, ct);
+            if (stored != null)
+            {
+                var updatedAtUtc = TryParseUpdatedAt(storageObject.LastModified) ?? stored.UpdatedAtUtc;
+                workflows.Add(stored with { UpdatedAtUtc = updatedAtUtc });
+            }
+        }
+
+        return workflows;
+    }
+
+    public async Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct)
+    {
+        var normalizedWorkflowId = workflowId?.Trim() ?? string.Empty;
+        if (normalizedWorkflowId.Length == 0)
+            return null;
+
+        var context = _blobClient.TryResolveContext(string.Empty, $"{WorkflowDirectory}/{normalizedWorkflowId}.yaml");
+        if (context == null)
+            return null;
+
+        var payload = await _blobClient.TryDownloadAsync(context, ct);
+        if (payload == null || payload.Length == 0)
+            return null;
+
+        var yaml = Encoding.UTF8.GetString(payload);
+        return new StoredWorkflowYaml(
+            normalizedWorkflowId,
+            normalizedWorkflowId,
+            yaml,
+            UpdatedAtUtc: null);
+    }
+
+    private ChronoStorageCatalogBlobClient.RemoteScopeContext? ResolveWorkflowDirectoryContext() =>
+        _blobClient.TryResolveContext(string.Empty, $"{WorkflowDirectory}/.index");
+
+    private static string? TryResolveWorkflowId(string relativeKey)
+    {
+        if (string.IsNullOrWhiteSpace(relativeKey))
+            return null;
+
+        var normalizedKey = relativeKey.Trim();
+        if (!normalizedKey.StartsWith($"{WorkflowDirectory}/", StringComparison.Ordinal) ||
+            !normalizedKey.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return Path.GetFileNameWithoutExtension(normalizedKey);
+    }
+
+    private static DateTimeOffset? TryParseUpdatedAt(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        return DateTimeOffset.TryParse(raw, out var parsed) ? parsed : null;
     }
 }

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorRuntimeForwardingTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorRuntimeForwardingTests.cs
@@ -58,6 +58,22 @@ public sealed class OrleansActorRuntimeForwardingTests
     }
 
     [Fact]
+    public async Task UnlinkAsync_ShouldCreateCallChainReentrancyScope_ForGrainCalls()
+    {
+        RequestContext.Clear();
+        var runtime = CreateRuntime(out _, out var grains, out _);
+        await runtime.LinkAsync("parent", "child");
+        grains["parent"].ObservedReentrancyIds.Clear();
+        grains["child"].ObservedReentrancyIds.Clear();
+
+        await runtime.UnlinkAsync("child");
+
+        grains["parent"].ObservedReentrancyIds.Should().Contain(id => id != Guid.Empty);
+        grains["child"].ObservedReentrancyIds.Should().Contain(id => id != Guid.Empty);
+        RequestContext.ReentrancyId.Should().Be(Guid.Empty);
+    }
+
+    [Fact]
     public async Task DestroyAsync_ShouldCleanupIncomingAndOutgoingForwardingBindings()
     {
         var runtime = CreateRuntime(out var registry, out var grains, out _);
@@ -128,6 +144,25 @@ public sealed class OrleansActorRuntimeForwardingTests
         await runtime.DestroyAsync("actor-1");
 
         callbackSchedulerGrains["actor-1"].PurgeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DestroyAsync_ShouldCreateCallChainReentrancyScope_ForGrainCalls()
+    {
+        RequestContext.Clear();
+        var runtime = CreateRuntime(out _, out var grains, out _);
+        await runtime.LinkAsync("parent", "middle");
+        await runtime.LinkAsync("middle", "child");
+        grains["parent"].ObservedReentrancyIds.Clear();
+        grains["middle"].ObservedReentrancyIds.Clear();
+        grains["child"].ObservedReentrancyIds.Clear();
+
+        await runtime.DestroyAsync("middle");
+
+        grains["parent"].ObservedReentrancyIds.Should().Contain(id => id != Guid.Empty);
+        grains["middle"].ObservedReentrancyIds.Should().Contain(id => id != Guid.Empty);
+        grains["child"].ObservedReentrancyIds.Should().Contain(id => id != Guid.Empty);
+        RequestContext.ReentrancyId.Should().Be(Guid.Empty);
     }
 
     private static OrleansActorRuntime CreateRuntime(

--- a/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkflowCompatibilityProfileTests.cs
@@ -14,6 +14,9 @@ public sealed class WorkflowCompatibilityProfileTests
     }
 
     [Theory]
+    [InlineData("llm", "llm_call")]
+    [InlineData("chat", "llm_call")]
+    [InlineData("task", "llm_call")]
     [InlineData("loop", "while")]
     [InlineData("sub_workflow", "workflow_call")]
     [InlineData("foreach_llm", "foreach")]

--- a/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
@@ -122,6 +122,58 @@ public sealed class AppScopedWorkflowServiceTests
         response.Yaml.Should().StartWith("name: renamed-workflow");
     }
 
+    [Fact]
+    public async Task ListAsync_WhenRuntimeListIsEmpty_ShouldFallbackToStoredWorkflowYaml()
+    {
+        var service = new AppScopedWorkflowService(
+            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
+            {
+                BaseAddress = new Uri("https://backend.example"),
+            }),
+            new StubWorkflowYamlDocumentService(),
+            workflowQueryPort: new StubScopeWorkflowQueryPort(),
+            workflowStoragePort: new StubWorkflowStoragePort(
+                new StoredWorkflowYaml(
+                    "hello-chat",
+                    "hello-chat",
+                    "name: hello-chat\ndescription: stored workflow\nsteps: []\n",
+                    new DateTimeOffset(2026, 4, 10, 9, 0, 0, TimeSpan.Zero))));
+
+        var workflows = await service.ListAsync("scope-1");
+
+        workflows.Should().ContainSingle();
+        workflows[0].WorkflowId.Should().Be("hello-chat");
+        workflows[0].Name.Should().Be("hello-chat");
+        workflows[0].Description.Should().Be("stored workflow");
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenRuntimeWorkflowMissing_ShouldFallbackToStoredWorkflowYaml()
+    {
+        var service = new AppScopedWorkflowService(
+            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
+            {
+                BaseAddress = new Uri("https://backend.example"),
+            }),
+            new StubWorkflowYamlDocumentService(),
+            workflowQueryPort: new StubScopeWorkflowQueryPort(),
+            workflowActorBindingReader: new StubWorkflowActorBindingReader(null),
+            workflowStoragePort: new StubWorkflowStoragePort(
+                new StoredWorkflowYaml(
+                    "hello-chat",
+                    "hello-chat",
+                    "name: hello-chat\ndescription: restored from storage\nsteps: []\n",
+                    new DateTimeOffset(2026, 4, 10, 9, 0, 0, TimeSpan.Zero))));
+
+        var workflow = await service.GetAsync("scope-1", "hello-chat");
+
+        workflow.Should().NotBeNull();
+        workflow!.WorkflowId.Should().Be("hello-chat");
+        workflow.Name.Should().Be("hello-chat");
+        workflow.Yaml.Should().Contain("restored from storage");
+        workflow.Findings.Should().BeEmpty();
+    }
+
     private static AppScopedWorkflowService CreateService(
         Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
     {
@@ -170,16 +222,20 @@ public sealed class AppScopedWorkflowServiceTests
     private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
     {
         private static readonly Regex NameRegex = new(@"(?m)^name:\s*(.+?)\s*$", RegexOptions.Compiled);
+        private static readonly Regex DescriptionRegex = new(@"(?m)^description:\s*(.+?)\s*$", RegexOptions.Compiled);
 
         public WorkflowParseResult Parse(string yaml)
         {
             if (string.IsNullOrWhiteSpace(yaml))
                 return new(null, []);
 
-            var match = NameRegex.Match(yaml ?? string.Empty);
+            var input = yaml ?? string.Empty;
+            var nameMatch = NameRegex.Match(input);
+            var descriptionMatch = DescriptionRegex.Match(input);
             return new(new WorkflowDocument
             {
-                Name = match.Success ? match.Groups[1].Value.Trim() : string.Empty,
+                Name = nameMatch.Success ? nameMatch.Groups[1].Value.Trim() : string.Empty,
+                Description = descriptionMatch.Success ? descriptionMatch.Groups[1].Value.Trim() : string.Empty,
             }, []);
         }
 
@@ -215,7 +271,11 @@ public sealed class AppScopedWorkflowServiceTests
 
     private sealed class StubScopeWorkflowQueryPort : IScopeWorkflowQueryPort
     {
-        private readonly ScopeWorkflowSummary _workflow;
+        private readonly ScopeWorkflowSummary? _workflow;
+
+        public StubScopeWorkflowQueryPort()
+        {
+        }
 
         public StubScopeWorkflowQueryPort(ScopeWorkflowSummary workflow)
         {
@@ -223,26 +283,35 @@ public sealed class AppScopedWorkflowServiceTests
         }
 
         public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>([_workflow]);
+            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>(_workflow == null ? [] : [_workflow]);
 
         public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default) =>
-            Task.FromResult<ScopeWorkflowSummary?>(string.Equals(workflowId, _workflow.WorkflowId, StringComparison.Ordinal) ? _workflow : null);
+            Task.FromResult<ScopeWorkflowSummary?>(
+                _workflow != null && string.Equals(workflowId, _workflow.WorkflowId, StringComparison.Ordinal)
+                    ? _workflow
+                    : null);
 
         public Task<ScopeWorkflowSummary?> GetByActorIdAsync(string scopeId, string actorId, CancellationToken ct = default) =>
-            Task.FromResult<ScopeWorkflowSummary?>(string.Equals(actorId, _workflow.ActorId, StringComparison.Ordinal) ? _workflow : null);
+            Task.FromResult<ScopeWorkflowSummary?>(
+                _workflow != null && string.Equals(actorId, _workflow.ActorId, StringComparison.Ordinal)
+                    ? _workflow
+                    : null);
     }
 
     private sealed class StubWorkflowActorBindingReader : IWorkflowActorBindingReader
     {
-        private readonly WorkflowActorBinding _binding;
+        private readonly WorkflowActorBinding? _binding;
 
-        public StubWorkflowActorBindingReader(WorkflowActorBinding binding)
+        public StubWorkflowActorBindingReader(WorkflowActorBinding? binding)
         {
             _binding = binding;
         }
 
         public Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default) =>
-            Task.FromResult<WorkflowActorBinding?>(string.Equals(actorId, _binding.ActorId, StringComparison.Ordinal) ? _binding : null);
+            Task.FromResult<WorkflowActorBinding?>(
+                _binding != null && string.Equals(actorId, _binding.ActorId, StringComparison.Ordinal)
+                    ? _binding
+                    : null);
     }
 
     private sealed class StubArtifactStore : IServiceRevisionArtifactStore
@@ -252,5 +321,27 @@ public sealed class AppScopedWorkflowServiceTests
 
         public Task<PreparedServiceRevisionArtifact?> GetAsync(string serviceKey, string revisionId, CancellationToken ct = default) =>
             Task.FromResult<PreparedServiceRevisionArtifact?>(null);
+    }
+
+    private sealed class StubWorkflowStoragePort : IWorkflowStoragePort
+    {
+        private readonly Dictionary<string, StoredWorkflowYaml> _storedWorkflows;
+
+        public StubWorkflowStoragePort(params StoredWorkflowYaml[] storedWorkflows)
+        {
+            _storedWorkflows = storedWorkflows.ToDictionary(item => item.WorkflowId, StringComparer.Ordinal);
+        }
+
+        public Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<StoredWorkflowYaml>>(_storedWorkflows.Values.ToList());
+
+        public Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromResult<StoredWorkflowYaml?>(
+                _storedWorkflows.TryGetValue(workflowId, out var storedWorkflow)
+                    ? storedWorkflow
+                    : null);
     }
 }

--- a/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
@@ -2,12 +2,14 @@ using System.Net;
 using System.Text;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Domain.Studio.Models;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using System.Text.RegularExpressions;
 
 namespace Aevatar.Tools.Cli.Tests;
 
@@ -92,6 +94,34 @@ public sealed class AppScopedWorkflowServiceTests
         response.Findings[0].Message.Should().Be("Workflow YAML is not available yet.");
     }
 
+    [Fact]
+    public async Task SaveAsync_ShouldRewriteYamlNameFromRequestedWorkflowName()
+    {
+        var commandPort = new StubScopeWorkflowCommandPort();
+        var service = new AppScopedWorkflowService(
+            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
+            {
+                BaseAddress = new Uri("https://backend.example"),
+            }),
+            new StubWorkflowYamlDocumentService(),
+            workflowCommandPort: commandPort);
+
+        var response = await service.SaveAsync(
+            "scope-1",
+            new SaveWorkflowFileRequest(
+                WorkflowId: null,
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "renamed-workflow",
+                FileName: null,
+                Yaml: "name: draft\nsteps: []\n"));
+
+        commandPort.LastRequest.Should().NotBeNull();
+        commandPort.LastRequest!.WorkflowName.Should().Be("renamed-workflow");
+        commandPort.LastRequest.WorkflowYaml.Should().StartWith("name: renamed-workflow");
+        response.Name.Should().Be("renamed-workflow");
+        response.Yaml.Should().StartWith("name: renamed-workflow");
+    }
+
     private static AppScopedWorkflowService CreateService(
         Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
     {
@@ -139,9 +169,48 @@ public sealed class AppScopedWorkflowServiceTests
 
     private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
     {
-        public WorkflowParseResult Parse(string yaml) => new(null, []);
+        private static readonly Regex NameRegex = new(@"(?m)^name:\s*(.+?)\s*$", RegexOptions.Compiled);
 
-        public string Serialize(WorkflowDocument document) => string.Empty;
+        public WorkflowParseResult Parse(string yaml)
+        {
+            if (string.IsNullOrWhiteSpace(yaml))
+                return new(null, []);
+
+            var match = NameRegex.Match(yaml ?? string.Empty);
+            return new(new WorkflowDocument
+            {
+                Name = match.Success ? match.Groups[1].Value.Trim() : string.Empty,
+            }, []);
+        }
+
+        public string Serialize(WorkflowDocument document) => $"name: {document.Name}\nsteps: []\n";
+    }
+
+    private sealed class StubScopeWorkflowCommandPort : IScopeWorkflowCommandPort
+    {
+        public ScopeWorkflowUpsertRequest? LastRequest { get; private set; }
+
+        public Task<ScopeWorkflowUpsertResult> UpsertAsync(
+            ScopeWorkflowUpsertRequest request,
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            return Task.FromResult(new ScopeWorkflowUpsertResult(
+                new ScopeWorkflowSummary(
+                    ScopeId: request.ScopeId,
+                    WorkflowId: request.WorkflowId,
+                    DisplayName: request.DisplayName ?? request.WorkflowName ?? request.WorkflowId,
+                    ServiceKey: $"{request.ScopeId}:default:default:{request.WorkflowId}",
+                    WorkflowName: request.WorkflowName ?? request.WorkflowId,
+                    ActorId: "actor-1",
+                    ActiveRevisionId: "rev-1",
+                    DeploymentId: "deploy-1",
+                    DeploymentStatus: "draft",
+                    UpdatedAt: DateTimeOffset.UtcNow),
+                RevisionId: "rev-1",
+                DefinitionActorIdPrefix: "actor",
+                ExpectedActorId: "actor-1"));
+        }
     }
 
     private sealed class StubScopeWorkflowQueryPort : IScopeWorkflowQueryPort

--- a/test/Aevatar.Tools.Cli.Tests/WorkflowGenerateOrchestratorTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/WorkflowGenerateOrchestratorTests.cs
@@ -82,6 +82,48 @@ public class WorkflowGenerateOrchestratorTests
             .WithMessage("*valid workflow YAML*");
     }
 
+    [Fact]
+    public async Task GenerateAsync_ShouldNormalizeAiHallucinatedStepFieldsBeforeFailing()
+    {
+        var orchestrator = CreateOrchestrator();
+
+        var result = await orchestrator.GenerateAsync(
+            new WorkflowGenerateRequest(
+                "Create the simplest possible chat workflow",
+                null,
+                [],
+                null),
+            (prompt, metadata, ct) =>
+            {
+                _ = prompt;
+                _ = metadata;
+                _ = ct;
+                return Task.FromResult<string?>(
+                    """
+                    name: ai-draft
+                    steps:
+                      - id: chat
+                        type: llm_call
+                        model: gpt-5.4
+                        messages:
+                          - role: user
+                            content: hello
+                        params:
+                          prompt_prefix: "Reply clearly."
+                    """);
+            },
+            null,
+            CancellationToken.None);
+
+        result.Attempts.Should().Be(1);
+        result.Yaml.Should().Contain("name: ai-draft");
+        result.Yaml.Should().Contain("id: chat");
+        result.Yaml.Should().Contain("type: llm_call");
+        result.Yaml.Should().NotContain("model:");
+        result.Yaml.Should().NotContain("messages:");
+        result.Yaml.Should().NotContain("params:");
+    }
+
     [Theory]
     [InlineData("```yaml\nname: sample\nsteps:\n  - id: a\n    type: llm_call\n```", "name: sample")]
     [InlineData("name: sample\nsteps:\n  - id: a\n    type: llm_call", "name: sample")]

--- a/test/Aevatar.Tools.Cli.Tests/WorkflowGenerateOrchestratorTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/WorkflowGenerateOrchestratorTests.cs
@@ -125,6 +125,43 @@ public class WorkflowGenerateOrchestratorTests
     }
 
     [Theory]
+    [InlineData("task")]
+    [InlineData("llm")]
+    [InlineData("chat")]
+    public async Task GenerateAsync_ShouldNormalizeHallucinatedStepTypeAliases(string hallucinatedType)
+    {
+        var orchestrator = CreateOrchestrator();
+
+        var result = await orchestrator.GenerateAsync(
+            new WorkflowGenerateRequest(
+                "Create the simplest possible chat workflow",
+                null,
+                [],
+                null),
+            (prompt, metadata, ct) =>
+            {
+                _ = prompt;
+                _ = metadata;
+                _ = ct;
+                return Task.FromResult<string?>(
+                    $"""
+                    name: ai-draft
+                    steps:
+                      - id: chat
+                        type: {hallucinatedType}
+                        parameters:
+                          prompt_prefix: "Reply with a short joke."
+                    """);
+            },
+            null,
+            CancellationToken.None);
+
+        result.Attempts.Should().Be(1);
+        result.Yaml.Should().Contain("type: llm_call");
+        result.Yaml.Should().NotContain($"{Environment.NewLine}  type: {hallucinatedType}{Environment.NewLine}");
+    }
+
+    [Theory]
     [InlineData("```yaml\nname: sample\nsteps:\n  - id: a\n    type: llm_call\n```", "name: sample")]
     [InlineData("name: sample\nsteps:\n  - id: a\n    type: llm_call", "name: sample")]
     public void TryExtractYamlCandidate_ShouldSupportFencedAndRawYaml(string content, string expectedPrefix)

--- a/test/Aevatar.Tools.Cli.Tests/WorkspaceServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/WorkspaceServiceTests.cs
@@ -3,6 +3,7 @@ using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Application.Studio.Services;
 using Aevatar.Studio.Domain.Studio.Models;
 using FluentAssertions;
+using System.Text.RegularExpressions;
 
 namespace Aevatar.Tools.Cli.Tests;
 
@@ -38,11 +39,50 @@ public class WorkspaceServiceTests
         }
     }
 
+    [Fact]
+    public async Task SaveWorkflowAsync_ShouldRewriteYamlNameFromRequestedWorkflowName()
+    {
+        var store = new InMemoryStudioWorkspaceStore();
+        var directory = new StudioWorkspaceDirectory(
+            DirectoryId: "dir-1",
+            Label: "Test Root",
+            Path: Path.Combine(Path.GetTempPath(), $"studio-workflows-{Guid.NewGuid():N}"),
+            IsBuiltIn: false);
+        await store.SaveSettingsAsync(new StudioWorkspaceSettings(
+            RuntimeBaseUrl: "http://127.0.0.1:5100",
+            Directories: [directory],
+            AppearanceTheme: "blue",
+            ColorMode: "light"));
+
+        var service = new WorkspaceService(store, new StubWorkflowYamlDocumentService());
+
+        var response = await service.SaveWorkflowAsync(new SaveWorkflowFileRequest(
+            WorkflowId: null,
+            DirectoryId: directory.DirectoryId,
+            WorkflowName: "renamed-workflow",
+            FileName: null,
+            Yaml: "name: draft\nsteps: []\n"));
+
+        store.LastSavedWorkflowFile.Should().NotBeNull();
+        store.LastSavedWorkflowFile!.Yaml.Should().StartWith("name: renamed-workflow");
+        response.Name.Should().Be("renamed-workflow");
+        response.Yaml.Should().StartWith("name: renamed-workflow");
+    }
+
     private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
     {
-        public WorkflowParseResult Parse(string yaml) => new(new WorkflowDocument(), []);
+        private static readonly Regex NameRegex = new(@"(?m)^name:\s*(.+?)\s*$", RegexOptions.Compiled);
 
-        public string Serialize(WorkflowDocument document) => string.Empty;
+        public WorkflowParseResult Parse(string yaml)
+        {
+            var match = NameRegex.Match(yaml ?? string.Empty);
+            return new(new WorkflowDocument
+            {
+                Name = match.Success ? match.Groups[1].Value.Trim() : string.Empty,
+            }, []);
+        }
+
+        public string Serialize(WorkflowDocument document) => $"name: {document.Name}\nsteps: []\n";
     }
 
     private sealed class InMemoryStudioWorkspaceStore : IStudioWorkspaceStore
@@ -52,6 +92,7 @@ public class WorkspaceServiceTests
             Directories: [],
             AppearanceTheme: "blue",
             ColorMode: "light");
+        public StoredWorkflowFile? LastSavedWorkflowFile { get; private set; }
 
         public Task<StudioWorkspaceSettings> GetSettingsAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(_settings);
@@ -68,8 +109,11 @@ public class WorkspaceServiceTests
         public Task<StoredWorkflowFile?> GetWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default) =>
             Task.FromResult<StoredWorkflowFile?>(null);
 
-        public Task<StoredWorkflowFile> SaveWorkflowFileAsync(StoredWorkflowFile workflowFile, CancellationToken cancellationToken = default) =>
-            throw new NotSupportedException();
+        public Task<StoredWorkflowFile> SaveWorkflowFileAsync(StoredWorkflowFile workflowFile, CancellationToken cancellationToken = default)
+        {
+            LastSavedWorkflowFile = workflowFile;
+            return Task.FromResult(workflowFile);
+        }
 
         public Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult<IReadOnlyList<StoredExecutionRecord>>([]);


### PR DESCRIPTION
## Summary

This PR tightens the end-to-end Teams + Studio workflow experience in Console Web, focusing on real usage issues found while dogfooding the flow.

It mainly improves:

- Teams -> Advanced Edit -> Studio / Runs / Invoke navigation
- Ask AI workflow generation compatibility
- workflow save / restore / post-restart visibility
- layout and scrolling issues across Studio, Runs, and Invoke Lab
- local persistent development mode for workflow recovery

## What changed

### 1. Improved Teams + Studio + Runs navigation flow
- Added `returnTo` propagation so the Runs page can navigate back to the originating Studio route or the team advanced tab correctly
- Improved context handoff between Teams advanced editing, Studio, Runs, and Invoke Lab
- Fixed several broken or confusing back-navigation paths

### 2. Fixed Ask AI workflow generation failures
- Added compatibility normalization for pseudo step types such as `llm`, `chat`, and `task`, mapping them to `llm_call`
- Tightened Ask AI prompt guidance to reduce invalid YAML generations
- Fixed workflow rename/save behavior so the saved workflow name stays aligned with the YAML `name`

### 3. Fixed workflow execution and result presentation issues
- Fixed an Orleans self-cleanup deadlock during workflow actor destruction after run completion
- Fixed the gap where `Last output` existed but `Messages` still showed as empty
- Improved Runs page behavior around trace workspace, tab switching, and back navigation

### 4. Fixed Studio / Invoke Lab layout and scrolling issues
- Fixed the Studio workflows page where the lower workflow list area could be clipped and effectively unusable
- Fixed the Invoke Lab composer area being visually cut off
- Reduced nested/competing scroll container issues across Studio surfaces

### 5. Added stronger local persistence and workflow recovery support
- Added a `PersistentLocal` runtime profile using Orleans + Garnet for local persistent actor state
- Added workflow recovery support from chrono-storage when scope workflow state is missing after restart
- Updated local runtime documentation to make persistent local testing easier

## Impacted areas

- Console Web Teams / Studio / Runs / Invoke Lab
- Studio workflow save / load / Ask AI / bind flows
- Orleans runtime actor cleanup
- local persistent development setup
- chrono-storage-backed workflow recovery path

## Validation

Executed:

- `pnpm exec tsc --noEmit`
- `pnpm exec jest src/pages/studio/components/StudioShell.test.tsx src/pages/studio/components/StudioWorkflowsPage.test.tsx --runInBand --watchman=false`
- `~/.dotnet/dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --filter "FullyQualifiedName~WorkflowCompatibilityProfileTests"`
- `~/.dotnet/dotnet test test/Aevatar.Tools.Cli.Tests/Aevatar.Tools.Cli.Tests.csproj --filter "FullyQualifiedName~WorkflowGenerateOrchestratorTests|FullyQualifiedName~AppScopedWorkflowServiceTests"`
- `~/.dotnet/dotnet test test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj --filter "FullyQualifiedName~OrleansActorRuntimeForwardingTests"`

Manually verified flows:

- Teams -> Advanced Edit -> Ask AI workflow generation
- Run draft -> Messages / Events inspection
- Runs -> back to team advanced edit
- Bind team entry -> Open Project Invoke
- Studio workflow list browsing and scrolling
- workflow recovery after backend restart

## Docs

- Added `PersistentLocal` local runtime configuration
- Updated Host API README with local persistent runtime guidance

## Notes

There are still some outdated assertions in `apps/aevatar-console-web/src/pages/runs/index.test.tsx` that do not match the current UI. Those are pre-existing test expectation issues and were not treated as blockers for this PR.
