### PR TITLE
Replace LLM hallucination with deterministic slash-command flow on Lark daily-report path

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTurnRunner.cs
@@ -101,9 +101,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
         CancellationToken ct)
     {
         AgentBuilderFlowDecision? decision = null;
-        var relayMode = !string.IsNullOrWhiteSpace(registration.NyxAgentApiKeyId);
-        var relayDecisionMatched = relayMode &&
-                                  NyxRelayAgentBuilderFlow.TryResolve(inboundEvent, out decision);
+        var relayDecisionMatched = NyxRelayAgentBuilderFlow.TryResolve(inboundEvent, out decision);
         if (!relayDecisionMatched &&
             (!AgentBuilderCardFlow.TryResolve(inboundEvent, out decision) || decision is null))
         {

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxLarkProvisioningService.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxLarkProvisioningService.cs
@@ -37,6 +37,7 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService
 {
     private const string DefaultNyxProviderSlug = "api-lark-bot";
     private const string LarkBotTokenPlaceholder = "__unused_for_lark__";
+    private const string NyxRelayApiKeyPlatform = "generic";
 
     private readonly NyxIdApiClient _nyxClient;
     private readonly NyxIdToolOptions _nyxOptions;
@@ -149,7 +150,7 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService
             {
                 name = $"aevatar-lark-relay-{registrationId[..12]}",
                 scopes = "read write",
-                platform = "lark",
+                platform = NyxRelayApiKeyPlatform,
                 callback_url = relayCallbackUrl,
             }),
             ct);

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
@@ -198,9 +198,9 @@ internal static class NyxRelayAgentBuilderFlow
             var token = tokens[i];
             if (string.IsNullOrWhiteSpace(token))
                 continue;
-            var separator = token.IndexOf('=');
-            if (separator <= 0 || separator == token.Length - 1)
-                return token.Trim();
+            if (token.IndexOf('=', StringComparison.Ordinal) >= 0)
+                continue;
+            return token.Trim();
         }
         return null;
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
@@ -40,11 +40,11 @@ internal static class NyxRelayAgentBuilderFlow
         {
             case DailyReportCommand:
             case DailyReportAlias:
-                return TryResolveDailyReport(tokens, out decision);
+                return TryResolveDailyReport(tokens, evt.ConversationId, out decision);
 
             case SocialMediaCommand:
             case SocialMediaAlias:
-                return TryResolveSocialMedia(tokens, out decision);
+                return TryResolveSocialMedia(tokens, evt.ConversationId, out decision);
 
             case ListTemplatesCommand:
                 decision = AgentBuilderFlowDecision.ToolCall("list_templates", """{"action":"list_templates"}""");
@@ -103,6 +103,7 @@ internal static class NyxRelayAgentBuilderFlow
 
     private static bool TryResolveDailyReport(
         IReadOnlyList<string> tokens,
+        string? conversationId,
         out AgentBuilderFlowDecision? decision)
     {
         decision = null;
@@ -113,7 +114,9 @@ internal static class NyxRelayAgentBuilderFlow
         }
 
         var args = ChannelTextCommandParser.ParseNamedArguments(tokens);
-        if (!TryGetRequired(args, "github_username", out var githubUsername))
+        var githubUsername = GetOptional(args, "github_username")
+                             ?? FirstPositionalArgument(tokens);
+        if (string.IsNullOrWhiteSpace(githubUsername))
         {
             decision = AgentBuilderFlowDecision.DirectReply(
                 "github_username is required.\n\n" + BuildDailyReportHelpText());
@@ -139,12 +142,14 @@ internal static class NyxRelayAgentBuilderFlow
                 schedule_cron = scheduleCron,
                 schedule_timezone = scheduleTimezone,
                 run_immediately = runImmediately,
+                conversation_id = NormalizeOptional(conversationId),
             }));
         return true;
     }
 
     private static bool TryResolveSocialMedia(
         IReadOnlyList<string> tokens,
+        string? conversationId,
         out AgentBuilderFlowDecision? decision)
     {
         decision = null;
@@ -155,7 +160,8 @@ internal static class NyxRelayAgentBuilderFlow
         }
 
         var args = ChannelTextCommandParser.ParseNamedArguments(tokens);
-        if (!TryGetRequired(args, "topic", out var topic))
+        var topic = GetOptional(args, "topic") ?? FirstPositionalArgument(tokens);
+        if (string.IsNullOrWhiteSpace(topic))
         {
             decision = AgentBuilderFlowDecision.DirectReply(
                 "topic is required.\n\n" + BuildSocialMediaHelpText());
@@ -180,8 +186,23 @@ internal static class NyxRelayAgentBuilderFlow
                 schedule_cron = scheduleCron,
                 schedule_timezone = scheduleTimezone,
                 run_immediately = ResolveRunImmediately(args),
+                conversation_id = NormalizeOptional(conversationId),
             }));
         return true;
+    }
+
+    private static string? FirstPositionalArgument(IReadOnlyList<string> tokens)
+    {
+        for (var i = 1; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (string.IsNullOrWhiteSpace(token))
+                continue;
+            var separator = token.IndexOf('=');
+            if (separator <= 0 || separator == token.Length - 1)
+                return token.Trim();
+        }
+        return null;
     }
 
     private static bool TryResolveSimpleAgentAction(
@@ -448,15 +469,6 @@ internal static class NyxRelayAgentBuilderFlow
     {
         var raw = GetOptional(args, "run_immediately");
         return !bool.TryParse(raw, out var parsed) || parsed;
-    }
-
-    private static bool TryGetRequired(
-        IReadOnlyDictionary<string, string> args,
-        string key,
-        out string value)
-    {
-        value = GetOptional(args, key) ?? string.Empty;
-        return value.Length > 0;
     }
 
     private static string? GetOptional(IReadOnlyDictionary<string, string> args, string key)

--- a/docs/operations/2026-04-22-lark-nyx-cutover-runbook.md
+++ b/docs/operations/2026-04-22-lark-nyx-cutover-runbook.md
@@ -51,6 +51,10 @@ Operationally:
    - Aevatar -> Nyx `channel-relay/reply` success
    - `POST /api/channels/lark/callback/{registrationId}` returns `410 Gone`
 
+## Backfill Notes
+
+- Relay API keys created before `#323` were registered with `platform=lark`. New provisioning uses `platform=generic` because NyxID treats `lark` as the channel-bot platform identifier, not a relay platform name. Existing relay keys are not migrated automatically; if NyxID enforces the platform contract on relay use, rotate the existing relay key by re-running the Nyx-backed provisioning flow and updating the Lark Developer Console webhook URL to the new `webhook_url`.
+
 ## Expected Runtime Behavior
 
 - New Lark provisioning goes through Nyx only.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
@@ -107,6 +107,31 @@ public sealed class LarkConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldRouteSlashCommand_WhenRegistrationHasNoRelayApiKey()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var replyGenerator = new StubReplyGenerator("llm-fallback-should-not-fire");
+        var runner = CreateRunner(registrationQueryPort, adapter, replyGenerator: replyGenerator);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "/daily-report alice",
+                "msg-slash-1",
+                ConversationScope.DirectMessage,
+                "oc_p2p_chat_1"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.SentActivityId.Should().Be("direct-reply:msg-slash-1");
+        adapter.Replies.Should().ContainSingle();
+        adapter.Replies[0].ReplyText.Should().Contain("Create daily report agent failed");
+        adapter.Replies[0].ReplyText.Should().Contain("No NyxID access token available");
+        replyGenerator.GeneratedActivities.Should().BeEmpty(
+            because: "deterministic slash flow must not fall through to the LLM reply generator");
+    }
+
+    [Fact]
     public async Task RunContinueAsync_DirectMessageWithoutPartition_ReturnsPermanentFailure()
     {
         var registrationQueryPort = BuildRegistrationQueryPort();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -63,6 +63,7 @@ public class NyxLarkProvisioningServiceTests
 
         handler.Requests.Should().HaveCount(3);
         handler.Requests[0].Body.Should().Contain("\"callback_url\":\"https://aevatar.example.com/api/webhooks/nyxid-relay\"");
+        handler.Requests[0].Body.Should().Contain("\"platform\":\"generic\"");
         handler.Requests[1].Body.Should().Contain("\"bot_token\":\"__unused_for_lark__\"");
         handler.Requests[1].Body.Should().Contain("\"app_id\":\"cli_a1b2c3\"");
         handler.Requests[2].Body.Should().Contain("\"default_agent\":true");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
@@ -25,6 +25,53 @@ public sealed class NyxRelayAgentBuilderFlowTests
     }
 
     [Fact]
+    public void TryResolve_ShouldAcceptPositionalGithubUsername_AndForwardConversationId()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            ConversationId = "oc_8a70aeefbdb4340e1fa5f575b4c794eb",
+            Text = "/daily-report eanzhao",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeTrue();
+        decision.ToolAction.Should().Be("create_daily_report");
+
+        using var body = JsonDocument.Parse(decision.ToolArgumentsJson!);
+        body.RootElement.GetProperty("action").GetString().Should().Be("create_agent");
+        body.RootElement.GetProperty("template").GetString().Should().Be("daily_report");
+        body.RootElement.GetProperty("github_username").GetString().Should().Be("eanzhao");
+        body.RootElement.GetProperty("conversation_id").GetString().Should().Be("oc_8a70aeefbdb4340e1fa5f575b4c794eb");
+    }
+
+    [Fact]
+    public void TryResolve_ShouldAcceptPositionalSocialMediaTopic()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            ConversationId = "oc_chat_abc",
+            Text = "/social-media \"Launch update\" schedule_time=10:30",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeTrue();
+        decision.ToolAction.Should().Be("create_social_media");
+
+        using var body = JsonDocument.Parse(decision.ToolArgumentsJson!);
+        body.RootElement.GetProperty("topic").GetString().Should().Be("Launch update");
+        body.RootElement.GetProperty("schedule_cron").GetString().Should().Be("30 10 * * *");
+        body.RootElement.GetProperty("conversation_id").GetString().Should().Be("oc_chat_abc");
+    }
+
+    [Fact]
     public void TryResolve_ShouldBuildCreateSocialMediaToolCall_FromTextCommand()
     {
         var inbound = new ChannelInboundEvent

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
@@ -48,6 +48,26 @@ public sealed class NyxRelayAgentBuilderFlowTests
         body.RootElement.GetProperty("conversation_id").GetString().Should().Be("oc_8a70aeefbdb4340e1fa5f575b4c794eb");
     }
 
+    [Theory]
+    [InlineData("/daily-report =broken")]
+    [InlineData("/daily-report github_username=")]
+    public void TryResolve_ShouldNotTreatMalformedKeyValueTokenAsPositional(string text)
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            ConversationId = "oc_chat_xyz",
+            Text = text,
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeFalse();
+        decision.ReplyPayload.Should().Contain("github_username is required");
+    }
+
     [Fact]
     public void TryResolve_ShouldAcceptPositionalSocialMediaTopic()
     {


### PR DESCRIPTION
## Summary

修复 PR #323 第一轮 review 反馈,并更新 title 反映实际范围。

### 实际效果(诚实版)

之前的 title \"Make Lark slash commands work without relay API key\" 过强 —— 即便去掉 `relayMode` 闸门,`AgentBuilderTool.ExecuteAsync` 仍会因为 `RegistrationToken` 在 `LarkConversationTurnRunner.ToInboundEvent` 里被硬编码为 `string.Empty`(post-#308 credential boundary 的产物)而立刻返回 \"No NyxID access token available. User must be authenticated.\"

这个 PR **真正交付的**:把 `/daily-report alice` 在没有 relay key 的 bot 上的反馈,从 LLM 自由发挥的中文幻觉(\"还差一个必要条件: 当前没有可用的私聊会话 ID...\")替换成确定性的英文 auth 错误。**还不能完整跑通 daily-report 创建** —— 那需要单独修通 relay 路径上的 access token 注入。

### 改动清单

- **`LarkConversationTurnRunner.cs:104`** — 拿掉 `relayMode` 闸门,所有 bot 都先尝试 `NyxRelayAgentBuilderFlow`(slash 命令不再依赖 outbound API key)。
- **`NyxRelayAgentBuilderFlow.cs`** — `/daily-report` / `/social-media` 接受首个不含 `=` 的位置参数作为 `github_username` / `topic`;并把 `evt.ConversationId` 直接打进 tool args(不再单纯依赖 `AgentToolRequestContext` metadata)。Review 第一轮指出的 separator 边界 bug(`=foo` / `key=` 被当成位置参数)已收紧 —— 现在只有完全不含 `=` 的 token 才算位置参数。
- **`NyxLarkProvisioningService.cs`** — relay API key platform 改为 `generic`(NyxID 把 `lark` 当成 channel-bot 平台标识,不是 relay key 的平台名)。
- **`docs/operations/2026-04-22-lark-nyx-cutover-runbook.md`** — 加 \"Backfill Notes\" section,提示 pre-#323 用 `platform=lark` 注册过的 relay key 需要 rotate。

### 测试

- `NyxRelayAgentBuilderFlowTests` 加 3 个用例:位置参数 + `conversation_id` 透传(daily-report 和 social-media 各一个)+ 恶意 `=` token 边界(theory 两组数据)。
- `LarkConversationTurnRunnerTests` 加 1 个端到端用例:registration 没有 `NyxAgentApiKeyId` 时,`/daily-report alice` 走确定性 slash 分支,返回的 reply 包含 \"No NyxID access token available\" 而 `replyGenerator.GeneratedActivities` 为空(LLM 兜底没被触发)。这一条用例就是为了把 \"slash 分支必须命中、不准悄悄回滚到 LLM\" 钉住。

`dotnet test` 在 `Aevatar.GAgents.ChannelRuntime.Tests` 里运行:与本 PR 相关的 15 个用例(NyxRelayAgentBuilderFlow + LarkConversationTurnRunner)全绿。仓库 `dev` 上有 2 个无关的 `ServiceCollectionExtensionsTests` 在我 rebase 前就已经在 fail,与本 PR 改动无关(已通过在干净 dev tree 上复现确认)。

### 还没解决但 flag 出来的问题

- **#2 access token 注入缺口**: `RegistrationToken = string.Empty` 是 #308 \"Remove channel runtime credential ownership\" 的有意决策。要让 daily-report 在 relay bot 上端到端跑通,需要在 relay 路径(可能是 `NyxRelayJwtValidator` 或 inbound 流的某个 hook)把用户的 NyxID access token 注回 `inboundEvent.RegistrationToken`。这是单独的 channel-runtime credential boundary 工作,不在本 PR 范围。
- **#3 已有 relay key 不会自动回迁**: 已通过 runbook 说明覆盖。

## Test plan
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --filter \"FullyQualifiedName~NyxRelayAgentBuilderFlow|FullyQualifiedName~LarkConversationTurnRunner\"` — 15/15 通过
- [x] `dotnet build agents/Aevatar.GAgents.ChannelRuntime/Aevatar.GAgents.ChannelRuntime.csproj` — 0 errors
- [ ] 在私聊里发 `/daily-report eanzhao` 验证 reply 文本是 \"Create daily report agent failed: No NyxID access token available...\" 而不是中文 LLM 幻觉
- [ ] 在私聊里发 `/daily-report github_username=` 验证返回 help text 而不是 silently 把 `github_username=` 当成 username

🤖 Generated with [Claude Code](https://claude.com/claude-code)