### PR TITLE
[codex] Classify permanent Lark reply failures

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
@@ -461,8 +461,8 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
                              statusProp.ValueKind == JsonValueKind.Number
                     ? statusProp.GetInt32()
                     : (int?)null;
-                var body = root.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() : null;
-                var message = root.TryGetProperty("message", out var messageProp) ? messageProp.GetString() : null;
+                var body = TryReadStringProperty(root, "body");
+                var message = TryReadStringProperty(root, "message");
 
                 if (TryBuildLarkPlatformErrorDetail(body, status, out var detail, out var failureKind))
                 {
@@ -519,19 +519,19 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
                 if (code == 0)
                     return false;
 
-                var msg = root.TryGetProperty("msg", out var msgProp) ? msgProp.GetString() : null;
+                var msg = TryReadStringProperty(root, "msg");
                 detail = $"lark_code={code}" +
                          (string.IsNullOrWhiteSpace(msg) ? string.Empty : $" msg={msg}");
                 failureKind = ClassifyLarkPlatformError(code, error: null, status);
                 return true;
             }
 
-            var error = root.TryGetProperty("error", out var errorProp) ? errorProp.GetString() : null;
+            var error = TryReadStringProperty(root, "error");
             var errorCode = root.TryGetProperty("error_code", out var errorCodeProp) &&
                             errorCodeProp.ValueKind == JsonValueKind.Number
                 ? errorCodeProp.GetInt32()
                 : 0;
-            var message = root.TryGetProperty("message", out var messageProp) ? messageProp.GetString() : null;
+            var message = TryReadStringProperty(root, "message");
             if (string.IsNullOrWhiteSpace(error) && errorCode == 0 && string.IsNullOrWhiteSpace(message))
                 return false;
 
@@ -547,6 +547,13 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
             return false;
         }
     }
+
+    // Avoid JsonElement.GetString() on non-string values (e.g. boolean `error:true`),
+    // which throws InvalidOperationException and escapes the structured-failure flow.
+    private static string? TryReadStringProperty(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
 
     private static PlatformReplyFailureKind ClassifyNyxProxyStatus(int? status) =>
         status switch

--- a/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
@@ -301,23 +301,12 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
             extraHeaders: null,
             ct);
 
-        // ProxyRequestAsync returns error JSON ({"error": true, ...}) instead of
-        // throwing on 4xx/5xx responses. Surface these as exceptions so callers
-        // can record and diagnose the failure.
-        if (result != null && result.Contains("\"error\"", StringComparison.OrdinalIgnoreCase))
+        if (TryBuildLarkFailureResult(result, out var failure))
         {
             _logger.LogWarning(
-                "Lark outbound reply failed: slug={Slug}, result={Result}",
-                registration.NyxProviderSlug, result);
-            throw new InvalidOperationException($"Lark API error: {result}");
-        }
-
-        if (TryBuildLarkErrorDetail(result, out var larkErrorDetail))
-        {
-            _logger.LogWarning(
-                "Lark outbound reply rejected by platform: chat={ChatId}, slug={Slug}, detail={Detail}",
-                inbound.ConversationId, registration.NyxProviderSlug, larkErrorDetail);
-            return new PlatformReplyDeliveryResult(false, larkErrorDetail);
+                "Lark outbound reply rejected: chat={ChatId}, slug={Slug}, detail={Detail}, kind={Kind}",
+                inbound.ConversationId, registration.NyxProviderSlug, failure.Detail, failure.FailureKind);
+            return failure;
         }
 
         var successDetail = BuildLarkSuccessDetail(result);
@@ -451,12 +440,12 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
         }
     }
 
-    private static bool TryBuildLarkErrorDetail(string? result, out string detail)
+    private static bool TryBuildLarkFailureResult(string? result, out PlatformReplyDeliveryResult failure)
     {
-        detail = string.Empty;
+        failure = default;
         if (string.IsNullOrWhiteSpace(result))
         {
-            detail = "empty_lark_response";
+            failure = new PlatformReplyDeliveryResult(false, "empty_lark_response");
             return true;
         }
 
@@ -464,25 +453,118 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
         {
             using var doc = JsonDocument.Parse(result);
             var root = doc.RootElement;
-            if (!root.TryGetProperty("code", out var codeProp))
-                return false;
 
-            var code = codeProp.ValueKind == JsonValueKind.Number
-                ? codeProp.GetInt32()
+            if (root.TryGetProperty("error", out var errorProp) &&
+                errorProp.ValueKind == JsonValueKind.True)
+            {
+                var status = root.TryGetProperty("status", out var statusProp) &&
+                             statusProp.ValueKind == JsonValueKind.Number
+                    ? statusProp.GetInt32()
+                    : (int?)null;
+                var body = root.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() : null;
+
+                if (TryBuildLarkPlatformErrorDetail(body, status, out var detail, out var failureKind))
+                {
+                    failure = new PlatformReplyDeliveryResult(false, detail, failureKind);
+                    return true;
+                }
+
+                var nyxDetail = $"nyx_error status={status?.ToString() ?? "unknown"}" +
+                                (string.IsNullOrWhiteSpace(body) ? string.Empty : $" body={body}");
+                failure = new PlatformReplyDeliveryResult(
+                    false,
+                    nyxDetail,
+                    ClassifyNyxProxyStatus(status));
+                return true;
+            }
+
+            if (TryBuildLarkPlatformErrorDetail(result, status: null, out var larkDetail, out var larkFailureKind))
+            {
+                failure = new PlatformReplyDeliveryResult(false, larkDetail, larkFailureKind);
+                return true;
+            }
+
+            return false;
+        }
+        catch (JsonException)
+        {
+            failure = new PlatformReplyDeliveryResult(false, "invalid_lark_response_json");
+            return true;
+        }
+    }
+
+    private static bool TryBuildLarkPlatformErrorDetail(
+        string? body,
+        int? status,
+        out string detail,
+        out PlatformReplyFailureKind failureKind)
+    {
+        detail = string.Empty;
+        failureKind = PlatformReplyFailureKind.None;
+        if (string.IsNullOrWhiteSpace(body))
+            return false;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("code", out var codeProp))
+            {
+                var code = codeProp.ValueKind == JsonValueKind.Number
+                    ? codeProp.GetInt32()
+                    : 0;
+                if (code == 0)
+                    return false;
+
+                var msg = root.TryGetProperty("msg", out var msgProp) ? msgProp.GetString() : null;
+                detail = $"lark_code={code}" +
+                         (string.IsNullOrWhiteSpace(msg) ? string.Empty : $" msg={msg}");
+                failureKind = ClassifyLarkPlatformError(code, error: null, status);
+                return true;
+            }
+
+            var error = root.TryGetProperty("error", out var errorProp) ? errorProp.GetString() : null;
+            var errorCode = root.TryGetProperty("error_code", out var errorCodeProp) &&
+                            errorCodeProp.ValueKind == JsonValueKind.Number
+                ? errorCodeProp.GetInt32()
                 : 0;
-            if (code == 0)
+            var message = root.TryGetProperty("message", out var messageProp) ? messageProp.GetString() : null;
+            if (string.IsNullOrWhiteSpace(error) && errorCode == 0 && string.IsNullOrWhiteSpace(message))
                 return false;
 
-            var msg = root.TryGetProperty("msg", out var msgProp) ? msgProp.GetString() : null;
-            detail = $"lark_code={code}" +
-                     (string.IsNullOrWhiteSpace(msg) ? string.Empty : $" msg={msg}");
+            detail = $"nyx_status={status?.ToString() ?? "unknown"}" +
+                     (string.IsNullOrWhiteSpace(error) ? string.Empty : $" lark_error={error}") +
+                     (errorCode == 0 ? string.Empty : $" error_code={errorCode}") +
+                     (string.IsNullOrWhiteSpace(message) ? string.Empty : $" message={message}");
+            failureKind = ClassifyLarkPlatformError(errorCode, error, status);
             return true;
         }
         catch (JsonException)
         {
-            detail = "invalid_lark_response_json";
-            return true;
+            return false;
         }
+    }
+
+    private static PlatformReplyFailureKind ClassifyNyxProxyStatus(int? status) =>
+        status switch
+        {
+            400 or 401 or 403 or 404 => PlatformReplyFailureKind.Permanent,
+            408 or 425 or 429 => PlatformReplyFailureKind.Transient,
+            >= 500 => PlatformReplyFailureKind.Transient,
+            _ => PlatformReplyFailureKind.None,
+        };
+
+    private static PlatformReplyFailureKind ClassifyLarkPlatformError(int errorCode, string? error, int? status)
+    {
+        if (errorCode is 2001 or 230001 or 230002)
+            return PlatformReplyFailureKind.Permanent;
+
+        if (string.Equals(error, "token_expired", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(error, "invalid_auth", StringComparison.OrdinalIgnoreCase))
+            return PlatformReplyFailureKind.Permanent;
+
+        return ClassifyNyxProxyStatus(status);
     }
 
     private static string BuildLarkSuccessDetail(string? result)

--- a/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/Adapters/LarkPlatformAdapter.cs
@@ -462,6 +462,7 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
                     ? statusProp.GetInt32()
                     : (int?)null;
                 var body = root.TryGetProperty("body", out var bodyProp) ? bodyProp.GetString() : null;
+                var message = root.TryGetProperty("message", out var messageProp) ? messageProp.GetString() : null;
 
                 if (TryBuildLarkPlatformErrorDetail(body, status, out var detail, out var failureKind))
                 {
@@ -470,11 +471,12 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
                 }
 
                 var nyxDetail = $"nyx_error status={status?.ToString() ?? "unknown"}" +
-                                (string.IsNullOrWhiteSpace(body) ? string.Empty : $" body={body}");
+                                (string.IsNullOrWhiteSpace(body) ? string.Empty : $" body={body}") +
+                                (string.IsNullOrWhiteSpace(message) ? string.Empty : $" message={message}");
                 failure = new PlatformReplyDeliveryResult(
                     false,
                     nyxDetail,
-                    ClassifyNyxProxyStatus(status));
+                    ClassifyNyxProxyFailure(status, message));
                 return true;
             }
 
@@ -555,9 +557,23 @@ public sealed class LarkPlatformAdapter : IPlatformAdapter
             _ => PlatformReplyFailureKind.None,
         };
 
+    private static PlatformReplyFailureKind ClassifyNyxProxyFailure(int? status, string? message)
+    {
+        if (status.HasValue)
+            return ClassifyNyxProxyStatus(status);
+
+        // NyxIdApiClient exception envelopes omit status/body and only preserve the exception message.
+        // Treat them as transient so diagnostics retain useful context without promoting them to permanent.
+        return string.IsNullOrWhiteSpace(message)
+            ? PlatformReplyFailureKind.None
+            : PlatformReplyFailureKind.Transient;
+    }
+
     private static PlatformReplyFailureKind ClassifyLarkPlatformError(int errorCode, string? error, int? status)
     {
-        if (errorCode is 2001 or 230001 or 230002)
+        // 230001 means the receive target no longer exists or is invalid; 230002 means the
+        // configured bot/user is not in the target chat. Both require operator/configuration fixes.
+        if (errorCode is 230001 or 230002)
             return PlatformReplyFailureKind.Permanent;
 
         if (string.Equals(error, "token_expired", StringComparison.OrdinalIgnoreCase) ||

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserGAgent.cs
@@ -323,6 +323,7 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
 
         // Send reply via platform adapter.
         var replySucceeded = false;
+        var shouldComplete = forceComplete;
         try
         {
             var delivery = await SendPlatformReplyAsync(session, replyText);
@@ -338,6 +339,11 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
                     session.SessionId,
                     delivery.Detail);
                 RecordDiagnostic("Reply:error", session.Platform, session.RegistrationId, delivery.Detail);
+                if (delivery.FailureKind == PlatformReplyFailureKind.Permanent)
+                {
+                    shouldComplete = true;
+                    RecordDiagnostic("Reply:permanent", session.Platform, session.RegistrationId, delivery.Detail);
+                }
             }
         }
         catch (Exception ex)
@@ -350,7 +356,7 @@ public sealed class ChannelUserGAgent : GAgentBase<ChannelUserState>
 
         // On reply failure from HandleChatEnd, keep the session open so the
         // timeout can retry. On timeout (forceComplete), always complete.
-        if (!replySucceeded && !forceComplete)
+        if (!replySucceeded && !shouldComplete)
             return;
 
         // Persist completion (removes from pending_sessions via state transition)

--- a/agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs
@@ -37,6 +37,8 @@ public interface IPlatformAdapter
         CancellationToken ct);
 }
 
+// Today only Permanent changes ChannelUserGAgent completion behavior.
+// Transient and None both keep the session open for the normal timeout retry path.
 public enum PlatformReplyFailureKind
 {
     None = 0,

--- a/agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/IPlatformAdapter.cs
@@ -37,6 +37,14 @@ public interface IPlatformAdapter
         CancellationToken ct);
 }
 
+public enum PlatformReplyFailureKind
+{
+    None = 0,
+    Transient = 1,
+    Permanent = 2,
+}
+
 public readonly record struct PlatformReplyDeliveryResult(
     bool Succeeded,
-    string? Detail = null);
+    string? Detail = null,
+    PlatformReplyFailureKind FailureKind = PlatformReplyFailureKind.None);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
@@ -324,6 +324,40 @@ public class ChannelUserGAgentContinuationTests
     }
 
     [Fact]
+    public async Task HandleChatEnd_ShouldCompletePendingSession_WhenReplyDeliveryPermanentFailure()
+    {
+        var runtime = new RecordingActorRuntime();
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingPlatformAdapter("lark")
+        {
+            FailRepliesRemaining = 1,
+            FailureDetail = "lark_code=230002 msg=Bot not in chat",
+            FailureKind = PlatformReplyFailureKind.Permanent,
+        };
+        var diagnostics = new InMemoryChannelRuntimeDiagnostics();
+        using var services = BuildServices(runtime, streams, scheduler, adapter, new InMemoryEventStore(), diagnostics);
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(BuildInboundEvent());
+
+        var request = runtime.SingleChatRequest();
+        await agent.HandleEventAsync(BuildTopologyEnvelope(
+            "channel-lark-reg-1-ou_123",
+            TopologyAudience.Parent,
+            new TextMessageEndEvent
+            {
+                SessionId = request.SessionId,
+                Content = "hello world",
+            }));
+
+        adapter.Replies.Should().ContainSingle();
+        agent.State.PendingSessions.Should().BeEmpty();
+        diagnostics.GetRecent().Select(entry => entry.Stage).Should().Contain("Reply:permanent");
+    }
+
+    [Fact]
     public async Task HandleInbound_DailyReportIntent_ShouldSendInteractiveBuilderCard()
     {
         var runtime = new RecordingActorRuntime();
@@ -1925,6 +1959,7 @@ public class ChannelUserGAgentContinuationTests
         public List<ReplyRecord> Replies { get; } = [];
         public int FailRepliesRemaining { get; set; }
         public string FailureDetail { get; set; } = "reply_rejected";
+        public PlatformReplyFailureKind FailureKind { get; set; } = PlatformReplyFailureKind.None;
 
         public Task<IResult?> TryHandleVerificationAsync(HttpContext http, ChannelBotRegistrationEntry registration) =>
             Task.FromResult<IResult?>(null);
@@ -1944,7 +1979,7 @@ public class ChannelUserGAgentContinuationTests
             if (FailRepliesRemaining > 0)
             {
                 FailRepliesRemaining--;
-                return Task.FromResult(new PlatformReplyDeliveryResult(false, FailureDetail));
+                return Task.FromResult(new PlatformReplyDeliveryResult(false, FailureDetail, FailureKind));
             }
 
             return Task.FromResult(new PlatformReplyDeliveryResult(true, "ok"));

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
@@ -906,6 +906,29 @@ public class LarkPlatformAdapterTests
     }
 
     [Fact]
+    public async Task SendReplyAsync_preserves_proxy_exception_message_and_marks_it_transient()
+    {
+        var httpClient = new HttpClient(new ThrowingHandler(new HttpRequestException("dns failure")))
+        {
+            BaseAddress = new Uri("https://nyx.example.com"),
+        };
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            httpClient);
+        var inbound = new InboundMessage
+        {
+            Platform = "lark", ConversationId = "oc_1",
+            SenderId = "ou_1", SenderName = "s", Text = "hi",
+        };
+
+        var result = await _adapter.SendReplyAsync("reply", inbound, MakeRegistration(), nyxClient, CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("nyx_error status=unknown message=dns failure");
+        result.FailureKind.Should().Be(PlatformReplyFailureKind.Transient);
+    }
+
+    [Fact]
     public async Task SendReplyAsync_returns_result_length_when_no_message_id_in_response()
     {
         var httpClient = CreateHttpClient(HttpStatusCode.OK, """{"code":0,"msg":"success","data":{}}""", out _);
@@ -1070,5 +1093,11 @@ public class LarkPlatformAdapterTests
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),
             };
         }
+    }
+
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromException<HttpResponseMessage>(exception);
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
@@ -906,6 +906,30 @@ public class LarkPlatformAdapterTests
     }
 
     [Fact]
+    public async Task SendReplyAsync_classifies_failure_when_lark_body_uses_boolean_error_field()
+    {
+        // Nyx wraps a non-2xx upstream whose body is {"error": true, "message": "..."}.
+        // The inner `error` is a JSON boolean, not a string, and must not throw.
+        var httpClient = CreateHttpClient(HttpStatusCode.BadRequest, """
+            {"error":true,"message":"upstream refused"}
+            """, out _);
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            httpClient);
+        var inbound = new InboundMessage
+        {
+            Platform = "lark", ConversationId = "oc_1",
+            SenderId = "ou_1", SenderName = "s", Text = "hi",
+        };
+
+        var result = await _adapter.SendReplyAsync("reply", inbound, MakeRegistration(), nyxClient, CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("nyx_status=400 message=upstream refused");
+        result.FailureKind.Should().Be(PlatformReplyFailureKind.Permanent);
+    }
+
+    [Fact]
     public async Task SendReplyAsync_preserves_proxy_exception_message_and_marks_it_transient()
     {
         var httpClient = new HttpClient(new ThrowingHandler(new HttpRequestException("dns failure")))

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
@@ -862,9 +862,11 @@ public class LarkPlatformAdapterTests
     }
 
     [Fact]
-    public async Task SendReplyAsync_throws_when_response_contains_error_field()
+    public async Task SendReplyAsync_returns_failed_result_when_proxy_reports_permanent_lark_error()
     {
-        var httpClient = CreateHttpClient(HttpStatusCode.OK, """{"error":true,"message":"forbidden"}""", out _);
+        var httpClient = CreateHttpClient(HttpStatusCode.BadRequest, """
+            {"code":230002,"msg":"Bot/User can NOT be out of the chat."}
+            """, out _);
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
             httpClient);
@@ -874,10 +876,33 @@ public class LarkPlatformAdapterTests
             SenderId = "ou_1", SenderName = "s", Text = "hi",
         };
 
-        var act = () => _adapter.SendReplyAsync("reply", inbound, MakeRegistration(), nyxClient, CancellationToken.None);
+        var result = await _adapter.SendReplyAsync("reply", inbound, MakeRegistration(), nyxClient, CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Lark API error*");
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("lark_code=230002 msg=Bot/User can NOT be out of the chat.");
+        result.FailureKind.Should().Be(PlatformReplyFailureKind.Permanent);
+    }
+
+    [Fact]
+    public async Task SendReplyAsync_returns_failed_result_when_proxy_reports_token_expired()
+    {
+        var httpClient = CreateHttpClient(HttpStatusCode.Unauthorized, """
+            {"error":"token_expired","error_code":2001,"message":"Token expired"}
+            """, out _);
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            httpClient);
+        var inbound = new InboundMessage
+        {
+            Platform = "lark", ConversationId = "oc_1",
+            SenderId = "ou_1", SenderName = "s", Text = "hi",
+        };
+
+        var result = await _adapter.SendReplyAsync("reply", inbound, MakeRegistration(), nyxClient, CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("nyx_status=401 lark_error=token_expired error_code=2001 message=Token expired");
+        result.FailureKind.Should().Be(PlatformReplyFailureKind.Permanent);
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

- classify Nyx-proxied Lark outbound failures into structured permanent or transient reply failures instead of surfacing them only as generic exceptions
- treat `token_expired` and Lark `230002` as permanent reply failures
- complete pending channel sessions immediately on permanent reply failure instead of waiting for timeout and retrying once more
- add adapter and continuation tests covering permanent proxy failures and permanent session completion

## Why

Lark inbound chat execution was succeeding, but outbound delivery could still fail in two clear permanent cases:

- Nyx access token expired
- the configured bot was not in the target chat (`230002`)

Those failures were only recorded as generic adapter exceptions, and the actor flow retried them again at timeout even though the second attempt could not succeed. This made diagnosis noisier and left reply semantics less honest.

## Impact

- diagnostics become more actionable for Lark reply failures
- permanent delivery failures no longer trigger a redundant timeout retry
- tests cover the new failure classification and completion behavior

## Root cause

The Lark adapter treated Nyx proxy error envelopes as opaque exceptions instead of parsing platform error details, and the continuation actor could not distinguish retryable delivery failures from permanent ones.

## Validation

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~LarkPlatformAdapterTests"`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~ChannelUserGAgentContinuationTests"`
- `bash tools/ci/test_stability_guards.sh`
