### PR TITLE
Fix stale NyxID relay user-config messaging

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -508,7 +508,7 @@ public static class NyxIdChatEndpoints
         }
         catch (Exception ex)
         {
-            logger?.LogWarning(ex, "Failed to load user config from chrono-storage — falling back to server defaults");
+            logger?.LogWarning(ex, "Failed to load user config from the projection read model; falling back to server defaults");
         }
     }
 
@@ -821,10 +821,9 @@ public static class NyxIdChatEndpoints
             http.User = validation.Principal;
             var scopeId = validation.Subject!;
 
-            // Note: config.json in chrono-storage cannot be read in relay flow because
-            // ChronoStorageCatalogBlobClient reads the Bearer token from Authorization header,
-            // which is not present on relay callbacks (token is in X-NyxID-User-Token instead).
-            // InjectUserConfigMetadataAsync will silently fall back to server defaults.
+            // Relay callbacks reuse the same user-config projection path as Studio and web chat.
+            // After JWT validation we attach the relay principal to HttpContext.User so
+            // IAppScopeResolver can resolve the same scope from the validated subject.
 
             // ─── Resolve conversation ───
             var platform = message.Platform ?? "unknown";
@@ -1115,7 +1114,7 @@ public static class NyxIdChatEndpoints
         var scope = metadata.TryGetValue("scope_id", out var s) ? s : "<unknown>";
 
         var model = !string.IsNullOrWhiteSpace(modelOverride)
-            ? $"{modelOverride} (from config.json)"
+            ? $"{modelOverride} (from user config)"
             : $"server-default={serverDefault}";
 
         var error = errorMessage.Length > 300 ? errorMessage[..300] + "..." : errorMessage;

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -698,6 +698,62 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldInjectUserConfigMetadata_FromRelayScope()
+    {
+        var relay = CreateRelayInvocationDependencies(scopeId: "scope-relay", relayApiKeyId: "scope-relay");
+        var payload = """
+            {
+              "message_id":"msg-config",
+              "platform":"slack",
+              "agent":{"api_key_id":"scope-relay"},
+              "conversation":{"platform_id":"room-config"},
+              "content":{"text":"hello"}
+            }
+            """;
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .AddSingleton<INyxIdUserLlmPreferencesStore>(new StubPreferencesStore("relay-model", "relay-route", 9))
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Headers["X-NyxID-User-Token"] = relay.Token;
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+        var runtime = new StubActorRuntime();
+        var result = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            runtime,
+            new StubSubscriptionProvider
+            {
+                Messages =
+                {
+                    new EventEnvelope { Payload = Any.Pack(new TextMessageEndEvent { Content = "done" }) },
+                },
+            },
+            new StubGAgentActorStore(),
+            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
+            relay.Validator,
+            relay.Client,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+
+        var actor = runtime.Actors["nyxid-relay-slack-room-config"].Should().BeOfType<StubActor>().Subject;
+        var chatRequest = actor.HandledEnvelopes.Should().ContainSingle().Subject.Payload.Unpack<ChatRequestEvent>();
+        chatRequest.ScopeId.Should().Be("scope-relay");
+        chatRequest.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken].Should().Be(relay.Token);
+        chatRequest.Metadata["scope_id"].Should().Be("scope-relay");
+        chatRequest.Metadata[LLMRequestMetadataKeys.ModelOverride].Should().Be("relay-model");
+        chatRequest.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference].Should().Be("relay-route");
+        chatRequest.Metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride].Should().Be("9");
+    }
+
+    [Fact]
     public async Task HandleRelayWebhookAsync_ShouldReuseActorAndSessionId_ForDuplicateDailyReportWebhook()
     {
         const string scopeId = "scope-daily";
@@ -1039,7 +1095,7 @@ public class NyxIdChatEndpointsCoverageTests
             .And.BeOfType<string>()
             .Subject;
 
-        diag.Should().Contain("Model: deepseek-chat (from config.json)");
+        diag.Should().Contain("Model: deepseek-chat (from user config)");
         diag.Should().Contain("Route: direct");
         diag.Should().Contain("Scope: scope-a");
         diag.Should().Contain("Token: present");


### PR DESCRIPTION
## Summary
- replace the stale relay comment in `NyxIdChatEndpoints` with the current projection-backed user-config path
- update the relay user-config fallback warning and diagnostic copy so they no longer mention `chrono-storage` or `config.json`
- add relay coverage proving user-config metadata is injected from the validated relay scope

## Root Cause
`NyxIdChatEndpoints` still described the pre-refactor `chrono-storage/config.json` behavior after user config moved to the actor-backed projection query path.

## Impact
- relay user-config behavior is documented accurately for contributors and operators
- relay diagnostics now point at user config instead of `config.json`
- tests cover the current relay scope injection path

## Validation
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter NyxIdChatEndpointsCoverageTests --nologo`
- `bash tools/ci/test_stability_guards.sh`

Closes #326