### PR TITLE
Add transport extras and Nyx identity lookup

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -264,6 +264,18 @@ message OutboundDeliveryContext {
   string reply_access_token = 2;
 }
 
+// Carries transport-specific ingress facts that must survive normalization without polluting core conversation semantics.
+message TransportExtras {
+  // The Nyx relay message id that identifies the original callback on async reply.
+  string nyx_message_id = 1;
+  // The Nyx agent API key id that owns the callback route and identifies the local registration.
+  string nyx_agent_api_key_id = 2;
+  // The source platform name reported by Nyx relay.
+  string nyx_platform = 3;
+  // The Nyx relay conversation id observed on ingress.
+  string nyx_conversation_id = 4;
+}
+
 // Represents one normalized activity flowing through the channel pipeline.
 message ChatActivity {
   // The deterministic adapter-owned activity identifier.
@@ -290,4 +302,6 @@ message ChatActivity {
   string raw_payload_blob_ref = 11;
   // The optional async reply delivery facts emitted by the ingress transport.
   OutboundDeliveryContext outbound_delivery = 12;
+  // The optional transport-specific ingress facts preserved for adapter/runtime handoff.
+  TransportExtras transport_extras = 13;
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationQueryPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationQueryPort.cs
@@ -3,6 +3,7 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 namespace Aevatar.GAgents.ChannelRuntime;
 
 public sealed class ChannelBotRegistrationQueryPort : IChannelBotRegistrationQueryPort
+    , IChannelBotRegistrationQueryByNyxIdentityPort
 {
     private readonly IProjectionDocumentReader<ChannelBotRegistrationDocument, string> _documentReader;
 
@@ -39,6 +40,44 @@ public sealed class ChannelBotRegistrationQueryPort : IChannelBotRegistrationQue
         return result.Items
             .Select(static doc => ToEntry(doc))
             .ToArray();
+    }
+
+    public Task<ChannelBotRegistrationEntry?> GetByNyxAgentApiKeyIdAsync(
+        string nyxAgentApiKeyId,
+        CancellationToken ct = default) =>
+        QuerySingleByFieldAsync(nameof(ChannelBotRegistrationDocument.NyxAgentApiKeyId), nyxAgentApiKeyId, ct);
+
+    public Task<ChannelBotRegistrationEntry?> GetByNyxChannelBotIdAsync(
+        string nyxChannelBotId,
+        CancellationToken ct = default) =>
+        QuerySingleByFieldAsync(nameof(ChannelBotRegistrationDocument.NyxChannelBotId), nyxChannelBotId, ct);
+
+    private async Task<ChannelBotRegistrationEntry?> QuerySingleByFieldAsync(
+        string fieldPath,
+        string fieldValue,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(fieldValue))
+            return null;
+
+        var result = await _documentReader.QueryAsync(
+            new ProjectionDocumentQuery
+            {
+                Take = 1,
+                Filters =
+                [
+                    new ProjectionDocumentFilter
+                    {
+                        FieldPath = fieldPath,
+                        Operator = ProjectionDocumentFilterOperator.Eq,
+                        Value = ProjectionDocumentValue.FromString(fieldValue),
+                    },
+                ],
+            },
+            ct);
+
+        var document = result.Items.FirstOrDefault();
+        return document == null ? null : ToEntry(document);
     }
 
     private static ChannelBotRegistrationEntry ToEntry(ChannelBotRegistrationDocument document) =>

--- a/agents/Aevatar.GAgents.ChannelRuntime/IChannelBotRegistrationQueryByNyxIdentityPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/IChannelBotRegistrationQueryByNyxIdentityPort.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.GAgents.ChannelRuntime;
+
+public interface IChannelBotRegistrationQueryByNyxIdentityPort
+{
+    Task<ChannelBotRegistrationEntry?> GetByNyxAgentApiKeyIdAsync(
+        string nyxAgentApiKeyId,
+        CancellationToken ct = default);
+
+    Task<ChannelBotRegistrationEntry?> GetByNyxChannelBotIdAsync(
+        string nyxChannelBotId,
+        CancellationToken ct = default);
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/InboundMessage.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/InboundMessage.cs
@@ -15,5 +15,6 @@ public sealed class InboundMessage
     public string? MessageId { get; init; }
     public string? ChatType { get; init; }
     public OutboundDeliveryContext? OutboundDelivery { get; init; }
+    public TransportExtras? TransportExtras { get; init; }
     public IReadOnlyDictionary<string, string> Extra { get; init; } = new Dictionary<string, string>();
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTurnRunner.cs
@@ -14,6 +14,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
 {
     private readonly IServiceProvider _services;
     private readonly IChannelBotRegistrationQueryPort _registrationQueryPort;
+    private readonly IChannelBotRegistrationQueryByNyxIdentityPort? _registrationQueryByNyxIdentityPort;
     private readonly IEnumerable<IPlatformAdapter> _platformAdapters;
     private readonly NyxIdApiClient _nyxClient;
     private readonly IConversationReplyGenerator _replyGenerator;
@@ -22,6 +23,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
     public LarkConversationTurnRunner(
         IServiceProvider services,
         IChannelBotRegistrationQueryPort registrationQueryPort,
+        IChannelBotRegistrationQueryByNyxIdentityPort? registrationQueryByNyxIdentityPort,
         IEnumerable<IPlatformAdapter> platformAdapters,
         NyxIdApiClient nyxClient,
         IConversationReplyGenerator replyGenerator,
@@ -29,6 +31,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
         _registrationQueryPort = registrationQueryPort ?? throw new ArgumentNullException(nameof(registrationQueryPort));
+        _registrationQueryByNyxIdentityPort = registrationQueryByNyxIdentityPort;
         _platformAdapters = platformAdapters ?? throw new ArgumentNullException(nameof(platformAdapters));
         _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
         _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
@@ -39,7 +42,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
     {
         ArgumentNullException.ThrowIfNull(activity);
 
-        var registration = await ResolveRegistrationAsync(activity.Bot?.Value, ct);
+        var registration = await ResolveRegistrationAsync(activity, ct);
         if (registration is null)
             return ConversationTurnResult.PermanentFailure("registration_not_found", "Channel registration not found.");
 
@@ -197,6 +200,24 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
         return await _registrationQueryPort.GetAsync(registrationId, ct);
     }
 
+    private async Task<ChannelBotRegistrationEntry?> ResolveRegistrationAsync(ChatActivity activity, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        var nyxAgentApiKeyId = activity.TransportExtras?.NyxAgentApiKeyId;
+        if (!string.IsNullOrWhiteSpace(nyxAgentApiKeyId) &&
+            _registrationQueryByNyxIdentityPort is not null)
+        {
+            var byNyxIdentity = await _registrationQueryByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync(
+                nyxAgentApiKeyId,
+                ct);
+            if (byNyxIdentity is not null)
+                return byNyxIdentity;
+        }
+
+        return await ResolveRegistrationAsync(activity.Bot?.Value, ct);
+    }
+
     private async Task<ConversationTurnResult?> TryHandleWorkflowResumeAsync(InboundMessage inbound, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(inbound);
@@ -327,6 +348,7 @@ internal sealed class LarkConversationTurnRunner : IConversationTurnRunner
             MessageId = activity.Id,
             ChatType = ResolveChatType(activity.Conversation, activity.Type),
             OutboundDelivery = activity.OutboundDelivery?.Clone(),
+            TransportExtras = activity.TransportExtras?.Clone(),
             Extra = extra,
         };
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
@@ -96,6 +96,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ChannelBotRegistrationDocument>,
             ChannelBotRegistrationDocumentMetadataProvider>();
         services.TryAddSingleton<IChannelBotRegistrationQueryPort, ChannelBotRegistrationQueryPort>();
+        services.TryAddSingleton<IChannelBotRegistrationQueryByNyxIdentityPort, ChannelBotRegistrationQueryPort>();
         services.TryAddSingleton<IChannelBotRegistrationRuntimeQueryPort, ChannelBotRegistrationRuntimeQueryPort>();
         services.TryAddSingleton<ChannelBotRegistrationProjectionPort>();
         services.TryAddSingleton<ChannelPlatformReplyService>();

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -185,7 +185,7 @@ sequenceDiagram
 
 | Proto 归属 | 类型 |
 |---|---|
-| `agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto` | `ChatActivity` / `ConversationReference` / `ParticipantRef` / `MessageContent` / `OutboundDeliveryContext` / `AttachmentRef` / `AttachmentKind` (enum) / `ActionElement` / `CardBlock` / `MessageDisposition` / `ActivityType` / `ConversationScope` / `ChannelId` / `BotInstanceId` / `TransportMode` |
+| `agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto` | `ChatActivity` / `ConversationReference` / `ParticipantRef` / `MessageContent` / `OutboundDeliveryContext` / `TransportExtras` / `AttachmentRef` / `AttachmentKind` (enum) / `ActionElement` / `CardBlock` / `MessageDisposition` / `ActivityType` / `ConversationScope` / `ChannelId` / `BotInstanceId` / `TransportMode` |
 | `agents/Aevatar.GAgents.Channel.Abstractions/protos/channel_contracts.proto` | `EmitResult` / `ComposeCapability` / `ComposeContext` / `ChannelBotDescriptor` / `ChannelTransportBinding` / `ChannelCapabilities` / `StreamingSupport` / `AuthContext` / `PrincipalKind` / `StreamChunk` |
 | `agents/Aevatar.GAgents.Channel.Abstractions/protos/schedule.proto` | `ScheduleState` / `ProjectionVerdict` |
 | `agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto` | `ConversationTurnCompletedEvent` / `ConversationContinueRequestedEvent` / `ConversationContinueRejectedEvent` / `ConversationContinueFailedEvent` / `ChannelBotRegistrationEntry` / `UserAgentCatalogEntry` / `DeviceRegistrationEntry`（含 `IsDeleted` flag 支持 tombstone retention）。详细 field schema 见 §4.3.1 |
@@ -301,8 +301,9 @@ public record ChatActivity(
     DateTimeOffset Timestamp,
     MessageContent Content,             // Text + Attachments + Actions + Cards
     string? ReplyToActivityId,
-    string? RawPayloadBlobRef,          // 原始 payload 存储引用，逃生舱
-    OutboundDeliveryContext? OutboundDelivery
+    string? RawPayloadBlobRef,          // 原始 payload 的 forensic 引用，不承载 reply 凭证或路由事实
+    OutboundDeliveryContext? OutboundDelivery,
+    TransportExtras? TransportExtras    // transport-specific ingress facts（typed）
 );
 ```
 
@@ -311,6 +312,8 @@ public record ChatActivity(
 **为什么没有 `ChannelData`**：早期草稿里有 `ChannelData : IReadOnlyDictionary<string, string>`，但 Slack event envelope / Discord interaction 带嵌套结构（user profile / guild member / team info），string→string 天然太窄；放宽到 `object` 又让调用方陷入动态类型。已有 `RawPayloadBlobRef` 作为 escape hatch（原始 payload 按需取），两套冗余的结构化索引反而让 adapter 作者"两边都想塞点东西"，抽象边界打糊。结论：**只留 `RawPayloadBlobRef`，不要 `ChannelData`**。
 
 **为什么新增 `OutboundDeliveryContext`**：Nyx relay 这类 async callback transport 的 reply 不只是 "往这个 conversation 发一条消息"，还需要把 ingress 提供的 **opaque reply target**（如 relay `message_id`）和 **opaque delivery credential**（如 relay access token）带回 outbound 边界。它们不是业务 metadata bag，也不是 `ConversationReference` 的稳定会话语义，而是**一次 inbound turn 派生出的 reply-delivery 事实**。因此单独建模成 `ChatActivity.OutboundDelivery`，并在 `ConversationTurnCompletedEvent` 上原样保留，避免后续 projection/outbound path 再退回字符串 key bag。
+
+**为什么新增 `TransportExtras`**：某些 transport ingress 会带来必须穿过 runtime 的结构化事实，例如 Nyx relay 的 `nyx_message_id`、`nyx_agent_api_key_id`、`nyx_platform`、`nyx_conversation_id`。这些值会影响 registration lookup、reply correlation 和 platform dispatch，但它们**不属于** `ConversationReference` 的稳定业务语义，也不应该退回到开放式 metadata bag。`TransportExtras` 的职责正是承载这类 typed ingress facts；`RawPayloadBlobRef` 继续只做 forensic hash/blob 引用，**不能**反向充当 reply credential 或 structured routing metadata 的回查通道。
 
 ### 5.1b Supporting types
 

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
@@ -49,6 +49,13 @@ public sealed class ChannelAbstractionsProtoTests
                 ReplyMessageId = "relay-msg-1",
                 ReplyAccessToken = "relay-token-1",
             },
+            TransportExtras = new TransportExtras
+            {
+                NyxMessageId = "nyx-msg-1",
+                NyxAgentApiKeyId = "nyx-key-1",
+                NyxPlatform = "lark",
+                NyxConversationId = "nyx-conv-1",
+            },
         };
         activity.Mentions.Add(new ParticipantRef
         {
@@ -88,6 +95,7 @@ public sealed class ChannelAbstractionsProtoTests
         parsed.Content.Actions[0].Kind.ShouldBe(ActionElementKind.Button);
         parsed.Conversation.Scope.ShouldBe(ConversationScope.Thread);
         parsed.OutboundDelivery.ReplyMessageId.ShouldBe("relay-msg-1");
+        parsed.TransportExtras.NyxAgentApiKeyId.ShouldBe("nyx-key-1");
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(ChatActivity));
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
@@ -96,6 +104,8 @@ public sealed class ChannelAbstractionsProtoTests
             .ShouldContain(nameof(CardActionSubmission));
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(OutboundDeliveryContext));
+        ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
+            .ShouldContain(nameof(TransportExtras));
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
@@ -47,6 +47,49 @@ public sealed class LarkConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldResolveRegistrationByNyxAgentApiKeyId_WhenBotIdDoesNotMatch()
+    {
+        var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        registrationQueryPort.GetAsync("missing-reg", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(null));
+        var registrationByNyxIdentityPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        registrationByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(BuildRegistrationEntry()));
+        var adapter = new RecordingPlatformAdapter();
+        var replyGenerator = new StubReplyGenerator("reply-from-nyx");
+        var runner = CreateRunner(
+            registrationQueryPort,
+            adapter,
+            replyGenerator: replyGenerator,
+            registrationQueryByNyxIdentityPort: registrationByNyxIdentityPort);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello from relay",
+                "msg-nyx-1",
+                botId: "missing-reg",
+                transportExtras: new TransportExtras
+                {
+                    NyxAgentApiKeyId = "nyx-key-1",
+                    NyxMessageId = "nyx-msg-1",
+                    NyxPlatform = "lark",
+                    NyxConversationId = "nyx-conv-1",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        adapter.Replies.Should().ContainSingle();
+        adapter.Replies[0].ReplyText.Should().Be("reply-from-nyx");
+        adapter.Replies[0].Inbound.TransportExtras?.NyxAgentApiKeyId.Should().Be("nyx-key-1");
+        replyGenerator.GeneratedActivities.Should().ContainSingle();
+        replyGenerator.GeneratedActivities[0].TransportExtras?.NyxAgentApiKeyId.Should().Be("nyx-key-1");
+        await registrationByNyxIdentityPort.Received(1)
+            .GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
+        await registrationQueryPort.DidNotReceive()
+            .GetAsync("missing-reg", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldReturnTransientFailure_WhenWorkflowResumeServiceIsMissing()
     {
         var registrationQueryPort = BuildRegistrationQueryPort();
@@ -204,12 +247,14 @@ public sealed class LarkConversationTurnRunnerTests
         IChannelBotRegistrationQueryPort registrationQueryPort,
         RecordingPlatformAdapter adapter,
         IServiceProvider? services = null,
-        IConversationReplyGenerator? replyGenerator = null)
+        IConversationReplyGenerator? replyGenerator = null,
+        IChannelBotRegistrationQueryByNyxIdentityPort? registrationQueryByNyxIdentityPort = null)
     {
         services ??= new ServiceCollection().BuildServiceProvider();
         return new LarkConversationTurnRunner(
             services,
             registrationQueryPort,
+            registrationQueryByNyxIdentityPort,
             [adapter],
             new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://example.com" }),
             replyGenerator ?? new StubReplyGenerator(),
@@ -221,17 +266,19 @@ public sealed class LarkConversationTurnRunnerTests
         string messageId,
         ConversationScope scope = ConversationScope.Group,
         string? partition = "oc_group_chat_1",
-        OutboundDeliveryContext? outboundDelivery = null)
+        OutboundDeliveryContext? outboundDelivery = null,
+        TransportExtras? transportExtras = null,
+        string botId = "reg-1")
     {
         return new ChatActivity
         {
             Id = messageId,
             Type = ActivityType.Message,
             ChannelId = ChannelId.From("lark"),
-            Bot = BotInstanceId.From("reg-1"),
+            Bot = BotInstanceId.From(botId),
             Conversation = ConversationReference.Create(
                 ChannelId.From("lark"),
-                BotInstanceId.From("reg-1"),
+                BotInstanceId.From(botId),
                 scope,
                 partition,
                 scope == ConversationScope.Group ? "group" : "dm",
@@ -246,25 +293,28 @@ public sealed class LarkConversationTurnRunnerTests
                 Text = text,
             },
             OutboundDelivery = outboundDelivery?.Clone(),
+            TransportExtras = transportExtras?.Clone(),
         };
     }
 
     private static IChannelBotRegistrationQueryPort BuildRegistrationQueryPort()
     {
-        var registration = new ChannelBotRegistrationEntry
-        {
-            Id = "reg-1",
-            Platform = "lark",
-            NyxProviderSlug = "api-lark-bot",
-            ScopeId = "scope-1",
-            CreatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-        };
-
+        var registration = BuildRegistrationEntry();
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
         queryPort.GetAsync(registration.Id, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(registration));
         return queryPort;
     }
+
+    private static ChannelBotRegistrationEntry BuildRegistrationEntry(string id = "reg-1") =>
+        new()
+        {
+            Id = id,
+            Platform = "lark",
+            NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-1",
+            CreatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
 
     private sealed class RecordingPlatformAdapter : IPlatformAdapter
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/RegistrationQueryPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/RegistrationQueryPortTests.cs
@@ -94,6 +94,74 @@ public sealed class RegistrationQueryPortTests
     }
 
     [Fact]
+    public async Task BotQueryPort_GetByNyxAgentApiKeyIdAsync_QueriesProjectionByIdentityField()
+    {
+        ProjectionDocumentQuery? capturedQuery = null;
+        var reader = Substitute.For<IProjectionDocumentReader<ChannelBotRegistrationDocument, string>>();
+        reader.QueryAsync(
+                Arg.Do<ProjectionDocumentQuery>(query => capturedQuery = query),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ProjectionDocumentQueryResult<ChannelBotRegistrationDocument>
+            {
+                Items =
+                [
+                    new ChannelBotRegistrationDocument
+                    {
+                        Id = "bot-1",
+                        Platform = "lark",
+                        NyxAgentApiKeyId = "key-1",
+                    },
+                ],
+            }));
+
+        var queryPort = new ChannelBotRegistrationQueryPort(reader);
+        var result = await queryPort.GetByNyxAgentApiKeyIdAsync("key-1");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("bot-1");
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Take.Should().Be(1);
+        capturedQuery.Filters.Should().ContainSingle();
+        capturedQuery.Filters[0].FieldPath.Should().Be(nameof(ChannelBotRegistrationDocument.NyxAgentApiKeyId));
+        capturedQuery.Filters[0].Operator.Should().Be(ProjectionDocumentFilterOperator.Eq);
+        capturedQuery.Filters[0].Value.RawValue.Should().Be("key-1");
+    }
+
+    [Fact]
+    public async Task BotQueryPort_GetByNyxChannelBotIdAsync_QueriesProjectionByIdentityField()
+    {
+        ProjectionDocumentQuery? capturedQuery = null;
+        var reader = Substitute.For<IProjectionDocumentReader<ChannelBotRegistrationDocument, string>>();
+        reader.QueryAsync(
+                Arg.Do<ProjectionDocumentQuery>(query => capturedQuery = query),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ProjectionDocumentQueryResult<ChannelBotRegistrationDocument>
+            {
+                Items =
+                [
+                    new ChannelBotRegistrationDocument
+                    {
+                        Id = "bot-2",
+                        Platform = "lark",
+                        NyxChannelBotId = "nyx-bot-2",
+                    },
+                ],
+            }));
+
+        var queryPort = new ChannelBotRegistrationQueryPort(reader);
+        var result = await queryPort.GetByNyxChannelBotIdAsync("nyx-bot-2");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("bot-2");
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Take.Should().Be(1);
+        capturedQuery.Filters.Should().ContainSingle();
+        capturedQuery.Filters[0].FieldPath.Should().Be(nameof(ChannelBotRegistrationDocument.NyxChannelBotId));
+        capturedQuery.Filters[0].Operator.Should().Be(ProjectionDocumentFilterOperator.Eq);
+        capturedQuery.Filters[0].Value.RawValue.Should().Be("nyx-bot-2");
+    }
+
+    [Fact]
     public async Task BotRuntimeQueryPort_DelegatesToPublicQueryPort()
     {
         var publicQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -14,14 +14,13 @@ public sealed class ServiceCollectionExtensionsTests
     {
         var services = new ServiceCollection();
 
-        var act = () => services.AddChannelRuntime();
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("*IHostedService*");
+        services.AddChannelRuntime();
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IProjectionDocumentMetadataProvider<ChannelBotRegistrationDocument>));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IChannelBotRegistrationRuntimeQueryPort));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IChannelBotRegistrationQueryByNyxIdentityPort));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IPlatformAdapter) &&
             descriptor.ImplementationType == typeof(LarkPlatformAdapter));
@@ -41,14 +40,13 @@ public sealed class ServiceCollectionExtensionsTests
             .Build();
         var services = new ServiceCollection();
 
-        var act = () => services.AddChannelRuntime(configuration);
-
-        act.Should().Throw<ArgumentException>()
-            .WithMessage("*IHostedService*");
+        services.AddChannelRuntime(configuration);
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IProjectionDocumentMetadataProvider<ChannelBotRegistrationDocument>));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IChannelBotRegistrationRuntimeQueryPort));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IChannelBotRegistrationQueryByNyxIdentityPort));
         services.Should().NotContain(descriptor =>
             descriptor.ServiceType.Name.Contains("ChannelBotDirectCallbackBinding", StringComparison.Ordinal));
     }


### PR DESCRIPTION
## Summary
- add typed `TransportExtras` to `ChatActivity` and carry it through the legacy runner inbound path
- add `IChannelBotRegistrationQueryByNyxIdentityPort` plus projection-field lookups for `nyx_agent_api_key_id` and `nyx_channel_bot_id`
- let `LarkConversationTurnRunner` resolve registrations by `TransportExtras.NyxAgentApiKeyId` before falling back to `Bot.Value`
- update protocol/runtime tests and canon docs to keep `RawPayloadBlobRef` forensic-only and move Nyx ingress facts into typed fields

## Why
Issue #328 was updated to make two Phase 1 boundaries explicit on the Aevatar side:
1. ingress transport facts must not be stuffed into `RawPayloadBlobRef`
2. Nyx relay callbacks need a registration lookup path that does not depend on the Aevatar registration id being present in `activity.Bot`

This PR implements that contract slice without changing traffic or the LLM reply path yet.

## Scope
This stacked PR is based on #335 and keeps the diff limited to:
- `ChatActivity.TransportExtras`
- Nyx identity query port + projection lookup support
- runner fallback from `Bot.Value` to `nyx_agent_api_key_id`
- related tests and architecture docs

Not included here:
- Nyx relay transport/outbound adapter project
- event-driven `NeedsLlmReplyEvent` / `LlmReplyReadyEvent` cutover
- traffic switch in `NyxIdChatEndpoints`
- Phase 3 unknown-slash fallback

## Validation
- `dotnet build aevatar.slnx --nologo --no-restore -m:1`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo --no-restore --filter "FullyQualifiedName~RegistrationQueryPortTests|FullyQualifiedName~LarkConversationTurnRunnerTests|FullyQualifiedName~ServiceCollectionExtensionsTests"`
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo --no-build --filter "FullyQualifiedName~ChannelAbstractionsProtoTests|FullyQualifiedName~ChannelRuntimeProtoTests|FullyQualifiedName~ConversationGAgentDedupTests"`
- `bash tools/ci/architecture_guards.sh`

Refs #328