### PR TITLE
Fix hosted service registration ambiguity in channel runtime

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationInboxRuntime.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationInboxRuntime.cs
@@ -110,3 +110,17 @@ internal sealed class LarkConversationInboxRuntime :
             _services);
     }
 }
+
+internal sealed class LarkConversationInboxHostedService : IHostedService
+{
+    private readonly LarkConversationInboxRuntime _runtime;
+
+    public LarkConversationInboxHostedService(LarkConversationInboxRuntime runtime)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+    }
+
+    public Task StartAsync(CancellationToken ct) => _runtime.StartAsync(ct);
+
+    public Task StopAsync(CancellationToken ct) => _runtime.StopAsync(ct);
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
@@ -195,8 +195,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IConversationReplyGenerator, NyxIdConversationReplyGenerator>();
         services.TryAddSingleton<LarkConversationInboxRuntime>();
         services.TryAddSingleton<ILarkConversationInbox>(sp => sp.GetRequiredService<LarkConversationInboxRuntime>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService>(sp =>
-            sp.GetRequiredService<LarkConversationInboxRuntime>()));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, LarkConversationInboxHostedService>());
 
         return services;
     }


### PR DESCRIPTION
## Summary
- replace the factory-based `IHostedService` registration for the Lark inbox runtime
- add a thin hosted-service adapter that delegates to the shared runtime singleton
- keep `ILarkConversationInbox` and hosted startup bound to the same runtime instance

## Problem
`.NET 10` rejects `TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService>(factory))` for `IHostedService` because the implementation type is indistinguishable from other hosted-service registrations. `AddChannelRuntime(...)` hit that path during startup and the host failed before serving traffic.

## Solution
- keep `LarkConversationInboxRuntime` as the concrete singleton
- keep `ILarkConversationInbox` resolving to that singleton
- introduce `LarkConversationInboxHostedService` as a small adapter implementing `IHostedService`
- register the adapter via `TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, LarkConversationInboxHostedService>())`

## Verification
- `dotnet build src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj --nologo`