### PR TITLE
[codex] Fix Lark card form submission

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -533,6 +533,7 @@ internal static class AgentBuilderCardFlow
     {
         return JsonSerializer.Serialize(new
         {
+            schema = "2.0",
             config = new
             {
                 wide_screen_mode = true,
@@ -554,46 +555,29 @@ internal static class AgentBuilderCardFlow
                     content =
                         "**Day One template:** Daily GitHub report\nFill in the fields below. The agent will run once now and then repeat every day at your chosen local time.",
                 },
-                BuildInput("github_username", "GitHub Username", "alice"),
-                BuildInput("repositories", "Repositories (Optional)", "owner/repo, owner/repo"),
-                BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
-                BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
+                BuildForm(
+                    "daily_report_form",
+                    BuildInput("github_username", "GitHub Username", "alice"),
+                    BuildInput("repositories", "Repositories (Optional)", "owner/repo, owner/repo"),
+                    BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
+                    BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
+                    BuildAction(
+                        BuildSubmitButton("Create Agent", "primary", "submit_daily_report", new
+                        {
+                            agent_builder_action = DailyReportAction,
+                            run_immediately = true,
+                        }))),
                 new
                 {
                     tag = "action",
                     actions = new object[]
                     {
-                        new
+                        BuildButton("List Agents", "default", new
                         {
-                            tag = "button",
-                            type = "primary",
-                            text = new
-                            {
-                                tag = "plain_text",
-                                content = "Create Agent",
-                            },
-                            value = new
-                            {
-                                agent_builder_action = DailyReportAction,
-                                run_immediately = true,
-                            },
-                        },
-                        new
-                        {
-                            tag = "button",
-                            type = "default",
-                            text = new
-                            {
-                                tag = "plain_text",
-                                content = "List Agents",
-                            },
-                            value = new
-                            {
-                                agent_builder_action = ListAgentsAction,
-                            },
-                        },
+                            agent_builder_action = ListAgentsAction,
+                        }),
                     },
-                },
+                }
             },
         });
     }
@@ -602,6 +586,7 @@ internal static class AgentBuilderCardFlow
     {
         return JsonSerializer.Serialize(new
         {
+            schema = "2.0",
             config = new
             {
                 wide_screen_mode = true,
@@ -623,50 +608,48 @@ internal static class AgentBuilderCardFlow
                     content =
                         "**Workflow-backed template:** Social media draft + approval\nFill in the fields below. Each scheduled run will generate one draft and send an approval card into this Feishu private chat.",
                 },
-                BuildInput("topic", "Topic", "Launch update for the new workflow feature"),
-                BuildInput("audience", "Audience (Optional)", "Developers and technical founders"),
-                BuildInput("style", "Style (Optional)", "Confident, concise, product-focused"),
-                BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
-                BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
+                BuildForm(
+                    "social_media_form",
+                    BuildInput("topic", "Topic", "Launch update for the new workflow feature"),
+                    BuildInput("audience", "Audience (Optional)", "Developers and technical founders"),
+                    BuildInput("style", "Style (Optional)", "Confident, concise, product-focused"),
+                    BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
+                    BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
+                    BuildAction(
+                        BuildSubmitButton("Create Agent", "primary", "submit_social_media", new
+                        {
+                            agent_builder_action = SocialMediaAction,
+                            run_immediately = true,
+                        }))),
                 new
                 {
                     tag = "action",
                     actions = new object[]
                     {
-                        new
+                        BuildButton("List Agents", "default", new
                         {
-                            tag = "button",
-                            type = "primary",
-                            text = new
-                            {
-                                tag = "plain_text",
-                                content = "Create Agent",
-                            },
-                            value = new
-                            {
-                                agent_builder_action = SocialMediaAction,
-                                run_immediately = true,
-                            },
-                        },
-                        new
-                        {
-                            tag = "button",
-                            type = "default",
-                            text = new
-                            {
-                                tag = "plain_text",
-                                content = "List Agents",
-                            },
-                            value = new
-                            {
-                                agent_builder_action = ListAgentsAction,
-                            },
-                        },
+                            agent_builder_action = ListAgentsAction,
+                        }),
                     },
-                },
+                }
             },
         });
     }
+
+    private static object BuildForm(string name, params object[] elements) =>
+        new
+        {
+            tag = "form",
+            name,
+            elements,
+        };
+
+    private static object BuildAction(params object[] actions) =>
+        new
+        {
+            tag = "action",
+            actions,
+        };
 
     private static object BuildInput(string name, string label, string placeholder)
     {
@@ -686,6 +669,21 @@ internal static class AgentBuilderCardFlow
             },
         };
     }
+
+    private static object BuildSubmitButton(string label, string style, string name, object value) =>
+        new
+        {
+            tag = "button",
+            type = style,
+            name,
+            form_action_type = "submit",
+            text = new
+            {
+                tag = "plain_text",
+                content = label,
+            },
+            value,
+        };
 
     private static string FormatCreateDailyReportResult(JsonElement root)
     {

--- a/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
@@ -92,21 +92,25 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
 
         if (SupportsApproveReject(request))
         {
-            elements.Add(BuildEditedContentInput());
-            elements.Add(BuildFeedbackInput());
-            elements.Add(new
-            {
-                tag = "action",
-                actions = new object[]
+            elements.Add(BuildForm(
+                "human_interaction_form",
+                BuildEditedContentInput(),
+                BuildFeedbackInput(),
+                new
                 {
-                    BuildActionButton("Approve", "primary", request, approved: true),
-                    BuildActionButton("Reject", "default", request, approved: false),
-                },
-            });
+                    tag = "action",
+                    actions = new object[]
+                    {
+                        BuildActionButton("Approve", "primary", request, approved: true),
+                        BuildActionButton("Reject", "default", request, approved: false),
+                    },
+                }
+            ));
         }
 
         return JsonSerializer.Serialize(new
         {
+            schema = "2.0",
             config = new
             {
                 wide_screen_mode = true,
@@ -174,6 +178,7 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
 
         return JsonSerializer.Serialize(new
         {
+            schema = "2.0",
             config = new
             {
                 wide_screen_mode = true,
@@ -284,6 +289,8 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         {
             tag = "button",
             type = style,
+            name = approved ? "approve" : "reject",
+            form_action_type = "submit",
             text = new
             {
                 tag = "plain_text",
@@ -296,6 +303,14 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
                 step_id = request.StepId,
                 approved,
             },
+        };
+
+    private static object BuildForm(string name, params object[] elements) =>
+        new
+        {
+            tag = "form",
+            name,
+            elements,
         };
 
     private static object BuildAgentActionButton(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
@@ -377,8 +377,12 @@ public class ChannelUserGAgentContinuationTests
         LarkPlatformAdapter.IsInteractiveCardPayload(adapter.Replies[0].ReplyText).Should().BeTrue();
 
         using var card = JsonDocument.Parse(adapter.Replies[0].ReplyText);
+        card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Create Daily Report Agent");
+        card.RootElement.GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
+        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
+            .Should().Be("github_username");
 
         agent.State.PendingSessions.Should().BeEmpty();
         agent.State.ProcessedMessageIds.Should().Contain("om_msg_1");
@@ -404,8 +408,12 @@ public class ChannelUserGAgentContinuationTests
         LarkPlatformAdapter.IsInteractiveCardPayload(adapter.Replies[0].ReplyText).Should().BeTrue();
 
         using var card = JsonDocument.Parse(adapter.Replies[0].ReplyText);
+        card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Create Social Media Agent");
+        card.RootElement.GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
+        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
+            .Should().Be("topic");
 
         agent.State.PendingSessions.Should().BeEmpty();
         agent.State.ProcessedMessageIds.Should().Contain("om_msg_1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
@@ -58,18 +58,20 @@ public sealed class FeishuCardHumanInteractionPortTests
         body.RootElement.GetProperty("msg_type").GetString().Should().Be("interactive");
 
         using var card = JsonDocument.Parse(body.RootElement.GetProperty("content").GetString()!);
+        card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("orange");
-        var editedContentInput = card.RootElement.GetProperty("elements")[1];
-        editedContentInput.GetProperty("tag").GetString().Should().Be("input");
+        var formElement = card.RootElement.GetProperty("elements")[1];
+        formElement.GetProperty("tag").GetString().Should().Be("form");
+        var editedContentInput = formElement.GetProperty("elements")[0];
         editedContentInput.GetProperty("name").GetString().Should().Be("edited_content");
 
-        var feedbackInput = card.RootElement.GetProperty("elements")[2];
-        feedbackInput.GetProperty("tag").GetString().Should().Be("input");
+        var feedbackInput = formElement.GetProperty("elements")[1];
         feedbackInput.GetProperty("name").GetString().Should().Be("user_input");
 
-        var actionElement = card.RootElement.GetProperty("elements")[3];
+        var actionElement = formElement.GetProperty("elements")[2];
         actionElement.GetProperty("tag").GetString().Should().Be("action");
         var approve = actionElement.GetProperty("actions")[0];
+        approve.GetProperty("form_action_type").GetString().Should().Be("submit");
         approve.GetProperty("value").GetProperty("actor_id").GetString().Should().Be("workflow-actor-1");
         approve.GetProperty("value").GetProperty("run_id").GetString().Should().Be("run-1");
         approve.GetProperty("value").GetProperty("step_id").GetString().Should().Be("approval-1");
@@ -242,6 +244,7 @@ public sealed class FeishuCardHumanInteractionPortTests
         });
 
         using var card = JsonDocument.Parse(json);
+        card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("blue");
         card.RootElement.GetProperty("elements").GetArrayLength().Should().Be(1);
     }
@@ -261,9 +264,13 @@ public sealed class FeishuCardHumanInteractionPortTests
         });
 
         using var card = JsonDocument.Parse(json);
-        card.RootElement.GetProperty("elements").GetArrayLength().Should().Be(4);
-        card.RootElement.GetProperty("elements")[1].GetProperty("name").GetString().Should().Be("edited_content");
-        card.RootElement.GetProperty("elements")[2].GetProperty("name").GetString().Should().Be("user_input");
+        card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
+        card.RootElement.GetProperty("elements").GetArrayLength().Should().Be(2);
+        card.RootElement.GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
+        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
+            .Should().Be("edited_content");
+        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[1].GetProperty("name").GetString()
+            .Should().Be("user_input");
     }
 
     [Fact]
@@ -278,6 +285,7 @@ public sealed class FeishuCardHumanInteractionPortTests
         });
 
         using var card = JsonDocument.Parse(json);
+        card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("green");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Approval Recorded");


### PR DESCRIPTION
## What changed
- switched the `/daily-report` and `/social-media` builder cards to Feishu/Lark card schema `2.0`
- wrapped builder inputs in a `form` container and made `Create Agent` a submit action so `form_value` is sent back on click
- aligned approval cards in `FeishuCardHumanInteractionPort` to the same form-submit structure
- updated ChannelRuntime tests to assert the rendered card shape and submit semantics

## Why this changed
The bot was receiving `card.action.trigger`, but the builder card was rendered as plain interactive content instead of a submit-capable form card. Feishu rendered the buttons, but did not return the input fields, so `Create Agent` always failed with `GitHub username is required`.

## Impact
- `/daily-report` now renders a fillable form instead of buttons-only content
- clicking `Create Agent` can carry `github_username` and the other fields back to the backend
- approval/reject cards use the same card form pattern, which reduces drift between the two Lark card paths

## Validation
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~ChannelUserGAgentContinuationTests|FullyQualifiedName~FeishuCardHumanInteractionPortTests"`

## Notes
- the targeted test suite passed on the updated `origin/dev` base
- existing repository-wide warning noise is unchanged and not introduced by this patch