### PR TITLE
[codex] Fix Lark schema 2 card body layout

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -547,36 +547,39 @@ internal static class AgentBuilderCardFlow
                 },
                 template = "blue",
             },
-            elements = new object[]
+            body = new
             {
-                new
+                elements = new object[]
                 {
-                    tag = "markdown",
-                    content =
-                        "**Day One template:** Daily GitHub report\nFill in the fields below. The agent will run once now and then repeat every day at your chosen local time.",
-                },
-                BuildForm(
-                    "daily_report_form",
-                    BuildInput("github_username", "GitHub Username", "alice"),
-                    BuildInput("repositories", "Repositories (Optional)", "owner/repo, owner/repo"),
-                    BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
-                    BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
-                    BuildAction(
-                        BuildSubmitButton("Create Agent", "primary", "submit_daily_report", new
-                        {
-                            agent_builder_action = DailyReportAction,
-                            run_immediately = true,
-                        }))),
-                new
-                {
-                    tag = "action",
-                    actions = new object[]
+                    new
                     {
-                        BuildButton("List Agents", "default", new
-                        {
-                            agent_builder_action = ListAgentsAction,
-                        }),
+                        tag = "markdown",
+                        content =
+                            "**Day One template:** Daily GitHub report\nFill in the fields below. The agent will run once now and then repeat every day at your chosen local time.",
                     },
+                    BuildForm(
+                        "daily_report_form",
+                        BuildInput("github_username", "GitHub Username", "alice"),
+                        BuildInput("repositories", "Repositories (Optional)", "owner/repo, owner/repo"),
+                        BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
+                        BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
+                        BuildAction(
+                            BuildSubmitButton("Create Agent", "primary", "submit_daily_report", new
+                            {
+                                agent_builder_action = DailyReportAction,
+                                run_immediately = true,
+                            }))),
+                    new
+                    {
+                        tag = "action",
+                        actions = new object[]
+                        {
+                            BuildButton("List Agents", "default", new
+                            {
+                                agent_builder_action = ListAgentsAction,
+                            }),
+                        },
+                    }
                 }
             },
         });
@@ -600,37 +603,40 @@ internal static class AgentBuilderCardFlow
                 },
                 template = "orange",
             },
-            elements = new object[]
+            body = new
             {
-                new
+                elements = new object[]
                 {
-                    tag = "markdown",
-                    content =
-                        "**Workflow-backed template:** Social media draft + approval\nFill in the fields below. Each scheduled run will generate one draft and send an approval card into this Feishu private chat.",
-                },
-                BuildForm(
-                    "social_media_form",
-                    BuildInput("topic", "Topic", "Launch update for the new workflow feature"),
-                    BuildInput("audience", "Audience (Optional)", "Developers and technical founders"),
-                    BuildInput("style", "Style (Optional)", "Confident, concise, product-focused"),
-                    BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
-                    BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
-                    BuildAction(
-                        BuildSubmitButton("Create Agent", "primary", "submit_social_media", new
-                        {
-                            agent_builder_action = SocialMediaAction,
-                            run_immediately = true,
-                        }))),
-                new
-                {
-                    tag = "action",
-                    actions = new object[]
+                    new
                     {
-                        BuildButton("List Agents", "default", new
-                        {
-                            agent_builder_action = ListAgentsAction,
-                        }),
+                        tag = "markdown",
+                        content =
+                            "**Workflow-backed template:** Social media draft + approval\nFill in the fields below. Each scheduled run will generate one draft and send an approval card into this Feishu private chat.",
                     },
+                    BuildForm(
+                        "social_media_form",
+                        BuildInput("topic", "Topic", "Launch update for the new workflow feature"),
+                        BuildInput("audience", "Audience (Optional)", "Developers and technical founders"),
+                        BuildInput("style", "Style (Optional)", "Confident, concise, product-focused"),
+                        BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
+                        BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
+                        BuildAction(
+                            BuildSubmitButton("Create Agent", "primary", "submit_social_media", new
+                            {
+                                agent_builder_action = SocialMediaAction,
+                                run_immediately = true,
+                            }))),
+                    new
+                    {
+                        tag = "action",
+                        actions = new object[]
+                        {
+                            BuildButton("List Agents", "default", new
+                            {
+                                agent_builder_action = ListAgentsAction,
+                            }),
+                        },
+                    }
                 }
             },
         });

--- a/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
@@ -124,7 +124,10 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
                 },
                 template = SupportsApproveReject(request) ? "orange" : "blue",
             },
-            elements,
+            body = new
+            {
+                elements,
+            },
         });
     }
 
@@ -192,7 +195,10 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
                 },
                 template = resolution.Approved ? "green" : "red",
             },
-            elements,
+            body = new
+            {
+                elements,
+            },
         });
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserGAgentContinuationTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -380,8 +381,8 @@ public class ChannelUserGAgentContinuationTests
         card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Create Daily Report Agent");
-        card.RootElement.GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
-        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
             .Should().Be("github_username");
 
         agent.State.PendingSessions.Should().BeEmpty();
@@ -411,8 +412,8 @@ public class ChannelUserGAgentContinuationTests
         card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Create Social Media Agent");
-        card.RootElement.GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
-        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
             .Should().Be("topic");
 
         agent.State.PendingSessions.Should().BeEmpty();
@@ -517,6 +518,114 @@ public class ChannelUserGAgentContinuationTests
         adapter.Replies[0].ReplyText.Should().Contain("View Agents");
         agent.State.PendingSessions.Should().BeEmpty();
         agent.State.ProcessedMessageIds.Should().Contain("evt_card_1");
+
+        await skillRunnerActor.Received(1).HandleEventAsync(
+            Arg.Is<EventEnvelope>(e =>
+                e.Payload != null &&
+                e.Payload.Is(InitializeSkillRunnerCommand.Descriptor) &&
+                e.Payload.Unpack<InitializeSkillRunnerCommand>().TemplateName == "daily_report" &&
+                e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.ConversationId == "oc_chat_1"),
+            Arg.Any<CancellationToken>());
+
+        await skillRunnerActor.Received(1).HandleEventAsync(
+            Arg.Is<EventEnvelope>(e =>
+                e.Payload != null &&
+                e.Payload.Is(TriggerSkillRunnerExecutionCommand.Descriptor) &&
+                e.Payload.Unpack<TriggerSkillRunnerExecutionCommand>().Reason == "create_agent"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleInbound_CreateDailyReportCardSubmitFromRenderedForm_ShouldExecuteAgentBuilder()
+    {
+        var queryPort = Substitute.For<IAgentRegistryQueryPort>();
+        queryPort.GetStateVersionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult<AgentRegistryEntry?>(new AgentRegistryEntry
+            {
+                AgentId = callInfo.ArgAt<string>(0),
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+            }));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-1");
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync(Arg.Any<string>()).Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<SkillRunnerGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(skillRunnerActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {
+                  "provider_id":"provider-github",
+                  "provider_name":"GitHub",
+                  "provider_slug":"github",
+                  "provider_type":"oauth2",
+                  "status":"active",
+                  "connected_at":"2026-04-15T00:00:00Z"
+                }
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/services", """
+            [
+              {"id":"svc-github","slug":"api-github"},
+              {"id":"svc-lark","slug":"api-lark-bot"}
+            ]
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-1","full_key":"full-key-1"}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingPlatformAdapter("lark");
+        using var services = BuildServices(
+            actorRuntime,
+            streams,
+            scheduler,
+            adapter,
+            new InMemoryEventStore(),
+            configure: serviceCollection =>
+            {
+                serviceCollection.AddSingleton(queryPort);
+                serviceCollection.AddSingleton(nyxClient);
+            });
+
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+        var launchInbound = BuildInboundEvent();
+        launchInbound.Text = "/daily-report";
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(launchInbound);
+
+        adapter.Replies.Should().ContainSingle();
+        var submitInbound = await BuildCardSubmitInboundEventAsync(
+            adapter.Replies[0].ReplyText,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["github_username"] = "alice",
+                ["repositories"] = "aevatarAI/aevatar",
+                ["schedule_time"] = "09:00",
+                ["schedule_timezone"] = "UTC",
+            },
+            "evt_daily_submit_1");
+
+        await agent.HandleInbound(submitInbound);
+
+        adapter.Replies.Should().HaveCount(2);
+        LarkPlatformAdapter.IsInteractiveCardPayload(adapter.Replies[1].ReplyText).Should().BeTrue();
+        adapter.Replies[1].ReplyText.Should().Contain("Daily report agent created: skill-runner-");
+        adapter.Replies[1].ReplyText.Should().Contain("View Agents");
+        agent.State.ProcessedMessageIds.Should().Contain("evt_daily_submit_1");
 
         await skillRunnerActor.Received(1).HandleEventAsync(
             Arg.Is<EventEnvelope>(e =>
@@ -719,6 +828,120 @@ public class ChannelUserGAgentContinuationTests
         adapter.Replies[0].ReplyText.Should().Contain("View Agents");
         agent.State.PendingSessions.Should().BeEmpty();
         agent.State.ProcessedMessageIds.Should().Contain("evt_card_social_1");
+
+        await workflowAgentActor.Received(1).HandleEventAsync(
+            Arg.Is<EventEnvelope>(e =>
+                e.Payload != null &&
+                e.Payload.Is(InitializeWorkflowAgentCommand.Descriptor) &&
+                e.Payload.Unpack<InitializeWorkflowAgentCommand>().WorkflowActorId == "workflow-actor-1" &&
+                e.Payload.Unpack<InitializeWorkflowAgentCommand>().ConversationId == "oc_chat_1"),
+            Arg.Any<CancellationToken>());
+
+        await workflowAgentActor.Received(1).HandleEventAsync(
+            Arg.Is<EventEnvelope>(e =>
+                e.Payload != null &&
+                e.Payload.Is(TriggerWorkflowAgentExecutionCommand.Descriptor) &&
+                e.Payload.Unpack<TriggerWorkflowAgentExecutionCommand>().Reason == "create_agent"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleInbound_CreateSocialMediaCardSubmitFromRenderedForm_ShouldExecuteAgentBuilder()
+    {
+        var queryPort = Substitute.For<IAgentRegistryQueryPort>();
+        queryPort.GetStateVersionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult<AgentRegistryEntry?>(new AgentRegistryEntry
+            {
+                AgentId = callInfo.ArgAt<string>(0),
+                AgentType = WorkflowAgentDefaults.AgentType,
+                TemplateName = WorkflowAgentDefaults.TemplateName,
+                Status = WorkflowAgentDefaults.StatusRunning,
+            }));
+
+        var workflowAgentActor = Substitute.For<IActor>();
+        workflowAgentActor.Id.Returns("workflow-agent-1");
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync(Arg.Any<string>()).Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<WorkflowAgentGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(workflowAgentActor));
+
+        var workflowCommandPort = Substitute.For<IScopeWorkflowCommandPort>();
+        workflowCommandPort.UpsertAsync(Arg.Any<ScopeWorkflowUpsertRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ScopeWorkflowUpsertResult(
+                new ScopeWorkflowSummary(
+                    "scope-1",
+                    "social-media-workflow-agent-1",
+                    "Social Media Approval workflow-agent-1",
+                    "service-key",
+                    "social_media_workflow_agent_1",
+                    "workflow-actor-1",
+                    "rev-1",
+                    "deploy-1",
+                    "active",
+                    DateTimeOffset.UtcNow),
+                "rev-1",
+                "workflow-actor-prefix",
+                "workflow-actor-1")));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/services", """
+            [
+              {"id":"svc-lark","slug":"api-lark-bot"}
+            ]
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-2","full_key":"full-key-2"}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var streams = new RecordingStreamProvider();
+        var scheduler = new RecordingCallbackScheduler();
+        var adapter = new RecordingPlatformAdapter("lark");
+        using var services = BuildServices(
+            actorRuntime,
+            streams,
+            scheduler,
+            adapter,
+            new InMemoryEventStore(),
+            configure: serviceCollection =>
+            {
+                serviceCollection.AddSingleton(queryPort);
+                serviceCollection.AddSingleton(workflowCommandPort);
+                serviceCollection.AddSingleton(nyxClient);
+            });
+
+        var agent = CreateAgent(services, "channel-user-lark-reg-1-ou_123");
+        var launchInbound = BuildInboundEvent();
+        launchInbound.Text = "/social-media";
+
+        await agent.ActivateAsync();
+        await agent.HandleInbound(launchInbound);
+
+        adapter.Replies.Should().ContainSingle();
+        var submitInbound = await BuildCardSubmitInboundEventAsync(
+            adapter.Replies[0].ReplyText,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["topic"] = "Launch update for the new workflow feature",
+                ["audience"] = "Developers",
+                ["style"] = "Confident and concise",
+                ["schedule_time"] = "09:00",
+                ["schedule_timezone"] = "UTC",
+            },
+            "evt_social_submit_1");
+
+        await agent.HandleInbound(submitInbound);
+
+        adapter.Replies.Should().HaveCount(2);
+        LarkPlatformAdapter.IsInteractiveCardPayload(adapter.Replies[1].ReplyText).Should().BeTrue();
+        adapter.Replies[1].ReplyText.Should().Contain("Social media agent created: workflow-agent-");
+        adapter.Replies[1].ReplyText.Should().Contain("View Agents");
+        agent.State.ProcessedMessageIds.Should().Contain("evt_social_submit_1");
 
         await workflowAgentActor.Received(1).HandleEventAsync(
             Arg.Is<EventEnvelope>(e =>
@@ -1693,6 +1916,110 @@ public class ChannelUserGAgentContinuationTests
         RegistrationScopeId = "scope-1",
         NyxProviderSlug = "api-lark-bot",
     };
+
+    private static async Task<ChannelInboundEvent> BuildCardSubmitInboundEventAsync(
+        string cardJson,
+        IReadOnlyDictionary<string, string> formValues,
+        string eventId)
+    {
+        var actionValue = ExtractPrimaryFormActionValue(cardJson);
+        var payload = new
+        {
+            schema = "2.0",
+            header = new
+            {
+                event_type = "card.action.trigger",
+                token = "verify-token",
+                event_id = eventId,
+            },
+            @event = new
+            {
+                @operator = new
+                {
+                    open_id = "ou_123",
+                },
+                context = new
+                {
+                    open_chat_id = "oc_chat_1",
+                    open_message_id = "om_card_msg_1",
+                },
+                action = new
+                {
+                    value = actionValue,
+                    form_value = formValues,
+                },
+            },
+        };
+
+        var http = CreateHttpContext(payload);
+        var adapter = new LarkPlatformAdapter(NullLogger<LarkPlatformAdapter>.Instance);
+        var registration = BuildLarkRegistration();
+        var inbound = await adapter.ParseInboundAsync(http, registration);
+
+        inbound.Should().NotBeNull();
+        return ToChannelInboundEvent(inbound!, registration);
+    }
+
+    private static JsonElement ExtractPrimaryFormActionValue(string cardJson)
+    {
+        using var card = JsonDocument.Parse(cardJson);
+        var form = card.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(element => element.GetProperty("tag").GetString() == "form");
+        var action = form
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(element => element.GetProperty("tag").GetString() == "action");
+        return action.GetProperty("actions")[0].GetProperty("value").Clone();
+    }
+
+    private static HttpContext CreateHttpContext(object payload)
+    {
+        var json = JsonSerializer.Serialize(payload);
+        var context = new DefaultHttpContext();
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        context.Request.ContentType = "application/json";
+        context.Request.EnableBuffering();
+        return context;
+    }
+
+    private static ChannelBotRegistrationEntry BuildLarkRegistration() => new()
+    {
+        Id = "reg-1",
+        Platform = "lark",
+        NyxProviderSlug = "api-lark-bot",
+        NyxUserToken = "org-token",
+        VerificationToken = "verify-token",
+        ScopeId = "scope-1",
+        CreatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+    };
+
+    private static ChannelInboundEvent ToChannelInboundEvent(
+        InboundMessage inbound,
+        ChannelBotRegistrationEntry registration)
+    {
+        var inboundEvent = new ChannelInboundEvent
+        {
+            Text = inbound.Text,
+            SenderId = inbound.SenderId,
+            SenderName = inbound.SenderName,
+            ConversationId = inbound.ConversationId,
+            MessageId = inbound.MessageId ?? string.Empty,
+            ChatType = inbound.ChatType ?? string.Empty,
+            Platform = inbound.Platform,
+            RegistrationId = registration.Id,
+            RegistrationToken = registration.NyxUserToken,
+            RegistrationScopeId = registration.ScopeId,
+            NyxProviderSlug = registration.NyxProviderSlug,
+        };
+
+        foreach (var pair in inbound.Extra)
+            inboundEvent.Extra[pair.Key] = pair.Value;
+
+        return inboundEvent;
+    }
 
     private static EventEnvelope BuildTopologyEnvelope(
         string publisherActorId,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
@@ -60,7 +60,7 @@ public sealed class FeishuCardHumanInteractionPortTests
         using var card = JsonDocument.Parse(body.RootElement.GetProperty("content").GetString()!);
         card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("orange");
-        var formElement = card.RootElement.GetProperty("elements")[1];
+        var formElement = card.RootElement.GetProperty("body").GetProperty("elements")[1];
         formElement.GetProperty("tag").GetString().Should().Be("form");
         var editedContentInput = formElement.GetProperty("elements")[0];
         editedContentInput.GetProperty("name").GetString().Should().Be("edited_content");
@@ -161,7 +161,7 @@ public sealed class FeishuCardHumanInteractionPortTests
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("green");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Approval Recorded");
-        card.RootElement.GetProperty("elements")[0].GetProperty("content").GetString()
+        card.RootElement.GetProperty("body").GetProperty("elements")[0].GetProperty("content").GetString()
             .Should().Contain("posted below");
 
         using var textBody = JsonDocument.Parse(handler.Bodies[1]);
@@ -213,10 +213,10 @@ public sealed class FeishuCardHumanInteractionPortTests
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("red");
         card.RootElement.GetProperty("header").GetProperty("title").GetProperty("content").GetString()
             .Should().Be("Rejection Recorded");
-        card.RootElement.GetProperty("elements")[0].GetProperty("content").GetString()
+        card.RootElement.GetProperty("body").GetProperty("elements")[0].GetProperty("content").GetString()
             .Should().Contain("Need stronger hook");
 
-        var actionElement = card.RootElement.GetProperty("elements")[1];
+        var actionElement = card.RootElement.GetProperty("body").GetProperty("elements")[1];
         actionElement.GetProperty("tag").GetString().Should().Be("action");
         var rerun = actionElement.GetProperty("actions")[0];
         rerun.GetProperty("text").GetProperty("content").GetString().Should().Be("Run Again");
@@ -246,7 +246,7 @@ public sealed class FeishuCardHumanInteractionPortTests
         using var card = JsonDocument.Parse(json);
         card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
         card.RootElement.GetProperty("header").GetProperty("template").GetString().Should().Be("blue");
-        card.RootElement.GetProperty("elements").GetArrayLength().Should().Be(1);
+        card.RootElement.GetProperty("body").GetProperty("elements").GetArrayLength().Should().Be(1);
     }
 
     [Fact]
@@ -265,11 +265,11 @@ public sealed class FeishuCardHumanInteractionPortTests
 
         using var card = JsonDocument.Parse(json);
         card.RootElement.GetProperty("schema").GetString().Should().Be("2.0");
-        card.RootElement.GetProperty("elements").GetArrayLength().Should().Be(2);
-        card.RootElement.GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
-        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
+        card.RootElement.GetProperty("body").GetProperty("elements").GetArrayLength().Should().Be(2);
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("tag").GetString().Should().Be("form");
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("elements")[0].GetProperty("name").GetString()
             .Should().Be("edited_content");
-        card.RootElement.GetProperty("elements")[1].GetProperty("elements")[1].GetProperty("name").GetString()
+        card.RootElement.GetProperty("body").GetProperty("elements")[1].GetProperty("elements")[1].GetProperty("name").GetString()
             .Should().Be("user_input");
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkPlatformAdapterTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Net;
 using System.Net.Http;
 using Aevatar.GAgents.ChannelRuntime.Adapters;
+using Aevatar.Foundation.Abstractions.HumanInteraction;
 using Aevatar.AI.ToolProviders.NyxId;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
@@ -251,6 +252,66 @@ public class LarkPlatformAdapterTests
         inbound.Extra.Should().Contain(new KeyValuePair<string, string>("step_id", "approval-1"));
         inbound.Extra.Should().Contain(new KeyValuePair<string, string>("approved", "True"));
         inbound.Extra.Should().Contain(new KeyValuePair<string, string>("user_input", "Looks good"));
+    }
+
+    [Fact]
+    public async Task ParseInbound_extracts_resume_command_from_rendered_approval_form_submit()
+    {
+        var cardJson = FeishuCardHumanInteractionPort.BuildCardJson(new HumanInteractionRequest
+        {
+            ActorId = "workflow-actor-1",
+            RunId = "run-1",
+            StepId = "approval-1",
+            SuspensionType = "human_approval",
+            Prompt = "Need approval",
+            Content = "Please confirm the publication.",
+            Options = ["approve", "reject"],
+        });
+
+        using var card = JsonDocument.Parse(cardJson);
+        var formElement = card.RootElement.GetProperty("body").GetProperty("elements")[1];
+        var approveActionValue = formElement.GetProperty("elements")[2].GetProperty("actions")[0].GetProperty("value").Clone();
+
+        var payload = new
+        {
+            schema = "2.0",
+            header = new { event_type = "card.action.trigger", token = "verify-token", event_id = "evt_card_submit_1" },
+            @event = new
+            {
+                @operator = new
+                {
+                    open_id = "ou_operator_1",
+                },
+                context = new
+                {
+                    open_chat_id = "oc_chat_card_1",
+                    open_message_id = "om_card_msg_1",
+                },
+                action = new
+                {
+                    value = approveActionValue,
+                    form_value = new
+                    {
+                        edited_content = "Updated final draft",
+                        user_input = "Looks good",
+                    },
+                },
+            },
+        };
+
+        var http = CreateHttpContext(payload);
+        var inbound = await _adapter.ParseInboundAsync(http, MakeRegistration());
+
+        inbound.Should().NotBeNull();
+        ChannelCardActionRouting.TryBuildWorkflowResumeCommand(inbound!, out var command).Should().BeTrue();
+        command.Should().NotBeNull();
+        command!.ActorId.Should().Be("workflow-actor-1");
+        command.RunId.Should().Be("run-1");
+        command.StepId.Should().Be("approval-1");
+        command.Approved.Should().BeTrue();
+        command.UserInput.Should().Be("Updated final draft");
+        command.EditedContent.Should().Be("Updated final draft");
+        command.Feedback.Should().Be("Looks good");
     }
 
     [Fact]


### PR DESCRIPTION
## What changed
- moved the Day One builder cards and the Feishu approval cards from root-level `elements` to `body.elements` for Lark schema `2.0`
- updated the rendered-card tests and submit-event helpers to read the new schema `2.0` structure
- aligned the Lark adapter coverage test that reconstructs a submit event from the rendered approval form

## Why this changed
PR #283 fixed the form-submit flow, but live diagnostics on April 21, 2026 showed Lark still rejecting the `/daily-report` card with:

`lark_code=230099 ... parse card json err ... unknown property, property: elements, path:`

That means the follow-up issue was not command routing. The bot was matching `/daily-report`, but Lark rejected the schema `2.0` payload because the card body was still shaped incorrectly.

## Impact
- `/daily-report` can render again after deploy instead of failing at outbound card creation
- `/templates -> Create Daily Report` and other card-entry paths can reuse the corrected schema `2.0` layout
- approval-card rendering stays consistent with the same Lark card structure

## Validation
- `dotnet build test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter "FullyQualifiedName~LarkPlatformAdapterTests.ParseInbound_extracts_resume_command_from_rendered_approval_form_submit|FullyQualifiedName~ChannelUserGAgentContinuationTests|FullyQualifiedName~FeishuCardHumanInteractionPortTests"`

## Notes
- this is a follow-up PR after merged PR #283
- the live failure was confirmed via `https://aevatar-console-backend-api.aevatar.ai/api/channels/diagnostics/errors` before the fix