### PR TITLE
Fix Studio actor-backed reads, StreamingProxy SSE, and distributed boot wiring

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -80,6 +80,9 @@ public static class NyxIdChatEndpoints
         [FromServices] IGAgentActorStore actorStore,
         CancellationToken ct)
     {
+        // Conversation creation is fail-fast on IGAgentActorStore persistence.
+        // NyxId chat depends on the registry being available; there is no
+        // degraded mode where a conversation can run without being registered.
         var actorId = NyxIdChatServiceDefaults.GenerateActorId();
         await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
         return Results.Ok(new { actorId });
@@ -317,8 +320,8 @@ public static class NyxIdChatEndpoints
         [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
-        await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
         await chatHistoryStore.DeleteConversationAsync(scopeId, actorId, ct);
+        await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
         return Results.Ok();
     }
 
@@ -785,16 +788,12 @@ public static class NyxIdChatEndpoints
                 platform, conversationId, message.Sender?.DisplayName);
 
             // ─── Get or create actor ───
+            // Relay follows the same strict lifecycle contract as create:
+            // registry persistence via IGAgentActorStore is mandatory, and
+            // registry failures must surface instead of silently degrading.
             var actor = await actorRuntime.GetAsync(actorId)
                         ?? await actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
-            try
-            {
-                await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
-            }
-            catch (InvalidOperationException)
-            {
-                // chrono-storage unavailable — actor still usable via runtime
-            }
+            await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
 
             // ─── Subscribe and collect response ───
             var responseTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -918,6 +917,10 @@ public static class NyxIdChatEndpoints
         catch (OperationCanceledException)
         {
             return FriendlyReply("The request was cancelled. Please try again.");
+        }
+        catch (InvalidOperationException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -78,33 +78,30 @@ public static class NyxIdChatEndpoints
         HttpContext http,
         string scopeId,
         [FromServices] IGAgentActorStore actorStore,
+        [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
-        var actorId = NyxIdChatServiceDefaults.GenerateActorId();
-        try
-        {
-            await actorStore.AddActorAsync(NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
-        }
-        catch (InvalidOperationException)
-        {
-            // chrono-storage unavailable — actor still usable via runtime
-        }
-        return Results.Ok(new { actorId });
+        var entry = await CreateConversationAsync(scopeId, actorStore, chatHistoryStore, ct);
+        return Results.Ok(new { actorId = entry.ActorId, createdAt = entry.CreatedAt });
     }
 
     private static async Task<IResult> HandleListConversationsAsync(
         HttpContext http,
         string scopeId,
         [FromServices] IGAgentActorStore actorStore,
+        [FromServices] IChatHistoryStore chatHistoryStore,
+        [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         try
         {
-            var groups = await actorStore.GetAsync(ct);
-            var group = groups.FirstOrDefault(g =>
-                string.Equals(g.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal));
-            var actorIds = group?.ActorIds ?? [];
-            return Results.Ok(actorIds.Select(id => new { actorId = id }));
+            var conversations = await ListConversationsAsync(
+                scopeId,
+                actorStore,
+                chatHistoryStore,
+                loggerFactory.CreateLogger("Aevatar.NyxId.Chat.Endpoints"),
+                ct);
+            return Results.Ok(conversations.Select(entry => new { actorId = entry.ActorId, createdAt = entry.CreatedAt }));
         }
         catch (InvalidOperationException)
         {
@@ -320,11 +317,13 @@ public static class NyxIdChatEndpoints
         string scopeId,
         string actorId,
         [FromServices] IGAgentActorStore actorStore,
+        [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
         try
         {
-            await actorStore.RemoveActorAsync(NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+            await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+            await chatHistoryStore.DeleteConversationAsync(scopeId, actorId, ct);
         }
         catch (InvalidOperationException)
         {
@@ -332,6 +331,88 @@ public static class NyxIdChatEndpoints
         }
         return Results.Ok();
     }
+
+    private static async Task<NyxIdConversationEntry> CreateConversationAsync(
+        string scopeId,
+        IGAgentActorStore actorStore,
+        IChatHistoryStore chatHistoryStore,
+        CancellationToken ct)
+    {
+        var actorId = NyxIdChatServiceDefaults.GenerateActorId();
+        var createdAt = DateTimeOffset.UtcNow;
+
+        await chatHistoryStore.SaveMessagesAsync(
+            scopeId,
+            actorId,
+            BuildConversationMeta(actorId, createdAt),
+            [],
+            ct);
+
+        await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+        return new NyxIdConversationEntry(actorId, createdAt);
+    }
+
+    private static async Task<IReadOnlyList<NyxIdConversationEntry>> ListConversationsAsync(
+        string scopeId,
+        IGAgentActorStore actorStore,
+        IChatHistoryStore chatHistoryStore,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var groups = await actorStore.GetAsync(scopeId, ct);
+        var actorIds = groups
+            .FirstOrDefault(g => string.Equals(g.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal))
+            ?.ActorIds
+            ?.ToHashSet(StringComparer.Ordinal)
+            ?? [];
+
+        if (actorIds.Count == 0)
+            return [];
+
+        var index = await chatHistoryStore.GetIndexAsync(scopeId, ct);
+        var entries = index.Conversations
+            .Where(meta => actorIds.Contains(meta.Id))
+            .Select(meta => new NyxIdConversationEntry(meta.Id, meta.CreatedAt))
+            .OrderByDescending(static entry => entry.CreatedAt)
+            .ThenBy(static entry => entry.ActorId, StringComparer.Ordinal)
+            .ToList();
+
+        if (entries.Count == actorIds.Count)
+            return entries.AsReadOnly();
+
+        foreach (var actorId in actorIds)
+        {
+            if (entries.Any(entry => string.Equals(entry.ActorId, actorId, StringComparison.Ordinal)))
+                continue;
+
+            logger.LogDebug(
+                "NyxId conversation metadata missing from chat history index. scopeId={ScopeId}, actorId={ActorId}",
+                scopeId,
+                actorId);
+
+            entries.Add(new NyxIdConversationEntry(actorId, DateTimeOffset.UnixEpoch));
+        }
+
+        return entries
+            .OrderByDescending(static entry => entry.CreatedAt)
+            .ThenBy(static entry => entry.ActorId, StringComparer.Ordinal)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    private static ConversationMeta BuildConversationMeta(string actorId, DateTimeOffset createdAt) =>
+        new(
+            Id: actorId,
+            Title: NyxIdChatServiceDefaults.DisplayName,
+            ServiceId: NyxIdChatServiceDefaults.ServiceId,
+            ServiceKind: "chat",
+            CreatedAt: createdAt,
+            UpdatedAt: createdAt,
+            MessageCount: 0,
+            LlmRoute: null,
+            LlmModel: null);
+
+    private sealed record NyxIdConversationEntry(string ActorId, DateTimeOffset CreatedAt);
 
     /// <summary>
     /// Handles tool approval decisions from the frontend.
@@ -800,7 +881,7 @@ public static class NyxIdChatEndpoints
                         ?? await actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
             try
             {
-                await actorStore.AddActorAsync(NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+                await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
             }
             catch (InvalidOperationException)
             {

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -320,15 +320,8 @@ public static class NyxIdChatEndpoints
         [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
-        try
-        {
-            await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
-            await chatHistoryStore.DeleteConversationAsync(scopeId, actorId, ct);
-        }
-        catch (InvalidOperationException)
-        {
-            // chrono-storage unavailable
-        }
+        await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+        await chatHistoryStore.DeleteConversationAsync(scopeId, actorId, ct);
         return Results.Ok();
     }
 
@@ -341,14 +334,14 @@ public static class NyxIdChatEndpoints
         var actorId = NyxIdChatServiceDefaults.GenerateActorId();
         var createdAt = DateTimeOffset.UtcNow;
 
+        await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+
         await chatHistoryStore.SaveMessagesAsync(
             scopeId,
             actorId,
             BuildConversationMeta(actorId, createdAt),
             [],
             ct);
-
-        await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
         return new NyxIdConversationEntry(actorId, createdAt);
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -78,30 +78,27 @@ public static class NyxIdChatEndpoints
         HttpContext http,
         string scopeId,
         [FromServices] IGAgentActorStore actorStore,
-        [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
-        var entry = await CreateConversationAsync(scopeId, actorStore, chatHistoryStore, ct);
-        return Results.Ok(new { actorId = entry.ActorId, createdAt = entry.CreatedAt });
+        var actorId = NyxIdChatServiceDefaults.GenerateActorId();
+        await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
+        return Results.Ok(new { actorId });
     }
 
     private static async Task<IResult> HandleListConversationsAsync(
         HttpContext http,
         string scopeId,
         [FromServices] IGAgentActorStore actorStore,
-        [FromServices] IChatHistoryStore chatHistoryStore,
-        [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         try
         {
-            var conversations = await ListConversationsAsync(
-                scopeId,
-                actorStore,
-                chatHistoryStore,
-                loggerFactory.CreateLogger("Aevatar.NyxId.Chat.Endpoints"),
-                ct);
-            return Results.Ok(conversations.Select(entry => new { actorId = entry.ActorId, createdAt = entry.CreatedAt }));
+            var groups = await actorStore.GetAsync(scopeId, ct);
+            var actorIds = groups
+                .FirstOrDefault(g => string.Equals(g.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal))
+                ?.ActorIds
+                ?? [];
+            return Results.Ok(actorIds.Select(actorId => new { actorId }));
         }
         catch (InvalidOperationException)
         {
@@ -324,88 +321,6 @@ public static class NyxIdChatEndpoints
         await chatHistoryStore.DeleteConversationAsync(scopeId, actorId, ct);
         return Results.Ok();
     }
-
-    private static async Task<NyxIdConversationEntry> CreateConversationAsync(
-        string scopeId,
-        IGAgentActorStore actorStore,
-        IChatHistoryStore chatHistoryStore,
-        CancellationToken ct)
-    {
-        var actorId = NyxIdChatServiceDefaults.GenerateActorId();
-        var createdAt = DateTimeOffset.UtcNow;
-
-        await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
-
-        await chatHistoryStore.SaveMessagesAsync(
-            scopeId,
-            actorId,
-            BuildConversationMeta(actorId, createdAt),
-            [],
-            ct);
-        return new NyxIdConversationEntry(actorId, createdAt);
-    }
-
-    private static async Task<IReadOnlyList<NyxIdConversationEntry>> ListConversationsAsync(
-        string scopeId,
-        IGAgentActorStore actorStore,
-        IChatHistoryStore chatHistoryStore,
-        ILogger logger,
-        CancellationToken ct)
-    {
-        var groups = await actorStore.GetAsync(scopeId, ct);
-        var actorIds = groups
-            .FirstOrDefault(g => string.Equals(g.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal))
-            ?.ActorIds
-            ?.ToHashSet(StringComparer.Ordinal)
-            ?? [];
-
-        if (actorIds.Count == 0)
-            return [];
-
-        var index = await chatHistoryStore.GetIndexAsync(scopeId, ct);
-        var entries = index.Conversations
-            .Where(meta => actorIds.Contains(meta.Id))
-            .Select(meta => new NyxIdConversationEntry(meta.Id, meta.CreatedAt))
-            .OrderByDescending(static entry => entry.CreatedAt)
-            .ThenBy(static entry => entry.ActorId, StringComparer.Ordinal)
-            .ToList();
-
-        if (entries.Count == actorIds.Count)
-            return entries.AsReadOnly();
-
-        foreach (var actorId in actorIds)
-        {
-            if (entries.Any(entry => string.Equals(entry.ActorId, actorId, StringComparison.Ordinal)))
-                continue;
-
-            logger.LogDebug(
-                "NyxId conversation metadata missing from chat history index. scopeId={ScopeId}, actorId={ActorId}",
-                scopeId,
-                actorId);
-
-            entries.Add(new NyxIdConversationEntry(actorId, DateTimeOffset.UnixEpoch));
-        }
-
-        return entries
-            .OrderByDescending(static entry => entry.CreatedAt)
-            .ThenBy(static entry => entry.ActorId, StringComparer.Ordinal)
-            .ToList()
-            .AsReadOnly();
-    }
-
-    private static ConversationMeta BuildConversationMeta(string actorId, DateTimeOffset createdAt) =>
-        new(
-            Id: actorId,
-            Title: NyxIdChatServiceDefaults.DisplayName,
-            ServiceId: NyxIdChatServiceDefaults.ServiceId,
-            ServiceKind: "chat",
-            CreatedAt: createdAt,
-            UpdatedAt: createdAt,
-            MessageCount: 0,
-            LlmRoute: null,
-            LlmModel: null);
-
-    private sealed record NyxIdConversationEntry(string ActorId, DateTimeOffset CreatedAt);
 
     /// <summary>
     /// Handles tool approval decisions from the frontend.

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -59,7 +59,7 @@ public static class StreamingProxyEndpoints
         var roomId = StreamingProxyDefaults.GenerateRoomId();
         try
         {
-            await actorStore.AddActorAsync(StreamingProxyDefaults.GAgentTypeName, roomId, ct);
+            await actorStore.AddActorAsync(scopeId, StreamingProxyDefaults.GAgentTypeName, roomId, ct);
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
@@ -88,7 +88,7 @@ public static class StreamingProxyEndpoints
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to activate room {RoomId}; rolling back registration", roomId);
-            await TryRollbackRoomCreationAsync(roomId, actorStore, actorRuntime, logger);
+            await TryRollbackRoomCreationAsync(scopeId, roomId, actorStore, actorRuntime, logger);
             return Results.Json(
                 new { error = "Failed to create room" },
                 statusCode: StatusCodes.Status500InternalServerError);
@@ -107,7 +107,7 @@ public static class StreamingProxyEndpoints
         var logger = loggerFactory.CreateLogger("Aevatar.GAgents.StreamingProxy.Endpoints");
         try
         {
-            var groups = await actorStore.GetAsync(ct);
+            var groups = await actorStore.GetAsync(scopeId, ct);
             var group = groups.FirstOrDefault(g =>
                 string.Equals(g.GAgentType, StreamingProxyDefaults.GAgentTypeName, StringComparison.Ordinal));
             var roomIds = group?.ActorIds ?? [];
@@ -133,7 +133,7 @@ public static class StreamingProxyEndpoints
         var logger = loggerFactory.CreateLogger("Aevatar.GAgents.StreamingProxy.Endpoints");
         try
         {
-            await actorStore.RemoveActorAsync(StreamingProxyDefaults.GAgentTypeName, roomId, ct);
+            await actorStore.RemoveActorAsync(scopeId, StreamingProxyDefaults.GAgentTypeName, roomId, ct);
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception ex)
@@ -504,6 +504,7 @@ public static class StreamingProxyEndpoints
         envelope.Route?.IsTopologyPublication() == true;
 
     private static async Task TryRollbackRoomCreationAsync(
+        string scopeId,
         string roomId,
         IGAgentActorStore actorStore,
         IActorRuntime actorRuntime,
@@ -521,6 +522,7 @@ public static class StreamingProxyEndpoints
         try
         {
             await actorStore.RemoveActorAsync(
+                scopeId,
                 StreamingProxyDefaults.GAgentTypeName,
                 roomId,
                 CancellationToken.None);

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -471,7 +471,7 @@ public static class StreamingProxyEndpoints
     private static async ValueTask<StreamingProxyStreamSignal?> MapAndWriteEventAsync(EventEnvelope envelope, StreamingProxySseWriter writer)
     {
         var payload = envelope.Payload;
-        if (payload is null)
+        if (payload is null || !ShouldWriteToSse(envelope))
             return null;
 
         if (payload.Is(GroupChatTopicEvent.Descriptor))
@@ -499,6 +499,9 @@ public static class StreamingProxyEndpoints
 
         return null;
     }
+
+    private static bool ShouldWriteToSse(EventEnvelope envelope) =>
+        envelope.Route?.IsTopologyPublication() == true;
 
     private static async Task TryRollbackRoomCreationAsync(
         string roomId,

--- a/docs/history/2026-04/2026-04-17-nyxid-chat-registry-lifecycle.md
+++ b/docs/history/2026-04/2026-04-17-nyxid-chat-registry-lifecycle.md
@@ -1,0 +1,20 @@
+# 2026-04-17 NyxId Chat Registry Lifecycle
+
+## Decision
+
+NyxId chat conversation lifecycle depends on `IGAgentActorStore` being available.
+The system does not support a degraded mode where a conversation can be created or
+continued without being persisted in the registry.
+
+## Required behavior
+
+- `POST /api/scopes/{scopeId}/nyxid-chat/conversations` is fail-fast on registry persistence failure.
+- Relay webhook conversation registration follows the same rule and must not silently continue when `IGAgentActorStore` fails.
+- Conversation deletion deletes chat history first and removes the registry entry second, so a history delete failure does not orphan history behind a missing registry entry.
+
+## Rationale
+
+The conversation list is registry-backed. Allowing create or relay to continue after
+registry failure would leave the system in a mixed contract where some chat sessions
+exist only in runtime state and cannot be explained or retried consistently from the
+registry-backed UI path.

--- a/src/Aevatar.Mainnet.Host.Api/boot.sh
+++ b/src/Aevatar.Mainnet.Host.Api/boot.sh
@@ -111,6 +111,9 @@ fi
 
 ensure_neo4j_env() {
   local environment_name="${ASPNETCORE_ENVIRONMENT:-${DOTNET_ENVIRONMENT:-}}"
+  if [[ -z "${environment_name}" && "${APP_MODE}" == "distributed" ]]; then
+    environment_name="Distributed"
+  fi
   local neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-}"
 
   if [[ "${environment_name}" != "Distributed" && "${neo4j_enabled}" != "true" ]]; then
@@ -289,9 +292,11 @@ case "${APP_MODE}" in
 esac
 
 env_cmd=(env)
-for name in "${unset_env[@]}"; do
-  env_cmd+=(-u "${name}")
-done
+if (( ${#unset_env[@]} > 0 )); then
+  for name in "${unset_env[@]}"; do
+    env_cmd+=(-u "${name}")
+  done
+fi
 env_cmd+=("${launch_env[@]}")
 
 nohup "${env_cmd[@]}" "${DOTNET_CMD}" run \

--- a/src/Aevatar.Mainnet.Host.Api/boot.sh
+++ b/src/Aevatar.Mainnet.Host.Api/boot.sh
@@ -109,6 +109,33 @@ if [[ -z "${DOTNET_CMD}" ]]; then
   fi
 fi
 
+ensure_neo4j_env() {
+  local environment_name="${ASPNETCORE_ENVIRONMENT:-${DOTNET_ENVIRONMENT:-}}"
+  local neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-}"
+
+  if [[ "${environment_name}" != "Distributed" && "${neo4j_enabled}" != "true" ]]; then
+    return 0
+  fi
+
+  if [[ -z "${AEVATAR_Projection__Graph__Providers__Neo4j__Username:-}" && -n "${NEO4J_USERNAME:-}" ]]; then
+    export AEVATAR_Projection__Graph__Providers__Neo4j__Username="${NEO4J_USERNAME}"
+  fi
+
+  if [[ -z "${AEVATAR_Projection__Graph__Providers__Neo4j__Password:-}" && -n "${NEO4J_PASSWORD:-}" ]]; then
+    export AEVATAR_Projection__Graph__Providers__Neo4j__Password="${NEO4J_PASSWORD}"
+  fi
+
+  if [[ -z "${AEVATAR_Projection__Graph__Providers__Neo4j__Password:-}" ]]; then
+    cat >&2 <<'EOF'
+Distributed mode with Neo4j enabled requires an explicit Neo4j password.
+Set one of:
+  export NEO4J_PASSWORD="<password>"
+  export AEVATAR_Projection__Graph__Providers__Neo4j__Password="<password>"
+EOF
+    exit 1
+  fi
+}
+
 list_listening_pids() {
   lsof -tiTCP:"${1}" -sTCP:LISTEN 2>/dev/null | sort -u || true
 }
@@ -204,6 +231,7 @@ wait_for_port_ready() {
 }
 
 kill_existing_processes
+ensure_neo4j_env
 
 if [[ -n "$(list_listening_pids "${API_PORT}")" ]]; then
   echo "Port ${API_PORT} is still occupied after cleanup." >&2

--- a/src/Aevatar.Mainnet.Host.Api/boot.sh
+++ b/src/Aevatar.Mainnet.Host.Api/boot.sh
@@ -113,7 +113,11 @@ ensure_neo4j_env() {
   local environment_name="${1:-}"
   local neo4j_enabled="${2:-}"
 
-  if [[ "${environment_name}" != "Distributed" && "${neo4j_enabled}" != "true" ]]; then
+  if [[ "${neo4j_enabled}" != "true" ]]; then
+    return 0
+  fi
+
+  if [[ "${environment_name}" != "Distributed" ]]; then
     return 0
   fi
 

--- a/src/Aevatar.Mainnet.Host.Api/boot.sh
+++ b/src/Aevatar.Mainnet.Host.Api/boot.sh
@@ -110,11 +110,8 @@ if [[ -z "${DOTNET_CMD}" ]]; then
 fi
 
 ensure_neo4j_env() {
-  local environment_name="${ASPNETCORE_ENVIRONMENT:-${DOTNET_ENVIRONMENT:-}}"
-  if [[ -z "${environment_name}" && "${APP_MODE}" == "distributed" ]]; then
-    environment_name="Distributed"
-  fi
-  local neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-}"
+  local environment_name="${1:-}"
+  local neo4j_enabled="${2:-}"
 
   if [[ "${environment_name}" != "Distributed" && "${neo4j_enabled}" != "true" ]]; then
     return 0
@@ -234,7 +231,6 @@ wait_for_port_ready() {
 }
 
 kill_existing_processes
-ensure_neo4j_env
 
 if [[ -n "$(list_listening_pids "${API_PORT}")" ]]; then
   echo "Port ${API_PORT} is still occupied after cleanup." >&2
@@ -251,9 +247,13 @@ launch_env=(
 )
 
 unset_env=()
+effective_environment_name="${ASPNETCORE_ENVIRONMENT:-${DOTNET_ENVIRONMENT:-}}"
+effective_neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-}"
 
 case "${APP_MODE}" in
   local)
+    effective_environment_name="Development"
+    effective_neo4j_enabled="false"
     launch_env+=(
       "ASPNETCORE_ENVIRONMENT=Development"
       "DOTNET_ENVIRONMENT=Development"
@@ -280,16 +280,20 @@ case "${APP_MODE}" in
     )
     ;;
   persistent-local)
+    effective_environment_name="PersistentLocal"
     launch_env+=(
       "ASPNETCORE_ENVIRONMENT=PersistentLocal"
     )
     ;;
   distributed)
+    effective_environment_name="Distributed"
     launch_env+=(
       "ASPNETCORE_ENVIRONMENT=Distributed"
     )
     ;;
 esac
+
+ensure_neo4j_env "${effective_environment_name}" "${effective_neo4j_enabled}"
 
 env_cmd=(env)
 if (( ${#unset_env[@]} > 0 )); then

--- a/src/Aevatar.Mainnet.Host.Api/boot.sh
+++ b/src/Aevatar.Mainnet.Host.Api/boot.sh
@@ -251,8 +251,8 @@ launch_env=(
 )
 
 unset_env=()
-effective_environment_name="${ASPNETCORE_ENVIRONMENT:-${DOTNET_ENVIRONMENT:-}}"
-effective_neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-}"
+effective_environment_name=""
+effective_neo4j_enabled=""
 
 case "${APP_MODE}" in
   local)
@@ -285,12 +285,14 @@ case "${APP_MODE}" in
     ;;
   persistent-local)
     effective_environment_name="PersistentLocal"
+    effective_neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-false}"
     launch_env+=(
       "ASPNETCORE_ENVIRONMENT=PersistentLocal"
     )
     ;;
   distributed)
     effective_environment_name="Distributed"
+    effective_neo4j_enabled="${AEVATAR_Projection__Graph__Providers__Neo4j__Enabled:-true}"
     launch_env+=(
       "ASPNETCORE_ENVIRONMENT=Distributed"
     )

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IGAgentActorStore.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IGAgentActorStore.cs
@@ -3,8 +3,11 @@ namespace Aevatar.Studio.Application.Studio.Abstractions;
 public interface IGAgentActorStore
 {
     Task<IReadOnlyList<GAgentActorGroup>> GetAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<GAgentActorGroup>> GetAsync(string scopeId, CancellationToken cancellationToken = default);
     Task AddActorAsync(string gagentType, string actorId, CancellationToken cancellationToken = default);
+    Task AddActorAsync(string scopeId, string gagentType, string actorId, CancellationToken cancellationToken = default);
     Task RemoveActorAsync(string gagentType, string actorId, CancellationToken cancellationToken = default);
+    Task RemoveActorAsync(string scopeId, string gagentType, string actorId, CancellationToken cancellationToken = default);
 }
 
 public sealed record GAgentActorGroup(string GAgentType, IReadOnlyList<string> ActorIds);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IUserConfigDefaults.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IUserConfigDefaults.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.Studio.Application.Studio.Abstractions;
+
+public interface IUserConfigDefaults
+{
+    string LocalRuntimeBaseUrl { get; }
+
+    string RemoteRuntimeBaseUrl { get; }
+}

--- a/src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj
+++ b/src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\Aevatar.CQRS.Projection.Providers.Elasticsearch\Aevatar.CQRS.Projection.Providers.Elasticsearch.csproj" />
+    <ProjectReference Include="..\Aevatar.CQRS.Projection.Providers.InMemory\Aevatar.CQRS.Projection.Providers.InMemory.csproj" />
     <ProjectReference Include="..\Aevatar.Studio.Infrastructure\Aevatar.Studio.Infrastructure.csproj" />
     <ProjectReference Include="..\Aevatar.Studio.Projection\Aevatar.Studio.Projection.csproj" />
     <ProjectReference Include="..\Aevatar.CQRS.Projection.Providers.Elasticsearch\Aevatar.CQRS.Projection.Providers.Elasticsearch.csproj" />

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -1,15 +1,4 @@
 using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
-using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
-using Aevatar.CQRS.Projection.Stores.Abstractions;
-using Aevatar.GAgents.ChatHistory;
-using Aevatar.GAgents.ConnectorCatalog;
-using Aevatar.GAgents.Registry;
-using Aevatar.GAgents.RoleCatalog;
-using Aevatar.GAgents.StreamingProxyParticipant;
-using Aevatar.GAgents.UserConfig;
-using Aevatar.GAgents.UserMemory;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.DependencyInjection;
@@ -18,8 +7,6 @@ using Aevatar.Studio.Hosting.Endpoints;
 using Aevatar.Studio.Infrastructure.DependencyInjection;
 using Aevatar.Studio.Infrastructure.ScopeResolution; // DefaultAppScopeResolver
 using Aevatar.Studio.Projection.DependencyInjection;
-using Aevatar.Studio.Projection.ReadModels;
-using Google.Protobuf.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -85,124 +72,5 @@ internal static class StudioHostingServiceCollectionExtensions
         services.AddSingleton<ScriptGenerateActorService>();
         services.AddSingleton<ScriptEditorValidationService>();
         return services;
-    }
-
-    private static IServiceCollection AddStudioProjectionReadModelProviders(
-        this IServiceCollection services,
-        IConfiguration configuration)
-    {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(configuration);
-
-        if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<GAgentRegistryCurrentStateDocument, string>)))
-            return services;
-
-        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
-        var inMemoryEnabled = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !elasticsearchEnabled);
-        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
-        if (providerCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled for Studio.");
-        }
-
-        if (elasticsearchEnabled)
-        {
-            AddElasticsearchDocumentProjectionStore<GAgentRegistryCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<ConnectorCatalogCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<RoleCatalogCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<UserMemoryCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<StreamingProxyParticipantCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<ChatHistoryIndexCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<ChatConversationCurrentStateDocument>(services, configuration);
-            AddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration);
-        }
-        else
-        {
-            AddInMemoryDocumentProjectionStore<GAgentRegistryCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<ConnectorCatalogCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<RoleCatalogCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<UserMemoryCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<StreamingProxyParticipantCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<ChatHistoryIndexCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<ChatConversationCurrentStateDocument>(services);
-            AddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services);
-        }
-
-        return services;
-    }
-
-    private static void AddElasticsearchDocumentProjectionStore<TReadModel>(
-        IServiceCollection services,
-        IConfiguration configuration)
-        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
-    {
-        services.AddElasticsearchDocumentProjectionStore<TReadModel, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TReadModel>>().Metadata,
-            keySelector: readModel => readModel.ActorId,
-            keyFormatter: key => key,
-            typeRegistry: BuildStudioStateTypeRegistry());
-    }
-
-    private static void AddInMemoryDocumentProjectionStore<TReadModel>(
-        IServiceCollection services)
-        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
-    {
-        services.AddInMemoryDocumentProjectionStore<TReadModel, string>(
-            keySelector: readModel => readModel.ActorId,
-            keyFormatter: key => key,
-            defaultSortSelector: readModel => readModel.UpdatedAt);
-    }
-
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
-    }
-
-    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
-    {
-        if (string.IsNullOrWhiteSpace(rawValue))
-            return fallbackValue;
-        if (!bool.TryParse(rawValue, out var parsed))
-            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
-
-        return parsed;
-    }
-
-    private static TypeRegistry BuildStudioStateTypeRegistry()
-    {
-        return TypeRegistry.FromMessages(
-            UserConfigGAgentState.Descriptor,
-            GAgentRegistryState.Descriptor,
-            ConnectorCatalogState.Descriptor,
-            RoleCatalogState.Descriptor,
-            UserMemoryState.Descriptor,
-            StreamingProxyParticipantGAgentState.Descriptor,
-            ChatHistoryIndexState.Descriptor,
-            ChatConversationState.Descriptor);
     }
 }

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -1,4 +1,15 @@
 using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.ChatHistory;
+using Aevatar.GAgents.ConnectorCatalog;
+using Aevatar.GAgents.Registry;
+using Aevatar.GAgents.RoleCatalog;
+using Aevatar.GAgents.StreamingProxyParticipant;
+using Aevatar.GAgents.UserConfig;
+using Aevatar.GAgents.UserMemory;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.DependencyInjection;
@@ -7,6 +18,8 @@ using Aevatar.Studio.Hosting.Endpoints;
 using Aevatar.Studio.Infrastructure.DependencyInjection;
 using Aevatar.Studio.Infrastructure.ScopeResolution; // DefaultAppScopeResolver
 using Aevatar.Studio.Projection.DependencyInjection;
+using Aevatar.Studio.Projection.ReadModels;
+using Google.Protobuf.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -72,5 +85,124 @@ internal static class StudioHostingServiceCollectionExtensions
         services.AddSingleton<ScriptGenerateActorService>();
         services.AddSingleton<ScriptEditorValidationService>();
         return services;
+    }
+
+    private static IServiceCollection AddStudioProjectionReadModelProviders(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<GAgentRegistryCurrentStateDocument, string>)))
+            return services;
+
+        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
+        var inMemoryEnabled = ResolveOptionalBool(
+            configuration["Projection:Document:Providers:InMemory:Enabled"],
+            fallbackValue: !elasticsearchEnabled);
+        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
+        if (providerCount != 1)
+        {
+            throw new InvalidOperationException(
+                "Exactly one document projection provider must be enabled for Studio.");
+        }
+
+        if (elasticsearchEnabled)
+        {
+            AddElasticsearchDocumentProjectionStore<GAgentRegistryCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<ConnectorCatalogCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<RoleCatalogCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<UserMemoryCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<StreamingProxyParticipantCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<ChatHistoryIndexCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<ChatConversationCurrentStateDocument>(services, configuration);
+            AddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration);
+        }
+        else
+        {
+            AddInMemoryDocumentProjectionStore<GAgentRegistryCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<ConnectorCatalogCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<RoleCatalogCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<UserMemoryCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<StreamingProxyParticipantCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<ChatHistoryIndexCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<ChatConversationCurrentStateDocument>(services);
+            AddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services);
+        }
+
+        return services;
+    }
+
+    private static void AddElasticsearchDocumentProjectionStore<TReadModel>(
+        IServiceCollection services,
+        IConfiguration configuration)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        services.AddElasticsearchDocumentProjectionStore<TReadModel, string>(
+            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TReadModel>>().Metadata,
+            keySelector: readModel => readModel.ActorId,
+            keyFormatter: key => key,
+            typeRegistry: BuildStudioStateTypeRegistry());
+    }
+
+    private static void AddInMemoryDocumentProjectionStore<TReadModel>(
+        IServiceCollection services)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        services.AddInMemoryDocumentProjectionStore<TReadModel, string>(
+            keySelector: readModel => readModel.ActorId,
+            keyFormatter: key => key,
+            defaultSortSelector: readModel => readModel.UpdatedAt);
+    }
+
+    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
+    {
+        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
+        var explicitEnabled = section["Enabled"];
+        var hasEndpoints = section
+            .GetSection("Endpoints")
+            .GetChildren()
+            .Select(x => x.Value?.Trim() ?? string.Empty)
+            .Any(x => x.Length > 0);
+        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
+    }
+
+    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
+        IConfiguration configuration)
+    {
+        var options = new ElasticsearchProjectionDocumentStoreOptions();
+        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
+        if (options.Endpoints.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
+        }
+
+        return options;
+    }
+
+    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue))
+            return fallbackValue;
+        if (!bool.TryParse(rawValue, out var parsed))
+            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
+
+        return parsed;
+    }
+
+    private static TypeRegistry BuildStudioStateTypeRegistry()
+    {
+        return TypeRegistry.FromMessages(
+            UserConfigGAgentState.Descriptor,
+            GAgentRegistryState.Descriptor,
+            ConnectorCatalogState.Descriptor,
+            RoleCatalogState.Descriptor,
+            UserMemoryState.Descriptor,
+            StreamingProxyParticipantGAgentState.Descriptor,
+            ChatHistoryIndexState.Descriptor,
+            ChatConversationState.Descriptor);
     }
 }

--- a/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
@@ -2,7 +2,15 @@ using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.ChatHistory;
+using Aevatar.GAgents.ConnectorCatalog;
+using Aevatar.GAgents.Registry;
+using Aevatar.GAgents.RoleCatalog;
+using Aevatar.GAgents.StreamingProxyParticipant;
+using Aevatar.GAgents.UserConfig;
+using Aevatar.GAgents.UserMemory;
 using Aevatar.Studio.Projection.ReadModels;
+using Google.Protobuf.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -46,23 +54,25 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
 
         if (elasticsearchEnabled)
         {
-            RegisterElasticsearch<RoleCatalogCurrentStateDocument>(services, configuration, d => d.Id);
-            RegisterElasticsearch<ConnectorCatalogCurrentStateDocument>(services, configuration, d => d.Id);
-            RegisterElasticsearch<ChatHistoryIndexCurrentStateDocument>(services, configuration, d => d.Id);
-            RegisterElasticsearch<ChatConversationCurrentStateDocument>(services, configuration, d => d.Id);
-            RegisterElasticsearch<GAgentRegistryCurrentStateDocument>(services, configuration, d => d.Id);
-            RegisterElasticsearch<UserMemoryCurrentStateDocument>(services, configuration, d => d.Id);
-            RegisterElasticsearch<StreamingProxyParticipantCurrentStateDocument>(services, configuration, d => d.Id);
+            RegisterElasticsearch<RoleCatalogCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<ConnectorCatalogCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<ChatHistoryIndexCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<ChatConversationCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<GAgentRegistryCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<UserMemoryCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<StreamingProxyParticipantCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<UserConfigCurrentStateDocument>(services, configuration);
         }
         else
         {
-            RegisterInMemory<RoleCatalogCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
-            RegisterInMemory<ConnectorCatalogCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
-            RegisterInMemory<ChatHistoryIndexCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
-            RegisterInMemory<ChatConversationCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
-            RegisterInMemory<GAgentRegistryCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
-            RegisterInMemory<UserMemoryCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
-            RegisterInMemory<StreamingProxyParticipantCurrentStateDocument>(services, d => d.Id, d => d.UpdatedAt);
+            RegisterInMemory<RoleCatalogCurrentStateDocument>(services);
+            RegisterInMemory<ConnectorCatalogCurrentStateDocument>(services);
+            RegisterInMemory<ChatHistoryIndexCurrentStateDocument>(services);
+            RegisterInMemory<ChatConversationCurrentStateDocument>(services);
+            RegisterInMemory<GAgentRegistryCurrentStateDocument>(services);
+            RegisterInMemory<UserMemoryCurrentStateDocument>(services);
+            RegisterInMemory<StreamingProxyParticipantCurrentStateDocument>(services);
+            RegisterInMemory<UserConfigCurrentStateDocument>(services);
         }
 
         return services;
@@ -70,27 +80,25 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
 
     private static void RegisterElasticsearch<TDoc>(
         IServiceCollection services,
-        IConfiguration configuration,
-        Func<TDoc, string> keySelector)
+        IConfiguration configuration)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
         services.AddElasticsearchDocumentProjectionStore<TDoc, string>(
             optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
             metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDoc>>().Metadata,
-            keySelector: keySelector,
-            keyFormatter: key => key);
+            keySelector: readModel => readModel.ActorId,
+            keyFormatter: key => key,
+            typeRegistry: BuildStudioStateTypeRegistry());
     }
 
     private static void RegisterInMemory<TDoc>(
-        IServiceCollection services,
-        Func<TDoc, string> keySelector,
-        Func<TDoc, object?> defaultSortSelector)
+        IServiceCollection services)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
         services.AddInMemoryDocumentProjectionStore<TDoc, string>(
-            keySelector: keySelector,
+            keySelector: readModel => readModel.ActorId,
             keyFormatter: key => key,
-            defaultSortSelector: defaultSortSelector);
+            defaultSortSelector: readModel => readModel.UpdatedAt);
     }
 
     private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
@@ -127,5 +135,18 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
 
         return parsed;
+    }
+
+    private static TypeRegistry BuildStudioStateTypeRegistry()
+    {
+        return TypeRegistry.FromMessages(
+            UserConfigGAgentState.Descriptor,
+            GAgentRegistryState.Descriptor,
+            ConnectorCatalogState.Descriptor,
+            RoleCatalogState.Descriptor,
+            UserMemoryState.Descriptor,
+            StreamingProxyParticipantGAgentState.Descriptor,
+            ChatHistoryIndexState.Descriptor,
+            ChatConversationState.Descriptor);
     }
 }

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedGAgentActorStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedGAgentActorStore.cs
@@ -40,6 +40,21 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         CancellationToken cancellationToken = default)
     {
         var actorId = ResolveWriteActorId();
+        return await GetByActorIdAsync(actorId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<GAgentActorGroup>> GetAsync(
+        string scopeId,
+        CancellationToken cancellationToken = default)
+    {
+        var actorId = ResolveWriteActorId(scopeId);
+        return await GetByActorIdAsync(actorId, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<GAgentActorGroup>> GetByActorIdAsync(
+        string actorId,
+        CancellationToken cancellationToken)
+    {
         var document = await _documentReader.GetAsync(actorId, cancellationToken);
         if (document?.StateRoot == null ||
             !document.StateRoot.Is(GAgentRegistryState.Descriptor))
@@ -54,11 +69,22 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
             .AsReadOnly();
     }
 
-    public async Task AddActorAsync(
+    public Task AddActorAsync(
         string gagentType, string actorId,
+        CancellationToken cancellationToken = default) =>
+        AddActorAsync(
+            _scopeResolver.ResolveScopeIdOrDefault(),
+            gagentType,
+            actorId,
+            cancellationToken);
+
+    public async Task AddActorAsync(
+        string scopeId,
+        string gagentType,
+        string actorId,
         CancellationToken cancellationToken = default)
     {
-        var actor = await EnsureWriteActorAsync(cancellationToken);
+        var actor = await EnsureWriteActorAsync(scopeId, cancellationToken);
         await ActorCommandDispatcher.SendAsync(_dispatchPort, actor, new ActorRegisteredEvent
         {
             GagentType = gagentType,
@@ -66,11 +92,22 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         }, cancellationToken);
     }
 
-    public async Task RemoveActorAsync(
+    public Task RemoveActorAsync(
         string gagentType, string actorId,
+        CancellationToken cancellationToken = default) =>
+        RemoveActorAsync(
+            _scopeResolver.ResolveScopeIdOrDefault(),
+            gagentType,
+            actorId,
+            cancellationToken);
+
+    public async Task RemoveActorAsync(
+        string scopeId,
+        string gagentType,
+        string actorId,
         CancellationToken cancellationToken = default)
     {
-        var actor = await EnsureWriteActorAsync(cancellationToken);
+        var actor = await EnsureWriteActorAsync(scopeId, cancellationToken);
         await ActorCommandDispatcher.SendAsync(_dispatchPort, actor, new ActorUnregisteredEvent
         {
             GagentType = gagentType,
@@ -80,8 +117,14 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
 
     // ── Actor resolution ──
 
-    private string ResolveWriteActorId() => WriteActorIdPrefix + _scopeResolver.ResolveScopeIdOrDefault();
+    private string ResolveWriteActorId(string? scopeId = null) =>
+        WriteActorIdPrefix + NormalizeScopeId(scopeId);
 
-    private Task<IActor> EnsureWriteActorAsync(CancellationToken ct) =>
-        _bootstrap.EnsureAsync<GAgentRegistryGAgent>(ResolveWriteActorId(), ct);
+    private Task<IActor> EnsureWriteActorAsync(string? scopeId, CancellationToken ct) =>
+        _bootstrap.EnsureAsync<GAgentRegistryGAgent>(ResolveWriteActorId(scopeId), ct);
+
+    private string NormalizeScopeId(string? scopeId) =>
+        string.IsNullOrWhiteSpace(scopeId)
+            ? _scopeResolver.ResolveScopeIdOrDefault()
+            : scopeId.Trim();
 }

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedGAgentActorStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedGAgentActorStore.cs
@@ -2,6 +2,7 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Registry;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.ReadModels;
 using Microsoft.Extensions.Logging;
 
@@ -19,6 +20,7 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
     private readonly IStudioActorBootstrap _bootstrap;
     private readonly IActorDispatchPort _dispatchPort;
     private readonly IAppScopeResolver _scopeResolver;
+    private readonly StudioCurrentStateProjectionPort _projectionPort;
     private readonly IProjectionDocumentReader<GAgentRegistryCurrentStateDocument, string> _documentReader;
     private readonly ILogger<ActorBackedGAgentActorStore> _logger;
 
@@ -26,12 +28,14 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         IStudioActorBootstrap bootstrap,
         IActorDispatchPort dispatchPort,
         IAppScopeResolver scopeResolver,
+        StudioCurrentStateProjectionPort projectionPort,
         IProjectionDocumentReader<GAgentRegistryCurrentStateDocument, string> documentReader,
         ILogger<ActorBackedGAgentActorStore> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _scopeResolver = scopeResolver ?? throw new ArgumentNullException(nameof(scopeResolver));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -40,6 +44,7 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         CancellationToken cancellationToken = default)
     {
         var actorId = ResolveWriteActorId();
+        await _projectionPort.EnsureProjectionForActorAsync(actorId, cancellationToken);
         var document = await _documentReader.GetAsync(actorId, cancellationToken);
         if (document?.StateRoot == null ||
             !document.StateRoot.Is(GAgentRegistryState.Descriptor))
@@ -58,6 +63,7 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         string gagentType, string actorId,
         CancellationToken cancellationToken = default)
     {
+        await _projectionPort.EnsureProjectionForActorAsync(ResolveWriteActorId(), cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         await ActorCommandDispatcher.SendAsync(_dispatchPort, actor, new ActorRegisteredEvent
         {
@@ -70,6 +76,7 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         string gagentType, string actorId,
         CancellationToken cancellationToken = default)
     {
+        await _projectionPort.EnsureProjectionForActorAsync(ResolveWriteActorId(), cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         await ActorCommandDispatcher.SendAsync(_dispatchPort, actor, new ActorUnregisteredEvent
         {

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedGAgentActorStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedGAgentActorStore.cs
@@ -2,7 +2,6 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Registry;
 using Aevatar.Studio.Application.Studio.Abstractions;
-using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.ReadModels;
 using Microsoft.Extensions.Logging;
 
@@ -20,7 +19,6 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
     private readonly IStudioActorBootstrap _bootstrap;
     private readonly IActorDispatchPort _dispatchPort;
     private readonly IAppScopeResolver _scopeResolver;
-    private readonly StudioCurrentStateProjectionPort _projectionPort;
     private readonly IProjectionDocumentReader<GAgentRegistryCurrentStateDocument, string> _documentReader;
     private readonly ILogger<ActorBackedGAgentActorStore> _logger;
 
@@ -28,14 +26,12 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         IStudioActorBootstrap bootstrap,
         IActorDispatchPort dispatchPort,
         IAppScopeResolver scopeResolver,
-        StudioCurrentStateProjectionPort projectionPort,
         IProjectionDocumentReader<GAgentRegistryCurrentStateDocument, string> documentReader,
         ILogger<ActorBackedGAgentActorStore> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _scopeResolver = scopeResolver ?? throw new ArgumentNullException(nameof(scopeResolver));
-        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -44,7 +40,6 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         CancellationToken cancellationToken = default)
     {
         var actorId = ResolveWriteActorId();
-        await _projectionPort.EnsureProjectionForActorAsync(actorId, cancellationToken);
         var document = await _documentReader.GetAsync(actorId, cancellationToken);
         if (document?.StateRoot == null ||
             !document.StateRoot.Is(GAgentRegistryState.Descriptor))
@@ -63,7 +58,6 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         string gagentType, string actorId,
         CancellationToken cancellationToken = default)
     {
-        await _projectionPort.EnsureProjectionForActorAsync(ResolveWriteActorId(), cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         await ActorCommandDispatcher.SendAsync(_dispatchPort, actor, new ActorRegisteredEvent
         {
@@ -76,7 +70,6 @@ internal sealed class ActorBackedGAgentActorStore : IGAgentActorStore
         string gagentType, string actorId,
         CancellationToken cancellationToken = default)
     {
-        await _projectionPort.EnsureProjectionForActorAsync(ResolveWriteActorId(), cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         await ActorCommandDispatcher.SendAsync(_dispatchPort, actor, new ActorUnregisteredEvent
         {

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedStreamingProxyParticipantStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedStreamingProxyParticipantStore.cs
@@ -2,6 +2,7 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.StreamingProxyParticipant;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.ReadModels;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -20,17 +21,20 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
 
     private readonly IStudioActorBootstrap _bootstrap;
     private readonly IActorDispatchPort _dispatchPort;
+    private readonly StudioCurrentStateProjectionPort _projectionPort;
     private readonly IProjectionDocumentReader<StreamingProxyParticipantCurrentStateDocument, string> _documentReader;
     private readonly ILogger<ActorBackedStreamingProxyParticipantStore> _logger;
 
     public ActorBackedStreamingProxyParticipantStore(
         IStudioActorBootstrap bootstrap,
         IActorDispatchPort dispatchPort,
+        StudioCurrentStateProjectionPort projectionPort,
         IProjectionDocumentReader<StreamingProxyParticipantCurrentStateDocument, string> documentReader,
         ILogger<ActorBackedStreamingProxyParticipantStore> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -38,6 +42,7 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
     public async Task<IReadOnlyList<StreamingProxyParticipant>> ListAsync(
         string roomId, CancellationToken cancellationToken = default)
     {
+        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var document = await _documentReader.GetAsync(WriteActorId, cancellationToken);
         if (document?.StateRoot == null ||
             !document.StateRoot.Is(StreamingProxyParticipantGAgentState.Descriptor))
@@ -60,6 +65,7 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
         string roomId, string agentId, string displayName,
         CancellationToken cancellationToken = default)
     {
+        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         var evt = new ParticipantAddedEvent
         {
@@ -74,6 +80,7 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
     public async Task RemoveParticipantAsync(
         string roomId, string agentId, CancellationToken cancellationToken = default)
     {
+        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         var evt = new ParticipantRemovedEvent
         {
@@ -86,6 +93,7 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
     public async Task RemoveRoomAsync(
         string roomId, CancellationToken cancellationToken = default)
     {
+        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         var evt = new RoomParticipantsRemovedEvent
         {

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedStreamingProxyParticipantStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedStreamingProxyParticipantStore.cs
@@ -2,7 +2,6 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.StreamingProxyParticipant;
 using Aevatar.Studio.Application.Studio.Abstractions;
-using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.ReadModels;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -21,20 +20,17 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
 
     private readonly IStudioActorBootstrap _bootstrap;
     private readonly IActorDispatchPort _dispatchPort;
-    private readonly StudioCurrentStateProjectionPort _projectionPort;
     private readonly IProjectionDocumentReader<StreamingProxyParticipantCurrentStateDocument, string> _documentReader;
     private readonly ILogger<ActorBackedStreamingProxyParticipantStore> _logger;
 
     public ActorBackedStreamingProxyParticipantStore(
         IStudioActorBootstrap bootstrap,
         IActorDispatchPort dispatchPort,
-        StudioCurrentStateProjectionPort projectionPort,
         IProjectionDocumentReader<StreamingProxyParticipantCurrentStateDocument, string> documentReader,
         ILogger<ActorBackedStreamingProxyParticipantStore> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
-        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -42,7 +38,6 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
     public async Task<IReadOnlyList<StreamingProxyParticipant>> ListAsync(
         string roomId, CancellationToken cancellationToken = default)
     {
-        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var document = await _documentReader.GetAsync(WriteActorId, cancellationToken);
         if (document?.StateRoot == null ||
             !document.StateRoot.Is(StreamingProxyParticipantGAgentState.Descriptor))
@@ -65,7 +60,6 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
         string roomId, string agentId, string displayName,
         CancellationToken cancellationToken = default)
     {
-        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         var evt = new ParticipantAddedEvent
         {
@@ -80,7 +74,6 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
     public async Task RemoveParticipantAsync(
         string roomId, string agentId, CancellationToken cancellationToken = default)
     {
-        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         var evt = new ParticipantRemovedEvent
         {
@@ -93,7 +86,6 @@ internal sealed class ActorBackedStreamingProxyParticipantStore
     public async Task RemoveRoomAsync(
         string roomId, CancellationToken cancellationToken = default)
     {
-        await _projectionPort.EnsureProjectionForActorAsync(WriteActorId, cancellationToken);
         var actor = await EnsureWriteActorAsync(cancellationToken);
         var evt = new RoomParticipantsRemovedEvent
         {

--- a/src/Aevatar.Studio.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IWorkflowYamlDocumentService, YamlWorkflowDocumentService>();
         services.AddSingleton<FileStudioWorkspaceStore>();
         services.AddSingleton<IStudioWorkspaceStore>(sp => sp.GetRequiredService<FileStudioWorkspaceStore>());
+        services.AddSingleton<IUserConfigDefaults, ConfiguredUserConfigDefaults>();
         services.AddSingleton<IConnectorCatalogImportParser, ConnectorCatalogImportParser>();
         services.AddSingleton<IRoleCatalogImportParser, RoleCatalogImportParser>();
         // chrono-storage blob client retained for media file uploads (ExplorerEndpoints)

--- a/src/Aevatar.Studio.Infrastructure/Storage/ConfiguredUserConfigDefaults.cs
+++ b/src/Aevatar.Studio.Infrastructure/Storage/ConfiguredUserConfigDefaults.cs
@@ -1,0 +1,19 @@
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Studio.Infrastructure.Storage;
+
+internal sealed class ConfiguredUserConfigDefaults : IUserConfigDefaults
+{
+    public ConfiguredUserConfigDefaults(IOptions<StudioStorageOptions> studioStorageOptions)
+    {
+        var resolvedOptions = (studioStorageOptions?.Value ?? throw new ArgumentNullException(nameof(studioStorageOptions)))
+            .ResolveRootDirectory();
+        LocalRuntimeBaseUrl = resolvedOptions.ResolveDefaultLocalRuntimeBaseUrl();
+        RemoteRuntimeBaseUrl = resolvedOptions.ResolveDefaultRemoteRuntimeBaseUrl();
+    }
+
+    public string LocalRuntimeBaseUrl { get; }
+
+    public string RemoteRuntimeBaseUrl { get; }
+}

--- a/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class ServiceCollectionExtensions
                 ProjectionKind = scopeKey.ProjectionKind,
             },
             context => new StudioMaterializationRuntimeLease(context));
+        services.TryAddSingleton<StudioCurrentStateProjectionPort>();
 
         // ── Projectors ──
 

--- a/src/Aevatar.Studio.Projection/Orchestration/StudioCurrentStateProjectionPort.cs
+++ b/src/Aevatar.Studio.Projection/Orchestration/StudioCurrentStateProjectionPort.cs
@@ -1,0 +1,28 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+
+namespace Aevatar.Studio.Projection.Orchestration;
+
+public sealed class StudioCurrentStateProjectionPort
+    : MaterializationProjectionPortBase<StudioMaterializationRuntimeLease>
+{
+    public const string ProjectionKind = "studio-current-state";
+
+    public StudioCurrentStateProjectionPort(
+        IProjectionScopeActivationService<StudioMaterializationRuntimeLease> activationService)
+        : base(static () => true, activationService)
+    {
+    }
+
+    public Task<StudioMaterializationRuntimeLease?> EnsureProjectionForActorAsync(
+        string actorId,
+        CancellationToken ct = default) =>
+        EnsureProjectionAsync(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = actorId,
+                ProjectionKind = ProjectionKind,
+                Mode = ProjectionRuntimeMode.DurableMaterialization,
+            },
+            ct);
+}

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionUserConfigQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionUserConfigQueryPort.cs
@@ -14,13 +14,23 @@ public sealed class ProjectionUserConfigQueryPort : IUserConfigQueryPort
 
     private readonly IProjectionDocumentReader<UserConfigCurrentStateDocument, string> _documentReader;
     private readonly IAppScopeResolver _scopeResolver;
+    private readonly string _defaultLocalRuntimeBaseUrl;
+    private readonly string _defaultRemoteRuntimeBaseUrl;
 
     public ProjectionUserConfigQueryPort(
         IProjectionDocumentReader<UserConfigCurrentStateDocument, string> documentReader,
-        IAppScopeResolver scopeResolver)
+        IAppScopeResolver scopeResolver,
+        IUserConfigDefaults userConfigDefaults)
     {
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _scopeResolver = scopeResolver ?? throw new ArgumentNullException(nameof(scopeResolver));
+        var resolvedDefaults = userConfigDefaults ?? throw new ArgumentNullException(nameof(userConfigDefaults));
+        _defaultLocalRuntimeBaseUrl = UserConfigRuntime.NormalizeBaseUrl(
+            resolvedDefaults.LocalRuntimeBaseUrl,
+            UserConfigRuntimeDefaults.LocalRuntimeBaseUrl);
+        _defaultRemoteRuntimeBaseUrl = UserConfigRuntime.NormalizeBaseUrl(
+            resolvedDefaults.RemoteRuntimeBaseUrl,
+            UserConfigRuntimeDefaults.RemoteRuntimeBaseUrl);
     }
 
     public async Task<UserConfig> GetAsync(CancellationToken ct = default)
@@ -40,19 +50,19 @@ public sealed class ProjectionUserConfigQueryPort : IUserConfigQueryPort
                 ? UserConfigRuntimeDefaults.LocalMode
                 : document.RuntimeMode,
             LocalRuntimeBaseUrl: string.IsNullOrEmpty(document.LocalRuntimeBaseUrl)
-                ? UserConfigRuntimeDefaults.LocalRuntimeBaseUrl
+                ? _defaultLocalRuntimeBaseUrl
                 : document.LocalRuntimeBaseUrl,
             RemoteRuntimeBaseUrl: string.IsNullOrEmpty(document.RemoteRuntimeBaseUrl)
-                ? UserConfigRuntimeDefaults.RemoteRuntimeBaseUrl
+                ? _defaultRemoteRuntimeBaseUrl
                 : document.RemoteRuntimeBaseUrl,
             MaxToolRounds: document.MaxToolRounds);
     }
 
-    private static UserConfig CreateDefaultConfig() =>
+    private UserConfig CreateDefaultConfig() =>
         new(
             DefaultModel: string.Empty,
             PreferredLlmRoute: UserConfigLlmRouteDefaults.Gateway,
             RuntimeMode: UserConfigRuntimeDefaults.LocalMode,
-            LocalRuntimeBaseUrl: UserConfigRuntimeDefaults.LocalRuntimeBaseUrl,
-            RemoteRuntimeBaseUrl: UserConfigRuntimeDefaults.RemoteRuntimeBaseUrl);
+            LocalRuntimeBaseUrl: _defaultLocalRuntimeBaseUrl,
+            RemoteRuntimeBaseUrl: _defaultRemoteRuntimeBaseUrl);
 }

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs
@@ -321,7 +321,7 @@ public static class ScopeGAgentEndpoints
             {
                 try
                 {
-                    await actorStore.AddActorAsync(request.ActorTypeName.Trim(), actor.Id, ct);
+                    await actorStore.AddActorAsync(scopeId, request.ActorTypeName.Trim(), actor.Id, ct);
                 }
                 catch (Exception ex)
                 {
@@ -728,7 +728,7 @@ public static class ScopeGAgentEndpoints
     {
         try
         {
-            var groups = await actorStore.GetAsync(ct);
+            var groups = await actorStore.GetAsync(scopeId, ct);
             return Results.Ok(groups);
         }
         catch (InvalidOperationException ex)
@@ -755,7 +755,7 @@ public static class ScopeGAgentEndpoints
             if (string.IsNullOrWhiteSpace(request.GAgentType) || string.IsNullOrWhiteSpace(request.ActorId))
                 return Results.BadRequest(new { code = "INVALID_REQUEST", message = "gagentType and actorId are required." });
 
-            await actorStore.AddActorAsync(request.GAgentType.Trim(), request.ActorId.Trim(), ct);
+            await actorStore.AddActorAsync(scopeId, request.GAgentType.Trim(), request.ActorId.Trim(), ct);
             return Results.Ok();
         }
         catch (InvalidOperationException ex)
@@ -783,7 +783,7 @@ public static class ScopeGAgentEndpoints
             if (string.IsNullOrWhiteSpace(gagentType))
                 return Results.BadRequest(new { code = "INVALID_REQUEST", message = "gagentType query parameter is required." });
 
-            await actorStore.RemoveActorAsync(gagentType.Trim(), actorId.Trim(), ct);
+            await actorStore.RemoveActorAsync(scopeId, gagentType.Trim(), actorId.Trim(), ct);
             return Results.Ok();
         }
         catch (InvalidOperationException ex)

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -52,34 +52,27 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
-    public async Task HandleCreateConversationAsync_ShouldReturnCreatedConversation()
+    public async Task HandleCreateConversationAsync_ShouldReturnConversationReceipt()
     {
         var actorStore = new StubGAgentActorStore();
-        var historyStore = new StubChatHistoryStore();
         var result = await InvokeResultAsync(
             "HandleCreateConversationAsync",
             new DefaultHttpContext(),
             "scope-a",
             actorStore,
-            historyStore,
             CancellationToken.None);
 
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         using var doc = JsonDocument.Parse(response.Body);
         doc.RootElement.TryGetProperty("actorId", out var actorId).Should().BeTrue();
-        doc.RootElement.TryGetProperty("createdAt", out var createdAt).Should().BeTrue();
+        doc.RootElement.TryGetProperty("createdAt", out _).Should().BeFalse();
         var createdActorId = actorId.GetString();
         createdActorId.Should().NotBeNullOrWhiteSpace();
-        createdAt.GetDateTimeOffset().Should().NotBe(default);
         actorStore.AddedActors.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
             entry.ActorId == createdActorId);
-        historyStore.SavedConversations.Should().ContainSingle(entry =>
-            entry.ScopeId == "scope-a" &&
-            entry.ConversationId == createdActorId &&
-            entry.Meta.CreatedAt == createdAt.GetDateTimeOffset());
     }
 
     [Fact]
@@ -89,23 +82,20 @@ public class NyxIdChatEndpointsCoverageTests
         {
             AddActorException = new InvalidOperationException("actor store unavailable"),
         };
-        var historyStore = new StubChatHistoryStore();
 
         var act = async () => await InvokeResultAsync(
             "HandleCreateConversationAsync",
             new DefaultHttpContext(),
             "scope-a",
             actorStore,
-            historyStore,
             CancellationToken.None);
 
         var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
         assertion.Which.Message.Should().Be("actor store unavailable");
-        historyStore.SavedConversations.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task HandleListConversationsAsync_ShouldReturnList()
+    public async Task HandleListConversationsAsync_ShouldReturnRegisteredActors()
     {
         var actorStore = new StubGAgentActorStore
         {
@@ -115,27 +105,11 @@ public class NyxIdChatEndpointsCoverageTests
                 new GAgentActorGroup("other-agent", ["actor-2"]),
             ],
         };
-        var historyStore = new StubChatHistoryStore
-        {
-            IndexToReturn = new ChatHistoryIndex(
-            [
-                new ConversationMeta(
-                    Id: "actor-1",
-                    Title: NyxIdChatServiceDefaults.DisplayName,
-                    ServiceId: NyxIdChatServiceDefaults.ServiceId,
-                    ServiceKind: "chat",
-                    CreatedAt: DateTimeOffset.Parse("2026-04-16T10:20:30Z"),
-                    UpdatedAt: DateTimeOffset.Parse("2026-04-16T10:20:30Z"),
-                    MessageCount: 0),
-            ]),
-        };
         var result = await InvokeResultAsync(
             "HandleListConversationsAsync",
             new DefaultHttpContext(),
             "scope-a",
             actorStore,
-            historyStore,
-            NullLoggerFactory.Instance,
             CancellationToken.None);
 
         var response = await ExecuteResultAsync(result);
@@ -143,8 +117,7 @@ public class NyxIdChatEndpointsCoverageTests
         using var doc = JsonDocument.Parse(response.Body);
         doc.RootElement.GetArrayLength().Should().Be(1);
         doc.RootElement[0].GetProperty("actorId").GetString().Should().Be("actor-1");
-        doc.RootElement[0].GetProperty("createdAt").GetDateTimeOffset()
-            .Should().Be(DateTimeOffset.Parse("2026-04-16T10:20:30Z"));
+        doc.RootElement[0].TryGetProperty("createdAt", out _).Should().BeFalse();
         actorStore.LastRequestedScopeId.Should().Be("scope-a");
     }
 
@@ -1190,6 +1163,7 @@ public class NyxIdChatEndpointsCoverageTests
         public ChatHistoryIndex IndexToReturn { get; init; } = new([]);
         public List<(string ScopeId, string ConversationId, ConversationMeta Meta)> SavedConversations { get; } = [];
         public List<(string ScopeId, string ConversationId)> DeletedConversations { get; } = [];
+        public Exception? SaveMessagesException { get; init; }
 
         public Task<ChatHistoryIndex> GetIndexAsync(string scopeId, CancellationToken ct = default)
         {
@@ -1215,6 +1189,8 @@ public class NyxIdChatEndpointsCoverageTests
             CancellationToken ct = default)
         {
             _ = messages;
+            if (SaveMessagesException is not null)
+                throw SaveMessagesException;
             SavedConversations.Add((scopeId, conversationId, meta));
             return Task.CompletedTask;
         }

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -54,29 +54,59 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleCreateConversationAsync_ShouldReturnCreatedConversation()
     {
-        var store = new StubGAgentActorStore();
+        var actorStore = new StubGAgentActorStore();
+        var historyStore = new StubChatHistoryStore();
         var result = await InvokeResultAsync(
             "HandleCreateConversationAsync",
             new DefaultHttpContext(),
             "scope-a",
-            store,
+            actorStore,
+            historyStore,
             CancellationToken.None);
 
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         using var doc = JsonDocument.Parse(response.Body);
         doc.RootElement.TryGetProperty("actorId", out var actorId).Should().BeTrue();
+        doc.RootElement.TryGetProperty("createdAt", out var createdAt).Should().BeTrue();
         var createdActorId = actorId.GetString();
         createdActorId.Should().NotBeNullOrWhiteSpace();
-        store.AddedActors.Should().ContainSingle(entry =>
+        createdAt.GetDateTimeOffset().Should().NotBe(default);
+        actorStore.AddedActors.Should().ContainSingle(entry =>
+            entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
             entry.ActorId == createdActorId);
+        historyStore.SavedConversations.Should().ContainSingle(entry =>
+            entry.ScopeId == "scope-a" &&
+            entry.ConversationId == createdActorId &&
+            entry.Meta.CreatedAt == createdAt.GetDateTimeOffset());
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_ShouldBubbleFailure_WhenActorRegistrationFails()
+    {
+        var actorStore = new StubGAgentActorStore
+        {
+            AddActorException = new InvalidOperationException("actor store unavailable"),
+        };
+        var historyStore = new StubChatHistoryStore();
+
+        var act = async () => await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            actorStore,
+            historyStore,
+            CancellationToken.None);
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Message.Should().Be("actor store unavailable");
     }
 
     [Fact]
     public async Task HandleListConversationsAsync_ShouldReturnList()
     {
-        var store = new StubGAgentActorStore
+        var actorStore = new StubGAgentActorStore
         {
             GroupsToReturn =
             [
@@ -84,12 +114,27 @@ public class NyxIdChatEndpointsCoverageTests
                 new GAgentActorGroup("other-agent", ["actor-2"]),
             ],
         };
-
+        var historyStore = new StubChatHistoryStore
+        {
+            IndexToReturn = new ChatHistoryIndex(
+            [
+                new ConversationMeta(
+                    Id: "actor-1",
+                    Title: NyxIdChatServiceDefaults.DisplayName,
+                    ServiceId: NyxIdChatServiceDefaults.ServiceId,
+                    ServiceKind: "chat",
+                    CreatedAt: DateTimeOffset.Parse("2026-04-16T10:20:30Z"),
+                    UpdatedAt: DateTimeOffset.Parse("2026-04-16T10:20:30Z"),
+                    MessageCount: 0),
+            ]),
+        };
         var result = await InvokeResultAsync(
             "HandleListConversationsAsync",
             new DefaultHttpContext(),
             "scope-a",
-            store,
+            actorStore,
+            historyStore,
+            NullLoggerFactory.Instance,
             CancellationToken.None);
 
         var response = await ExecuteResultAsync(result);
@@ -97,25 +142,34 @@ public class NyxIdChatEndpointsCoverageTests
         using var doc = JsonDocument.Parse(response.Body);
         doc.RootElement.GetArrayLength().Should().Be(1);
         doc.RootElement[0].GetProperty("actorId").GetString().Should().Be("actor-1");
+        doc.RootElement[0].GetProperty("createdAt").GetDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-04-16T10:20:30Z"));
+        actorStore.LastRequestedScopeId.Should().Be("scope-a");
     }
 
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldReturnOk_AndRemoveActor()
     {
-        var store = new StubGAgentActorStore();
+        var actorStore = new StubGAgentActorStore();
+        var historyStore = new StubChatHistoryStore();
         var result = await InvokeResultAsync(
             "HandleDeleteConversationAsync",
             new DefaultHttpContext(),
             "scope-a",
             "actor-1",
-            store,
+            actorStore,
+            historyStore,
             CancellationToken.None);
 
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        store.RemovedActors.Should().ContainSingle(entry =>
+        actorStore.RemovedActors.Should().ContainSingle(entry =>
+            entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
             entry.ActorId == "actor-1");
+        historyStore.DeletedConversations.Should().ContainSingle(entry =>
+            entry.ScopeId == "scope-a" &&
+            entry.ConversationId == "actor-1");
     }
 
     [Fact]
@@ -1043,18 +1097,42 @@ public class NyxIdChatEndpointsCoverageTests
     private sealed class StubGAgentActorStore : IGAgentActorStore
     {
         public IReadOnlyList<GAgentActorGroup> GroupsToReturn { get; init; } = [];
-        public List<(string GAgentType, string ActorId)> AddedActors { get; } = [];
-        public List<(string GAgentType, string ActorId)> RemovedActors { get; } = [];
+        public Exception? AddActorException { get; init; }
+        public List<(string ScopeId, string GAgentType, string ActorId)> AddedActors { get; } = [];
+        public List<(string ScopeId, string GAgentType, string ActorId)> RemovedActors { get; } = [];
+        public string? LastRequestedScopeId { get; private set; }
 
         public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult(GroupsToReturn);
+
+        public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(
+            string scopeId,
+            CancellationToken cancellationToken = default)
+        {
+            LastRequestedScopeId = scopeId;
+            return Task.FromResult(GroupsToReturn);
+        }
 
         public Task AddActorAsync(
             string gagentType,
             string actorId,
             CancellationToken cancellationToken = default)
         {
-            AddedActors.Add((gagentType, actorId));
+            if (AddActorException is not null)
+                throw AddActorException;
+            AddedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task AddActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            if (AddActorException is not null)
+                throw AddActorException;
+            AddedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
 
@@ -1063,7 +1141,58 @@ public class NyxIdChatEndpointsCoverageTests
             string actorId,
             CancellationToken cancellationToken = default)
         {
-            RemovedActors.Add((gagentType, actorId));
+            RemovedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            RemovedActors.Add((scopeId, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubChatHistoryStore : IChatHistoryStore
+    {
+        public ChatHistoryIndex IndexToReturn { get; init; } = new([]);
+        public List<(string ScopeId, string ConversationId, ConversationMeta Meta)> SavedConversations { get; } = [];
+        public List<(string ScopeId, string ConversationId)> DeletedConversations { get; } = [];
+
+        public Task<ChatHistoryIndex> GetIndexAsync(string scopeId, CancellationToken ct = default)
+        {
+            _ = scopeId;
+            return Task.FromResult(IndexToReturn);
+        }
+
+        public Task<IReadOnlyList<StoredChatMessage>> GetMessagesAsync(
+            string scopeId,
+            string conversationId,
+            CancellationToken ct = default)
+        {
+            _ = scopeId;
+            _ = conversationId;
+            return Task.FromResult<IReadOnlyList<StoredChatMessage>>([]);
+        }
+
+        public Task SaveMessagesAsync(
+            string scopeId,
+            string conversationId,
+            ConversationMeta meta,
+            IReadOnlyList<StoredChatMessage> messages,
+            CancellationToken ct = default)
+        {
+            _ = messages;
+            SavedConversations.Add((scopeId, conversationId, meta));
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteConversationAsync(string scopeId, string conversationId, CancellationToken ct = default)
+        {
+            DeletedConversations.Add((scopeId, conversationId));
             return Task.CompletedTask;
         }
     }

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -166,7 +166,32 @@ public class NyxIdChatEndpointsCoverageTests
 
         var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
         assertion.Which.Message.Should().Be("actor store unavailable");
-        historyStore.DeletedConversations.Should().BeEmpty();
+        historyStore.DeletedConversations.Should().ContainSingle(entry =>
+            entry.ScopeId == "scope-a" &&
+            entry.ConversationId == "actor-1");
+    }
+
+    [Fact]
+    public async Task HandleDeleteConversationAsync_ShouldNotRemoveActor_WhenHistoryDeleteFails()
+    {
+        var actorStore = new StubGAgentActorStore();
+        var historyStore = new StubChatHistoryStore
+        {
+            DeleteConversationException = new InvalidOperationException("history unavailable"),
+        };
+
+        var act = async () => await InvokeResultAsync(
+            "HandleDeleteConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            "actor-1",
+            actorStore,
+            historyStore,
+            CancellationToken.None);
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Message.Should().Be("history unavailable");
+        actorStore.RemovedActors.Should().BeEmpty();
     }
 
     [Fact]
@@ -629,6 +654,45 @@ public class NyxIdChatEndpointsCoverageTests
         response.Body.Should().Contain("Route: gateway");
         response.Body.Should().Contain("Token: present");
         response.Body.Should().Contain("Scope: scope-b");
+    }
+
+    [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldBubbleFailure_WhenActorRegistrationFails()
+    {
+        var payload = """
+            {
+              "message_id":"msg-3",
+              "platform":"slack",
+              "agent":{"api_key_id":"scope-c"},
+              "conversation":{"platform_id":"room-3"},
+              "content":{"text":"hello"}
+            }
+            """;
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Headers["X-NyxID-User-Token"] = "not-a-jwt";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+        var act = async () => await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            new StubActorRuntime(),
+            new StubSubscriptionProvider(),
+            new StubGAgentActorStore
+            {
+                AddActorException = new InvalidOperationException("actor store unavailable"),
+            },
+            new NyxIdRelayOptions(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Message.Should().Be("actor store unavailable");
     }
 
     [Fact]
@@ -1164,6 +1228,7 @@ public class NyxIdChatEndpointsCoverageTests
         public List<(string ScopeId, string ConversationId, ConversationMeta Meta)> SavedConversations { get; } = [];
         public List<(string ScopeId, string ConversationId)> DeletedConversations { get; } = [];
         public Exception? SaveMessagesException { get; init; }
+        public Exception? DeleteConversationException { get; init; }
 
         public Task<ChatHistoryIndex> GetIndexAsync(string scopeId, CancellationToken ct = default)
         {
@@ -1197,6 +1262,8 @@ public class NyxIdChatEndpointsCoverageTests
 
         public Task DeleteConversationAsync(string scopeId, string conversationId, CancellationToken ct = default)
         {
+            if (DeleteConversationException is not null)
+                throw DeleteConversationException;
             DeletedConversations.Add((scopeId, conversationId));
             return Task.CompletedTask;
         }

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -101,6 +101,7 @@ public class NyxIdChatEndpointsCoverageTests
 
         var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
         assertion.Which.Message.Should().Be("actor store unavailable");
+        historyStore.SavedConversations.Should().BeEmpty();
     }
 
     [Fact]
@@ -170,6 +171,29 @@ public class NyxIdChatEndpointsCoverageTests
         historyStore.DeletedConversations.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.ConversationId == "actor-1");
+    }
+
+    [Fact]
+    public async Task HandleDeleteConversationAsync_ShouldBubbleFailure_WhenActorRemovalFails()
+    {
+        var actorStore = new StubGAgentActorStore
+        {
+            RemoveActorException = new InvalidOperationException("actor store unavailable"),
+        };
+        var historyStore = new StubChatHistoryStore();
+
+        var act = async () => await InvokeResultAsync(
+            "HandleDeleteConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            "actor-1",
+            actorStore,
+            historyStore,
+            CancellationToken.None);
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.Which.Message.Should().Be("actor store unavailable");
+        historyStore.DeletedConversations.Should().BeEmpty();
     }
 
     [Fact]
@@ -1098,6 +1122,7 @@ public class NyxIdChatEndpointsCoverageTests
     {
         public IReadOnlyList<GAgentActorGroup> GroupsToReturn { get; init; } = [];
         public Exception? AddActorException { get; init; }
+        public Exception? RemoveActorException { get; init; }
         public List<(string ScopeId, string GAgentType, string ActorId)> AddedActors { get; } = [];
         public List<(string ScopeId, string GAgentType, string ActorId)> RemovedActors { get; } = [];
         public string? LastRequestedScopeId { get; private set; }
@@ -1141,6 +1166,8 @@ public class NyxIdChatEndpointsCoverageTests
             string actorId,
             CancellationToken cancellationToken = default)
         {
+            if (RemoveActorException is not null)
+                throw RemoveActorException;
             RemovedActors.Add((string.Empty, gagentType, actorId));
             return Task.CompletedTask;
         }
@@ -1151,6 +1178,8 @@ public class NyxIdChatEndpointsCoverageTests
             string actorId,
             CancellationToken cancellationToken = default)
         {
+            if (RemoveActorException is not null)
+                throw RemoveActorException;
             RemovedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -84,7 +84,9 @@ public class StreamingProxyCoverageTests
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         response.Body.Should().Contain("roomName");
-        actorStore.AddedActors.Should().ContainSingle(x => x.gagentType == StreamingProxyDefaults.GAgentTypeName);
+        actorStore.AddedActors.Should().ContainSingle(x =>
+            x.scopeId == "scope-a" &&
+            x.gagentType == StreamingProxyDefaults.GAgentTypeName);
         runtime.CreateCalls.Should().ContainSingle();
         runtime.CreateCalls[0].agentType.Should().Be(typeof(StreamingProxyGAgent));
     }
@@ -129,6 +131,7 @@ public class StreamingProxyCoverageTests
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         actorStore.RemovedActors.Should().ContainSingle(x =>
+            x.scopeId == "scope-a" &&
             x.gagentType == StreamingProxyDefaults.GAgentTypeName && x.actorId == "room-1");
         participantStore.RemovedRooms.Should().ContainSingle(x => x == "room-1");
     }
@@ -622,21 +625,46 @@ public class StreamingProxyCoverageTests
     private sealed class StubGAgentActorStore : IGAgentActorStore
     {
         public List<GAgentActorGroup> Groups { get; } = [];
-        public List<(string gagentType, string actorId)> AddedActors { get; } = [];
-        public List<(string gagentType, string actorId)> RemovedActors { get; } = [];
+        public List<(string scopeId, string gagentType, string actorId)> AddedActors { get; } = [];
+        public List<(string scopeId, string gagentType, string actorId)> RemovedActors { get; } = [];
 
         public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(CancellationToken cancellationToken = default)
             => Task.FromResult<IReadOnlyList<GAgentActorGroup>>(Groups.AsReadOnly());
 
+        public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(
+            string scopeId,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<GAgentActorGroup>>(Groups.AsReadOnly());
+
         public Task AddActorAsync(string gagentType, string actorId, CancellationToken cancellationToken = default)
         {
-            AddedActors.Add((gagentType, actorId));
+            AddedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task AddActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            AddedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
 
         public Task RemoveActorAsync(string gagentType, string actorId, CancellationToken cancellationToken = default)
         {
-            RemovedActors.Add((gagentType, actorId));
+            RemovedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            RemovedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
     }

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -264,10 +264,10 @@ public class StreamingProxyCoverageTests
                 BindingFlags.NonPublic | BindingFlags.Static)!;
         var methodCalls = new[]
         {
-            new EventEnvelope { Payload = Any.Pack(new GroupChatTopicEvent { Prompt = "topic", SessionId = "s1" }) },
-            new EventEnvelope { Payload = Any.Pack(new GroupChatMessageEvent { AgentId = "a1", AgentName = "A1", Content = "hi", SessionId = "s1" }) },
-            new EventEnvelope { Payload = Any.Pack(new GroupChatParticipantJoinedEvent { AgentId = "a1", DisplayName = "A1" }) },
-            new EventEnvelope { Payload = Any.Pack(new GroupChatParticipantLeftEvent { AgentId = "a1" }) },
+            CreateTopologyEnvelope(new GroupChatTopicEvent { Prompt = "topic", SessionId = "s1" }),
+            CreateTopologyEnvelope(new GroupChatMessageEvent { AgentId = "a1", AgentName = "A1", Content = "hi", SessionId = "s1" }),
+            CreateTopologyEnvelope(new GroupChatParticipantJoinedEvent { AgentId = "a1", DisplayName = "A1" }),
+            CreateTopologyEnvelope(new GroupChatParticipantLeftEvent { AgentId = "a1" }),
         };
 
         foreach (var envelope in methodCalls)
@@ -292,6 +292,47 @@ public class StreamingProxyCoverageTests
         body.Should().Contain("AGENT_MESSAGE");
         body.Should().Contain("PARTICIPANT_JOINED");
         body.Should().Contain("PARTICIPANT_LEFT");
+    }
+
+    [Fact]
+    public async Task MapAndWriteEventAsync_ShouldIgnoreDirectInboundEvents()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        var writer = AgentCoverageTestSupport.CreateNonPublicInstance(
+            typeof(StreamingProxyGAgent).Assembly,
+            "Aevatar.GAgents.StreamingProxy.StreamingProxySseWriter",
+            context.Response);
+
+        var method = typeof(StreamingProxyEndpoints).GetMethod(
+            "MapAndWriteEventAsync",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var result = method.Invoke(null, [new EventEnvelope
+        {
+            Payload = Any.Pack(new GroupChatMessageEvent
+            {
+                AgentId = "a1",
+                AgentName = "A1",
+                Content = "hi",
+                SessionId = "s1",
+            }),
+            Route = EnvelopeRouteSemantics.CreateDirect("api", "room-1"),
+        }, writer])!;
+
+        switch (result)
+        {
+            case ValueTask valueTask:
+                await valueTask;
+                break;
+            case Task task:
+                await task;
+                break;
+        }
+
+        context.Response.Body.Position = 0;
+        var body = new StreamReader(context.Response.Body).ReadToEnd();
+        body.Should().BeEmpty();
     }
 
     [Fact]
@@ -422,6 +463,15 @@ public class StreamingProxyCoverageTests
         AgentCoverageTestSupport.AssignActorId(agent, actorId);
         return agent;
     }
+
+    private static EventEnvelope CreateTopologyEnvelope(IMessage payload) =>
+        new()
+        {
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(
+                "streaming-proxy-room",
+                TopologyAudience.Parent),
+        };
 
     private static async Task<(int StatusCode, string Body)> ExecuteResultAsync(IResult result)
     {

--- a/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
@@ -43,6 +43,7 @@ public sealed class StreamingProxyEndpointsCoverageTests
 
         statusCode.Should().Be(StatusCodes.Status200OK);
         actorStore.AddedActors.Should().ContainSingle();
+        actorStore.AddedActors[0].ScopeId.Should().Be("scope-a");
         var registeredActorId = actorStore.AddedActors[0].ActorId;
         operations.Should().ContainInOrder(
             $"store:add:{registeredActorId}",
@@ -80,6 +81,7 @@ public sealed class StreamingProxyEndpointsCoverageTests
         statusCode.Should().Be(StatusCodes.Status500InternalServerError);
         actorStore.AddedActors.Should().ContainSingle();
         actorStore.RemovedActors.Should().ContainSingle();
+        actorStore.RemovedActors[0].ScopeId.Should().Be("scope-a");
         actorStore.RemovedActors[0].ActorId.Should().Be(actorStore.AddedActors[0].ActorId);
         runtime.DestroyedActorIds.Should().ContainSingle(actorStore.AddedActors[0].ActorId);
         operations.Should().ContainInOrder(
@@ -184,23 +186,50 @@ public sealed class StreamingProxyEndpointsCoverageTests
 
     private sealed class RecordingGAgentActorStore(List<string> operations) : IGAgentActorStore
     {
-        public List<(string GAgentType, string ActorId)> AddedActors { get; } = [];
-        public List<(string GAgentType, string ActorId)> RemovedActors { get; } = [];
+        public List<(string ScopeId, string GAgentType, string ActorId)> AddedActors { get; } = [];
+        public List<(string ScopeId, string GAgentType, string ActorId)> RemovedActors { get; } = [];
 
         public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<GAgentActorGroup>>([]);
+
+        public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(
+            string scopeId,
+            CancellationToken cancellationToken = default) =>
             Task.FromResult<IReadOnlyList<GAgentActorGroup>>([]);
 
         public Task AddActorAsync(string gagentType, string actorId, CancellationToken cancellationToken = default)
         {
             operations.Add($"store:add:{actorId}");
-            AddedActors.Add((gagentType, actorId));
+            AddedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task AddActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            operations.Add($"store:add:{actorId}");
+            AddedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
 
         public Task RemoveActorAsync(string gagentType, string actorId, CancellationToken cancellationToken = default)
         {
             operations.Add($"store:remove:{actorId}");
-            RemovedActors.Add((gagentType, actorId));
+            RemovedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            operations.Add($"store:remove:{actorId}");
+            RemovedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
     }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
@@ -362,6 +362,7 @@ public sealed class ScopeGAgentEndpointsTests
 
         var listResult = await InvokeHandleListActorsAsync("scope-a", store, logger, CancellationToken.None);
         ((IStatusCodeHttpResult)listResult).StatusCode.Should().Be((int)HttpStatusCode.OK);
+        store.LastRequestedScopeId.Should().Be("scope-a");
 
         var addResult = await InvokeHandleAddActorAsync(
             "scope-a",
@@ -370,7 +371,10 @@ public sealed class ScopeGAgentEndpointsTests
             logger,
             CancellationToken.None);
         ((IStatusCodeHttpResult)addResult).StatusCode.Should().Be((int)HttpStatusCode.OK);
-        store.AddedActors.Should().ContainSingle(x => x.GAgentType == "gagent-a" && x.ActorId == "actor-3");
+        store.AddedActors.Should().ContainSingle(x =>
+            x.ScopeId == "scope-a" &&
+            x.GAgentType == "gagent-a" &&
+            x.ActorId == "actor-3");
 
         var removeResult = await InvokeHandleRemoveActorAsync(
             "scope-a",
@@ -380,6 +384,10 @@ public sealed class ScopeGAgentEndpointsTests
             logger,
             CancellationToken.None);
         ((IStatusCodeHttpResult)removeResult).StatusCode.Should().Be((int)HttpStatusCode.OK);
+        store.RemovedActors.Should().ContainSingle(x =>
+            x.ScopeId == "scope-a" &&
+            x.GAgentType == "gagent-a" &&
+            x.ActorId == "actor-1");
 
         var invalidAdd = await InvokeHandleAddActorAsync(
             "scope-a",
@@ -618,14 +626,25 @@ public sealed class ScopeGAgentEndpointsTests
     private sealed class RecordingGAgentActorStore : IGAgentActorStore
     {
         public List<GAgentActorGroup> Actors { get; set; } = [];
-        public List<(string GAgentType, string ActorId)> AddedActors { get; } = [];
+        public List<(string ScopeId, string GAgentType, string ActorId)> AddedActors { get; } = [];
+        public List<(string ScopeId, string GAgentType, string ActorId)> RemovedActors { get; } = [];
         public Exception? ThrowOnGet { get; set; }
         public Exception? ThrowOnAdd { get; set; }
         public Exception? ThrowOnRemove { get; set; }
+        public string? LastRequestedScopeId { get; private set; }
 
         public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(CancellationToken cancellationToken = default)
         {
             if (ThrowOnGet != null) throw ThrowOnGet;
+            return Task.FromResult<IReadOnlyList<GAgentActorGroup>>(Actors);
+        }
+
+        public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(
+            string scopeId,
+            CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnGet != null) throw ThrowOnGet;
+            LastRequestedScopeId = scopeId;
             return Task.FromResult<IReadOnlyList<GAgentActorGroup>>(Actors);
         }
 
@@ -634,7 +653,20 @@ public sealed class ScopeGAgentEndpointsTests
             if (ThrowOnAdd != null)
                 throw ThrowOnAdd;
 
-            AddedActors.Add((gagentType, actorId));
+            AddedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task AddActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnAdd != null)
+                throw ThrowOnAdd;
+
+            AddedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
 
@@ -643,6 +675,20 @@ public sealed class ScopeGAgentEndpointsTests
             if (ThrowOnRemove != null)
                 throw ThrowOnRemove;
 
+            RemovedActors.Add((string.Empty, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            if (ThrowOnRemove != null)
+                throw ThrowOnRemove;
+
+            RemovedActors.Add((scopeId, gagentType, actorId));
             return Task.CompletedTask;
         }
     }

--- a/test/Aevatar.Hosting.Tests/MainnetBootScriptTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetBootScriptTests.cs
@@ -68,6 +68,41 @@ public sealed class MainnetBootScriptTests
         stdout.Should().Contain("==> Mode: distributed");
     }
 
+    [Fact]
+    public async Task BootScript_DistributedMode_ShouldRequireNeo4jPassword_ByDefault()
+    {
+        var repoRoot = FindRepoRoot();
+        var sourceDir = Path.Combine(repoRoot, "src", "Aevatar.Mainnet.Host.Api");
+
+        using var tempDir = new TemporaryDirectory();
+        var scriptPath = Path.Combine(tempDir.Path, "boot.sh");
+        var projectPath = Path.Combine(tempDir.Path, "Aevatar.Mainnet.Host.Api.csproj");
+        File.Copy(Path.Combine(sourceDir, "boot.sh"), scriptPath);
+        File.Copy(Path.Combine(sourceDir, "Aevatar.Mainnet.Host.Api.csproj"), projectPath);
+
+        using var process = Process.Start(CreateProcessStartInfo(
+            scriptPath,
+            tempDir.Path,
+            "distributed",
+            new Dictionary<string, string?>
+            {
+                ["AEVATAR_Projection__Graph__Providers__Neo4j__Enabled"] = null,
+            }));
+        process.Should().NotBeNull();
+
+        var stdoutTask = process!.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        process.ExitCode.Should().NotBe(0);
+        stderr.Should().Contain("Distributed mode with Neo4j enabled requires an explicit Neo4j password.");
+        stderr.Should().NotContain("Aevatar.Mainnet.Host.Api failed to start.");
+        stdout.Should().Contain("==> Mode: distributed");
+    }
+
     private static ProcessStartInfo CreateProcessStartInfo(
         string scriptPath,
         string workingDirectory,

--- a/test/Aevatar.Hosting.Tests/MainnetBootScriptTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetBootScriptTests.cs
@@ -33,7 +33,46 @@ public sealed class MainnetBootScriptTests
         stdout.Should().Contain("==> Starting Aevatar.Mainnet.Host.Api");
     }
 
-    private static ProcessStartInfo CreateProcessStartInfo(string scriptPath, string workingDirectory)
+    [Fact]
+    public async Task BootScript_DistributedMode_ShouldNotRequireNeo4jPassword_WhenNeo4jDisabled()
+    {
+        var repoRoot = FindRepoRoot();
+        var sourceDir = Path.Combine(repoRoot, "src", "Aevatar.Mainnet.Host.Api");
+
+        using var tempDir = new TemporaryDirectory();
+        var scriptPath = Path.Combine(tempDir.Path, "boot.sh");
+        var projectPath = Path.Combine(tempDir.Path, "Aevatar.Mainnet.Host.Api.csproj");
+        File.Copy(Path.Combine(sourceDir, "boot.sh"), scriptPath);
+        File.Copy(Path.Combine(sourceDir, "Aevatar.Mainnet.Host.Api.csproj"), projectPath);
+
+        using var process = Process.Start(CreateProcessStartInfo(
+            scriptPath,
+            tempDir.Path,
+            "distributed",
+            new Dictionary<string, string?>
+            {
+                ["AEVATAR_Projection__Graph__Providers__Neo4j__Enabled"] = "false",
+            }));
+        process.Should().NotBeNull();
+
+        var stdoutTask = process!.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        process.ExitCode.Should().NotBe(0);
+        stderr.Should().NotContain("Distributed mode with Neo4j enabled requires an explicit Neo4j password.");
+        stderr.Should().Contain("Aevatar.Mainnet.Host.Api failed to start.");
+        stdout.Should().Contain("==> Mode: distributed");
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(
+        string scriptPath,
+        string workingDirectory,
+        string mode = "local",
+        IReadOnlyDictionary<string, string?>? overrides = null)
     {
         var startInfo = new ProcessStartInfo("/bin/bash")
         {
@@ -44,7 +83,7 @@ public sealed class MainnetBootScriptTests
 
         startInfo.ArgumentList.Add(scriptPath);
         startInfo.ArgumentList.Add("--mode");
-        startInfo.ArgumentList.Add("local");
+        startInfo.ArgumentList.Add(mode);
         startInfo.ArgumentList.Add("--port");
         startInfo.ArgumentList.Add("5187");
 
@@ -53,6 +92,17 @@ public sealed class MainnetBootScriptTests
         startInfo.Environment["AEVATAR_Projection__Graph__Providers__Neo4j__Enabled"] = "true";
         startInfo.Environment.Remove("AEVATAR_Projection__Graph__Providers__Neo4j__Password");
         startInfo.Environment.Remove("NEO4J_PASSWORD");
+
+        if (overrides is not null)
+        {
+            foreach (var entry in overrides)
+            {
+                if (entry.Value is null)
+                    startInfo.Environment.Remove(entry.Key);
+                else
+                    startInfo.Environment[entry.Key] = entry.Value;
+            }
+        }
 
         return startInfo;
     }

--- a/test/Aevatar.Hosting.Tests/MainnetBootScriptTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetBootScriptTests.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics;
+using FluentAssertions;
+
+namespace Aevatar.Hosting.Tests;
+
+public sealed class MainnetBootScriptTests
+{
+    [Fact]
+    public async Task BootScript_LocalMode_ShouldNotRequireNeo4jPasswordFromInheritedDistributedEnv()
+    {
+        var repoRoot = FindRepoRoot();
+        var sourceDir = Path.Combine(repoRoot, "src", "Aevatar.Mainnet.Host.Api");
+
+        using var tempDir = new TemporaryDirectory();
+        var scriptPath = Path.Combine(tempDir.Path, "boot.sh");
+        var projectPath = Path.Combine(tempDir.Path, "Aevatar.Mainnet.Host.Api.csproj");
+        File.Copy(Path.Combine(sourceDir, "boot.sh"), scriptPath);
+        File.Copy(Path.Combine(sourceDir, "Aevatar.Mainnet.Host.Api.csproj"), projectPath);
+
+        using var process = Process.Start(CreateProcessStartInfo(scriptPath, tempDir.Path));
+        process.Should().NotBeNull();
+
+        var stdoutTask = process!.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        process.ExitCode.Should().NotBe(0);
+        stderr.Should().NotContain("Distributed mode with Neo4j enabled requires an explicit Neo4j password.");
+        stderr.Should().Contain("Aevatar.Mainnet.Host.Api failed to start.");
+        stdout.Should().Contain("==> Starting Aevatar.Mainnet.Host.Api");
+    }
+
+    private static ProcessStartInfo CreateProcessStartInfo(string scriptPath, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo("/bin/bash")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add("--mode");
+        startInfo.ArgumentList.Add("local");
+        startInfo.ArgumentList.Add("--port");
+        startInfo.ArgumentList.Add("5187");
+
+        startInfo.Environment["DOTNET_CMD"] = "/usr/bin/false";
+        startInfo.Environment["ASPNETCORE_ENVIRONMENT"] = "Distributed";
+        startInfo.Environment["AEVATAR_Projection__Graph__Providers__Neo4j__Enabled"] = "true";
+        startInfo.Environment.Remove("AEVATAR_Projection__Graph__Providers__Neo4j__Password");
+        startInfo.Environment.Remove("NEO4J_PASSWORD");
+
+        return startInfo;
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "aevatar.slnx")))
+                return current.FullName;
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test output directory.");
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"aevatar-mainnet-boot-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/test/Aevatar.Hosting.Tests/MainnetHealthEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetHealthEndpointsTests.cs
@@ -21,6 +21,20 @@ public sealed class MainnetHealthEndpointsTests
     public async Task MainnetHost_ShouldExposeHealthEndpoints_AndDocumentThemInOpenApi()
     {
         using var home = new TemporaryAevatarHomeScope();
+        using var documentProvider = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Document__Providers__InMemory__Enabled", "true");
+        using var documentElasticsearch = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Document__Providers__Elasticsearch__Enabled", "false");
+        using var graphProvider = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Graph__Providers__InMemory__Enabled", "true");
+        using var graphNeo4j = new EnvironmentVariableScope(
+            "AEVATAR_Projection__Graph__Providers__Neo4j__Enabled", "false");
+        using var projectionEnvironment = new EnvironmentVariableScope(
+            "Projection__Policies__Environment", "Development");
+        using var denyInMemoryDocument = new EnvironmentVariableScope(
+            "Projection__Policies__DenyInMemoryDocumentReadStore", "false");
+        using var denyInMemoryGraph = new EnvironmentVariableScope(
+            "Projection__Policies__DenyInMemoryGraphFactStore", "false");
         var builder = CreateBuilder();
         builder.WebHost.UseTestServer();
 
@@ -133,6 +147,24 @@ public sealed class MainnetHealthEndpointsTests
             Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, _previous);
             if (Directory.Exists(_path))
                 Directory.Delete(_path, recursive: true);
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _previous;
+
+        public EnvironmentVariableScope(string name, string value)
+        {
+            _name = name;
+            _previous = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _previous);
         }
     }
 }

--- a/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
@@ -401,6 +401,22 @@ public sealed class ActorBackedStoreAdapterTests
     }
 
     [Fact]
+    public async Task GAgentActorStore_AddActorAsync_WithExplicitScope_UsesRouteScope()
+    {
+        var runtime = new FakeActorRuntime();
+        var scopeResolver = new FakeScopeResolver { ScopeIdToReturn = "ambient-scope" };
+        var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
+
+        var store = new ActorBackedGAgentActorStore(
+            runtime, scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+
+        await store.AddActorAsync("route-scope", "MyGAgent", "actor-789");
+
+        runtime.Actors.Should().ContainKey("gagent-registry-route-scope");
+        runtime.Actors.Should().NotContainKey("gagent-registry-ambient-scope");
+    }
+
+    [Fact]
     public async Task GAgentActorStore_RemoveActorAsync_SendsActorUnregisteredEvent()
     {
         var runtime = new FakeActorRuntime();

--- a/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
@@ -408,7 +408,11 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            runtime, scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime),
+            new FakeActorDispatchPort(runtime),
+            scopeResolver,
+            EmptyReader<GAgentRegistryCurrentStateDocument>(),
+            logger);
 
         await store.AddActorAsync("route-scope", "MyGAgent", "actor-789");
 
@@ -639,7 +643,6 @@ public sealed class ActorBackedStoreAdapterTests
             StateRoot = Any.Pack(state),
         });
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
-        var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), reader, logger);
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), reader, logger);
 
         var participants = await store.ListAsync("room-1");

--- a/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
@@ -337,7 +337,7 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
 
         var groups = await store.GetAsync();
 
@@ -363,7 +363,7 @@ public sealed class ActorBackedStoreAdapterTests
         });
         var scopeResolver = new FakeScopeResolver { ScopeIdToReturn = "scope-1" };
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
-        var store = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, reader, logger);
+        var store = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), reader, logger);
 
         var groups = await store.GetAsync();
 
@@ -384,7 +384,7 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
 
         await store.AddActorAsync("MyGAgent", "actor-123");
 
@@ -411,7 +411,7 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
 
         await store.RemoveActorAsync("MyGAgent", "actor-456");
 
@@ -548,7 +548,11 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
+<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+=======
+        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+>>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         await store.AddAsync("room-1", "agent-abc", "Alice");
 
@@ -566,7 +570,11 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
+<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+=======
+        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+>>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         await store.RemoveRoomAsync("room-1");
 
@@ -581,7 +589,11 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
+<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+=======
+        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+>>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         await store.RemoveParticipantAsync("room-1", "agent-abc");
 
@@ -597,7 +609,11 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
+<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+=======
+        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
+>>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         var participants = await store.ListAsync("room-1");
 
@@ -626,7 +642,11 @@ public sealed class ActorBackedStoreAdapterTests
             StateRoot = Any.Pack(state),
         });
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
+<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), reader, logger);
+=======
+        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), reader, logger);
+>>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         var participants = await store.ListAsync("room-1");
 
@@ -1579,11 +1599,19 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var scopeA = new FakeScopeResolver { ScopeIdToReturn = "scope-a" };
+<<<<<<< HEAD
         var storeA = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeA, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
         await storeA.AddActorAsync("MyAgent", "actor-1");
 
         var scopeB = new FakeScopeResolver { ScopeIdToReturn = "scope-b" };
         var storeB = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeB, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+=======
+        var storeA = new ActorBackedGAgentActorStore(runtime, scopeA, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+        await storeA.AddActorAsync("MyAgent", "actor-1");
+
+        var scopeB = new FakeScopeResolver { ScopeIdToReturn = "scope-b" };
+        var storeB = new ActorBackedGAgentActorStore(runtime, scopeB, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+>>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
         await storeB.AddActorAsync("MyAgent", "actor-2");
 
         runtime.Actors.Should().ContainKey("gagent-registry-scope-a");
@@ -1658,6 +1686,25 @@ public sealed class ActorBackedStoreAdapterTests
         {
             RoleDraftDeleted = true;
             return Task.CompletedTask;
+        }
+    }
+
+    private static StudioCurrentStateProjectionPort CreateProjectionPort() =>
+        new(new NoOpProjectionScopeActivationService());
+
+    private sealed class NoOpProjectionScopeActivationService
+        : IProjectionScopeActivationService<StudioMaterializationRuntimeLease>
+    {
+        public Task<StudioMaterializationRuntimeLease> EnsureAsync(
+            ProjectionScopeStartRequest request,
+            CancellationToken ct = default)
+        {
+            var context = new StudioMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+            };
+            return Task.FromResult(new StudioMaterializationRuntimeLease(context));
         }
     }
 }

--- a/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
@@ -1,6 +1,4 @@
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.CQRS.Projection.Core.Abstractions;
-using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.ChatHistory;
@@ -12,7 +10,6 @@ using Aevatar.GAgents.UserConfig;
 using Aevatar.GAgents.UserMemory;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Infrastructure.ActorBacked;
-using Aevatar.Studio.Projection.Orchestration;
 using Aevatar.Studio.Projection.ReadModels;
 using FluentAssertions;
 using Google.Protobuf;
@@ -337,7 +334,7 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
 
         var groups = await store.GetAsync();
 
@@ -363,7 +360,7 @@ public sealed class ActorBackedStoreAdapterTests
         });
         var scopeResolver = new FakeScopeResolver { ScopeIdToReturn = "scope-1" };
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
-        var store = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), reader, logger);
+        var store = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, reader, logger);
 
         var groups = await store.GetAsync();
 
@@ -384,7 +381,7 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
 
         await store.AddActorAsync("MyGAgent", "actor-123");
 
@@ -411,7 +408,7 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var store = new ActorBackedGAgentActorStore(
-            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
+            new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeResolver, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
 
         await store.RemoveActorAsync("MyGAgent", "actor-456");
 
@@ -548,11 +545,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
-<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
-=======
-        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
->>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         await store.AddAsync("room-1", "agent-abc", "Alice");
 
@@ -570,11 +563,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
-<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
-=======
-        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
->>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         await store.RemoveRoomAsync("room-1");
 
@@ -589,11 +578,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
-<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
-=======
-        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
->>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         await store.RemoveParticipantAsync("room-1", "agent-abc");
 
@@ -609,11 +594,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
-<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
-=======
-        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), EmptyReader<StreamingProxyParticipantCurrentStateDocument>(), logger);
->>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
 
         var participants = await store.ListAsync("room-1");
 
@@ -642,11 +623,8 @@ public sealed class ActorBackedStoreAdapterTests
             StateRoot = Any.Pack(state),
         });
         var logger = NullLogger<ActorBackedStreamingProxyParticipantStore>.Instance;
-<<<<<<< HEAD
         var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), reader, logger);
-=======
-        var store = new ActorBackedStreamingProxyParticipantStore(runtime, CreateProjectionPort(), reader, logger);
->>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
+        var store = new ActorBackedStreamingProxyParticipantStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), reader, logger);
 
         var participants = await store.ListAsync("room-1");
 
@@ -1599,19 +1577,11 @@ public sealed class ActorBackedStoreAdapterTests
         var logger = NullLogger<ActorBackedGAgentActorStore>.Instance;
 
         var scopeA = new FakeScopeResolver { ScopeIdToReturn = "scope-a" };
-<<<<<<< HEAD
         var storeA = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeA, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
         await storeA.AddActorAsync("MyAgent", "actor-1");
 
         var scopeB = new FakeScopeResolver { ScopeIdToReturn = "scope-b" };
         var storeB = new ActorBackedGAgentActorStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), scopeB, EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
-=======
-        var storeA = new ActorBackedGAgentActorStore(runtime, scopeA, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
-        await storeA.AddActorAsync("MyAgent", "actor-1");
-
-        var scopeB = new FakeScopeResolver { ScopeIdToReturn = "scope-b" };
-        var storeB = new ActorBackedGAgentActorStore(runtime, scopeB, CreateProjectionPort(), EmptyReader<GAgentRegistryCurrentStateDocument>(), logger);
->>>>>>> 778dad9b (Fix Studio actor-backed projection reads)
         await storeB.AddActorAsync("MyAgent", "actor-2");
 
         runtime.Actors.Should().ContainKey("gagent-registry-scope-a");
@@ -1689,22 +1659,4 @@ public sealed class ActorBackedStoreAdapterTests
         }
     }
 
-    private static StudioCurrentStateProjectionPort CreateProjectionPort() =>
-        new(new NoOpProjectionScopeActivationService());
-
-    private sealed class NoOpProjectionScopeActivationService
-        : IProjectionScopeActivationService<StudioMaterializationRuntimeLease>
-    {
-        public Task<StudioMaterializationRuntimeLease> EnsureAsync(
-            ProjectionScopeStartRequest request,
-            CancellationToken ct = default)
-        {
-            var context = new StudioMaterializationContext
-            {
-                RootActorId = request.RootActorId,
-                ProjectionKind = request.ProjectionKind,
-            };
-            return Task.FromResult(new StudioMaterializationRuntimeLease(context));
-        }
-    }
 }

--- a/test/Aevatar.Tools.Cli.Tests/UserConfigProjectionAndControllerTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/UserConfigProjectionAndControllerTests.cs
@@ -36,6 +36,7 @@ public sealed class UserConfigProjectionAndControllerTests
         services.AddSingleton<IActorDispatchPort>(dispatchPort);
         services.AddSingleton<IActorRuntime>(actorRuntime);
         services.AddSingleton<IAppScopeResolver>(scopeResolver);
+        services.AddSingleton<IUserConfigDefaults>(new StubUserConfigDefaults());
         services.AddSingleton<IProjectionDocumentReader<UserConfigCurrentStateDocument, string>>(
             new StubUserConfigDocumentReader());
         services.AddStudioProjectionComponents();
@@ -164,7 +165,14 @@ public sealed class UserConfigProjectionAndControllerTests
     {
         var reader = new StubUserConfigDocumentReader();
         var scopeResolver = new StubScopeResolver();
-        var port = new ProjectionUserConfigQueryPort(reader, scopeResolver);
+        var port = new ProjectionUserConfigQueryPort(
+            reader,
+            scopeResolver,
+            new StubUserConfigDefaults
+            {
+                LocalRuntimeBaseUrl = "http://127.0.0.1:6100/",
+                RemoteRuntimeBaseUrl = "https://runtime.example.cn/",
+            });
 
         var result = await port.GetAsync();
 
@@ -172,8 +180,8 @@ public sealed class UserConfigProjectionAndControllerTests
         result.DefaultModel.Should().BeEmpty();
         result.PreferredLlmRoute.Should().Be(UserConfigLlmRouteDefaults.Gateway);
         result.RuntimeMode.Should().Be(UserConfigRuntimeDefaults.LocalMode);
-        result.LocalRuntimeBaseUrl.Should().Be(UserConfigRuntimeDefaults.LocalRuntimeBaseUrl);
-        result.RemoteRuntimeBaseUrl.Should().Be(UserConfigRuntimeDefaults.RemoteRuntimeBaseUrl);
+        result.LocalRuntimeBaseUrl.Should().Be("http://127.0.0.1:6100");
+        result.RemoteRuntimeBaseUrl.Should().Be("https://runtime.example.cn");
         result.MaxToolRounds.Should().Be(0);
     }
 
@@ -195,7 +203,14 @@ public sealed class UserConfigProjectionAndControllerTests
             },
         };
         var scopeResolver = new StubScopeResolver { ScopeIdToReturn = "scope-2" };
-        var port = new ProjectionUserConfigQueryPort(reader, scopeResolver);
+        var port = new ProjectionUserConfigQueryPort(
+            reader,
+            scopeResolver,
+            new StubUserConfigDefaults
+            {
+                LocalRuntimeBaseUrl = "http://127.0.0.1:6200/",
+                RemoteRuntimeBaseUrl = "https://runtime.example.net/",
+            });
 
         var result = await port.GetAsync();
 
@@ -203,8 +218,8 @@ public sealed class UserConfigProjectionAndControllerTests
         result.DefaultModel.Should().Be("gpt-4.1");
         result.PreferredLlmRoute.Should().Be(UserConfigLlmRouteDefaults.Gateway);
         result.RuntimeMode.Should().Be(UserConfigRuntimeDefaults.LocalMode);
-        result.LocalRuntimeBaseUrl.Should().Be(UserConfigRuntimeDefaults.LocalRuntimeBaseUrl);
-        result.RemoteRuntimeBaseUrl.Should().Be(UserConfigRuntimeDefaults.RemoteRuntimeBaseUrl);
+        result.LocalRuntimeBaseUrl.Should().Be("http://127.0.0.1:6200");
+        result.RemoteRuntimeBaseUrl.Should().Be("https://runtime.example.net");
         result.MaxToolRounds.Should().Be(7);
     }
 
@@ -453,6 +468,13 @@ public sealed class UserConfigProjectionAndControllerTests
 
         public AppScopeContext? Resolve(HttpContext? httpContext = null) =>
             ScopeIdToReturn is null ? null : new AppScopeContext(ScopeIdToReturn, "test");
+    }
+
+    private sealed class StubUserConfigDefaults : IUserConfigDefaults
+    {
+        public string LocalRuntimeBaseUrl { get; init; } = UserConfigRuntimeDefaults.LocalRuntimeBaseUrl;
+
+        public string RemoteRuntimeBaseUrl { get; init; } = UserConfigRuntimeDefaults.RemoteRuntimeBaseUrl;
     }
 
     private sealed class RecordingActorDispatchPort : IActorDispatchPort

--- a/tools/Aevatar.Tools.Cli/Frontend/src/api.ts
+++ b/tools/Aevatar.Tools.Cli/Frontend/src/api.ts
@@ -681,10 +681,10 @@ export const runtime = scope;
 /* ─── NyxID Chat APIs (runtime) ─── */
 export const nyxidChat = {
   createConversation: (scopeId: string) =>
-    request<{ actorId: string; createdAt: string }>(`/scopes/${enc(scopeId)}/nyxid-chat/conversations`, { method: 'POST' }),
+    request<{ actorId: string }>(`/scopes/${enc(scopeId)}/nyxid-chat/conversations`, { method: 'POST' }),
 
   listConversations: (scopeId: string) =>
-    request<Array<{ actorId: string; createdAt: string }>>(`/scopes/${enc(scopeId)}/nyxid-chat/conversations`),
+    request<Array<{ actorId: string }>>(`/scopes/${enc(scopeId)}/nyxid-chat/conversations`),
 
   streamMessage: (
     scopeId: string,


### PR DESCRIPTION
## Summary

This PR folds the remaining ownership-v2 follow-up fixes onto latest `dev` and includes one extra boot-path fix discovered during distributed validation.

### What changed

- fix Studio actor-backed projection reads and scope-aware registry semantics
- fix Studio user-config / projection boundary wiring
- collapse duplicate Studio read-model provider registration into a single implementation
- prevent duplicate StreamingProxy SSE events
- require and correctly wire explicit Neo4j credentials for distributed boot
- fix `boot.sh` for macOS bash 3.2 / `set -u` empty-array handling

## Validation

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter "NyxIdChatEndpointsCoverageTests|StreamingProxyCoverageTests|StreamingProxyEndpointsCoverageTests" --nologo`
- `dotnet test test/Aevatar.Tools.Cli.Tests/Aevatar.Tools.Cli.Tests.csproj --filter "ActorBackedStoreAdapterTests|UserConfigProjectionAndControllerTests" --nologo`
- validated StreamingProxy endpoints in `Distributed` mode:
  - room create/list
  - participant join/list
  - post message
  - `messages:stream`
  - `:chat`
- validated projection-backed participant visibility converges after a short delay and survives restart
- validated `bash src/Aevatar.Mainnet.Host.Api/boot.sh --mode distributed` no longer fails on empty-array expansion and now propagates Neo4j password env wiring

## Related Issues

Closes #233
Closes #234
Closes #235