### PR TITLE
Stream Lark bot replies progressively as LLM deltas arrive

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
@@ -12,7 +12,7 @@ namespace Aevatar.GAgents.ChannelRuntime.Adapters;
 /// Handles URL verification challenges and im.message.receive_v1 events.
 /// Outbound replies go through Nyx's api-lark-bot provider.
 /// </summary>
-public sealed class LarkPlatformAdapter : IPlatformAdapter
+public sealed class LarkPlatformAdapter : IStreamingPlatformAdapter
 {
     private readonly ILogger<LarkPlatformAdapter> _logger;
 
@@ -325,6 +325,139 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
             "Lark outbound reply sent: chat={ChatId}, slug={Slug}, detail={Detail}",
             inbound.ConversationId, registration.NyxProviderSlug, successDetail);
         return new PlatformReplyDeliveryResult(true, successDetail);
+    }
+
+    public async Task<string?> PostStreamingPlaceholderAsync(
+        string initialText,
+        InboundMessage inbound,
+        ChannelBotRegistrationEntry registration,
+        NyxIdApiClient nyxClient,
+        CancellationToken ct)
+    {
+        // Interactive-card placeholders are not supported: the LLM can't stream
+        // partial cards, and rewriting a text message into a card via PATCH
+        // changes the message type. Interactive payloads take the SendReplyAsync
+        // path; streaming is for plain-text deltas only.
+        if (IsInteractiveCardPayload(initialText))
+            return null;
+
+        var body = JsonSerializer.Serialize(new
+        {
+            receive_id = inbound.ConversationId,
+            msg_type = "text",
+            content = JsonSerializer.Serialize(new { text = initialText }),
+        });
+
+        var result = await nyxClient.ProxyRequestAsync(
+            registration.NyxUserToken,
+            registration.NyxProviderSlug,
+            "open-apis/im/v1/messages?receive_id_type=chat_id",
+            "POST",
+            body,
+            extraHeaders: null,
+            ct);
+
+        if (result != null && result.Contains("\"error\"", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Lark streaming placeholder post failed: slug={Slug}, result={Result}",
+                registration.NyxProviderSlug, result);
+            return null;
+        }
+
+        if (TryBuildLarkErrorDetail(result, out var errorDetail))
+        {
+            _logger.LogWarning(
+                "Lark streaming placeholder rejected: slug={Slug}, detail={Detail}",
+                registration.NyxProviderSlug, errorDetail);
+            return null;
+        }
+
+        var messageId = TryExtractLarkMessageId(result);
+        if (string.IsNullOrEmpty(messageId))
+        {
+            _logger.LogWarning(
+                "Lark streaming placeholder succeeded but no message_id in response: slug={Slug}",
+                registration.NyxProviderSlug);
+            return null;
+        }
+
+        return messageId;
+    }
+
+    public async Task<PlatformReplyDeliveryResult> UpdateStreamingMessageAsync(
+        string messageId,
+        string replyText,
+        InboundMessage inbound,
+        ChannelBotRegistrationEntry registration,
+        NyxIdApiClient nyxClient,
+        CancellationToken ct)
+    {
+        // Lark PATCH accepts the same content shape as send; msg_type is fixed
+        // at message creation time. Rewriting to a card payload would violate
+        // the text-message contract, so surface it as a non-retryable failure.
+        if (IsInteractiveCardPayload(replyText))
+            return new PlatformReplyDeliveryResult(false, "cannot_patch_to_interactive");
+
+        var body = JsonSerializer.Serialize(new
+        {
+            content = JsonSerializer.Serialize(new { text = replyText }),
+        });
+
+        var result = await nyxClient.ProxyRequestAsync(
+            registration.NyxUserToken,
+            registration.NyxProviderSlug,
+            $"open-apis/im/v1/messages/{Uri.EscapeDataString(messageId)}",
+            "PATCH",
+            body,
+            extraHeaders: null,
+            ct);
+
+        if (result != null && result.Contains("\"error\"", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Lark streaming update failed: messageId={MessageId}, slug={Slug}, result={Result}",
+                messageId, registration.NyxProviderSlug, result);
+            return new PlatformReplyDeliveryResult(false, $"proxy_error: {TrimForLog(result)}");
+        }
+
+        if (TryBuildLarkErrorDetail(result, out var errorDetail))
+        {
+            _logger.LogWarning(
+                "Lark streaming update rejected: messageId={MessageId}, slug={Slug}, detail={Detail}",
+                messageId, registration.NyxProviderSlug, errorDetail);
+            return new PlatformReplyDeliveryResult(false, errorDetail);
+        }
+
+        return new PlatformReplyDeliveryResult(true, $"message_id={messageId}");
+    }
+
+    private static string? TryExtractLarkMessageId(string? result)
+    {
+        if (string.IsNullOrWhiteSpace(result))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(result);
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("data", out var dataProp))
+                return null;
+            if (!dataProp.TryGetProperty("message_id", out var idProp))
+                return null;
+            return idProp.ValueKind == JsonValueKind.String ? idProp.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string TrimForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        return value.Length > 200 ? value[..200] + "…" : value;
     }
 
     private InboundMessage? ParseCardAction(JsonElement root, JsonElement header)

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
@@ -182,28 +182,35 @@ public sealed class ChannelRegistrationTool : IAgentTool
         await actor.HandleEventAsync(envelope);
 
         // Projection scope is now activated. Poll for the document to appear.
-        // The projector runs async via the materialization scope agent.
-        string? confirmedId = null;
+        // Mirrors HandleRegisterAsync: keep the register-accepted response even
+        // when the projection wait times out (5xx would cause caller retries
+        // that duplicate-write fresh registrationIds), but surface the degraded
+        // state via projection_ready + projection_warning so the caller can
+        // warn the user before they paste a potentially-zombie callback URL
+        // into the platform developer console.
+        var projectionReady = false;
         for (var attempt = 0; attempt < 10; attempt++)
         {
             await Task.Delay(500, ct);
-            var entry = await queryPort.GetAsync(registrationId, ct);
-            if (entry != null)
+            if (await queryPort.GetAsync(registrationId, ct) != null)
             {
-                confirmedId = entry.Id;
+                projectionReady = true;
                 break;
             }
         }
 
         return JsonSerializer.Serialize(new
         {
-            status = confirmedId != null ? "registered" : "accepted",
+            status = "registered",
             registration_id = registrationId,
             platform = cmd.Platform,
             nyx_provider_slug = cmd.NyxProviderSlug,
             callback_url = $"{callbackPath}/{registrationId}",
             webhook_url = !string.IsNullOrWhiteSpace(webhookUrl) ? $"{webhookUrl}/{registrationId}" : "",
-            note = confirmedId == null ? "Registration submitted but projection not yet confirmed. Try 'list' after a few seconds." : "",
+            projection_ready = projectionReady,
+            projection_warning = projectionReady
+                ? null
+                : "Registration dispatched but projection did not materialize within timeout. Callbacks may 404 briefly; check projection pipeline health if this persists.",
         });
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs
@@ -345,28 +345,23 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
             {
                 replySucceeded = await TryStreamingUpdateAsync(session, replyText, isFinal: true);
                 if (replySucceeded)
+                {
                     RecordDiagnostic("Reply:done", session.Platform, session.RegistrationId,
                         $"stream message_id={streamState!.MessageId} edits={streamState.EditCount}");
+                }
                 else
+                {
                     RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId,
                         $"stream final PATCH failed messageId={streamState!.MessageId}");
+                    replySucceeded = await TrySendDirectReplyAsync(
+                        session,
+                        replyText,
+                        "stream_fallback");
+                }
             }
             else
             {
-                var delivery = await SendPlatformReplyAsync(session, replyText);
-                if (delivery.Succeeded)
-                {
-                    replySucceeded = true;
-                    RecordDiagnostic("Reply:done", session.Platform, session.RegistrationId, delivery.Detail);
-                }
-                else
-                {
-                    Logger.LogWarning("SendReply rejected: platform={Platform}, session={SessionId}, detail={Detail}",
-                        session.Platform,
-                        session.SessionId,
-                        delivery.Detail);
-                    RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId, delivery.Detail);
-                }
+                replySucceeded = await TrySendDirectReplyAsync(session, replyText);
             }
         }
         catch (Exception ex)
@@ -508,6 +503,7 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
             {
                 if (isFinal)
                 {
+                    state.Disabled = true;
                     Logger.LogWarning(
                         "Streaming final PATCH rejected: session={SessionId}, detail={Detail}",
                         session.SessionId, delivery.Detail);
@@ -521,11 +517,36 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
             Logger.LogWarning(ex, "Streaming update error for session {SessionId}", session.SessionId);
             if (isFinal)
             {
+                state.Disabled = true;
                 RecordDiagnostic("Stream:final:error", session.Platform, session.RegistrationId,
                     $"{ex.GetType().Name}: {ex.Message}");
             }
             return false;
         }
+    }
+
+    private async Task<bool> TrySendDirectReplyAsync(
+        ChannelPendingChatSession session,
+        string replyText,
+        string? detailPrefix = null)
+    {
+        var delivery = await SendPlatformReplyAsync(session, replyText);
+        var detail = string.IsNullOrWhiteSpace(detailPrefix)
+            ? delivery.Detail
+            : $"{detailPrefix} {delivery.Detail}";
+
+        if (delivery.Succeeded)
+        {
+            RecordDiagnostic("Reply:done", session.Platform, session.RegistrationId, detail);
+            return true;
+        }
+
+        Logger.LogWarning("SendReply rejected: platform={Platform}, session={SessionId}, detail={Detail}",
+            session.Platform,
+            session.SessionId,
+            detail);
+        RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId, detail);
+        return false;
     }
 
     private IPlatformAdapter? ResolvePlatformAdapter(string platform)

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs
@@ -37,9 +37,20 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
     private static readonly TimeSpan ChatTimeout = TimeSpan.FromSeconds(120);
     private static readonly TimeSpan RecoveryTimeoutDelay = TimeSpan.FromMilliseconds(1);
 
+    // Progressive reply pacing. On first delta the adapter posts a placeholder
+    // message; subsequent deltas PATCH it at most once per throttle interval to
+    // keep platform rate limits happy while still feeling responsive. Final
+    // HandleChatEnd always flushes regardless of throttle.
+    private static readonly TimeSpan StreamingEditThrottle = TimeSpan.FromMilliseconds(750);
+    private static readonly TimeSpan StreamingHttpTimeout = TimeSpan.FromSeconds(10);
+
     // Non-persisted accumulator for streaming text deltas.
     // Actor is single-threaded — plain Dictionary is correct (no locks).
     private readonly Dictionary<string, StringBuilder> _responseBuilders = new();
+
+    // Per-session progressive-delivery state. Lost on restart — recovery
+    // falls back to posting a fresh final reply via the non-streaming path.
+    private readonly Dictionary<string, StreamingDeliveryState> _streamingDeliveries = new();
 
     // Timeout leases keyed by sessionId — needed to cancel on completion.
     private readonly Dictionary<string, RuntimeCallbackLease> _timeoutLeases = new();
@@ -230,29 +241,29 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
     // ─── Turn 2+: Accumulate streaming text deltas ───
 
     [EventHandler]
-    public Task HandleChatContent(TextMessageContentEvent evt)
+    public async Task HandleChatContent(TextMessageContentEvent evt)
     {
-        // Only record first delta per session to avoid flooding diagnostics
-        if (!string.IsNullOrEmpty(evt.SessionId) &&
-            State.PendingSessions.TryGetValue(evt.SessionId, out var contentSession) &&
-            !_responseBuilders.ContainsKey(evt.SessionId))
+        if (string.IsNullOrEmpty(evt.SessionId) ||
+            !State.PendingSessions.TryGetValue(evt.SessionId, out var session))
         {
-            RecordDiagnostic("Chat:content:first", contentSession.Platform, contentSession.RegistrationId,
-                $"sessionId={evt.SessionId} delta_length={evt.Delta?.Length ?? 0}");
+            return;
         }
-
-        if (string.IsNullOrEmpty(evt.SessionId) || !State.PendingSessions.ContainsKey(evt.SessionId))
-            return Task.CompletedTask;
 
         if (!_responseBuilders.TryGetValue(evt.SessionId, out var builder))
         {
             builder = new StringBuilder();
             _responseBuilders[evt.SessionId] = builder;
+            RecordDiagnostic("Chat:content:first", session.Platform, session.RegistrationId,
+                $"sessionId={evt.SessionId} delta_length={evt.Delta?.Length ?? 0}");
         }
         if (!string.IsNullOrEmpty(evt.Delta))
             builder.Append(evt.Delta);
 
-        return Task.CompletedTask;
+        var accumulated = builder.ToString();
+        if (string.IsNullOrWhiteSpace(accumulated))
+            return;
+
+        await TryStreamingUpdateAsync(session, accumulated, isFinal: false);
     }
 
     // ─── Turn N: Chat complete → send reply ───
@@ -321,23 +332,41 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
         RecordDiagnostic("Reply:sending", session.Platform, session.RegistrationId,
             $"sessionId={session.SessionId} reply_length={replyText.Length} forceComplete={forceComplete}");
 
-        // Send reply via platform adapter.
+        // If the progressive path already posted a placeholder, the user is
+        // looking at that message — finalize by PATCHing it. Posting a fresh
+        // message would leave a duplicate visible reply.
+        var streamingActive = _streamingDeliveries.TryGetValue(session.SessionId, out var streamState)
+                              && streamState is { MessageId: not null, Disabled: false };
+
         var replySucceeded = false;
         try
         {
-            var delivery = await SendPlatformReplyAsync(session, replyText);
-            if (delivery.Succeeded)
+            if (streamingActive)
             {
-                replySucceeded = true;
-                RecordDiagnostic("Reply:done", session.Platform, session.RegistrationId, delivery.Detail);
+                replySucceeded = await TryStreamingUpdateAsync(session, replyText, isFinal: true);
+                if (replySucceeded)
+                    RecordDiagnostic("Reply:done", session.Platform, session.RegistrationId,
+                        $"stream message_id={streamState!.MessageId} edits={streamState.EditCount}");
+                else
+                    RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId,
+                        $"stream final PATCH failed messageId={streamState!.MessageId}");
             }
             else
             {
-                Logger.LogWarning("SendReply rejected: platform={Platform}, session={SessionId}, detail={Detail}",
-                    session.Platform,
-                    session.SessionId,
-                    delivery.Detail);
-                RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId, delivery.Detail);
+                var delivery = await SendPlatformReplyAsync(session, replyText);
+                if (delivery.Succeeded)
+                {
+                    replySucceeded = true;
+                    RecordDiagnostic("Reply:done", session.Platform, session.RegistrationId, delivery.Detail);
+                }
+                else
+                {
+                    Logger.LogWarning("SendReply rejected: platform={Platform}, session={SessionId}, detail={Detail}",
+                        session.Platform,
+                        session.SessionId,
+                        delivery.Detail);
+                    RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId, delivery.Detail);
+                }
             }
         }
         catch (Exception ex)
@@ -356,6 +385,7 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
         // Persist completion (removes from pending_sessions via state transition)
         await PersistDomainEventAsync(new ChannelChatCompletedEvent { SessionId = session.SessionId });
         _responseBuilders.Remove(session.SessionId);
+        _streamingDeliveries.Remove(session.SessionId);
 
         RecordDiagnostic("Session:completed", session.Platform, session.RegistrationId,
             $"sessionId={session.SessionId} reply_succeeded={replySucceeded}");
@@ -390,15 +420,123 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
     private async Task<PlatformReplyDeliveryResult> SendPlatformReplyAsync(
         ChannelPendingChatSession session, string replyText)
     {
-        var adapters = Services.GetRequiredService<IEnumerable<IPlatformAdapter>>();
-        var adapter = adapters.FirstOrDefault(a =>
-            string.Equals(a.Platform, session.Platform, StringComparison.OrdinalIgnoreCase));
-
+        var adapter = ResolvePlatformAdapter(session.Platform);
         if (adapter is null)
             return new PlatformReplyDeliveryResult(false, $"No adapter for platform: {session.Platform}");
 
         var nyxClient = Services.GetRequiredService<NyxIdApiClient>();
-        var inbound = new InboundMessage
+        var inbound = BuildInboundFromSession(session);
+        var registration = BuildRegistrationFromSession(session);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        return await adapter.SendReplyAsync(replyText, inbound, registration, nyxClient, cts.Token);
+    }
+
+    // ─── Progressive reply: post placeholder, PATCH as deltas stream in ───
+
+    /// <summary>
+    /// If the session's platform supports streaming replies, post the placeholder
+    /// (first call) or PATCH it with the accumulated text (throttled). When
+    /// <paramref name="isFinal"/>, bypass the throttle — used by HandleChatEnd /
+    /// HandleChatTimeout to flush the last state. Returns true iff the placeholder
+    /// exists AND the latest HTTP call (if any) succeeded.
+    /// </summary>
+    private async Task<bool> TryStreamingUpdateAsync(
+        ChannelPendingChatSession session, string accumulated, bool isFinal)
+    {
+        var adapter = ResolvePlatformAdapter(session.Platform) as IStreamingPlatformAdapter;
+        if (adapter is null)
+            return false;
+
+        if (!_streamingDeliveries.TryGetValue(session.SessionId, out var state))
+        {
+            state = new StreamingDeliveryState();
+            _streamingDeliveries[session.SessionId] = state;
+        }
+        if (state.Disabled)
+            return false;
+
+        var nyxClient = Services.GetRequiredService<NyxIdApiClient>();
+        var inbound = BuildInboundFromSession(session);
+        var registration = BuildRegistrationFromSession(session);
+
+        using var cts = new CancellationTokenSource(StreamingHttpTimeout);
+
+        if (state.MessageId is null)
+        {
+            try
+            {
+                var messageId = await adapter.PostStreamingPlaceholderAsync(
+                    accumulated, inbound, registration, nyxClient, cts.Token);
+                if (string.IsNullOrEmpty(messageId))
+                {
+                    state.Disabled = true;
+                    RecordDiagnostic("Stream:placeholder:failed", session.Platform, session.RegistrationId,
+                        $"sessionId={session.SessionId}");
+                    return false;
+                }
+                state.MessageId = messageId;
+                state.LastEditAt = DateTimeOffset.UtcNow;
+                state.EditCount = 1;
+                RecordDiagnostic("Stream:placeholder:posted", session.Platform, session.RegistrationId,
+                    $"sessionId={session.SessionId} messageId={messageId}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                state.Disabled = true;
+                Logger.LogWarning(ex, "Streaming placeholder post failed for session {SessionId}", session.SessionId);
+                RecordDiagnostic("Stream:placeholder:error", session.Platform, session.RegistrationId,
+                    $"{ex.GetType().Name}: {ex.Message}");
+                return false;
+            }
+        }
+
+        // Intermediate deltas: honour throttle so we don't hammer the platform.
+        // Still report the placeholder as "active" so callers treat the session
+        // as streamed — the next delta or the final flush will catch up.
+        if (!isFinal && DateTimeOffset.UtcNow - state.LastEditAt < StreamingEditThrottle)
+            return true;
+
+        try
+        {
+            var delivery = await adapter.UpdateStreamingMessageAsync(
+                state.MessageId!, accumulated, inbound, registration, nyxClient, cts.Token);
+            state.LastEditAt = DateTimeOffset.UtcNow;
+            state.EditCount++;
+            if (!delivery.Succeeded)
+            {
+                if (isFinal)
+                {
+                    Logger.LogWarning(
+                        "Streaming final PATCH rejected: session={SessionId}, detail={Detail}",
+                        session.SessionId, delivery.Detail);
+                }
+                return false;
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Streaming update error for session {SessionId}", session.SessionId);
+            if (isFinal)
+            {
+                RecordDiagnostic("Stream:final:error", session.Platform, session.RegistrationId,
+                    $"{ex.GetType().Name}: {ex.Message}");
+            }
+            return false;
+        }
+    }
+
+    private IPlatformAdapter? ResolvePlatformAdapter(string platform)
+    {
+        var adapters = Services.GetRequiredService<IEnumerable<IPlatformAdapter>>();
+        return adapters.FirstOrDefault(a =>
+            string.Equals(a.Platform, platform, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static InboundMessage BuildInboundFromSession(ChannelPendingChatSession session) =>
+        new()
         {
             Platform = session.Platform,
             ConversationId = session.ConversationId,
@@ -409,7 +547,8 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
             ChatType = session.ChatType,
         };
 
-        var registration = new ChannelBotRegistrationEntry
+    private static ChannelBotRegistrationEntry BuildRegistrationFromSession(ChannelPendingChatSession session) =>
+        new()
         {
             Id = session.RegistrationId,
             Platform = session.Platform,
@@ -418,8 +557,12 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
             ScopeId = session.RegistrationScopeId,
         };
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        return await adapter.SendReplyAsync(replyText, inbound, registration, nyxClient, cts.Token);
+    private sealed class StreamingDeliveryState
+    {
+        public string? MessageId;
+        public DateTimeOffset LastEditAt;
+        public bool Disabled;
+        public int EditCount;
     }
 
     private async Task<bool> TryHandleAgentBuilderAsync(

--- a/agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs
@@ -37,6 +37,39 @@ public interface IPlatformAdapter
         CancellationToken ct);
 }
 
+/// <summary>
+/// Optional capability: platforms that support progressive reply delivery.
+/// The caller posts an initial placeholder message when the first LLM delta arrives,
+/// then patches it as deltas accumulate. Reduces perceived latency for long
+/// LLM responses (user sees text stream in, ChatGPT-style) instead of staring
+/// at silence until the full response is ready.
+/// </summary>
+public interface IStreamingPlatformAdapter : IPlatformAdapter
+{
+    /// <summary>
+    /// Post a placeholder message carrying the first partial text.
+    /// Returns the platform-assigned message id used for subsequent updates,
+    /// or null if the post failed — caller should fall back to <see cref="IPlatformAdapter.SendReplyAsync"/>.
+    /// </summary>
+    Task<string?> PostStreamingPlaceholderAsync(
+        string initialText,
+        InboundMessage inbound,
+        ChannelBotRegistrationEntry registration,
+        NyxIdApiClient nyxClient,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Replace the content of an existing placeholder message with the accumulated text.
+    /// </summary>
+    Task<PlatformReplyDeliveryResult> UpdateStreamingMessageAsync(
+        string messageId,
+        string replyText,
+        InboundMessage inbound,
+        ChannelBotRegistrationEntry registration,
+        NyxIdApiClient nyxClient,
+        CancellationToken ct);
+}
+
 public readonly record struct PlatformReplyDeliveryResult(
     bool Succeeded,
     string? Detail = null);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
@@ -126,6 +126,101 @@ public class ChannelUserGAgentContinuationTests
     }
 
     [Fact]
+    public async Task StreamingAdapter_WhenFinalUpdateFails_ShouldFallBackToSendReplyAtEnd()
+    {
+        var runtime = new RecordingActorRuntime();
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingStreamingPlatformAdapter("lark")
+        {
+            UpdateDeliveryResult = new PlatformReplyDeliveryResult(false, "cannot_patch_to_interactive"),
+        };
+        using var services = BuildServices(runtime, streams, scheduler, adapter, new InMemoryEventStore());
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(BuildInboundEvent());
+
+        var request = runtime.SingleChatRequest();
+
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "hello ",
+            }));
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "world",
+            }));
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageEndEvent
+            {
+                SessionId = request.SessionId,
+                Content = "hello world",
+            }));
+
+        adapter.Placeholders.Should().ContainSingle();
+        adapter.Updates.Should().ContainSingle()
+            .Which.ReplyText.Should().Be("hello world");
+        adapter.Replies.Should().ContainSingle("final PATCH rejection should downgrade to send-once")
+            .Which.ReplyText.Should().Be("hello world");
+        agent.State.PendingSessions.Should().BeEmpty();
+        scheduler.Canceled.Should().ContainSingle(x => x.CallbackId == $"chat-timeout-{request.SessionId}");
+    }
+
+    [Fact]
+    public async Task StreamingAdapter_WhenTimeoutFinalUpdateFails_ShouldFallBackToSendReply()
+    {
+        var runtime = new RecordingActorRuntime();
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingStreamingPlatformAdapter("lark")
+        {
+            UpdateDeliveryResult = new PlatformReplyDeliveryResult(false, "cannot_patch_to_interactive"),
+        };
+        using var services = BuildServices(runtime, streams, scheduler, adapter, new InMemoryEventStore());
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(BuildInboundEvent());
+
+        var request = runtime.SingleChatRequest();
+
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "partial reply",
+            }));
+
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-user-lark-reg-1-ou_123",
+            TopologyAudience.Self,
+            new ChannelChatTimeoutEvent
+            {
+                SessionId = request.SessionId,
+            }));
+
+        adapter.Placeholders.Should().ContainSingle();
+        adapter.Updates.Should().ContainSingle()
+            .Which.ReplyText.Should().Be("partial reply");
+        adapter.Replies.Should().ContainSingle("timeout should still deliver a direct reply after final PATCH rejection")
+            .Which.ReplyText.Should().Be("partial reply");
+        agent.State.PendingSessions.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleChatEnd_ShouldSendReply_AndCompletePendingSession()
     {
         var runtime = new RecordingActorRuntime();
@@ -2077,6 +2172,8 @@ public class ChannelUserGAgentContinuationTests
         /// agent falls back to SendReplyAsync at HandleChatEnd.
         /// </summary>
         public string? PlaceholderMessageId { get; set; } = "om_stream_1";
+        public PlatformReplyDeliveryResult UpdateDeliveryResult { get; set; } =
+            new(true, "ok");
 
         public Task<IResult?> TryHandleVerificationAsync(HttpContext http, ChannelBotRegistrationEntry registration) =>
             Task.FromResult<IResult?>(null);
@@ -2118,7 +2215,7 @@ public class ChannelUserGAgentContinuationTests
         {
             ct.ThrowIfCancellationRequested();
             Updates.Add(new StreamingUpdateRecord(messageId, replyText, inbound, registration));
-            return Task.FromResult(new PlatformReplyDeliveryResult(true, $"message_id={messageId}"));
+            return Task.FromResult(UpdateDeliveryResult);
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
@@ -27,6 +27,105 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public class ChannelUserGAgentContinuationTests
 {
     [Fact]
+    public async Task StreamingAdapter_ShouldPostPlaceholder_AndFinalizeViaUpdate()
+    {
+        var runtime = new RecordingActorRuntime();
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingStreamingPlatformAdapter("lark");
+        using var services = BuildServices(runtime, streams, scheduler, adapter, new InMemoryEventStore());
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(BuildInboundEvent());
+
+        var request = runtime.SingleChatRequest();
+
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "hello ",
+            }));
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "world",
+            }));
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageEndEvent
+            {
+                SessionId = request.SessionId,
+                Content = "hello world",
+            }));
+
+        adapter.Placeholders.Should().ContainSingle().Which.InitialText.Should().Be("hello ");
+        adapter.Updates.Should().ContainSingle()
+            .Which.ReplyText.Should().Be("hello world");
+        adapter.Updates[0].MessageId.Should().Be("om_stream_1");
+        adapter.Replies.Should().BeEmpty("streaming finalize via PATCH must not also post a fresh message");
+        agent.State.PendingSessions.Should().BeEmpty();
+        scheduler.Canceled.Should().ContainSingle(x => x.CallbackId == $"chat-timeout-{request.SessionId}");
+    }
+
+    [Fact]
+    public async Task StreamingAdapter_WhenPlaceholderFails_ShouldFallBackToSendReplyAtEnd()
+    {
+        var runtime = new RecordingActorRuntime();
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingStreamingPlatformAdapter("lark")
+        {
+            PlaceholderMessageId = null,
+        };
+        using var services = BuildServices(runtime, streams, scheduler, adapter, new InMemoryEventStore());
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(BuildInboundEvent());
+
+        var request = runtime.SingleChatRequest();
+
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "hello ",
+            }));
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageContentEvent
+            {
+                SessionId = request.SessionId,
+                Delta = "world",
+            }));
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageEndEvent
+            {
+                SessionId = request.SessionId,
+                Content = "hello world",
+            }));
+
+        adapter.Placeholders.Should().ContainSingle("first delta should try to post placeholder once");
+        adapter.Updates.Should().BeEmpty("streaming is disabled after placeholder failure");
+        adapter.Replies.Should().ContainSingle()
+            .Which.ReplyText.Should().Be("hello world");
+        agent.State.PendingSessions.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleChatEnd_ShouldSendReply_AndCompletePendingSession()
     {
         var runtime = new RecordingActorRuntime();
@@ -1707,6 +1806,16 @@ public class ChannelUserGAgentContinuationTests
         RecordingPlatformAdapter adapter,
         IEventStore eventStore,
         IChannelRuntimeDiagnostics? diagnostics = null,
+        Action<IServiceCollection>? configure = null) =>
+        BuildServices(runtime, streams, scheduler, (IPlatformAdapter)adapter, eventStore, diagnostics, configure);
+
+    private static ServiceProvider BuildServices(
+        IActorRuntime runtime,
+        RecordingStreamProvider streams,
+        RecordingCallbackScheduler scheduler,
+        IPlatformAdapter adapter,
+        IEventStore eventStore,
+        IChannelRuntimeDiagnostics? diagnostics = null,
         Action<IServiceCollection>? configure = null)
     {
         var services = new ServiceCollection()
@@ -1952,6 +2061,74 @@ public class ChannelUserGAgentContinuationTests
     }
 
     private sealed record ReplyRecord(
+        string ReplyText,
+        InboundMessage Inbound,
+        ChannelBotRegistrationEntry Registration);
+
+    private sealed class RecordingStreamingPlatformAdapter(string platform) : IStreamingPlatformAdapter
+    {
+        public string Platform { get; } = platform;
+        public List<ReplyRecord> Replies { get; } = [];
+        public List<StreamingPlaceholderRecord> Placeholders { get; } = [];
+        public List<StreamingUpdateRecord> Updates { get; } = [];
+
+        /// <summary>
+        /// When null, simulate a platform rejection on the first placeholder post so the
+        /// agent falls back to SendReplyAsync at HandleChatEnd.
+        /// </summary>
+        public string? PlaceholderMessageId { get; set; } = "om_stream_1";
+
+        public Task<IResult?> TryHandleVerificationAsync(HttpContext http, ChannelBotRegistrationEntry registration) =>
+            Task.FromResult<IResult?>(null);
+
+        public Task<InboundMessage?> ParseInboundAsync(HttpContext http, ChannelBotRegistrationEntry registration) =>
+            Task.FromResult<InboundMessage?>(null);
+
+        public Task<PlatformReplyDeliveryResult> SendReplyAsync(
+            string replyText,
+            InboundMessage inbound,
+            ChannelBotRegistrationEntry registration,
+            NyxIdApiClient nyxClient,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Replies.Add(new ReplyRecord(replyText, inbound, registration));
+            return Task.FromResult(new PlatformReplyDeliveryResult(true, "ok"));
+        }
+
+        public Task<string?> PostStreamingPlaceholderAsync(
+            string initialText,
+            InboundMessage inbound,
+            ChannelBotRegistrationEntry registration,
+            NyxIdApiClient nyxClient,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Placeholders.Add(new StreamingPlaceholderRecord(initialText, inbound, registration));
+            return Task.FromResult(PlaceholderMessageId);
+        }
+
+        public Task<PlatformReplyDeliveryResult> UpdateStreamingMessageAsync(
+            string messageId,
+            string replyText,
+            InboundMessage inbound,
+            ChannelBotRegistrationEntry registration,
+            NyxIdApiClient nyxClient,
+            CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Updates.Add(new StreamingUpdateRecord(messageId, replyText, inbound, registration));
+            return Task.FromResult(new PlatformReplyDeliveryResult(true, $"message_id={messageId}"));
+        }
+    }
+
+    private sealed record StreamingPlaceholderRecord(
+        string InitialText,
+        InboundMessage Inbound,
+        ChannelBotRegistrationEntry Registration);
+
+    private sealed record StreamingUpdateRecord(
+        string MessageId,
         string ReplyText,
         InboundMessage Inbound,
         ChannelBotRegistrationEntry Registration);


### PR DESCRIPTION
## 问题

Lark bot 收到消息后，用户要静默等待 5–30s 才能看到 LLM 回复。`HandleChatContent` 把所有 delta 累到 `StringBuilder`，直到 `HandleChatEnd` 才一次 POST 到 Lark。

## 方案

- 新增 `IStreamingPlatformAdapter` 能力接口（扩展 `IPlatformAdapter`）：`PostStreamingPlaceholderAsync` + `UpdateStreamingMessageAsync`。
- `LarkPlatformAdapter` 实现该接口：第一条 delta 通过 Lark `POST /open-apis/im/v1/messages` 发占位消息并捕获 `message_id`；后续 delta 通过 `PATCH /open-apis/im/v1/messages/{id}` 覆盖内容。互动卡片载荷保持走原 send-once 路径，避免消息类型冲突。
- `ChannelUserGAgent.HandleChatContent` 改为 async：首 delta 立即发占位消息，后续 delta 按 750ms 节流 PATCH；`HandleChatEnd` / `HandleChatTimeout` 通过同一 helper `isFinal: true` 强制 flush 最终文本，绕过节流。
- 占位 POST 失败 / 后续 PATCH 抛异常 → session 标 `Disabled`，`SendReplyAndCompleteAsync` 回退到原有 `SendReplyAsync` 路径。
- 占位消息 id 只在内存，actor 重启后新 delta 另开占位，不阻塞正确性；仅属 UX 增强。

## 影响路径

- `agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs` — 新接口 `IStreamingPlatformAdapter`
- `agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs` — 实现流式接口 + 辅助方法
- `agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs` — 引入 `_streamingDeliveries` per-session 状态、`TryStreamingUpdateAsync` helper；重写 `HandleChatContent` 为 async；`SendReplyAndCompleteAsync` 增加 streaming-first 分支
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs` — 新增 happy path + placeholder 失败回退两条测试，提供 `RecordingStreamingPlatformAdapter`

## 验证

- [x] `dotnet build agents/Aevatar.GAgents.ChannelRuntime/Aevatar.GAgents.ChannelRuntime.csproj` — 0 errors
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — 228/228 pass（原 226 + 2 新增）
- [x] `bash tools/ci/architecture_guards.sh` — 全部通过
- [ ] 部署后在 Lark 真实机器人上观察：发送 "写一段 300 字的介绍" 这类长回复，确认占位消息先出现、内容按 ~750ms 节奏增量刷新、最终结果正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)