### PR TITLE
Extend architecture guard scans to agents

### DIFF
--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -47,13 +47,13 @@ if rg -n "docs[\\\\/]agents-working-space[\\\\/]" aevatar.slnx; then
   exit 1
 fi
 
-if rg -n "GetAwaiter\(\)\.GetResult\(\)" src; then
+if rg -n "GetAwaiter\(\)\.GetResult\(\)" src agents; then
   echo "Found sync-over-async usage."
   exit 1
 fi
 
 if rg -n "CommandContext\.Metadata|AgentRunContext\.Metadata|LLMCallContext\.Metadata|ToolCallContext\.Metadata|GAgentExecutionHookContext\.Metadata" \
-  src test
+  src agents test
 then
   echo "Legacy internal metadata bags are forbidden in core contexts. Use Headers / Items / typed fields where semantics are explicit."
   exit 1
@@ -77,7 +77,7 @@ bash "${SCRIPT_DIR}/query_projection_priming_guard.sh"
 bash "${SCRIPT_DIR}/projection_state_version_guard.sh"
 bash "${SCRIPT_DIR}/projection_state_mirror_current_state_guard.sh"
 
-if rg -n "ExecuteDeclaredQueryAsync|ExecuteReadModelQueryAsync" src; then
+if rg -n "ExecuteDeclaredQueryAsync|ExecuteReadModelQueryAsync" src agents; then
   echo "Declared readmodel query execution is forbidden. Query must read persisted snapshots/documents only."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- extend the existing architecture guard scan scope from `src` to `agents` for sync-over-async detection
- extend the existing architecture guard scan scope from `src` to `agents` for legacy internal metadata bag detection
- extend the declared readmodel query guard scan scope from `src` to `agents`

## Problem
`agents/` currently sits outside several baseline architecture guard scans, which leaves a real blind spot in the part of the repo that already contains architectural drift. This PR does not add new blocking rules yet. It makes the existing generic checks apply to `agents/` too.

## Verification
- `rg -n "GetAwaiter\(\)\.GetResult\(\)" src agents`
- `rg -n "CommandContext\.Metadata|AgentRunContext\.Metadata|LLMCallContext\.Metadata|ToolCallContext\.Metadata|GAgentExecutionHookContext\.Metadata" src agents test`
- `rg -n "ExecuteDeclaredQueryAsync|ExecuteReadModelQueryAsync" src agents`

## Notes
- I did not claim a full `bash tools/ci/architecture_guards.sh` pass here because `dev` already has an unrelated existing failure in `playground_asset_drift_guard.sh`.
- This PR is intentionally narrow. It only removes the current scan blind spot; stronger agent-specific architecture guards can land separately.