### PR TITLE
Implement Channel.Runtime package (grains + middleware + inbox + observability)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Aevatar.GAgents.Channel.Runtime.csproj
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Aevatar.GAgents.Channel.Runtime.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aevatar.GAgents.Channel.Abstractions\Aevatar.GAgents.Channel.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
@@ -15,6 +17,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="protos\*.proto"

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -99,10 +99,7 @@ public sealed class ConversationGAgent : GAgentBase<ConversationGAgentState>
             ErrorSummary = result.ErrorSummary,
             FailedAtUnixMs = nowMs,
         };
-        if (result.RetryAfter is { } retry)
-            failed.RetryAfterMs = (long)retry.TotalMilliseconds;
-        else
-            failed.NotRetryable = new Google.Protobuf.WellKnownTypes.Empty();
+        AssignRetryPolicy(failed, result);
         await PersistDomainEventAsync(failed);
         Logger.LogWarning(
             "Inbound turn failed: activity={ActivityId} code={Code} kind={Kind}",
@@ -167,14 +164,28 @@ public sealed class ConversationGAgent : GAgentBase<ConversationGAgentState>
             ErrorSummary = result.ErrorSummary,
             FailedAtUnixMs = nowMs,
         };
-        if (result.RetryAfter is { } retry)
-            failed.RetryAfterMs = (long)retry.TotalMilliseconds;
-        else
-            failed.NotRetryable = new Google.Protobuf.WellKnownTypes.Empty();
+        AssignRetryPolicy(failed, result);
         await PersistDomainEventAsync(failed);
         Logger.LogWarning(
             "Continue command failed: cmd={CommandId} code={Code} kind={Kind}",
             cmd.CommandId, result.ErrorCode, result.FailureKind);
+    }
+
+    // Retry policy is driven by FailureKind, not by whether the caller supplied a backoff.
+    // Only PermanentAdapterError terminates the command id; every other kind is retriable and
+    // carries the supplied retry_after_ms (0 when omitted). This preserves transient recovery
+    // paths even when runners report a transient failure without an explicit backoff.
+    private static void AssignRetryPolicy(ConversationContinueFailedEvent failed, ConversationTurnResult result)
+    {
+        if (result.FailureKind == FailureKind.PermanentAdapterError)
+        {
+            failed.NotRetryable = new Google.Protobuf.WellKnownTypes.Empty();
+            return;
+        }
+
+        failed.RetryAfterMs = result.RetryAfter is { } retry
+            ? (long)retry.TotalMilliseconds
+            : 0;
     }
 
     private static string AuthPrincipalForContinue(ConversationContinueRequestedEvent cmd) =>

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -245,7 +245,11 @@ public sealed class ConversationGAgent : GAgentBase<ConversationGAgentState>
         ConversationContinueFailedEvent evt)
     {
         var next = current.Clone();
-        if (!string.IsNullOrEmpty(evt.CommandId))
+        // Only terminal failures (NotRetryable oneof) consume the command id. `retry_after_ms`
+        // failures must stay retriable — if we appended them here the next redispatch of the same
+        // logical command id would come back as DuplicateCommand instead of executing.
+        if (!string.IsNullOrEmpty(evt.CommandId)
+            && evt.RetryPolicyCase == ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable)
         {
             AppendBounded(next.ProcessedCommandIds, evt.CommandId, ProcessedIdsCap);
         }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -1,0 +1,265 @@
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgents.Channel.Abstractions;
+using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Per-conversation single-activation actor keyed by <see cref="ConversationReference.CanonicalKey"/>.
+/// Owns conversation-scoped dedup state and is the authoritative boundary for atomic
+/// "admit activity → invoke bot turn → commit outbound + dedup entry" semantics per RFC §5.2b.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Dedup is strongly serialized by the actor turn. The pipeline may fast-path-check
+/// <see cref="ConversationGAgentState.ProcessedMessageIds"/> upstream, but the authoritative
+/// check lives inside <see cref="HandleInboundActivityAsync"/>. Double delivery of the same
+/// <see cref="ChatActivity.Id"/> is collapsed to one emitted <see cref="ConversationTurnCompletedEvent"/>.
+/// </para>
+/// <para>
+/// Downstream projections subscribe through the standard
+/// <see cref="Aevatar.Foundation.Abstractions.CommittedStateEventPublished"/> pipeline wired up by
+/// <see cref="GAgentBase{TState}.PersistDomainEventAsync{TEvent}"/>. No inline projection writes.
+/// </para>
+/// </remarks>
+public sealed class ConversationGAgent : GAgentBase<ConversationGAgentState>
+{
+    /// <summary>
+    /// Sliding window cap on retained processed ids. Keeps state size bounded while still
+    /// catching typical redelivery windows (seconds to minutes).
+    /// </summary>
+    public const int ProcessedIdsCap = 10000;
+
+    /// <inheritdoc />
+    protected override ConversationGAgentState TransitionState(ConversationGAgentState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<ConversationTurnCompletedEvent>(ApplyTurnCompleted)
+            .On<ConversationContinueRejectedEvent>(ApplyContinueRejected)
+            .On<ConversationContinueFailedEvent>(ApplyContinueFailed)
+            .OrCurrent();
+
+    /// <summary>
+    /// Authoritative inbound admission: dedup + run bot turn + commit atomically.
+    /// </summary>
+    [EventHandler]
+    public async Task HandleInboundActivityAsync(ChatActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        if (string.IsNullOrWhiteSpace(activity.Id))
+        {
+            Logger.LogWarning("Dropping ChatActivity with empty id (conversation={Key})",
+                activity.Conversation?.CanonicalKey);
+            return;
+        }
+
+        if (State.ProcessedMessageIds.Contains(activity.Id))
+        {
+            Logger.LogInformation(
+                "Duplicate inbound activity {ActivityId} (conversation={Key}); skipping turn",
+                activity.Id, activity.Conversation?.CanonicalKey);
+            return;
+        }
+
+        var runner = ResolveRunner();
+        var result = await runner.RunInboundAsync(activity, CancellationToken.None);
+
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (result.Success)
+        {
+            var completed = new ConversationTurnCompletedEvent
+            {
+                ProcessedActivityId = activity.Id,
+                CausationCommandId = string.Empty,
+                SentActivityId = result.SentActivityId,
+                AuthPrincipal = result.AuthPrincipal,
+                Conversation = activity.Conversation?.Clone() ?? new ConversationReference(),
+                Outbound = result.Outbound?.Clone() ?? new MessageContent(),
+                CompletedAtUnixMs = nowMs,
+            };
+            await PersistDomainEventAsync(completed);
+            Logger.LogInformation(
+                "Completed inbound turn: activity={ActivityId} sent={SentId} conversation={Key}",
+                activity.Id, result.SentActivityId, activity.Conversation?.CanonicalKey);
+            return;
+        }
+
+        var failed = new ConversationContinueFailedEvent
+        {
+            CommandId = string.Empty,
+            CorrelationId = activity.Id,
+            CausationId = string.Empty,
+            Kind = result.FailureKind,
+            ErrorCode = result.ErrorCode,
+            ErrorSummary = result.ErrorSummary,
+            FailedAtUnixMs = nowMs,
+        };
+        if (result.RetryAfter is { } retry)
+            failed.RetryAfterMs = (long)retry.TotalMilliseconds;
+        else
+            failed.NotRetryable = new Google.Protobuf.WellKnownTypes.Empty();
+        await PersistDomainEventAsync(failed);
+        Logger.LogWarning(
+            "Inbound turn failed: activity={ActivityId} code={Code} kind={Kind}",
+            activity.Id, result.ErrorCode, result.FailureKind);
+    }
+
+    /// <summary>
+    /// Proactive command path: dedup by command id, optionally reject, otherwise invoke bot turn.
+    /// </summary>
+    [EventHandler]
+    public async Task HandleContinueCommandAsync(ConversationContinueRequestedEvent cmd)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+
+        if (string.IsNullOrWhiteSpace(cmd.CommandId))
+        {
+            await EmitRejectAsync(cmd, RejectReason.Unspecified, "empty command_id");
+            return;
+        }
+
+        if (State.ProcessedCommandIds.Contains(cmd.CommandId))
+        {
+            Logger.LogInformation(
+                "Duplicate continue command {CommandId}; emitting DuplicateCommand rejection",
+                cmd.CommandId);
+            await EmitRejectAsync(cmd, RejectReason.DuplicateCommand, "duplicate command id");
+            return;
+        }
+
+        var runner = ResolveRunner();
+        var result = await runner.RunContinueAsync(cmd, CancellationToken.None);
+
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (result.Success)
+        {
+            var completed = new ConversationTurnCompletedEvent
+            {
+                ProcessedActivityId = string.Empty,
+                CausationCommandId = cmd.CommandId,
+                SentActivityId = result.SentActivityId,
+                AuthPrincipal = string.IsNullOrEmpty(result.AuthPrincipal)
+                    ? AuthPrincipalForContinue(cmd)
+                    : result.AuthPrincipal,
+                Conversation = cmd.Conversation?.Clone() ?? new ConversationReference(),
+                Outbound = result.Outbound?.Clone() ?? (cmd.Payload?.Clone() ?? new MessageContent()),
+                CompletedAtUnixMs = nowMs,
+            };
+            await PersistDomainEventAsync(completed);
+            Logger.LogInformation(
+                "Completed continue command: cmd={CommandId} sent={SentId} conversation={Key}",
+                cmd.CommandId, result.SentActivityId, cmd.Conversation?.CanonicalKey);
+            return;
+        }
+
+        var failed = new ConversationContinueFailedEvent
+        {
+            CommandId = cmd.CommandId,
+            CorrelationId = cmd.CorrelationId,
+            CausationId = cmd.CausationId,
+            Kind = result.FailureKind,
+            ErrorCode = result.ErrorCode,
+            ErrorSummary = result.ErrorSummary,
+            FailedAtUnixMs = nowMs,
+        };
+        if (result.RetryAfter is { } retry)
+            failed.RetryAfterMs = (long)retry.TotalMilliseconds;
+        else
+            failed.NotRetryable = new Google.Protobuf.WellKnownTypes.Empty();
+        await PersistDomainEventAsync(failed);
+        Logger.LogWarning(
+            "Continue command failed: cmd={CommandId} code={Code} kind={Kind}",
+            cmd.CommandId, result.ErrorCode, result.FailureKind);
+    }
+
+    private static string AuthPrincipalForContinue(ConversationContinueRequestedEvent cmd) =>
+        cmd.Kind == PrincipalKind.OnBehalfOfUser
+            ? $"user:{cmd.OnBehalfOfUserId}"
+            : "bot";
+
+    private Task EmitRejectAsync(ConversationContinueRequestedEvent cmd, RejectReason reason, string detail)
+    {
+        var rejected = new ConversationContinueRejectedEvent
+        {
+            CommandId = cmd.CommandId,
+            CorrelationId = cmd.CorrelationId,
+            CausationId = cmd.CausationId,
+            Reason = reason,
+            ReasonDetail = detail,
+            RejectedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        };
+        return PersistDomainEventAsync(rejected);
+    }
+
+    private IConversationTurnRunner ResolveRunner() =>
+        Services.GetService<IConversationTurnRunner>() ?? new NullConversationTurnRunner();
+
+    // ─── State transitions ───
+
+    private static ConversationGAgentState ApplyTurnCompleted(
+        ConversationGAgentState current,
+        ConversationTurnCompletedEvent evt)
+    {
+        var next = current.Clone();
+        if (!string.IsNullOrEmpty(evt.ProcessedActivityId))
+        {
+            AppendBounded(next.ProcessedMessageIds, evt.ProcessedActivityId, ProcessedIdsCap);
+        }
+        if (!string.IsNullOrEmpty(evt.CausationCommandId))
+        {
+            AppendBounded(next.ProcessedCommandIds, evt.CausationCommandId, ProcessedIdsCap);
+        }
+        if (evt.Conversation != null && next.Conversation == null)
+        {
+            next.Conversation = evt.Conversation.Clone();
+        }
+        next.LastUpdatedUnixMs = evt.CompletedAtUnixMs;
+        return next;
+    }
+
+    private static ConversationGAgentState ApplyContinueRejected(
+        ConversationGAgentState current,
+        ConversationContinueRejectedEvent evt)
+    {
+        var next = current.Clone();
+        if (evt.Reason == RejectReason.DuplicateCommand && !string.IsNullOrEmpty(evt.CommandId))
+        {
+            // DuplicateCommand rejection is emitted *because* the command id is already processed.
+            // No state change. Fall through and just stamp the timestamp.
+        }
+        else if (!string.IsNullOrEmpty(evt.CommandId))
+        {
+            AppendBounded(next.ProcessedCommandIds, evt.CommandId, ProcessedIdsCap);
+        }
+        next.LastUpdatedUnixMs = evt.RejectedAtUnixMs;
+        return next;
+    }
+
+    private static ConversationGAgentState ApplyContinueFailed(
+        ConversationGAgentState current,
+        ConversationContinueFailedEvent evt)
+    {
+        var next = current.Clone();
+        if (!string.IsNullOrEmpty(evt.CommandId))
+        {
+            AppendBounded(next.ProcessedCommandIds, evt.CommandId, ProcessedIdsCap);
+        }
+        next.LastUpdatedUnixMs = evt.FailedAtUnixMs;
+        return next;
+    }
+
+    private static void AppendBounded(
+        Google.Protobuf.Collections.RepeatedField<string> field,
+        string value,
+        int cap)
+    {
+        field.Add(value);
+        while (field.Count > cap)
+            field.RemoveAt(0);
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationTurnRunner.cs
@@ -1,0 +1,73 @@
+using Aevatar.GAgents.Channel.Abstractions;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Runs one bot turn inside <see cref="ConversationGAgent"/>. The seam lets the grain stay
+/// channel-agnostic while deferring actual <see cref="IBot"/> invocation + outbound send to
+/// runtime-specific implementations (middleware pipeline + adapter outbound port).
+/// </summary>
+/// <remarks>
+/// The grain assumes turn-serial execution and will call this seam at most once per dedup-admitted
+/// inbound activity or proactive command. Implementations must be safe under that single-threaded
+/// invariant and must not return partial state: either success with a <see cref="ConversationTurnResult.SentActivityId"/>
+/// or a well-formed failure.
+/// </remarks>
+public interface IConversationTurnRunner
+{
+    /// <summary>
+    /// Executes one bot turn for an inbound activity.
+    /// </summary>
+    Task<ConversationTurnResult> RunInboundAsync(ChatActivity activity, CancellationToken ct);
+
+    /// <summary>
+    /// Executes one bot turn for a proactive continue command.
+    /// </summary>
+    Task<ConversationTurnResult> RunContinueAsync(ConversationContinueRequestedEvent command, CancellationToken ct);
+}
+
+/// <summary>
+/// Describes the outcome of one bot turn (either inbound-activity-driven or proactive-command-driven).
+/// </summary>
+public sealed record ConversationTurnResult(
+    bool Success,
+    string SentActivityId,
+    MessageContent Outbound,
+    string AuthPrincipal,
+    string ErrorCode,
+    string ErrorSummary,
+    FailureKind FailureKind,
+    TimeSpan? RetryAfter)
+{
+    /// <summary>
+    /// Success factory.
+    /// </summary>
+    public static ConversationTurnResult Sent(string sentActivityId, MessageContent outbound, string authPrincipal) =>
+        new(true, sentActivityId, outbound, authPrincipal, string.Empty, string.Empty, FailureKind.Unspecified, null);
+
+    /// <summary>
+    /// Transient failure factory.
+    /// </summary>
+    public static ConversationTurnResult TransientFailure(string errorCode, string errorSummary, TimeSpan? retryAfter = null) =>
+        new(false, string.Empty, new MessageContent(), string.Empty, errorCode, errorSummary, FailureKind.TransientAdapterError, retryAfter);
+
+    /// <summary>
+    /// Permanent failure factory.
+    /// </summary>
+    public static ConversationTurnResult PermanentFailure(string errorCode, string errorSummary) =>
+        new(false, string.Empty, new MessageContent(), string.Empty, errorCode, errorSummary, FailureKind.PermanentAdapterError, null);
+}
+
+/// <summary>
+/// No-op default that every turn reports transient failure. Production DI registers a real implementation.
+/// </summary>
+public sealed class NullConversationTurnRunner : IConversationTurnRunner
+{
+    /// <inheritdoc />
+    public Task<ConversationTurnResult> RunInboundAsync(ChatActivity activity, CancellationToken ct) =>
+        Task.FromResult(ConversationTurnResult.TransientFailure("no_runner", "no IConversationTurnRunner registered"));
+
+    /// <inheritdoc />
+    public Task<ConversationTurnResult> RunContinueAsync(ConversationContinueRequestedEvent command, CancellationToken ct) =>
+        Task.FromResult(ConversationTurnResult.TransientFailure("no_runner", "no IConversationTurnRunner registered"));
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/DependencyInjection/ChannelRuntimeServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/DependencyInjection/ChannelRuntimeServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// DI registration entry point for the channel runtime package.
+/// </summary>
+public static class ChannelRuntimeServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the channel runtime middlewares, diagnostics, and default turn-runner fallback.
+    /// Consumers override <see cref="IConversationTurnRunner"/> with a real implementation bound to
+    /// their bot + outbound adapter.
+    /// </summary>
+    public static IServiceCollection AddChannelRuntime(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<ConversationResolverMiddleware>();
+        services.TryAddSingleton<LoggingMiddleware>();
+        services.TryAddSingleton<TracingMiddleware>();
+        services.TryAddSingleton<IConversationTurnRunner, NullConversationTurnRunner>();
+        services.TryAddSingleton(_ => new MiddlewarePipelineBuilder()
+            .Use<TracingMiddleware>()
+            .Use<LoggingMiddleware>()
+            .Use<ConversationResolverMiddleware>());
+
+        return services;
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Diagnostics/ChannelDiagnostics.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Diagnostics/ChannelDiagnostics.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Shared OpenTelemetry / System.Diagnostics primitives for the channel runtime.
+/// Span names follow RFC §6.1 mandatory spans and tags follow the mandatory dimensions contract.
+/// </summary>
+public static class ChannelDiagnostics
+{
+    /// <summary>
+    /// The single <see cref="ActivitySource"/> name subscribed by OTEL pipelines for channel
+    /// runtime spans.
+    /// </summary>
+    public const string ActivitySourceName = "Aevatar.Channel";
+
+    /// <summary>
+    /// The semver-like version string attached to the activity source.
+    /// </summary>
+    public const string ActivitySourceVersion = "1.0.0";
+
+    /// <summary>
+    /// Shared <see cref="ActivitySource"/> instance emitted by all channel-runtime components.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName, ActivitySourceVersion);
+
+    /// <summary>
+    /// Mandatory span names per RFC §6.1. Callers use these so dashboards can rely on stable names.
+    /// </summary>
+    public static class Spans
+    {
+        /// <summary>Ingress: activity received by adapter (prior to durable inbox commit).</summary>
+        public const string IngressVerify = "channel.ingress.verify";
+
+        /// <summary>Ingress: durable-inbox commit completed.</summary>
+        public const string IngressCommit = "channel.ingress.commit";
+
+        /// <summary>Pipeline-wide top-level span that wraps dedup + resolve + bot.turn + egress.</summary>
+        public const string PipelineInvoke = "channel.pipeline.invoke";
+
+        /// <summary>Pipeline: authoritative dedup check inside conversation grain turn.</summary>
+        public const string PipelineDedup = "channel.pipeline.dedup";
+
+        /// <summary>Pipeline: resolve conversation-scoped context + target grain.</summary>
+        public const string PipelineResolve = "channel.pipeline.resolve";
+
+        /// <summary>Bot-turn span: bot logic execution between middleware and egress.</summary>
+        public const string BotTurn = "channel.bot.turn";
+
+        /// <summary>Egress send.</summary>
+        public const string EgressSend = "channel.egress.send";
+
+        /// <summary>Egress update.</summary>
+        public const string EgressUpdate = "channel.egress.update";
+
+        /// <summary>Egress delete.</summary>
+        public const string EgressDelete = "channel.egress.delete";
+
+        /// <summary>Egress commit — durable confirmation that an emit has been recorded.</summary>
+        public const string EgressCommit = "channel.egress.commit";
+    }
+
+    /// <summary>
+    /// Mandatory tag names per RFC §6.1. Callers use these so observability joins consistently.
+    /// </summary>
+    public static class Tags
+    {
+        /// <summary>Normalized inbound activity id.</summary>
+        public const string ActivityId = "activity_id";
+
+        /// <summary>Adapter-provided event id (raw-payload identifier).</summary>
+        public const string ProviderEventId = "provider_event_id";
+
+        /// <summary>ConversationReference canonical key.</summary>
+        public const string CanonicalKey = "canonical_key";
+
+        /// <summary>Bot instance id.</summary>
+        public const string BotInstanceId = "bot_instance_id";
+
+        /// <summary>Sent activity id (set after outbound success).</summary>
+        public const string SentActivityId = "sent_activity_id";
+
+        /// <summary>Retry attempt count.</summary>
+        public const string RetryCount = "retry_count";
+
+        /// <summary>Redacted raw payload blob ref.</summary>
+        public const string RawPayloadBlobRef = "raw_payload_blob_ref";
+
+        /// <summary>Auth principal kind + id summary (e.g. <c>bot</c> or <c>user:u1</c>).</summary>
+        public const string AuthPrincipal = "auth_principal";
+
+        /// <summary>Channel id.</summary>
+        public const string ChannelId = "channel_id";
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
@@ -42,6 +42,7 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
     private readonly TimeSpan _producerTimeout;
     private readonly CancellationTokenSource _cts = new();
     private Task? _worker;
+    private PendingItem? _inFlight;
 
     /// <summary>
     /// Creates one subscriber. Use <see cref="OnNextAsync"/> as the delivery handler passed to
@@ -128,6 +129,8 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
         {
             await foreach (var pending in _buffer.Reader.ReadAllAsync(ct))
             {
+                ArgumentNullException.ThrowIfNull(pending);
+                _inFlight = pending;
                 try
                 {
                     var turnCtx = _contextFactory(pending.Activity);
@@ -136,7 +139,8 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
                 }
                 catch (OperationCanceledException) when (ct.IsCancellationRequested)
                 {
-                    pending.Completion.TrySetCanceled(ct);
+                    pending.Completion.TrySetException(CreateRedeliveryException(
+                        "DurableInboxSubscriber stopped while the activity was in flight; redelivery expected."));
                     throw;
                 }
                 catch (Exception ex)
@@ -144,8 +148,13 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
                     _logger.LogWarning(
                         ex,
                         "Durable inbox worker failed for activity {ActivityId}; propagating redelivery",
-                        pending.Activity?.Id);
+                        pending.Activity.Id);
                     pending.Completion.TrySetException(ex);
+                }
+                finally
+                {
+                    if (ReferenceEquals(_inFlight, pending))
+                        _inFlight = null;
                 }
             }
         }
@@ -161,12 +170,24 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
 
     private void DrainPending()
     {
+        FailInFlight();
+
         // Signal any observers still waiting on enqueued-but-not-processed items so they don't hang.
         while (_buffer.Reader.TryRead(out var pending))
         {
-            pending.Completion.TrySetException(
-                new InvalidOperationException("DurableInboxSubscriber stopped before activity was processed; redelivery expected."));
+            pending.Completion.TrySetException(CreateRedeliveryException(
+                "DurableInboxSubscriber stopped before activity was processed; redelivery expected."));
         }
+    }
+
+    private void FailInFlight()
+    {
+        var inFlight = _inFlight;
+        if (inFlight is null)
+            return;
+
+        inFlight.Completion.TrySetException(CreateRedeliveryException(
+            "DurableInboxSubscriber stopped while the activity was in flight; redelivery expected."));
     }
 
     /// <inheritdoc />
@@ -174,7 +195,12 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
     {
         _cts.Cancel();
         _buffer.Writer.TryComplete();
-        if (_worker is not null)
+        DrainPending();
+
+        // Do not block forever on an uncooperative pipeline that ignores cancellation; observers
+        // have already been signalled for redelivery above. If the worker exits promptly, observe
+        // its final status. Otherwise log and let the host tear the process down normally.
+        if (_worker is not null && _worker.IsCompleted)
         {
             try
             {
@@ -188,9 +214,15 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
                 _logger.LogInformation(ex, "DurableInboxSubscriber worker terminated with exception during dispose");
             }
         }
-        DrainPending();
+        else if (_worker is not null)
+        {
+            _logger.LogInformation(
+                "DurableInboxSubscriber dispose returned before worker exit; in-flight middleware ignored cancellation.");
+        }
         _cts.Dispose();
     }
+
+    private static InvalidOperationException CreateRedeliveryException(string message) => new(message);
 
     private sealed class PendingItem
     {

--- a/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
@@ -1,0 +1,160 @@
+using System.Threading.Channels;
+using Aevatar.GAgents.Channel.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Bridges a durable-inbox <see cref="ChatActivity"/> feed into the channel pipeline with the
+/// return→commit / throw→redeliver observer semantics described by RFC §5.8 / §9.5.2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The subscriber owns one bounded <see cref="System.Threading.Channels.Channel{T}"/> working
+/// buffer (default capacity <see cref="DefaultBufferCapacity"/>, <see cref="BoundedChannelFullMode.Wait"/>,
+/// producer timeout <see cref="DefaultProducerTimeout"/>). If a producer can't enqueue within the
+/// timeout, it throws so the stream observer propagates the exception and the persistent provider
+/// re-delivers.
+/// </para>
+/// <para>
+/// Delivery handler <see cref="OnNextAsync"/> completes <em>before</em> it returns, so a successful
+/// return signals "pipeline fully awaited → safe to commit the stream offset". If the pipeline
+/// throws, the exception propagates and triggers redelivery per Orleans persistent-stream semantics.
+/// </para>
+/// </remarks>
+public sealed class DurableInboxSubscriber : IAsyncDisposable
+{
+    /// <summary>Default working buffer capacity per RFC §5.8.</summary>
+    public const int DefaultBufferCapacity = 1000;
+
+    /// <summary>Default producer timeout per RFC §5.8 (500 ms).</summary>
+    public static readonly TimeSpan DefaultProducerTimeout = TimeSpan.FromMilliseconds(500);
+
+    private readonly ChannelPipeline _pipeline;
+    private readonly IServiceProvider _services;
+    private readonly Func<ChatActivity, ITurnContext> _contextFactory;
+    private readonly ILogger<DurableInboxSubscriber> _logger;
+    private readonly System.Threading.Channels.Channel<ChatActivity> _buffer;
+    private readonly TimeSpan _producerTimeout;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _worker;
+
+    /// <summary>
+    /// Creates one subscriber. Use <see cref="OnNextAsync"/> as the delivery handler passed to
+    /// <see cref="Aevatar.Foundation.Abstractions.IStream.SubscribeAsync{T}"/>.
+    /// </summary>
+    public DurableInboxSubscriber(
+        ChannelPipeline pipeline,
+        IServiceProvider services,
+        Func<ChatActivity, ITurnContext> contextFactory,
+        ILogger<DurableInboxSubscriber> logger,
+        int bufferCapacity = DefaultBufferCapacity,
+        TimeSpan? producerTimeout = null)
+    {
+        _pipeline = pipeline;
+        _services = services;
+        _contextFactory = contextFactory;
+        _logger = logger;
+        _producerTimeout = producerTimeout ?? DefaultProducerTimeout;
+        _buffer = System.Threading.Channels.Channel.CreateBounded<ChatActivity>(new BoundedChannelOptions(bufferCapacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    /// <summary>
+    /// Starts the worker loop that drains the bounded buffer into the pipeline.
+    /// </summary>
+    public void Start()
+    {
+        if (_worker is not null)
+            return;
+
+        _worker = Task.Run(() => WorkerLoopAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Delivery handler. Returns successfully when the activity has reached the pipeline without
+    /// throwing; throws when the buffer is full past the configured timeout or the pipeline faults.
+    /// </summary>
+    public async Task OnNextAsync(ChatActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+        timeoutCts.CancelAfter(_producerTimeout);
+
+        try
+        {
+            await _buffer.Writer.WriteAsync(activity, timeoutCts.Token);
+        }
+        catch (OperationCanceledException ex) when (!_cts.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"DurableInboxSubscriber buffer full for {_producerTimeout.TotalMilliseconds}ms; triggering redelivery.",
+                ex);
+        }
+    }
+
+    /// <summary>
+    /// Synchronous delivery handler that forwards directly to the pipeline without buffering.
+    /// Useful for tests and for adapters that guarantee back-pressure upstream.
+    /// </summary>
+    public Task OnNextInlineAsync(ChatActivity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        var turnCtx = _contextFactory(activity);
+        return _pipeline.InvokeAsync(turnCtx, () => Task.CompletedTask, _cts.Token);
+    }
+
+    private async Task WorkerLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var activity in _buffer.Reader.ReadAllAsync(ct))
+            {
+                try
+                {
+                    var turnCtx = _contextFactory(activity);
+                    await _pipeline.InvokeAsync(turnCtx, () => Task.CompletedTask, ct);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Durable inbox worker failed for activity {ActivityId}; caller is expected to redeliver",
+                        activity?.Id);
+                    throw;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        _buffer.Writer.TryComplete();
+        if (_worker is not null)
+        {
+            try
+            {
+                await _worker;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                _logger.LogInformation(ex, "DurableInboxSubscriber worker terminated with exception during dispose");
+            }
+        }
+        _cts.Dispose();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
@@ -70,20 +70,18 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
     }
 
     /// <summary>
-    /// Starts the worker loop that drains the bounded buffer into the pipeline.
+    /// Starts the worker loop that drains the bounded buffer into the pipeline. Idempotent and
+    /// safe to call concurrently; the worker is singleton-captured via <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/>.
+    /// <see cref="OnNextAsync"/> auto-starts if the caller forgot.
     /// </summary>
-    public void Start()
-    {
-        if (_worker is not null)
-            return;
-
-        _worker = Task.Run(() => WorkerLoopAsync(_cts.Token));
-    }
+    public void Start() => EnsureWorkerStarted();
 
     /// <summary>
     /// Delivery handler. Only returns after the pipeline has fully processed the activity, so a
     /// successful return signals "safe to commit" and a throw signals "redeliver". Bounded-buffer
     /// saturation at enqueue time throws <see cref="TimeoutException"/> for the same redelivery path.
+    /// Auto-starts the worker loop on first delivery so the handler can be wired directly to a
+    /// stream subscription without a separate <see cref="Start"/> call.
     /// </summary>
     public async Task OnNextAsync(ChatActivity activity)
     {
@@ -92,6 +90,7 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
         if (_cts.IsCancellationRequested)
             throw new InvalidOperationException("DurableInboxSubscriber is disposed.");
 
+        EnsureWorkerStarted();
         var pending = new PendingItem(activity);
         using (var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token))
         {
@@ -121,6 +120,21 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(activity);
         var turnCtx = _contextFactory(activity);
         return _pipeline.InvokeAsync(turnCtx, () => Task.CompletedTask, _cts.Token);
+    }
+
+    private void EnsureWorkerStarted()
+    {
+        if (Volatile.Read(ref _worker) is not null)
+            return;
+
+        // Build the task lazily and only publish it if we win the race; concurrent callers see
+        // a single worker without risk of accidentally starting two loops against one bounded channel.
+        var candidate = new Task<Task>(() => WorkerLoopAsync(_cts.Token));
+        var observed = Interlocked.CompareExchange(ref _worker, candidate.Unwrap(), null);
+        if (observed is null)
+        {
+            candidate.Start();
+        }
     }
 
     private async Task WorkerLoopAsync(CancellationToken ct)

--- a/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Inbox/DurableInboxSubscriber.cs
@@ -12,14 +12,18 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// <para>
 /// The subscriber owns one bounded <see cref="System.Threading.Channels.Channel{T}"/> working
 /// buffer (default capacity <see cref="DefaultBufferCapacity"/>, <see cref="BoundedChannelFullMode.Wait"/>,
-/// producer timeout <see cref="DefaultProducerTimeout"/>). If a producer can't enqueue within the
+/// producer timeout <see cref="DefaultProducerTimeout"/>). If a producer cannot enqueue within the
 /// timeout, it throws so the stream observer propagates the exception and the persistent provider
 /// re-delivers.
 /// </para>
 /// <para>
-/// Delivery handler <see cref="OnNextAsync"/> completes <em>before</em> it returns, so a successful
-/// return signals "pipeline fully awaited → safe to commit the stream offset". If the pipeline
-/// throws, the exception propagates and triggers redelivery per Orleans persistent-stream semantics.
+/// Each enqueued activity carries its own <see cref="TaskCompletionSource"/>; the worker loop awaits
+/// <see cref="ChannelPipeline.InvokeAsync"/> and then signals the completion source with either the
+/// success or the pipeline exception. <see cref="OnNextAsync"/> only returns after that completion
+/// source signals, so a successful return guarantees the pipeline really finished and the stream
+/// provider may commit. A pipeline fault propagates back through the completion source so the
+/// observer throws and the provider re-delivers. This preserves the <c>return → commit,
+/// throw → redeliver</c> contract even under a buffered worker.
 /// </para>
 /// </remarks>
 public sealed class DurableInboxSubscriber : IAsyncDisposable
@@ -34,7 +38,7 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
     private readonly IServiceProvider _services;
     private readonly Func<ChatActivity, ITurnContext> _contextFactory;
     private readonly ILogger<DurableInboxSubscriber> _logger;
-    private readonly System.Threading.Channels.Channel<ChatActivity> _buffer;
+    private readonly System.Threading.Channels.Channel<PendingItem> _buffer;
     private readonly TimeSpan _producerTimeout;
     private readonly CancellationTokenSource _cts = new();
     private Task? _worker;
@@ -56,7 +60,7 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
         _contextFactory = contextFactory;
         _logger = logger;
         _producerTimeout = producerTimeout ?? DefaultProducerTimeout;
-        _buffer = System.Threading.Channels.Channel.CreateBounded<ChatActivity>(new BoundedChannelOptions(bufferCapacity)
+        _buffer = System.Threading.Channels.Channel.CreateBounded<PendingItem>(new BoundedChannelOptions(bufferCapacity)
         {
             FullMode = BoundedChannelFullMode.Wait,
             SingleReader = true,
@@ -76,26 +80,35 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
     }
 
     /// <summary>
-    /// Delivery handler. Returns successfully when the activity has reached the pipeline without
-    /// throwing; throws when the buffer is full past the configured timeout or the pipeline faults.
+    /// Delivery handler. Only returns after the pipeline has fully processed the activity, so a
+    /// successful return signals "safe to commit" and a throw signals "redeliver". Bounded-buffer
+    /// saturation at enqueue time throws <see cref="TimeoutException"/> for the same redelivery path.
     /// </summary>
     public async Task OnNextAsync(ChatActivity activity)
     {
         ArgumentNullException.ThrowIfNull(activity);
 
-        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
-        timeoutCts.CancelAfter(_producerTimeout);
+        if (_cts.IsCancellationRequested)
+            throw new InvalidOperationException("DurableInboxSubscriber is disposed.");
 
-        try
+        var pending = new PendingItem(activity);
+        using (var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token))
         {
-            await _buffer.Writer.WriteAsync(activity, timeoutCts.Token);
+            timeoutCts.CancelAfter(_producerTimeout);
+            try
+            {
+                await _buffer.Writer.WriteAsync(pending, timeoutCts.Token);
+            }
+            catch (OperationCanceledException ex) when (!_cts.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"DurableInboxSubscriber buffer full for {_producerTimeout.TotalMilliseconds}ms; triggering redelivery.",
+                    ex);
+            }
         }
-        catch (OperationCanceledException ex) when (!_cts.IsCancellationRequested)
-        {
-            throw new TimeoutException(
-                $"DurableInboxSubscriber buffer full for {_producerTimeout.TotalMilliseconds}ms; triggering redelivery.",
-                ex);
-        }
+
+        // Block until the worker has actually finished (successful → commit; throw → redeliver).
+        await pending.Completion.Task.ConfigureAwait(false);
     }
 
     /// <summary>
@@ -113,26 +126,46 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
     {
         try
         {
-            await foreach (var activity in _buffer.Reader.ReadAllAsync(ct))
+            await foreach (var pending in _buffer.Reader.ReadAllAsync(ct))
             {
                 try
                 {
-                    var turnCtx = _contextFactory(activity);
+                    var turnCtx = _contextFactory(pending.Activity);
                     await _pipeline.InvokeAsync(turnCtx, () => Task.CompletedTask, ct);
+                    pending.Completion.TrySetResult();
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    pending.Completion.TrySetCanceled(ct);
+                    throw;
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(
                         ex,
-                        "Durable inbox worker failed for activity {ActivityId}; caller is expected to redeliver",
-                        activity?.Id);
-                    throw;
+                        "Durable inbox worker failed for activity {ActivityId}; propagating redelivery",
+                        pending.Activity?.Id);
+                    pending.Completion.TrySetException(ex);
                 }
             }
         }
         catch (OperationCanceledException)
         {
-            // Normal shutdown.
+            // Normal shutdown — any still-waiting OnNextAsync callers get cancelled via DrainPending.
+        }
+        finally
+        {
+            DrainPending();
+        }
+    }
+
+    private void DrainPending()
+    {
+        // Signal any observers still waiting on enqueued-but-not-processed items so they don't hang.
+        while (_buffer.Reader.TryRead(out var pending))
+        {
+            pending.Completion.TrySetException(
+                new InvalidOperationException("DurableInboxSubscriber stopped before activity was processed; redelivery expected."));
         }
     }
 
@@ -155,6 +188,20 @@ public sealed class DurableInboxSubscriber : IAsyncDisposable
                 _logger.LogInformation(ex, "DurableInboxSubscriber worker terminated with exception during dispose");
             }
         }
+        DrainPending();
         _cts.Dispose();
+    }
+
+    private sealed class PendingItem
+    {
+        public PendingItem(ChatActivity activity)
+        {
+            Activity = activity;
+            Completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public ChatActivity Activity { get; }
+
+        public TaskCompletionSource Completion { get; }
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Middleware/ChannelPipeline.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Middleware/ChannelPipeline.cs
@@ -1,0 +1,45 @@
+using Aevatar.GAgents.Channel.Abstractions;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Composed channel pipeline. Runs registered <see cref="IChannelMiddleware"/> instances in
+/// registration order, then calls <paramref name="terminal" /> as the innermost delegate.
+/// </summary>
+/// <remarks>
+/// Middleware can short-circuit by not invoking the <c>next</c> delegate, or wrap it with span /
+/// try-catch / timing logic. Exceptions propagate to the caller so the durable inbox observer can
+/// translate them into redelivery.
+/// </remarks>
+public sealed class ChannelPipeline
+{
+    private readonly IReadOnlyList<IChannelMiddleware> _middlewares;
+
+    internal ChannelPipeline(IReadOnlyList<IChannelMiddleware> middlewares)
+    {
+        _middlewares = middlewares;
+    }
+
+    /// <summary>
+    /// Gets the middlewares in registration order. Exposed for diagnostics / tests.
+    /// </summary>
+    public IReadOnlyList<IChannelMiddleware> Middlewares => _middlewares;
+
+    /// <summary>
+    /// Invokes the pipeline end-to-end.
+    /// </summary>
+    public Task InvokeAsync(ITurnContext context, Func<Task> terminal, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(terminal);
+
+        Func<Task> next = terminal;
+        for (var i = _middlewares.Count - 1; i >= 0; i--)
+        {
+            var middleware = _middlewares[i];
+            var capturedNext = next;
+            next = () => middleware.InvokeAsync(context, capturedNext, ct);
+        }
+        return next();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Middleware/ConversationResolverMiddleware.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Middleware/ConversationResolverMiddleware.cs
@@ -1,0 +1,40 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Resolves the conversation grain key from <see cref="ChatActivity.Conversation"/> and validates
+/// that the canonical key is non-empty before the turn reaches the bot. Per RFC §5.7 this keeps
+/// ConversationReference routing decisions in middleware rather than the bot implementation.
+/// </summary>
+public sealed class ConversationResolverMiddleware : IChannelMiddleware
+{
+    private readonly ILogger<ConversationResolverMiddleware> _logger;
+
+    /// <summary>
+    /// Creates one resolver middleware.
+    /// </summary>
+    public ConversationResolverMiddleware(ILogger<ConversationResolverMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var conversation = context.Activity?.Conversation;
+        if (conversation is null || string.IsNullOrWhiteSpace(conversation.CanonicalKey))
+        {
+            _logger.LogWarning(
+                "Dropping activity {ActivityId}: missing or empty conversation canonical key",
+                context.Activity?.Id);
+            return Task.CompletedTask;
+        }
+
+        return next();
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Middleware/LoggingMiddleware.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Middleware/LoggingMiddleware.cs
@@ -1,0 +1,56 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Structured inbound-audit middleware. Logs activity id + conversation key + bot at
+/// <see cref="LogLevel.Information"/> so dashboards can correlate with tracing spans.
+/// </summary>
+public sealed class LoggingMiddleware : IChannelMiddleware
+{
+    private readonly ILogger<LoggingMiddleware> _logger;
+
+    /// <summary>
+    /// Creates one logging middleware.
+    /// </summary>
+    public LoggingMiddleware(ILogger<LoggingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var activity = context.Activity;
+        _logger.LogInformation(
+            "Channel inbound: activity={ActivityId} conversation={Key} bot={Bot} type={Type}",
+            activity?.Id,
+            activity?.Conversation?.CanonicalKey,
+            activity?.Bot?.Value,
+            activity?.Type);
+
+        try
+        {
+            await next();
+        }
+        catch (Exception ex) when (LogAndRethrow(ex, activity))
+        {
+            // Unreachable — LogAndRethrow always returns false so the throw propagates.
+            throw;
+        }
+    }
+
+    private bool LogAndRethrow(Exception ex, ChatActivity? activity)
+    {
+        _logger.LogWarning(
+            ex,
+            "Channel inbound pipeline threw for activity={ActivityId} conversation={Key}",
+            activity?.Id,
+            activity?.Conversation?.CanonicalKey);
+        return false;
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Middleware/MiddlewarePipelineBuilder.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Middleware/MiddlewarePipelineBuilder.cs
@@ -1,0 +1,59 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Fluent builder that composes one <see cref="ChannelPipeline"/> from ordered
+/// <see cref="IChannelMiddleware"/> registrations.
+/// </summary>
+/// <remarks>
+/// The builder does not own middleware lifecycle; singleton + scoped lookup is delegated to the
+/// <see cref="IServiceProvider"/> captured at <see cref="Build"/> time. Registration order is
+/// preserved and matches the invocation order inside <see cref="ChannelPipeline.InvokeAsync"/>.
+/// </remarks>
+public sealed class MiddlewarePipelineBuilder
+{
+    private readonly List<Func<IServiceProvider, IChannelMiddleware>> _factories = [];
+
+    /// <summary>
+    /// Adds a middleware type resolved via DI at build time.
+    /// </summary>
+    public MiddlewarePipelineBuilder Use<TMiddleware>() where TMiddleware : IChannelMiddleware
+    {
+        _factories.Add(sp => ActivatorUtilities.GetServiceOrCreateInstance<TMiddleware>(sp));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a pre-constructed middleware instance.
+    /// </summary>
+    public MiddlewarePipelineBuilder Use(IChannelMiddleware middleware)
+    {
+        ArgumentNullException.ThrowIfNull(middleware);
+        _factories.Add(_ => middleware);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a factory-backed middleware registration.
+    /// </summary>
+    public MiddlewarePipelineBuilder Use(Func<IServiceProvider, IChannelMiddleware> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factories.Add(factory);
+        return this;
+    }
+
+    /// <summary>
+    /// Resolves and freezes the middleware list into a pipeline.
+    /// </summary>
+    public ChannelPipeline Build(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        var middlewares = new IChannelMiddleware[_factories.Count];
+        for (var i = 0; i < _factories.Count; i++)
+            middlewares[i] = _factories[i](services);
+        return new ChannelPipeline(middlewares);
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Middleware/TracingMiddleware.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Middleware/TracingMiddleware.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using Aevatar.GAgents.Channel.Abstractions;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Opens one <see cref="Activity"/> around the pipeline invocation and tags it with the mandatory
+/// observability dimensions from RFC §6.1. Downstream middlewares and grain spans run inside this
+/// span so OTEL pipelines can aggregate on a single trace.
+/// </summary>
+public sealed class TracingMiddleware : IChannelMiddleware
+{
+    /// <summary>Default retry-count tag value when inbound hasn't been redelivered.</summary>
+    public const int DefaultRetryCount = 0;
+
+    /// <inheritdoc />
+    public async Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        var activity = context.Activity;
+        using var span = ChannelDiagnostics.ActivitySource.StartActivity(
+            ChannelDiagnostics.Spans.PipelineInvoke,
+            ActivityKind.Server);
+
+        if (span is not null)
+        {
+            span.SetTag(ChannelDiagnostics.Tags.ActivityId, activity?.Id);
+            span.SetTag(ChannelDiagnostics.Tags.ProviderEventId, activity?.RawPayloadBlobRef);
+            span.SetTag(ChannelDiagnostics.Tags.CanonicalKey, activity?.Conversation?.CanonicalKey);
+            span.SetTag(ChannelDiagnostics.Tags.BotInstanceId, activity?.Bot?.Value ?? context.Bot?.Bot?.Value);
+            span.SetTag(ChannelDiagnostics.Tags.ChannelId, activity?.ChannelId?.Value ?? context.Bot?.Channel?.Value);
+            span.SetTag(ChannelDiagnostics.Tags.RetryCount, DefaultRetryCount);
+            span.SetTag(ChannelDiagnostics.Tags.RawPayloadBlobRef, activity?.RawPayloadBlobRef);
+            span.SetTag(ChannelDiagnostics.Tags.AuthPrincipal, ResolveAuthPrincipal(context));
+        }
+
+        try
+        {
+            await next();
+            span?.SetStatus(ActivityStatusCode.Ok);
+        }
+        catch (Exception ex)
+        {
+            span?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            span?.SetTag("error.type", ex.GetType().FullName);
+            throw;
+        }
+    }
+
+    private static string ResolveAuthPrincipal(ITurnContext context)
+    {
+        var bot = context.Bot;
+        if (bot is null)
+            return "bot";
+        return string.IsNullOrWhiteSpace(bot.RegistrationId) ? "bot" : $"bot:{bot.RegistrationId}";
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/ShardLeader/IShardLeaderGrain.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ShardLeader/IShardLeaderGrain.cs
@@ -1,0 +1,38 @@
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Per-shard single-activation grain contract used by gateway-based transports (Discord, WeChat
+/// wechaty, etc.) to serialize gateway session ownership via a fencing lease.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface is part of issue #258 deliverables but the Discord gateway + lease implementation
+/// is explicitly deferred to a later RFC sub-issue. Adapters that do not need gateway fencing
+/// (Lark webhook, Telegram webhook) are not required to depend on this contract.
+/// </para>
+/// <para>
+/// Fencing semantics: one shard-id maps to at most one live activation. Lease holders must renew
+/// before TTL expiry, otherwise the activation releases and another caller may acquire. The
+/// <see cref="LeaseToken"/> includes an <c>epoch</c> monotonic counter so late writes from a lost
+/// lease can be rejected by downstream stores.
+/// </para>
+/// </remarks>
+public interface IShardLeaderGrain
+{
+    /// <summary>
+    /// Acquires the lease for <paramref name="shardId"/>. Throws when another owner holds an
+    /// unexpired lease. Returns a fresh <see cref="LeaseToken"/> with a bumped epoch.
+    /// </summary>
+    Task<LeaseToken> AcquireLeaseAsync(string shardId, TimeSpan ttl, CancellationToken ct);
+
+    /// <summary>
+    /// Renews the existing lease. Returns <see langword="false"/> when the token's epoch no longer
+    /// matches the current activation's view, so the caller must stop writing under that lease.
+    /// </summary>
+    Task<bool> RenewLeaseAsync(LeaseToken token, TimeSpan ttl, CancellationToken ct);
+
+    /// <summary>
+    /// Releases the lease if the caller still owns the current epoch.
+    /// </summary>
+    Task ReleaseLeaseAsync(LeaseToken token, CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/UserBinding/ChannelUserBindingGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/UserBinding/ChannelUserBindingGAgent.cs
@@ -1,0 +1,126 @@
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgents.Channel.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Per-user-per-bot-instance actor keyed by <c>{bot_instance_id}:{channel}:{sender_canonical_id}</c>.
+/// Holds user-scoped credential binding and preferences so <see cref="ConversationGAgent"/> state
+/// stays conversation-scoped. Split out from the legacy <c>ChannelUserGAgent</c> per RFC §5.2b.
+/// </summary>
+public sealed class ChannelUserBindingGAgent : GAgentBase<ChannelUserBindingState>
+{
+    /// <inheritdoc />
+    protected override ChannelUserBindingState TransitionState(ChannelUserBindingState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<UserCredentialBoundEvent>(ApplyBound)
+            .On<UserCredentialUnboundEvent>(ApplyUnbound)
+            .On<UserPreferencesUpdatedEvent>(ApplyPreferencesUpdated)
+            .OrCurrent();
+
+    /// <summary>
+    /// Binds one user credential reference.
+    /// </summary>
+    [EventHandler]
+    public async Task HandleBindCredentialAsync(BindUserCredentialCommand cmd)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        if (string.IsNullOrWhiteSpace(cmd.CredentialRef))
+        {
+            Logger.LogWarning("Bind rejected: empty credential_ref for sender={Sender}", cmd.SenderCanonicalId);
+            return;
+        }
+
+        var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        await PersistDomainEventAsync(new UserCredentialBoundEvent
+        {
+            Bot = cmd.Bot?.Clone() ?? new BotInstanceId(),
+            Channel = cmd.Channel?.Clone() ?? new ChannelId(),
+            SenderCanonicalId = cmd.SenderCanonicalId,
+            CredentialRef = cmd.CredentialRef,
+            BoundAt = now,
+        });
+    }
+
+    /// <summary>
+    /// Unbinds the stored user credential reference.
+    /// </summary>
+    [EventHandler]
+    public async Task HandleUnbindCredentialAsync(UnbindUserCredentialCommand cmd)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+        if (string.IsNullOrWhiteSpace(State.CredentialRef))
+        {
+            Logger.LogInformation("Unbind skipped: no credential bound for sender={Sender}", cmd.SenderCanonicalId);
+            return;
+        }
+
+        var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        await PersistDomainEventAsync(new UserCredentialUnboundEvent
+        {
+            Bot = cmd.Bot?.Clone() ?? new BotInstanceId(),
+            Channel = cmd.Channel?.Clone() ?? new ChannelId(),
+            SenderCanonicalId = cmd.SenderCanonicalId,
+            UnboundAt = now,
+        });
+    }
+
+    /// <summary>
+    /// Persists one preferences delta (opaque JSON blob owned by the caller).
+    /// </summary>
+    [EventHandler]
+    public async Task HandleUpdatePreferencesAsync(UpdateUserPreferencesCommand cmd)
+    {
+        ArgumentNullException.ThrowIfNull(cmd);
+
+        var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        await PersistDomainEventAsync(new UserPreferencesUpdatedEvent
+        {
+            Bot = cmd.Bot?.Clone() ?? new BotInstanceId(),
+            Channel = cmd.Channel?.Clone() ?? new ChannelId(),
+            SenderCanonicalId = cmd.SenderCanonicalId,
+            PreferencesJson = cmd.PreferencesJson ?? string.Empty,
+            UpdatedAt = now,
+        });
+    }
+
+    // ─── State transitions ───
+
+    private static ChannelUserBindingState ApplyBound(ChannelUserBindingState current, UserCredentialBoundEvent evt)
+    {
+        var next = current.Clone();
+        next.Bot = evt.Bot?.Clone();
+        next.Channel = evt.Channel?.Clone();
+        next.SenderCanonicalId = evt.SenderCanonicalId;
+        next.CredentialRef = evt.CredentialRef;
+        next.CreatedAt ??= evt.BoundAt;
+        next.UpdatedAt = evt.BoundAt;
+        return next;
+    }
+
+    private static ChannelUserBindingState ApplyUnbound(ChannelUserBindingState current, UserCredentialUnboundEvent evt)
+    {
+        var next = current.Clone();
+        next.CredentialRef = string.Empty;
+        next.UpdatedAt = evt.UnboundAt;
+        return next;
+    }
+
+    private static ChannelUserBindingState ApplyPreferencesUpdated(ChannelUserBindingState current, UserPreferencesUpdatedEvent evt)
+    {
+        var next = current.Clone();
+        next.Bot = evt.Bot?.Clone();
+        next.Channel = evt.Channel?.Clone();
+        next.SenderCanonicalId = evt.SenderCanonicalId;
+        next.PreferencesJson = evt.PreferencesJson ?? string.Empty;
+        next.CreatedAt ??= evt.UpdatedAt;
+        next.UpdatedAt = evt.UpdatedAt;
+        return next;
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/UserBinding/ChannelUserBindingGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/UserBinding/ChannelUserBindingGAgent.cs
@@ -72,7 +72,8 @@ public sealed class ChannelUserBindingGAgent : GAgentBase<ChannelUserBindingStat
     }
 
     /// <summary>
-    /// Persists one preferences delta (opaque JSON blob owned by the caller).
+    /// Persists a typed preferences snapshot. Callers supply a full <see cref="ChannelUserPreferences"/>
+    /// message; the grain replaces the stored snapshot atomically.
     /// </summary>
     [EventHandler]
     public async Task HandleUpdatePreferencesAsync(UpdateUserPreferencesCommand cmd)
@@ -85,7 +86,7 @@ public sealed class ChannelUserBindingGAgent : GAgentBase<ChannelUserBindingStat
             Bot = cmd.Bot?.Clone() ?? new BotInstanceId(),
             Channel = cmd.Channel?.Clone() ?? new ChannelId(),
             SenderCanonicalId = cmd.SenderCanonicalId,
-            PreferencesJson = cmd.PreferencesJson ?? string.Empty,
+            Preferences = cmd.Preferences?.Clone() ?? new ChannelUserPreferences(),
             UpdatedAt = now,
         });
     }
@@ -118,7 +119,7 @@ public sealed class ChannelUserBindingGAgent : GAgentBase<ChannelUserBindingStat
         next.Bot = evt.Bot?.Clone();
         next.Channel = evt.Channel?.Clone();
         next.SenderCanonicalId = evt.SenderCanonicalId;
-        next.PreferencesJson = evt.PreferencesJson ?? string.Empty;
+        next.Preferences = evt.Preferences?.Clone() ?? new ChannelUserPreferences();
         next.CreatedAt ??= evt.UpdatedAt;
         next.UpdatedAt = evt.UpdatedAt;
         return next;

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_user_binding.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_user_binding.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+package aevatar.gagents.channel.runtime;
+
+option csharp_namespace = "Aevatar.GAgents.Channel.Runtime";
+
+import "google/protobuf/timestamp.proto";
+import "chat_activity.proto";
+
+message ChannelUserBindingState {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+  string credential_ref = 4;
+  string preferences_json = 5;
+  google.protobuf.Timestamp created_at = 6;
+  google.protobuf.Timestamp updated_at = 7;
+}
+
+message BindUserCredentialCommand {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+  string credential_ref = 4;
+}
+
+message UnbindUserCredentialCommand {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+}
+
+message UpdateUserPreferencesCommand {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+  string preferences_json = 4;
+}
+
+message UserCredentialBoundEvent {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+  string credential_ref = 4;
+  google.protobuf.Timestamp bound_at = 5;
+}
+
+message UserCredentialUnboundEvent {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+  google.protobuf.Timestamp unbound_at = 4;
+}
+
+message UserPreferencesUpdatedEvent {
+  aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
+  aevatar.gagents.channel.abstractions.ChannelId channel = 2;
+  string sender_canonical_id = 3;
+  string preferences_json = 4;
+  google.protobuf.Timestamp updated_at = 5;
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_user_binding.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_user_binding.proto
@@ -7,12 +7,27 @@ option csharp_namespace = "Aevatar.GAgents.Channel.Runtime";
 import "google/protobuf/timestamp.proto";
 import "chat_activity.proto";
 
+// Typed preference surface stored on the per-user-per-bot binding actor. New preferences land as
+// new fields here — do not introduce a generic string/JSON bag; runtime state must stay proto-typed
+// (CLAUDE.md Metadata decision tree).
+message ChannelUserPreferences {
+  // BCP-47 locale tag (e.g. "en-US", "zh-CN"). Empty means "inherit channel default".
+  string locale = 1;
+  // IANA timezone (e.g. "America/Los_Angeles"). Empty means "inherit channel default".
+  string timezone = 2;
+  // Suppresses per-user notifications where the target channel supports muting.
+  bool mute_notifications = 3;
+  // Optional topic tags the user has opted out of (channel-specific semantics; MVP keeps this a
+  // narrow typed list rather than a free-form bag).
+  repeated string muted_topics = 4;
+}
+
 message ChannelUserBindingState {
   aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
   aevatar.gagents.channel.abstractions.ChannelId channel = 2;
   string sender_canonical_id = 3;
   string credential_ref = 4;
-  string preferences_json = 5;
+  ChannelUserPreferences preferences = 5;
   google.protobuf.Timestamp created_at = 6;
   google.protobuf.Timestamp updated_at = 7;
 }
@@ -34,7 +49,7 @@ message UpdateUserPreferencesCommand {
   aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
   aevatar.gagents.channel.abstractions.ChannelId channel = 2;
   string sender_canonical_id = 3;
-  string preferences_json = 4;
+  ChannelUserPreferences preferences = 4;
 }
 
 message UserCredentialBoundEvent {
@@ -56,6 +71,6 @@ message UserPreferencesUpdatedEvent {
   aevatar.gagents.channel.abstractions.BotInstanceId bot = 1;
   aevatar.gagents.channel.abstractions.ChannelId channel = 2;
   string sender_canonical_id = 3;
-  string preferences_json = 4;
+  ChannelUserPreferences preferences = 4;
   google.protobuf.Timestamp updated_at = 5;
 }

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package aevatar.gagents.channel.runtime;
+
+option csharp_namespace = "Aevatar.GAgents.Channel.Runtime";
+
+import "chat_activity.proto";
+
+message ConversationGAgentState {
+  aevatar.gagents.channel.abstractions.ConversationReference conversation = 1;
+  repeated string processed_message_ids = 2;
+  repeated string processed_command_ids = 3;
+  repeated PendingSession pending_sessions = 4;
+  int64 last_updated_unix_ms = 5;
+}
+
+message PendingSession {
+  string session_id = 1;
+  string correlation_id = 2;
+  int64 started_at_unix_ms = 3;
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj
@@ -26,6 +26,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Abstractions\Aevatar.GAgents.Channel.Abstractions.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Runtime\Aevatar.GAgents.Channel.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Runtime\Aevatar.Foundation.Runtime.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Protobuf Include="test_projector_contracts.proto" GrpcServices="None" />

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelTracingSmokeTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelTracingSmokeTests.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class ChannelTracingSmokeTests
+{
+    [Fact]
+    public async Task TracingMiddleware_EmitsPipelineInvokeSpanWithMandatoryDimensions()
+    {
+        var spans = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ChannelDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = spans.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var pipeline = new MiddlewarePipelineBuilder()
+            .Use(new TracingMiddleware())
+            .Build(new ServiceCollection().BuildServiceProvider());
+
+        await pipeline.InvokeAsync(
+            new MiddlewarePipelineTests.StubTurnContext(),
+            () => Task.CompletedTask,
+            CancellationToken.None);
+
+        spans.ShouldHaveSingleItem();
+        var span = spans[0];
+        span.OperationName.ShouldBe(ChannelDiagnostics.Spans.PipelineInvoke);
+        span.Status.ShouldBe(ActivityStatusCode.Ok);
+
+        var tags = span.TagObjects.ToDictionary(pair => pair.Key, pair => pair.Value);
+        tags.ShouldContainKey(ChannelDiagnostics.Tags.ActivityId);
+        tags[ChannelDiagnostics.Tags.ActivityId].ShouldBe("act-1");
+        tags.ShouldContainKey(ChannelDiagnostics.Tags.CanonicalKey);
+        tags[ChannelDiagnostics.Tags.CanonicalKey].ShouldBe("slack:team:channel");
+        tags.ShouldContainKey(ChannelDiagnostics.Tags.BotInstanceId);
+        tags[ChannelDiagnostics.Tags.BotInstanceId].ShouldBe("ops-bot");
+        tags.ShouldContainKey(ChannelDiagnostics.Tags.ChannelId);
+        tags[ChannelDiagnostics.Tags.ChannelId].ShouldBe("slack");
+        tags.ShouldContainKey(ChannelDiagnostics.Tags.RetryCount);
+        tags[ChannelDiagnostics.Tags.RetryCount].ShouldBe(TracingMiddleware.DefaultRetryCount);
+        tags.ShouldContainKey(ChannelDiagnostics.Tags.AuthPrincipal);
+        tags[ChannelDiagnostics.Tags.AuthPrincipal].ShouldBe("bot:reg-1");
+    }
+
+    [Fact]
+    public async Task TracingMiddleware_WhenDownstreamThrows_MarksSpanErrorAndRethrows()
+    {
+        var spans = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ChannelDiagnostics.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = spans.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var pipeline = new MiddlewarePipelineBuilder()
+            .Use(new TracingMiddleware())
+            .Use(new ThrowingMiddleware())
+            .Build(new ServiceCollection().BuildServiceProvider());
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => pipeline.InvokeAsync(
+                new MiddlewarePipelineTests.StubTurnContext(),
+                () => Task.CompletedTask,
+                CancellationToken.None));
+
+        spans.ShouldHaveSingleItem();
+        spans[0].Status.ShouldBe(ActivityStatusCode.Error);
+    }
+
+    private sealed class ThrowingMiddleware : IChannelMiddleware
+    {
+        public Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct) =>
+            throw new InvalidOperationException("boom");
+    }
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -1,0 +1,231 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class ConversationGAgentDedupTests
+{
+    [Fact]
+    public async Task HandleInboundActivityAsync_WhenDuplicateActivityId_CollapsesToSingleCommit()
+    {
+        var runner = new RecordingTurnRunner();
+        var (agent, store) = CreateAgent(runner, "conv-1");
+
+        var activity = CreateActivity("act-1", "conv:slack:C1");
+        await agent.HandleInboundActivityAsync(activity);
+        await agent.HandleInboundActivityAsync(activity.Clone());
+
+        runner.InboundCount.ShouldBe(1);
+        agent.State.ProcessedMessageIds.ShouldBe(new[] { "act-1" });
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_SequentialDistinctActivities_CommitAtomicallyInOrder()
+    {
+        var runner = new RecordingTurnRunner();
+        var (agent, store) = CreateAgent(runner, "conv-2");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-1", "conv:slack:C1"));
+        await agent.HandleInboundActivityAsync(CreateActivity("act-2", "conv:slack:C1"));
+        await agent.HandleInboundActivityAsync(CreateActivity("act-3", "conv:slack:C1"));
+
+        runner.InboundCount.ShouldBe(3);
+        agent.State.ProcessedMessageIds.ShouldBe(new[] { "act-1", "act-2", "act-3" });
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(3);
+        events.Select(e => e.Version).ShouldBe(new long[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_ActivityRedeliveredAfterCommit_UsesStateGuardNotRunner()
+    {
+        // TOCTOU scenario: the pipeline-level fast-path check may have missed the dedup entry
+        // because redelivery arrived during a concurrent commit window. The grain's post-commit
+        // state must still reject the duplicate without invoking the turn runner a second time.
+        var runner = new RecordingTurnRunner();
+        var (agent, _) = CreateAgent(runner, "conv-3");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-redeliver", "conv:slack:C1"));
+        runner.InboundCount.ShouldBe(1);
+
+        // Simulate a stream provider redelivering the same activity after the first commit landed.
+        await agent.HandleInboundActivityAsync(CreateActivity("act-redeliver", "conv:slack:C1"));
+        runner.InboundCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task HandleContinueCommandAsync_WhenDuplicateCommandId_EmitsDuplicateCommandRejection()
+    {
+        var runner = new RecordingTurnRunner();
+        var (agent, store) = CreateAgent(runner, "conv-4");
+
+        var cmd = CreateContinueCommand("cmd-1");
+        await agent.HandleContinueCommandAsync(cmd);
+        await agent.HandleContinueCommandAsync(cmd.Clone());
+
+        runner.ContinueCount.ShouldBe(1);
+        agent.State.ProcessedCommandIds.ShouldContain("cmd-1");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(2);
+
+        var rejected = events.Skip(1).First();
+        rejected.EventType.ShouldContain(nameof(ConversationContinueRejectedEvent));
+        var parsed = ConversationContinueRejectedEvent.Parser.ParseFrom(rejected.EventData.Value);
+        parsed.Reason.ShouldBe(RejectReason.DuplicateCommand);
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_WhenCapExceeded_RemovesOldestDedupEntry()
+    {
+        var runner = new RecordingTurnRunner();
+        var (agent, _) = CreateAgent(runner, "conv-5");
+
+        // Seed the state with cap - 1 entries, then add two more so the sliding window triggers.
+        for (var i = 0; i < ConversationGAgent.ProcessedIdsCap; i++)
+            agent.State.ProcessedMessageIds.Add($"seed-{i}");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("new-1", "conv:slack:C1"));
+        await agent.HandleInboundActivityAsync(CreateActivity("new-2", "conv:slack:C1"));
+
+        agent.State.ProcessedMessageIds.Count.ShouldBe(ConversationGAgent.ProcessedIdsCap);
+        agent.State.ProcessedMessageIds.ShouldNotContain("seed-0");
+        agent.State.ProcessedMessageIds.ShouldNotContain("seed-1");
+        agent.State.ProcessedMessageIds.ShouldContain("new-1");
+        agent.State.ProcessedMessageIds.ShouldContain("new-2");
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_WhenRunnerReportsFailure_EmitsFailedEvent()
+    {
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = _ => ConversationTurnResult.TransientFailure("rate_limited", "retry later", TimeSpan.FromMilliseconds(250)),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-6");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-fail", "conv:slack:C1"));
+
+        agent.State.ProcessedMessageIds.ShouldBeEmpty();
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(1);
+        events[0].EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
+        var parsed = ConversationContinueFailedEvent.Parser.ParseFrom(events[0].EventData.Value);
+        parsed.Kind.ShouldBe(FailureKind.TransientAdapterError);
+        parsed.RetryAfterMs.ShouldBe(250);
+    }
+
+    private static (ConversationGAgent agent, IEventStore store) CreateAgent(RecordingTurnRunner runner, string agentId)
+    {
+        var store = new InMemoryEventStore();
+        var services = new ServiceCollection();
+        services.AddSingleton<IEventStore>(store);
+        services.AddSingleton<EventSourcingRuntimeOptions>();
+        services.AddSingleton<IConversationTurnRunner>(runner);
+        services.AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
+
+        var sp = services.BuildServiceProvider();
+        var agent = new ConversationGAgent
+        {
+            Services = sp,
+            EventSourcingBehaviorFactory =
+                sp.GetRequiredService<IEventSourcingBehaviorFactory<ConversationGAgentState>>(),
+        };
+        SetId(agent, agentId);
+        agent.ActivateAsync().GetAwaiter().GetResult();
+        return (agent, store);
+    }
+
+    private static void SetId(object agent, string id)
+    {
+        var type = agent.GetType();
+        var prop = type.GetProperty("Id")!;
+        var setter = prop.GetSetMethod(nonPublic: true);
+        if (setter is not null)
+        {
+            setter.Invoke(agent, new object?[] { id });
+            return;
+        }
+
+        // Fall back to walking the base type for the internal SetId method.
+        var current = type;
+        while (current is not null)
+        {
+            var setIdMethod = current.GetMethod("SetId",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            if (setIdMethod is not null)
+            {
+                setIdMethod.Invoke(agent, new object?[] { id });
+                return;
+            }
+            current = current.BaseType;
+        }
+
+        throw new InvalidOperationException("Unable to set agent id via reflection.");
+    }
+
+    private static ChatActivity CreateActivity(string id, string canonicalKey) => new()
+    {
+        Id = id,
+        Type = ActivityType.Message,
+        ChannelId = new ChannelId { Value = "slack" },
+        Bot = new BotInstanceId { Value = "ops-bot" },
+        Conversation = new ConversationReference
+        {
+            Channel = new ChannelId { Value = "slack" },
+            Bot = new BotInstanceId { Value = "ops-bot" },
+            Scope = ConversationScope.Channel,
+            CanonicalKey = canonicalKey,
+        },
+        Content = new MessageContent { Text = "hi" },
+    };
+
+    private static ConversationContinueRequestedEvent CreateContinueCommand(string commandId) => new()
+    {
+        CommandId = commandId,
+        CorrelationId = "corr-1",
+        CausationId = string.Empty,
+        Kind = PrincipalKind.Bot,
+        Conversation = new ConversationReference
+        {
+            Channel = new ChannelId { Value = "slack" },
+            Bot = new BotInstanceId { Value = "ops-bot" },
+            Scope = ConversationScope.Channel,
+            CanonicalKey = "conv:slack:C1",
+        },
+        Payload = new MessageContent { Text = "ping" },
+        DispatchedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+    };
+
+    private sealed class RecordingTurnRunner : IConversationTurnRunner
+    {
+        public int InboundCount;
+        public int ContinueCount;
+        public Func<ChatActivity, ConversationTurnResult>? InboundResultFactory { get; set; }
+
+        public Task<ConversationTurnResult> RunInboundAsync(ChatActivity activity, CancellationToken ct)
+        {
+            Interlocked.Increment(ref InboundCount);
+            var result = InboundResultFactory is null
+                ? ConversationTurnResult.Sent("sent:" + activity.Id, new MessageContent { Text = "ack" }, "bot")
+                : InboundResultFactory(activity);
+            return Task.FromResult(result);
+        }
+
+        public Task<ConversationTurnResult> RunContinueAsync(ConversationContinueRequestedEvent command, CancellationToken ct)
+        {
+            Interlocked.Increment(ref ContinueCount);
+            return Task.FromResult(
+                ConversationTurnResult.Sent("sent:" + command.CommandId, new MessageContent { Text = "ack" }, "bot"));
+        }
+    }
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -124,6 +124,52 @@ public sealed class ConversationGAgentDedupTests
         parsed.RetryAfterMs.ShouldBe(250);
     }
 
+    [Fact]
+    public async Task HandleContinueCommandAsync_TransientFailure_LeavesCommandRetriable()
+    {
+        // Retriable continue failures (retry_after_ms) must NOT mark the command id as processed —
+        // callers expect to re-dispatch the same command id after the back-off elapses.
+        var runner = new RecordingTurnRunner
+        {
+            ContinueResultFactory = _ => ConversationTurnResult.TransientFailure("rate_limited", "retry later", TimeSpan.FromMilliseconds(250)),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-7");
+
+        await agent.HandleContinueCommandAsync(CreateContinueCommand("cmd-retry"));
+
+        agent.State.ProcessedCommandIds.ShouldNotContain("cmd-retry");
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(1);
+        events[0].EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
+
+        // A subsequent retry succeeds rather than being rejected as DuplicateCommand.
+        runner.ContinueResultFactory = null;
+        await agent.HandleContinueCommandAsync(CreateContinueCommand("cmd-retry"));
+        runner.ContinueCount.ShouldBe(2);
+        agent.State.ProcessedCommandIds.ShouldContain("cmd-retry");
+    }
+
+    [Fact]
+    public async Task HandleContinueCommandAsync_PermanentFailure_MarksCommandProcessed()
+    {
+        // Terminal (non-retryable) continue failures consume the command id so a buggy caller's
+        // redispatch is collapsed to DuplicateCommand rather than re-executing the failing turn.
+        var runner = new RecordingTurnRunner
+        {
+            ContinueResultFactory = _ => ConversationTurnResult.PermanentFailure("permanent_error", "bad input"),
+        };
+        var (agent, _) = CreateAgent(runner, "conv-8");
+
+        await agent.HandleContinueCommandAsync(CreateContinueCommand("cmd-permanent"));
+
+        agent.State.ProcessedCommandIds.ShouldContain("cmd-permanent");
+        runner.ContinueCount.ShouldBe(1);
+
+        // Redispatch of the same id is now rejected as DuplicateCommand; runner is not invoked again.
+        await agent.HandleContinueCommandAsync(CreateContinueCommand("cmd-permanent"));
+        runner.ContinueCount.ShouldBe(1);
+    }
+
     private static (ConversationGAgent agent, IEventStore store) CreateAgent(RecordingTurnRunner runner, string agentId)
     {
         var store = new InMemoryEventStore();
@@ -211,6 +257,7 @@ public sealed class ConversationGAgentDedupTests
         public int InboundCount;
         public int ContinueCount;
         public Func<ChatActivity, ConversationTurnResult>? InboundResultFactory { get; set; }
+        public Func<ConversationContinueRequestedEvent, ConversationTurnResult>? ContinueResultFactory { get; set; }
 
         public Task<ConversationTurnResult> RunInboundAsync(ChatActivity activity, CancellationToken ct)
         {
@@ -224,8 +271,10 @@ public sealed class ConversationGAgentDedupTests
         public Task<ConversationTurnResult> RunContinueAsync(ConversationContinueRequestedEvent command, CancellationToken ct)
         {
             Interlocked.Increment(ref ContinueCount);
-            return Task.FromResult(
-                ConversationTurnResult.Sent("sent:" + command.CommandId, new MessageContent { Text = "ack" }, "bot"));
+            var result = ContinueResultFactory is null
+                ? ConversationTurnResult.Sent("sent:" + command.CommandId, new MessageContent { Text = "ack" }, "bot")
+                : ContinueResultFactory(command);
+            return Task.FromResult(result);
         }
     }
 }

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -150,6 +150,29 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleContinueCommandAsync_TransientFailureWithoutRetryAfter_StaysRetriable()
+    {
+        // Runner returns TransientFailure without an explicit retryAfter. Retry policy must derive
+        // from FailureKind (retriable), not from whether RetryAfter was supplied — otherwise the
+        // command id gets consumed and the caller cannot re-dispatch.
+        var runner = new RecordingTurnRunner
+        {
+            ContinueResultFactory = _ => ConversationTurnResult.TransientFailure("rate_limited", "retry later"),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-9");
+
+        await agent.HandleContinueCommandAsync(CreateContinueCommand("cmd-transient"));
+
+        agent.State.ProcessedCommandIds.ShouldNotContain("cmd-transient");
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(1);
+        events[0].EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
+        var parsed = ConversationContinueFailedEvent.Parser.ParseFrom(events[0].EventData.Value);
+        parsed.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.RetryAfterMs);
+        parsed.RetryAfterMs.ShouldBe(0);
+    }
+
+    [Fact]
     public async Task HandleContinueCommandAsync_PermanentFailure_MarksCommandProcessed()
     {
         // Terminal (non-retryable) continue failures consume the command id so a buggy caller's

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/DurableInboxSubscriberTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/DurableInboxSubscriberTests.cs
@@ -1,7 +1,6 @@
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Shouldly;
 
@@ -10,31 +9,30 @@ namespace Aevatar.GAgents.Channel.Protocol.Tests;
 public sealed class DurableInboxSubscriberTests
 {
     [Fact]
-    public async Task OnNextAsync_WhenPipelineSucceeds_ReturnsToCaller()
+    public async Task OnNextAsync_WhenPipelineSucceeds_ReturnsAfterPipelineCompletes()
     {
-        // return→commit path: caller is free to commit the stream offset.
-        var completed = new TaskCompletionSource<ChatActivity>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var pipeline = BuildPipeline((ctx, next, ct) =>
+        // return→commit path: OnNextAsync must not return until the pipeline has actually run.
+        var invoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pipeline = BuildPipeline(async (ctx, next, ct) =>
         {
-            completed.TrySetResult(ctx.Activity);
-            return next();
+            invoked.TrySetResult();
+            await next();
         });
 
         await using var subscriber = BuildSubscriber(pipeline);
         subscriber.Start();
 
-        var activity = CreateActivity("act-1");
-        await subscriber.OnNextAsync(activity);
+        await subscriber.OnNextAsync(CreateActivity("act-1"));
 
-        var processed = await completed.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        processed.Id.ShouldBe("act-1");
+        // If OnNextAsync returned, the pipeline must have been invoked (completion handshake).
+        invoked.Task.IsCompletedSuccessfully.ShouldBeTrue();
     }
 
     [Fact]
     public async Task OnNextInlineAsync_WhenPipelineThrows_PropagatesToCaller()
     {
-        // throw→redeliver path: stream observer must receive the exception so the persistent
-        // provider re-delivers instead of committing.
+        // throw→redeliver path via the inline variant: stream observer must receive the exception
+        // so the persistent provider re-delivers instead of committing.
         var pipeline = BuildPipeline((ctx, next, ct) =>
             throw new InvalidOperationException("boom"));
 
@@ -45,29 +43,69 @@ public sealed class DurableInboxSubscriberTests
     }
 
     [Fact]
+    public async Task OnNextAsync_WhenPipelineThrows_PropagatesThroughCompletionHandshake()
+    {
+        // throw→redeliver path via the buffered variant. With the per-item handshake, exceptions
+        // surfaced by the worker must reach the observer through OnNextAsync's returned task, not
+        // just the background worker task.
+        var pipeline = BuildPipeline((ctx, next, ct) =>
+            throw new InvalidOperationException("boom"));
+
+        await using var subscriber = BuildSubscriber(pipeline);
+        subscriber.Start();
+
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => subscriber.OnNextAsync(CreateActivity("act-throw")));
+        ex.Message.ShouldBe("boom");
+    }
+
+    [Fact]
     public async Task OnNextAsync_WhenBufferFull_ThrowsTimeoutExceptionForRedelivery()
     {
-        // bounded channel saturation path: producer timeout elapses so the observer throws and
-        // the provider re-delivers the blocked activity.
-        var stall = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        // bounded channel saturation path: worker is busy, buffer is at capacity, and a third
+        // producer's write request times out so the observer throws and the provider re-delivers.
+        var stall = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var pipeline = BuildPipeline(async (ctx, next, ct) =>
         {
-            await stall.Task; // Hold the first activity so the buffer fills.
+            await stall.Task; // Hold the first activity so downstream back-pressures.
             await next();
         });
 
         await using var subscriber = BuildSubscriber(pipeline, bufferCapacity: 1, producerTimeout: TimeSpan.FromMilliseconds(50));
         subscriber.Start();
 
-        // Fill the single-slot buffer; worker reads it and awaits the stall.
-        await subscriber.OnNextAsync(CreateActivity("act-1"));
-        // Fill the single-slot buffer second slot which sits in the channel.
-        await subscriber.OnNextAsync(CreateActivity("act-2"));
-        // Third attempt must time out because the buffer is saturated and the worker is blocked.
+        // Fire-and-forget the first two sends because their completion handshake will block on the
+        // stall; we only need back-pressure to build up behind the worker.
+        var first = subscriber.OnNextAsync(CreateActivity("act-1"));
+        var second = subscriber.OnNextAsync(CreateActivity("act-2"));
+
         var ex = await Should.ThrowAsync<TimeoutException>(() => subscriber.OnNextAsync(CreateActivity("act-3")));
         ex.Message.ShouldContain("buffer full");
 
-        stall.TrySetResult(true);
+        stall.TrySetResult();
+        await first;
+        await second;
+    }
+
+    [Fact]
+    public async Task OnNextAsync_WhenDisposedWithInFlightItems_SignalsRedelivery()
+    {
+        // If the subscriber is torn down while items are still buffered, the observer for those
+        // items must surface an exception instead of hanging forever.
+        var stall = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pipeline = BuildPipeline(async (ctx, next, ct) =>
+        {
+            await stall.Task;
+            await next();
+        });
+
+        var subscriber = BuildSubscriber(pipeline, bufferCapacity: 4);
+        subscriber.Start();
+        var pending = subscriber.OnNextAsync(CreateActivity("act-1"));
+        await subscriber.DisposeAsync();
+
+        await Should.ThrowAsync<Exception>(() => pending);
+        stall.TrySetResult();
     }
 
     private static ChannelPipeline BuildPipeline(Func<ITurnContext, Func<Task>, CancellationToken, Task> handler)

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/DurableInboxSubscriberTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/DurableInboxSubscriberTests.cs
@@ -88,6 +88,24 @@ public sealed class DurableInboxSubscriberTests
     }
 
     [Fact]
+    public async Task OnNextAsync_AutoStartsWorker_WhenStartWasNotCalled()
+    {
+        // Wiring OnNextAsync directly as a stream handler must not hang if the caller forgets to
+        // call Start() — the subscriber auto-starts the worker on first delivery.
+        var invoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pipeline = BuildPipeline(async (ctx, next, ct) =>
+        {
+            invoked.TrySetResult();
+            await next();
+        });
+
+        await using var subscriber = BuildSubscriber(pipeline);
+        // Deliberately skip subscriber.Start().
+        await subscriber.OnNextAsync(CreateActivity("act-autostart"));
+        invoked.Task.IsCompletedSuccessfully.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task OnNextAsync_WhenDisposedWithInFlightItems_SignalsRedelivery()
     {
         // If the subscriber is torn down while items are still buffered, the observer for those

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/DurableInboxSubscriberTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/DurableInboxSubscriberTests.cs
@@ -1,0 +1,120 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Shouldly;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class DurableInboxSubscriberTests
+{
+    [Fact]
+    public async Task OnNextAsync_WhenPipelineSucceeds_ReturnsToCaller()
+    {
+        // return→commit path: caller is free to commit the stream offset.
+        var completed = new TaskCompletionSource<ChatActivity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pipeline = BuildPipeline((ctx, next, ct) =>
+        {
+            completed.TrySetResult(ctx.Activity);
+            return next();
+        });
+
+        await using var subscriber = BuildSubscriber(pipeline);
+        subscriber.Start();
+
+        var activity = CreateActivity("act-1");
+        await subscriber.OnNextAsync(activity);
+
+        var processed = await completed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        processed.Id.ShouldBe("act-1");
+    }
+
+    [Fact]
+    public async Task OnNextInlineAsync_WhenPipelineThrows_PropagatesToCaller()
+    {
+        // throw→redeliver path: stream observer must receive the exception so the persistent
+        // provider re-delivers instead of committing.
+        var pipeline = BuildPipeline((ctx, next, ct) =>
+            throw new InvalidOperationException("boom"));
+
+        await using var subscriber = BuildSubscriber(pipeline);
+        var ex = await Should.ThrowAsync<InvalidOperationException>(
+            () => subscriber.OnNextInlineAsync(CreateActivity("act-throw")));
+        ex.Message.ShouldBe("boom");
+    }
+
+    [Fact]
+    public async Task OnNextAsync_WhenBufferFull_ThrowsTimeoutExceptionForRedelivery()
+    {
+        // bounded channel saturation path: producer timeout elapses so the observer throws and
+        // the provider re-delivers the blocked activity.
+        var stall = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pipeline = BuildPipeline(async (ctx, next, ct) =>
+        {
+            await stall.Task; // Hold the first activity so the buffer fills.
+            await next();
+        });
+
+        await using var subscriber = BuildSubscriber(pipeline, bufferCapacity: 1, producerTimeout: TimeSpan.FromMilliseconds(50));
+        subscriber.Start();
+
+        // Fill the single-slot buffer; worker reads it and awaits the stall.
+        await subscriber.OnNextAsync(CreateActivity("act-1"));
+        // Fill the single-slot buffer second slot which sits in the channel.
+        await subscriber.OnNextAsync(CreateActivity("act-2"));
+        // Third attempt must time out because the buffer is saturated and the worker is blocked.
+        var ex = await Should.ThrowAsync<TimeoutException>(() => subscriber.OnNextAsync(CreateActivity("act-3")));
+        ex.Message.ShouldContain("buffer full");
+
+        stall.TrySetResult(true);
+    }
+
+    private static ChannelPipeline BuildPipeline(Func<ITurnContext, Func<Task>, CancellationToken, Task> handler)
+    {
+        var mw = new DelegateMiddleware(handler);
+        return new MiddlewarePipelineBuilder()
+            .Use(mw)
+            .Build(new ServiceCollection().BuildServiceProvider());
+    }
+
+    private static DurableInboxSubscriber BuildSubscriber(
+        ChannelPipeline pipeline,
+        int bufferCapacity = DurableInboxSubscriber.DefaultBufferCapacity,
+        TimeSpan? producerTimeout = null)
+    {
+        return new DurableInboxSubscriber(
+            pipeline,
+            new ServiceCollection().BuildServiceProvider(),
+            activity => new MiddlewarePipelineTests.StubTurnContext(),
+            NullLogger<DurableInboxSubscriber>.Instance,
+            bufferCapacity,
+            producerTimeout);
+    }
+
+    private static ChatActivity CreateActivity(string id) => new()
+    {
+        Id = id,
+        Bot = new BotInstanceId { Value = "ops-bot" },
+        ChannelId = new ChannelId { Value = "slack" },
+        Conversation = new ConversationReference
+        {
+            Channel = new ChannelId { Value = "slack" },
+            Bot = new BotInstanceId { Value = "ops-bot" },
+            Scope = ConversationScope.Channel,
+            CanonicalKey = "slack:team:C1",
+        },
+    };
+
+    private sealed class DelegateMiddleware : IChannelMiddleware
+    {
+        private readonly Func<ITurnContext, Func<Task>, CancellationToken, Task> _invoke;
+
+        public DelegateMiddleware(Func<ITurnContext, Func<Task>, CancellationToken, Task> invoke)
+        {
+            _invoke = invoke;
+        }
+
+        public Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct) => _invoke(context, next, ct);
+    }
+}

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/MiddlewarePipelineTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/MiddlewarePipelineTests.cs
@@ -1,0 +1,109 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Aevatar.GAgents.Channel.Protocol.Tests;
+
+public sealed class MiddlewarePipelineTests
+{
+    [Fact]
+    public async Task InvokeAsync_RunsMiddlewareInRegistrationOrder()
+    {
+        var trace = new List<string>();
+        var mw1 = new DelegateMiddleware(async (ctx, next, ct) => { trace.Add("m1:before"); await next(); trace.Add("m1:after"); });
+        var mw2 = new DelegateMiddleware(async (ctx, next, ct) => { trace.Add("m2:before"); await next(); trace.Add("m2:after"); });
+
+        var pipeline = new MiddlewarePipelineBuilder()
+            .Use(mw1)
+            .Use(mw2)
+            .Build(new ServiceCollection().BuildServiceProvider());
+
+        var ctx = new StubTurnContext();
+        await pipeline.InvokeAsync(ctx, () => { trace.Add("terminal"); return Task.CompletedTask; }, CancellationToken.None);
+
+        trace.ShouldBe(new[] { "m1:before", "m2:before", "terminal", "m2:after", "m1:after" });
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenMiddlewareDoesNotCallNext_TerminalIsNotInvoked()
+    {
+        var terminalCalled = false;
+        var shortCircuit = new DelegateMiddleware((ctx, next, ct) => Task.CompletedTask);
+
+        var pipeline = new MiddlewarePipelineBuilder()
+            .Use(shortCircuit)
+            .Build(new ServiceCollection().BuildServiceProvider());
+
+        await pipeline.InvokeAsync(new StubTurnContext(), () => { terminalCalled = true; return Task.CompletedTask; }, CancellationToken.None);
+
+        terminalCalled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenMiddlewareThrows_PropagatesUp()
+    {
+        var throwing = new DelegateMiddleware((ctx, next, ct) => throw new InvalidOperationException("boom"));
+        var pipeline = new MiddlewarePipelineBuilder()
+            .Use(throwing)
+            .Build(new ServiceCollection().BuildServiceProvider());
+
+        await Should.ThrowAsync<InvalidOperationException>(
+            () => pipeline.InvokeAsync(new StubTurnContext(), () => Task.CompletedTask, CancellationToken.None));
+    }
+
+    [Fact]
+    public void MiddlewarePipelineBuilder_NullMiddleware_Throws()
+    {
+        var builder = new MiddlewarePipelineBuilder();
+        Should.Throw<ArgumentNullException>(() => builder.Use((IChannelMiddleware)null!));
+    }
+
+    private sealed class DelegateMiddleware : IChannelMiddleware
+    {
+        private readonly Func<ITurnContext, Func<Task>, CancellationToken, Task> _invoke;
+
+        public DelegateMiddleware(Func<ITurnContext, Func<Task>, CancellationToken, Task> invoke)
+        {
+            _invoke = invoke;
+        }
+
+        public Task InvokeAsync(ITurnContext context, Func<Task> next, CancellationToken ct) => _invoke(context, next, ct);
+    }
+
+    internal sealed class StubTurnContext : ITurnContext
+    {
+        public ChatActivity Activity { get; } = new()
+        {
+            Id = "act-1",
+            Bot = new BotInstanceId { Value = "ops-bot" },
+            ChannelId = new ChannelId { Value = "slack" },
+            Conversation = new ConversationReference
+            {
+                Channel = new ChannelId { Value = "slack" },
+                Bot = new BotInstanceId { Value = "ops-bot" },
+                Scope = ConversationScope.Channel,
+                CanonicalKey = "slack:team:channel",
+            },
+        };
+
+        public ChannelBotDescriptor Bot { get; } = ChannelBotDescriptor.Create(
+            "reg-1",
+            ChannelId.From("slack"),
+            BotInstanceId.From("ops-bot"));
+
+        public IServiceProvider Services { get; } = new ServiceCollection().BuildServiceProvider();
+
+        public Task<EmitResult> SendAsync(MessageContent content, CancellationToken ct) => Task.FromResult(EmitResult.Sent("sent-1"));
+
+        public Task<EmitResult> ReplyAsync(MessageContent content, CancellationToken ct) => Task.FromResult(EmitResult.Sent("reply-1"));
+
+        public Task<StreamingHandle> BeginStreamingReplyAsync(MessageContent initial, CancellationToken ct) =>
+            throw new NotSupportedException();
+
+        public Task<EmitResult> UpdateAsync(string activityId, MessageContent content, CancellationToken ct) =>
+            Task.FromResult(EmitResult.Sent(activityId));
+
+        public Task DeleteAsync(string activityId, CancellationToken ct) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #258 once merged through the channel-abstractions → dev chain.

## Summary

Implements `Aevatar.GAgents.Channel.Runtime` package on top of the abstractions
merged in #272 (issue #257).

- **Grains**
  - `ConversationGAgent` (`GAgentBase<ConversationGAgentState>`) — per-conversation
    single-activation actor keyed by `ConversationReference.CanonicalKey`.
    Authoritative dedup on `ProcessedMessageIds` / `ProcessedCommandIds` with a
    sliding-window cap (10 000). Turn runner seam (`IConversationTurnRunner`)
    keeps bot invocation out of the grain.
  - `ChannelUserBindingGAgent` — user credential + preferences split out of the
    legacy `ChannelUserGAgent` per RFC §5.2b.
  - `IShardLeaderGrain` — abstraction only; Discord gateway implementation
    deferred per issue scope.
- **Middleware Pipeline** — `ChannelPipeline` + `MiddlewarePipelineBuilder`
  compose `IChannelMiddleware` instances (ASP.NET-Core-style). Three
  standard middlewares shipped:
  - `ConversationResolverMiddleware`
  - `LoggingMiddleware`
  - `TracingMiddleware`
- **Durable inbox** — `DurableInboxSubscriber` bridges `ChatActivity` stream
  into the pipeline with RFC §5.8 / §9.5.2 semantics: `return→commit`,
  `throw→redeliver`, bounded `Channel<T>` (1000 / `Wait` / 500 ms).
- **Observability** — `ChannelDiagnostics` centralises the `Aevatar.Channel`
  `ActivitySource`, RFC §6.1 span names, and mandatory tag keys.
- **DI** — `AddChannelRuntime()` extension.
- **Protos** — `conversation_state.proto`, `channel_user_binding.proto` define
  state + command/event contracts per CLAUDE.md proto-first rule.

## Issue #258 acceptance checklist

- [x] `Aevatar.GAgents.Channel.Runtime.csproj` 独立 build 通过
- [x] Orleans Streams subscription `OnNextAsync` 语义单测通过 (exercised via
      transport-agnostic `IStream` analog in `DurableInboxSubscriberTests` —
      success-commit, throw-redeliver, buffer-full-timeout)
- [x] `ConversationGAgent` 的 dedup + atomic commit 测试通过 (TOCTOU scenario
      covered in `ConversationGAgentDedupTests`)
- [x] Observability spans 通过 tracing smoke test (ActivityListener-based in
      `ChannelTracingSmokeTests`; avoids pulling `OpenTelemetry.Exporter.InMemory`
      into the test project)

## Test plan

- [x] `dotnet build aevatar.slnx --nologo` — 0 errors.
- [x] `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj` — 28 passed, 0 failed.
- [x] `bash tools/ci/channel_mega_interface_guard.sh` — ok.
- [x] `bash tools/ci/architecture_guards.sh` — passed.
- [x] `bash tools/ci/test_stability_guards.sh` — passed (no new polling waits).

## Deviations / scope notes

- Stream subscription is validated against the channel-runtime-facing contract
  (`DurableInboxSubscriber.OnNextAsync` / `OnNextInlineAsync`) rather than by
  spinning up Orleans streams — Orleans-specific wiring belongs in host-layer
  packages, not `Channel.Runtime` (matches "no Orleans package in Runtime"
  constraint). The semantics tested are the ones the observer contract must
  honor regardless of provider.
- `IShardLeaderGrain` is intentionally abstraction-only.
- Projection integration is achieved through the standard
  `PersistDomainEventAsync` → `CommittedStateEventPublisher` flow inherited from
  `GAgentBase`. No new projector is introduced — readmodels come in follow-up
  PRs for `ChatHistory` / `UserMemory` consumers.

## Dependencies

Depends on #272 (issue #257 abstractions). PR is stacked on that base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)