### PR TITLE
Implement channel abstractions package

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/Aevatar.GAgents.Channel.Abstractions.csproj
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Aevatar.GAgents.Channel.Abstractions.csproj
@@ -5,7 +5,14 @@
     <Nullable>enable</Nullable>
     <AssemblyName>Aevatar.GAgents.Channel.Abstractions</AssemblyName>
     <RootNamespace>Aevatar.GAgents.Channel.Abstractions</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core\Aevatar.CQRS.Projection.Core.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Runtime.Abstractions\Aevatar.CQRS.Projection.Runtime.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools">

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Aevatar.GAgents.Channel.Abstractions.csproj
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Aevatar.GAgents.Channel.Abstractions.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Aevatar.GAgents.Channel.Abstractions</AssemblyName>
     <RootNamespace>Aevatar.GAgents.Channel.Abstractions</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Bots/IBot.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Bots/IBot.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Handles one normalized inbound activity within the channel bot pipeline.
+/// </summary>
+public interface IBot
+{
+    /// <summary>
+    /// Processes the current activity using the turn-scoped outbound helpers exposed by <paramref name="context"/>.
+    /// </summary>
+    Task OnActivityAsync(ITurnContext context, CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Bots/IBot.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Bots/IBot.cs
@@ -3,10 +3,18 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Handles one normalized inbound activity within the channel bot pipeline.
 /// </summary>
+/// <remarks>
+/// Per-conversation ordering is supplied by the conversation actor that invokes this contract. Bot implementations should
+/// therefore assume turn-serial execution within one conversation and keep channel-specific transport details behind
+/// <see cref="ITurnContext"/>.
+/// </remarks>
 public interface IBot
 {
     /// <summary>
-    /// Processes the current activity using the turn-scoped outbound helpers exposed by <paramref name="context"/>.
+     /// Processes the current activity using the turn-scoped outbound helpers exposed by <paramref name="context"/>.
     /// </summary>
+    /// <param name="context">The turn-scoped activity and outbound helpers for the current conversation turn.</param>
+    /// <param name="ct">A token that cancels turn processing.</param>
+    /// <returns>A task that completes when the bot has finished processing the inbound activity.</returns>
     Task OnActivityAsync(ITurnContext context, CancellationToken ct);
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Bots/ITurnContext.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Bots/ITurnContext.cs
@@ -3,6 +3,11 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Exposes one inbound activity together with the constrained outbound operations allowed during the turn.
 /// </summary>
+/// <remarks>
+/// This contract intentionally hides <see cref="IChannelTransport"/> and <see cref="IChannelOutboundPort"/> so bot code
+/// cannot bypass turn-scoped auth, targeting, or ordering rules. Outbound helpers automatically target
+/// <see cref="Activity"/>'s conversation and use the bot credential bound to the active adapter instance.
+/// </remarks>
 public interface ITurnContext
 {
     /// <summary>
@@ -23,25 +28,47 @@ public interface ITurnContext
     /// <summary>
     /// Sends a new outbound activity in the current conversation.
     /// </summary>
+    /// <param name="content">The channel-agnostic outbound message intent.</param>
+    /// <returns>The emit result produced by the active adapter.</returns>
+    /// <remarks>
+    /// This helper always targets <see cref="Activity"/>'s conversation and uses the adapter's bot credential for the
+    /// current turn.
+    /// </remarks>
     Task<EmitResult> SendAsync(MessageContent content);
 
     /// <summary>
     /// Sends a reply associated with the current inbound activity.
     /// </summary>
+    /// <param name="content">The channel-agnostic reply intent.</param>
+    /// <returns>The emit result produced by the active adapter.</returns>
+    /// <remarks>
+    /// Implementations should preserve reply linkage with the triggering inbound activity where the target channel supports it.
+    /// </remarks>
     Task<EmitResult> ReplyAsync(MessageContent content);
 
     /// <summary>
     /// Starts a streaming reply whose concrete lifecycle is implemented by the active adapter.
     /// </summary>
+    /// <param name="initial">The initial message content used to seed the streaming reply.</param>
+    /// <returns>The adapter-owned streaming handle for the in-flight reply.</returns>
+    /// <remarks>
+    /// The returned handle encapsulates debounce, chunk ordering, and interruption semantics so bot code does not need
+    /// channel-specific streaming logic.
+    /// </remarks>
     Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial);
 
     /// <summary>
     /// Updates one activity previously emitted during this turn.
     /// </summary>
+    /// <param name="activityId">The opaque activity identifier returned by a previous send or reply.</param>
+    /// <param name="content">The replacement content.</param>
+    /// <returns>The emit result produced by the active adapter.</returns>
     Task<EmitResult> UpdateAsync(string activityId, MessageContent content);
 
     /// <summary>
     /// Deletes one activity previously emitted during this turn.
     /// </summary>
+    /// <param name="activityId">The opaque activity identifier returned by a previous send or reply.</param>
+    /// <returns>The emit result produced by the active adapter.</returns>
     Task<EmitResult> DeleteAsync(string activityId);
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Bots/ITurnContext.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Bots/ITurnContext.cs
@@ -1,0 +1,47 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Exposes one inbound activity together with the constrained outbound operations allowed during the turn.
+/// </summary>
+public interface ITurnContext
+{
+    /// <summary>
+    /// Gets the normalized inbound activity that triggered this turn.
+    /// </summary>
+    ChatActivity Activity { get; }
+
+    /// <summary>
+    /// Gets the bot descriptor bound to the current turn without exposing transport credentials.
+    /// </summary>
+    ChannelBotDescriptor Bot { get; }
+
+    /// <summary>
+    /// Gets the service provider that owns the turn lifetime.
+    /// </summary>
+    IServiceProvider Services { get; }
+
+    /// <summary>
+    /// Sends a new outbound activity in the current conversation.
+    /// </summary>
+    Task<EmitResult> SendAsync(MessageContent content);
+
+    /// <summary>
+    /// Sends a reply associated with the current inbound activity.
+    /// </summary>
+    Task<EmitResult> ReplyAsync(MessageContent content);
+
+    /// <summary>
+    /// Starts a streaming reply whose concrete lifecycle is implemented by the active adapter.
+    /// </summary>
+    Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial);
+
+    /// <summary>
+    /// Updates one activity previously emitted during this turn.
+    /// </summary>
+    Task<EmitResult> UpdateAsync(string activityId, MessageContent content);
+
+    /// <summary>
+    /// Deletes one activity previously emitted during this turn.
+    /// </summary>
+    Task<EmitResult> DeleteAsync(string activityId);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Bots/ITurnContext.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Bots/ITurnContext.cs
@@ -29,46 +29,56 @@ public interface ITurnContext
     /// Sends a new outbound activity in the current conversation.
     /// </summary>
     /// <param name="content">The channel-agnostic outbound message intent.</param>
+    /// <param name="ct">A token that cancels the send. Callers should propagate the turn cancellation token supplied to <see cref="IBot.OnActivityAsync"/>.</param>
     /// <returns>The emit result produced by the active adapter.</returns>
     /// <remarks>
     /// This helper always targets <see cref="Activity"/>'s conversation and uses the adapter's bot credential for the
     /// current turn.
     /// </remarks>
-    Task<EmitResult> SendAsync(MessageContent content);
+    Task<EmitResult> SendAsync(MessageContent content, CancellationToken ct);
 
     /// <summary>
     /// Sends a reply associated with the current inbound activity.
     /// </summary>
     /// <param name="content">The channel-agnostic reply intent.</param>
+    /// <param name="ct">A token that cancels the reply. Callers should propagate the turn cancellation token supplied to <see cref="IBot.OnActivityAsync"/>.</param>
     /// <returns>The emit result produced by the active adapter.</returns>
     /// <remarks>
     /// Implementations should preserve reply linkage with the triggering inbound activity where the target channel supports it.
     /// </remarks>
-    Task<EmitResult> ReplyAsync(MessageContent content);
+    Task<EmitResult> ReplyAsync(MessageContent content, CancellationToken ct);
 
     /// <summary>
     /// Starts a streaming reply whose concrete lifecycle is implemented by the active adapter.
     /// </summary>
     /// <param name="initial">The initial message content used to seed the streaming reply.</param>
+    /// <param name="ct">A token that cancels streaming startup. Callers should propagate the turn cancellation token supplied to <see cref="IBot.OnActivityAsync"/>.</param>
     /// <returns>The adapter-owned streaming handle for the in-flight reply.</returns>
     /// <remarks>
     /// The returned handle encapsulates debounce, chunk ordering, and interruption semantics so bot code does not need
     /// channel-specific streaming logic.
     /// </remarks>
-    Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial);
+    Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial, CancellationToken ct);
 
     /// <summary>
     /// Updates one activity previously emitted during this turn.
     /// </summary>
     /// <param name="activityId">The opaque activity identifier returned by a previous send or reply.</param>
     /// <param name="content">The replacement content.</param>
+    /// <param name="ct">A token that cancels the update. Callers should propagate the turn cancellation token supplied to <see cref="IBot.OnActivityAsync"/>.</param>
     /// <returns>The emit result produced by the active adapter.</returns>
-    Task<EmitResult> UpdateAsync(string activityId, MessageContent content);
+    Task<EmitResult> UpdateAsync(string activityId, MessageContent content, CancellationToken ct);
 
     /// <summary>
     /// Deletes one activity previously emitted during this turn.
     /// </summary>
     /// <param name="activityId">The opaque activity identifier returned by a previous send or reply.</param>
-    /// <returns>The emit result produced by the active adapter.</returns>
-    Task<EmitResult> DeleteAsync(string activityId);
+    /// <param name="ct">A token that cancels the delete. Callers should propagate the turn cancellation token supplied to <see cref="IBot.OnActivityAsync"/>.</param>
+    /// <returns>A task that completes when the delete attempt has finished.</returns>
+    /// <remarks>
+    /// This surface mirrors <see cref="IChannelOutboundPort.DeleteAsync"/>: the adapter-owned activity has no successor id, and
+    /// <see cref="EmitResult"/> semantics (success plus <see cref="EmitResult.SentActivityId"/>) do not apply. Implementations
+    /// must surface delete failures as exceptions rather than fabricating emit results.
+    /// </remarks>
+    Task DeleteAsync(string activityId, CancellationToken ct);
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Composition/IMessageComposer.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Composition/IMessageComposer.cs
@@ -1,0 +1,34 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Converts channel-agnostic message intent into one channel-native payload shape.
+/// </summary>
+public interface IMessageComposer
+{
+    /// <summary>
+    /// Gets the channel this composer targets.
+    /// </summary>
+    ChannelId Channel { get; }
+
+    /// <summary>
+    /// Produces the channel-native payload for the supplied intent.
+    /// </summary>
+    object Compose(MessageContent intent, ComposeContext context);
+
+    /// <summary>
+    /// Evaluates whether the supplied intent can be expressed exactly, degraded, or not at all.
+    /// </summary>
+    ComposeCapability Evaluate(MessageContent intent, ComposeContext context);
+}
+
+/// <summary>
+/// Converts channel-agnostic message intent into one strongly typed channel-native payload.
+/// </summary>
+/// <typeparam name="TNativePayload">The adapter-native payload shape produced by this composer.</typeparam>
+public interface IMessageComposer<out TNativePayload> : IMessageComposer
+{
+    /// <summary>
+    /// Produces the strongly typed channel-native payload for the supplied intent.
+    /// </summary>
+    new TNativePayload Compose(MessageContent intent, ComposeContext context);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Composition/IMessageComposer.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Composition/IMessageComposer.cs
@@ -3,6 +3,10 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Converts channel-agnostic message intent into one channel-native payload shape.
 /// </summary>
+/// <remarks>
+/// Composers are pure payload translators. They do not own transport lifecycle, auth resolution, or outbound I/O.
+/// <see cref="Evaluate"/> is expected to be side-effect free so callers can probe capability before composing.
+/// </remarks>
 public interface IMessageComposer
 {
     /// <summary>
@@ -13,11 +17,21 @@ public interface IMessageComposer
     /// <summary>
     /// Produces the channel-native payload for the supplied intent.
     /// </summary>
+    /// <param name="intent">The channel-agnostic outbound message intent.</param>
+    /// <param name="context">The target conversation and capability context used during composition.</param>
+    /// <returns>The channel-native payload ready for the adapter's outbound SDK call.</returns>
     object Compose(MessageContent intent, ComposeContext context);
 
     /// <summary>
     /// Evaluates whether the supplied intent can be expressed exactly, degraded, or not at all.
     /// </summary>
+    /// <param name="intent">The channel-agnostic outbound message intent.</param>
+    /// <param name="context">The target conversation and capability context used during evaluation.</param>
+    /// <returns>
+    /// <see cref="ComposeCapability.Exact"/> when the intent can be rendered losslessly,
+    /// <see cref="ComposeCapability.Degraded"/> when a deterministic downgrade exists, or
+    /// <see cref="ComposeCapability.Unsupported"/> when composition must be rejected.
+    /// </returns>
     ComposeCapability Evaluate(MessageContent intent, ComposeContext context);
 }
 
@@ -30,5 +44,8 @@ public interface IMessageComposer<out TNativePayload> : IMessageComposer
     /// <summary>
     /// Produces the strongly typed channel-native payload for the supplied intent.
     /// </summary>
+    /// <param name="intent">The channel-agnostic outbound message intent.</param>
+    /// <param name="context">The target conversation and capability context used during composition.</param>
+    /// <returns>The strongly typed adapter-native payload.</returns>
     new TNativePayload Compose(MessageContent intent, ComposeContext context);
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Identifiers/BotInstanceId.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Identifiers/BotInstanceId.Partial.cs
@@ -1,0 +1,28 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for working with stable bot instance identifiers.
+/// </summary>
+public sealed partial class BotInstanceId
+{
+    /// <summary>
+    /// Creates one normalized bot instance identifier.
+    /// </summary>
+    public static BotInstanceId From(string value) => new()
+    {
+        Value = Normalize(value, nameof(value)),
+    };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the identifier is empty.
+    /// </summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Value);
+
+    private static string Normalize(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Bot instance id cannot be empty.", paramName);
+
+        return value.Trim();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Identifiers/ChannelId.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Identifiers/ChannelId.Partial.cs
@@ -1,0 +1,28 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for working with stable channel identifiers.
+/// </summary>
+public sealed partial class ChannelId
+{
+    /// <summary>
+    /// Creates one normalized channel identifier.
+    /// </summary>
+    public static ChannelId From(string value) => new()
+    {
+        Value = Normalize(value, nameof(value)),
+    };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the identifier is empty.
+    /// </summary>
+    public bool IsEmpty => string.IsNullOrWhiteSpace(Value);
+
+    private static string Normalize(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Channel id cannot be empty.", paramName);
+
+        return value.Trim();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Middleware/IChannelMiddleware.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Middleware/IChannelMiddleware.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Represents one narrow turn-scoped middleware in the channel inbound pipeline.
+/// </summary>
+public interface IChannelMiddleware
+{
+    /// <summary>
+    /// Invokes the middleware and optionally forwards control to the next component.
+    /// </summary>
+    Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Middleware/IChannelMiddleware.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Middleware/IChannelMiddleware.cs
@@ -3,10 +3,18 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Represents one narrow turn-scoped middleware in the channel inbound pipeline.
 /// </summary>
+/// <remarks>
+/// Middleware runs after the adapter has constructed a <see cref="ChatActivity"/> and before bot logic executes. It is not
+/// responsible for ingress signature verification, durable deduplication, or adapter-owned outbound retry behavior.
+/// </remarks>
 public interface IChannelMiddleware
 {
     /// <summary>
     /// Invokes the middleware and optionally forwards control to the next component.
     /// </summary>
+    /// <param name="context">The current turn context.</param>
+    /// <param name="next">The next middleware or bot delegate in the pipeline.</param>
+    /// <param name="ct">A token that cancels pipeline execution.</param>
+    /// <returns>A task that completes when the middleware and downstream components have finished.</returns>
     Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct);
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Projection/PerEntryDocumentProjector.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Projection/PerEntryDocumentProjector.cs
@@ -1,0 +1,113 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Google.Protobuf;
+
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Shared current-state projector loop for actor states that materialize one read-model document per retained entry.
+/// </summary>
+/// <typeparam name="TState">The committed actor state message unpacked from the envelope.</typeparam>
+/// <typeparam name="TEntry">The entry type enumerated from the authoritative state.</typeparam>
+/// <typeparam name="TDocument">The read-model document written by the projection dispatcher.</typeparam>
+public abstract class PerEntryDocumentProjector<TState, TEntry, TDocument>
+    : ICurrentStateProjectionMaterializer<IProjectionMaterializationContext>
+    where TState : class, IMessage<TState>, new()
+    where TEntry : class
+    where TDocument : class, IProjectionReadModel<TDocument>, IMessage<TDocument>, new()
+{
+    private readonly IProjectionWriteDispatcher<TDocument> _writeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    /// <summary>
+    /// Initializes one shared per-entry projector loop.
+    /// </summary>
+    protected PerEntryDocumentProjector(
+        IProjectionWriteDispatcher<TDocument> writeDispatcher,
+        IProjectionClock clock)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ProjectAsync(
+        IProjectionMaterializationContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!CommittedStateEventEnvelope.TryUnpackState<TState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out var state) ||
+            stateEvent == null ||
+            state == null)
+        {
+            return;
+        }
+
+        var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
+        foreach (var entry in ExtractEntries(state) ?? [])
+        {
+            if (entry == null)
+                continue;
+
+            var key = EntryKey(entry);
+            if (string.IsNullOrWhiteSpace(key))
+                continue;
+
+            switch (Evaluate(entry))
+            {
+                case ProjectionVerdict.Project:
+                    var document = Materialize(entry, context, stateEvent, updatedAt) ??
+                                   throw new InvalidOperationException("Projector materialization returned null.");
+                    if (!string.Equals(document.Id, key, StringComparison.Ordinal))
+                    {
+                        throw new InvalidOperationException(
+                            $"Projected document id '{document.Id}' does not match entry key '{key}'.");
+                    }
+
+                    await _writeDispatcher.UpsertAsync(document, ct);
+                    break;
+                case ProjectionVerdict.Skip:
+                    break;
+                case ProjectionVerdict.Tombstone:
+                    await _writeDispatcher.DeleteAsync(key, ct);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entry), "Unsupported projection verdict.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts every authoritative entry that should be considered by the projection loop.
+    /// </summary>
+    protected abstract IEnumerable<TEntry> ExtractEntries(TState state);
+
+    /// <summary>
+    /// Returns the stable read-model key for one authoritative entry.
+    /// </summary>
+    protected abstract string EntryKey(TEntry entry);
+
+    /// <summary>
+    /// Materializes one read-model document for the supplied entry.
+    /// </summary>
+    protected abstract TDocument Materialize(
+        TEntry entry,
+        IProjectionMaterializationContext context,
+        StateEvent stateEvent,
+        DateTimeOffset updatedAt);
+
+    /// <summary>
+    /// Evaluates whether the supplied entry should be projected, skipped, or deleted from the read model.
+    /// </summary>
+    protected virtual ProjectionVerdict Evaluate(TEntry entry) => ProjectionVerdict.Project;
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Scheduling/ISchedulable.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Scheduling/ISchedulable.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Marks one actor state as carrying the shared schedule contract used by channel-triggered runners.
+/// </summary>
+public interface ISchedulable
+{
+    /// <summary>
+    /// Gets the stable schedule state owned by this object.
+    /// </summary>
+    ScheduleState Schedule { get; }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Scheduling/ScheduleState.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Scheduling/ScheduleState.Partial.cs
@@ -1,0 +1,27 @@
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for the stable schedule state carried by schedulable channel actors.
+/// </summary>
+public sealed partial class ScheduleState
+{
+    /// <summary>
+    /// Gets or sets the next scheduled execution timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset? NextRunAtUtc
+    {
+        get => NextRunAt == null ? null : NextRunAt.ToDateTimeOffset();
+        set => NextRunAt = value.HasValue ? Timestamp.FromDateTimeOffset(value.Value.ToUniversalTime()) : null;
+    }
+
+    /// <summary>
+    /// Gets or sets the last completed execution timestamp in UTC.
+    /// </summary>
+    public DateTimeOffset? LastRunAtUtc
+    {
+        get => LastRunAt == null ? null : LastRunAt.ToDateTimeOffset();
+        set => LastRunAt = value.HasValue ? Timestamp.FromDateTimeOffset(value.Value.ToUniversalTime()) : null;
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Security/ChannelCredentialProviderExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Security/ChannelCredentialProviderExtensions.cs
@@ -1,0 +1,46 @@
+using Aevatar.Foundation.Abstractions.Credentials;
+
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Channel-facing helpers over the shared credential-resolution contract introduced in foundation abstractions.
+/// </summary>
+public static class ChannelCredentialProviderExtensions
+{
+    /// <summary>
+    /// Resolves the bot credential referenced by one transport binding.
+    /// </summary>
+    public static Task<string?> ResolveBotCredentialAsync(
+        this ICredentialProvider credentialProvider,
+        ChannelTransportBinding binding,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentialProvider);
+        ArgumentNullException.ThrowIfNull(binding);
+
+        if (string.IsNullOrWhiteSpace(binding.CredentialRef))
+            throw new ArgumentException("Transport binding must carry a credential reference.", nameof(binding));
+
+        return credentialProvider.ResolveAsync(binding.CredentialRef, ct);
+    }
+
+    /// <summary>
+    /// Resolves the delegated user credential referenced by one auth context.
+    /// </summary>
+    public static Task<string?> ResolveUserCredentialAsync(
+        this ICredentialProvider credentialProvider,
+        AuthContext authContext,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credentialProvider);
+        ArgumentNullException.ThrowIfNull(authContext);
+
+        if (authContext.Kind != PrincipalKind.OnBehalfOfUser)
+            throw new ArgumentException("Only delegated user auth contexts carry a user credential reference.", nameof(authContext));
+
+        if (string.IsNullOrWhiteSpace(authContext.UserCredentialRef))
+            throw new ArgumentException("Auth context must carry a user credential reference.", nameof(authContext));
+
+        return credentialProvider.ResolveAsync(authContext.UserCredentialRef, ct);
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Security/HealthStatus.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Security/HealthStatus.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Describes whether a payload redactor is currently healthy enough for ingress traffic.
+/// </summary>
+public enum HealthStatus
+{
+    /// <summary>
+    /// The redactor is healthy and can process ingress traffic normally.
+    /// </summary>
+    Healthy = 0,
+
+    /// <summary>
+    /// The redactor is partially available but should remain out of the main ingress path.
+    /// </summary>
+    Degraded = 1,
+
+    /// <summary>
+    /// The redactor is unavailable and ingress should remain fail-closed.
+    /// </summary>
+    Unhealthy = 2,
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Security/IPayloadRedactor.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Security/IPayloadRedactor.cs
@@ -1,0 +1,17 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Removes short-lived credentials and non-required sensitive fields from one raw channel payload before ingress commit.
+/// </summary>
+public interface IPayloadRedactor
+{
+    /// <summary>
+    /// Produces the sanitized payload that may continue through the durable ingress path.
+    /// </summary>
+    Task<RedactionResult> RedactAsync(ChannelId channel, byte[] rawPayload, CancellationToken ct);
+
+    /// <summary>
+    /// Probes whether the redactor can safely re-enter the ingress path.
+    /// </summary>
+    Task<HealthStatus> HealthCheckAsync(CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Security/IPayloadRedactor.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Security/IPayloadRedactor.cs
@@ -3,15 +3,25 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Removes short-lived credentials and non-required sensitive fields from one raw channel payload before ingress commit.
 /// </summary>
+/// <remarks>
+/// Redaction is part of the ingress safety boundary. Implementations should fail closed: if payload sanitization or health
+/// probing cannot complete safely, ingress should remain blocked rather than persisting unsafe raw payloads.
+/// </remarks>
 public interface IPayloadRedactor
 {
     /// <summary>
     /// Produces the sanitized payload that may continue through the durable ingress path.
     /// </summary>
+    /// <param name="channel">The channel whose payload is being sanitized.</param>
+    /// <param name="rawPayload">The raw vendor payload bytes received at ingress.</param>
+    /// <param name="ct">A token that cancels redaction.</param>
+    /// <returns>The sanitized payload and a flag that records whether the bytes were modified.</returns>
     Task<RedactionResult> RedactAsync(ChannelId channel, byte[] rawPayload, CancellationToken ct);
 
     /// <summary>
     /// Probes whether the redactor can safely re-enter the ingress path.
     /// </summary>
+    /// <param name="ct">A token that cancels the health probe.</param>
+    /// <returns>The current health state used to decide whether ingress may proceed.</returns>
     Task<HealthStatus> HealthCheckAsync(CancellationToken ct);
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Security/RedactionResult.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Security/RedactionResult.cs
@@ -1,0 +1,21 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Represents one sanitized payload emitted by <see cref="IPayloadRedactor"/>.
+/// </summary>
+/// <param name="SanitizedPayload">The payload bytes that may proceed through ingress storage or normalization.</param>
+/// <param name="WasModified">Whether the redactor changed the payload contents.</param>
+public sealed record RedactionResult(byte[] SanitizedPayload, bool WasModified)
+{
+    /// <summary>
+    /// Creates a result that preserves the original payload bytes.
+    /// </summary>
+    public static RedactionResult Unchanged(byte[] payload) =>
+        new(payload ?? throw new ArgumentNullException(nameof(payload)), false);
+
+    /// <summary>
+    /// Creates a result that carries a modified sanitized payload.
+    /// </summary>
+    public static RedactionResult Modified(byte[] payload) =>
+        new(payload ?? throw new ArgumentNullException(nameof(payload)), true);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Security/RedactionResult.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Security/RedactionResult.cs
@@ -3,10 +3,24 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Represents one sanitized payload emitted by <see cref="IPayloadRedactor"/>.
 /// </summary>
-/// <param name="SanitizedPayload">The payload bytes that may proceed through ingress storage or normalization.</param>
-/// <param name="WasModified">Whether the redactor changed the payload contents.</param>
-public sealed record RedactionResult(byte[] SanitizedPayload, bool WasModified)
+public sealed record RedactionResult
 {
+    private RedactionResult(byte[] sanitizedPayload, bool wasModified)
+    {
+        SanitizedPayload = ClonePayload(sanitizedPayload, nameof(sanitizedPayload));
+        WasModified = wasModified;
+    }
+
+    /// <summary>
+    /// Gets the payload bytes that may proceed through ingress storage or normalization.
+    /// </summary>
+    public byte[] SanitizedPayload { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the redactor changed the payload contents.
+    /// </summary>
+    public bool WasModified { get; }
+
     /// <summary>
     /// Creates a result that preserves the original payload bytes.
     /// </summary>
@@ -18,4 +32,7 @@ public sealed record RedactionResult(byte[] SanitizedPayload, bool WasModified)
     /// </summary>
     public static RedactionResult Modified(byte[] payload) =>
         new(payload ?? throw new ArgumentNullException(nameof(payload)), true);
+
+    private static byte[] ClonePayload(byte[] payload, string paramName) =>
+        payload is null ? throw new ArgumentNullException(paramName) : payload.ToArray();
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Streaming/StreamingHandle.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Streaming/StreamingHandle.cs
@@ -3,20 +3,35 @@ namespace Aevatar.GAgents.Channel.Abstractions;
 /// <summary>
 /// Represents one adapter-owned streaming reply session.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AppendAsync"/> is idempotent by <see cref="StreamChunk.SequenceNumber"/>. Replays of the same sequence number
+/// must be ignored, while equal text with different sequence numbers remains valid output.
+/// </para>
+/// <para>
+/// <see cref="CompleteAsync"/> must be called at most once. <see cref="DisposeAsync"/> is the idempotent safety net for
+/// interrupted streams and may run before or after completion.
+/// </para>
+/// </remarks>
 public abstract class StreamingHandle : IAsyncDisposable
 {
     /// <summary>
     /// Appends one sequenced chunk to the in-flight reply.
     /// </summary>
+    /// <param name="chunk">The monotonic chunk emitted by the caller.</param>
+    /// <returns>A task that completes when the adapter has accepted the chunk into its streaming state machine.</returns>
     public abstract Task AppendAsync(StreamChunk chunk);
 
     /// <summary>
     /// Finalizes the streaming reply with the completed message content.
     /// </summary>
+    /// <param name="final">The final message content to persist as the completed reply.</param>
+    /// <returns>A task that completes when the adapter has finalized the reply.</returns>
     public abstract Task CompleteAsync(MessageContent final);
 
     /// <summary>
     /// Disposes the handle and releases adapter-owned streaming resources.
     /// </summary>
+    /// <returns>A task that completes when adapter-owned streaming resources have been released.</returns>
     public abstract ValueTask DisposeAsync();
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Streaming/StreamingHandle.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Streaming/StreamingHandle.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Represents one adapter-owned streaming reply session.
+/// </summary>
+public abstract class StreamingHandle : IAsyncDisposable
+{
+    /// <summary>
+    /// Appends one sequenced chunk to the in-flight reply.
+    /// </summary>
+    public abstract Task AppendAsync(StreamChunk chunk);
+
+    /// <summary>
+    /// Finalizes the streaming reply with the completed message content.
+    /// </summary>
+    public abstract Task CompleteAsync(MessageContent final);
+
+    /// <summary>
+    /// Disposes the handle and releases adapter-owned streaming resources.
+    /// </summary>
+    public abstract ValueTask DisposeAsync();
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/AuthContext.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/AuthContext.Partial.cs
@@ -1,0 +1,38 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for the transport-facing auth context contract.
+/// </summary>
+public sealed partial class AuthContext
+{
+    /// <summary>
+    /// Creates one bot-scoped auth context.
+    /// </summary>
+    public static AuthContext Bot() => new()
+    {
+        Kind = PrincipalKind.Bot,
+    };
+
+    /// <summary>
+    /// Creates one delegated user auth context.
+    /// </summary>
+    public static AuthContext OnBehalfOfUser(string userCredentialRef, string onBehalfOfUserId) => new()
+    {
+        Kind = PrincipalKind.OnBehalfOfUser,
+        UserCredentialRef = NormalizeRequired(userCredentialRef, nameof(userCredentialRef)),
+        OnBehalfOfUserId = NormalizeRequired(onBehalfOfUserId, nameof(onBehalfOfUserId)),
+    };
+
+    /// <summary>
+    /// Returns <see langword="true"/> when this context uses the adapter's bot identity.
+    /// </summary>
+    public bool UsesBotIdentity => Kind == PrincipalKind.Bot;
+
+    private static string NormalizeRequired(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty.", paramName);
+
+        return value.Trim();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ChannelBotDescriptor.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ChannelBotDescriptor.Partial.cs
@@ -1,0 +1,33 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for one transport-facing bot descriptor.
+/// </summary>
+public sealed partial class ChannelBotDescriptor
+{
+    /// <summary>
+    /// Creates one normalized bot descriptor.
+    /// </summary>
+    public static ChannelBotDescriptor Create(
+        string registrationId,
+        ChannelId channel,
+        BotInstanceId bot,
+        string? scopeId = null) => new()
+    {
+        RegistrationId = NormalizeRequired(registrationId, nameof(registrationId)),
+        Channel = channel?.Clone() ?? throw new ArgumentNullException(nameof(channel)),
+        Bot = bot?.Clone() ?? throw new ArgumentNullException(nameof(bot)),
+        ScopeId = NormalizeOptional(scopeId),
+    };
+
+    private static string NormalizeRequired(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty.", paramName);
+
+        return value.Trim();
+    }
+
+    private static string NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ChannelTransportBinding.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ChannelTransportBinding.Partial.cs
@@ -1,0 +1,31 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for one adapter bootstrap binding.
+/// </summary>
+public sealed partial class ChannelTransportBinding
+{
+    /// <summary>
+    /// Creates one normalized transport binding.
+    /// </summary>
+    public static ChannelTransportBinding Create(
+        ChannelBotDescriptor bot,
+        string credentialRef,
+        string? verificationToken = null) => new()
+    {
+        Bot = bot?.Clone() ?? throw new ArgumentNullException(nameof(bot)),
+        CredentialRef = NormalizeRequired(credentialRef, nameof(credentialRef)),
+        VerificationToken = NormalizeOptional(verificationToken),
+    };
+
+    private static string NormalizeRequired(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty.", paramName);
+
+        return value.Trim();
+    }
+
+    private static string NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ConversationReference.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ConversationReference.Partial.cs
@@ -8,6 +8,10 @@ public sealed partial class ConversationReference
     /// <summary>
     /// Creates one normalized conversation reference from deterministic canonical-key segments.
     /// </summary>
+    /// <remarks>
+    /// Callers must provide at least one deterministic segment beyond the channel id so the canonical key remains stable
+    /// for routing and deduplication.
+    /// </remarks>
     public static ConversationReference Create(
         ChannelId channel,
         BotInstanceId bot,
@@ -29,6 +33,12 @@ public sealed partial class ConversationReference
     {
         ArgumentNullException.ThrowIfNull(channel);
         ArgumentNullException.ThrowIfNull(segments);
+        if (segments.Length == 0)
+        {
+            throw new ArgumentException(
+                "Canonical key must include at least one deterministic segment beyond the channel id.",
+                nameof(segments));
+        }
 
         var normalized = new List<string> { NormalizeSegment(channel.Value, nameof(channel)) };
         for (var i = 0; i < segments.Length; i++)

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ConversationReference.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/ConversationReference.Partial.cs
@@ -1,0 +1,60 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for deterministic conversation reference construction.
+/// </summary>
+public sealed partial class ConversationReference
+{
+    /// <summary>
+    /// Creates one normalized conversation reference from deterministic canonical-key segments.
+    /// </summary>
+    public static ConversationReference Create(
+        ChannelId channel,
+        BotInstanceId bot,
+        ConversationScope scope,
+        string? partition,
+        params string[] canonicalSegments) => new()
+    {
+        Channel = channel?.Clone() ?? throw new ArgumentNullException(nameof(channel)),
+        Bot = bot?.Clone() ?? throw new ArgumentNullException(nameof(bot)),
+        Scope = scope,
+        Partition = NormalizeOptional(partition),
+        CanonicalKey = BuildCanonicalKey(channel, canonicalSegments),
+    };
+
+    /// <summary>
+    /// Builds one deterministic canonical key by prefixing the normalized channel id and joining each segment with <c>:</c>.
+    /// </summary>
+    public static string BuildCanonicalKey(ChannelId channel, params string[] segments)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        ArgumentNullException.ThrowIfNull(segments);
+
+        var normalized = new List<string> { NormalizeSegment(channel.Value, nameof(channel)) };
+        for (var i = 0; i < segments.Length; i++)
+        {
+            normalized.Add(NormalizeSegment(segments[i], $"segments[{i}]"));
+        }
+
+        return string.Join(':', normalized);
+    }
+
+    private static string NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+
+    private static string NormalizeSegment(string? value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Canonical key segment cannot be empty.", paramName);
+
+        var normalized = value.Trim();
+        if (normalized.Contains(':', StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Canonical key segments must not contain ':'. Supply each deterministic segment separately.",
+                paramName);
+        }
+
+        return normalized;
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/EmitResult.Partial.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/EmitResult.Partial.cs
@@ -1,0 +1,56 @@
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Helpers for constructing transport emit results.
+/// </summary>
+public sealed partial class EmitResult
+{
+    /// <summary>
+    /// Gets or sets the retry delay as a CLR <see cref="TimeSpan"/>.
+    /// </summary>
+    public TimeSpan? RetryAfterTimeSpan
+    {
+        get => RetryAfter == null ? null : RetryAfter.ToTimeSpan();
+        set => RetryAfter = value.HasValue ? Duration.FromTimeSpan(value.Value) : null;
+    }
+
+    /// <summary>
+    /// Creates one successful emit result.
+    /// </summary>
+    public static EmitResult Sent(string sentActivityId, ComposeCapability capability = ComposeCapability.Exact) => new()
+    {
+        Success = true,
+        SentActivityId = NormalizeRequired(sentActivityId, nameof(sentActivityId)),
+        Capability = capability,
+    };
+
+    /// <summary>
+    /// Creates one failed emit result.
+    /// </summary>
+    public static EmitResult Failed(
+        string errorCode,
+        string? errorMessage = null,
+        TimeSpan? retryAfter = null,
+        ComposeCapability capability = ComposeCapability.Unsupported)
+    {
+        var result = new EmitResult
+        {
+            Success = false,
+            ErrorCode = NormalizeRequired(errorCode, nameof(errorCode)),
+            ErrorMessage = string.IsNullOrWhiteSpace(errorMessage) ? string.Empty : errorMessage.Trim(),
+            Capability = capability,
+        };
+        result.RetryAfterTimeSpan = retryAfter;
+        return result;
+    }
+
+    private static string NormalizeRequired(string value, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Value cannot be empty.", paramName);
+
+        return value.Trim();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelOutboundPort.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelOutboundPort.cs
@@ -1,0 +1,45 @@
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Sends, updates, deletes, and proactively continues one channel conversation.
+/// </summary>
+public interface IChannelOutboundPort
+{
+    /// <summary>
+    /// Gets the channel this outbound port targets.
+    /// </summary>
+    ChannelId Channel { get; }
+
+    /// <summary>
+    /// Gets the declared capability matrix for this outbound path.
+    /// </summary>
+    ChannelCapabilities Capabilities { get; }
+
+    /// <summary>
+    /// Sends a new outbound message using the adapter's bot credential.
+    /// </summary>
+    Task<EmitResult> SendAsync(ConversationReference to, MessageContent content, CancellationToken ct);
+
+    /// <summary>
+    /// Updates one previously emitted activity identified by the adapter-owned activity id.
+    /// </summary>
+    Task<EmitResult> UpdateAsync(
+        ConversationReference to,
+        string activityId,
+        MessageContent content,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Deletes one previously emitted activity identified by the adapter-owned activity id.
+    /// </summary>
+    Task DeleteAsync(ConversationReference to, string activityId, CancellationToken ct);
+
+    /// <summary>
+    /// Starts or continues a conversation from outside an inbound turn using the explicit auth context supplied by the caller.
+    /// </summary>
+    Task<EmitResult> ContinueConversationAsync(
+        ConversationReference reference,
+        MessageContent content,
+        AuthContext auth,
+        CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelOutboundPort.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelOutboundPort.cs
@@ -1,28 +1,62 @@
 namespace Aevatar.GAgents.Channel.Abstractions;
 
 /// <summary>
-/// Sends, updates, deletes, and proactively continues one channel conversation.
+/// Sends, updates, deletes, and proactively continues channel conversations through the dispatch-facing side of one adapter.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Implementations are expected to share lifecycle and credential state with the same concrete object's
+/// <see cref="IChannelTransport"/> implementation.
+/// </para>
+/// <para>
+/// <see cref="SendAsync"/>, <see cref="UpdateAsync"/>, and <see cref="DeleteAsync"/> use the adapter's initialized bot
+/// credential by default. <see cref="ContinueConversationAsync"/> requires an explicit <see cref="AuthContext"/> because no
+/// inbound turn exists to infer the principal.
+/// </para>
+/// </remarks>
 public interface IChannelOutboundPort
 {
     /// <summary>
-    /// Gets the channel this outbound port targets.
+    /// Gets the stable channel identifier targeted by this adapter instance.
     /// </summary>
     ChannelId Channel { get; }
 
     /// <summary>
-    /// Gets the declared capability matrix for this outbound path.
+    /// Gets the declared capability matrix shared with the transport-side contract implemented by the same adapter instance.
     /// </summary>
     ChannelCapabilities Capabilities { get; }
 
     /// <summary>
-    /// Sends a new outbound message using the adapter's bot credential.
+    /// Sends a new outbound message using the adapter's initialized bot credential.
     /// </summary>
+    /// <param name="to">The normalized target conversation.</param>
+    /// <param name="content">The channel-agnostic outbound message intent.</param>
+    /// <param name="ct">A token that cancels the send.</param>
+    /// <returns>The emit result, including the adapter-owned activity identifier on success.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the adapter has not completed initialization and receive startup.
+    /// </exception>
+    /// <remarks>
+    /// This method is the narrow outbound primitive used by turn-scoped helpers. Callers must treat the returned
+    /// <see cref="EmitResult.SentActivityId"/> as an opaque token that is only meaningful to the same adapter.
+    /// </remarks>
     Task<EmitResult> SendAsync(ConversationReference to, MessageContent content, CancellationToken ct);
 
     /// <summary>
     /// Updates one previously emitted activity identified by the adapter-owned activity id.
     /// </summary>
+    /// <param name="to">The normalized target conversation.</param>
+    /// <param name="activityId">The opaque activity identifier previously returned by this adapter.</param>
+    /// <param name="content">The replacement message content.</param>
+    /// <param name="ct">A token that cancels the update.</param>
+    /// <returns>The emit result for the update attempt.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the adapter has not completed initialization and receive startup.
+    /// </exception>
+    /// <remarks>
+    /// The supplied <paramref name="activityId"/> must be echoed back to the same adapter implementation that produced it.
+    /// Business code must not parse or reconstruct it.
+    /// </remarks>
     Task<EmitResult> UpdateAsync(
         ConversationReference to,
         string activityId,
@@ -32,11 +66,30 @@ public interface IChannelOutboundPort
     /// <summary>
     /// Deletes one previously emitted activity identified by the adapter-owned activity id.
     /// </summary>
+    /// <param name="to">The normalized target conversation.</param>
+    /// <param name="activityId">The opaque activity identifier previously returned by this adapter.</param>
+    /// <param name="ct">A token that cancels the delete operation.</param>
+    /// <returns>A task that completes when the delete attempt has finished.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the adapter has not completed initialization and receive startup.
+    /// </exception>
     Task DeleteAsync(ConversationReference to, string activityId, CancellationToken ct);
 
     /// <summary>
     /// Starts or continues a conversation from outside an inbound turn using the explicit auth context supplied by the caller.
     /// </summary>
+    /// <param name="reference">The normalized target conversation or conversation seed.</param>
+    /// <param name="content">The outbound message intent.</param>
+    /// <param name="auth">The explicit bot or delegated-user principal chosen by the caller.</param>
+    /// <param name="ct">A token that cancels the proactive send.</param>
+    /// <returns>The emit result for the proactive send attempt.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the adapter has not completed initialization and receive startup.
+    /// </exception>
+    /// <remarks>
+    /// This method is reserved for proactive paths that do not have an inbound turn. The caller must decide whether the
+    /// send occurs as the bot or on behalf of a user; implementations must not infer that identity implicitly.
+    /// </remarks>
     Task<EmitResult> ContinueConversationAsync(
         ConversationReference reference,
         MessageContent content,

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelTransport.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelTransport.cs
@@ -1,0 +1,44 @@
+using System.Threading.Channels;
+
+namespace Aevatar.GAgents.Channel.Abstractions;
+
+/// <summary>
+/// Owns adapter lifecycle and exposes the normalized inbound stream consumed by the channel pipeline.
+/// </summary>
+public interface IChannelTransport
+{
+    /// <summary>
+    /// Gets the channel this transport instance serves.
+    /// </summary>
+    ChannelId Channel { get; }
+
+    /// <summary>
+    /// Gets the transport mode used by the adapter.
+    /// </summary>
+    TransportMode TransportMode { get; }
+
+    /// <summary>
+    /// Gets the declared capability matrix for this transport instance.
+    /// </summary>
+    ChannelCapabilities Capabilities { get; }
+
+    /// <summary>
+    /// Initializes the transport with the stable binding data for one bot registration.
+    /// </summary>
+    Task InitializeAsync(ChannelTransportBinding binding, CancellationToken ct);
+
+    /// <summary>
+    /// Starts receiving inbound activities.
+    /// </summary>
+    Task StartReceivingAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Stops receiving inbound activities and releases transport-owned resources.
+    /// </summary>
+    Task StopReceivingAsync(CancellationToken ct);
+
+    /// <summary>
+    /// Gets the single-consumer inbound stream of normalized activities emitted by this transport.
+    /// </summary>
+    ChannelReader<ChatActivity> InboundStream { get; }
+}

--- a/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelTransport.cs
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/Transport/IChannelTransport.cs
@@ -3,42 +3,81 @@ using System.Threading.Channels;
 namespace Aevatar.GAgents.Channel.Abstractions;
 
 /// <summary>
-/// Owns adapter lifecycle and exposes the normalized inbound stream consumed by the channel pipeline.
+/// Owns the runtime-side adapter lifecycle and exposes the normalized inbound working buffer consumed by the channel pipeline.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The same concrete adapter instance is expected to implement both <see cref="IChannelTransport"/> and
+/// <see cref="IChannelOutboundPort"/> so lifecycle, capability, and credential state remain shared.
+/// </para>
+/// <para>
+/// <see cref="InitializeAsync"/> must succeed exactly once before <see cref="StartReceivingAsync"/>. The inbound stream is
+/// a single-reader, in-process buffer and is not the durable ingress boundary.
+/// </para>
+/// </remarks>
 public interface IChannelTransport
 {
     /// <summary>
-    /// Gets the channel this transport instance serves.
+    /// Gets the stable channel identifier served by this adapter instance.
     /// </summary>
     ChannelId Channel { get; }
 
     /// <summary>
-    /// Gets the transport mode used by the adapter.
+    /// Gets the transport mode used by the adapter to accept inbound traffic.
     /// </summary>
     TransportMode TransportMode { get; }
 
     /// <summary>
-    /// Gets the declared capability matrix for this transport instance.
+    /// Gets the declared capability matrix shared with the outbound contract implemented by the same adapter instance.
     /// </summary>
     ChannelCapabilities Capabilities { get; }
 
     /// <summary>
-    /// Initializes the transport with the stable binding data for one bot registration.
+    /// Initializes the adapter with the stable binding data for one bot registration.
     /// </summary>
+    /// <param name="binding">The bot descriptor, credential reference, and verification material that bootstrap the adapter.</param>
+    /// <param name="ct">A token that cancels initialization.</param>
+    /// <returns>A task that completes when initialization finishes.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when initialization is attempted more than once, or after the adapter has already started receiving.
+    /// </exception>
+    /// <remarks>
+    /// This method binds the capability, credential, and lifecycle state later consumed by
+    /// <see cref="IChannelOutboundPort"/>. Implementations must treat it as an exactly-once transition.
+    /// </remarks>
     Task InitializeAsync(ChannelTransportBinding binding, CancellationToken ct);
 
     /// <summary>
-    /// Starts receiving inbound activities.
+    /// Starts receiving inbound activities after initialization has completed.
     /// </summary>
+    /// <param name="ct">A token that cancels startup.</param>
+    /// <returns>A task that completes when the adapter is ready to publish inbound activities.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the adapter has not been initialized, or when receive startup is attempted more than once.
+    /// </exception>
+    /// <remarks>
+    /// Host startup is expected to call this method exactly once. After this transition succeeds, outbound methods on the
+    /// same adapter instance may begin sending traffic.
+    /// </remarks>
     Task StartReceivingAsync(CancellationToken ct);
 
     /// <summary>
     /// Stops receiving inbound activities and releases transport-owned resources.
     /// </summary>
+    /// <param name="ct">A token that cancels shutdown.</param>
+    /// <returns>A task that completes when the adapter has stopped accepting new inbound work.</returns>
+    /// <remarks>
+    /// Implementations must stop receiving exactly once, wait for in-flight outbound work they own to settle, and release
+    /// transport resources. They are not required to drain <see cref="InboundStream"/> to empty before returning.
+    /// </remarks>
     Task StopReceivingAsync(CancellationToken ct);
 
     /// <summary>
     /// Gets the single-consumer inbound stream of normalized activities emitted by this transport.
     /// </summary>
+    /// <remarks>
+    /// The adapter must not fan out this stream. The pipeline is the only supported reader, and ordering must remain stable
+    /// for activities as the adapter normalizes them into <see cref="ChatActivity"/> values.
+    /// </remarks>
     ChannelReader<ChatActivity> InboundStream { get; }
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/channel_contracts.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/channel_contracts.proto
@@ -7,81 +7,140 @@ option csharp_namespace = "Aevatar.GAgents.Channel.Abstractions";
 import "google/protobuf/duration.proto";
 import "chat_activity.proto";
 
+// Describes how precisely a channel-native payload can represent one message intent.
 enum ComposeCapability {
+  // Default zero value.
   COMPOSE_CAPABILITY_UNSPECIFIED = 0;
+  // The channel can render the intent without loss.
   COMPOSE_CAPABILITY_EXACT = 1;
+  // The channel can render the intent with a deterministic downgrade.
   COMPOSE_CAPABILITY_DEGRADED = 2;
+  // The channel cannot represent the intent.
   COMPOSE_CAPABILITY_UNSUPPORTED = 3;
 }
 
+// Describes the streaming strategy supported by one adapter.
 enum StreamingSupport {
+  // Default zero value.
   STREAMING_SUPPORT_UNSPECIFIED = 0;
+  // Streaming replies are not supported.
   STREAMING_SUPPORT_NONE = 1;
+  // Streaming is implemented through repeated edit loops with rate limiting.
   STREAMING_SUPPORT_EDIT_LOOP_RATE_LIMITED = 2;
+  // Streaming is implemented with a channel-native API.
   STREAMING_SUPPORT_NATIVE = 3;
 }
 
+// Identifies which principal an outbound operation should use.
 enum PrincipalKind {
+  // Default zero value.
   PRINCIPAL_KIND_UNSPECIFIED = 0;
+  // Send as the bot bound to the adapter.
   PRINCIPAL_KIND_BOT = 1;
+  // Send on behalf of a delegated user.
   PRINCIPAL_KIND_ON_BEHALF_OF_USER = 2;
 }
 
+// Records the outcome of one outbound send or update operation.
 message EmitResult {
+  // Whether the adapter operation succeeded.
   bool success = 1;
+  // The opaque adapter-owned identifier for the emitted activity.
   string sent_activity_id = 2;
+  // The composition fidelity used to emit the activity.
   ComposeCapability capability = 3;
+  // The retry delay suggested by the adapter when the operation failed.
   google.protobuf.Duration retry_after = 4;
+  // The structured adapter error code for failed operations.
   string error_code = 5;
+  // The sanitized short error message for failed operations.
   string error_message = 6;
 }
 
+// Carries the normalized conversation and capability inputs used during composition.
 message ComposeContext {
+  // The target conversation for the composed payload.
   ConversationReference conversation = 1;
+  // The capability matrix declared by the active adapter.
   ChannelCapabilities capabilities = 2;
+  // Additional typed-callsite annotations for composition decisions.
   map<string, string> annotations = 3;
 }
 
+// Identifies the bot registration bound to one adapter instance.
 message ChannelBotDescriptor {
+  // The stable registration identifier owned by runtime state.
   string registration_id = 1;
+  // The stable bot instance identifier used by the registration.
   BotInstanceId bot = 2;
+  // The channel served by the bot registration.
   ChannelId channel = 3;
+  // The optional runtime scope identifier associated with the registration.
   string scope_id = 4;
 }
 
+// Carries the bootstrap data required to initialize one adapter instance.
 message ChannelTransportBinding {
+  // The bot registration descriptor bound to the adapter.
   ChannelBotDescriptor bot = 1;
+  // The credential reference resolved by the adapter at runtime.
   string credential_ref = 2;
+  // The optional verification token used by webhook-style transports.
   string verification_token = 3;
 }
 
+// Declares the UX and transport capabilities exposed by one adapter instance.
 message ChannelCapabilities {
+  // Whether ephemeral delivery is supported.
   bool supports_ephemeral = 1;
+  // Whether previously emitted messages can be edited.
   bool supports_edit = 2;
+  // Whether previously emitted messages can be deleted.
   bool supports_delete = 3;
+  // Whether threaded conversations are supported.
   bool supports_thread = 4;
+  // The streaming strategy exposed by the adapter.
   StreamingSupport streaming = 5;
+  // Whether file attachments are supported.
   bool supports_files = 6;
+  // The recommended maximum message length in characters.
   int32 max_message_length = 7;
+  // Whether action buttons are supported.
   bool supports_action_buttons = 8;
+  // Whether confirm dialogs are supported.
   bool supports_confirm_dialog = 9;
+  // Whether modal interactions are supported.
   bool supports_modal = 10;
+  // Whether participant mentions are supported.
   bool supports_mention = 11;
+  // Whether typing indicators are supported.
   bool supports_typing = 12;
+  // Whether reactions are supported.
   bool supports_reactions = 13;
+  // The recommended debounce interval for streaming edits in milliseconds.
   int32 recommended_stream_debounce_ms = 14;
+  // The keepalive interval for typing indicators in milliseconds.
   int32 typing_keepalive_interval_ms = 15;
+  // The maximum typing indicator lifetime in milliseconds.
   int32 typing_ttl_ms = 16;
+  // The transport mode used to receive inbound traffic.
   TransportMode transport = 17;
 }
 
+// Carries the explicit auth choice for proactive outbound operations.
 message AuthContext {
+  // The principal kind selected by the caller.
   PrincipalKind kind = 1;
+  // The delegated user credential reference when sending on behalf of a user.
   string user_credential_ref = 2;
+  // The channel-native user identifier that the delegated send should represent.
   string on_behalf_of_user_id = 3;
 }
 
+// Represents one sequenced streaming delta emitted by caller-controlled streaming logic.
 message StreamChunk {
+  // The text delta for this chunk.
   string delta = 1;
+  // The monotonic chunk sequence number used for idempotency.
   int64 sequence_number = 2;
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -6,150 +6,262 @@ option csharp_namespace = "Aevatar.GAgents.Channel.Abstractions";
 
 import "google/protobuf/timestamp.proto";
 
+// Identifies one logical channel.
 message ChannelId {
+  // The normalized channel identifier value.
   string value = 1;
 }
 
+// Identifies one bot instance within a channel family.
 message BotInstanceId {
+  // The normalized bot instance identifier value.
   string value = 1;
 }
 
+// Classifies the kind of inbound or outbound activity.
 enum ActivityType {
+  // Default zero value.
   ACTIVITY_TYPE_UNSPECIFIED = 0;
+  // A user-visible message activity.
   ACTIVITY_TYPE_MESSAGE = 1;
+  // A command invocation activity.
   ACTIVITY_TYPE_COMMAND = 2;
+  // A card or component action activity.
   ACTIVITY_TYPE_CARD_ACTION = 3;
+  // A reaction activity.
   ACTIVITY_TYPE_REACTION = 4;
+  // A membership change activity.
   ACTIVITY_TYPE_MEMBERSHIP_CHANGE = 5;
+  // A typing indicator activity.
   ACTIVITY_TYPE_TYPING = 6;
+  // An adapter lifecycle activity.
   ACTIVITY_TYPE_ADAPTER_LIFECYCLE = 7;
 }
 
+// Describes the conversation scope targeted by an activity.
 enum ConversationScope {
+  // Default zero value.
   CONVERSATION_SCOPE_UNSPECIFIED = 0;
+  // A direct-message conversation.
   CONVERSATION_SCOPE_DIRECT_MESSAGE = 1;
+  // A group conversation.
   CONVERSATION_SCOPE_GROUP = 2;
+  // A channel-wide conversation.
   CONVERSATION_SCOPE_CHANNEL = 3;
+  // A thread-scoped conversation.
   CONVERSATION_SCOPE_THREAD = 4;
 }
 
+// Describes the kind of attachment referenced by one message.
 enum AttachmentKind {
+  // Default zero value.
   ATTACHMENT_KIND_UNSPECIFIED = 0;
+  // A generic file attachment.
   ATTACHMENT_KIND_FILE = 1;
+  // An image attachment.
   ATTACHMENT_KIND_IMAGE = 2;
+  // An audio attachment.
   ATTACHMENT_KIND_AUDIO = 3;
+  // A video attachment.
   ATTACHMENT_KIND_VIDEO = 4;
+  // An external link attachment.
   ATTACHMENT_KIND_LINK = 5;
+  // A card-style attachment.
   ATTACHMENT_KIND_CARD = 6;
 }
 
+// Describes the delivery disposition requested for one message.
 enum MessageDisposition {
+  // Default zero value.
   MESSAGE_DISPOSITION_UNSPECIFIED = 0;
+  // A normal visible message.
   MESSAGE_DISPOSITION_NORMAL = 1;
+  // An ephemeral message visible to a limited audience.
   MESSAGE_DISPOSITION_EPHEMERAL = 2;
+  // A silent message that avoids user-facing noise where supported.
   MESSAGE_DISPOSITION_SILENT = 3;
+  // A pinned message where supported.
   MESSAGE_DISPOSITION_PINNED = 4;
 }
 
+// Describes one interactive element supported by card-style payloads.
 enum ActionElementKind {
+  // Default zero value.
   ACTION_ELEMENT_KIND_UNSPECIFIED = 0;
+  // A button action.
   ACTION_ELEMENT_KIND_BUTTON = 1;
+  // A select-menu action.
   ACTION_ELEMENT_KIND_SELECT = 2;
+  // A form-submit action.
   ACTION_ELEMENT_KIND_FORM_SUBMIT = 3;
+  // A link-style action.
   ACTION_ELEMENT_KIND_LINK = 4;
 }
 
+// Describes one card block shape.
 enum CardBlockKind {
+  // Default zero value.
   CARD_BLOCK_KIND_UNSPECIFIED = 0;
+  // A text section block.
   CARD_BLOCK_KIND_SECTION = 1;
+  // An actions block.
   CARD_BLOCK_KIND_ACTIONS = 2;
+  // An image block.
   CARD_BLOCK_KIND_IMAGE = 3;
+  // A context block.
   CARD_BLOCK_KIND_CONTEXT = 4;
+  // A divider block.
   CARD_BLOCK_KIND_DIVIDER = 5;
 }
 
+// Describes how the adapter receives inbound traffic.
 enum TransportMode {
+  // Default zero value.
   TRANSPORT_MODE_UNSPECIFIED = 0;
+  // Inbound traffic is received through webhooks.
   TRANSPORT_MODE_WEBHOOK = 1;
+  // Inbound traffic is received through a gateway connection.
   TRANSPORT_MODE_GATEWAY = 2;
+  // Inbound traffic is received through long polling.
   TRANSPORT_MODE_LONG_POLLING = 3;
+  // Inbound traffic uses a hybrid transport strategy.
   TRANSPORT_MODE_HYBRID = 4;
 }
 
+// Identifies one conversation with a deterministic canonical key.
 message ConversationReference {
+  // The channel served by the conversation.
   ChannelId channel = 1;
+  // The bot instance bound to the conversation.
   BotInstanceId bot = 2;
+  // The optional shard or partition used for routing.
   string partition = 3;
+  // The conversation scope.
   ConversationScope scope = 4;
+  // The deterministic canonical key used for routing and deduplication.
   string canonical_key = 5;
 }
 
+// Identifies one participant mentioned in or sending an activity.
 message ParticipantRef {
+  // The canonical participant identifier.
   string canonical_id = 1;
+  // The best-effort display name.
   string display_name = 2;
 }
 
+// References one attachment carried by or associated with a message.
 message AttachmentRef {
+  // The adapter-owned attachment identifier.
   string attachment_id = 1;
+  // The attachment kind.
   AttachmentKind kind = 2;
+  // The attachment display name.
   string name = 3;
+  // The MIME content type.
   string content_type = 4;
+  // The stable blob reference for persisted attachment content.
   string blob_ref = 5;
+  // The attachment size in bytes.
   int64 size_bytes = 6;
+  // The external URL when the attachment is referenced remotely.
   string external_url = 7;
 }
 
+// Declares one selectable option for an action element.
 message ActionOption {
+  // The user-visible label.
   string label = 1;
+  // The value submitted when the option is chosen.
   string value = 2;
 }
 
+// Declares one interactive card element.
 message ActionElement {
+  // The element kind.
   ActionElementKind kind = 1;
+  // The stable action identifier.
   string action_id = 2;
+  // The user-visible label.
   string label = 3;
+  // The submitted or linked value.
   string value = 4;
+  // The placeholder text where supported.
   string placeholder = 5;
+  // The selectable options for choice-based controls.
   repeated ActionOption options = 6;
+  // Whether the element is emphasized as primary.
   bool is_primary = 7;
+  // Whether the element is emphasized as dangerous.
   bool is_danger = 8;
+  // Whether the element is disabled.
   bool is_disabled = 9;
 }
 
+// Declares one title-text pair rendered inside a card.
 message CardField {
+  // The field title.
   string title = 1;
+  // The field text.
   string text = 2;
+  // Whether the field should render in a compact layout.
   bool is_short = 3;
 }
 
+// Declares one structured card block.
 message CardBlock {
+  // The block kind.
   CardBlockKind kind = 1;
+  // The stable block identifier.
   string block_id = 2;
+  // The block title.
   string title = 3;
+  // The main block text.
   string text = 4;
+  // The image URL for image-style blocks.
   string image_url = 5;
+  // The structured fields rendered by the block.
   repeated CardField fields = 6;
+  // The interactive elements rendered by the block.
   repeated ActionElement actions = 7;
 }
 
+// Carries the channel-agnostic message content used for send, update, and reply operations.
 message MessageContent {
+  // The primary text body.
   string text = 1;
+  // The attachments rendered with the message.
   repeated AttachmentRef attachments = 2;
+  // The interactive actions rendered with the message.
   repeated ActionElement actions = 3;
+  // The structured card blocks rendered with the message.
   repeated CardBlock cards = 4;
+  // The requested delivery disposition.
   MessageDisposition disposition = 5;
 }
 
+// Represents one normalized activity flowing through the channel pipeline.
 message ChatActivity {
+  // The deterministic adapter-owned activity identifier.
   string id = 1;
+  // The activity kind.
   ActivityType type = 2;
+  // The channel that produced the activity.
   ChannelId channel_id = 3;
+  // The bot instance that received the activity.
   BotInstanceId bot = 4;
+  // The normalized conversation reference.
   ConversationReference conversation = 5;
+  // The participant that originated the activity.
   ParticipantRef from = 6;
+  // The participants mentioned by the activity.
   repeated ParticipantRef mentions = 7;
+  // The activity timestamp.
   google.protobuf.Timestamp timestamp = 8;
+  // The normalized message content.
   MessageContent content = 9;
+  // The adapter-owned reply target when the activity is a reply.
   string reply_to_activity_id = 10;
+  // The stable blob reference for sanitized raw payload storage.
   string raw_payload_blob_ref = 11;
 }

--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/schedule.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/schedule.proto
@@ -6,18 +6,30 @@ option csharp_namespace = "Aevatar.GAgents.Channel.Abstractions";
 
 import "google/protobuf/timestamp.proto";
 
+// Carries the stable schedule state owned by schedulable channel actors.
 message ScheduleState {
+  // Whether the schedule is enabled.
   bool enabled = 1;
+  // The cron expression used to compute the schedule.
   string cron = 2;
+  // The IANA timezone identifier used to evaluate the cron expression.
   string timezone = 3;
+  // The next scheduled execution time in UTC.
   google.protobuf.Timestamp next_run_at = 4;
+  // The last completed execution time in UTC.
   google.protobuf.Timestamp last_run_at = 5;
+  // The consecutive scheduler error count.
   int32 error_count = 6;
 }
 
+// Describes how one projector should treat a state entry.
 enum ProjectionVerdict {
+  // Default zero value.
   PROJECTION_VERDICT_UNSPECIFIED = 0;
+  // Upsert the projected document.
   PROJECTION_VERDICT_PROJECT = 1;
+  // Ignore the entry for this materialization pass.
   PROJECTION_VERDICT_SKIP = 2;
+  // Delete the projected document for the entry.
   PROJECTION_VERDICT_TOMBSTONE = 3;
 }

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -684,14 +684,16 @@ public interface ITurnContext {
     // bot logic 通过下面的 SendAsync / ReplyAsync / UpdateAsync / DeleteAsync / BeginStreamingReplyAsync
     // 操作 outbound，内部由 runtime 注入 adapter 引用（runtime-only / internal visibility）。
 
-    Task<EmitResult> SendAsync(MessageContent content);
-    Task<EmitResult> ReplyAsync(MessageContent content);
-    Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial);
+    Task<EmitResult> SendAsync(MessageContent content, CancellationToken ct);
+    Task<EmitResult> ReplyAsync(MessageContent content, CancellationToken ct);
+    Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial, CancellationToken ct);
 
     // 修改/删除 bot 自己发出的消息。activityId 来自之前 SendAsync / ReplyAsync 返回的
     // EmitResult.SentActivityId。内部用 Activity.Conversation 作为 target，自动附带 bot credential。
-    Task<EmitResult> UpdateAsync(string activityId, MessageContent content);
-    Task<EmitResult> DeleteAsync(string activityId);
+    // Delete 与 IChannelOutboundPort.DeleteAsync 对齐返回 Task：被删消息没有后继 activity id，
+    // EmitResult.SentActivityId 语义不适用；失败由 adapter 以异常形式暴露。
+    Task<EmitResult> UpdateAsync(string activityId, MessageContent content, CancellationToken ct);
+    Task DeleteAsync(string activityId, CancellationToken ct);
 }
 
 public class StreamingHandle : IAsyncDisposable {

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
@@ -21,5 +26,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Abstractions\Aevatar.GAgents.Channel.Abstractions.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Runtime\Aevatar.GAgents.Channel.Runtime.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="test_projector_contracts.proto" GrpcServices="None" />
   </ItemGroup>
 </Project>

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsSurfaceTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsSurfaceTests.cs
@@ -1,0 +1,218 @@
+using System.Reflection;
+using System.Threading.Channels;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Shouldly;
+using FoundationCredentialProvider = Aevatar.Foundation.Abstractions.Credentials.ICredentialProvider;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class ChannelAbstractionsSurfaceTests
+{
+    [Fact]
+    public void ConversationReferenceHelpers_ShouldBuildDeterministicCanonicalKey()
+    {
+        var reference = ConversationReference.Create(
+            ChannelId.From("slack"),
+            BotInstanceId.From("ops-bot"),
+            ConversationScope.Thread,
+            "team-1",
+            "team-1",
+            "C123",
+            "thread",
+            "1710000.123");
+
+        reference.CanonicalKey.ShouldBe("slack:team-1:C123:thread:1710000.123");
+        reference.Partition.ShouldBe("team-1");
+        reference.Channel.Value.ShouldBe("slack");
+    }
+
+    [Fact]
+    public void EmitResultHelpers_ShouldCaptureRetryDelay()
+    {
+        var sent = EmitResult.Sent("msg-1");
+        var failed = EmitResult.Failed("rate_limited", "retry later", TimeSpan.FromSeconds(5));
+
+        sent.Success.ShouldBeTrue();
+        sent.SentActivityId.ShouldBe("msg-1");
+        failed.Success.ShouldBeFalse();
+        failed.RetryAfterTimeSpan.ShouldBe(TimeSpan.FromSeconds(5));
+        failed.ErrorCode.ShouldBe("rate_limited");
+    }
+
+    [Fact]
+    public void ScheduleStateHelpers_ShouldRoundTripDateTimes()
+    {
+        var nextRun = new DateTimeOffset(2026, 4, 21, 12, 0, 0, TimeSpan.Zero);
+        var lastRun = nextRun.AddMinutes(-30);
+        var schedule = new ScheduleState();
+
+        schedule.NextRunAtUtc = nextRun;
+        schedule.LastRunAtUtc = lastRun;
+
+        schedule.NextRunAtUtc.ShouldBe(nextRun);
+        schedule.LastRunAtUtc.ShouldBe(lastRun);
+    }
+
+    [Fact]
+    public async Task ChannelCredentialProviderExtensions_ShouldReuseFoundationCredentialContract()
+    {
+        var provider = new StubCredentialProvider();
+        var binding = ChannelTransportBinding.Create(
+            ChannelBotDescriptor.Create(
+                "bot-reg-1",
+                ChannelId.From("slack"),
+                BotInstanceId.From("ops-bot"),
+                "scope-1"),
+            "vault://bots/ops-bot",
+            "verify-me");
+        var authContext = AuthContext.OnBehalfOfUser("vault://users/u1", "U1");
+
+        (await provider.ResolveBotCredentialAsync(binding)).ShouldBe("secret:vault://bots/ops-bot");
+        (await provider.ResolveUserCredentialAsync(authContext)).ShouldBe("secret:vault://users/u1");
+        provider.ResolvedRefs.ShouldBe(["vault://bots/ops-bot", "vault://users/u1"]);
+    }
+
+    [Fact]
+    public void ChannelInterfaces_ShouldExposeExpectedCoreSignatures()
+    {
+        typeof(IChannelTransport).GetProperty(nameof(IChannelTransport.InboundStream))!.PropertyType
+            .ShouldBe(typeof(ChannelReader<ChatActivity>));
+        typeof(ITurnContext).GetProperty(nameof(ITurnContext.Bot))!.PropertyType
+            .ShouldBe(typeof(ChannelBotDescriptor));
+        typeof(IChannelOutboundPort).GetMethod(nameof(IChannelOutboundPort.ContinueConversationAsync))!
+            .GetParameters()[2]
+            .ParameterType
+            .ShouldBe(typeof(AuthContext));
+
+        var genericComposer = typeof(IMessageComposer<>);
+        genericComposer.IsGenericTypeDefinition.ShouldBeTrue();
+        genericComposer.GetMethod(nameof(IMessageComposer.Compose))!.ReturnType.IsGenericParameter.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task PerEntryDocumentProjector_ShouldUpsertAndDeleteByVerdict()
+    {
+        var now = new DateTimeOffset(2026, 4, 21, 12, 0, 0, TimeSpan.Zero);
+        var dispatcher = new TestProjectionWriteDispatcher();
+        var projector = new TestProjector(dispatcher, new FixedProjectionClock(now));
+        var state = new TestProjectorState();
+        state.Entries.Add(new TestProjectorEntry
+        {
+            Id = "entry-1",
+            Value = "alpha",
+        });
+        state.Entries.Add(new TestProjectorEntry
+        {
+            Id = "entry-2",
+            Value = "beta",
+            IsDeleted = true,
+        });
+
+        var envelope = new EventEnvelope
+        {
+            Id = "outer-envelope",
+            Route = EnvelopeRouteSemantics.CreateObserverPublication("actor-1"),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = "evt-1",
+                    Version = 7,
+                    Timestamp = Timestamp.FromDateTimeOffset(now),
+                    EventData = Any.Pack(new StringValue { Value = "projected" }),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+
+        await projector.ProjectAsync(new TestProjectionContext("actor-1", "channel.current-state"), envelope);
+
+        dispatcher.Upserts.Count.ShouldBe(1);
+        dispatcher.Upserts[0].Id.ShouldBe("entry-1");
+        dispatcher.Upserts[0].StateVersion.ShouldBe(7);
+        dispatcher.Upserts[0].ActorId.ShouldBe("actor-1");
+        dispatcher.Upserts[0].Value.ShouldBe("alpha");
+        dispatcher.Upserts[0].UpdatedAt.ShouldBe(now);
+        dispatcher.Deletes.ShouldBe(["entry-2"]);
+    }
+
+    private sealed class TestProjector
+        : PerEntryDocumentProjector<TestProjectorState, TestProjectorEntry, TestProjectorDocument>
+    {
+        public TestProjector(
+            IProjectionWriteDispatcher<TestProjectorDocument> writeDispatcher,
+            IProjectionClock clock)
+            : base(writeDispatcher, clock)
+        {
+        }
+
+        protected override IEnumerable<TestProjectorEntry> ExtractEntries(TestProjectorState state) => state.Entries;
+
+        protected override string EntryKey(TestProjectorEntry entry) => entry.Id;
+
+        protected override TestProjectorDocument Materialize(
+            TestProjectorEntry entry,
+            IProjectionMaterializationContext context,
+            StateEvent stateEvent,
+            DateTimeOffset updatedAt) => new()
+        {
+            Id = entry.Id,
+            ActorId = context.RootActorId,
+            StateVersion = stateEvent.Version,
+            LastEventId = stateEvent.EventId ?? string.Empty,
+            UpdatedAt = updatedAt,
+            Value = entry.Value,
+        };
+
+        protected override ProjectionVerdict Evaluate(TestProjectorEntry entry) =>
+            entry.IsDeleted ? ProjectionVerdict.Tombstone : ProjectionVerdict.Project;
+    }
+
+    private sealed class TestProjectionWriteDispatcher : IProjectionWriteDispatcher<TestProjectorDocument>
+    {
+        public List<TestProjectorDocument> Upserts { get; } = [];
+
+        public List<string> Deletes { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(TestProjectorDocument readModel, CancellationToken ct = default)
+        {
+            Upserts.Add(readModel.Clone());
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default)
+        {
+            Deletes.Add(id);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+    }
+
+    private sealed class FixedProjectionClock(DateTimeOffset utcNow) : IProjectionClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+    }
+
+    private sealed class TestProjectionContext(string rootActorId, string projectionKind) : IProjectionMaterializationContext
+    {
+        public string RootActorId { get; } = rootActorId;
+
+        public string ProjectionKind { get; } = projectionKind;
+    }
+
+    private sealed class StubCredentialProvider : FoundationCredentialProvider
+    {
+        public List<string> ResolvedRefs { get; } = [];
+
+        public Task<string?> ResolveAsync(string credentialRef, CancellationToken ct = default)
+        {
+            ResolvedRefs.Add(credentialRef);
+            return Task.FromResult<string?>($"secret:{credentialRef}");
+        }
+    }
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsSurfaceTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsSurfaceTests.cs
@@ -33,6 +33,18 @@ public sealed class ChannelAbstractionsSurfaceTests
     }
 
     [Fact]
+    public void ConversationReferenceHelpers_ShouldRejectMissingCanonicalSegments()
+    {
+        var exception = Should.Throw<ArgumentException>(() => ConversationReference.Create(
+            ChannelId.From("slack"),
+            BotInstanceId.From("ops-bot"),
+            ConversationScope.Thread,
+            "team-1"));
+
+        exception.ParamName.ShouldBe("segments");
+    }
+
+    [Fact]
     public void EmitResultHelpers_ShouldCaptureRetryDelay()
     {
         var sent = EmitResult.Sent("msg-1");
@@ -43,6 +55,24 @@ public sealed class ChannelAbstractionsSurfaceTests
         failed.Success.ShouldBeFalse();
         failed.RetryAfterTimeSpan.ShouldBe(TimeSpan.FromSeconds(5));
         failed.ErrorCode.ShouldBe("rate_limited");
+    }
+
+    [Fact]
+    public void RedactionResultHelpers_ShouldDefensivelyCopyPayloadBytes()
+    {
+        var payload = new byte[] { 1, 2, 3 };
+
+        var unchanged = RedactionResult.Unchanged(payload);
+        var modified = RedactionResult.Modified(payload);
+
+        payload[0] = 9;
+
+        unchanged.SanitizedPayload.ShouldNotBeSameAs(payload);
+        modified.SanitizedPayload.ShouldNotBeSameAs(payload);
+        unchanged.SanitizedPayload[0].ShouldBe((byte)1);
+        modified.SanitizedPayload[0].ShouldBe((byte)1);
+        unchanged.WasModified.ShouldBeFalse();
+        modified.WasModified.ShouldBeTrue();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAdapterConformanceSuiteTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAdapterConformanceSuiteTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using System.Threading.Channels;
+using Aevatar.GAgents.Channel.Abstractions;
+using Shouldly;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class ChannelAdapterConformanceConstraintTests
+{
+    [Fact]
+    public void ChannelAdapterConformanceSuite_ShouldRequireTransportAndOutboundPortOnTheSameType()
+    {
+        var adapterType = typeof(ChannelAdapterConformanceSuite<>).GetGenericArguments()[0];
+        var constraints = adapterType.GetGenericParameterConstraints();
+
+        adapterType.GenericParameterAttributes.HasFlag(GenericParameterAttributes.ReferenceTypeConstraint).ShouldBeTrue();
+        constraints.ShouldContain(typeof(IChannelTransport));
+        constraints.ShouldContain(typeof(IChannelOutboundPort));
+    }
+}
+
+public sealed class StubChannelAdapterConformanceTests : ChannelAdapterConformanceSuite<StubChannelAdapter>
+{
+    protected override StubChannelAdapter CreateAdapter() => new();
+}
+
+public abstract class ChannelAdapterConformanceSuite<TAdapter>
+    where TAdapter : class, IChannelTransport, IChannelOutboundPort
+{
+    protected abstract TAdapter CreateAdapter();
+
+    [Fact]
+    public void AdapterInstance_ShouldShareTransportAndOutboundState()
+    {
+        var adapter = CreateAdapter();
+        IChannelTransport transport = adapter;
+        IChannelOutboundPort outbound = adapter;
+
+        ReferenceEquals(transport, outbound).ShouldBeTrue();
+        transport.Channel.Value.ShouldBe(outbound.Channel.Value);
+        transport.Capabilities.ShouldBe(outbound.Capabilities);
+    }
+}
+
+public sealed class StubChannelAdapter : IChannelTransport, IChannelOutboundPort
+{
+    private readonly Channel<ChatActivity> _inbound = System.Threading.Channels.Channel.CreateBounded<ChatActivity>(8);
+
+    public ChannelId Channel { get; } = ChannelId.From("slack");
+
+    public TransportMode TransportMode { get; } = TransportMode.Webhook;
+
+    public ChannelCapabilities Capabilities { get; } = new()
+    {
+        SupportsEdit = true,
+        SupportsDelete = true,
+        Streaming = StreamingSupport.Native,
+        Transport = TransportMode.Webhook,
+    };
+
+    public ChannelReader<ChatActivity> InboundStream => _inbound.Reader;
+
+    public Task InitializeAsync(ChannelTransportBinding binding, CancellationToken ct) => Task.CompletedTask;
+
+    public Task StartReceivingAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task StopReceivingAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task<EmitResult> SendAsync(ConversationReference to, MessageContent content, CancellationToken ct) =>
+        Task.FromResult(EmitResult.Sent("sent-1"));
+
+    public Task<EmitResult> UpdateAsync(
+        ConversationReference to,
+        string activityId,
+        MessageContent content,
+        CancellationToken ct) => Task.FromResult(EmitResult.Sent(activityId));
+
+    public Task DeleteAsync(ConversationReference to, string activityId, CancellationToken ct) => Task.CompletedTask;
+
+    public Task<EmitResult> ContinueConversationAsync(
+        ConversationReference reference,
+        MessageContent content,
+        AuthContext auth,
+        CancellationToken ct) => Task.FromResult(EmitResult.Sent("continued-1"));
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelMegaInterfaceGuardTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelMegaInterfaceGuardTests.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+
+using Shouldly;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class ChannelMegaInterfaceGuardTests
+{
+    [Fact]
+    public async Task ChannelMegaInterfaceGuard_ShouldRejectPartialInterfaceThatCombinesRuntimeAndOutboundSurface()
+    {
+        var tempRoot = Directory.CreateTempSubdirectory("channel-guard-");
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(tempRoot.FullName, "RuntimePart.cs"),
+                """
+                namespace GuardFixture;
+
+                public partial interface ILeakyAdapter
+                {
+                    Task InitializeAsync();
+                }
+                """);
+            await File.WriteAllTextAsync(
+                Path.Combine(tempRoot.FullName, "OutboundPart.cs"),
+                """
+                namespace GuardFixture;
+
+                public partial interface ILeakyAdapter
+                {
+                    Task SendAsync();
+                }
+                """);
+
+            var (exitCode, output) = await RunGuardAsync(tempRoot.FullName);
+
+            exitCode.ShouldBe(1);
+            output.ShouldContain("Channel mega-interface regression detected:");
+            output.ShouldContain("ILeakyAdapter");
+        }
+        finally
+        {
+            tempRoot.Delete(recursive: true);
+        }
+    }
+
+    private static async Task<(int ExitCode, string Output)> RunGuardAsync(string scanRoot)
+    {
+        var repoRoot = FindRepoRoot();
+        var scriptPath = Path.Combine(repoRoot, "tools", "ci", "channel_mega_interface_guard.sh");
+        var startInfo = new ProcessStartInfo("bash", scriptPath)
+        {
+            WorkingDirectory = repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.Environment["CHANNEL_MEGA_INTERFACE_GUARD_ROOT"] = scanRoot;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        await process.WaitForExitAsync();
+
+        var output = $"{await stdoutTask}{await stderrTask}";
+        return (process.ExitCode, output);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "tools", "ci", "channel_mega_interface_guard.sh")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root for channel mega-interface guard test.");
+    }
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/TestProjectorContracts.Partial.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/TestProjectorContracts.Partial.cs
@@ -1,0 +1,13 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed partial class TestProjectorDocument : IProjectionReadModel<TestProjectorDocument>
+{
+    public DateTimeOffset UpdatedAt
+    {
+        get => UpdatedAtUtc == null ? default : UpdatedAtUtc.ToDateTimeOffset();
+        set => UpdatedAtUtc = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
+    }
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/test_projector_contracts.proto
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/test_projector_contracts.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package aevatar.gagents.channel.protocol.tests;
+
+option csharp_namespace = "Aevatar.GAgents.Channel.Protocol.Tests";
+
+import "google/protobuf/timestamp.proto";
+
+message TestProjectorEntry {
+  string id = 1;
+  string value = 2;
+  bool is_deleted = 3;
+}
+
+message TestProjectorState {
+  repeated TestProjectorEntry entries = 1;
+}
+
+message TestProjectorDocument {
+  string id = 1;
+  string actor_id = 2;
+  int64 state_version = 3;
+  string last_event_id = 4;
+  google.protobuf.Timestamp updated_at_utc = 5;
+  string value = 6;
+}

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -7,6 +7,7 @@ This directory keeps CI gate scripts and smoke tests.
 - `tools/ci/coverage_quality_guard.sh`: coverage collection and threshold gate (generated files are excluded by default via file filters, e.g. `obj/**`, `Generated/**`, `*.g.cs`).
   - Produces a filtered `Cobertura.xml` under `artifacts/coverage/<timestamp>-ci-gate/report/` after applying assembly/file exclusions for non-core shells/adapters such as `Aevatar.Tools.*`, `Aevatar.Studio.*`, `Aevatar.Authentication.*`, and host app entrypoints.
 - `tools/ci/architecture_guards.sh`: architecture/static guards (includes projection route mapping guard).
+- `tools/ci/channel_mega_interface_guard.sh`: blocks regressions that merge channel runtime and outbound methods back into one mega interface.
 - `tools/ci/fetch_latest_ci_failure.sh`: downloads the latest failed GitHub Actions run metadata and failed logs into `artifacts/ci-failures/latest/` via `gh`.
 - `tools/ci/test_stability_guards.sh`: polling/unstable test pattern guard.
 - `tools/ci/solution_split_guards.sh`: split build guard.

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -78,6 +78,7 @@ bash "${SCRIPT_DIR}/scripting_write_path_cqrs_guard.sh"
 bash "${SCRIPT_DIR}/projection_state_version_guard.sh"
 bash "${SCRIPT_DIR}/projection_state_mirror_current_state_guard.sh"
 bash "${SCRIPT_DIR}/proto_lint_guard.sh"
+bash "${SCRIPT_DIR}/channel_mega_interface_guard.sh"
 
 if rg -n "ExecuteDeclaredQueryAsync|ExecuteReadModelQueryAsync" src; then
   echo "Declared readmodel query execution is forbidden. Query must read persisted snapshots/documents only."

--- a/tools/ci/channel_mega_interface_guard.sh
+++ b/tools/ci/channel_mega_interface_guard.sh
@@ -7,15 +7,16 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
 cd "${REPO_ROOT}"
 
 python3 <<'PY'
+import os
 from pathlib import Path
 import re
 import sys
 
-root = Path("agents/Aevatar.GAgents.Channel.Abstractions")
+root = Path(os.environ.get("CHANNEL_MEGA_INTERFACE_GUARD_ROOT", "agents/Aevatar.GAgents.Channel.Abstractions"))
 files = [path for path in root.rglob("*.cs") if "obj" not in path.parts and "bin" not in path.parts]
 pattern = re.compile(r"\binterface\s+([A-Za-z_][A-Za-z0-9_]*)\s*([^{}]*)\{", re.MULTILINE)
 
-violations: list[str] = []
+surfaces: dict[str, dict[str, object]] = {}
 
 for path in files:
     text = path.read_text(encoding="utf-8")
@@ -40,12 +41,33 @@ for path in files:
             continue
 
         body = text[body_start + 1:body_end]
-        has_runtime_surface = any(token in body for token in ("InitializeAsync(", "StartReceivingAsync(", "StopReceivingAsync("))
-        has_outbound_surface = any(token in body for token in ("SendAsync(", "UpdateAsync(", "DeleteAsync(", "ContinueConversationAsync("))
-        inherits_both = "IChannelTransport" in declaration_suffix and "IChannelOutboundPort" in declaration_suffix
+        surface = surfaces.setdefault(
+            name,
+            {
+                "paths": set(),
+                "has_runtime_surface": False,
+                "has_outbound_surface": False,
+                "inherits_transport": False,
+                "inherits_outbound": False,
+            },
+        )
+        surface["paths"].add(str(path))
+        surface["has_runtime_surface"] = surface["has_runtime_surface"] or any(
+            token in body for token in ("InitializeAsync(", "StartReceivingAsync(", "StopReceivingAsync(")
+        )
+        surface["has_outbound_surface"] = surface["has_outbound_surface"] or any(
+            token in body for token in ("SendAsync(", "UpdateAsync(", "DeleteAsync(", "ContinueConversationAsync(")
+        )
+        surface["inherits_transport"] = surface["inherits_transport"] or "IChannelTransport" in declaration_suffix
+        surface["inherits_outbound"] = surface["inherits_outbound"] or "IChannelOutboundPort" in declaration_suffix
 
-        if (has_runtime_surface and has_outbound_surface) or inherits_both:
-            violations.append(f"{path}:{name}")
+violations: list[str] = []
+for name, surface in sorted(surfaces.items()):
+    exposes_runtime_surface = bool(surface["has_runtime_surface"] or surface["inherits_transport"])
+    exposes_outbound_surface = bool(surface["has_outbound_surface"] or surface["inherits_outbound"])
+    if exposes_runtime_surface and exposes_outbound_surface:
+        paths = ", ".join(sorted(surface["paths"]))
+        violations.append(f"{name} ({paths})")
 
 if violations:
     print("Channel mega-interface regression detected:")

--- a/tools/ci/channel_mega_interface_guard.sh
+++ b/tools/ci/channel_mega_interface_guard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+python3 <<'PY'
+from pathlib import Path
+import re
+import sys
+
+root = Path("agents/Aevatar.GAgents.Channel.Abstractions")
+files = [path for path in root.rglob("*.cs") if "obj" not in path.parts and "bin" not in path.parts]
+pattern = re.compile(r"\binterface\s+([A-Za-z_][A-Za-z0-9_]*)\s*([^{}]*)\{", re.MULTILINE)
+
+violations: list[str] = []
+
+for path in files:
+    text = path.read_text(encoding="utf-8")
+    for match in pattern.finditer(text):
+        name = match.group(1)
+        declaration_suffix = match.group(2) or ""
+        body_start = match.end() - 1
+        depth = 0
+        body_end = None
+
+        for index in range(body_start, len(text)):
+            char = text[index]
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    body_end = index
+                    break
+
+        if body_end is None:
+            continue
+
+        body = text[body_start + 1:body_end]
+        has_runtime_surface = any(token in body for token in ("InitializeAsync(", "StartReceivingAsync(", "StopReceivingAsync("))
+        has_outbound_surface = any(token in body for token in ("SendAsync(", "UpdateAsync(", "DeleteAsync(", "ContinueConversationAsync("))
+        inherits_both = "IChannelTransport" in declaration_suffix and "IChannelOutboundPort" in declaration_suffix
+
+        if (has_runtime_surface and has_outbound_surface) or inherits_both:
+            violations.append(f"{path}:{name}")
+
+if violations:
+    print("Channel mega-interface regression detected:")
+    for violation in violations:
+        print(f"  {violation}")
+    sys.exit(1)
+
+print("channel_mega_interface_guard: ok")
+PY


### PR DESCRIPTION
Closes #257 

## Summary
- implement the initial `Aevatar.GAgents.Channel.Abstractions` surface for `#257`
- add compile-time and CI enforcement for the `single-class two-interfaces` contract via a conformance suite and `channel_mega_interface_guard.sh`
- inline the remaining interface contract semantics as XML docs and enable `CS1591` as an error for the abstractions package
- closes #257

## Notes
- `#256` is now merged into `dev`, so this PR carries only the `#257` abstractions changes
- proto comments now back the generated public API docs for the abstractions package
- credential integration still reuses the foundation `ICredentialProvider` contract instead of introducing a channel-local duplicate

## Validation
- `dotnet build agents/Aevatar.GAgents.Channel.Abstractions/Aevatar.GAgents.Channel.Abstractions.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo`
- `bash tools/ci/architecture_guards.sh`