### PR TITLE
Add bind contract endpoints for Studio Bind

### DIFF
--- a/apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.test.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.test.ts
@@ -189,6 +189,62 @@ describe("scopeRuntimeApi", () => {
     expect(input).toBe("/api/scopes/scope-a/services/default/revisions");
   });
 
+  it("loads endpoint invoke contract details for Bind surfaces", async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        scopeId: "scope-a",
+        serviceId: "default",
+        endpointId: "chat",
+        invokePath: "/api/scopes/scope-a/services/default/invoke/chat:stream",
+        method: "POST",
+        requestContentType: "application/json",
+        responseContentType: "text/event-stream",
+        requestTypeUrl: "type.googleapis.com/Aevatar.AI.Abstractions.ChatRequestEvent",
+        responseTypeUrl: "type.googleapis.com/Aevatar.AI.Abstractions.ChatResponseEvent",
+        supportsSse: true,
+        supportsWebSocket: false,
+        supportsAguiFrames: false,
+        streamFrameFormat: "workflow-run-event",
+        smokeTestSupported: true,
+        defaultSmokeInputMode: "prompt",
+        defaultSmokePrompt: "Hello from Studio Bind.",
+        sampleRequestJson: null,
+        deploymentStatus: "Active",
+        revisionId: "rev-chat",
+        curlExample: "curl -N ...",
+        fetchExample: "const response = await fetch(...)",
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      scopeRuntimeApi.getServiceEndpointContract("scope-a", "default", "chat"),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        endpointId: "chat",
+        invokePath: "/api/scopes/scope-a/services/default/invoke/chat:stream",
+        supportsSse: true,
+        supportsAguiFrames: false,
+        defaultSmokeInputMode: "prompt",
+        defaultSmokePrompt: "Hello from Studio Bind.",
+        revisionId: "rev-chat",
+      }),
+    );
+
+    const [input, init] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit | undefined,
+    ];
+    expect(input).toBe(
+      "/api/scopes/scope-a/services/default/endpoints/chat/contract",
+    );
+    expect(new Headers(init?.headers).get("Authorization")).toBe(
+      "Bearer access-token",
+    );
+  });
+
   it("loads run audit for a scope-scoped service run", async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,

--- a/apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.ts
+++ b/apps/aevatar-console-web/src/shared/api/scopeRuntimeApi.ts
@@ -13,6 +13,7 @@ import {
 import type {
   ScopeServiceBindingCatalogSnapshot,
   ScopeServiceBindingInput,
+  ScopeServiceEndpointContract,
   ScopeServiceRevisionActionResult,
   ScopeServiceRevisionCatalogSnapshot,
   ScopeServiceRunAuditReport,
@@ -551,6 +552,112 @@ function decodeScopeServiceRevisionActionResult(
       `${label}.revisionId`,
     ),
     status: readString(record, ["status", "Status"], `${label}.status`),
+  };
+}
+
+function decodeScopeServiceEndpointContract(
+  value: unknown,
+  label = "ScopeServiceEndpointContract",
+): ScopeServiceEndpointContract {
+  const record = expectRecord(value, label);
+  return {
+    scopeId: readString(record, ["scopeId", "ScopeId"], `${label}.scopeId`),
+    serviceId: readString(
+      record,
+      ["serviceId", "ServiceId"],
+      `${label}.serviceId`,
+    ),
+    endpointId: readString(
+      record,
+      ["endpointId", "EndpointId"],
+      `${label}.endpointId`,
+    ),
+    invokePath: readString(
+      record,
+      ["invokePath", "InvokePath"],
+      `${label}.invokePath`,
+    ),
+    method: readString(record, ["method", "Method"], `${label}.method`),
+    requestContentType: readString(
+      record,
+      ["requestContentType", "RequestContentType"],
+      `${label}.requestContentType`,
+    ),
+    responseContentType: readString(
+      record,
+      ["responseContentType", "ResponseContentType"],
+      `${label}.responseContentType`,
+    ),
+    requestTypeUrl: readString(
+      record,
+      ["requestTypeUrl", "RequestTypeUrl"],
+      `${label}.requestTypeUrl`,
+    ),
+    responseTypeUrl: readString(
+      record,
+      ["responseTypeUrl", "ResponseTypeUrl"],
+      `${label}.responseTypeUrl`,
+    ),
+    supportsSse: readBoolean(
+      record,
+      ["supportsSse", "SupportsSse"],
+      `${label}.supportsSse`,
+    ),
+    supportsWebSocket: readBoolean(
+      record,
+      ["supportsWebSocket", "SupportsWebSocket"],
+      `${label}.supportsWebSocket`,
+    ),
+    supportsAguiFrames: readBoolean(
+      record,
+      ["supportsAguiFrames", "SupportsAguiFrames"],
+      `${label}.supportsAguiFrames`,
+    ),
+    streamFrameFormat: readNullableString(
+      record,
+      ["streamFrameFormat", "StreamFrameFormat"],
+      `${label}.streamFrameFormat`,
+    ),
+    smokeTestSupported: readBoolean(
+      record,
+      ["smokeTestSupported", "SmokeTestSupported"],
+      `${label}.smokeTestSupported`,
+    ),
+    defaultSmokeInputMode: readString(
+      record,
+      ["defaultSmokeInputMode", "DefaultSmokeInputMode"],
+      `${label}.defaultSmokeInputMode`,
+    ) as ScopeServiceEndpointContract["defaultSmokeInputMode"],
+    defaultSmokePrompt: readNullableString(
+      record,
+      ["defaultSmokePrompt", "DefaultSmokePrompt"],
+      `${label}.defaultSmokePrompt`,
+    ),
+    sampleRequestJson: readNullableString(
+      record,
+      ["sampleRequestJson", "SampleRequestJson"],
+      `${label}.sampleRequestJson`,
+    ),
+    deploymentStatus: readString(
+      record,
+      ["deploymentStatus", "DeploymentStatus"],
+      `${label}.deploymentStatus`,
+    ),
+    revisionId: readString(
+      record,
+      ["revisionId", "RevisionId"],
+      `${label}.revisionId`,
+    ),
+    curlExample: readNullableString(
+      record,
+      ["curlExample", "CurlExample"],
+      `${label}.curlExample`,
+    ),
+    fetchExample: readNullableString(
+      record,
+      ["fetchExample", "FetchExample"],
+      `${label}.fetchExample`,
+    ),
   };
 }
 
@@ -1116,6 +1223,17 @@ export const scopeRuntimeApi = {
     return requestJson(
       `/api/scopes/${encodeURIComponent(scopeId)}/services/${encodeURIComponent(serviceId)}/revisions/${encodeURIComponent(revisionId)}`,
       decodeScopeServiceRevision,
+    );
+  },
+
+  getServiceEndpointContract(
+    scopeId: string,
+    serviceId: string,
+    endpointId: string,
+  ): Promise<ScopeServiceEndpointContract> {
+    return requestJson(
+      `/api/scopes/${encodeURIComponent(scopeId)}/services/${encodeURIComponent(serviceId)}/endpoints/${encodeURIComponent(endpointId)}/contract`,
+      decodeScopeServiceEndpointContract,
     );
   },
 

--- a/apps/aevatar-console-web/src/shared/models/runtime/scopeServices.ts
+++ b/apps/aevatar-console-web/src/shared/models/runtime/scopeServices.ts
@@ -42,6 +42,30 @@ export interface ScopeServiceRevisionActionResult {
   readonly status: string;
 }
 
+export interface ScopeServiceEndpointContract {
+  readonly scopeId: string;
+  readonly serviceId: string;
+  readonly endpointId: string;
+  readonly invokePath: string;
+  readonly method: string;
+  readonly requestContentType: string;
+  readonly responseContentType: string;
+  readonly requestTypeUrl: string;
+  readonly responseTypeUrl: string;
+  readonly supportsSse: boolean;
+  readonly supportsWebSocket: boolean;
+  readonly supportsAguiFrames: boolean;
+  readonly streamFrameFormat: string | null;
+  readonly smokeTestSupported: boolean;
+  readonly defaultSmokeInputMode: "prompt" | "typed-payload";
+  readonly defaultSmokePrompt: string | null;
+  readonly sampleRequestJson: string | null;
+  readonly deploymentStatus: string;
+  readonly revisionId: string;
+  readonly curlExample: string | null;
+  readonly fetchExample: string | null;
+}
+
 export interface ScopeServiceRunSummary {
   readonly scopeId: string;
   readonly serviceId: string;

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -55,6 +55,8 @@ export interface StudioAuthSession {
   readonly providerDisplayName?: string;
   readonly loginUrl?: string;
   readonly logoutUrl?: string;
+  readonly invokeAuthMode?: "studio-session" | "bearer-token" | "anonymous";
+  readonly externalCallerHint?: string;
   readonly name?: string;
   readonly email?: string;
   readonly picture?: string;

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
@@ -229,13 +229,6 @@ internal static class StudioEndpoints
             return "NyxID";
         }
 
-        var configuredAuthority = configuration?[$"{AuthenticationSectionName}:Authority"];
-        if (!string.IsNullOrWhiteSpace(configuredAuthority) &&
-            configuredAuthority.Contains("nyx", StringComparison.OrdinalIgnoreCase))
-        {
-            return "NyxID";
-        }
-
         if (schemeProvider == null)
             return null;
 

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Scripts.Contracts;
 using Aevatar.Studio.Application.Studio;
@@ -23,6 +24,8 @@ namespace Aevatar.Studio.Hosting.Endpoints;
 
 internal static class StudioEndpoints
 {
+    private const string AuthenticationSectionName = "Aevatar:Authentication";
+
     public static void Map(IEndpointRouteBuilder app, bool embeddedWorkflowMode)
     {
         app.MapGet("/api/auth/me", HandleGetAuthMeAsync)
@@ -182,17 +185,106 @@ internal static class StudioEndpoints
         var scopeResolver = http.RequestServices.GetService<IAppScopeResolver>();
         var scope = scopeResolver?.Resolve(http);
         var schemeProvider = http.RequestServices.GetService<IAuthenticationSchemeProvider>();
+        var configuration = http.RequestServices.GetService<IConfiguration>();
         var authEnabled = schemeProvider != null &&
                           (await schemeProvider.GetAllSchemesAsync())
                           .Any(static scheme => !string.IsNullOrWhiteSpace(scheme.Name));
+        var providerDisplayName = await ResolveAuthProviderDisplayNameAsync(configuration, schemeProvider);
+        var loginUrl = authEnabled
+            ? AppApiErrors.BuildLoginUrl("/")
+            : null;
+        var logoutUrl = authEnabled
+            ? BuildLogoutUrl("/")
+            : null;
+        var invokeAuthMode = ResolveInvokeAuthMode(authEnabled, isAuthenticated);
+        var externalCallerHint = BuildExternalCallerHint(
+            providerDisplayName,
+            authEnabled,
+            invokeAuthMode);
 
         return new AppAuthMeResponse(
             Enabled: authEnabled,
             Authenticated: isAuthenticated,
+            ProviderDisplayName: providerDisplayName,
+            LoginUrl: loginUrl,
+            LogoutUrl: logoutUrl,
             Name: user?.Identity?.Name,
             Email: user?.FindFirst("email")?.Value,
+            InvokeAuthMode: invokeAuthMode,
+            ExternalCallerHint: externalCallerHint,
             ScopeId: scope?.ScopeId,
             ScopeSource: scope?.Source);
+    }
+
+    private static async Task<string?> ResolveAuthProviderDisplayNameAsync(
+        IConfiguration? configuration,
+        IAuthenticationSchemeProvider? schemeProvider)
+    {
+        var nyxIdAuthority = configuration?["Cli:App:NyxId:Authority"]
+            ?? configuration?["Aevatar:NyxId:Authority"]
+            ?? configuration?[$"{AuthenticationSectionName}:Authority"];
+        if (!string.IsNullOrWhiteSpace(nyxIdAuthority) &&
+            nyxIdAuthority.Contains("nyx", StringComparison.OrdinalIgnoreCase))
+        {
+            return "NyxID";
+        }
+
+        var configuredAuthority = configuration?[$"{AuthenticationSectionName}:Authority"];
+        if (!string.IsNullOrWhiteSpace(configuredAuthority) &&
+            configuredAuthority.Contains("nyx", StringComparison.OrdinalIgnoreCase))
+        {
+            return "NyxID";
+        }
+
+        if (schemeProvider == null)
+            return null;
+
+        var scheme = (await schemeProvider.GetAllSchemesAsync())
+            .FirstOrDefault(static item => !string.IsNullOrWhiteSpace(item.DisplayName) || !string.IsNullOrWhiteSpace(item.Name));
+        if (scheme == null)
+            return null;
+
+        var displayName = string.IsNullOrWhiteSpace(scheme.DisplayName)
+            ? scheme.Name
+            : scheme.DisplayName;
+        return string.IsNullOrWhiteSpace(displayName) ? null : displayName.Trim();
+    }
+
+    private static string BuildLogoutUrl(string returnUrl)
+    {
+        var normalizedReturnUrl = string.IsNullOrWhiteSpace(returnUrl)
+            ? "/"
+            : returnUrl.Trim();
+        return $"/auth/logout?returnUrl={Uri.EscapeDataString(normalizedReturnUrl)}";
+    }
+
+    private static string ResolveInvokeAuthMode(bool authEnabled, bool isAuthenticated) =>
+        !authEnabled
+            ? "anonymous"
+            : isAuthenticated
+                ? "studio-session"
+                : "bearer-token";
+
+    private static string? BuildExternalCallerHint(
+        string? providerDisplayName,
+        bool authEnabled,
+        string invokeAuthMode)
+    {
+        if (!authEnabled)
+            return "Invoke requests are accepted without authentication.";
+
+        var providerLabel = string.IsNullOrWhiteSpace(providerDisplayName)
+            ? "the configured identity provider"
+            : providerDisplayName.Trim();
+        return invokeAuthMode switch
+        {
+            "studio-session" =>
+                $"Studio invoke uses your current {providerLabel} session. External callers should send Authorization: Bearer <token> from the same provider.",
+            "bearer-token" =>
+                $"Sign in with {providerLabel} to establish a Studio session, or call the invoke endpoints directly with Authorization: Bearer <token>.",
+            _ =>
+                $"Use {providerLabel} credentials when the invoke endpoints require authentication.",
+        };
     }
 
     private static async Task<IResult> HandleGetHealthAsync(
@@ -1137,8 +1229,13 @@ internal static class StudioEndpoints
 public sealed record AppAuthMeResponse(
     bool Enabled,
     bool Authenticated,
+    string? ProviderDisplayName,
+    string? LoginUrl,
+    string? LogoutUrl,
     string? Name,
     string? Email,
+    string? InvokeAuthMode,
+    string? ExternalCallerHint,
     string? ScopeId,
     string? ScopeSource);
 

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioEndpoints.cs
@@ -186,10 +186,11 @@ internal static class StudioEndpoints
         var scope = scopeResolver?.Resolve(http);
         var schemeProvider = http.RequestServices.GetService<IAuthenticationSchemeProvider>();
         var configuration = http.RequestServices.GetService<IConfiguration>();
-        var authEnabled = schemeProvider != null &&
-                          (await schemeProvider.GetAllSchemesAsync())
-                          .Any(static scheme => !string.IsNullOrWhiteSpace(scheme.Name));
-        var providerDisplayName = await ResolveAuthProviderDisplayNameAsync(configuration, schemeProvider);
+        var schemes = schemeProvider == null
+            ? Array.Empty<AuthenticationScheme>()
+            : (await schemeProvider.GetAllSchemesAsync()).ToArray();
+        var authEnabled = schemes.Any(static scheme => !string.IsNullOrWhiteSpace(scheme.Name));
+        var providerDisplayName = ResolveAuthProviderDisplayName(configuration, schemes);
         var loginUrl = authEnabled
             ? AppApiErrors.BuildLoginUrl("/")
             : null;
@@ -216,9 +217,9 @@ internal static class StudioEndpoints
             ScopeSource: scope?.Source);
     }
 
-    private static async Task<string?> ResolveAuthProviderDisplayNameAsync(
+    private static string? ResolveAuthProviderDisplayName(
         IConfiguration? configuration,
-        IAuthenticationSchemeProvider? schemeProvider)
+        IReadOnlyList<AuthenticationScheme> schemes)
     {
         var nyxIdAuthority = configuration?["Cli:App:NyxId:Authority"]
             ?? configuration?["Aevatar:NyxId:Authority"]
@@ -229,10 +230,10 @@ internal static class StudioEndpoints
             return "NyxID";
         }
 
-        if (schemeProvider == null)
+        if (schemes.Count == 0)
             return null;
 
-        var scheme = (await schemeProvider.GetAllSchemesAsync())
+        var scheme = schemes
             .FirstOrDefault(static item => !string.IsNullOrWhiteSpace(item.DisplayName) || !string.IsNullOrWhiteSpace(item.Name));
         if (scheme == null)
             return null;

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -27,11 +27,18 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System.Text.Json;
 
 namespace Aevatar.GAgentService.Hosting.Endpoints;
 
 public static class ScopeServiceEndpoints
 {
+    private const string DefaultScopeServiceSmokePrompt = "Hello from Studio Bind.";
+    private static readonly JsonSerializerOptions PrettyJsonSerializerOptions = new()
+    {
+        WriteIndented = true,
+    };
+
     public static IEndpointRouteBuilder MapScopeServiceEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/scopes").WithTags("ScopeServices").RequireAuthorization();
@@ -65,6 +72,7 @@ public static class ScopeServiceEndpoints
         group.MapPut("/{scopeId}/services/{serviceId}/bindings/{bindingId}", HandleUpdateBindingAsync);
         group.MapPost("/{scopeId}/services/{serviceId}/bindings/{bindingId}:retire", HandleRetireBindingAsync);
         group.MapGet("/{scopeId}/services/{serviceId}/bindings", HandleGetBindingsAsync);
+        group.MapGet("/{scopeId}/services/{serviceId}/endpoints/{endpointId}/contract", HandleGetEndpointContractAsync);
         return app;
     }
 
@@ -1466,6 +1474,43 @@ public static class ScopeServiceEndpoints
         return snapshot == null ? Results.NotFound() : Results.Ok(snapshot);
     }
 
+    private static async Task<IResult> HandleGetEndpointContractAsync(
+        HttpContext http,
+        string scopeId,
+        string serviceId,
+        string endpointId,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        var resolution = await ResolveScopeServiceAsync(
+            http,
+            scopeId,
+            serviceId,
+            lifecycleQueryPort,
+            options.Value,
+            ct);
+        if (resolution.Failure != null)
+            return resolution.Failure;
+
+        var revisions = await lifecycleQueryPort.GetServiceRevisionsAsync(resolution.Identity!, ct);
+        var contract = BuildScopeServiceEndpointContractResponse(
+            scopeId,
+            serviceId,
+            endpointId,
+            resolution.Service!,
+            revisions);
+        if (contract != null)
+            return Results.Ok(contract);
+
+        var normalizedEndpointId = NormalizeOptional(endpointId) ?? endpointId?.Trim() ?? string.Empty;
+        return Results.NotFound(new
+        {
+            code = "SCOPE_SERVICE_ENDPOINT_CONTRACT_NOT_FOUND",
+            message = $"Endpoint '{normalizedEndpointId}' was not found on service '{serviceId}' in scope '{scopeId}'.",
+        });
+    }
+
     private static async Task<ScopeServiceResolution> ResolveScopeServiceAsync(
         HttpContext http,
         string scopeId,
@@ -1602,6 +1647,205 @@ public static class ScopeServiceEndpoints
             revisions?.LastEventId ?? string.Empty,
             revisions?.UpdatedAt ?? service.UpdatedAt,
             BuildScopeRevisionResponses(service, revisions, servingSet));
+    }
+
+    private static ScopeServiceEndpointContractHttpResponse? BuildScopeServiceEndpointContractResponse(
+        string scopeId,
+        string serviceId,
+        string endpointId,
+        ServiceCatalogSnapshot service,
+        ServiceRevisionCatalogSnapshot? revisions)
+    {
+        var normalizedEndpointId = ScopeWorkflowCapabilityOptions.NormalizeRequired(endpointId, nameof(endpointId));
+        var currentRevision = ResolveCurrentContractRevision(service, revisions, normalizedEndpointId);
+        var endpoint = currentRevision?.Endpoints.FirstOrDefault(x =>
+                string.Equals(x.EndpointId, normalizedEndpointId, StringComparison.Ordinal))
+            ?? service.Endpoints.FirstOrDefault(x =>
+                string.Equals(x.EndpointId, normalizedEndpointId, StringComparison.Ordinal));
+        if (endpoint == null)
+            return null;
+
+        var implementationKind = NormalizeOptional(currentRevision?.ImplementationKind) ?? string.Empty;
+        var supportsSse = IsChatEndpoint(endpoint.Kind);
+        var supportsAguiFrames = supportsSse &&
+                                 !string.Equals(implementationKind, "workflow", StringComparison.OrdinalIgnoreCase);
+        var invokePath = supportsSse
+            ? BuildScopeServiceStreamInvokePath(scopeId, serviceId, normalizedEndpointId)
+            : BuildScopeServiceInvokePath(scopeId, serviceId, normalizedEndpointId);
+        var responseContentType = supportsSse
+            ? "text/event-stream"
+            : "application/json";
+        var defaultSmokeInputMode = supportsSse
+            ? "prompt"
+            : "typed-payload";
+        var defaultSmokePrompt = supportsSse
+            ? DefaultScopeServiceSmokePrompt
+            : null;
+        var sampleRequestJson = supportsSse
+            ? null
+            : BuildTypedInvokeRequestExampleBody(endpoint.RequestTypeUrl, prettyPrinted: true);
+        var smokeTestSupported = supportsSse || sampleRequestJson != null;
+
+        return new ScopeServiceEndpointContractHttpResponse(
+            ScopeId: scopeId,
+            ServiceId: serviceId,
+            EndpointId: normalizedEndpointId,
+            InvokePath: invokePath,
+            Method: "POST",
+            RequestContentType: "application/json",
+            ResponseContentType: responseContentType,
+            RequestTypeUrl: endpoint.RequestTypeUrl,
+            ResponseTypeUrl: endpoint.ResponseTypeUrl,
+            SupportsSse: supportsSse,
+            SupportsWebSocket: false,
+            SupportsAguiFrames: supportsAguiFrames,
+            StreamFrameFormat: supportsSse
+                ? supportsAguiFrames
+                    ? "agui"
+                    : "workflow-run-event"
+                : null,
+            SmokeTestSupported: smokeTestSupported,
+            DefaultSmokeInputMode: defaultSmokeInputMode,
+            DefaultSmokePrompt: defaultSmokePrompt,
+            SampleRequestJson: sampleRequestJson,
+            DeploymentStatus: service.DeploymentStatus,
+            RevisionId: currentRevision?.RevisionId
+                ?? NormalizeOptional(service.DefaultServingRevisionId)
+                ?? NormalizeOptional(service.ActiveServingRevisionId)
+                ?? string.Empty,
+            CurlExample: smokeTestSupported
+                ? BuildScopeServiceCurlExample(invokePath, supportsSse, endpoint.RequestTypeUrl)
+                : null,
+            FetchExample: smokeTestSupported
+                ? BuildScopeServiceFetchExample(invokePath, supportsSse, endpoint.RequestTypeUrl)
+                : null);
+    }
+
+    private static ServiceRevisionSnapshot? ResolveCurrentContractRevision(
+        ServiceCatalogSnapshot service,
+        ServiceRevisionCatalogSnapshot? revisions,
+        string endpointId)
+    {
+        if (revisions == null || revisions.Revisions.Count == 0)
+            return null;
+
+        var preferredRevisionId = NormalizeOptional(service.DefaultServingRevisionId)
+            ?? NormalizeOptional(service.ActiveServingRevisionId);
+        if (!string.IsNullOrWhiteSpace(preferredRevisionId))
+        {
+            var preferredRevision = revisions.Revisions.FirstOrDefault(x =>
+                string.Equals(x.RevisionId, preferredRevisionId, StringComparison.Ordinal));
+            if (preferredRevision != null)
+                return preferredRevision;
+        }
+
+        return revisions.Revisions.FirstOrDefault(x =>
+                   x.Endpoints.Any(endpoint => string.Equals(endpoint.EndpointId, endpointId, StringComparison.Ordinal)))
+               ?? revisions.Revisions[0];
+    }
+
+    private static bool IsChatEndpoint(string? endpointKind) =>
+        string.Equals(endpointKind?.Trim(), "chat", StringComparison.OrdinalIgnoreCase);
+
+    private static string BuildScopeServiceInvokePath(string scopeId, string serviceId, string endpointId) =>
+        $"/api/scopes/{Uri.EscapeDataString(scopeId)}/services/{Uri.EscapeDataString(serviceId)}/invoke/{Uri.EscapeDataString(endpointId)}";
+
+    private static string BuildScopeServiceStreamInvokePath(string scopeId, string serviceId, string endpointId) =>
+        $"{BuildScopeServiceInvokePath(scopeId, serviceId, endpointId)}:stream";
+
+    private static string? BuildTypedInvokeRequestExampleBody(string? requestTypeUrl, bool prettyPrinted)
+    {
+        var normalizedRequestTypeUrl = NormalizeOptional(requestTypeUrl);
+        if (normalizedRequestTypeUrl == null)
+            return null;
+
+        return JsonSerializer.Serialize(
+            new
+            {
+                payloadTypeUrl = normalizedRequestTypeUrl,
+                payloadBase64 = BuildBase64PayloadPlaceholder(normalizedRequestTypeUrl),
+            },
+            prettyPrinted ? PrettyJsonSerializerOptions : null);
+    }
+
+    private static string BuildBase64PayloadPlaceholder(string requestTypeUrl)
+    {
+        var typeName = requestTypeUrl
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault();
+        return string.IsNullOrWhiteSpace(typeName)
+            ? "<base64-encoded-protobuf-bytes>"
+            : $"<base64-encoded-{typeName}-protobuf-bytes>";
+    }
+
+    private static string BuildScopeServiceCurlExample(
+        string invokePath,
+        bool supportsSse,
+        string? requestTypeUrl)
+    {
+        if (supportsSse)
+        {
+            var requestBody = JsonSerializer.Serialize(
+                new { prompt = DefaultScopeServiceSmokePrompt });
+            return $"""
+curl -N -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -H "Authorization: Bearer <token>" \
+  "{invokePath}" \
+  -d '{requestBody}'
+""";
+        }
+
+        var typedBody = BuildTypedInvokeRequestExampleBody(requestTypeUrl, prettyPrinted: false) ?? "{}";
+        return $"""
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  "{invokePath}" \
+  -d '{typedBody}'
+""";
+    }
+
+    private static string BuildScopeServiceFetchExample(
+        string invokePath,
+        bool supportsSse,
+        string? requestTypeUrl)
+    {
+        if (supportsSse)
+        {
+            return $$"""
+const response = await fetch("{{invokePath}}", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Accept": "text/event-stream",
+    "Authorization": "Bearer <token>",
+  },
+  body: JSON.stringify({
+    prompt: "{{DefaultScopeServiceSmokePrompt}}",
+  }),
+});
+
+// Consume response.body as an SSE stream.
+""";
+        }
+
+        var normalizedRequestTypeUrl = NormalizeOptional(requestTypeUrl) ?? "<type-url>";
+        var payloadBase64 = BuildBase64PayloadPlaceholder(normalizedRequestTypeUrl);
+        return $$"""
+const response = await fetch("{{invokePath}}", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer <token>",
+  },
+  body: JSON.stringify({
+    payloadTypeUrl: "{{normalizedRequestTypeUrl}}",
+    payloadBase64: "{{payloadBase64}}",
+  }),
+});
+""";
     }
 
     private static IReadOnlyList<ScopeBindingRevisionHttpResponse> BuildScopeRevisionResponses(
@@ -2293,6 +2537,29 @@ public static class ScopeServiceEndpoints
         string ServiceId,
         string RevisionId,
         string Status);
+
+    public sealed record ScopeServiceEndpointContractHttpResponse(
+        string ScopeId,
+        string ServiceId,
+        string EndpointId,
+        string InvokePath,
+        string Method,
+        string RequestContentType,
+        string ResponseContentType,
+        string RequestTypeUrl,
+        string ResponseTypeUrl,
+        bool SupportsSse,
+        bool SupportsWebSocket,
+        bool SupportsAguiFrames,
+        string? StreamFrameFormat,
+        bool SmokeTestSupported,
+        string DefaultSmokeInputMode,
+        string? DefaultSmokePrompt,
+        string? SampleRequestJson,
+        string DeploymentStatus,
+        string RevisionId,
+        string? CurlExample = null,
+        string? FetchExample = null);
 
     public sealed record ScopeServiceRunCatalogHttpResponse(
         string ScopeId,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1697,6 +1697,7 @@ public static class ScopeServiceEndpoints
             RequestTypeUrl: endpoint.RequestTypeUrl,
             ResponseTypeUrl: endpoint.ResponseTypeUrl,
             SupportsSse: supportsSse,
+            // This contract currently exposes HTTP POST plus optional SSE streaming only.
             SupportsWebSocket: false,
             SupportsAguiFrames: supportsAguiFrames,
             StreamFrameFormat: supportsSse

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1483,6 +1483,15 @@ public static class ScopeServiceEndpoints
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
+        if (string.IsNullOrWhiteSpace(endpointId))
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_ENDPOINT_ID",
+                message = "endpointId is required.",
+            });
+        }
+
         var resolution = await ResolveScopeServiceAsync(
             http,
             scopeId,
@@ -1665,10 +1674,10 @@ public static class ScopeServiceEndpoints
         if (endpoint == null)
             return null;
 
-        var implementationKind = NormalizeOptional(currentRevision?.ImplementationKind) ?? string.Empty;
+        var implementationKind = NormalizeOptional(currentRevision?.ImplementationKind);
         var supportsSse = IsChatEndpoint(endpoint.Kind);
-        var supportsAguiFrames = supportsSse &&
-                                 !string.Equals(implementationKind, "workflow", StringComparison.OrdinalIgnoreCase);
+        var streamFrameFormat = ResolveScopeServiceStreamFrameFormat(supportsSse, implementationKind);
+        var supportsAguiFrames = string.Equals(streamFrameFormat, "agui", StringComparison.Ordinal);
         var invokePath = supportsSse
             ? BuildScopeServiceStreamInvokePath(scopeId, serviceId, normalizedEndpointId)
             : BuildScopeServiceInvokePath(scopeId, serviceId, normalizedEndpointId);
@@ -1700,11 +1709,7 @@ public static class ScopeServiceEndpoints
             // This contract currently exposes HTTP POST plus optional SSE streaming only.
             SupportsWebSocket: false,
             SupportsAguiFrames: supportsAguiFrames,
-            StreamFrameFormat: supportsSse
-                ? supportsAguiFrames
-                    ? "agui"
-                    : "workflow-run-event"
-                : null,
+            StreamFrameFormat: streamFrameFormat,
             SmokeTestSupported: smokeTestSupported,
             DefaultSmokeInputMode: defaultSmokeInputMode,
             DefaultSmokePrompt: defaultSmokePrompt,
@@ -1720,6 +1725,23 @@ public static class ScopeServiceEndpoints
             FetchExample: smokeTestSupported
                 ? BuildScopeServiceFetchExample(invokePath, supportsSse, endpoint.RequestTypeUrl)
                 : null);
+    }
+
+    private static string? ResolveScopeServiceStreamFrameFormat(bool supportsSse, string? implementationKind)
+    {
+        if (!supportsSse)
+            return null;
+
+        if (string.Equals(implementationKind, ServiceImplementationKind.Workflow.ToString(), StringComparison.OrdinalIgnoreCase))
+            return "workflow-run-event";
+
+        if (string.Equals(implementationKind, ServiceImplementationKind.Static.ToString(), StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(implementationKind, ServiceImplementationKind.Scripting.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return "agui";
+        }
+
+        return null;
     }
 
     private static ServiceRevisionSnapshot? ResolveCurrentContractRevision(

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -34,6 +34,8 @@ namespace Aevatar.GAgentService.Hosting.Endpoints;
 public static class ScopeServiceEndpoints
 {
     private const string DefaultScopeServiceSmokePrompt = "Hello from Studio Bind.";
+    private const string StreamFrameFormatWorkflow = "workflow-run-event";
+    private const string StreamFrameFormatAgui = "agui";
     private static readonly JsonSerializerOptions PrettyJsonSerializerOptions = new()
     {
         WriteIndented = true,
@@ -1479,6 +1481,7 @@ public static class ScopeServiceEndpoints
         string scopeId,
         string serviceId,
         string endpointId,
+        string? appId,
         [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
@@ -1498,7 +1501,8 @@ public static class ScopeServiceEndpoints
             serviceId,
             lifecycleQueryPort,
             options.Value,
-            ct);
+            ct,
+            appId);
         if (resolution.Failure != null)
             return resolution.Failure;
 
@@ -1512,7 +1516,7 @@ public static class ScopeServiceEndpoints
         if (contract != null)
             return Results.Ok(contract);
 
-        var normalizedEndpointId = NormalizeOptional(endpointId) ?? endpointId?.Trim() ?? string.Empty;
+        var normalizedEndpointId = NormalizeOptional(endpointId) ?? endpointId.Trim();
         return Results.NotFound(new
         {
             code = "SCOPE_SERVICE_ENDPOINT_CONTRACT_NOT_FOUND",
@@ -1677,7 +1681,7 @@ public static class ScopeServiceEndpoints
         var implementationKind = NormalizeOptional(currentRevision?.ImplementationKind);
         var supportsSse = IsChatEndpoint(endpoint.Kind);
         var streamFrameFormat = ResolveScopeServiceStreamFrameFormat(supportsSse, implementationKind);
-        var supportsAguiFrames = string.Equals(streamFrameFormat, "agui", StringComparison.Ordinal);
+        var supportsAguiFrames = string.Equals(streamFrameFormat, StreamFrameFormatAgui, StringComparison.Ordinal);
         var invokePath = supportsSse
             ? BuildScopeServiceStreamInvokePath(scopeId, serviceId, normalizedEndpointId)
             : BuildScopeServiceInvokePath(scopeId, serviceId, normalizedEndpointId);
@@ -1733,12 +1737,12 @@ public static class ScopeServiceEndpoints
             return null;
 
         if (string.Equals(implementationKind, ServiceImplementationKind.Workflow.ToString(), StringComparison.OrdinalIgnoreCase))
-            return "workflow-run-event";
+            return StreamFrameFormatWorkflow;
 
         if (string.Equals(implementationKind, ServiceImplementationKind.Static.ToString(), StringComparison.OrdinalIgnoreCase) ||
             string.Equals(implementationKind, ServiceImplementationKind.Scripting.ToString(), StringComparison.OrdinalIgnoreCase))
         {
-            return "agui";
+            return StreamFrameFormatAgui;
         }
 
         return null;
@@ -1752,20 +1756,36 @@ public static class ScopeServiceEndpoints
         if (revisions == null || revisions.Revisions.Count == 0)
             return null;
 
-        var preferredRevisionId = NormalizeOptional(service.DefaultServingRevisionId)
-            ?? NormalizeOptional(service.ActiveServingRevisionId);
-        if (!string.IsNullOrWhiteSpace(preferredRevisionId))
+        foreach (var preferredRevisionId in EnumeratePreferredContractRevisionIds(service))
         {
             var preferredRevision = revisions.Revisions.FirstOrDefault(x =>
-                string.Equals(x.RevisionId, preferredRevisionId, StringComparison.Ordinal));
+                string.Equals(x.RevisionId, preferredRevisionId, StringComparison.Ordinal) &&
+                RevisionContainsEndpoint(x, endpointId));
             if (preferredRevision != null)
                 return preferredRevision;
         }
 
         return revisions.Revisions.FirstOrDefault(x =>
-                   x.Endpoints.Any(endpoint => string.Equals(endpoint.EndpointId, endpointId, StringComparison.Ordinal)))
+                   RevisionContainsEndpoint(x, endpointId))
                ?? revisions.Revisions[0];
     }
+
+    private static IEnumerable<string> EnumeratePreferredContractRevisionIds(ServiceCatalogSnapshot service)
+    {
+        var defaultRevisionId = NormalizeOptional(service.DefaultServingRevisionId);
+        if (!string.IsNullOrWhiteSpace(defaultRevisionId))
+            yield return defaultRevisionId;
+
+        var activeRevisionId = NormalizeOptional(service.ActiveServingRevisionId);
+        if (!string.IsNullOrWhiteSpace(activeRevisionId) &&
+            !string.Equals(activeRevisionId, defaultRevisionId, StringComparison.Ordinal))
+        {
+            yield return activeRevisionId;
+        }
+    }
+
+    private static bool RevisionContainsEndpoint(ServiceRevisionSnapshot revision, string endpointId) =>
+        revision.Endpoints.Any(endpoint => string.Equals(endpoint.EndpointId, endpointId, StringComparison.Ordinal));
 
     private static bool IsChatEndpoint(string? endpointKind) =>
         string.Equals(endpointKind?.Trim(), "chat", StringComparison.OrdinalIgnoreCase);

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -358,6 +358,147 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldReturnWorkflowChatStreamContract()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = new ServiceCatalogSnapshot(
+            "scope-a:default:default:default",
+            "scope-a",
+            "default",
+            "default",
+            "default",
+            "Orders App",
+            "rev-chat",
+            "rev-chat",
+            "dep-chat",
+            "workflow-actor-1",
+            "Active",
+            [
+                new ServiceEndpointSnapshot(
+                    "chat",
+                    "Chat",
+                    "chat",
+                    Any.Pack(new ChatRequestEvent()).TypeUrl,
+                    Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    "Chat entrypoint"),
+            ],
+            [],
+            DateTimeOffset.UtcNow);
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:default:default:default",
+            [
+                new ServiceRevisionSnapshot(
+                    "rev-chat",
+                    "workflow",
+                    "Published",
+                    "hash-chat",
+                    string.Empty,
+                    [
+                        new ServiceEndpointSnapshot(
+                            "chat",
+                            "Chat",
+                            "chat",
+                            Any.Pack(new ChatRequestEvent()).TypeUrl,
+                            Any.Pack(new ChatResponseEvent()).TypeUrl,
+                            "Chat entrypoint"),
+                    ],
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    DateTimeOffset.UtcNow.AddMinutes(-9),
+                    DateTimeOffset.UtcNow.AddMinutes(-8),
+                    null),
+            ],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.ScopeServiceEndpointContractHttpResponse>(
+            "/api/scopes/scope-a/services/default/endpoints/chat/contract");
+
+        response.Should().NotBeNull();
+        response!.InvokePath.Should().Be("/api/scopes/scope-a/services/default/invoke/chat:stream");
+        response.Method.Should().Be("POST");
+        response.RequestContentType.Should().Be("application/json");
+        response.ResponseContentType.Should().Be("text/event-stream");
+        response.SupportsSse.Should().BeTrue();
+        response.SupportsAguiFrames.Should().BeFalse();
+        response.StreamFrameFormat.Should().Be("workflow-run-event");
+        response.DefaultSmokeInputMode.Should().Be("prompt");
+        response.DefaultSmokePrompt.Should().Be("Hello from Studio Bind.");
+        response.SampleRequestJson.Should().BeNull();
+        response.RevisionId.Should().Be("rev-chat");
+        response.CurlExample.Should().Contain("Accept: text/event-stream");
+        response.FetchExample.Should().Contain("prompt");
+    }
+
+    [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldReturnTypedInvokeContractForCommandEndpoint()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = new ServiceCatalogSnapshot(
+            "scope-a:default:default:default",
+            "scope-a",
+            "default",
+            "default",
+            "default",
+            "Orders App",
+            "rev-cmd",
+            "rev-cmd",
+            "dep-cmd",
+            "gagent-actor-1",
+            "Active",
+            [
+                new ServiceEndpointSnapshot(
+                    "run",
+                    "Run",
+                    "command",
+                    Any.Pack(new StringValue()).TypeUrl,
+                    string.Empty,
+                    "Run command"),
+            ],
+            [],
+            DateTimeOffset.UtcNow);
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:default:default:default",
+            [
+                new ServiceRevisionSnapshot(
+                    "rev-cmd",
+                    "gagent",
+                    "Published",
+                    "hash-cmd",
+                    string.Empty,
+                    [
+                        new ServiceEndpointSnapshot(
+                            "run",
+                            "Run",
+                            "command",
+                            Any.Pack(new StringValue()).TypeUrl,
+                            string.Empty,
+                            "Run command"),
+                    ],
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    DateTimeOffset.UtcNow.AddMinutes(-9),
+                    DateTimeOffset.UtcNow.AddMinutes(-8),
+                    null),
+            ],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.ScopeServiceEndpointContractHttpResponse>(
+            "/api/scopes/scope-a/services/default/endpoints/run/contract");
+
+        response.Should().NotBeNull();
+        response!.InvokePath.Should().Be("/api/scopes/scope-a/services/default/invoke/run");
+        response.ResponseContentType.Should().Be("application/json");
+        response.SupportsSse.Should().BeFalse();
+        response.SupportsAguiFrames.Should().BeFalse();
+        response.StreamFrameFormat.Should().BeNull();
+        response.DefaultSmokeInputMode.Should().Be("typed-payload");
+        response.DefaultSmokePrompt.Should().BeNull();
+        response.SampleRequestJson.Should().Contain("payloadTypeUrl");
+        response.SampleRequestJson.Should().Contain("StringValue");
+        response.CurlExample.Should().Contain("payloadBase64");
+        response.FetchExample.Should().Contain("payloadTypeUrl");
+        response.RevisionId.Should().Be("rev-cmd");
+    }
+
+    [Fact]
     public async Task ActivateBindingRevisionEndpoint_ShouldPromoteHistoricalRevisionOnDefaultService()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -429,6 +429,67 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldReturnAguiStreamContractForStaticChatEndpoint()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = new ServiceCatalogSnapshot(
+            "scope-a:default:default:default",
+            "scope-a",
+            "default",
+            "default",
+            "default",
+            "Orders App",
+            "rev-chat",
+            "rev-chat",
+            "dep-chat",
+            "static-actor-1",
+            "Active",
+            [
+                new ServiceEndpointSnapshot(
+                    "chat",
+                    "Chat",
+                    "chat",
+                    Any.Pack(new ChatRequestEvent()).TypeUrl,
+                    Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    "Chat entrypoint"),
+            ],
+            [],
+            DateTimeOffset.UtcNow);
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:default:default:default",
+            [
+                new ServiceRevisionSnapshot(
+                    "rev-chat",
+                    ServiceImplementationKind.Static.ToString(),
+                    "Published",
+                    "hash-chat",
+                    string.Empty,
+                    [
+                        new ServiceEndpointSnapshot(
+                            "chat",
+                            "Chat",
+                            "chat",
+                            Any.Pack(new ChatRequestEvent()).TypeUrl,
+                            Any.Pack(new ChatResponseEvent()).TypeUrl,
+                            "Chat entrypoint"),
+                    ],
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    DateTimeOffset.UtcNow.AddMinutes(-9),
+                    DateTimeOffset.UtcNow.AddMinutes(-8),
+                    null),
+            ],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.ScopeServiceEndpointContractHttpResponse>(
+            "/api/scopes/scope-a/services/default/endpoints/chat/contract");
+
+        response.Should().NotBeNull();
+        response!.SupportsSse.Should().BeTrue();
+        response.SupportsAguiFrames.Should().BeTrue();
+        response.StreamFrameFormat.Should().Be("agui");
+    }
+
+    [Fact]
     public async Task GetEndpointContractEndpoint_ShouldReturnTypedInvokeContractForCommandEndpoint()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -460,7 +521,7 @@ public sealed class ScopeServiceEndpointsTests
             [
                 new ServiceRevisionSnapshot(
                     "rev-cmd",
-                    "gagent",
+                    ServiceImplementationKind.Static.ToString(),
                     "Published",
                     "hash-cmd",
                     string.Empty,
@@ -496,6 +557,20 @@ public sealed class ScopeServiceEndpointsTests
         response.CurlExample.Should().Contain("payloadBase64");
         response.FetchExample.Should().Contain("payloadTypeUrl");
         response.RevisionId.Should().Be("rev-cmd");
+    }
+
+    [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldReturnBadRequest_WhenEndpointIdIsBlank()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.GetAsync("/api/scopes/scope-a/services/default/endpoints/%20/contract");
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("INVALID_ENDPOINT_ID");
+        body["message"].Should().Be("endpointId is required.");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -429,6 +429,86 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldPreferServingRevisionThatContainsRequestedEndpoint()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = new ServiceCatalogSnapshot(
+            "scope-a:default:default:default",
+            "scope-a",
+            "default",
+            "default",
+            "default",
+            "Orders App",
+            "rev-default",
+            "rev-active",
+            "dep-chat",
+            "static-actor-1",
+            "Active",
+            [
+                new ServiceEndpointSnapshot(
+                    "chat",
+                    "Chat",
+                    "chat",
+                    Any.Pack(new ChatRequestEvent()).TypeUrl,
+                    Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    "Chat entrypoint"),
+            ],
+            [],
+            DateTimeOffset.UtcNow);
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:default:default:default",
+            [
+                new ServiceRevisionSnapshot(
+                    "rev-default",
+                    ServiceImplementationKind.Workflow.ToString(),
+                    "Published",
+                    "hash-default",
+                    string.Empty,
+                    [
+                        new ServiceEndpointSnapshot(
+                            "legacy",
+                            "Legacy",
+                            "chat",
+                            Any.Pack(new ChatRequestEvent()).TypeUrl,
+                            Any.Pack(new ChatResponseEvent()).TypeUrl,
+                            "Legacy endpoint"),
+                    ],
+                    DateTimeOffset.UtcNow.AddMinutes(-12),
+                    DateTimeOffset.UtcNow.AddMinutes(-11),
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    null),
+                new ServiceRevisionSnapshot(
+                    "rev-active",
+                    ServiceImplementationKind.Static.ToString(),
+                    "Published",
+                    "hash-active",
+                    string.Empty,
+                    [
+                        new ServiceEndpointSnapshot(
+                            "chat",
+                            "Chat",
+                            "chat",
+                            Any.Pack(new ChatRequestEvent()).TypeUrl,
+                            Any.Pack(new ChatResponseEvent()).TypeUrl,
+                            "Chat entrypoint"),
+                    ],
+                    DateTimeOffset.UtcNow.AddMinutes(-9),
+                    DateTimeOffset.UtcNow.AddMinutes(-8),
+                    DateTimeOffset.UtcNow.AddMinutes(-7),
+                    null),
+            ],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.ScopeServiceEndpointContractHttpResponse>(
+            "/api/scopes/scope-a/services/default/endpoints/chat/contract");
+
+        response.Should().NotBeNull();
+        response!.RevisionId.Should().Be("rev-active");
+        response.SupportsAguiFrames.Should().BeTrue();
+        response.StreamFrameFormat.Should().Be("agui");
+    }
+
+    [Fact]
     public async Task GetEndpointContractEndpoint_ShouldReturnAguiStreamContractForStaticChatEndpoint()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -571,6 +651,110 @@ public sealed class ScopeServiceEndpointsTests
         body.Should().NotBeNull();
         body!["code"].Should().Be("INVALID_ENDPOINT_ID");
         body["message"].Should().Be("endpointId is required.");
+    }
+
+    [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldForwardAppIdToLifecycleQueries()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = new ServiceCatalogSnapshot(
+            "scope-a:custom-app:default:orders",
+            "scope-a",
+            "custom-app",
+            "default",
+            "orders",
+            "Orders App",
+            "rev-run",
+            "rev-run",
+            "dep-run",
+            "actor-1",
+            "Active",
+            [
+                new ServiceEndpointSnapshot(
+                    "run",
+                    "Run",
+                    "command",
+                    Any.Pack(new StringValue()).TypeUrl,
+                    string.Empty,
+                    "Run command"),
+            ],
+            [],
+            DateTimeOffset.UtcNow);
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:custom-app:default:orders",
+            [
+                new ServiceRevisionSnapshot(
+                    "rev-run",
+                    ServiceImplementationKind.Static.ToString(),
+                    "Published",
+                    "hash-run",
+                    string.Empty,
+                    [
+                        new ServiceEndpointSnapshot(
+                            "run",
+                            "Run",
+                            "command",
+                            Any.Pack(new StringValue()).TypeUrl,
+                            string.Empty,
+                            "Run command"),
+                    ],
+                    DateTimeOffset.UtcNow.AddMinutes(-10),
+                    DateTimeOffset.UtcNow.AddMinutes(-9),
+                    DateTimeOffset.UtcNow.AddMinutes(-8),
+                    null),
+            ],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.ScopeServiceEndpointContractHttpResponse>(
+            "/api/scopes/scope-a/services/orders/endpoints/run/contract?appId=custom-app");
+
+        response.Should().NotBeNull();
+        host.LifecycleQueryPort.LastServiceIdentity.Should().NotBeNull();
+        host.LifecycleQueryPort.LastServiceIdentity!.AppId.Should().Be("custom-app");
+        host.LifecycleQueryPort.LastRevisionsIdentity.Should().NotBeNull();
+        host.LifecycleQueryPort.LastRevisionsIdentity!.AppId.Should().Be("custom-app");
+    }
+
+    [Fact]
+    public async Task GetEndpointContractEndpoint_ShouldReturnNotFound_WhenEndpointDoesNotExist()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = new ServiceCatalogSnapshot(
+            "scope-a:default:default:default",
+            "scope-a",
+            "default",
+            "default",
+            "default",
+            "Orders App",
+            "rev-chat",
+            "rev-chat",
+            "dep-chat",
+            "workflow-actor-1",
+            "Active",
+            [
+                new ServiceEndpointSnapshot(
+                    "chat",
+                    "Chat",
+                    "chat",
+                    Any.Pack(new ChatRequestEvent()).TypeUrl,
+                    Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    "Chat entrypoint"),
+            ],
+            [],
+            DateTimeOffset.UtcNow);
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:default:default:default",
+            [],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetAsync(
+            "/api/scopes/scope-a/services/default/endpoints/nonexistent/contract");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("SCOPE_SERVICE_ENDPOINT_CONTRACT_NOT_FOUND");
+        body["message"].Should().Contain("nonexistent");
     }
 
     [Fact]
@@ -3623,8 +3807,17 @@ public sealed class ScopeServiceEndpointsTests
 
         public ServiceDeploymentCatalogSnapshot? Deployments { get; set; }
 
-        public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult(Service);
+        public ServiceIdentity? LastServiceIdentity { get; private set; }
+
+        public ServiceIdentity? LastRevisionsIdentity { get; private set; }
+
+        public ServiceIdentity? LastDeploymentsIdentity { get; private set; }
+
+        public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            LastServiceIdentity = identity;
+            return Task.FromResult(Service);
+        }
 
         public Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
             string tenantId,
@@ -3634,11 +3827,17 @@ public sealed class ScopeServiceEndpointsTests
             CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult(Revisions);
+        public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            LastRevisionsIdentity = identity;
+            return Task.FromResult(Revisions);
+        }
 
-        public Task<ServiceDeploymentCatalogSnapshot?> GetServiceDeploymentsAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult(Deployments);
+        public Task<ServiceDeploymentCatalogSnapshot?> GetServiceDeploymentsAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            LastDeploymentsIdentity = identity;
+            return Task.FromResult(Deployments);
+        }
     }
 
     private sealed class RecordingServiceServingQueryPort : IServiceServingQueryPort

--- a/test/Aevatar.Tools.Cli.Tests/AppStudioAuthEndpointTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/AppStudioAuthEndpointTests.cs
@@ -46,6 +46,43 @@ public sealed class AppStudioAuthEndpointTests
         payload.ScopeSource.Should().Be("claim:scope_id");
     }
 
+    [Fact]
+    public async Task AuthMeEndpoint_ShouldReturnBearerTokenMode_WhenUnauthenticated()
+    {
+        await using var host = await StudioAuthTestHost.StartAsync(
+            authenticated: false,
+            resolvedScopeId: null);
+
+        var payload = await host.Client.GetFromJsonAsync<AppAuthMeResponse>("/api/auth/me");
+
+        payload.Should().NotBeNull();
+        payload!.Enabled.Should().BeTrue();
+        payload.Authenticated.Should().BeFalse();
+        payload.InvokeAuthMode.Should().Be("bearer-token");
+        payload.ExternalCallerHint.Should().Contain("Sign in with");
+        payload.LoginUrl.Should().Be("/auth/login?returnUrl=%2F");
+        payload.LogoutUrl.Should().Be("/auth/logout?returnUrl=%2F");
+    }
+
+    [Fact]
+    public async Task AuthMeEndpoint_ShouldReturnAnonymousMode_WhenAuthIsDisabled()
+    {
+        await using var host = await StudioAuthTestHost.StartAsync(
+            authenticated: false,
+            resolvedScopeId: null,
+            enableAuth: false);
+
+        var payload = await host.Client.GetFromJsonAsync<AppAuthMeResponse>("/api/auth/me");
+
+        payload.Should().NotBeNull();
+        payload!.Enabled.Should().BeFalse();
+        payload.Authenticated.Should().BeFalse();
+        payload.InvokeAuthMode.Should().Be("anonymous");
+        payload.ExternalCallerHint.Should().Contain("without authentication");
+        payload.LoginUrl.Should().BeNull();
+        payload.LogoutUrl.Should().BeNull();
+    }
+
     private sealed class StudioAuthTestHost : IAsyncDisposable
     {
         private readonly WebApplication _app;
@@ -60,19 +97,26 @@ public sealed class AppStudioAuthEndpointTests
 
         public static async Task<StudioAuthTestHost> StartAsync(
             bool authenticated,
-            string? resolvedScopeId)
+            string? resolvedScopeId,
+            bool enableAuth = true)
         {
             var builder = WebApplication.CreateBuilder(new WebApplicationOptions
             {
                 EnvironmentName = Environments.Development,
             });
             builder.WebHost.UseUrls("http://127.0.0.1:0");
-            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+
+            if (enableAuth)
             {
-                ["Aevatar:Authentication:Enabled"] = "true",
-                ["Aevatar:Authentication:Authority"] = "https://nyx.example.com",
-                ["Cli:App:NyxId:Authority"] = "https://nyx.example.com",
-            });
+                builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Aevatar:Authentication:Enabled"] = "true",
+                    ["Aevatar:Authentication:Authority"] = "https://nyx.example.com",
+                    ["Cli:App:NyxId:Authority"] = "https://nyx.example.com",
+                });
+                builder.Services.AddAuthentication("Test")
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+            }
 
             builder.Services.AddSingleton<IAppScopeResolver>(new StubAppScopeResolver(resolvedScopeId));
             builder.Services.AddSingleton(new AevatarHostMetadata
@@ -80,11 +124,10 @@ public sealed class AppStudioAuthEndpointTests
                 ServiceName = "test-studio-auth",
             });
             builder.Services.AddSingleton<AevatarHostHealthService>();
-            builder.Services.AddAuthentication("Test")
-                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
 
             var app = builder.Build();
-            app.UseAuthentication();
+            if (enableAuth)
+                app.UseAuthentication();
             app.Use(async (http, next) =>
             {
                 if (authenticated)

--- a/test/Aevatar.Tools.Cli.Tests/AppStudioAuthEndpointTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/AppStudioAuthEndpointTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using Aevatar.Hosting;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Hosting.Endpoints;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging;
+using System.Text.Encodings.Web;
+
+namespace Aevatar.Tools.Cli.Tests;
+
+public sealed class AppStudioAuthEndpointTests
+{
+    [Fact]
+    public async Task AuthMeEndpoint_ShouldExposeBindAuthContractFields()
+    {
+        await using var host = await StudioAuthTestHost.StartAsync(
+            authenticated: true,
+            resolvedScopeId: "scope-a");
+
+        var response = await host.Client.GetAsync("/api/auth/me");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        var payload = await response.Content.ReadFromJsonAsync<AppAuthMeResponse>();
+        payload.Should().NotBeNull();
+        payload!.Enabled.Should().BeTrue();
+        payload.Authenticated.Should().BeTrue();
+        payload.ProviderDisplayName.Should().Be("NyxID");
+        payload.LoginUrl.Should().Be("/auth/login?returnUrl=%2F");
+        payload.LogoutUrl.Should().Be("/auth/logout?returnUrl=%2F");
+        payload.InvokeAuthMode.Should().Be("studio-session");
+        payload.ExternalCallerHint.Should().Contain("Authorization: Bearer <token>");
+        payload.ScopeId.Should().Be("scope-a");
+        payload.ScopeSource.Should().Be("claim:scope_id");
+    }
+
+    private sealed class StudioAuthTestHost : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+
+        private StudioAuthTestHost(WebApplication app, HttpClient client)
+        {
+            _app = app;
+            Client = client;
+        }
+
+        public HttpClient Client { get; }
+
+        public static async Task<StudioAuthTestHost> StartAsync(
+            bool authenticated,
+            string? resolvedScopeId)
+        {
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                EnvironmentName = Environments.Development,
+            });
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Aevatar:Authentication:Enabled"] = "true",
+                ["Aevatar:Authentication:Authority"] = "https://nyx.example.com",
+                ["Cli:App:NyxId:Authority"] = "https://nyx.example.com",
+            });
+
+            builder.Services.AddSingleton<IAppScopeResolver>(new StubAppScopeResolver(resolvedScopeId));
+            builder.Services.AddSingleton(new AevatarHostMetadata
+            {
+                ServiceName = "test-studio-auth",
+            });
+            builder.Services.AddSingleton<AevatarHostHealthService>();
+            builder.Services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+
+            var app = builder.Build();
+            app.UseAuthentication();
+            app.Use(async (http, next) =>
+            {
+                if (authenticated)
+                {
+                    http.User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [
+                        new Claim("scope_id", resolvedScopeId ?? string.Empty),
+                        new Claim("email", "studio@example.com"),
+                        new Claim(ClaimTypes.Name, "Studio User"),
+                    ], "Test"));
+                }
+
+                await next();
+            });
+
+            StudioEndpoints.Map(app, embeddedWorkflowMode: false);
+            await app.StartAsync();
+
+            var addressFeature = app.Services
+                .GetRequiredService<IServer>()
+                .Features
+                .Get<IServerAddressesFeature>()
+                ?? throw new InvalidOperationException("Server addresses are unavailable.");
+            var client = new HttpClient
+            {
+                BaseAddress = new Uri(addressFeature.Addresses.Single()),
+            };
+
+            return new StudioAuthTestHost(app, client);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await _app.DisposeAsync();
+        }
+    }
+
+    private sealed class StubAppScopeResolver : IAppScopeResolver
+    {
+        private readonly string? _scopeId;
+
+        public StubAppScopeResolver(string? scopeId)
+        {
+            _scopeId = scopeId;
+        }
+
+        public AppScopeContext? Resolve(HttpContext? httpContext = null) =>
+            string.IsNullOrWhiteSpace(_scopeId)
+                ? null
+                : new AppScopeContext(_scopeId, "claim:scope_id");
+    }
+
+    private sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public TestAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() =>
+            Task.FromResult(AuthenticateResult.NoResult());
+    }
+}


### PR DESCRIPTION
## Summary
- enrich `/api/auth/me` so Studio Bind can read invoke auth mode, login/logout URLs, and external caller hints without inferring them client-side
- add `/api/scopes/{scopeId}/services/{serviceId}/endpoints/{endpointId}/contract` to expose bindable invoke contract details, stream capability, smoke defaults, and request examples from the backend
- add frontend shared contract decoding plus tests that consume the new bind contract surface

## Problem
Studio Bind had to infer invoke/auth/example details from partial runtime responses. That duplicated backend knowledge and made bind behavior fragile.

## Solution
Move the bind contract shape into backend endpoints so the frontend reads a single authoritative contract for auth and invocation.

## Impact
- Studio auth contract now exposes bind-oriented auth metadata
- Scope service endpoint contract is now queryable from the backend
- Frontend bind flows can consume typed contract data directly

## Validation
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "FullyQualifiedName~ScopeServiceEndpointsTests"`
- `dotnet test test/Aevatar.Tools.Cli.Tests/Aevatar.Tools.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~AppStudioAuthEndpointTests"`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`
- `npm exec -- jest src/shared/api/scopeRuntimeApi.test.ts --runInBand --config jest.config.ts` (run in `apps/aevatar-console-web` after local dependency install)

Closes #305