### PR TITLE
Refactor channel turns to carry outbound delivery context

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -256,6 +256,14 @@ message MessageContent {
   CardActionSubmission card_action = 6;
 }
 
+// Carries the transport-issued facts required to deliver one async reply back through the same boundary.
+message OutboundDeliveryContext {
+  // The opaque reply target identifier that the transport expects when publishing the async reply.
+  string reply_message_id = 1;
+  // The opaque credential or access token that authorizes reply delivery on the current transport.
+  string reply_access_token = 2;
+}
+
 // Represents one normalized activity flowing through the channel pipeline.
 message ChatActivity {
   // The deterministic adapter-owned activity identifier.
@@ -280,4 +288,6 @@ message ChatActivity {
   string reply_to_activity_id = 10;
   // The stable blob reference for sanitized raw payload storage.
   string raw_payload_blob_ref = 11;
+  // The optional async reply delivery facts emitted by the ingress transport.
+  OutboundDeliveryContext outbound_delivery = 12;
 }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -81,6 +81,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 Conversation = activity.Conversation?.Clone() ?? new ConversationReference(),
                 Outbound = result.Outbound?.Clone() ?? new MessageContent(),
                 CompletedAtUnixMs = nowMs,
+                OutboundDelivery = result.OutboundDelivery?.Clone(),
             };
             await PersistDomainEventAsync(completed);
             Logger.LogInformation(
@@ -146,6 +147,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 Conversation = cmd.Conversation?.Clone() ?? new ConversationReference(),
                 Outbound = result.Outbound?.Clone() ?? (cmd.Payload?.Clone() ?? new MessageContent()),
                 CompletedAtUnixMs = nowMs,
+                OutboundDelivery = result.OutboundDelivery?.Clone(),
             };
             await PersistDomainEventAsync(completed);
             Logger.LogInformation(

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationTurnRunner.cs
@@ -34,6 +34,7 @@ public sealed record ConversationTurnResult(
     string SentActivityId,
     MessageContent Outbound,
     string AuthPrincipal,
+    OutboundDeliveryContext? OutboundDelivery,
     string ErrorCode,
     string ErrorSummary,
     FailureKind FailureKind,
@@ -42,20 +43,51 @@ public sealed record ConversationTurnResult(
     /// <summary>
     /// Success factory.
     /// </summary>
-    public static ConversationTurnResult Sent(string sentActivityId, MessageContent outbound, string authPrincipal) =>
-        new(true, sentActivityId, outbound, authPrincipal, string.Empty, string.Empty, FailureKind.Unspecified, null);
+    public static ConversationTurnResult Sent(
+        string sentActivityId,
+        MessageContent outbound,
+        string authPrincipal,
+        OutboundDeliveryContext? outboundDelivery = null) =>
+        new(
+            true,
+            sentActivityId,
+            outbound,
+            authPrincipal,
+            outboundDelivery,
+            string.Empty,
+            string.Empty,
+            FailureKind.Unspecified,
+            null);
 
     /// <summary>
     /// Transient failure factory.
     /// </summary>
     public static ConversationTurnResult TransientFailure(string errorCode, string errorSummary, TimeSpan? retryAfter = null) =>
-        new(false, string.Empty, new MessageContent(), string.Empty, errorCode, errorSummary, FailureKind.TransientAdapterError, retryAfter);
+        new(
+            false,
+            string.Empty,
+            new MessageContent(),
+            string.Empty,
+            null,
+            errorCode,
+            errorSummary,
+            FailureKind.TransientAdapterError,
+            retryAfter);
 
     /// <summary>
     /// Permanent failure factory.
     /// </summary>
     public static ConversationTurnResult PermanentFailure(string errorCode, string errorSummary) =>
-        new(false, string.Empty, new MessageContent(), string.Empty, errorCode, errorSummary, FailureKind.PermanentAdapterError, null);
+        new(
+            false,
+            string.Empty,
+            new MessageContent(),
+            string.Empty,
+            null,
+            errorCode,
+            errorSummary,
+            FailureKind.PermanentAdapterError,
+            null);
 }
 
 /// <summary>

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -18,6 +18,7 @@ message ConversationTurnCompletedEvent {
   aevatar.gagents.channel.abstractions.ConversationReference conversation = 5;
   aevatar.gagents.channel.abstractions.MessageContent outbound = 6;
   int64 completed_at_unix_ms = 7;
+  aevatar.gagents.channel.abstractions.OutboundDeliveryContext outbound_delivery = 8;
 }
 
 message ConversationContinueRequestedEvent {

--- a/agents/Aevatar.GAgents.ChannelRuntime/InboundMessage.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/InboundMessage.cs
@@ -1,3 +1,5 @@
+using Aevatar.GAgents.Channel.Abstractions;
+
 namespace Aevatar.GAgents.ChannelRuntime;
 
 /// <summary>
@@ -12,5 +14,6 @@ public sealed class InboundMessage
     public required string Text { get; init; }
     public string? MessageId { get; init; }
     public string? ChatType { get; init; }
+    public OutboundDeliveryContext? OutboundDelivery { get; init; }
     public IReadOnlyDictionary<string, string> Extra { get; init; } = new Dictionary<string, string>();
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTurnRunner.cs
@@ -135,7 +135,8 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
             ? ConversationTurnResult.Sent(
                 sentActivityId: $"direct-reply:{activity.Id}",
                 outbound: new MessageContent { Text = replyPayload },
-                authPrincipal: "bot")
+                authPrincipal: "bot",
+                outboundDelivery: result.OutboundDelivery?.Clone())
             : result;
     }
 
@@ -184,7 +185,8 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
         return ConversationTurnResult.Sent(
             sentActivityId: $"direct-reply:{sentActivitySeed}",
             outbound: new MessageContent { Text = replyText },
-            authPrincipal: "bot");
+            authPrincipal: "bot",
+            outboundDelivery: inbound.OutboundDelivery?.Clone());
     }
 
     private async Task<ChannelBotRegistrationEntry?> ResolveRegistrationAsync(string? registrationId, CancellationToken ct)
@@ -324,6 +326,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
             Text = activity.Content?.Text ?? string.Empty,
             MessageId = activity.Id,
             ChatType = ResolveChatType(activity.Conversation, activity.Type),
+            OutboundDelivery = activity.OutboundDelivery?.Clone(),
             Extra = extra,
         };
     }

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -185,7 +185,7 @@ sequenceDiagram
 
 | Proto 归属 | 类型 |
 |---|---|
-| `agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto` | `ChatActivity` / `ConversationReference` / `ParticipantRef` / `MessageContent` / `AttachmentRef` / `AttachmentKind` (enum) / `ActionElement` / `CardBlock` / `MessageDisposition` / `ActivityType` / `ConversationScope` / `ChannelId` / `BotInstanceId` / `TransportMode` |
+| `agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto` | `ChatActivity` / `ConversationReference` / `ParticipantRef` / `MessageContent` / `OutboundDeliveryContext` / `AttachmentRef` / `AttachmentKind` (enum) / `ActionElement` / `CardBlock` / `MessageDisposition` / `ActivityType` / `ConversationScope` / `ChannelId` / `BotInstanceId` / `TransportMode` |
 | `agents/Aevatar.GAgents.Channel.Abstractions/protos/channel_contracts.proto` | `EmitResult` / `ComposeCapability` / `ComposeContext` / `ChannelBotDescriptor` / `ChannelTransportBinding` / `ChannelCapabilities` / `StreamingSupport` / `AuthContext` / `PrincipalKind` / `StreamChunk` |
 | `agents/Aevatar.GAgents.Channel.Abstractions/protos/schedule.proto` | `ScheduleState` / `ProjectionVerdict` |
 | `agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto` | `ConversationTurnCompletedEvent` / `ConversationContinueRequestedEvent` / `ConversationContinueRejectedEvent` / `ConversationContinueFailedEvent` / `ChannelBotRegistrationEntry` / `UserAgentCatalogEntry` / `DeviceRegistrationEntry`（含 `IsDeleted` flag 支持 tombstone retention）。详细 field schema 见 §4.3.1 |
@@ -301,13 +301,16 @@ public record ChatActivity(
     DateTimeOffset Timestamp,
     MessageContent Content,             // Text + Attachments + Actions + Cards
     string? ReplyToActivityId,
-    string? RawPayloadBlobRef           // 原始 payload 存储引用，逃生舱
+    string? RawPayloadBlobRef,          // 原始 payload 存储引用，逃生舱
+    OutboundDeliveryContext? OutboundDelivery
 );
 ```
 
 **为什么字段命名对齐 BF**：未来如果要接入社区 BF adapter（例如 Teams），迁移/借鉴成本低。但我们**不 import 任何 `Microsoft.Bot.*` 包**。
 
 **为什么没有 `ChannelData`**：早期草稿里有 `ChannelData : IReadOnlyDictionary<string, string>`，但 Slack event envelope / Discord interaction 带嵌套结构（user profile / guild member / team info），string→string 天然太窄；放宽到 `object` 又让调用方陷入动态类型。已有 `RawPayloadBlobRef` 作为 escape hatch（原始 payload 按需取），两套冗余的结构化索引反而让 adapter 作者"两边都想塞点东西"，抽象边界打糊。结论：**只留 `RawPayloadBlobRef`，不要 `ChannelData`**。
+
+**为什么新增 `OutboundDeliveryContext`**：Nyx relay 这类 async callback transport 的 reply 不只是 "往这个 conversation 发一条消息"，还需要把 ingress 提供的 **opaque reply target**（如 relay `message_id`）和 **opaque delivery credential**（如 relay access token）带回 outbound 边界。它们不是业务 metadata bag，也不是 `ConversationReference` 的稳定会话语义，而是**一次 inbound turn 派生出的 reply-delivery 事实**。因此单独建模成 `ChatActivity.OutboundDelivery`，并在 `ConversationTurnCompletedEvent` 上原样保留，避免后续 projection/outbound path 再退回字符串 key bag。
 
 ### 5.1b Supporting types
 

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
@@ -44,6 +44,11 @@ public sealed class ChannelAbstractionsProtoTests
             },
             ReplyToActivityId = "orig-1",
             RawPayloadBlobRef = "blob://payload/1",
+            OutboundDelivery = new OutboundDeliveryContext
+            {
+                ReplyMessageId = "relay-msg-1",
+                ReplyAccessToken = "relay-token-1",
+            },
         };
         activity.Mentions.Add(new ParticipantRef
         {
@@ -82,12 +87,15 @@ public sealed class ChannelAbstractionsProtoTests
         parsed.Content.CardAction.ActionId.ShouldBe("approve");
         parsed.Content.Actions[0].Kind.ShouldBe(ActionElementKind.Button);
         parsed.Conversation.Scope.ShouldBe(ConversationScope.Thread);
+        parsed.OutboundDelivery.ReplyMessageId.ShouldBe("relay-msg-1");
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(ChatActivity));
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(MessageContent));
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(CardActionSubmission));
+        ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
+            .ShouldContain(nameof(OutboundDeliveryContext));
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelRuntimeProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelRuntimeProtoTests.cs
@@ -70,6 +70,11 @@ public sealed class ChannelRuntimeProtoTests
                 Disposition = MessageDisposition.Normal,
             },
             CompletedAtUnixMs = 123,
+            OutboundDelivery = new OutboundDeliveryContext
+            {
+                ReplyMessageId = "relay-msg-1",
+                ReplyAccessToken = "relay-token-1",
+            },
         };
         var registration = new ChannelBotRegistrationEntry
         {
@@ -91,6 +96,7 @@ public sealed class ChannelRuntimeProtoTests
         };
 
         completed.Clone().ShouldBe(completed);
+        completed.OutboundDelivery.ReplyMessageId.ShouldBe("relay-msg-1");
         registration.Clone().ShouldBe(registration);
         registration.TransportBinding.Bot.RegistrationId.ShouldBe("bot-reg-1");
         ChannelBotRegistrationEntry.Descriptor.FindFieldByName("transport_binding")!.FieldNumber.ShouldBe(1);

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -125,6 +125,32 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleInboundActivityAsync_PersistsOutboundDeliveryContext_OnCompletedEvent()
+    {
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = _ => ConversationTurnResult.Sent(
+                "sent:act-relay",
+                new MessageContent { Text = "ack" },
+                "bot",
+                new OutboundDeliveryContext
+                {
+                    ReplyMessageId = "relay-msg-1",
+                    ReplyAccessToken = "relay-token-1",
+                }),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-relay");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-relay", "conv:slack:C1"));
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(1);
+        var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events[0].EventData.Value);
+        completed.OutboundDelivery.ReplyMessageId.ShouldBe("relay-msg-1");
+        completed.OutboundDelivery.ReplyAccessToken.ShouldBe("relay-token-1");
+    }
+
+    [Fact]
     public async Task HandleContinueCommandAsync_TransientFailure_LeavesCommandRetriable()
     {
         // Retriable continue failures (retry_after_ms) must NOT mark the command id as processed —

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
@@ -24,14 +24,25 @@ public sealed class LarkConversationTurnRunnerTests
         var runner = CreateRunner(registrationQueryPort, adapter, replyGenerator: replyGenerator);
 
         var result = await runner.RunInboundAsync(
-            BuildInboundActivity("hello", "msg-1", ConversationScope.Group, "oc_group_chat_1"),
+            BuildInboundActivity(
+                "hello",
+                "msg-1",
+                ConversationScope.Group,
+                "oc_group_chat_1",
+                new OutboundDeliveryContext
+                {
+                    ReplyMessageId = "relay-msg-1",
+                    ReplyAccessToken = "relay-token-1",
+                }),
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
         result.SentActivityId.Should().Be("direct-reply:msg-1");
+        result.OutboundDelivery?.ReplyMessageId.Should().Be("relay-msg-1");
         adapter.Replies.Should().ContainSingle();
         adapter.Replies[0].ReplyText.Should().Be("reply-1");
         adapter.Replies[0].Inbound.ConversationId.Should().Be("oc_group_chat_1");
+        adapter.Replies[0].Inbound.OutboundDelivery?.ReplyAccessToken.Should().Be("relay-token-1");
         replyGenerator.GeneratedActivities.Should().ContainSingle(activity => activity.Id == "msg-1");
     }
 
@@ -209,7 +220,8 @@ public sealed class LarkConversationTurnRunnerTests
         string text,
         string messageId,
         ConversationScope scope = ConversationScope.Group,
-        string? partition = "oc_group_chat_1")
+        string? partition = "oc_group_chat_1",
+        OutboundDeliveryContext? outboundDelivery = null)
     {
         return new ChatActivity
         {
@@ -233,6 +245,7 @@ public sealed class LarkConversationTurnRunnerTests
             {
                 Text = text,
             },
+            OutboundDelivery = outboundDelivery?.Clone(),
         };
     }
 


### PR DESCRIPTION
## Summary
- add typed `OutboundDeliveryContext` to `ChatActivity` and `ConversationTurnCompletedEvent`
- thread the new contract through `ConversationTurnResult`, `InboundMessage`, and the legacy channel runner reply path
- add protocol/runtime tests and update the channel canon doc to describe the new contract

## Why
Issue #328 Phase 1 needs relay reply facts such as the inbound relay `message_id` and relay access token to survive the unified inbound backbone as typed contract, not as ad-hoc metadata keys.

This slice only makes the canonical `ChatActivity -> turn result -> completed event` chain able to carry those facts. It does **not** switch relay traffic or change `IChannelOutboundPort` yet.

## Impact
- downstream projection/outbound work can now read reply-delivery facts from committed turn events instead of re-deriving them from bags
- the existing legacy runner path no longer drops delivery context when it turns an inbound activity into a sent result
- docs now describe `OutboundDeliveryContext` as a first-class channel contract

## Validation
- `dotnet build aevatar.slnx --nologo --no-restore -m:1`
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo --no-build`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --no-build --filter "FullyQualifiedName~LarkConversationTurnRunnerTests|FullyQualifiedName~ChannelPlatformReplyServiceTests"`
- `bash tools/ci/architecture_guards.sh`

## Notes
- stacked on #333 / `refactor/2026-04-23_platform-lark-rename`
- `IChannelOutboundPort` stays unchanged in this PR by design; transport/outbound cutover remains follow-up work
- Refs #328