### PR TITLE
Refine Studio collapsed sider affordance

### DIFF
--- a/apps/aevatar-console-web/src/app.layout.test.ts
+++ b/apps/aevatar-console-web/src/app.layout.test.ts
@@ -1,0 +1,19 @@
+import defaultSettings from "../config/defaultSettings";
+import { layout } from "./app";
+
+describe("layout menu collapse behavior", () => {
+  it("keeps grouped navigation titles hidden in collapsed mode", () => {
+    const runtimeLayout = layout({
+      initialState: {
+        auth: {} as never,
+        settings: defaultSettings,
+      },
+    });
+
+    expect(runtimeLayout.menu).toMatchObject({
+      collapsedShowGroupTitle: false,
+      collapsedShowTitle: false,
+      type: "group",
+    });
+  });
+});

--- a/apps/aevatar-console-web/src/app.tsx
+++ b/apps/aevatar-console-web/src/app.tsx
@@ -800,6 +800,8 @@ export const layout = ({
     ...initialState?.settings,
     menu: {
       ...(initialState?.settings.menu as Record<string, unknown> | undefined),
+      collapsedShowGroupTitle: false,
+      collapsedShowTitle: false,
       type: "group",
     },
     contentStyle: {

--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -87,6 +87,38 @@ body,
   width: 100%;
 }
 
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed {
+  padding-inline: 8px;
+}
+
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-item,
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-submenu-title {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-inline: 0;
+  padding-inline: 0 !important;
+  width: 100%;
+}
+
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-item .ant-menu-item-icon,
+.ant-pro-sider
+  .ant-menu-inline.ant-menu-inline-collapsed
+  .ant-menu-submenu-title
+  .ant-menu-item-icon,
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-item .anticon,
+.ant-pro-sider
+  .ant-menu-inline.ant-menu-inline-collapsed
+  .ant-menu-submenu-title
+  .anticon {
+  margin-inline-end: 0 !important;
+}
+
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-title-content,
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-item-group-title {
+  display: none !important;
+}
+
 .ant-pro-sider .ant-menu-inline .ant-menu-item-group {
   margin: 0;
 }
@@ -108,6 +140,40 @@ body,
 .ant-pro-sider .ant-menu-inline .ant-pro-base-menu-inline-divider {
   margin: 10px 10px 12px !important;
   border-color: rgba(148, 163, 184, 0.28) !important;
+}
+
+body.aevatar-studio-host
+  .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed {
+  flex: 0 0 0 !important;
+  max-width: 0 !important;
+  min-width: 0 !important;
+  overflow: visible !important;
+  width: 0 !important;
+}
+
+body.aevatar-studio-host
+  .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-layout-sider-children {
+  overflow: hidden;
+}
+
+body.aevatar-studio-host
+  .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  + .ant-pro-layout-container {
+  margin-inline-start: -64px;
+  width: calc(100% + 64px);
+}
+
+body.aevatar-studio-host
+  .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-pro-sider-collapsed-button {
+  border-radius: 0 12px 12px 0;
+  bottom: 24px;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.14);
+  min-width: 36px;
+  position: fixed;
+  inset-inline-start: 0;
+  width: 36px !important;
 }
 
 .aevatar-console-shell .ant-pro-page-container,

--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -143,37 +143,71 @@ body,
 }
 
 body.aevatar-studio-host
+  .ant-design-pro
+  > .ant-layout
+  > div:first-child:has(
+      + .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+    ) {
+  flex: 0 0 40px !important;
+  max-width: 40px !important;
+  min-width: 40px !important;
+  width: 40px !important;
+}
+
+body.aevatar-studio-host
   .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed {
-  flex: 0 0 0 !important;
-  max-width: 0 !important;
-  min-width: 0 !important;
+  background: linear-gradient(180deg, #f8fbff 0%, #f3f7fc 100%);
+  border-inline-end: 1px solid rgba(148, 163, 184, 0.18);
+  flex: 0 0 40px !important;
+  max-width: 40px !important;
+  min-width: 40px !important;
   overflow: visible !important;
-  width: 0 !important;
+  width: 40px !important;
 }
 
 body.aevatar-studio-host
   .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
   .ant-layout-sider-children {
   overflow: hidden;
+  padding-inline: 0 !important;
 }
 
 body.aevatar-studio-host
   .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
-  + .ant-pro-layout-container {
-  margin-inline-start: -64px;
-  width: calc(100% + 64px);
+  .ant-layout-sider-children
+  > * {
+  display: none;
 }
 
 body.aevatar-studio-host
   .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
   .ant-pro-sider-collapsed-button {
-  border-radius: 0 12px 12px 0;
-  bottom: 24px;
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.14);
-  min-width: 36px;
-  position: fixed;
-  inset-inline-start: 0;
-  width: 36px !important;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  box-shadow:
+    0 16px 32px rgba(15, 23, 42, 0.14),
+    0 2px 6px rgba(15, 23, 42, 0.08);
+  display: flex;
+  height: 24px;
+  inset-block-start: 18px;
+  inset-inline-end: auto;
+  inset-inline-start: 8px;
+  justify-content: center;
+  min-width: 24px;
+  position: absolute;
+  width: 24px !important;
+  z-index: 140;
+}
+
+body.aevatar-studio-host
+  .ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-pro-sider-collapsed-button:hover {
+  background: #ffffff;
+  box-shadow:
+    0 18px 36px rgba(15, 23, 42, 0.18),
+    0 4px 10px rgba(15, 23, 42, 0.1);
 }
 
 .aevatar-console-shell .ant-pro-page-container,

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -76,6 +76,7 @@ import {
   buildStudioRoute,
   type StudioTab,
 } from '@/shared/studio/navigation';
+import { syncStudioHostBodyClass } from '@/shared/studio/studioLayout';
 import type {
   WorkflowCatalogDefinition,
 } from '@/shared/models/runtime/catalog';
@@ -968,6 +969,7 @@ const StudioPage: React.FC = () => {
   );
   const isStudioLocation =
     typeof window !== 'undefined' && window.location.pathname === '/studio';
+  useEffect(() => syncStudioHostBodyClass(isStudioLocation), [isStudioLocation]);
   const nyxIdConfig = useMemo(() => getNyxIDRuntimeConfig(), []);
   const queryClient = useQueryClient();
   const [workspacePage, setWorkspacePage] = useState<StudioWorkspacePage>(

--- a/apps/aevatar-console-web/src/shared/studio/studioLayout.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/studioLayout.test.ts
@@ -1,0 +1,32 @@
+import {
+  STUDIO_HOST_BODY_CLASS,
+  syncStudioHostBodyClass,
+} from "./studioLayout";
+
+describe("syncStudioHostBodyClass", () => {
+  beforeEach(() => {
+    document.body.classList.remove(STUDIO_HOST_BODY_CLASS);
+  });
+
+  it("marks the document body while the Studio host route is active", () => {
+    const cleanup = syncStudioHostBodyClass(true);
+
+    expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(true);
+
+    cleanup();
+
+    expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(false);
+  });
+
+  it("clears any stale body marker when Studio host mode is not active", () => {
+    document.body.classList.add(STUDIO_HOST_BODY_CLASS);
+
+    const cleanup = syncStudioHostBodyClass(false);
+
+    expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(false);
+
+    cleanup();
+
+    expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(false);
+  });
+});

--- a/apps/aevatar-console-web/src/shared/studio/studioLayout.ts
+++ b/apps/aevatar-console-web/src/shared/studio/studioLayout.ts
@@ -1,0 +1,17 @@
+export const STUDIO_HOST_BODY_CLASS = "aevatar-studio-host";
+
+export function syncStudioHostBodyClass(enabled: boolean): () => void {
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
+  document.body.classList.toggle(STUDIO_HOST_BODY_CLASS, enabled);
+
+  return () => {
+    if (!enabled) {
+      return;
+    }
+
+    document.body.classList.remove(STUDIO_HOST_BODY_CLASS);
+  };
+}


### PR DESCRIPTION
## Summary
- keep the Studio collapse state on a visible narrow rail instead of collapsing the sidenav to an unreachable edge case
- move the reopen affordance fully inside the rail so the handle stays visible and clickable after collapse
- preserve the Studio-only collapse treatment without changing the wider console navigation behavior

## Verification
- `pnpm exec tsc --noEmit`

## Notes
- no docs changes were needed for this UI-only follow-up