### PR TITLE
Confirm registration deletion before reporting success

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
@@ -226,6 +226,25 @@ public sealed class ChannelRegistrationTool : IAgentTool
         };
 
         await actor.HandleEventAsync(envelope);
-        return JsonSerializer.Serialize(new { status = "deleted", registration_id = registrationId });
+
+        var confirmed = false;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            if (attempt > 0)
+                await Task.Delay(500, ct);
+
+            if (await queryPort.GetAsync(registrationId, ct) == null)
+            {
+                confirmed = true;
+                break;
+            }
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            status = confirmed ? "deleted" : "accepted",
+            registration_id = registrationId,
+            note = confirmed ? string.Empty : "Delete submitted but projection not yet confirmed. Try 'list' after a few seconds.",
+        });
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -168,11 +168,13 @@ public sealed class ChannelRegistrationToolTests
     {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
         queryPort.GetAsync("reg-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(new ChannelBotRegistrationEntry
-            {
-                Id = "reg-1",
-                Platform = "lark",
-            }));
+            .Returns(
+                Task.FromResult<ChannelBotRegistrationEntry?>(new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-1",
+                    Platform = "lark",
+                }),
+                Task.FromResult<ChannelBotRegistrationEntry?>(null));
 
         EventEnvelope? capturedEnvelope = null;
         var actor = Substitute.For<IActor>();
@@ -192,10 +194,47 @@ public sealed class ChannelRegistrationToolTests
 
         using var scope = PushNyxToken();
         var json = await tool.ExecuteAsync("""{"action":"delete","registration_id":"reg-1","confirm":true}""");
+        using var doc = JsonDocument.Parse(json);
 
-        json.Should().Contain("\"status\":\"deleted\"");
+        doc.RootElement.GetProperty("status").GetString().Should().Be("deleted");
         capturedEnvelope.Should().NotBeNull();
         capturedEnvelope!.Payload.Unpack<ChannelBotUnregisterCommand>().RegistrationId.Should().Be("reg-1");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Delete_WithConfirm_ReturnsAccepted_WhenProjectionStillShowsRegistration()
+    {
+        var registration = new ChannelBotRegistrationEntry
+        {
+            Id = "reg-1",
+            Platform = "lark",
+        };
+
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.GetAsync("reg-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(registration));
+
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns(ChannelBotRegistrationGAgent.WellKnownId);
+        actor.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(actor));
+
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(queryPort)
+            .AddSingleton(actorRuntime)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken();
+        var json = await tool.ExecuteAsync("""{"action":"delete","registration_id":"reg-1","confirm":true}""");
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        doc.RootElement.GetProperty("note").GetString().Should().Contain("projection not yet confirmed");
     }
 
     private static IDisposable PushNyxToken()


### PR DESCRIPTION
## Summary
- move the registration delete follow-up into its own PR
- confirm projection removal before reporting `deleted`
- return `accepted` when the unregister command is submitted but the read model still shows the registration

## Problem
`channel_registrations action=delete` could report `status="deleted"` immediately after dispatching the unregister command, even when the projection had not yet confirmed removal. That made delete results misleading during the Lark cutover investigation.

## Solution
- poll the registration read model after dispatching `ChannelBotUnregisterCommand`
- return `deleted` only after the registration disappears from the query port
- otherwise return `accepted` with a note telling the caller that projection confirmation is still pending
- add coverage for both confirmed delete and still-pending projection cases

## Verification
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --filter FullyQualifiedName~ChannelRegistrationToolTests`