### PR TITLE
feat(studio): add Delete Draft backend for workflow drafts

### DIFF
--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -261,15 +261,9 @@ public sealed class AppScopedWorkflowService
         var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
         var normalizedWorkflowId = NormalizeRequired(workflowId, nameof(workflowId));
 
-        try
+        if (_workflowStoragePort != null)
         {
-            if (_workflowStoragePort != null)
-            {
-                await _workflowStoragePort.DeleteWorkflowYamlAsync(normalizedWorkflowId, ct);
-            }
-        }
-        catch
-        {
+            await _workflowStoragePort.DeleteWorkflowYamlAsync(normalizedWorkflowId, ct);
         }
 
         DeletePersistedLayout(normalizedScopeId, normalizedWorkflowId);

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -253,6 +253,28 @@ public sealed class AppScopedWorkflowService
             parsed);
     }
 
+    public async Task DeleteDraftAsync(
+        string scopeId,
+        string workflowId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
+        var normalizedWorkflowId = NormalizeRequired(workflowId, nameof(workflowId));
+
+        try
+        {
+            if (_workflowStoragePort != null)
+            {
+                await _workflowStoragePort.DeleteWorkflowYamlAsync(normalizedWorkflowId, ct);
+            }
+        }
+        catch
+        {
+        }
+
+        DeletePersistedLayout(normalizedScopeId, normalizedWorkflowId);
+    }
+
     private string AlignWorkflowYamlName(string yaml, string workflowName)
     {
         if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
@@ -601,6 +623,13 @@ public sealed class AppScopedWorkflowService
 
         var json = JsonSerializer.Serialize(layout, JsonOptions);
         File.WriteAllText(path, json);
+    }
+
+    private static void DeletePersistedLayout(string scopeId, string workflowId)
+    {
+        var path = BuildLayoutCachePath(scopeId, workflowId);
+        if (File.Exists(path))
+            File.Delete(path);
     }
 
     private static string BuildLayoutCachePath(string scopeId, string workflowId) =>

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioWorkspaceStore.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioWorkspaceStore.cs
@@ -14,6 +14,8 @@ public interface IStudioWorkspaceStore
 
     Task<StoredWorkflowFile> SaveWorkflowFileAsync(StoredWorkflowFile workflowFile, CancellationToken cancellationToken = default);
 
+    Task DeleteWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken cancellationToken = default);
 
     Task<StoredExecutionRecord?> GetExecutionAsync(string executionId, CancellationToken cancellationToken = default);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkflowStoragePort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IWorkflowStoragePort.cs
@@ -10,6 +10,8 @@ public interface IWorkflowStoragePort
     Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct);
 
     Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct);
+
+    Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct);
 }
 
 public sealed record StoredWorkflowYaml(

--- a/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
@@ -149,6 +149,28 @@ public sealed class WorkspaceService
         return ToWorkflowFileResponse(stored);
     }
 
+    public async Task DeleteDraftAsync(string workflowId, CancellationToken cancellationToken = default)
+    {
+        var normalizedWorkflowId = NormalizeRequired(workflowId, nameof(workflowId));
+        string filePath;
+
+        try
+        {
+            filePath = DecodeStableId(normalizedWorkflowId);
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidOperationException($"{nameof(workflowId)} is invalid.", exception);
+        }
+
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new InvalidOperationException($"{nameof(workflowId)} is invalid.");
+        }
+
+        await _store.DeleteWorkflowFileAsync(CreateStableId(filePath), cancellationToken);
+    }
+
     private string AlignWorkflowYamlName(string yaml, string workflowName)
     {
         if (string.IsNullOrWhiteSpace(yaml) || string.IsNullOrWhiteSpace(workflowName))
@@ -242,6 +264,17 @@ public sealed class WorkspaceService
         }
 
         return Path.GetFullPath(Environment.ExpandEnvironmentVariables(path));
+    }
+
+    private static string NormalizeRequired(string value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+        {
+            throw new InvalidOperationException($"{fieldName} is required.");
+        }
+
+        return normalized;
     }
 
     private static string EnsureYamlExtension(string fileName)

--- a/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
@@ -168,7 +168,43 @@ public sealed class WorkspaceService
             throw new InvalidOperationException($"{nameof(workflowId)} is invalid.");
         }
 
+        var settings = await _store.GetSettingsAsync(cancellationToken);
+        if (!IsInsideRegisteredDirectory(filePath, settings.Directories))
+        {
+            throw new InvalidOperationException($"{nameof(workflowId)} does not point to a registered workspace directory.");
+        }
+
         await _store.DeleteWorkflowFileAsync(CreateStableId(filePath), cancellationToken);
+    }
+
+    private static bool IsInsideRegisteredDirectory(
+        string filePath,
+        IReadOnlyList<StudioWorkspaceDirectory> directories)
+    {
+        string fullFile;
+        try
+        {
+            fullFile = Path.GetFullPath(filePath);
+        }
+        catch (Exception exception) when (exception is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            return false;
+        }
+
+        foreach (var directory in directories)
+        {
+            if (string.IsNullOrWhiteSpace(directory.Path))
+                continue;
+
+            var fullDir = directory.Path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (fullDir.Length == 0)
+                continue;
+
+            if (fullFile.StartsWith(fullDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 
     private string AlignWorkflowYamlName(string yaml, string workflowName)

--- a/src/Aevatar.Studio.Hosting/Controllers/WorkspaceController.cs
+++ b/src/Aevatar.Studio.Hosting/Controllers/WorkspaceController.cs
@@ -147,4 +147,31 @@ public sealed class WorkspaceController : ControllerBase
 
         return Ok(await _workspaceService.SaveWorkflowAsync(request, cancellationToken));
     }
+
+    [HttpDelete("workflows/{workflowId}")]
+    public async Task<IActionResult> DeleteWorkflow(string workflowId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var scopeContext = _scopeResolver.Resolve(HttpContext);
+            if (scopeContext != null)
+            {
+                await _scopeWorkflowService.DeleteDraftAsync(scopeContext.ScopeId, workflowId, cancellationToken);
+            }
+            else
+            {
+                await _workspaceService.DeleteDraftAsync(workflowId, cancellationToken);
+            }
+
+            return NoContent();
+        }
+        catch (AppApiException exception)
+        {
+            return StatusCode(exception.StatusCode, AppApiErrors.CreatePayload(exception));
+        }
+        catch (InvalidOperationException exception)
+        {
+            return BadRequest(new { message = exception.Message });
+        }
+    }
 }

--- a/src/Aevatar.Studio.Infrastructure/Storage/ChronoStorageWorkflowStoragePort.cs
+++ b/src/Aevatar.Studio.Infrastructure/Storage/ChronoStorageWorkflowStoragePort.cs
@@ -76,6 +76,19 @@ internal sealed class ChronoStorageWorkflowStoragePort : IWorkflowStoragePort
             UpdatedAtUtc: null);
     }
 
+    public async Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct)
+    {
+        var normalizedWorkflowId = workflowId?.Trim() ?? string.Empty;
+        if (normalizedWorkflowId.Length == 0)
+            return;
+
+        var context = _blobClient.TryResolveContext(string.Empty, $"{WorkflowDirectory}/{normalizedWorkflowId}.yaml");
+        if (context == null)
+            return;
+
+        await _blobClient.DeleteIfExistsAsync(context, ct);
+    }
+
     private ChronoStorageCatalogBlobClient.RemoteScopeContext? ResolveWorkflowDirectoryContext() =>
         _blobClient.TryResolveContext(string.Empty, $"{WorkflowDirectory}/.index");
 

--- a/src/Aevatar.Studio.Infrastructure/Storage/FileStudioWorkspaceStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/Storage/FileStudioWorkspaceStore.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Services;
 using Aevatar.Studio.Domain.Studio.Models;
 using Microsoft.Extensions.Options;
 
@@ -167,6 +168,25 @@ public sealed class FileStudioWorkspaceStore : IStudioWorkspaceStore
             Layout = workflowFile.Layout ?? await ReadJsonAsync<WorkflowLayoutDocument>(GetLayoutFilePath(workflowFile.FilePath), cancellationToken),
             UpdatedAtUtc = new DateTimeOffset(updatedAtUtc, TimeSpan.Zero),
         };
+    }
+
+    public Task DeleteWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default)
+    {
+        _ = cancellationToken;
+
+        var filePath = WorkspaceService.DecodeStableId(workflowId);
+        if (File.Exists(filePath))
+        {
+            File.Delete(filePath);
+        }
+
+        var layoutFilePath = GetLayoutFilePath(filePath);
+        if (File.Exists(layoutFilePath))
+        {
+            File.Delete(layoutFilePath);
+        }
+
+        return Task.CompletedTask;
     }
 
     public async Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken cancellationToken = default)

--- a/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj
+++ b/test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -18,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Aevatar.Studio.Domain/Aevatar.Studio.Domain.csproj" />
     <ProjectReference Include="../../src/Aevatar.Studio.Application/Aevatar.Studio.Application.csproj" />
+    <ProjectReference Include="../../src/Aevatar.Studio.Infrastructure/Aevatar.Studio.Infrastructure.csproj" />
     <ProjectReference Include="../../src/platform/Aevatar.GAgentService.Hosting/Aevatar.GAgentService.Hosting.csproj" />
     <ProjectReference Include="../../src/Aevatar.Authentication.Providers.NyxId/Aevatar.Authentication.Providers.NyxId.csproj" />
   </ItemGroup>

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -72,6 +72,38 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         File.Exists(layoutPath).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task DeleteDraftAsync_WhenStoragePortThrows_ShouldPropagateAndLeaveLayoutIntact()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var storagePort = new ThrowingWorkflowStoragePort(
+            new InvalidOperationException("chrono-storage is unavailable"));
+        var service = environment.CreateService(workflowStoragePort: storagePort);
+        var layoutPath = environment.BuildLayoutPath("scope-1", "workflow-1");
+        Directory.CreateDirectory(Path.GetDirectoryName(layoutPath)!);
+        await File.WriteAllTextAsync(layoutPath, "{}");
+
+        var act = () => service.DeleteDraftAsync("scope-1", "workflow-1");
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("chrono-storage is unavailable");
+        File.Exists(layoutPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_WhenCancelled_ShouldPropagateOperationCanceledException()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var storagePort = new ThrowingWorkflowStoragePort(new OperationCanceledException(cts.Token));
+        var service = environment.CreateService(workflowStoragePort: storagePort);
+
+        var act = () => service.DeleteDraftAsync("scope-1", "workflow-1", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
     private sealed class ScopedWorkflowEnvironment : IDisposable
     {
         private readonly string? _previousHome;
@@ -154,6 +186,28 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             DeletedWorkflowIds.Add(workflowId);
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class ThrowingWorkflowStoragePort : IWorkflowStoragePort
+    {
+        private readonly Exception _exception;
+
+        public ThrowingWorkflowStoragePort(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<StoredWorkflowYaml>>([]);
+
+        public Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromResult<StoredWorkflowYaml?>(null);
+
+        public Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromException(_exception);
     }
 
     private sealed class RuntimePortSpies

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -1,0 +1,300 @@
+using Aevatar.Configuration;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.Studio.Application;
+using Aevatar.Studio.Application.Studio;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class AppScopedWorkflowServiceDeleteDraftTests
+{
+    [Fact]
+    public async Task DeleteDraftAsync_ShouldCallWorkflowStorageDelete()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var storagePort = new RecordingWorkflowStoragePort();
+        var service = environment.CreateService(workflowStoragePort: storagePort);
+
+        await service.DeleteDraftAsync("scope-1", "workflow-1");
+
+        storagePort.DeletedWorkflowIds.Should().Equal("workflow-1");
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_ShouldNotCallRuntimePorts()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var runtimePorts = new RuntimePortSpies();
+        var service = environment.CreateService(
+            workflowQueryPort: runtimePorts.QueryPort,
+            workflowCommandPort: runtimePorts.CommandPort,
+            workflowActorBindingReader: runtimePorts.BindingReader,
+            artifactStore: runtimePorts.ArtifactStore,
+            serviceLifecycleQueryPort: runtimePorts.ServiceLifecycleQueryPort,
+            workflowStoragePort: new RecordingWorkflowStoragePort());
+
+        await service.DeleteDraftAsync("scope-1", "workflow-1");
+
+        runtimePorts.TotalInvocations.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_ShouldRemoveLocalLayoutSidecarWhenPresent()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var service = environment.CreateService(workflowStoragePort: new RecordingWorkflowStoragePort());
+        var layoutPath = environment.BuildLayoutPath("scope-1", "workflow-1");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(layoutPath)!);
+        await File.WriteAllTextAsync(layoutPath, "{}");
+        File.Exists(layoutPath).Should().BeTrue();
+
+        await service.DeleteDraftAsync("scope-1", "workflow-1");
+
+        File.Exists(layoutPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_WhenStoragePortAndLayoutAreMissing_ShouldSucceedSilently()
+    {
+        using var environment = new ScopedWorkflowEnvironment();
+        var service = environment.CreateService();
+        var layoutPath = environment.BuildLayoutPath("scope-1", "missing-workflow");
+
+        var act = () => service.DeleteDraftAsync("scope-1", "missing-workflow");
+
+        await act.Should().NotThrowAsync();
+        File.Exists(layoutPath).Should().BeFalse();
+    }
+
+    private sealed class ScopedWorkflowEnvironment : IDisposable
+    {
+        private readonly string? _previousHome;
+
+        public ScopedWorkflowEnvironment()
+        {
+            HomeDirectory = Path.Combine(Path.GetTempPath(), $"studio-scoped-delete-home-{Guid.NewGuid():N}");
+            _previousHome = Environment.GetEnvironmentVariable(AevatarPaths.HomeEnv);
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, HomeDirectory);
+        }
+
+        public string HomeDirectory { get; }
+
+        public AppScopedWorkflowService CreateService(
+            IScopeWorkflowQueryPort? workflowQueryPort = null,
+            IScopeWorkflowCommandPort? workflowCommandPort = null,
+            IWorkflowActorBindingReader? workflowActorBindingReader = null,
+            IServiceRevisionArtifactStore? artifactStore = null,
+            IServiceLifecycleQueryPort? serviceLifecycleQueryPort = null,
+            IWorkflowStoragePort? workflowStoragePort = null)
+        {
+            return new AppScopedWorkflowService(
+                new StubHttpClientFactory(),
+                new StubWorkflowYamlDocumentService(),
+                workflowQueryPort,
+                workflowCommandPort,
+                workflowActorBindingReader,
+                artifactStore,
+                serviceLifecycleQueryPort,
+                workflowStoragePort);
+        }
+
+        public string BuildLayoutPath(string scopeId, string workflowId) =>
+            Path.Combine(
+                AevatarPaths.Root,
+                "app",
+                "scope-workflow-layouts",
+                $"{StudioDocumentIdNormalizer.Normalize(scopeId, "scope")}--{StudioDocumentIdNormalizer.Normalize(workflowId, "workflow")}.json");
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, _previousHome);
+            if (Directory.Exists(HomeDirectory))
+            {
+                Directory.Delete(HomeDirectory, recursive: true);
+            }
+        }
+    }
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            throw new InvalidOperationException("HTTP backend should not be called.");
+    }
+
+    private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
+    {
+        public WorkflowParseResult Parse(string yaml) =>
+            new(new WorkflowDocument { Name = "workflow" }, []);
+
+        public string Serialize(WorkflowDocument document) =>
+            $"name: {document.Name}\nsteps: []\n";
+    }
+
+    private sealed class RecordingWorkflowStoragePort : IWorkflowStoragePort
+    {
+        public List<string> DeletedWorkflowIds { get; } = [];
+
+        public Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<StoredWorkflowYaml>>([]);
+
+        public Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromResult<StoredWorkflowYaml?>(null);
+
+        public Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct)
+        {
+            DeletedWorkflowIds.Add(workflowId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RuntimePortSpies
+    {
+        public RuntimePortSpies()
+        {
+            QueryPort = new RecordingScopeWorkflowQueryPort(this);
+            CommandPort = new RecordingScopeWorkflowCommandPort(this);
+            BindingReader = new RecordingWorkflowActorBindingReader(this);
+            ArtifactStore = new RecordingServiceRevisionArtifactStore(this);
+            ServiceLifecycleQueryPort = new RecordingServiceLifecycleQueryPort(this);
+        }
+
+        public int TotalInvocations { get; private set; }
+
+        public IScopeWorkflowQueryPort QueryPort { get; }
+
+        public IScopeWorkflowCommandPort CommandPort { get; }
+
+        public IWorkflowActorBindingReader BindingReader { get; }
+
+        public IServiceRevisionArtifactStore ArtifactStore { get; }
+
+        public IServiceLifecycleQueryPort ServiceLifecycleQueryPort { get; }
+
+        public void RecordInvocation() => TotalInvocations += 1;
+    }
+
+    private sealed class RecordingScopeWorkflowQueryPort : IScopeWorkflowQueryPort
+    {
+        private readonly RuntimePortSpies _owner;
+
+        public RecordingScopeWorkflowQueryPort(RuntimePortSpies owner)
+        {
+            _owner = owner;
+        }
+
+        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>([]);
+        }
+
+        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<ScopeWorkflowSummary?>(null);
+        }
+
+        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(string scopeId, string actorId, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<ScopeWorkflowSummary?>(null);
+        }
+    }
+
+    private sealed class RecordingScopeWorkflowCommandPort : IScopeWorkflowCommandPort
+    {
+        private readonly RuntimePortSpies _owner;
+
+        public RecordingScopeWorkflowCommandPort(RuntimePortSpies owner)
+        {
+            _owner = owner;
+        }
+
+        public Task<ScopeWorkflowUpsertResult> UpsertAsync(ScopeWorkflowUpsertRequest request, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            throw new InvalidOperationException("Runtime command port should not be called.");
+        }
+    }
+
+    private sealed class RecordingWorkflowActorBindingReader : IWorkflowActorBindingReader
+    {
+        private readonly RuntimePortSpies _owner;
+
+        public RecordingWorkflowActorBindingReader(RuntimePortSpies owner)
+        {
+            _owner = owner;
+        }
+
+        public Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<WorkflowActorBinding?>(null);
+        }
+    }
+
+    private sealed class RecordingServiceRevisionArtifactStore : IServiceRevisionArtifactStore
+    {
+        private readonly RuntimePortSpies _owner;
+
+        public RecordingServiceRevisionArtifactStore(RuntimePortSpies owner)
+        {
+            _owner = owner;
+        }
+
+        public Task SaveAsync(string serviceKey, string revisionId, PreparedServiceRevisionArtifact artifact, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.CompletedTask;
+        }
+
+        public Task<PreparedServiceRevisionArtifact?> GetAsync(string serviceKey, string revisionId, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<PreparedServiceRevisionArtifact?>(null);
+        }
+    }
+
+    private sealed class RecordingServiceLifecycleQueryPort : IServiceLifecycleQueryPort
+    {
+        private readonly RuntimePortSpies _owner;
+
+        public RecordingServiceLifecycleQueryPort(RuntimePortSpies owner)
+        {
+            _owner = owner;
+        }
+
+        public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<ServiceCatalogSnapshot?>(null);
+        }
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(string tenantId, string appId, string @namespace, int take = 200, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
+        }
+
+        public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<ServiceRevisionCatalogSnapshot?>(null);
+        }
+
+        public Task<ServiceDeploymentCatalogSnapshot?> GetServiceDeploymentsAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            _owner.RecordInvocation();
+            return Task.FromResult<ServiceDeploymentCatalogSnapshot?>(null);
+        }
+    }
+}

--- a/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftEdgeCaseTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftEdgeCaseTests.cs
@@ -1,0 +1,30 @@
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed partial class WorkspaceServiceDeleteDraftTests
+{
+    [Fact]
+    public async Task DeleteDraftAsync_WhenWorkflowIdIsNotStableId_ShouldThrowInvalidOperationException()
+    {
+        using var environment = new WorkspaceEnvironment();
+
+        var act = () => environment.Service.DeleteDraftAsync("not-base64!");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("workflowId is invalid.");
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_WhenStableIdDecodesToWhitespace_ShouldThrowInvalidOperationException()
+    {
+        using var environment = new WorkspaceEnvironment();
+        var workflowId = WorkspaceService.CreateStableId("   ");
+
+        var act = () => environment.Service.DeleteDraftAsync(workflowId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("workflowId is invalid.");
+    }
+}

--- a/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Options;
 
 namespace Aevatar.Studio.Tests;
 
-public sealed class WorkspaceServiceDeleteDraftTests
+public sealed partial class WorkspaceServiceDeleteDraftTests
 {
     [Fact]
     public async Task DeleteDraftAsync_DeleteThenList_ShouldRemoveStoredWorkflow()

--- a/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs
@@ -93,6 +93,52 @@ public sealed class WorkspaceServiceDeleteDraftTests
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    [Fact]
+    public async Task DeleteDraftAsync_WhenPathIsOutsideRegisteredDirectory_ShouldRejectAndNotDelete()
+    {
+        using var environment = new WorkspaceEnvironment();
+        var outsidePath = Path.Combine(Path.GetTempPath(), $"studio-delete-draft-outside-{Guid.NewGuid():N}.yaml");
+        await File.WriteAllTextAsync(outsidePath, "name: outside\nsteps: []\n");
+        var outsideWorkflowId = WorkspaceService.CreateStableId(outsidePath);
+
+        try
+        {
+            var act = () => environment.Service.DeleteDraftAsync(outsideWorkflowId);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            File.Exists(outsidePath).Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(outsidePath))
+                File.Delete(outsidePath);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_WhenPathTraversesOutsideRegisteredDirectory_ShouldRejectAndNotDelete()
+    {
+        using var environment = new WorkspaceEnvironment();
+        var settings = await environment.Store.GetSettingsAsync();
+        var registeredDirectory = settings.Directories.Single().Path;
+        var escapePath = Path.GetFullPath(Path.Combine(registeredDirectory, "..", $"studio-delete-draft-escape-{Guid.NewGuid():N}.yaml"));
+        await File.WriteAllTextAsync(escapePath, "name: escape\nsteps: []\n");
+        var traversalWorkflowId = WorkspaceService.CreateStableId(Path.Combine(registeredDirectory, "..", Path.GetFileName(escapePath)));
+
+        try
+        {
+            var act = () => environment.Service.DeleteDraftAsync(traversalWorkflowId);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+            File.Exists(escapePath).Should().BeTrue();
+        }
+        finally
+        {
+            if (File.Exists(escapePath))
+                File.Delete(escapePath);
+        }
+    }
+
     private sealed class WorkspaceEnvironment : IDisposable
     {
         private readonly string? _previousHome;

--- a/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs
@@ -1,0 +1,163 @@
+using System.Text.RegularExpressions;
+using Aevatar.Configuration;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Studio.Infrastructure.Storage;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class WorkspaceServiceDeleteDraftTests
+{
+    [Fact]
+    public async Task DeleteDraftAsync_DeleteThenList_ShouldRemoveStoredWorkflow()
+    {
+        using var environment = new WorkspaceEnvironment();
+        var settings = await environment.Store.GetSettingsAsync();
+        var directoryId = settings.Directories.Single().DirectoryId;
+
+        var saved = await environment.Service.SaveWorkflowAsync(new SaveWorkflowFileRequest(
+            WorkflowId: null,
+            DirectoryId: directoryId,
+            WorkflowName: "hello-chat",
+            FileName: null,
+            Yaml: "name: hello-chat\ndescription: saved draft\nsteps: []\n"));
+
+        (await environment.Service.ListWorkflowsAsync())
+            .Should()
+            .Contain(summary => summary.WorkflowId == saved.WorkflowId);
+
+        await environment.Service.DeleteDraftAsync(saved.WorkflowId);
+
+        (await environment.Service.ListWorkflowsAsync())
+            .Should()
+            .NotContain(summary => summary.WorkflowId == saved.WorkflowId);
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_ShouldRemoveLayoutAlongWithYaml()
+    {
+        using var environment = new WorkspaceEnvironment();
+        var settings = await environment.Store.GetSettingsAsync();
+        var directoryId = settings.Directories.Single().DirectoryId;
+        var layout = new WorkflowLayoutDocument
+        {
+            NodePositions = new Dictionary<string, WorkflowNodeLayout>(StringComparer.Ordinal)
+            {
+                ["step-1"] = new(12, 34),
+            },
+        };
+
+        var saved = await environment.Service.SaveWorkflowAsync(new SaveWorkflowFileRequest(
+            WorkflowId: null,
+            DirectoryId: directoryId,
+            WorkflowName: "hello-layout",
+            FileName: null,
+            Yaml: "name: hello-layout\nsteps: []\n",
+            Layout: layout));
+        var layoutPath = $"{saved.FilePath}.layout.json";
+
+        File.Exists(saved.FilePath).Should().BeTrue();
+        File.Exists(layoutPath).Should().BeTrue();
+
+        await environment.Service.DeleteDraftAsync(saved.WorkflowId);
+
+        File.Exists(saved.FilePath).Should().BeFalse();
+        File.Exists(layoutPath).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeleteDraftAsync_WhenWorkflowIsMissing_ShouldSucceedIdempotently()
+    {
+        using var environment = new WorkspaceEnvironment();
+        var missingPath = Path.Combine(environment.HomeDirectory, "workflows", "missing.yaml");
+        var missingWorkflowId = WorkspaceService.CreateStableId(missingPath);
+
+        var act = () => environment.Service.DeleteDraftAsync(missingWorkflowId);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DeleteDraftAsync_WhenWorkflowIdIsEmpty_ShouldThrowInvalidOperationException(string workflowId)
+    {
+        using var environment = new WorkspaceEnvironment();
+
+        var act = () => environment.Service.DeleteDraftAsync(workflowId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private sealed class WorkspaceEnvironment : IDisposable
+    {
+        private readonly string? _previousHome;
+        private readonly string _rootDirectory;
+
+        public WorkspaceEnvironment()
+        {
+            HomeDirectory = Path.Combine(Path.GetTempPath(), $"studio-delete-draft-home-{Guid.NewGuid():N}");
+            _rootDirectory = Path.Combine(Path.GetTempPath(), $"studio-delete-draft-root-{Guid.NewGuid():N}");
+            _previousHome = Environment.GetEnvironmentVariable(AevatarPaths.HomeEnv);
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, HomeDirectory);
+
+            Store = new FileStudioWorkspaceStore(Options.Create(new StudioStorageOptions
+            {
+                RootDirectory = _rootDirectory,
+            }));
+            Service = new WorkspaceService(Store, new StubWorkflowYamlDocumentService());
+        }
+
+        public string HomeDirectory { get; }
+
+        public FileStudioWorkspaceStore Store { get; }
+
+        public WorkspaceService Service { get; }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, _previousHome);
+            if (Directory.Exists(HomeDirectory))
+            {
+                Directory.Delete(HomeDirectory, recursive: true);
+            }
+
+            if (Directory.Exists(_rootDirectory))
+            {
+                Directory.Delete(_rootDirectory, recursive: true);
+            }
+        }
+    }
+
+    private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
+    {
+        private static readonly Regex NameRegex = new(@"(?m)^name:\s*(.+?)\s*$", RegexOptions.Compiled);
+        private static readonly Regex DescriptionRegex = new(@"(?m)^description:\s*(.+?)\s*$", RegexOptions.Compiled);
+
+        public WorkflowParseResult Parse(string yaml)
+        {
+            if (string.IsNullOrWhiteSpace(yaml))
+            {
+                return new WorkflowParseResult(null, []);
+            }
+
+            var input = yaml ?? string.Empty;
+            var nameMatch = NameRegex.Match(input);
+            var descriptionMatch = DescriptionRegex.Match(input);
+            return new WorkflowParseResult(
+                new WorkflowDocument
+                {
+                    Name = nameMatch.Success ? nameMatch.Groups[1].Value.Trim() : string.Empty,
+                    Description = descriptionMatch.Success ? descriptionMatch.Groups[1].Value.Trim() : string.Empty,
+                },
+                []);
+        }
+
+        public string Serialize(WorkflowDocument document) =>
+            $"name: {document.Name}\nsteps: []\n";
+    }
+}

--- a/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
@@ -1621,6 +1621,8 @@ public sealed class ActorBackedStoreAdapterTests
             Task.FromResult<StoredWorkflowFile?>(null);
         public Task<StoredWorkflowFile> SaveWorkflowFileAsync(StoredWorkflowFile f, CancellationToken ct = default) =>
             Task.FromResult(f);
+        public Task DeleteWorkflowFileAsync(string workflowId, CancellationToken ct = default) =>
+            Task.CompletedTask;
         public Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<StoredExecutionRecord>>([]);
         public Task<StoredExecutionRecord?> GetExecutionAsync(string executionId, CancellationToken ct = default) =>

--- a/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
@@ -343,5 +343,11 @@ public sealed class AppScopedWorkflowServiceTests
                 _storedWorkflows.TryGetValue(workflowId, out var storedWorkflow)
                     ? storedWorkflow
                     : null);
+
+        public Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct)
+        {
+            _storedWorkflows.Remove(workflowId);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/Aevatar.Tools.Cli.Tests/ExecutionServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ExecutionServiceTests.cs
@@ -403,6 +403,9 @@ public sealed class ExecutionServiceTests
         public Task<StoredWorkflowFile> SaveWorkflowFileAsync(StoredWorkflowFile workflowFile, CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
 
+        public Task DeleteWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
         public Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken cancellationToken = default)
         {
             lock (_sync)

--- a/test/Aevatar.Tools.Cli.Tests/WorkspaceDeleteDraftControllerAndStorageTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/WorkspaceDeleteDraftControllerAndStorageTests.cs
@@ -1,0 +1,346 @@
+using System.Net;
+using Aevatar.Studio.Application;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Services;
+using Aevatar.Studio.Domain.Studio.Models;
+using Aevatar.Studio.Hosting.Controllers;
+using Aevatar.Studio.Infrastructure.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.Tools.Cli.Tests;
+
+public sealed class WorkspaceDeleteDraftControllerAndStorageTests
+{
+    [Fact]
+    public async Task DeleteWorkflow_WhenScopeIsNotResolved_DeletesWorkspaceDraftAndReturnsNoContent()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), $"workspace-delete-{Guid.NewGuid():N}");
+        var store = new RecordingWorkspaceStore(workspaceRoot);
+        var controller = CreateController(
+            new WorkspaceService(store, new StubWorkflowYamlDocumentService()),
+            CreateScopeWorkflowService(new RecordingWorkflowStoragePort()),
+            new StubScopeResolver());
+        var workflowPath = Path.Combine(workspaceRoot, "drafts", "hello.yaml");
+        var workflowId = WorkspaceService.CreateStableId(workflowPath);
+
+        var result = await controller.DeleteWorkflow(workflowId, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        store.DeletedWorkflowIds.Should().ContainSingle().Which.Should().Be(workflowId);
+    }
+
+    [Fact]
+    public async Task DeleteWorkflow_WhenScopeIsResolved_DeletesScopedDraftAndReturnsNoContent()
+    {
+        var storagePort = new RecordingWorkflowStoragePort();
+        var workflowId = $"workflow-{Guid.NewGuid():N}";
+        var controller = CreateController(
+            new WorkspaceService(new RecordingWorkspaceStore(Path.GetTempPath()), new StubWorkflowYamlDocumentService()),
+            CreateScopeWorkflowService(storagePort),
+            new StubScopeResolver { ScopeIdToReturn = "scope-1" });
+
+        var result = await controller.DeleteWorkflow(workflowId, CancellationToken.None);
+
+        result.Should().BeOfType<NoContentResult>();
+        storagePort.DeletedWorkflowIds.Should().ContainSingle().Which.Should().Be(workflowId);
+    }
+
+    [Fact]
+    public async Task DeleteWorkflow_WhenScopedDeleteThrowsAppApiException_ReturnsStatusCodePayload()
+    {
+        var exception = new AppApiException(
+            StatusCodes.Status502BadGateway,
+            AppApiErrors.BackendInvalidResponseCode,
+            "delete failed");
+        var controller = CreateController(
+            new WorkspaceService(new RecordingWorkspaceStore(Path.GetTempPath()), new StubWorkflowYamlDocumentService()),
+            CreateScopeWorkflowService(new ThrowingWorkflowStoragePort(exception)),
+            new StubScopeResolver { ScopeIdToReturn = "scope-1" });
+
+        var result = await controller.DeleteWorkflow("workflow-1", CancellationToken.None);
+
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
+        objectResult.Value.Should().BeEquivalentTo(new AppApiErrorResponse(
+            AppApiErrors.BackendInvalidResponseCode,
+            "delete failed"));
+    }
+
+    [Fact]
+    public async Task DeleteWorkflow_WhenDeleteThrowsInvalidOperationException_ReturnsBadRequest()
+    {
+        var controller = CreateController(
+            new WorkspaceService(new RecordingWorkspaceStore(Path.GetTempPath()), new StubWorkflowYamlDocumentService()),
+            CreateScopeWorkflowService(new RecordingWorkflowStoragePort()),
+            new StubScopeResolver());
+
+        var result = await controller.DeleteWorkflow(string.Empty, CancellationToken.None);
+
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        badRequest.Value.Should().BeEquivalentTo(new { message = "workflowId is required." });
+    }
+
+    [Fact]
+    public async Task DeleteWorkflowYamlAsync_WhenWorkflowIdIsBlank_DoesNotSendRequest()
+    {
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.NoContent);
+        var port = CreateWorkflowStoragePort(handler, enabled: true);
+
+        await port.DeleteWorkflowYamlAsync("   ", CancellationToken.None);
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteWorkflowYamlAsync_WhenWorkflowIdIsNull_DoesNotSendRequest()
+    {
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.NoContent);
+        var port = CreateWorkflowStoragePort(handler, enabled: true);
+
+        await port.DeleteWorkflowYamlAsync(null!, CancellationToken.None);
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteWorkflowYamlAsync_WhenChronoStorageIsDisabled_DoesNotSendRequest()
+    {
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.NoContent);
+        var port = CreateWorkflowStoragePort(handler, enabled: false);
+
+        await port.DeleteWorkflowYamlAsync("workflow-1", CancellationToken.None);
+
+        handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteWorkflowYamlAsync_WhenWorkflowIdIsValid_SendsDeleteToScopedObjectKey()
+    {
+        var handler = new RecordingHttpMessageHandler(HttpStatusCode.NoContent);
+        var port = CreateWorkflowStoragePort(handler, enabled: true);
+
+        await port.DeleteWorkflowYamlAsync(" workflow-1 ", CancellationToken.None);
+
+        var request = handler.Requests.Should().ContainSingle().Subject;
+        request.Method.Should().Be(HttpMethod.Delete);
+        request.RequestUri.Should().Be("https://chrono.example.com/api/buckets/test-bucket/objects?key=scope-1%2Fworkflows%2Fworkflow-1.yaml");
+    }
+
+    private static WorkspaceController CreateController(
+        WorkspaceService workspaceService,
+        AppScopedWorkflowService scopeWorkflowService,
+        IAppScopeResolver scopeResolver)
+    {
+        var controller = new WorkspaceController(workspaceService, scopeWorkflowService, scopeResolver)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+        return controller;
+    }
+
+    private static AppScopedWorkflowService CreateScopeWorkflowService(IWorkflowStoragePort? workflowStoragePort) =>
+        new(
+            new StubHttpClientFactory(new HttpClient(new ThrowingHttpMessageHandler())),
+            new StubWorkflowYamlDocumentService(),
+            workflowStoragePort: workflowStoragePort);
+
+    private static ChronoStorageWorkflowStoragePort CreateWorkflowStoragePort(
+        HttpMessageHandler handler,
+        bool enabled)
+    {
+        var blobClient = new ChronoStorageCatalogBlobClient(
+            new StubScopeResolver { ScopeIdToReturn = "scope-1" },
+            new StubHttpClientFactory(new HttpClient(handler)),
+            Options.Create(new ConnectorCatalogStorageOptions
+            {
+                Enabled = enabled,
+                UseNyxProxy = false,
+                BaseUrl = "https://chrono.example.com",
+                Bucket = "test-bucket",
+            }));
+        return new ChronoStorageWorkflowStoragePort(blobClient);
+    }
+
+    private sealed class StubScopeResolver : IAppScopeResolver
+    {
+        public string? ScopeIdToReturn { get; set; }
+
+        public AppScopeContext? Resolve(HttpContext? httpContext = null) =>
+            ScopeIdToReturn is null ? null : new AppScopeContext(ScopeIdToReturn, "test");
+    }
+
+    private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
+    {
+        public WorkflowParseResult Parse(string yaml) =>
+            new(new WorkflowDocument { Name = "workflow" }, []);
+
+        public string Serialize(WorkflowDocument document) =>
+            $"name: {document.Name}\nsteps: []\n";
+    }
+
+    private sealed class StubHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public StubHttpClientFactory(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name) => _client;
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("HTTP client should not be used in this test.");
+    }
+
+    private sealed class RecordingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+
+        public RecordingHttpMessageHandler(HttpStatusCode statusCode)
+        {
+            _statusCode = statusCode;
+        }
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri?.ToString()));
+            return Task.FromResult(new HttpResponseMessage(_statusCode));
+        }
+    }
+
+    private sealed record CapturedRequest(HttpMethod Method, string? RequestUri);
+
+    private sealed class RecordingWorkflowStoragePort : IWorkflowStoragePort
+    {
+        public List<string> DeletedWorkflowIds { get; } = [];
+
+        public Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<StoredWorkflowYaml>>([]);
+
+        public Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromResult<StoredWorkflowYaml?>(null);
+
+        public Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct)
+        {
+            DeletedWorkflowIds.Add(workflowId);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingWorkflowStoragePort : IWorkflowStoragePort
+    {
+        private readonly Exception _exception;
+
+        public ThrowingWorkflowStoragePort(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        public Task UploadWorkflowYamlAsync(string workflowId, string workflowName, string yaml, CancellationToken ct) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<StoredWorkflowYaml>> ListWorkflowYamlsAsync(CancellationToken ct) =>
+            Task.FromResult<IReadOnlyList<StoredWorkflowYaml>>([]);
+
+        public Task<StoredWorkflowYaml?> GetWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromResult<StoredWorkflowYaml?>(null);
+
+        public Task DeleteWorkflowYamlAsync(string workflowId, CancellationToken ct) =>
+            Task.FromException(_exception);
+    }
+
+    private sealed class RecordingWorkspaceStore : IStudioWorkspaceStore
+    {
+        public RecordingWorkspaceStore(string rootDirectory)
+        {
+            RootDirectory = rootDirectory;
+        }
+
+        public string RootDirectory { get; }
+
+        public List<string> DeletedWorkflowIds { get; } = [];
+
+        public Task<StudioWorkspaceSettings> GetSettingsAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new StudioWorkspaceSettings(
+                RuntimeBaseUrl: "http://127.0.0.1:5100",
+                Directories:
+                [
+                    new StudioWorkspaceDirectory("dir-1", "Drafts", RootDirectory),
+                ],
+                AppearanceTheme: "default",
+                ColorMode: "system"));
+
+        public Task DeleteWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default)
+        {
+            DeletedWorkflowIds.Add(workflowId);
+            return Task.CompletedTask;
+        }
+
+        public Task SaveSettingsAsync(StudioWorkspaceSettings settings, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<StoredWorkflowFile>> ListWorkflowFilesAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredWorkflowFile?> GetWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredWorkflowFile> SaveWorkflowFileAsync(StoredWorkflowFile workflowFile, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredExecutionRecord?> GetExecutionAsync(string executionId, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredExecutionRecord> SaveExecutionAsync(StoredExecutionRecord execution, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredConnectorCatalog> GetConnectorCatalogAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredConnectorCatalog> SaveConnectorCatalogAsync(StoredConnectorCatalog catalog, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredConnectorDraft> GetConnectorDraftAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredConnectorDraft> SaveConnectorDraftAsync(StoredConnectorDraft draft, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteConnectorDraftAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredRoleCatalog> GetRoleCatalogAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredRoleCatalog> SaveRoleCatalogAsync(StoredRoleCatalog catalog, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredRoleDraft> GetRoleDraftAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<StoredRoleDraft> SaveRoleDraftAsync(StoredRoleDraft draft, CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task DeleteRoleDraftAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.Tools.Cli.Tests/WorkspaceServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/WorkspaceServiceTests.cs
@@ -115,6 +115,9 @@ public class WorkspaceServiceTests
             return Task.FromResult(workflowFile);
         }
 
+        public Task DeleteWorkflowFileAsync(string workflowId, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
         public Task<IReadOnlyList<StoredExecutionRecord>> ListExecutionsAsync(CancellationToken cancellationToken = default) =>
             Task.FromResult<IReadOnlyList<StoredExecutionRecord>>([]);
 


### PR DESCRIPTION
## Summary

- 新增 `DELETE /api/workspace/workflows/{workflowId}`，workspace / scoped 两个模式分支对称，成功返回 `204 No Content`，幂等（草稿不存在也返回 204）
- `WorkspaceService.DeleteDraftAsync` / `AppScopedWorkflowService.DeleteDraftAsync` 采用业务语义命名；前者清本地 YAML + layout 文件，后者清 chrono-storage blob + 本地 layout sidecar
- 严格限定为**删 Studio 草稿**：不调任何 runtime 端口（command / query / binding / artifact / lifecycle），不触达 actor 事实、binding、service revision

Closes #232.

## Architecture notes（CLAUDE.md 对照）

- **读写分离 / 权威状态唯一**：删除只作用于副本存储（chrono-storage / 本地文件 + layout sidecar），runtime workflow 事实由对应 actor 持有，不会被本接口动
- **删除优先**：真删 YAML + layout，不留"逻辑删除"标记
- **应用层承载业务语义**：`DeleteDraftAsync` 做了 `workflowId` 校验、`DecodeStableId` 解析、layout 清理、幂等处理，非纯转发
- **命名**：storage port 上 `Delete*Async`（与 `Save/Get/List` 对称）；application service 上 `DeleteDraftAsync`，让"删草稿、不是删 workflow"写进接口名
- **零中间层事实态**、**零新增 proto/event**、**不改 save 链路 / runtime binding**

## 关键文件

- `src/Aevatar.Studio.Hosting/Controllers/WorkspaceController.cs:151`
- `src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs:152`
- `src/Aevatar.Studio.Application/AppScopedWorkflowService.cs:256`
- `src/Aevatar.Studio.Infrastructure/Storage/FileStudioWorkspaceStore.cs:173`
- `src/Aevatar.Studio.Infrastructure/Storage/ChronoStorageWorkflowStoragePort.cs:79`
- 接口扩展：`IStudioWorkspaceStore` / `IWorkflowStoragePort`

## Test plan

- [x] `test/Aevatar.Studio.Tests/WorkspaceServiceDeleteDraftTests.cs`: 删除后 `ListWorkflowsAsync` 不再返回 / layout 同步清除 / 幂等 / 非法 `workflowId` 抛 `InvalidOperationException`
- [x] `test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs`:
  - 调用 `IWorkflowStoragePort.DeleteWorkflowYamlAsync`
  - **断言 runtime 端口调用次数 = 0**（QueryPort / CommandPort / BindingReader / ArtifactStore / ServiceLifecycleQueryPort 全部 spy）
  - 本地 layout sidecar 删除
  - storage port 缺席 + layout 不存在时静默成功
- [x] `dotnet build aevatar.slnx`: 0 errors
- [x] `dotnet test test/Aevatar.Studio.Tests/...`: 194/0/0
- [x] `dotnet test test/Aevatar.Tools.Cli.Tests/...`: 321/0/0
- [x] `bash tools/ci/architecture_guards.sh`: passed
- [x] `bash tools/ci/test_stability_guards.sh`: passed

## Non-goals（明确不做）

- 不动 runtime / actor / binding / service revision
- 不新增 readmodel / projection / proto / event type
- 不改 save 链路
- 前端接入（新 `studioApi.deleteWorkflow` + 启用 `Delete Draft` 按钮）在前端分支另开 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
