### PR TITLE
Polish Studio binding UX and team homepage semantics

### DIFF
--- a/apps/aevatar-console-web/src/app.layout.test.ts
+++ b/apps/aevatar-console-web/src/app.layout.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import defaultSettings from "../config/defaultSettings";
 import { layout } from "./app";
 
@@ -11,9 +13,26 @@ describe("layout menu collapse behavior", () => {
     });
 
     expect(runtimeLayout.menu).toMatchObject({
+      collapsedWidth: 40,
       collapsedShowGroupTitle: false,
       collapsedShowTitle: false,
       type: "group",
     });
+  });
+
+  it("styles collapsed menu items without icons as visible tokens", () => {
+    const globalStyles = fs.readFileSync(
+      path.resolve(__dirname, "./global.less"),
+      "utf8",
+    );
+
+    expect(globalStyles).toContain(".ant-menu-inline-collapsed-noicon");
+    expect(globalStyles).toContain(
+      ".ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed",
+    );
+    expect(globalStyles).toContain("flex: 0 0 40px !important;");
+    expect(globalStyles).toContain("inset-inline-start: 8px;");
+    expect(globalStyles).toContain("text-transform: uppercase;");
+    expect(globalStyles).toContain("min-width: 20px;");
   });
 });

--- a/apps/aevatar-console-web/src/app.tsx
+++ b/apps/aevatar-console-web/src/app.tsx
@@ -800,6 +800,7 @@ export const layout = ({
     ...initialState?.settings,
     menu: {
       ...(initialState?.settings.menu as Record<string, unknown> | undefined),
+      collapsedWidth: 40,
       collapsedShowGroupTitle: false,
       collapsedShowTitle: false,
       type: "group",

--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -119,6 +119,23 @@ body,
   display: none !important;
 }
 
+.ant-pro-sider .ant-menu-inline.ant-menu-inline-collapsed .ant-menu-inline-collapsed-noicon {
+  align-items: center;
+  background: rgba(226, 232, 240, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 7px;
+  color: #475569;
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 700;
+  height: 20px;
+  justify-content: center;
+  line-height: 1;
+  min-width: 20px;
+  overflow: hidden;
+  text-transform: uppercase;
+}
+
 .ant-pro-sider .ant-menu-inline .ant-menu-item-group {
   margin: 0;
 }
@@ -140,6 +157,57 @@ body,
 .ant-pro-sider .ant-menu-inline .ant-pro-base-menu-inline-divider {
   margin: 10px 10px 12px !important;
   border-color: rgba(148, 163, 184, 0.28) !important;
+}
+
+.ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed {
+  background: linear-gradient(180deg, #f8fbff 0%, #f3f7fc 100%);
+  border-inline-end: 1px solid rgba(148, 163, 184, 0.18);
+  flex: 0 0 40px !important;
+  max-width: 40px !important;
+  min-width: 40px !important;
+  overflow: visible !important;
+  width: 40px !important;
+}
+
+.ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-layout-sider-children {
+  overflow: hidden;
+  padding-inline: 0 !important;
+}
+
+.ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-layout-sider-children
+  > * {
+  display: none;
+}
+
+.ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-pro-sider-collapsed-button {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  border-radius: 999px;
+  box-shadow:
+    0 16px 32px rgba(15, 23, 42, 0.14),
+    0 2px 6px rgba(15, 23, 42, 0.08);
+  display: flex;
+  height: 24px;
+  inset-block-start: 18px;
+  inset-inline-end: auto;
+  inset-inline-start: 8px;
+  justify-content: center;
+  min-width: 24px;
+  position: absolute;
+  width: 24px !important;
+  z-index: 140;
+}
+
+.ant-pro-sider.ant-layout-sider.ant-pro-sider-fixed.ant-pro-sider-collapsed
+  .ant-pro-sider-collapsed-button:hover {
+  background: #ffffff;
+  box-shadow:
+    0 18px 36px rgba(15, 23, 42, 0.18),
+    0 4px 10px rgba(15, 23, 42, 0.1);
 }
 
 body.aevatar-studio-host

--- a/apps/aevatar-console-web/src/layouts/MainLayout.test.tsx
+++ b/apps/aevatar-console-web/src/layouts/MainLayout.test.tsx
@@ -1,0 +1,60 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { ConfigProvider } from "antd";
+import React from "react";
+import MainLayout from "./MainLayout";
+import { history } from "@/shared/navigation/history";
+import { STUDIO_HOST_BODY_CLASS } from "@/shared/studio/studioLayout";
+import { aevatarThemeConfig } from "@/shared/ui/aevatarWorkbench";
+
+function renderMainLayout(): void {
+  render(
+    <ConfigProvider theme={aevatarThemeConfig}>
+      <MainLayout>
+        <div>layout content</div>
+      </MainLayout>
+    </ConfigProvider>,
+  );
+}
+
+describe("MainLayout", () => {
+  beforeEach(() => {
+    document.body.classList.remove(STUDIO_HOST_BODY_CLASS);
+  });
+
+  it("clears stale Studio host styling on non-Studio routes", async () => {
+    document.body.classList.add(STUDIO_HOST_BODY_CLASS);
+    window.history.replaceState({}, "", "/teams");
+
+    renderMainLayout();
+
+    await waitFor(() => {
+      expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(false);
+    });
+  });
+
+  it("tracks Studio route transitions while the shell stays mounted", async () => {
+    window.history.replaceState({}, "", "/teams");
+
+    renderMainLayout();
+
+    await waitFor(() => {
+      expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(false);
+    });
+
+    act(() => {
+      history.push("/studio");
+    });
+
+    await waitFor(() => {
+      expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(true);
+    });
+
+    act(() => {
+      history.push("/teams");
+    });
+
+    await waitFor(() => {
+      expect(document.body.classList.contains(STUDIO_HOST_BODY_CLASS)).toBe(false);
+    });
+  });
+});

--- a/apps/aevatar-console-web/src/layouts/MainLayout.tsx
+++ b/apps/aevatar-console-web/src/layouts/MainLayout.tsx
@@ -1,6 +1,11 @@
 import { theme } from "antd";
 import React from "react";
 import {
+  getLocationSnapshot,
+  subscribeToLocationChanges,
+} from "@/shared/navigation/history";
+import { syncStudioHostBodyClass } from "@/shared/studio/studioLayout";
+import {
   buildAevatarViewportStyle,
   type AevatarThemeSurfaceToken,
 } from "@/shared/ui/aevatarWorkbench";
@@ -11,6 +16,16 @@ type MainLayoutProps = {
 
 const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
   const { token } = theme.useToken();
+  const locationSnapshot = React.useSyncExternalStore(
+    subscribeToLocationChanges,
+    getLocationSnapshot,
+    () => "",
+  );
+
+  React.useEffect(() => {
+    const pathname = locationSnapshot.split("?")[0]?.split("#")[0] ?? "";
+    return syncStudioHostBodyClass(pathname === "/studio");
+  }, [locationSnapshot]);
 
   return (
     <div

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioEditorPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioEditorPage.test.tsx
@@ -436,4 +436,45 @@ describe('StudioEditorPage', () => {
       );
     });
   });
+
+  it('keeps the GAgent binding dialog open when binding fails', async () => {
+    const onBindGAgent = jest.fn(async () => {
+      throw new Error('Bind failed');
+    });
+
+    render(
+      React.createElement(
+        StudioEditorPage,
+        createBaseProps({
+          resolvedScopeId: 'scope-a',
+          gAgentTypes: [
+            {
+              typeName: 'OrdersGAgent',
+              fullName: 'Tests.OrdersGAgent',
+              assemblyName: 'Tests',
+            },
+          ],
+          onBindGAgent,
+        }) as any,
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '绑定团队入口' }));
+
+    expect(
+      await screen.findByRole('dialog', { name: '绑定团队入口' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '仅绑定' }));
+
+    await waitFor(() => {
+      expect(onBindGAgent).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: '绑定团队入口' }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioEditorPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioEditorPage.test.tsx
@@ -1,6 +1,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { message } from 'antd';
 import React from 'react';
-import { StudioEditorPage } from './StudioWorkbenchSections';
+import {
+  dedupeStudioWorkflowSummaries,
+  StudioEditorPage,
+} from './StudioWorkbenchSections';
 
 jest.mock('@/shared/graphs/GraphCanvas', () => ({
   __esModule: true,
@@ -243,6 +247,40 @@ function createBaseProps(overrides = {}) {
 }
 
 describe('StudioEditorPage', () => {
+  it('keeps workflow summaries in a stable order when selection changes', () => {
+    const workflows = [
+      {
+        workflowId: 'workflow-a',
+        name: 'alpha',
+        description: '',
+        fileName: 'alpha.yaml',
+        filePath: '/tmp/workflows/alpha.yaml',
+        directoryId: 'dir-1',
+        directoryLabel: 'Workspace',
+        stepCount: 1,
+        hasLayout: true,
+        updatedAtUtc: '2026-03-25T00:00:00Z',
+      },
+      {
+        workflowId: 'workflow-b',
+        name: 'beta',
+        description: '',
+        fileName: 'beta.yaml',
+        filePath: '/tmp/workflows/beta.yaml',
+        directoryId: 'dir-1',
+        directoryLabel: 'Workspace',
+        stepCount: 1,
+        hasLayout: true,
+        updatedAtUtc: '2026-03-24T00:00:00Z',
+      },
+    ];
+
+    expect(dedupeStudioWorkflowSummaries(workflows).map((item) => item.workflowId)).toEqual([
+      'workflow-a',
+      'workflow-b',
+    ]);
+  });
+
   it('opens the node library drawer from the toolbar and inserts a node', async () => {
     const onAddGraphNode = jest.fn();
 
@@ -437,6 +475,61 @@ describe('StudioEditorPage', () => {
     });
   });
 
+  it('prefills a chat endpoint for chat-oriented GAgent types', async () => {
+    render(
+      React.createElement(
+        StudioEditorPage,
+        createBaseProps({
+          resolvedScopeId: 'scope-a',
+          gAgentTypes: [
+            {
+              typeName: 'NyxIdChatGAgent',
+              fullName: 'Aevatar.GAgents.NyxidChat.NyxIdChatGAgent',
+              assemblyName: 'Aevatar.GAgents.NyxidChat',
+            },
+          ],
+          onBindGAgent: jest.fn(async () => undefined),
+        }) as any,
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '绑定团队入口' }));
+
+    expect(
+      await screen.findByRole('dialog', { name: '绑定团队入口' }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('入口 ID 1')).toHaveValue('chat');
+      expect(screen.getByLabelText('入口展示名称 1')).toHaveValue('Chat');
+    });
+
+    expect(
+      screen.getByText('聊天入口会直接打开聊天型测试运行。'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('测试运行默认入口'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('默认测试运行入口：Chat (chat)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('入口 Actor 类型'),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getAllByRole('button', { name: '显示高级设置' })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: '显示高级设置' }));
+    expect(screen.getByLabelText('入口 Actor 类型')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: '显示高级设置' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: '收起高级设置' })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /添加入口/i }));
+    expect(screen.getByLabelText('测试运行默认入口')).toBeInTheDocument();
+  });
+
   it('keeps the GAgent binding dialog open when binding fails', async () => {
     const onBindGAgent = jest.fn(async () => {
       throw new Error('Bind failed');
@@ -476,5 +569,50 @@ describe('StudioEditorPage', () => {
         screen.getByRole('dialog', { name: '绑定团队入口' }),
       ).toBeInTheDocument();
     });
+  });
+
+  it('shows a success toast after binding a GAgent without opening runs', async () => {
+    const messageSuccessSpy = jest
+      .spyOn(message, 'success')
+      .mockImplementation(() => ({}) as any);
+
+    try {
+      const onBindGAgent = jest.fn(async () => undefined);
+
+      render(
+        React.createElement(
+          StudioEditorPage,
+          createBaseProps({
+            resolvedScopeId: 'scope-a',
+            gAgentTypes: [
+              {
+                typeName: 'OrdersGAgent',
+                fullName: 'Tests.OrdersGAgent',
+                assemblyName: 'Tests',
+              },
+            ],
+            onBindGAgent,
+          }) as any,
+        ),
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: '绑定团队入口' }));
+
+      expect(
+        await screen.findByRole('dialog', { name: '绑定团队入口' }),
+      ).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: '仅绑定' }));
+
+      await waitFor(() => {
+        expect(onBindGAgent).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(messageSuccessSpy).toHaveBeenCalledWith('团队入口已绑定成功。');
+      });
+    } finally {
+      messageSuccessSpy.mockRestore();
+    }
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioSettingsPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioSettingsPage.test.tsx
@@ -215,4 +215,49 @@ describe('StudioSettingsPage', () => {
       screen.getByRole('button', { name: '检测宿主运行时' }),
     ).toBeInTheDocument();
   });
+
+  it('keeps the settings detail viewport stretchable so the active pane can scroll', () => {
+    const { container } = render(<StudioSettingsPage {...createBaseProps()} />);
+
+    expect(container.firstElementChild).toHaveStyle({
+      height: '100%',
+      minHeight: '0',
+      overflow: 'hidden',
+    });
+
+    const tabs = container.querySelector(`.${'studio-settings-tabs'}`);
+    expect(tabs).not.toBeNull();
+    expect(tabs).toHaveStyle({
+      flex: '1',
+      height: '100%',
+      minHeight: '0',
+      overflow: 'hidden',
+    });
+
+    const contentHolder = container.querySelector(
+      '.studio-settings-tabs .ant-tabs-content-holder',
+    );
+    expect(contentHolder).not.toBeNull();
+    expect(contentHolder).toHaveStyle({
+      flex: '1',
+      minHeight: '0',
+      overflow: 'hidden',
+    });
+
+    const tabContent = container.querySelector(
+      '.studio-settings-tab-content',
+    );
+    expect(tabContent).not.toBeNull();
+    expect(tabContent).toHaveStyle({
+      flex: '1',
+      minHeight: '0',
+      overflowY: 'auto',
+    });
+
+    const styleNode = container.querySelector('style');
+    expect(styleNode?.textContent).toContain('.studio-settings-tabs .ant-tabs-tabpane-active');
+    expect(styleNode?.textContent).toContain('display: flex !important');
+    expect(styleNode?.textContent).toContain('.studio-settings-tab-content');
+    expect(styleNode?.textContent).toContain('overflow-y: auto;');
+  });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -31,6 +31,7 @@ import {
   ProCard,
 } from '@ant-design/pro-components';
 import {
+  Alert,
   Button,
   Col,
   Divider,
@@ -44,6 +45,7 @@ import {
   Tag,
   Tabs,
   Typography,
+  message,
 } from 'antd';
 import React from 'react';
 import type { Edge, Node } from '@xyflow/react';
@@ -166,14 +168,7 @@ function readWorkflowSortTimestamp(value: string): number {
 function compareWorkflowSummaryPriority(
   left: StudioWorkflowSummary,
   right: StudioWorkflowSummary,
-  selectedWorkflowId = '',
 ): number {
-  const leftSelected = left.workflowId === selectedWorkflowId;
-  const rightSelected = right.workflowId === selectedWorkflowId;
-  if (leftSelected !== rightSelected) {
-    return leftSelected ? -1 : 1;
-  }
-
   const updatedDelta =
     readWorkflowSortTimestamp(right.updatedAtUtc) -
     readWorkflowSortTimestamp(left.updatedAtUtc);
@@ -196,7 +191,6 @@ function compareWorkflowSummaryPriority(
 
 export function dedupeStudioWorkflowSummaries(
   workflows: readonly StudioWorkflowSummary[],
-  selectedWorkflowId = '',
 ): StudioWorkflowSummary[] {
   const dedupedWorkflows = new Map<string, StudioWorkflowSummary>();
 
@@ -210,33 +204,52 @@ export function dedupeStudioWorkflowSummaries(
       continue;
     }
 
-    if (
-      compareWorkflowSummaryPriority(workflow, current, selectedWorkflowId) < 0
-    ) {
+    if (compareWorkflowSummaryPriority(workflow, current) < 0) {
       dedupedWorkflows.set(key, workflow);
     }
   }
 
   return Array.from(dedupedWorkflows.values()).sort((left, right) =>
-    compareWorkflowSummaryPriority(left, right, selectedWorkflowId),
+    compareWorkflowSummaryPriority(left, right),
   );
 }
 
 const DEFAULT_GAGENT_REQUEST_TYPE_URL =
   'type.googleapis.com/google.protobuf.StringValue';
 
-function createStudioGAgentBindingEndpointDraft(
+function createStudioGAgentBindingPresetEndpointDraft(
+  preset: 'command' | 'chat',
   overrides?: Partial<StudioGAgentBindingEndpointDraft>,
 ): StudioGAgentBindingEndpointDraft {
+  if (preset === 'chat') {
+    return {
+      endpointId: overrides?.endpointId ?? 'chat',
+      displayName: overrides?.displayName ?? 'Chat',
+      kind: 'chat',
+      requestTypeUrl: overrides?.requestTypeUrl ?? '',
+      responseTypeUrl: overrides?.responseTypeUrl ?? '',
+      description: overrides?.description ?? 'Open the chat endpoint.',
+    };
+  }
+
   return {
     endpointId: overrides?.endpointId ?? 'run',
     displayName: overrides?.displayName ?? 'Run',
-    kind: overrides?.kind ?? 'command',
+    kind: 'command',
     requestTypeUrl:
       overrides?.requestTypeUrl ?? DEFAULT_GAGENT_REQUEST_TYPE_URL,
     responseTypeUrl: overrides?.responseTypeUrl ?? '',
     description: overrides?.description ?? 'Run the bound GAgent.',
   };
+}
+
+function createStudioGAgentBindingEndpointDraft(
+  overrides?: Partial<StudioGAgentBindingEndpointDraft>,
+): StudioGAgentBindingEndpointDraft {
+  return createStudioGAgentBindingPresetEndpointDraft(
+    overrides?.kind ?? 'command',
+    overrides,
+  );
 }
 
 function createStudioGAgentBindingDraft(
@@ -250,6 +263,86 @@ function createStudioGAgentBindingDraft(
     openRunsEndpointId: defaultEndpoint.endpointId,
     prompt: '',
     payloadBase64: '',
+  };
+}
+
+function inferStudioGAgentEndpointPreset(
+  actorTypeName: string,
+  descriptor?: RuntimeGAgentTypeDescriptor | null,
+): 'command' | 'chat' {
+  const candidates = [
+    actorTypeName,
+    descriptor?.typeName,
+    descriptor?.fullName,
+  ]
+    .map((value) => value?.trim().toLowerCase() ?? '')
+    .filter((value) => value.length > 0);
+
+  return candidates.some((value) => value.includes('chat')) ? 'chat' : 'command';
+}
+
+function isDefaultStudioGAgentEndpointValue(
+  value: string,
+  defaults: readonly string[],
+): boolean {
+  const normalized = value.trim().toLowerCase();
+  return normalized.length === 0 || defaults.includes(normalized);
+}
+
+function applyStudioGAgentEndpointPreset(
+  endpoint: StudioGAgentBindingEndpointDraft,
+  preset: 'command' | 'chat',
+): StudioGAgentBindingEndpointDraft {
+  const previousPreset = endpoint.kind === 'chat' ? 'chat' : 'command';
+  const previousDefaults = previousPreset === 'chat'
+    ? {
+        endpointIds: ['chat'],
+        displayNames: ['chat'],
+        requestTypeUrls: [''],
+        descriptions: ['open the chat endpoint.'],
+      }
+    : {
+        endpointIds: ['run'],
+        displayNames: ['run'],
+        requestTypeUrls: [
+          '',
+          DEFAULT_GAGENT_REQUEST_TYPE_URL.toLowerCase(),
+        ],
+        descriptions: ['run the bound gagent.'],
+      };
+  const nextDefaults = createStudioGAgentBindingPresetEndpointDraft(preset);
+
+  return {
+    ...endpoint,
+    kind: nextDefaults.kind,
+    endpointId: isDefaultStudioGAgentEndpointValue(
+      endpoint.endpointId,
+      previousDefaults.endpointIds,
+    )
+      ? nextDefaults.endpointId
+      : endpoint.endpointId,
+    displayName: isDefaultStudioGAgentEndpointValue(
+      endpoint.displayName,
+      previousDefaults.displayNames,
+    )
+      ? nextDefaults.displayName
+      : endpoint.displayName,
+    requestTypeUrl: isDefaultStudioGAgentEndpointValue(
+      endpoint.requestTypeUrl,
+      previousDefaults.requestTypeUrls,
+    )
+      ? nextDefaults.requestTypeUrl
+      : endpoint.requestTypeUrl,
+    responseTypeUrl:
+      preset === 'chat' && endpoint.responseTypeUrl.trim().length === 0
+        ? ''
+        : endpoint.responseTypeUrl,
+    description: isDefaultStudioGAgentEndpointValue(
+      endpoint.description,
+      previousDefaults.descriptions,
+    )
+      ? nextDefaults.description
+      : endpoint.description,
   };
 }
 
@@ -1888,9 +1981,8 @@ export const StudioWorkflowsPage: React.FC<StudioWorkflowsPageProps> = ({
   const directories = workspaceSettings.data?.directories ?? [];
   const isScopeMode = workflowStorageMode === 'scope';
   const visibleWorkflows = React.useMemo(
-    () =>
-      dedupeStudioWorkflowSummaries(workflows.data ?? [], selectedWorkflowId),
-    [selectedWorkflowId, workflows.data],
+    () => dedupeStudioWorkflowSummaries(workflows.data ?? []),
+    [workflows.data],
   );
   const activeDirectory =
     directories.find((directory) => directory.directoryId === selectedDirectoryId) ||
@@ -3861,6 +3953,7 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
   const [runModalOpen, setRunModalOpen] = React.useState(false);
   const [gAgentModalOpen, setGAgentModalOpen] = React.useState(false);
   const [gAgentBindingPending, setGAgentBindingPending] = React.useState(false);
+  const [gAgentAdvancedOpen, setGAgentAdvancedOpen] = React.useState(false);
   const [gAgentDraft, setGAgentDraft] = React.useState<StudioGAgentBindingDraft>(
     () => createStudioGAgentBindingDraft(draftWorkflowName || templateWorkflowName || ''),
   );
@@ -3893,6 +3986,15 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
       launchableGAgentEndpoints[0] ||
       null,
     [gAgentDraft.openRunsEndpointId, launchableGAgentEndpoints],
+  );
+  const primaryGAgentEndpoint = gAgentDraft.endpoints[0] ?? null;
+  const inferredPrimaryGAgentPreset = React.useMemo(
+    () =>
+      inferStudioGAgentEndpointPreset(
+        gAgentDraft.actorTypeName,
+        selectedDiscoveredGAgentType,
+      ),
+    [gAgentDraft.actorTypeName, selectedDiscoveredGAgentType],
   );
 
   const updateGAgentEndpointDraft = React.useCallback(
@@ -4029,26 +4131,80 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
   };
 
   const openGAgentModal = React.useCallback(() => {
+    const defaultDescriptor = gAgentTypes[0] ?? null;
+    const defaultActorTypeName =
+      buildRuntimeGAgentAssemblyQualifiedName(defaultDescriptor ?? {
+        typeName: '',
+        fullName: '',
+        assemblyName: '',
+      }).trim() || '';
+    const defaultPreset = inferStudioGAgentEndpointPreset(
+      defaultActorTypeName,
+      defaultDescriptor,
+    );
     setGAgentDraft((current) => ({
       ...current,
       displayName: current.displayName || draftWorkflowName || templateWorkflowName || '',
       actorTypeName:
         current.actorTypeName.trim() ||
-        (gAgentTypes[0]
-          ? buildRuntimeGAgentAssemblyQualifiedName(gAgentTypes[0])
-          : '') ||
+        defaultActorTypeName ||
         '',
       endpoints:
         current.endpoints.length > 0
-          ? current.endpoints
-          : [createStudioGAgentBindingEndpointDraft()],
+          ? current.actorTypeName.trim()
+            ? current.endpoints
+            : [
+                applyStudioGAgentEndpointPreset(
+                  current.endpoints[0],
+                  defaultPreset,
+                ),
+                ...current.endpoints.slice(1),
+              ]
+          : [createStudioGAgentBindingPresetEndpointDraft(defaultPreset)],
       openRunsEndpointId:
         current.openRunsEndpointId ||
         current.endpoints[0]?.endpointId ||
-        'run',
+        createStudioGAgentBindingPresetEndpointDraft(defaultPreset).endpointId,
     }));
+    setGAgentAdvancedOpen(false);
     setGAgentModalOpen(true);
   }, [draftWorkflowName, gAgentTypes, templateWorkflowName]);
+
+  const updatePrimaryGAgentEndpointPreset = React.useCallback(
+    (preset: 'command' | 'chat') => {
+      setGAgentDraft((current) => {
+        const primaryEndpoint = current.endpoints[0];
+        if (!primaryEndpoint) {
+          const nextEndpoint = createStudioGAgentBindingPresetEndpointDraft(preset);
+          return {
+            ...current,
+            endpoints: [nextEndpoint],
+            openRunsEndpointId: nextEndpoint.endpointId,
+          };
+        }
+
+        const nextPrimaryEndpoint = applyStudioGAgentEndpointPreset(
+          primaryEndpoint,
+          preset,
+        );
+        const nextEndpoints = [
+          nextPrimaryEndpoint,
+          ...current.endpoints.slice(1),
+        ];
+        const nextOpenRunsEndpointId =
+          current.openRunsEndpointId.trim() === primaryEndpoint.endpointId.trim()
+            ? nextPrimaryEndpoint.endpointId
+            : current.openRunsEndpointId;
+
+        return {
+          ...current,
+          endpoints: nextEndpoints,
+          openRunsEndpointId: nextOpenRunsEndpointId,
+        };
+      });
+    },
+    [],
+  );
 
   const submitGAgentBinding = React.useCallback(async (openRuns: boolean) => {
     setGAgentBindingPending(true);
@@ -4080,6 +4236,9 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
           openRuns,
         },
       );
+      if (!openRuns) {
+        void message.success('团队入口已绑定成功。');
+      }
       setGAgentModalOpen(false);
     } catch {
       // The page-level binder already surfaces the error notice. Keep the dialog
@@ -4101,8 +4260,8 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
     templateWorkflowName ||
     'draft';
   const visibleWorkflowDefinitions = React.useMemo(
-    () => dedupeStudioWorkflowSummaries(workflows.data ?? [], selectedWorkflowId),
-    [selectedWorkflowId, workflows.data],
+    () => dedupeStudioWorkflowSummaries(workflows.data ?? []),
+    [workflows.data],
   );
 
   React.useEffect(() => {
@@ -4970,17 +5129,35 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
             ]}
           >
             <div style={cardStackStyle}>
-              <Input
-                aria-label="入口展示名称"
-                placeholder="展示名称"
-                value={gAgentDraft.displayName}
-                onChange={(event) =>
-                  setGAgentDraft((current) => ({
-                    ...current,
-                    displayName: event.target.value,
-                  }))
-                }
+              <Alert
+                type="info"
+                showIcon
+                message="先填 3 项就能绑定成功"
+                description="团队入口名称、能力类型和默认入口用途是最常用的必填项。程序集名称、类型 URL 和载荷草稿都在高级设置里。"
               />
+              <div style={{ display: 'grid', gap: 8 }}>
+                <Typography.Text strong>团队入口名称</Typography.Text>
+                <Input
+                  aria-label="入口展示名称"
+                  placeholder="例如 NyxID Chat"
+                  value={gAgentDraft.displayName}
+                  onChange={(event) =>
+                    setGAgentDraft((current) => ({
+                      ...current,
+                      displayName: event.target.value,
+                    }))
+                  }
+                />
+                <Typography.Text type="secondary">
+                  这就是首页团队卡和详情页里默认显示的名称。
+                </Typography.Text>
+              </div>
+              <div style={{ display: 'grid', gap: 8 }}>
+                <Typography.Text strong>能力类型</Typography.Text>
+                <Typography.Text type="secondary">
+                  先选一个可绑定的 GAgent 类型，系统会自动补一套推荐入口模板。
+                </Typography.Text>
+              </div>
               <Select
                 aria-label="已发现入口类型"
                 showSearch
@@ -5005,29 +5182,76 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
                 notFoundContent={
                   gAgentTypesLoading ? '正在读取入口类型...' : '没有找到入口类型。'
                 }
-                onChange={(value) =>
+                onChange={(value) => {
+                  const descriptor =
+                    gAgentTypes.find(
+                      (item) =>
+                        buildRuntimeGAgentAssemblyQualifiedName(item) === value,
+                    ) || null;
+                  const preset = inferStudioGAgentEndpointPreset(value, descriptor);
                   setGAgentDraft((current) => ({
                     ...current,
                     actorTypeName: value,
-                  }))
-                }
+                  }));
+                  updatePrimaryGAgentEndpointPreset(preset);
+                }}
               />
               {gAgentTypesError ? (
                 <Typography.Text type="danger">
                   {describeError(gAgentTypesError)}
                 </Typography.Text>
               ) : null}
-              <Input
-                aria-label="入口 Actor 类型"
-                placeholder="程序集限定 Actor 类型名"
-                value={gAgentDraft.actorTypeName}
-                onChange={(event) =>
-                  setGAgentDraft((current) => ({
-                    ...current,
-                    actorTypeName: event.target.value,
-                  }))
-                }
-              />
+              <Button
+                type="link"
+                style={{ alignSelf: 'flex-start', paddingInline: 0 }}
+                onClick={() => setGAgentAdvancedOpen((current) => !current)}
+              >
+                {gAgentAdvancedOpen ? '收起高级设置' : '显示高级设置'}
+              </Button>
+              {gAgentAdvancedOpen ? (
+                <>
+                  <Input
+                    aria-label="入口 Actor 类型"
+                    placeholder="程序集限定 Actor 类型名"
+                    value={gAgentDraft.actorTypeName}
+                    onChange={(event) =>
+                      setGAgentDraft((current) => ({
+                        ...current,
+                        actorTypeName: event.target.value,
+                      }))
+                    }
+                  />
+                  <Typography.Text type="secondary">
+                    只有在下拉里找不到目标类型，或者你想手动指定程序集限定名时，才需要修改这一项。
+                  </Typography.Text>
+                </>
+              ) : null}
+              <div style={{ display: 'grid', gap: 8 }}>
+                <Typography.Text strong>默认入口用途</Typography.Text>
+                <Select
+                  aria-label="默认入口用途"
+                  style={{ width: '100%' }}
+                  value={primaryGAgentEndpoint?.kind === 'chat' ? 'chat' : 'command'}
+                  options={[
+                    {
+                      label: '聊天对话',
+                      value: 'chat',
+                    },
+                    {
+                      label: '命令执行',
+                      value: 'command',
+                    },
+                  ]}
+                  onChange={(value) =>
+                    updatePrimaryGAgentEndpointPreset(value as 'command' | 'chat')
+                  }
+                />
+                <Typography.Text type="secondary">
+                  {primaryGAgentEndpoint?.kind === 'chat'
+                    ? '聊天入口会自动推荐入口 ID = chat，适合 NyxID Chat 这类对话型入口。'
+                    : '命令入口会自动推荐入口 ID = run，适合执行一次命令或任务。'}
+                </Typography.Text>
+              </div>
               <Divider style={{ marginBlock: 8 }}>服务入口</Divider>
               <Space
                 direction="vertical"
@@ -5039,7 +5263,7 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
                     alignItems: 'center',
                     display: 'flex',
                     gap: 12,
-                    justifyContent: 'space-between',
+                  justifyContent: 'space-between',
                   }}
                 >
                   <Button
@@ -5082,98 +5306,126 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
                         删除
                       </Button>
                     </div>
-                    <Input
-                      aria-label={`入口 ID ${endpointIndex + 1}`}
-                      placeholder="入口 ID"
-                      value={endpoint.endpointId}
-                      onChange={(event) =>
-                        updateGAgentEndpointDraft(endpointIndex, {
-                          endpointId: event.target.value,
-                        })
-                      }
-                    />
-                    <Input
-                      aria-label={`入口展示名称 ${endpointIndex + 1}`}
-                      placeholder="入口展示名称"
-                      value={endpoint.displayName}
-                      onChange={(event) =>
-                        updateGAgentEndpointDraft(endpointIndex, {
-                          displayName: event.target.value,
-                        })
-                      }
-                    />
-                    <Select
-                      aria-label={`入口类型 ${endpointIndex + 1}`}
-                      options={[
-                        {
-                          label: '命令入口',
-                          value: 'command',
-                        },
-                        {
-                          label: '聊天入口',
-                          value: 'chat',
-                        },
-                      ]}
-                      value={endpoint.kind}
-                      onChange={(value) =>
-                        updateGAgentEndpointDraft(endpointIndex, {
-                          kind: value,
-                        })
-                      }
-                    />
-                    <Input
-                      aria-label={`请求类型 URL ${endpointIndex + 1}`}
-                      placeholder="请求类型 URL"
-                      value={endpoint.requestTypeUrl}
-                      onChange={(event) =>
-                        updateGAgentEndpointDraft(endpointIndex, {
-                          requestTypeUrl: event.target.value,
-                        })
-                      }
-                    />
-                    <Input
-                      aria-label={`响应类型 URL ${endpointIndex + 1}`}
-                      placeholder="响应类型 URL（可选）"
-                      value={endpoint.responseTypeUrl}
-                      onChange={(event) =>
-                        updateGAgentEndpointDraft(endpointIndex, {
-                          responseTypeUrl: event.target.value,
-                        })
-                      }
-                    />
-                    <Input.TextArea
-                      aria-label={`入口说明 ${endpointIndex + 1}`}
-                      autoSize={{ minRows: 2, maxRows: 4 }}
-                      placeholder="入口说明"
-                      value={endpoint.description}
-                      onChange={(event) =>
-                        updateGAgentEndpointDraft(endpointIndex, {
-                          description: event.target.value,
-                        })
-                      }
-                    />
+                    <div style={{ display: 'grid', gap: 8 }}>
+                      <Typography.Text strong>入口 ID</Typography.Text>
+                      <Input
+                        aria-label={`入口 ID ${endpointIndex + 1}`}
+                        placeholder="聊天入口推荐 chat，命令入口推荐 run"
+                        value={endpoint.endpointId}
+                        onChange={(event) =>
+                          updateGAgentEndpointDraft(endpointIndex, {
+                            endpointId: event.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div style={{ display: 'grid', gap: 8 }}>
+                      <Typography.Text strong>入口名称</Typography.Text>
+                      <Input
+                        aria-label={`入口展示名称 ${endpointIndex + 1}`}
+                        placeholder="例如 Chat / Run"
+                        value={endpoint.displayName}
+                        onChange={(event) =>
+                          updateGAgentEndpointDraft(endpointIndex, {
+                            displayName: event.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                    <div style={{ display: 'grid', gap: 8 }}>
+                      <Typography.Text strong>入口类型</Typography.Text>
+                      <Select
+                        aria-label={`入口类型 ${endpointIndex + 1}`}
+                        options={[
+                          {
+                            label: '命令入口',
+                            value: 'command',
+                          },
+                          {
+                            label: '聊天入口',
+                            value: 'chat',
+                          },
+                        ]}
+                        value={endpoint.kind}
+                        onChange={(value) =>
+                          updateGAgentEndpointDraft(
+                            endpointIndex,
+                            applyStudioGAgentEndpointPreset(
+                              endpoint,
+                              value as 'command' | 'chat',
+                            ),
+                          )
+                        }
+                      />
+                      <Typography.Text type="secondary">
+                        {endpoint.kind === 'chat'
+                          ? '聊天入口会直接打开聊天型测试运行。'
+                          : '命令入口会把提示词或载荷草稿带入测试运行。'}
+                      </Typography.Text>
+                    </div>
+                    {gAgentAdvancedOpen ? (
+                      <>
+                        <Input
+                          aria-label={`请求类型 URL ${endpointIndex + 1}`}
+                          placeholder="请求类型 URL"
+                          value={endpoint.requestTypeUrl}
+                          onChange={(event) =>
+                            updateGAgentEndpointDraft(endpointIndex, {
+                              requestTypeUrl: event.target.value,
+                            })
+                          }
+                        />
+                        <Input
+                          aria-label={`响应类型 URL ${endpointIndex + 1}`}
+                          placeholder="响应类型 URL（可选）"
+                          value={endpoint.responseTypeUrl}
+                          onChange={(event) =>
+                            updateGAgentEndpointDraft(endpointIndex, {
+                              responseTypeUrl: event.target.value,
+                            })
+                          }
+                        />
+                        <Input.TextArea
+                          aria-label={`入口说明 ${endpointIndex + 1}`}
+                          autoSize={{ minRows: 2, maxRows: 4 }}
+                          placeholder="入口说明"
+                          value={endpoint.description}
+                          onChange={(event) =>
+                            updateGAgentEndpointDraft(endpointIndex, {
+                              description: event.target.value,
+                            })
+                          }
+                        />
+                      </>
+                    ) : null}
                   </div>
                 ))}
               </Space>
-              <Select
-                aria-label="测试运行默认入口"
-                style={{ width: '100%' }}
-                placeholder="选择绑定后默认打开的测试运行入口"
-                value={selectedOpenRunsEndpoint?.endpointId || undefined}
-                options={launchableGAgentEndpoints.map((endpoint) => ({
-                  value: endpoint.endpointId,
-                  label: `${
-                    endpoint.displayName.trim() || endpoint.endpointId.trim()
-                  } (${endpoint.kind})`,
-                }))}
-                notFoundContent="先填写入口 ID，才能启用测试运行跳转。"
-                onChange={(value) =>
-                  setGAgentDraft((current) => ({
-                    ...current,
-                    openRunsEndpointId: value,
-                  }))
-                }
-              />
+              {launchableGAgentEndpoints.length > 1 ? (
+                <Select
+                  aria-label="测试运行默认入口"
+                  style={{ width: '100%' }}
+                  placeholder="选择绑定后默认打开的测试运行入口"
+                  value={selectedOpenRunsEndpoint?.endpointId || undefined}
+                  options={launchableGAgentEndpoints.map((endpoint) => ({
+                    value: endpoint.endpointId,
+                    label: `${
+                      endpoint.displayName.trim() || endpoint.endpointId.trim()
+                    } (${endpoint.kind})`,
+                  }))}
+                  notFoundContent="先填写入口 ID，才能启用测试运行跳转。"
+                  onChange={(value) =>
+                    setGAgentDraft((current) => ({
+                      ...current,
+                      openRunsEndpointId: value,
+                    }))
+                  }
+                />
+              ) : selectedOpenRunsEndpoint ? (
+                <Typography.Text type="secondary">
+                  默认测试运行入口：{selectedOpenRunsEndpoint.displayName.trim() || selectedOpenRunsEndpoint.endpointId.trim()} ({selectedOpenRunsEndpoint.kind})
+                </Typography.Text>
+              ) : null}
               <Typography.Text type="secondary">
                 {selectedOpenRunsEndpoint?.kind === 'chat'
                   ? '测试运行目前会通过特殊的 “chat” 入口 ID 直接打开聊天类入口。'

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkbenchSections.tsx
@@ -817,6 +817,7 @@ const studioSurfaceStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
+  height: '100%',
   minHeight: 0,
   minWidth: 0,
   overflow: 'hidden',
@@ -848,10 +849,65 @@ const studioSurfaceBodyStyle: React.CSSProperties = {
 const studioSettingsTabsStyle: React.CSSProperties = {
   display: 'flex',
   flex: 1,
+  height: '100%',
   minHeight: 0,
   minWidth: 0,
+  overflow: 'hidden',
   width: '100%',
 };
+
+const studioSettingsTabsClassName = 'studio-settings-tabs';
+const studioSettingsTabContentClassName = 'studio-settings-tab-content';
+const studioSettingsTabsCss = `
+.${studioSettingsTabsClassName} {
+  align-items: stretch;
+  display: flex;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.${studioSettingsTabsClassName} .ant-tabs-content-holder {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.${studioSettingsTabsClassName} .ant-tabs-content {
+  display: flex;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+}
+
+.${studioSettingsTabsClassName} .ant-tabs-tabpane-hidden {
+  display: none !important;
+}
+
+.${studioSettingsTabsClassName} .ant-tabs-tabpane-active {
+  display: flex !important;
+  flex: 1;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.${studioSettingsTabContentClassName} {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+`;
 
 const studioSettingsTabLabelStyle: React.CSSProperties = {
   alignItems: 'center',
@@ -862,12 +918,9 @@ const studioSettingsTabLabelStyle: React.CSSProperties = {
 
 const studioSettingsTabContentStyle: React.CSSProperties = {
   ...cardStackStyle,
-  height: '100%',
+  flex: 1,
   minHeight: 0,
   minWidth: 0,
-  overflowX: 'hidden',
-  overflowY: 'auto',
-  paddingRight: 4,
 };
 
 const studioStatusStripStyle: React.CSSProperties = {
@@ -4028,6 +4081,9 @@ export const StudioEditorPage: React.FC<StudioEditorPageProps> = ({
         },
       );
       setGAgentModalOpen(false);
+    } catch {
+      // The page-level binder already surfaces the error notice. Keep the dialog
+      // open so the user can correct the input or retry.
     } finally {
       setGAgentBindingPending(false);
     }
@@ -6788,7 +6844,10 @@ export const StudioSettingsPage: React.FC<StudioSettingsPageProps> = ({
           </span>
         ),
         children: (
-          <div style={studioSettingsTabContentStyle}>
+          <div
+            className={studioSettingsTabContentClassName}
+            style={studioSettingsTabContentStyle}
+          >
             <div style={sectionPanelStyle}>
               <div style={cardStackStyle}>
                 <Typography.Text strong>运行时</Typography.Text>
@@ -6886,7 +6945,10 @@ export const StudioSettingsPage: React.FC<StudioSettingsPageProps> = ({
           </span>
         ),
         children: (
-          <div style={studioSettingsTabContentStyle}>
+          <div
+            className={studioSettingsTabContentClassName}
+            style={studioSettingsTabContentStyle}
+          >
             {settings.isError ? (
               <StudioNoticeCard
                 type="error"
@@ -7263,7 +7325,10 @@ export const StudioSettingsPage: React.FC<StudioSettingsPageProps> = ({
           </span>
         ),
         children: (
-          <div style={studioSettingsTabContentStyle}>
+          <div
+            className={studioSettingsTabContentClassName}
+            style={studioSettingsTabContentStyle}
+          >
             <div style={sectionPanelStyle}>
               <div
                 style={{
@@ -7373,7 +7438,10 @@ export const StudioSettingsPage: React.FC<StudioSettingsPageProps> = ({
           </span>
         ),
         children: (
-          <div style={studioSettingsTabContentStyle}>
+          <div
+            className={studioSettingsTabContentClassName}
+            style={studioSettingsTabContentStyle}
+          >
             <div style={cardStackStyle}>
               <div style={sectionPanelStyle}>
                 <div style={cardStackStyle}>
@@ -7777,9 +7845,11 @@ export const StudioSettingsPage: React.FC<StudioSettingsPageProps> = ({
             </div>
           </>
         ) : null}
+        <style>{studioSettingsTabsCss}</style>
         <Tabs
           activeKey={activeSection}
           animated={false}
+          className={studioSettingsTabsClassName}
           destroyOnHidden
           items={settingsTabs}
           onChange={(key) => setActiveSection(key as StudioSettingsSectionKey)}

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioWorkflowsPage.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioWorkflowsPage.test.tsx
@@ -71,7 +71,7 @@ function createProps(overrides = {}) {
 }
 
 describe('StudioWorkflowsPage', () => {
-  it('deduplicates same-name workflows and keeps the selected item visible', () => {
+  it('deduplicates same-name workflows by keeping the highest-priority saved summary', () => {
     const deduped = dedupeStudioWorkflowSummaries(
       [
         createWorkflowSummary({
@@ -85,11 +85,10 @@ describe('StudioWorkflowsPage', () => {
           updatedAtUtc: '2026-04-09T10:00:00Z',
         }),
       ],
-      'legacy-id',
     );
 
     expect(deduped).toHaveLength(1);
-    expect(deduped[0]?.workflowId).toBe('legacy-id');
+    expect(deduped[0]?.workflowId).toBe('hello-chat');
   });
 
   it('keeps the browser panel stretched and centers the empty state', () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -1039,8 +1039,7 @@ jest.mock("./components/StudioWorkbenchSections", () => {
   const React = require("react");
 
   const dedupeStudioWorkflowSummaries = (
-    workflows: readonly any[],
-    selectedWorkflowId = ""
+    workflows: readonly any[]
   ) => {
     const deduped = new Map<string, any>();
 
@@ -1050,12 +1049,6 @@ jest.mock("./components/StudioWorkbenchSections", () => {
     };
 
     const comparePriority = (left: any, right: any) => {
-      const leftSelected = left.workflowId === selectedWorkflowId;
-      const rightSelected = right.workflowId === selectedWorkflowId;
-      if (leftSelected !== rightSelected) {
-        return leftSelected ? -1 : 1;
-      }
-
       const updatedDelta =
         readTimestamp(right.updatedAtUtc) - readTimestamp(left.updatedAtUtc);
       if (updatedDelta !== 0) {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -1306,12 +1306,8 @@ const StudioPage: React.FC = () => {
     queryFn: () => runtimeQueryApi.listPrimitives(),
   });
   const visibleWorkflowSummaries = useMemo(
-    () =>
-      dedupeStudioWorkflowSummaries(
-        workflowsQuery.data ?? [],
-        selectedWorkflowId,
-      ),
-    [selectedWorkflowId, workflowsQuery.data],
+    () => dedupeStudioWorkflowSummaries(workflowsQuery.data ?? []),
+    [workflowsQuery.data],
   );
   const currentScopeBindingRevision = useMemo(
     () => getStudioScopeBindingCurrentRevision(scopeBindingQuery.data ?? null),

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -76,7 +76,6 @@ import {
   buildStudioRoute,
   type StudioTab,
 } from '@/shared/studio/navigation';
-import { syncStudioHostBodyClass } from '@/shared/studio/studioLayout';
 import type {
   WorkflowCatalogDefinition,
 } from '@/shared/models/runtime/catalog';
@@ -969,7 +968,6 @@ const StudioPage: React.FC = () => {
   );
   const isStudioLocation =
     typeof window !== 'undefined' && window.location.pathname === '/studio';
-  useEffect(() => syncStudioHostBodyClass(isStudioLocation), [isStudioLocation]);
   const nyxIdConfig = useMemo(() => getNyxIDRuntimeConfig(), []);
   const queryClient = useQueryClient();
   const [workspacePage, setWorkspacePage] = useState<StudioWorkspacePage>(
@@ -2675,6 +2673,9 @@ const StudioPage: React.FC = () => {
             ? error.message
             : 'Failed to bind the current scope to the GAgent service.',
       });
+      throw (error instanceof Error
+        ? error
+        : new Error('Failed to bind the current scope to the GAgent service.'));
     } finally {
       setPublishPending(false);
     }
@@ -4925,6 +4926,7 @@ const StudioPage: React.FC = () => {
           display: 'flex',
           flex: 1,
           flexDirection: 'column',
+          height: '100%',
           minHeight: 0,
           overflow: 'hidden',
         }}

--- a/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
@@ -17,6 +17,8 @@ type TeamActionRailProps = {
   readonly onOpenConversation: () => void;
   readonly onOpenServiceMapping: () => void;
   readonly onOpenTeamBuilder: () => void;
+  readonly serviceMappingDisabled?: boolean;
+  readonly serviceMappingHint?: string;
   readonly serviceMappingActionLabel: string;
   readonly teamBuilderActionLabel: string;
 };
@@ -60,13 +62,17 @@ export const TeamActionRail: React.FC<TeamActionRailProps> = ({
   onOpenConversation,
   onOpenServiceMapping,
   onOpenTeamBuilder,
+  serviceMappingDisabled = false,
+  serviceMappingHint,
   serviceMappingActionLabel,
   teamBuilderActionLabel,
 }) => (
   <Space key="team-detail-actions" wrap>
     <Button
+      disabled={serviceMappingDisabled}
       onClick={onOpenServiceMapping}
       style={topActionButtonStyle}
+      title={serviceMappingDisabled ? serviceMappingHint : undefined}
       type="primary"
     >
       {serviceMappingActionLabel}

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1,6 +1,8 @@
 import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
+import { servicesApi } from "@/shared/api/servicesApi";
+import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
 import { history } from "@/shared/navigation/history";
 import { studioApi } from "@/shared/studio/api";
 import { loadDraftRunPayload } from "@/shared/runs/draftRunSession";
@@ -751,6 +753,68 @@ describe("TeamDetailPage", () => {
     expect(params.get("runId")).toBe("run-current");
     expect(params.get("scopeId")).toBe("scope-1");
     expect(params.get("serviceId")).toBe("default");
+  });
+
+  it("updates the topology depth selection when the focus member is available", async () => {
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "服务映射" });
+    fireEvent.click(screen.getByRole("button", { name: "事件拓扑" }));
+    await screen.findByText("团队事件路径");
+
+    const nearButton = screen.getByRole("button", { name: "近邻" });
+    const expandButton = screen.getByRole("button", { name: "扩展" });
+    const panoramaButton = screen.getByRole("button", { name: "全景" });
+
+    expect(expandButton).toHaveAttribute("aria-pressed", "true");
+    expect(nearButton).toHaveAttribute("aria-pressed", "false");
+    expect(panoramaButton).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(panoramaButton);
+
+    expect(panoramaButton).toHaveAttribute("aria-pressed", "true");
+    expect(expandButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("disables topology controls when the current team has no focus member yet", async () => {
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce({
+      available: false,
+      scopeId: "scope-1",
+      serviceId: "",
+      displayName: "",
+      serviceKey: "",
+      defaultServingRevisionId: "",
+      activeServingRevisionId: "",
+      deploymentId: "",
+      deploymentStatus: "",
+      primaryActorId: "",
+      updatedAt: "2026-04-09T09:00:00Z",
+      revisions: [],
+    });
+    (servicesApi.listServices as jest.Mock).mockResolvedValueOnce([]);
+    (runtimeGAgentApi.listActors as jest.Mock).mockResolvedValueOnce([]);
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "服务映射" });
+    fireEvent.click(screen.getByRole("button", { name: "事件拓扑" }));
+    await screen.findByText("团队事件路径");
+
+    expect(
+      screen.getByText("当前还没有可用的团队成员焦点，待成员或运行信号可见后再切换视角。"),
+    ).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "服务映射" })[0]).toBeDisabled();
+    expect(screen.getByRole("button", { name: "近邻" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "扩展" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "全景" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "打开平台拓扑" })).toBeDisabled();
+    expect(
+      screen.getByText("当前还没有可用的团队成员焦点，所以暂时没有可展开的事件拓扑关系。"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "配置" }));
+    expect(await screen.findByText("继续调整这支团队")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "服务映射" })[0]).toBeDisabled();
   });
 
   it("opens platform workbenches from members and bindings", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -2944,26 +2944,39 @@ const TeamDetailPage: React.FC = () => {
   const conversationActionLabel = lens.playback.currentRunId ? "本次对话" : "运行记录";
   const serviceMappingActionLabel = "服务映射";
   const teamBuilderActionLabel = "高级编辑";
+  const topologyFocusActorId =
+    trimText(effectiveActorId) ||
+    trimText(lens.graph.focusActorId) ||
+    trimText(lens.playback.rootActorId) ||
+    trimText(lens.currentRun?.actorId) ||
+    "";
+  const canAdjustTopologyDepth = topologyFocusActorId.length > 0;
+  const canOpenPlatformTopology = topologyFocusActorId.length > 0;
+  const topologyDepthLabel = formatTopologyDepthLabel(graphDepth);
+  const topologyControlsHint = canAdjustTopologyDepth
+    ? ""
+    : "当前还没有可用的团队成员焦点，待成员或运行信号可见后再切换视角。";
+  const platformTopologyHint = canOpenPlatformTopology
+    ? ""
+    : "当前还没有可打开的平台拓扑焦点。";
+  const topologyEmptyDescription = canAdjustTopologyDepth
+    ? `当前在${topologyDepthLabel}视角下还没有更多可见的事件拓扑关系。`
+    : "当前还没有可用的团队成员焦点，所以暂时没有可展开的事件拓扑关系。";
   const handleOpenTeamsList = React.useCallback(() => {
     history.push(teamsListHref);
   }, [teamsListHref]);
 
   const handleOpenServiceMapping = React.useCallback(() => {
     handleOpenPlaybackActor(
-      effectiveActorId ||
-        lens.graph.focusActorId ||
-        lens.playback.rootActorId ||
-        lens.currentRun?.actorId,
+      topologyFocusActorId,
       lens.currentRun?.runId || lens.playback.currentRunId,
     );
   }, [
-    effectiveActorId,
     handleOpenPlaybackActor,
     lens.currentRun?.actorId,
     lens.currentRun?.runId,
-    lens.graph.focusActorId,
     lens.playback.currentRunId,
-    lens.playback.rootActorId,
+    topologyFocusActorId,
   ]);
   const handleOpenServices = React.useCallback(() => {
     history.push(buildPlatformServicesHref(platformRouteIdentity));
@@ -3040,16 +3053,18 @@ const TeamDetailPage: React.FC = () => {
   const renderTopologyTab = () => {
     return (
       <TeamTopologyTab
+        depthControlDisabled={!canAdjustTopologyDepth}
+        depthControlHint={topologyControlsHint || undefined}
         graphDepth={graphDepth}
         graphEdgeCount={topologyGraph.edges.length}
-        graphFocusLabel={`${formatTopologyDepthLabel(graphDepth)}视角 · 焦点 ${compactId(effectiveActorId)}`}
+        graphFocusLabel={`${topologyDepthLabel}视角 · 焦点 ${topologyFocusActorId ? compactId(topologyFocusActorId) : "未选中"}`}
         graphNodeCount={topologyGraph.nodes.length}
         isError={actorGraphQuery.isError}
         isLoading={actorGraphQuery.isLoading}
         onCanvasSelect={() =>
           setSelectedTopologyNodeId(
-            topologyGraph.entityMap.has(effectiveActorId)
-              ? effectiveActorId
+            topologyGraph.entityMap.has(topologyFocusActorId)
+              ? topologyFocusActorId
               : topologyGraph.nodes[0]?.id || "",
           )
         }
@@ -3061,6 +3076,8 @@ const TeamDetailPage: React.FC = () => {
         }}
         onOpenPlatformTopology={handleOpenServiceMapping}
         onSetGraphDepth={setGraphDepth}
+        platformTopologyDisabled={!canOpenPlatformTopology}
+        platformTopologyHint={platformTopologyHint || undefined}
         openPlatformTopologyButtonStyle={{
           borderRadius: 16,
           height: 40,
@@ -3091,7 +3108,8 @@ const TeamDetailPage: React.FC = () => {
         selectedFocusReason={
           selectedFocusReason || "围绕当前焦点成员展开团队消息路径。点击左侧节点即可切换视角。"
         }
-        selectedNodeId={selectedTopologyNodeId || effectiveActorId}
+        selectedNodeId={selectedTopologyNodeId || topologyFocusActorId}
+        topologyEmptyDescription={topologyEmptyDescription}
         topologyEdges={topologyGraph.edges}
         topologyNodes={topologyGraph.nodes}
       />
@@ -3136,6 +3154,8 @@ const TeamDetailPage: React.FC = () => {
       <TeamMembersTab
         compositionRows={memberCompositionRows}
         identityRows={memberIdentityRows}
+        openRuntimeExplorerDisabled={!canOpenPlatformTopology}
+        openRuntimeExplorerHint={platformTopologyHint || undefined}
         onOpenRuntimeExplorer={handleOpenServiceMapping}
         onOpenServices={handleOpenServices}
         onSelectActor={setSelectedActorId}
@@ -3212,6 +3232,8 @@ const TeamDetailPage: React.FC = () => {
         onOpenConversation={handleOpenConversation}
         onOpenServiceMapping={handleOpenServiceMapping}
         onOpenTeamBuilder={() => history.push(teamBuilderRoute)}
+        serviceMappingDisabled={!canOpenPlatformTopology}
+        serviceMappingHint={platformTopologyHint || undefined}
         primaryActionButtonStyle={resolveActionButtonStyle(token, "primary")}
         secondaryActionButtonStyle={resolveActionButtonStyle(token)}
         serviceMappingActionLabel={serviceMappingActionLabel}
@@ -3259,6 +3281,8 @@ const TeamDetailPage: React.FC = () => {
           onOpenConversation={handleOpenConversation}
           onOpenServiceMapping={handleOpenServiceMapping}
           onOpenTeamBuilder={() => history.push(teamBuilderRoute)}
+          serviceMappingDisabled={!canOpenPlatformTopology}
+          serviceMappingHint={platformTopologyHint || undefined}
           serviceMappingActionLabel={serviceMappingActionLabel}
           teamBuilderActionLabel={teamBuilderActionLabel}
         />

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
+import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
 import { scopesApi } from "@/shared/api/scopesApi";
 import { servicesApi } from "@/shared/api/servicesApi";
 import { studioApi } from "@/shared/studio/api";
@@ -106,7 +107,7 @@ jest.mock("@/shared/studio/api", () => ({
       available: true,
       scopeId: "scope-a",
       serviceId: "service-alpha",
-      displayName: "客服团队",
+      displayName: "NyxID Chat",
       serviceKey: "scope-a:alpha",
       defaultServingRevisionId: "rev-2",
       activeServingRevisionId: "rev-2",
@@ -146,55 +147,37 @@ jest.mock("@/shared/studio/api", () => ({
   },
 }));
 
-import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
-
 describe("TeamsHomePage", () => {
   beforeEach(() => {
     window.history.replaceState({}, "", "/teams?scopeId=scope-a");
     jest.clearAllMocks();
   });
 
-  it("renders the team homepage in the new summary-plus-cards layout", async () => {
+  it("renders the team homepage around the current scope-backed team preview", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByText("Aevatar / Teams")).toBeTruthy();
-    expect(await screen.findByText("我的 AI 团队")).toBeTruthy();
-    expect(await screen.findByText("客服团队")).toBeTruthy();
+    expect(await screen.findByRole("heading", { level: 3, name: "NyxID Chat" })).toBeTruthy();
+    expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
+    expect(screen.getByText("我的 AI 团队")).toBeTruthy();
     expect(screen.getByText("当前 Team")).toBeTruthy();
     expect(screen.getByText("当前可见团队")).toBeTruthy();
     expect(screen.getByText("可见运行信号")).toBeTruthy();
     expect(screen.getByText("草稿条目")).toBeTruthy();
     expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "切换到卡片视图" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "切换到列表视图" })).toBeTruthy();
     expect(screen.getByLabelText("团队卡片视图")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "查看团队" })).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "更多" }).length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "显示草稿团队 (1)" })).toBeTruthy();
     expect(screen.queryByText("草稿团队")).toBeNull();
+    expect(screen.queryByRole("button", { name: "显示草稿团队 (1)" })).toBeNull();
 
-    fireEvent.click(screen.getAllByRole("button", { name: "更多" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "更多" }));
 
     expect(await screen.findByText("查看运行")).toBeTruthy();
     expect(screen.getByText("进入 Studio")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "显示草稿团队 (1)" }));
-
-    expect(await screen.findByText("草稿团队")).toBeTruthy();
-    fireEvent.click(screen.getAllByRole("button", { name: "更多" })[0]);
-    expect(screen.getAllByText("进入 Studio").length).toBeGreaterThan(0);
-    expect(
-      screen.queryByText(
-        "先看到“我有哪些团队、这些团队在做什么、哪里需要我关注”，而不是先看到工程术语和底层模块。",
-      ),
-    ).toBeNull();
-    expect(screen.queryByText("产品意图：")).toBeNull();
   });
 
   it("lets the user switch from cards to the compact roster manually", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    await screen.findByText("客服团队");
+    await screen.findByRole("heading", { level: 3, name: "NyxID Chat" });
     fireEvent.click(screen.getByRole("button", { name: "切换到列表视图" }));
 
     expect(await screen.findByLabelText("团队紧凑视图")).toBeTruthy();
@@ -208,14 +191,14 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByText("客服团队")).toBeTruthy();
+    expect(await screen.findByRole("heading", { level: 3, name: "NyxID Chat" })).toBeTruthy();
     expect(screen.getByText("部分团队信号暂时不可见")).toBeTruthy();
     expect(
       screen.queryByText("No stub for /api/scopes/scope-a/services/service-alpha/runs"),
     ).toBeNull();
   });
 
-  it("opens the workflow-focused team detail handoff from the primary card action", async () => {
+  it("opens the scope-backed team detail handoff from the primary card action", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
     fireEvent.click(await screen.findByRole("button", { name: "查看团队" }));
@@ -225,125 +208,28 @@ describe("TeamsHomePage", () => {
     });
 
     const params = new URLSearchParams(window.location.search);
-    expect(params.get("workflowId")).toBe("workflow-alpha");
     expect(params.get("serviceId")).toBe("service-alpha");
+    expect(params.get("workflowId")).toBeNull();
     expect(params.get("runId")).toBe("run-latest");
   });
 
-  it("shows a scope-backed team card when the current scope has binding and service facts but no workflows yet", async () => {
-    (scopesApi.listWorkflows as jest.Mock).mockResolvedValueOnce([]);
-    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce({
-      available: true,
-      scopeId: "scope-a",
-      serviceId: "service-alpha",
-      displayName: "NyxID Chat",
-      serviceKey: "scope-a:alpha",
-      defaultServingRevisionId: "rev-2",
-      activeServingRevisionId: "rev-2",
-      deploymentId: "deploy-1",
-      deploymentStatus: "Active",
-      primaryActorId: "actor://nyxid-chat",
-      updatedAt: "2026-04-13T10:00:00Z",
-      revisions: [
-        {
-          revisionId: "rev-2",
-          implementationKind: "gagent",
-          status: "Published",
-          artifactHash: "hash-2",
-          failureReason: "",
-          isDefaultServing: true,
-          isActiveServing: true,
-          isServingTarget: true,
-          allocationWeight: 100,
-          servingState: "Active",
-          deploymentId: "deploy-1",
-          primaryActorId: "actor://nyxid-chat",
-          createdAt: "2026-04-13T09:00:00Z",
-          preparedAt: "2026-04-13T09:01:00Z",
-          publishedAt: "2026-04-13T09:02:00Z",
-          retiredAt: null,
-          workflowName: "",
-          workflowDefinitionActorId: "",
-          inlineWorkflowCount: 0,
-          scriptId: "",
-          scriptRevision: "",
-          scriptDefinitionActorId: "",
-          scriptSourceHash: "",
-          staticActorTypeName: "Aevatar.GAgents.NyxidChat.NyxIdChatGAgent",
-        },
-      ],
-    });
-    (servicesApi.listServices as jest.Mock).mockResolvedValueOnce([
-      {
-        serviceKey: "scope-a:alpha",
-        tenantId: "scope-a",
-        appId: "default",
-        namespace: "default",
-        serviceId: "service-alpha",
-        displayName: "NyxID Chat",
-        defaultServingRevisionId: "rev-2",
-        activeServingRevisionId: "rev-2",
-        deploymentId: "deploy-1",
-        primaryActorId: "actor://nyxid-chat",
-        deploymentStatus: "Active",
-        endpoints: [],
-        policyIds: [],
-        updatedAt: "2026-04-13T10:01:00Z",
-      },
-    ]);
+  it("does not turn saved workflows into homepage teams before the current scope has an entry", async () => {
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
+    (servicesApi.listServices as jest.Mock).mockResolvedValueOnce([]);
     (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       serviceId: "service-alpha",
       serviceKey: "scope-a:alpha",
-      displayName: "NyxID Chat",
+      displayName: "客服运行时",
       runs: [],
     });
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(
-      await screen.findByRole("heading", {
-        level: 3,
-        name: "NyxID Chat",
-      }),
-    ).toBeTruthy();
-    expect(screen.getByText("已存在 service 记录，但当前还没有可见的运行信号。")).toBeTruthy();
-    expect(screen.getAllByText("待运行").length).toBeGreaterThan(0);
-    expect(screen.queryByText("未知")).toBeNull();
-    expect(screen.getAllByText("service-alpha").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "查看团队" })).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "查看团队" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/teams/scope-a");
-    });
-
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("serviceId")).toBe("service-alpha");
-    expect(params.get("workflowId")).toBeNull();
-  });
-
-  it("switches to the compact roster when many teams are visible", async () => {
-    (scopesApi.listWorkflows as jest.Mock).mockResolvedValueOnce(
-      Array.from({ length: 7 }, (_, index) => ({
-        scopeId: "scope-a",
-        workflowId: `workflow-${index + 1}`,
-        displayName: `团队 ${index + 1}`,
-        serviceKey: "scope-a:alpha",
-        workflowName: `team-${index + 1}`,
-        actorId: `actor://workflow-${index + 1}`,
-        activeRevisionId: "rev-2",
-        deploymentStatus: "Active",
-        deploymentId: "deploy-1",
-        updatedAt: `2026-04-13T10:0${Math.min(index, 5)}:00Z`,
-      })),
-    );
-
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    expect(await screen.findByLabelText("团队紧凑视图")).toBeTruthy();
-    expect(screen.getByText("团队 1")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "查看团队" }).length).toBe(7);
+    expect(await screen.findByRole("button", { name: "打开 Studio" })).toBeTruthy();
+    expect(screen.getByText(/已保存的行为定义/)).toBeTruthy();
+    expect(screen.queryByText("客服团队")).toBeNull();
+    expect(screen.queryByText("草稿团队")).toBeNull();
+    expect(screen.queryByRole("button", { name: "查看团队" })).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { scopesApi } from "@/shared/api/scopesApi";
+import { servicesApi } from "@/shared/api/servicesApi";
+import { studioApi } from "@/shared/studio/api";
 import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
 import TeamsHomePage from "./home";
 
@@ -158,7 +160,7 @@ describe("TeamsHomePage", () => {
     expect(await screen.findByText("Aevatar / Teams")).toBeTruthy();
     expect(await screen.findByText("我的 AI 团队")).toBeTruthy();
     expect(await screen.findByText("客服团队")).toBeTruthy();
-    expect(screen.getByText("当前 Scope")).toBeTruthy();
+    expect(screen.getByText("当前 Team")).toBeTruthy();
     expect(screen.getByText("当前可见团队")).toBeTruthy();
     expect(screen.getByText("可见运行信号")).toBeTruthy();
     expect(screen.getByText("草稿条目")).toBeTruthy();
@@ -226,6 +228,100 @@ describe("TeamsHomePage", () => {
     expect(params.get("workflowId")).toBe("workflow-alpha");
     expect(params.get("serviceId")).toBe("service-alpha");
     expect(params.get("runId")).toBe("run-latest");
+  });
+
+  it("shows a scope-backed team card when the current scope has binding and service facts but no workflows yet", async () => {
+    (scopesApi.listWorkflows as jest.Mock).mockResolvedValueOnce([]);
+    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce({
+      available: true,
+      scopeId: "scope-a",
+      serviceId: "service-alpha",
+      displayName: "NyxID Chat",
+      serviceKey: "scope-a:alpha",
+      defaultServingRevisionId: "rev-2",
+      activeServingRevisionId: "rev-2",
+      deploymentId: "deploy-1",
+      deploymentStatus: "Active",
+      primaryActorId: "actor://nyxid-chat",
+      updatedAt: "2026-04-13T10:00:00Z",
+      revisions: [
+        {
+          revisionId: "rev-2",
+          implementationKind: "gagent",
+          status: "Published",
+          artifactHash: "hash-2",
+          failureReason: "",
+          isDefaultServing: true,
+          isActiveServing: true,
+          isServingTarget: true,
+          allocationWeight: 100,
+          servingState: "Active",
+          deploymentId: "deploy-1",
+          primaryActorId: "actor://nyxid-chat",
+          createdAt: "2026-04-13T09:00:00Z",
+          preparedAt: "2026-04-13T09:01:00Z",
+          publishedAt: "2026-04-13T09:02:00Z",
+          retiredAt: null,
+          workflowName: "",
+          workflowDefinitionActorId: "",
+          inlineWorkflowCount: 0,
+          scriptId: "",
+          scriptRevision: "",
+          scriptDefinitionActorId: "",
+          scriptSourceHash: "",
+          staticActorTypeName: "Aevatar.GAgents.NyxidChat.NyxIdChatGAgent",
+        },
+      ],
+    });
+    (servicesApi.listServices as jest.Mock).mockResolvedValueOnce([
+      {
+        serviceKey: "scope-a:alpha",
+        tenantId: "scope-a",
+        appId: "default",
+        namespace: "default",
+        serviceId: "service-alpha",
+        displayName: "NyxID Chat",
+        defaultServingRevisionId: "rev-2",
+        activeServingRevisionId: "rev-2",
+        deploymentId: "deploy-1",
+        primaryActorId: "actor://nyxid-chat",
+        deploymentStatus: "Active",
+        endpoints: [],
+        policyIds: [],
+        updatedAt: "2026-04-13T10:01:00Z",
+      },
+    ]);
+    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      serviceId: "service-alpha",
+      serviceKey: "scope-a:alpha",
+      displayName: "NyxID Chat",
+      runs: [],
+    });
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 3,
+        name: "NyxID Chat",
+      }),
+    ).toBeTruthy();
+    expect(screen.getByText("已存在 service 记录，但当前还没有可见的运行信号。")).toBeTruthy();
+    expect(screen.getAllByText("待运行").length).toBeGreaterThan(0);
+    expect(screen.queryByText("未知")).toBeNull();
+    expect(screen.getAllByText("service-alpha").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "查看团队" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "查看团队" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/teams/scope-a");
+    });
+
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("serviceId")).toBe("service-alpha");
+    expect(params.get("workflowId")).toBeNull();
   });
 
   it("switches to the compact roster when many teams are visible", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -33,10 +33,7 @@ import {
   getStudioScopeBindingCurrentRevision,
   type StudioScopeBindingStatus,
 } from "@/shared/studio/models";
-import {
-  buildStudioWorkflowEditorRoute,
-  buildStudioWorkflowWorkspaceRoute,
-} from "@/shared/studio/navigation";
+import { buildStudioWorkflowWorkspaceRoute } from "@/shared/studio/navigation";
 import {
   AevatarInspectorEmpty,
   AevatarPageShell,
@@ -55,7 +52,6 @@ import {
   collectWorkflowOperationalServiceIds,
   WORKFLOW_RUNTIME_GUARDRAIL,
   type WorkflowOperationalAttention,
-  type WorkflowOperationalUnit,
 } from "./workflowOperationalUnits";
 
 const initialDraft = readScopeQueryDraft();
@@ -176,27 +172,6 @@ function resolveAttentionPillStyle(
         background: token.colorFillQuaternary,
         color: token.colorTextSecondary,
       };
-  }
-}
-
-function formatCardDescription(unit: WorkflowOperationalUnit): string {
-  switch (unit.attention) {
-    case "waiting":
-      return "最近一次执行正在等待人工确认或外部信号。";
-    case "failed":
-      return "最近一次执行出现异常，建议先进入详情排查。";
-    case "healthy":
-      return "最近一次执行正常，可继续查看运行状态和配置。";
-    case "no-bound-service":
-      return "已存在 workflow 定义，但当前还没有匹配到可运行的服务入口。";
-    case "no-recent-runs":
-      return "已存在 service 记录，但当前还没有可见的运行信号。";
-    case "draft":
-      return "当前仍处在搭建阶段，建议先完成服务绑定或首次运行。";
-    case "runtime-unresolved":
-      return "当前运行信号暂时不完整，建议稍后刷新或进入详情继续查看。";
-    default:
-      return unit.attentionDetail;
   }
 }
 
@@ -406,53 +381,6 @@ const TeamFact: React.FC<{
   </div>
 );
 
-function buildWorkflowTeamActions(
-  scopeId: string,
-  unit: WorkflowOperationalUnit,
-): {
-  readonly builderHref: string;
-  readonly detailHref: string;
-  readonly moreActions: Array<{ key: string; label: string; onClick: () => void }>;
-} {
-  const detailHref = buildTeamDetailHref({
-    scopeId,
-    workflowId: unit.workflow.workflowId,
-    serviceId: unit.matchedService?.serviceId,
-    runId: unit.latestRun?.runId,
-  });
-  const builderHref = buildStudioWorkflowEditorRoute({
-    scopeId,
-    workflowId: unit.workflow.workflowId,
-  });
-  const runtimeHref = unit.matchedService
-    ? buildRuntimeRunsHref({
-        actorId: unit.latestRun?.actorId || undefined,
-        route: unit.workflow.workflowName || undefined,
-        scopeId,
-        serviceId: unit.matchedService.serviceId,
-      })
-    : "";
-  const moreActions: Array<{ key: string; label: string; onClick: () => void }> = [];
-  if (runtimeHref) {
-    moreActions.push({
-      key: "runtime",
-      label: "查看运行",
-      onClick: () => history.push(runtimeHref),
-    });
-  }
-  moreActions.push({
-    key: "builder",
-    label: "进入 Studio",
-    onClick: () => history.push(builderHref),
-  });
-
-  return {
-    builderHref,
-    detailHref,
-    moreActions,
-  };
-}
-
 function resolveScopePreviewService(input: {
   readonly binding: StudioScopeBindingStatus | null | undefined;
   readonly services: readonly ServiceCatalogSnapshot[];
@@ -515,22 +443,24 @@ function buildScopeBackedTeamPreview(input: {
   const runs =
     serviceId && !runtimeUnavailable ? input.runsByServiceId[serviceId] ?? [] : [];
   const latestRun = runs.slice().sort(compareRuns)[0] ?? null;
+  const hasEntryFacts = Boolean(
+    serviceId ||
+      matchedService ||
+      currentRevision ||
+      trimOptional(input.binding?.serviceKey) ||
+      trimOptional(input.binding?.displayName),
+  );
+
+  if (!hasEntryFacts) {
+    return null;
+  }
+
   const title =
     trimOptional(input.binding?.displayName) ||
     trimOptional(matchedService?.displayName) ||
     describeStudioScopeBindingRevisionTarget(currentRevision) ||
     serviceId ||
     input.scopeId;
-
-  if (
-    !trimOptional(title) &&
-    !serviceId &&
-    !matchedService &&
-    !currentRevision &&
-    !trimOptional(input.binding?.serviceKey)
-  ) {
-    return null;
-  }
 
   let attention: WorkflowOperationalAttention = "draft";
   let attentionDetail = "当前 Team 还没有形成可运行的入口。";
@@ -651,242 +581,6 @@ const MoreActionsButton: React.FC<{
     </Button>
   </Dropdown>
 );
-
-const WorkflowTeamCard: React.FC<{
-  readonly scopeId: string;
-  readonly unit: WorkflowOperationalUnit;
-}> = ({ scopeId, unit }) => {
-  const { token } = theme.useToken();
-  const { detailHref, moreActions } = buildWorkflowTeamActions(scopeId, unit);
-  const description = formatCardDescription(unit);
-  const factChips = [
-    trimOptional(unit.workflow.workflowName),
-    unit.matchedService?.displayName || "",
-    formatRunStatusLabel(unit.latestRun?.completionStatus),
-  ].filter(Boolean);
-
-  return (
-    <div
-      onClick={() => history.push(detailHref)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          history.push(detailHref);
-        }
-      }}
-      role="button"
-      style={{
-        background: token.colorBgContainer,
-        border: `1px solid ${token.colorBorderSecondary}`,
-        borderRadius: 24,
-        boxShadow: token.boxShadowTertiary,
-        cursor: "pointer",
-        display: "flex",
-        flexDirection: "column",
-        gap: 14,
-        minWidth: 0,
-        padding: 18,
-      }}
-      tabIndex={0}
-    >
-      <div
-        style={{
-          alignItems: "flex-start",
-          display: "flex",
-          gap: 16,
-          justifyContent: "space-between",
-        }}
-      >
-        <div style={{ minWidth: 0 }}>
-          <Typography.Title
-            level={3}
-            style={{
-              fontSize: 22,
-              margin: 0,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {unit.workflow.displayName || unit.workflow.workflowId}
-          </Typography.Title>
-          <Typography.Paragraph
-            ellipsis={{ rows: 1, tooltip: description }}
-            style={{
-              color: token.colorTextSecondary,
-              fontSize: 14,
-              marginBottom: 0,
-              marginTop: 6,
-            }}
-          >
-            {description}
-          </Typography.Paragraph>
-        </div>
-        <span
-          style={{
-            ...resolveAttentionPillStyle(token, unit.attention),
-            borderRadius: 999,
-            display: "inline-flex",
-            fontSize: 12,
-            fontWeight: 600,
-            lineHeight: 1,
-            padding: "8px 12px",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {formatAttentionLabel(unit.attention)}
-        </span>
-      </div>
-
-      <Space size={[10, 10]} wrap>
-        {factChips.map((chip) => (
-          <EvidencePill key={chip} text={chip} />
-        ))}
-      </Space>
-
-      <div
-        style={{
-          borderTop: `1px solid ${token.colorBorderSecondary}`,
-          display: "grid",
-          gap: 14,
-          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
-          paddingTop: 14,
-        }}
-      >
-        <TeamFact
-          label="当前状态"
-          value={formatOperationalStatusLabel(unit.latestRun?.completionStatus, unit.attention)}
-        />
-        <TeamFact
-          label="最近更新"
-          value={formatShortTime(unit.latestRun?.lastUpdatedAt || unit.workflow.updatedAt)}
-        />
-        <TeamFact
-          label="主服务"
-          value={unit.matchedService?.serviceId || "未发布"}
-        />
-      </div>
-
-      <Space wrap>
-        <Button
-          onClick={stopEvent(() => history.push(detailHref))}
-          size="large"
-          type="primary"
-        >
-          查看团队
-        </Button>
-        <MoreActionsButton actions={moreActions} />
-      </Space>
-    </div>
-  );
-};
-
-const WorkflowTeamRow: React.FC<{
-  readonly scopeId: string;
-  readonly unit: WorkflowOperationalUnit;
-}> = ({ scopeId, unit }) => {
-  const { token } = theme.useToken();
-  const { detailHref, moreActions } = buildWorkflowTeamActions(scopeId, unit);
-  const description = formatCardDescription(unit);
-  const factChips = [
-    trimOptional(unit.workflow.workflowName),
-    unit.matchedService?.displayName || "",
-  ].filter(Boolean);
-
-  return (
-    <div
-      onClick={() => history.push(detailHref)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          history.push(detailHref);
-        }
-      }}
-      role="button"
-      style={{
-        alignItems: "center",
-        background: token.colorBgContainer,
-        border: `1px solid ${token.colorBorderSecondary}`,
-        borderRadius: 20,
-        boxShadow: token.boxShadowTertiary,
-        cursor: "pointer",
-        display: "grid",
-        gap: 16,
-        gridTemplateColumns: "minmax(0, 1.8fr) repeat(3, minmax(88px, 120px)) auto",
-        minWidth: 0,
-        padding: 16,
-      }}
-      tabIndex={0}
-    >
-      <div style={{ minWidth: 0 }}>
-        <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
-          <Typography.Title
-            level={4}
-            style={{
-              margin: 0,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {unit.workflow.displayName || unit.workflow.workflowId}
-          </Typography.Title>
-          <span
-            style={{
-              ...resolveAttentionPillStyle(token, unit.attention),
-              borderRadius: 999,
-              display: "inline-flex",
-              fontSize: 12,
-              fontWeight: 600,
-              lineHeight: 1,
-              padding: "7px 10px",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {formatAttentionLabel(unit.attention)}
-          </span>
-        </Space>
-        <Typography.Paragraph
-          ellipsis={{ rows: 1, tooltip: description }}
-          style={{
-            color: token.colorTextSecondary,
-            fontSize: 13,
-            marginBottom: 0,
-            marginTop: 0,
-          }}
-        >
-          {description}
-        </Typography.Paragraph>
-        {factChips.length > 0 ? (
-          <Space size={[8, 8]} style={{ marginTop: 10 }} wrap>
-            {factChips.map((chip) => (
-              <EvidencePill key={chip} text={chip} />
-            ))}
-          </Space>
-        ) : null}
-      </div>
-
-      <TeamFact
-        label="状态"
-        value={formatOperationalStatusLabel(unit.latestRun?.completionStatus, unit.attention)}
-      />
-      <TeamFact
-        label="更新"
-        value={formatShortTime(unit.latestRun?.lastUpdatedAt || unit.workflow.updatedAt)}
-      />
-      <TeamFact
-        label="服务"
-        value={unit.matchedService?.serviceId || "未发布"}
-      />
-
-      <Space wrap>
-        <Button
-          onClick={stopEvent(() => history.push(detailHref))}
-          type="primary"
-        >
-          查看团队
-        </Button>
-        <MoreActionsButton actions={moreActions} />
-      </Space>
-    </div>
-  );
-};
 
 const ScopeBackedTeamCard: React.FC<{
   readonly preview: ScopeBackedTeamPreview;
@@ -1109,7 +803,6 @@ const TeamsHomePage: React.FC = () => {
   const [manualRosterView, setManualRosterView] = React.useState<
     "cards" | "list" | null
   >(null);
-  const [showDrafts, setShowDrafts] = React.useState(false);
   const [showScopePicker, setShowScopePicker] = React.useState(false);
 
   const authSessionQuery = useQuery({
@@ -1282,23 +975,19 @@ const TeamsHomePage: React.FC = () => {
     ],
   );
 
-  const draftUnits = units.filter((unit) => unit.isDraftOnly);
-  const visibleUnits = showDrafts
-    ? units
-    : units.filter((unit) => !unit.isDraftOnly);
-  const visibleTeamCount =
-    visibleUnits.length > 0 ? visibleUnits.length : scopePreviewTeam ? 1 : 0;
+  const draftUnits = units.filter(
+    (unit) => unit.isDraftOnly || (!unit.matchedService && !unit.latestRun),
+  );
+  const visibleTeamCount = scopePreviewTeam ? 1 : 0;
   const resolvedRosterView =
     manualRosterView ??
     (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
   const useCompactRoster = resolvedRosterView === "list";
-  const activeUnits = units.filter((unit) => !unit.isDraftOnly);
-  const visibleRuns =
-    activeUnits.length > 0
-      ? activeUnits.filter((unit) => unit.latestRun).length
-      : scopePreviewTeam?.latestRun
-        ? 1
-        : 0;
+  const visibleRuns = scopePreviewTeam?.latestRun ? 1 : 0;
+  const draftHint =
+    draftUnits.length > 0
+      ? `当前 Team 还有 ${draftUnits.length} 个已保存的行为定义，但它们还没有形成首页入口。`
+      : "当前 Team 还没有可展示的入口。";
   const partialIssues = [
     servicesQuery.isError ? "服务目录暂时不可见。" : null,
     bindingQuery.isError ? "当前 Team 绑定信息暂时不可见。" : null,
@@ -1441,7 +1130,7 @@ const TeamsHomePage: React.FC = () => {
                 title="当前 Team 的入口列表暂时无法加载。"
                 type="error"
               />
-            ) : visibleUnits.length > 0 || scopePreviewTeam ? (
+            ) : scopePreviewTeam ? (
               <>
                 <div
                   style={{
@@ -1482,17 +1171,7 @@ const TeamsHomePage: React.FC = () => {
                       gap: 14,
                     }}
                   >
-                    {visibleUnits.length > 0
-                      ? visibleUnits.map((unit) => (
-                          <WorkflowTeamRow
-                            key={unit.workflow.workflowId}
-                            scopeId={scopeId}
-                            unit={unit}
-                          />
-                        ))
-                      : scopePreviewTeam && (
-                          <ScopeBackedTeamRow preview={scopePreviewTeam} />
-                        )}
+                    <ScopeBackedTeamRow preview={scopePreviewTeam} />
                   </div>
                 ) : (
                   <div
@@ -1503,23 +1182,13 @@ const TeamsHomePage: React.FC = () => {
                       gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
                     }}
                   >
-                    {visibleUnits.length > 0
-                      ? visibleUnits.map((unit) => (
-                          <WorkflowTeamCard
-                            key={unit.workflow.workflowId}
-                            scopeId={scopeId}
-                            unit={unit}
-                          />
-                        ))
-                      : scopePreviewTeam && (
-                          <ScopeBackedTeamCard preview={scopePreviewTeam} />
-                        )}
+                    <ScopeBackedTeamCard preview={scopePreviewTeam} />
                   </div>
                 )}
               </>
             ) : (
               <Empty
-                description="当前 Team 还没有可展示的入口。"
+                description={draftHint}
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
               >
                 <Button
@@ -1537,16 +1206,6 @@ const TeamsHomePage: React.FC = () => {
                 </Button>
               </Empty>
             )}
-
-            {draftUnits.length > 0 ? (
-              <div style={{ display: "flex", justifyContent: "center" }}>
-                <Button onClick={() => setShowDrafts((value) => !value)}>
-                  {showDrafts
-                    ? `隐藏草稿团队 (${draftUnits.length})`
-                    : `显示草稿团队 (${draftUnits.length})`}
-                </Button>
-              </div>
-            ) : null}
 
           </>
         ) : null}

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -26,6 +26,13 @@ import {
 } from "@/shared/navigation/teamRoutes";
 import { buildRuntimeRunsHref } from "@/shared/navigation/runtimeRoutes";
 import { studioApi } from "@/shared/studio/api";
+import type { ScopeServiceRunSummary } from "@/shared/models/runtime/scopeServices";
+import type { ServiceCatalogSnapshot } from "@/shared/models/services";
+import {
+  describeStudioScopeBindingRevisionTarget,
+  getStudioScopeBindingCurrentRevision,
+  type StudioScopeBindingStatus,
+} from "@/shared/studio/models";
 import {
   buildStudioWorkflowEditorRoute,
   buildStudioWorkflowWorkspaceRoute,
@@ -56,6 +63,19 @@ const scopeServiceAppId = "default";
 const scopeServiceNamespace = "default";
 const compactTeamRosterThreshold = 6;
 
+type ScopeBackedTeamPreview = {
+  readonly attention: WorkflowOperationalAttention;
+  readonly attentionDetail: string;
+  readonly detailHref: string;
+  readonly latestRun: ScopeServiceRunSummary | null;
+  readonly moreActions: Array<{ key: string; label: string; onClick: () => void }>;
+  readonly primaryLabel: string;
+  readonly secondaryLabel: string;
+  readonly serviceId: string;
+  readonly title: string;
+  readonly updatedAt: string | null;
+};
+
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
@@ -73,6 +93,35 @@ function formatRunStatusLabel(status: string | null | undefined): string {
       return "稳定";
     default:
       return trimOptional(status) || "未知";
+  }
+}
+
+function formatOperationalStatusLabel(
+  status: string | null | undefined,
+  attention: WorkflowOperationalAttention,
+): string {
+  const normalizedStatus = trimOptional(status);
+  if (normalizedStatus) {
+    return formatRunStatusLabel(normalizedStatus);
+  }
+
+  switch (attention) {
+    case "healthy":
+      return "运行中";
+    case "waiting":
+      return "待关注";
+    case "failed":
+      return "异常";
+    case "draft":
+      return "草稿中";
+    case "no-bound-service":
+      return "待绑定";
+    case "no-recent-runs":
+      return "待运行";
+    case "runtime-unresolved":
+      return "待确认";
+    default:
+      return "未知";
   }
 }
 
@@ -166,6 +215,93 @@ function formatShortTime(value: string | null | undefined): string {
     hour: "2-digit",
     minute: "2-digit",
   }).format(parsed);
+}
+
+function parseTimestamp(value: string | null | undefined): number {
+  const parsed = Date.parse(value || "");
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeStatus(value: string | null | undefined): string {
+  return trimOptional(value).toLowerCase();
+}
+
+function compareRuns(
+  left: ScopeServiceRunSummary,
+  right: ScopeServiceRunSummary,
+): number {
+  const rightTime = parseTimestamp(right.lastUpdatedAt);
+  const leftTime = parseTimestamp(left.lastUpdatedAt);
+  if (rightTime !== leftTime) {
+    return rightTime - leftTime;
+  }
+
+  if (right.stateVersion !== left.stateVersion) {
+    return right.stateVersion - left.stateVersion;
+  }
+
+  return right.runId.localeCompare(left.runId);
+}
+
+function compareServices(
+  left: ServiceCatalogSnapshot,
+  right: ServiceCatalogSnapshot,
+): number {
+  const rightTime = parseTimestamp(right.updatedAt);
+  const leftTime = parseTimestamp(left.updatedAt);
+  if (rightTime !== leftTime) {
+    return rightTime - leftTime;
+  }
+
+  return right.serviceId.localeCompare(left.serviceId);
+}
+
+function isSuccessfulRun(run: ScopeServiceRunSummary | null | undefined): boolean {
+  if (!run) {
+    return false;
+  }
+
+  if (run.lastSuccess === true) {
+    return true;
+  }
+
+  return ["completed", "finished", "success", "succeeded"].includes(
+    normalizeStatus(run.completionStatus),
+  );
+}
+
+function isWaitingRun(run: ScopeServiceRunSummary | null | undefined): boolean {
+  if (!run) {
+    return false;
+  }
+
+  return [
+    "waiting",
+    "waiting_approval",
+    "waiting_signal",
+    "blocked",
+    "human_approval",
+    "human_input",
+    "suspended",
+  ].includes(normalizeStatus(run.completionStatus));
+}
+
+function isFailedRun(run: ScopeServiceRunSummary | null | undefined): boolean {
+  if (!run) {
+    return false;
+  }
+
+  if (isWaitingRun(run)) {
+    return false;
+  }
+
+  if (run.lastSuccess === false) {
+    return true;
+  }
+
+  return ["failed", "error", "stopped", "timed_out", "timedout"].includes(
+    normalizeStatus(run.completionStatus),
+  );
 }
 
 function stopEvent<T extends (...args: any[]) => void>(handler: T): T {
@@ -317,6 +453,174 @@ function buildWorkflowTeamActions(
   };
 }
 
+function resolveScopePreviewService(input: {
+  readonly binding: StudioScopeBindingStatus | null | undefined;
+  readonly services: readonly ServiceCatalogSnapshot[];
+}): ServiceCatalogSnapshot | null {
+  const boundServiceId = trimOptional(input.binding?.serviceId);
+  if (boundServiceId) {
+    const matchedBoundService =
+      input.services.find(
+        (service) => trimOptional(service.serviceId) === boundServiceId,
+      ) ?? null;
+    if (matchedBoundService) {
+      return matchedBoundService;
+    }
+  }
+
+  return input.services.slice().sort(compareServices)[0] ?? null;
+}
+
+function resolveRuntimeUnavailable(input: {
+  readonly serviceId: string;
+  readonly runtimeAvailableByServiceId?: ReadonlySet<string>;
+  readonly runtimeGuardrailedServiceIds?: ReadonlySet<string>;
+}): boolean {
+  const serviceId = trimOptional(input.serviceId);
+  if (!serviceId) {
+    return false;
+  }
+
+  if (input.runtimeGuardrailedServiceIds?.has(serviceId)) {
+    return true;
+  }
+
+  if (!input.runtimeAvailableByServiceId) {
+    return false;
+  }
+
+  return !input.runtimeAvailableByServiceId.has(serviceId);
+}
+
+function buildScopeBackedTeamPreview(input: {
+  readonly binding: StudioScopeBindingStatus | null | undefined;
+  readonly guardrailedServiceIds?: ReadonlySet<string>;
+  readonly runsByServiceId: Readonly<Record<string, readonly ScopeServiceRunSummary[]>>;
+  readonly runtimeAvailableByServiceId?: ReadonlySet<string>;
+  readonly scopeId: string;
+  readonly services: readonly ServiceCatalogSnapshot[];
+}): ScopeBackedTeamPreview | null {
+  const currentRevision = getStudioScopeBindingCurrentRevision(input.binding);
+  const matchedService = resolveScopePreviewService({
+    binding: input.binding,
+    services: input.services,
+  });
+  const boundServiceId = trimOptional(input.binding?.serviceId);
+  const serviceId = trimOptional(matchedService?.serviceId) || boundServiceId;
+  const runtimeUnavailable = resolveRuntimeUnavailable({
+    runtimeAvailableByServiceId: input.runtimeAvailableByServiceId,
+    runtimeGuardrailedServiceIds: input.guardrailedServiceIds,
+    serviceId,
+  });
+  const runs =
+    serviceId && !runtimeUnavailable ? input.runsByServiceId[serviceId] ?? [] : [];
+  const latestRun = runs.slice().sort(compareRuns)[0] ?? null;
+  const title =
+    trimOptional(input.binding?.displayName) ||
+    trimOptional(matchedService?.displayName) ||
+    describeStudioScopeBindingRevisionTarget(currentRevision) ||
+    serviceId ||
+    input.scopeId;
+
+  if (
+    !trimOptional(title) &&
+    !serviceId &&
+    !matchedService &&
+    !currentRevision &&
+    !trimOptional(input.binding?.serviceKey)
+  ) {
+    return null;
+  }
+
+  let attention: WorkflowOperationalAttention = "draft";
+  let attentionDetail = "当前 Team 还没有形成可运行的入口。";
+
+  if (runtimeUnavailable) {
+    attention = "runtime-unresolved";
+    attentionDetail = "团队入口已经存在，但当前运行信号暂时不可见。";
+  } else if (latestRun && isFailedRun(latestRun)) {
+    attention = "failed";
+    attentionDetail =
+      trimOptional(latestRun.lastError) || "最近一次团队运行处于异常状态。";
+  } else if (latestRun && isWaitingRun(latestRun)) {
+    attention = "waiting";
+    attentionDetail =
+      trimOptional(latestRun.lastError) || "最近一次团队运行正在等待人工或外部信号。";
+  } else if (latestRun && isSuccessfulRun(latestRun)) {
+    attention = "healthy";
+    attentionDetail = "最近一次团队运行正常，可继续进入详情查看。";
+  } else if (serviceId || matchedService) {
+    attention = "no-recent-runs";
+    attentionDetail = "已存在 service 记录，但当前还没有可见的运行信号。";
+  } else if (
+    currentRevision ||
+    trimOptional(input.binding?.serviceKey) ||
+    trimOptional(input.binding?.displayName)
+  ) {
+    attention = "no-bound-service";
+    attentionDetail = "当前 Team 已绑定入口，但服务能力还没有完整就绪。";
+  }
+
+  const detailHref = buildTeamDetailHref({
+    runId: latestRun?.runId || undefined,
+    scopeId: input.scopeId,
+    serviceId: serviceId || undefined,
+  });
+  const runtimeHref =
+    serviceId.length > 0
+      ? buildRuntimeRunsHref({
+          actorId:
+            latestRun?.actorId ||
+            matchedService?.primaryActorId ||
+            trimOptional(input.binding?.primaryActorId) ||
+            undefined,
+          scopeId: input.scopeId,
+          serviceId,
+        })
+      : "";
+  const builderHref = buildStudioWorkflowWorkspaceRoute({
+    scopeId: input.scopeId,
+    scopeLabel: input.scopeId,
+  });
+  const moreActions: Array<{ key: string; label: string; onClick: () => void }> = [];
+  if (runtimeHref) {
+    moreActions.push({
+      key: "runtime",
+      label: "查看运行",
+      onClick: () => history.push(runtimeHref),
+    });
+  }
+  moreActions.push({
+    key: "builder",
+    label: "进入 Studio",
+    onClick: () => history.push(builderHref),
+  });
+
+  return {
+    attention,
+    attentionDetail,
+    detailHref,
+    latestRun,
+    moreActions,
+    primaryLabel:
+      trimOptional(matchedService?.displayName) ||
+      trimOptional(input.binding?.displayName) ||
+      describeStudioScopeBindingRevisionTarget(currentRevision) ||
+      "当前团队入口",
+    secondaryLabel: formatOperationalStatusLabel(
+      latestRun?.completionStatus,
+      attention,
+    ),
+    serviceId,
+    title,
+    updatedAt:
+      latestRun?.lastUpdatedAt ||
+      matchedService?.updatedAt ||
+      input.binding?.updatedAt ||
+      null,
+  };
+}
+
 const MoreActionsButton: React.FC<{
   readonly actions: Array<{ key: string; label: string; onClick: () => void }>;
 }> = ({ actions }) => (
@@ -449,7 +753,7 @@ const WorkflowTeamCard: React.FC<{
       >
         <TeamFact
           label="当前状态"
-          value={formatRunStatusLabel(unit.latestRun?.completionStatus)}
+          value={formatOperationalStatusLabel(unit.latestRun?.completionStatus, unit.attention)}
         />
         <TeamFact
           label="最近更新"
@@ -560,7 +864,7 @@ const WorkflowTeamRow: React.FC<{
 
       <TeamFact
         label="状态"
-        value={formatRunStatusLabel(unit.latestRun?.completionStatus)}
+        value={formatOperationalStatusLabel(unit.latestRun?.completionStatus, unit.attention)}
       />
       <TeamFact
         label="更新"
@@ -579,6 +883,220 @@ const WorkflowTeamRow: React.FC<{
           查看团队
         </Button>
         <MoreActionsButton actions={moreActions} />
+      </Space>
+    </div>
+  );
+};
+
+const ScopeBackedTeamCard: React.FC<{
+  readonly preview: ScopeBackedTeamPreview;
+}> = ({ preview }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      onClick={() => history.push(preview.detailHref)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          history.push(preview.detailHref);
+        }
+      }}
+      role="button"
+      style={{
+        background: token.colorBgContainer,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 24,
+        boxShadow: token.boxShadowTertiary,
+        cursor: "pointer",
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        minWidth: 0,
+        padding: 18,
+      }}
+      tabIndex={0}
+    >
+      <div
+        style={{
+          alignItems: "flex-start",
+          display: "flex",
+          gap: 16,
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ minWidth: 0 }}>
+          <Typography.Title
+            level={3}
+            style={{
+              fontSize: 22,
+              margin: 0,
+              overflowWrap: "anywhere",
+            }}
+          >
+            {preview.title}
+          </Typography.Title>
+          <Typography.Paragraph
+            ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
+            style={{
+              color: token.colorTextSecondary,
+              fontSize: 14,
+              marginBottom: 0,
+              marginTop: 6,
+            }}
+          >
+            {preview.attentionDetail}
+          </Typography.Paragraph>
+        </div>
+        <span
+          style={{
+            ...resolveAttentionPillStyle(token, preview.attention),
+            borderRadius: 999,
+            display: "inline-flex",
+            fontSize: 12,
+            fontWeight: 600,
+            lineHeight: 1,
+            padding: "8px 12px",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {formatAttentionLabel(preview.attention)}
+        </span>
+      </div>
+
+      <Space size={[10, 10]} wrap>
+        <EvidencePill text={preview.primaryLabel} />
+        <EvidencePill text={preview.secondaryLabel} />
+      </Space>
+
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          display: "grid",
+          gap: 14,
+          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+          paddingTop: 14,
+        }}
+      >
+        <TeamFact
+          label="当前状态"
+          value={formatOperationalStatusLabel(
+            preview.latestRun?.completionStatus,
+            preview.attention,
+          )}
+        />
+        <TeamFact
+          label="最近更新"
+          value={formatShortTime(preview.updatedAt)}
+        />
+        <TeamFact label="主服务" value={preview.serviceId || "未记录"} />
+      </div>
+
+      <Space wrap>
+        <Button
+          onClick={stopEvent(() => history.push(preview.detailHref))}
+          size="large"
+          type="primary"
+        >
+          查看团队
+        </Button>
+        <MoreActionsButton actions={preview.moreActions} />
+      </Space>
+    </div>
+  );
+};
+
+const ScopeBackedTeamRow: React.FC<{
+  readonly preview: ScopeBackedTeamPreview;
+}> = ({ preview }) => {
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      onClick={() => history.push(preview.detailHref)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          history.push(preview.detailHref);
+        }
+      }}
+      role="button"
+      style={{
+        alignItems: "center",
+        background: token.colorBgContainer,
+        border: `1px solid ${token.colorBorderSecondary}`,
+        borderRadius: 20,
+        boxShadow: token.boxShadowTertiary,
+        cursor: "pointer",
+        display: "grid",
+        gap: 16,
+        gridTemplateColumns: "minmax(0, 1.8fr) repeat(3, minmax(88px, 120px)) auto",
+        minWidth: 0,
+        padding: 16,
+      }}
+      tabIndex={0}
+    >
+      <div style={{ minWidth: 0 }}>
+        <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
+          <Typography.Title
+            level={4}
+            style={{
+              margin: 0,
+              overflowWrap: "anywhere",
+            }}
+          >
+            {preview.title}
+          </Typography.Title>
+          <span
+            style={{
+              ...resolveAttentionPillStyle(token, preview.attention),
+              borderRadius: 999,
+              display: "inline-flex",
+              fontSize: 12,
+              fontWeight: 600,
+              lineHeight: 1,
+              padding: "7px 10px",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {formatAttentionLabel(preview.attention)}
+          </span>
+        </Space>
+        <Typography.Paragraph
+          ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
+          style={{
+            color: token.colorTextSecondary,
+            fontSize: 13,
+            marginBottom: 0,
+            marginTop: 0,
+          }}
+        >
+          {preview.attentionDetail}
+        </Typography.Paragraph>
+        <Space size={[8, 8]} style={{ marginTop: 10 }} wrap>
+          <EvidencePill text={preview.primaryLabel} />
+          <EvidencePill text={preview.secondaryLabel} />
+        </Space>
+      </div>
+
+      <TeamFact
+        label="状态"
+        value={formatOperationalStatusLabel(
+          preview.latestRun?.completionStatus,
+          preview.attention,
+        )}
+      />
+      <TeamFact label="更新" value={formatShortTime(preview.updatedAt)} />
+      <TeamFact label="服务" value={preview.serviceId || "未记录"} />
+
+      <Space wrap>
+        <Button
+          onClick={stopEvent(() => history.push(preview.detailHref))}
+          type="primary"
+        >
+          查看团队
+        </Button>
+        <MoreActionsButton actions={preview.moreActions} />
       </Space>
     </div>
   );
@@ -660,13 +1178,36 @@ const TeamsHomePage: React.FC = () => {
       }),
     [bindingQuery.data, servicesQuery.data, workflowsQuery.data],
   );
-  const runtimeSampleServiceIds = matchedServiceIds.slice(
+  const scopePreviewServiceId = React.useMemo(() => {
+    const boundServiceId = trimOptional(bindingQuery.data?.serviceId);
+    if (
+      boundServiceId &&
+      servicesQuery.data?.some(
+        (service) => trimOptional(service.serviceId) === boundServiceId,
+      )
+    ) {
+      return boundServiceId;
+    }
+
+    return servicesQuery.data?.slice().sort(compareServices)[0]?.serviceId ?? boundServiceId;
+  }, [bindingQuery.data?.serviceId, servicesQuery.data]);
+  const runtimeServiceIds = React.useMemo(() => {
+    const normalizedScopePreviewServiceId = trimOptional(scopePreviewServiceId);
+    const ordered = normalizedScopePreviewServiceId
+      ? [
+          normalizedScopePreviewServiceId,
+          ...matchedServiceIds.filter((serviceId) => serviceId !== normalizedScopePreviewServiceId),
+        ]
+      : matchedServiceIds;
+    return ordered;
+  }, [matchedServiceIds, scopePreviewServiceId]);
+  const runtimeSampleServiceIds = runtimeServiceIds.slice(
     0,
     WORKFLOW_RUNTIME_GUARDRAIL,
   );
   const guardrailedServiceIds = React.useMemo(
-    () => new Set(matchedServiceIds.slice(WORKFLOW_RUNTIME_GUARDRAIL)),
-    [matchedServiceIds],
+    () => new Set(runtimeServiceIds.slice(WORKFLOW_RUNTIME_GUARDRAIL)),
+    [runtimeServiceIds],
   );
   const serviceRunQueries = useQueries({
     queries: runtimeSampleServiceIds.map((serviceId) => ({
@@ -721,20 +1262,46 @@ const TeamsHomePage: React.FC = () => {
       workflowsQuery.data,
     ],
   );
+  const scopePreviewTeam = React.useMemo(
+    () =>
+      buildScopeBackedTeamPreview({
+        binding: bindingQuery.data ?? null,
+        guardrailedServiceIds,
+        runsByServiceId,
+        runtimeAvailableByServiceId,
+        scopeId,
+        services: servicesQuery.data ?? [],
+      }),
+    [
+      bindingQuery.data,
+      guardrailedServiceIds,
+      runsByServiceId,
+      runtimeAvailableByServiceId,
+      scopeId,
+      servicesQuery.data,
+    ],
+  );
 
   const draftUnits = units.filter((unit) => unit.isDraftOnly);
   const visibleUnits = showDrafts
     ? units
     : units.filter((unit) => !unit.isDraftOnly);
+  const visibleTeamCount =
+    visibleUnits.length > 0 ? visibleUnits.length : scopePreviewTeam ? 1 : 0;
   const resolvedRosterView =
     manualRosterView ??
-    (visibleUnits.length >= compactTeamRosterThreshold ? "list" : "cards");
+    (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
   const useCompactRoster = resolvedRosterView === "list";
   const activeUnits = units.filter((unit) => !unit.isDraftOnly);
-  const visibleRuns = activeUnits.filter((unit) => unit.latestRun).length;
+  const visibleRuns =
+    activeUnits.length > 0
+      ? activeUnits.filter((unit) => unit.latestRun).length
+      : scopePreviewTeam?.latestRun
+        ? 1
+        : 0;
   const partialIssues = [
     servicesQuery.isError ? "服务目录暂时不可见。" : null,
-    bindingQuery.isError ? "当前 Scope 绑定信息暂时不可见。" : null,
+    bindingQuery.isError ? "当前 Team 绑定信息暂时不可见。" : null,
     ...serviceRunQueries.map((query) =>
       query.isError ? "部分运行信号暂时不可见。" : null,
     ),
@@ -860,32 +1427,32 @@ const TeamsHomePage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
               }}
             >
-              <SummaryStatCard accent label="当前 Scope" value={scopeId} />
-              <SummaryStatCard label="当前可见团队" value={visibleUnits.length} />
+              <SummaryStatCard accent label="当前 Team" value={scopeId} />
+              <SummaryStatCard label="当前可见团队" value={visibleTeamCount} />
               <SummaryStatCard label="可见运行信号" value={visibleRuns} />
               <SummaryStatCard label="草稿条目" value={draftUnits.length} />
             </div>
 
             {workflowsQuery.isLoading ? (
-              <AevatarInspectorEmpty description="正在整理当前 Scope 下的团队卡片。" />
+              <AevatarInspectorEmpty description="正在整理当前 Team 的入口卡片。" />
             ) : workflowsQuery.isError ? (
               <Alert
                 showIcon
-                title="当前 Scope 下的团队列表暂时无法加载。"
+                title="当前 Team 的入口列表暂时无法加载。"
                 type="error"
               />
-            ) : visibleUnits.length > 0 ? (
+            ) : visibleUnits.length > 0 || scopePreviewTeam ? (
               <>
                 <div
                   style={{
                     alignItems: "center",
                     display: "flex",
                     gap: 12,
-                    justifyContent: "space-between",
+                  justifyContent: "space-between",
                   }}
                 >
                   <Typography.Text type="secondary">
-                    {visibleUnits.length} 支团队
+                    {visibleTeamCount} 支团队
                   </Typography.Text>
                   <Space.Compact>
                     <Tooltip title="卡片视图">
@@ -915,13 +1482,17 @@ const TeamsHomePage: React.FC = () => {
                       gap: 14,
                     }}
                   >
-                    {visibleUnits.map((unit) => (
-                      <WorkflowTeamRow
-                        key={unit.workflow.workflowId}
-                        scopeId={scopeId}
-                        unit={unit}
-                      />
-                    ))}
+                    {visibleUnits.length > 0
+                      ? visibleUnits.map((unit) => (
+                          <WorkflowTeamRow
+                            key={unit.workflow.workflowId}
+                            scopeId={scopeId}
+                            unit={unit}
+                          />
+                        ))
+                      : scopePreviewTeam && (
+                          <ScopeBackedTeamRow preview={scopePreviewTeam} />
+                        )}
                   </div>
                 ) : (
                   <div
@@ -932,19 +1503,23 @@ const TeamsHomePage: React.FC = () => {
                       gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
                     }}
                   >
-                    {visibleUnits.map((unit) => (
-                      <WorkflowTeamCard
-                        key={unit.workflow.workflowId}
-                        scopeId={scopeId}
-                        unit={unit}
-                      />
-                    ))}
+                    {visibleUnits.length > 0
+                      ? visibleUnits.map((unit) => (
+                          <WorkflowTeamCard
+                            key={unit.workflow.workflowId}
+                            scopeId={scopeId}
+                            unit={unit}
+                          />
+                        ))
+                      : scopePreviewTeam && (
+                          <ScopeBackedTeamCard preview={scopePreviewTeam} />
+                        )}
                   </div>
                 )}
               </>
             ) : (
               <Empty
-                description="当前 Scope 里还没有可展示的团队。"
+                description="当前 Team 还没有可展示的入口。"
                 image={Empty.PRESENTED_IMAGE_SIMPLE}
               >
                 <Button

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAdvancedTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAdvancedTab.tsx
@@ -39,6 +39,8 @@ type TeamAdvancedTabProps = {
   readonly onOpenConversation: () => void;
   readonly onOpenServiceMapping: () => void;
   readonly onOpenTeamBuilder: () => void;
+  readonly serviceMappingDisabled?: boolean;
+  readonly serviceMappingHint?: string;
   readonly primaryActionButtonStyle: React.CSSProperties;
   readonly secondaryActionButtonStyle: React.CSSProperties;
   readonly serviceMappingActionLabel: string;
@@ -59,6 +61,8 @@ const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
   onOpenConversation,
   onOpenServiceMapping,
   onOpenTeamBuilder,
+  serviceMappingDisabled = false,
+  serviceMappingHint,
   primaryActionButtonStyle,
   secondaryActionButtonStyle,
   serviceMappingActionLabel,
@@ -171,8 +175,10 @@ const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
             </div>
             <Space wrap>
               <Button
+                disabled={serviceMappingDisabled}
                 onClick={onOpenServiceMapping}
                 style={primaryActionButtonStyle}
+                title={serviceMappingDisabled ? serviceMappingHint : undefined}
                 type="primary"
               >
                 {serviceMappingActionLabel}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -35,6 +35,8 @@ type MemberIdentityRow = {
 type TeamMembersTabProps = {
   readonly compositionRows: readonly MemberCompositionRow[];
   readonly identityRows: readonly MemberIdentityRow[];
+  readonly openRuntimeExplorerDisabled?: boolean;
+  readonly openRuntimeExplorerHint?: string;
   readonly onOpenRuntimeExplorer: () => void;
   readonly onOpenServices: () => void;
   readonly onSelectActor: (actorId: string) => void;
@@ -43,6 +45,8 @@ type TeamMembersTabProps = {
 const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
   compositionRows,
   identityRows,
+  openRuntimeExplorerDisabled = false,
+  openRuntimeExplorerHint,
   onOpenRuntimeExplorer,
   onOpenServices,
   onSelectActor,
@@ -173,7 +177,13 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
             <Button onClick={onOpenServices} size="small" style={actionButtonStyle}>
               打开 Services
             </Button>
-            <Button onClick={onOpenRuntimeExplorer} size="small" style={actionButtonStyle}>
+            <Button
+              disabled={openRuntimeExplorerDisabled}
+              onClick={onOpenRuntimeExplorer}
+              size="small"
+              style={actionButtonStyle}
+              title={openRuntimeExplorerDisabled ? openRuntimeExplorerHint : undefined}
+            >
               查看拓扑
             </Button>
           </Space>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamTopologyTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamTopologyTab.tsx
@@ -24,6 +24,8 @@ type TopologyDetailDisplayRow = {
 };
 
 type TeamTopologyTabProps = {
+  readonly depthControlDisabled: boolean;
+  readonly depthControlHint?: string;
   readonly graphDepth: number;
   readonly graphEdgeCount: number;
   readonly graphFocusLabel: string;
@@ -34,6 +36,8 @@ type TeamTopologyTabProps = {
   readonly onNodeSelect: (nodeId: string) => void;
   readonly onOpenPlatformTopology: () => void;
   readonly onSetGraphDepth: (depth: number) => void;
+  readonly platformTopologyDisabled: boolean;
+  readonly platformTopologyHint?: string;
   readonly openPlatformTopologyButtonStyle: React.CSSProperties;
   readonly provenanceLabel: string;
   readonly provenanceStyle: React.CSSProperties;
@@ -47,11 +51,14 @@ type TeamTopologyTabProps = {
   readonly selectedEntityTitle?: string;
   readonly selectedFocusReason: string;
   readonly selectedNodeId: string;
+  readonly topologyEmptyDescription: string;
   readonly topologyEdges: readonly Edge[];
   readonly topologyNodes: readonly Node[];
 };
 
 const TeamTopologyTab: React.FC<TeamTopologyTabProps> = ({
+  depthControlDisabled,
+  depthControlHint,
   graphDepth,
   graphEdgeCount,
   graphFocusLabel,
@@ -62,6 +69,8 @@ const TeamTopologyTab: React.FC<TeamTopologyTabProps> = ({
   onNodeSelect,
   onOpenPlatformTopology,
   onSetGraphDepth,
+  platformTopologyDisabled,
+  platformTopologyHint,
   openPlatformTopologyButtonStyle,
   provenanceLabel,
   provenanceStyle,
@@ -75,10 +84,12 @@ const TeamTopologyTab: React.FC<TeamTopologyTabProps> = ({
   selectedEntityTitle,
   selectedFocusReason,
   selectedNodeId,
+  topologyEmptyDescription,
   topologyEdges,
   topologyNodes,
 }) => {
   const { token } = theme.useToken();
+  const controlsHint = depthControlHint || platformTopologyHint || "";
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 18 }}>
@@ -125,20 +136,28 @@ const TeamTopologyTab: React.FC<TeamTopologyTabProps> = ({
               const active = graphDepth === depth;
               return (
                 <button
+                  aria-pressed={active}
+                  disabled={depthControlDisabled}
                   key={depth}
                   onClick={() => onSetGraphDepth(depth)}
                   style={{
                     background: active ? token.colorPrimaryBg : "transparent",
                     border: "none",
                     borderRadius: 999,
-                    color: active ? token.colorPrimary : token.colorTextSecondary,
-                    cursor: "pointer",
+                    color: depthControlDisabled
+                      ? token.colorTextQuaternary
+                      : active
+                        ? token.colorPrimary
+                        : token.colorTextSecondary,
+                    cursor: depthControlDisabled ? "not-allowed" : "pointer",
                     fontSize: 13,
                     fontWeight: active ? 700 : 500,
                     height: 32,
+                    opacity: depthControlDisabled ? 0.72 : 1,
                     padding: "0 14px",
                     transition: "all 140ms ease",
                   }}
+                  title={depthControlDisabled ? depthControlHint : undefined}
                   type="button"
                 >
                   {depth === 1 ? "近邻" : depth === 3 ? "全景" : "扩展"}
@@ -147,13 +166,22 @@ const TeamTopologyTab: React.FC<TeamTopologyTabProps> = ({
             })}
           </div>
           <Button
+            disabled={platformTopologyDisabled}
             onClick={onOpenPlatformTopology}
             style={openPlatformTopologyButtonStyle}
+            title={platformTopologyDisabled ? platformTopologyHint : undefined}
             type="primary"
           >
             打开平台拓扑
           </Button>
         </Space>
+        {controlsHint ? (
+          <div style={{ width: "100%" }}>
+            <Typography.Text style={{ fontSize: 12 }} type="secondary">
+              {controlsHint}
+            </Typography.Text>
+          </div>
+        ) : null}
       </div>
       {isLoading ? (
         <AevatarInspectorEmpty description="正在加载团队拓扑。" />
@@ -232,7 +260,7 @@ const TeamTopologyTab: React.FC<TeamTopologyTabProps> = ({
             ) : (
               <AevatarInspectorEmpty
                 title="暂无可见关系"
-                description="当前没有更多可见的事件拓扑关系。"
+                description={topologyEmptyDescription}
               />
             )}
           </AevatarPanel>

--- a/src/Aevatar.Mainnet.Host.Api/README.md
+++ b/src/Aevatar.Mainnet.Host.Api/README.md
@@ -55,7 +55,25 @@ export AEVATAR_Orleans__GatewayPort=30000
 
 ## 本地持久化开发模式（Orleans + Garnet）
 
-如果只是想避免本地 scope workflow / actor state 因后端重启而完全丢失，而当前机器又没有 Kafka / Elasticsearch / Neo4j，可以先用仓库内置的 `PersistentLocal` 环境：
+如果只是想快速起一个本地开发后端，并且希望避免“写侧还在、读侧已丢失”的不对称状态，优先使用脚本默认的 `local` 模式。脚本会优先使用 `~/.dotnet/dotnet`，避免系统 `dotnet` 与仓库 `global.json` 的 SDK 版本不匹配：
+
+```bash
+bash src/Aevatar.Mainnet.Host.Api/boot.sh
+```
+
+该模式默认显式启用：
+
+- `AEVATAR_ActorRuntime__Provider=InMemory`
+- `Projection:Document:Providers:InMemory:Enabled=true`
+- `Projection:Graph:Providers:InMemory:Enabled=true`
+- `GAgentService:Demo:Enabled=false`
+
+说明：
+
+- 这是最一致的单机开发模式：read/write 都是本地临时态。
+- 后端重启后，actor state 与 projection/read model 会一起清空，不会出现“service definition 还在，但 services/read model 已空”的错位。
+
+如果只是想避免本地 scope workflow / actor state 因后端重启而完全丢失，而当前机器又没有 Kafka / Elasticsearch / Neo4j，可以使用仓库内置的 `PersistentLocal` 环境：
 
 ```bash
 ASPNETCORE_ENVIRONMENT=PersistentLocal dotnet run --project src/Aevatar.Mainnet.Host.Api
@@ -76,6 +94,7 @@ ASPNETCORE_ENVIRONMENT=PersistentLocal dotnet run --project src/Aevatar.Mainnet.
 说明：
 
 - 该模式的目标是保住本地 actor 持久态与 workflow 存储回补能力，适合单机开发验证。
+- 由于 document / graph projection 仍是 `InMemory`，后端重启后 read model 会清空；如果 write-side 仍保留，可能出现本地 Console 看不到团队卡、但重复绑定提示“already exists”的现象。
 - 它不是完整的 distributed / production profile；若需要 durable document / graph projection，仍应使用 `Distributed` 环境并启动 Kafka、Elasticsearch、Neo4j。
 
 ## 多机集群测试（Docker）

--- a/src/Aevatar.Mainnet.Host.Api/boot.sh
+++ b/src/Aevatar.Mainnet.Host.Api/boot.sh
@@ -9,22 +9,33 @@ CONFIGURATION="${AEVATAR_APP_CONFIGURATION:-Debug}"
 API_HOST="${AEVATAR_APP_HOST:-127.0.0.1}"
 API_PORT="${AEVATAR_APP_PORT:-5080}"
 API_URL="http://${API_HOST}:${API_PORT}"
+APP_MODE="${AEVATAR_APP_MODE:-local}"
+DOTNET_CMD="${DOTNET_CMD:-}"
 LOG_FILE="${SCRIPT_DIR}/boot.log"
 PID_FILE="${SCRIPT_DIR}/boot.pid"
 
 usage() {
   cat <<'EOF'
 Usage:
-  ./boot.sh [--port PORT] [--configuration CONFIGURATION]
+  ./boot.sh [--port PORT] [--configuration CONFIGURATION] [--mode MODE]
 
 Description:
   Stops the previous Aevatar.Mainnet.Host.Api process, frees the configured
   port, and starts a fresh instance in the background.
 
+Modes:
+  local             fully local dev mode. read/write state are both ephemeral,
+                    which avoids "write-side remains but read-side is empty"
+                    after a backend restart.
+  persistent-local  Orleans + Garnet + in-memory projections. keeps actor state
+                    across restarts, but read models are still ephemeral.
+  distributed       Orleans + Kafka + Elasticsearch/Neo4j profile.
+
 Environment:
   AEVATAR_APP_CONFIGURATION   dotnet configuration, default: Debug
   AEVATAR_APP_HOST            bind host, default: 127.0.0.1
   AEVATAR_APP_PORT            bind port, default: 5080
+  AEVATAR_APP_MODE            local | persistent-local | distributed
 
 Files:
   boot.log    runtime output
@@ -54,6 +65,15 @@ while [[ $# -gt 0 ]]; do
       CONFIGURATION="${1#--configuration=}"
       shift
       ;;
+    --mode)
+      [[ $# -lt 2 ]] && { echo "Missing value for ${1}" >&2; exit 1; }
+      APP_MODE="${2}"
+      shift 2
+      ;;
+    --mode=*)
+      APP_MODE="${1#--mode=}"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -66,9 +86,27 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+case "${APP_MODE}" in
+  local|persistent-local|distributed)
+    ;;
+  *)
+    echo "Unsupported mode: ${APP_MODE}" >&2
+    usage
+    exit 1
+    ;;
+esac
+
 if [[ ! -f "${PROJECT_FILE}" ]]; then
   echo "Project file not found: ${PROJECT_FILE}" >&2
   exit 1
+fi
+
+if [[ -z "${DOTNET_CMD}" ]]; then
+  if [[ -x "${HOME}/.dotnet/dotnet" ]]; then
+    DOTNET_CMD="${HOME}/.dotnet/dotnet"
+  else
+    DOTNET_CMD="dotnet"
+  fi
 fi
 
 list_listening_pids() {
@@ -174,9 +212,61 @@ fi
 
 echo "==> Starting Aevatar.Mainnet.Host.Api"
 echo "==> URL: ${API_URL}"
+echo "==> Mode: ${APP_MODE}"
 echo "==> Log: ${LOG_FILE}"
 
-nohup dotnet run \
+launch_env=(
+  "ASPNETCORE_URLS=${API_URL}"
+)
+
+unset_env=()
+
+case "${APP_MODE}" in
+  local)
+    launch_env+=(
+      "ASPNETCORE_ENVIRONMENT=Development"
+      "DOTNET_ENVIRONMENT=Development"
+      "AEVATAR_ActorRuntime__Provider=InMemory"
+      "AEVATAR_Projection__Document__Providers__InMemory__Enabled=true"
+      "AEVATAR_Projection__Document__Providers__Elasticsearch__Enabled=false"
+      "AEVATAR_Projection__Graph__Providers__InMemory__Enabled=true"
+      "AEVATAR_Projection__Graph__Providers__Neo4j__Enabled=false"
+      "AEVATAR_Projection__Policies__Environment=Development"
+      "AEVATAR_Projection__Policies__DenyInMemoryDocumentReadStore=false"
+      "AEVATAR_Projection__Policies__DenyInMemoryGraphFactStore=false"
+      "AEVATAR_GAgentService__Demo__Enabled=false"
+    )
+    unset_env+=(
+      ASPNETCORE_ENVIRONMENT
+      DOTNET_ENVIRONMENT
+      AEVATAR_ActorRuntime__OrleansStreamBackend
+      AEVATAR_ActorRuntime__OrleansPersistenceBackend
+      AEVATAR_ActorRuntime__OrleansGarnetConnectionString
+      AEVATAR_ActorRuntime__KafkaBootstrapServers
+      AEVATAR_ActorRuntime__KafkaTopicName
+      AEVATAR_ActorRuntime__KafkaConsumerGroup
+      AEVATAR_Projection__Graph__Providers__Neo4j__Password
+    )
+    ;;
+  persistent-local)
+    launch_env+=(
+      "ASPNETCORE_ENVIRONMENT=PersistentLocal"
+    )
+    ;;
+  distributed)
+    launch_env+=(
+      "ASPNETCORE_ENVIRONMENT=Distributed"
+    )
+    ;;
+esac
+
+env_cmd=(env)
+for name in "${unset_env[@]}"; do
+  env_cmd+=(-u "${name}")
+done
+env_cmd+=("${launch_env[@]}")
+
+nohup "${env_cmd[@]}" "${DOTNET_CMD}" run \
   --project "${PROJECT_FILE}" \
   -c "${CONFIGURATION}" \
   --urls "${API_URL}" \


### PR DESCRIPTION
## Summary
- make the Studio bind-entry dialog easier to fill by prefilling chat endpoints, collapsing advanced fields, and surfacing binding success/failure more clearly
- keep Studio workflow definitions in a stable order instead of re-sorting the list when the user selects a different definition
- restore `My Teams` to scope-first semantics so saved workflow drafts do not show up as homepage team cards until the current scope has a real entry

## Verification
- `pnpm exec jest src/pages/teams/home.test.tsx --runInBand`
- `pnpm exec jest src/pages/studio/components/StudioEditorPage.test.tsx src/pages/studio/components/StudioWorkflowsPage.test.tsx src/pages/studio/index.test.tsx --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `bash tools/ci/test_stability_guards.sh`

## Notes
- no backend core behavior was changed; the local Mainnet boot flow stays in the aligned local mode introduced on this branch