### PR TITLE
Bridge Day One slash commands over Nyx relay (#341)

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -29,8 +29,7 @@ internal static class AgentBuilderCardFlow
 
     private static readonly HashSet<string> LaunchIntents = new(StringComparer.OrdinalIgnoreCase)
     {
-        "/daily-report",
-        "/create-daily-report",
+        "/daily",
         "create daily report",
         "创建日报助手",
         "创建日报agent",
@@ -251,7 +250,7 @@ internal static class AgentBuilderCardFlow
 
         if (!TryGetRequiredExtra(evt, "github_username", out var githubUsername))
         {
-            validationError = "GitHub username is required. Send /daily-report and fill in the form again.";
+            validationError = "GitHub username is required. Send /daily and fill in the form again.";
             return false;
         }
 
@@ -1110,7 +1109,7 @@ internal static class AgentBuilderCardFlow
             new
             {
                 tag = "markdown",
-                content = "Quick commands: `/daily-report`, `/social-media`, `/agent-status <agent_id>`, `/run-agent <agent_id>`, `/disable-agent <agent_id>`, `/enable-agent <agent_id>`, `/delete-agent <agent_id>`",
+                content = "Quick commands: `/daily`, `/social-media`, `/agent-status <agent_id>`, `/run-agent <agent_id>`, `/disable-agent <agent_id>`, `/enable-agent <agent_id>`, `/delete-agent <agent_id>`",
             },
         };
 
@@ -1219,7 +1218,7 @@ internal static class AgentBuilderCardFlow
         elements.Add(new
         {
             tag = "markdown",
-            content = "Quick commands: `/templates`, `/daily-report`, `/social-media`, `/agent-status <agent_id>`",
+            content = "Quick commands: `/templates`, `/daily`, `/social-media`, `/agent-status <agent_id>`",
         });
         elements.Add(new
         {

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
@@ -7,8 +7,7 @@ namespace Aevatar.GAgents.ChannelRuntime;
 internal static class NyxRelayAgentBuilderFlow
 {
     private const string PrivateChatType = "p2p";
-    private const string DailyReportCommand = "/daily-report";
-    private const string DailyReportAlias = "/create-daily-report";
+    private const string DailyCommand = "/daily";
     private const string SocialMediaCommand = "/social-media";
     private const string SocialMediaAlias = "/create-social-media";
     private const string ListTemplatesCommand = "/templates";
@@ -25,53 +24,31 @@ internal static class NyxRelayAgentBuilderFlow
         ArgumentNullException.ThrowIfNull(evt);
         decision = null;
 
-        if (!string.Equals(evt.ChatType, PrivateChatType, StringComparison.OrdinalIgnoreCase) ||
-            string.IsNullOrWhiteSpace(evt.Text))
-        {
+        if (string.IsNullOrWhiteSpace(evt.Text))
             return false;
-        }
 
-        var tokens = ChannelTextCommandParser.Tokenize(evt.Text);
+        var trimmedText = evt.Text.TrimStart();
+        if (!trimmedText.StartsWith('/'))
+            return false;
+
+        var tokens = ChannelTextCommandParser.Tokenize(trimmedText);
         if (tokens.Count == 0)
             return false;
 
         var command = tokens[0];
-        switch (command)
+        if (!IsKnownCommand(command))
         {
-            case DailyReportCommand:
-            case DailyReportAlias:
-                return TryResolveDailyReport(tokens, evt.ConversationId, out decision);
-
-            case SocialMediaCommand:
-            case SocialMediaAlias:
-                return TryResolveSocialMedia(tokens, evt.ConversationId, out decision);
-
-            case ListTemplatesCommand:
-                decision = AgentBuilderFlowDecision.ToolCall("list_templates", """{"action":"list_templates"}""");
-                return true;
-
-            case ListAgentsCommand:
-                decision = AgentBuilderFlowDecision.ToolCall("list_agents", """{"action":"list_agents"}""");
-                return true;
-
-            case AgentStatusCommand:
-                return TryResolveSimpleAgentAction(tokens, "agent_status", "Usage: /agent-status <agent_id>", out decision);
-
-            case RunAgentCommand:
-                return TryResolveSimpleAgentAction(tokens, "run_agent", "Usage: /run-agent <agent_id>", out decision);
-
-            case DisableAgentCommand:
-                return TryResolveSimpleAgentAction(tokens, "disable_agent", "Usage: /disable-agent <agent_id>", out decision);
-
-            case EnableAgentCommand:
-                return TryResolveSimpleAgentAction(tokens, "enable_agent", "Usage: /enable-agent <agent_id>", out decision);
-
-            case DeleteAgentCommand:
-                return TryResolveDeleteAgent(tokens, out decision);
-
-            default:
-                return false;
+            decision = AgentBuilderFlowDecision.DirectReply(BuildUnknownCommandReply(command));
+            return true;
         }
+
+        if (!IsPrivateChat(evt.ChatType))
+        {
+            decision = AgentBuilderFlowDecision.DirectReply(BuildPrivateChatRestrictionReply(command));
+            return true;
+        }
+
+        return TryResolveKnownCommand(command, tokens, evt.ConversationId, out decision);
     }
 
     public static string FormatToolResult(AgentBuilderFlowDecision decision, string toolResultJson)
@@ -98,6 +75,64 @@ internal static class NyxRelayAgentBuilderFlow
         catch (JsonException)
         {
             return toolResultJson;
+        }
+    }
+
+    private static bool IsKnownCommand(string command) =>
+        command is DailyCommand
+            or SocialMediaCommand or SocialMediaAlias
+            or ListTemplatesCommand
+            or ListAgentsCommand
+            or AgentStatusCommand
+            or RunAgentCommand
+            or DisableAgentCommand
+            or EnableAgentCommand
+            or DeleteAgentCommand;
+
+    private static bool IsPrivateChat(string? chatType) =>
+        string.Equals(chatType, PrivateChatType, StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryResolveKnownCommand(
+        string command,
+        IReadOnlyList<string> tokens,
+        string? conversationId,
+        out AgentBuilderFlowDecision? decision)
+    {
+        switch (command)
+        {
+            case DailyCommand:
+                return TryResolveDailyReport(tokens, conversationId, out decision);
+
+            case SocialMediaCommand:
+            case SocialMediaAlias:
+                return TryResolveSocialMedia(tokens, conversationId, out decision);
+
+            case ListTemplatesCommand:
+                decision = AgentBuilderFlowDecision.ToolCall("list_templates", """{"action":"list_templates"}""");
+                return true;
+
+            case ListAgentsCommand:
+                decision = AgentBuilderFlowDecision.ToolCall("list_agents", """{"action":"list_agents"}""");
+                return true;
+
+            case AgentStatusCommand:
+                return TryResolveSimpleAgentAction(tokens, "agent_status", "Usage: /agent-status <agent_id>", out decision);
+
+            case RunAgentCommand:
+                return TryResolveSimpleAgentAction(tokens, "run_agent", "Usage: /run-agent <agent_id>", out decision);
+
+            case DisableAgentCommand:
+                return TryResolveSimpleAgentAction(tokens, "disable_agent", "Usage: /disable-agent <agent_id>", out decision);
+
+            case EnableAgentCommand:
+                return TryResolveSimpleAgentAction(tokens, "enable_agent", "Usage: /enable-agent <agent_id>", out decision);
+
+            case DeleteAgentCommand:
+                return TryResolveDeleteAgent(tokens, out decision);
+
+            default:
+                decision = null;
+                return false;
         }
     }
 
@@ -274,7 +309,7 @@ internal static class NyxRelayAgentBuilderFlow
                       ?? ReadString(root, "auth_url")
                       ?? ReadString(root, "url")
                       ?? ReadString(root, "documentation_url");
-            var note = ReadString(root, "note") ?? "Finish the GitHub authorization step, then run /daily-report again.";
+            var note = ReadString(root, "note") ?? "Finish the GitHub authorization step, then run /daily again.";
 
             return BuildTextBlock(
                 string.Equals(status, "oauth_required", StringComparison.OrdinalIgnoreCase)
@@ -515,10 +550,27 @@ internal static class NyxRelayAgentBuilderFlow
             "Optional: audience=\"Developers\" style=\"Confident and concise\" schedule_timezone=Asia/Singapore run_immediately=false");
 
     private static string BuildDailyReportCommandExample() =>
-        "/daily-report github_username=alice schedule_time=09:00 repositories=owner/repo";
+        "/daily github_username=alice schedule_time=09:00 repositories=owner/repo";
 
     private static string BuildSocialMediaCommandExample() =>
         "/social-media topic=\"Launch update\" schedule_time=10:30 audience=\"Developers\" style=\"Confident and concise\"";
+
+    private static string BuildUnknownCommandReply(string command) =>
+        BuildTextBlock(
+            $"Unknown command: {command}",
+            "Supported commands:",
+            BuildDailyReportCommandExample(),
+            BuildSocialMediaCommandExample(),
+            "/templates",
+            "/agents",
+            "/agent-status <agent_id>",
+            "/run-agent <agent_id>",
+            "/disable-agent <agent_id>",
+            "/enable-agent <agent_id>",
+            "/delete-agent <agent_id> confirm");
+
+    private static string BuildPrivateChatRestrictionReply(string command) =>
+        $"`{command}` only works in a private chat with this bot. Please DM me and run `{command}` again.";
 
     private static string BuildTextBlock(params string?[] lines)
     {

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayDayOneBridge.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayDayOneBridge.cs
@@ -1,0 +1,108 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgents.NyxidChat.Relay;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChannelRuntime;
+
+internal sealed class NyxRelayDayOneBridge : INyxRelayDayOneBridge
+{
+    private const string PrivateChatType = "p2p";
+    private const string GroupChatType = "group";
+    private const string DeviceConversationType = "device";
+
+    private readonly IServiceProvider _services;
+
+    public NyxRelayDayOneBridge(IServiceProvider services)
+    {
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+    }
+
+    public bool ShouldHandle(NyxRelayBridgeRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.Text))
+            return false;
+        if (!request.Text.TrimStart().StartsWith('/'))
+            return false;
+        if (IsDevice(request.ConversationType))
+            return false;
+
+        return true;
+    }
+
+    public async Task<string> HandleAsync(NyxRelayBridgeRequest request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var chatType = MapChatType(request.ConversationType);
+        var inboundEvent = new ChannelInboundEvent
+        {
+            Text = request.Text.TrimStart(),
+            ConversationId = request.ConversationId ?? string.Empty,
+            MessageId = request.MessageId ?? string.Empty,
+            ChatType = chatType,
+            Platform = request.Platform ?? string.Empty,
+            SenderId = request.SenderId ?? string.Empty,
+            SenderName = request.SenderName ?? string.Empty,
+            RegistrationScopeId = request.ScopeId,
+        };
+
+        if (!NyxRelayAgentBuilderFlow.TryResolve(inboundEvent, out var decision) || decision is null)
+        {
+            throw new InvalidOperationException(
+                "NyxRelayDayOneBridge.HandleAsync was invoked for a message that ShouldHandle did not own.");
+        }
+
+        if (!decision.RequiresToolExecution)
+            return decision.ReplyPayload;
+
+        var previousMetadata = AgentToolRequestContext.CurrentMetadata;
+        try
+        {
+            AgentToolRequestContext.CurrentMetadata = BuildToolMetadata(request, chatType);
+            var tool = ActivatorUtilities.CreateInstance<AgentBuilderTool>(_services);
+            var toolResult = await tool.ExecuteAsync(decision.ToolArgumentsJson!, ct);
+            return NyxRelayAgentBuilderFlow.FormatToolResult(decision, toolResult);
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = previousMetadata;
+        }
+    }
+
+    private static bool IsDevice(string? conversationType) =>
+        !string.IsNullOrWhiteSpace(conversationType) &&
+        string.Equals(conversationType.Trim(), DeviceConversationType, StringComparison.OrdinalIgnoreCase);
+
+    private static string MapChatType(string? conversationType)
+    {
+        if (string.IsNullOrWhiteSpace(conversationType))
+            return PrivateChatType;
+
+        return conversationType.Trim().ToLowerInvariant() switch
+        {
+            "private" => PrivateChatType,
+            "group" or "channel" => GroupChatType,
+            _ => PrivateChatType,
+        };
+    }
+
+    private static IReadOnlyDictionary<string, string> BuildToolMetadata(
+        NyxRelayBridgeRequest request,
+        string chatType)
+    {
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = request.NyxIdAccessToken,
+            [ChannelMetadataKeys.Platform] = request.Platform ?? string.Empty,
+            [ChannelMetadataKeys.SenderId] = request.SenderId ?? string.Empty,
+            [ChannelMetadataKeys.SenderName] = request.SenderName ?? string.Empty,
+            [ChannelMetadataKeys.ConversationId] = request.ConversationId ?? string.Empty,
+            [ChannelMetadataKeys.MessageId] = request.MessageId ?? string.Empty,
+            [ChannelMetadataKeys.ChatType] = chatType,
+            ["scope_id"] = request.ScopeId,
+        };
+    }
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayDayOneBridge.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayDayOneBridge.cs
@@ -76,16 +76,19 @@ internal sealed class NyxRelayDayOneBridge : INyxRelayDayOneBridge
         !string.IsNullOrWhiteSpace(conversationType) &&
         string.Equals(conversationType.Trim(), DeviceConversationType, StringComparison.OrdinalIgnoreCase);
 
+    // Fail-closed: only an explicit "private" maps to p2p. Missing or unrecognized types fall
+    // back to group so the known-command path returns a private-chat restriction instead of
+    // silently executing Day One side effects on an unexpected surface.
     private static string MapChatType(string? conversationType)
     {
         if (string.IsNullOrWhiteSpace(conversationType))
-            return PrivateChatType;
+            return GroupChatType;
 
         return conversationType.Trim().ToLowerInvariant() switch
         {
             "private" => PrivateChatType,
             "group" or "channel" => GroupChatType,
-            _ => PrivateChatType,
+            _ => GroupChatType,
         };
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgents.Channel.Lark;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.ChannelRuntime.Adapters;
+using Aevatar.GAgents.NyxidChat.Relay;
 using Aevatar.Foundation.Abstractions.HumanInteraction;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -193,6 +194,7 @@ public static class ServiceCollectionExtensions
             .Use<ConversationDispatchMiddleware>()));
         services.TryAddSingleton<ChannelPipeline>(sp => sp.GetRequiredService<MiddlewarePipelineBuilder>().Build(sp));
         services.TryAddSingleton<IConversationReplyGenerator, NyxIdConversationReplyGenerator>();
+        services.TryAddSingleton<INyxRelayDayOneBridge, NyxRelayDayOneBridge>();
         services.TryAddSingleton<LarkConversationInboxRuntime>();
         services.TryAddSingleton<ILarkConversationInbox>(sp => sp.GetRequiredService<LarkConversationInboxRuntime>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, LarkConversationInboxHostedService>());

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -7,6 +7,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.GAgents.NyxidChat.Relay;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -838,6 +839,54 @@ public static class NyxIdChatEndpoints
                 "Relay message: platform={Platform}, conversation={ConversationId}, sender={Sender}",
                 platform, conversationId, message.Sender?.DisplayName);
 
+            // ─── Day One slash-command bridge ───
+            // Intercept known and unknown slash commands deterministically so they do
+            // not reach the LLM. Free-text still falls through to the actor/LLM path.
+            // Bridge reply delivery uses the current callback token only — no long-term
+            // state, no durable credential, no projection write.
+            var dayOneBridge = http.RequestServices.GetService<INyxRelayDayOneBridge>();
+            if (dayOneBridge is not null)
+            {
+                var bridgeRequest = new NyxRelayBridgeRequest(
+                    Text: message.Content?.Text ?? string.Empty,
+                    ConversationType: message.Conversation?.Type,
+                    ConversationId: conversationId,
+                    MessageId: message.MessageId,
+                    Platform: message.Platform,
+                    SenderId: message.Sender?.PlatformId,
+                    SenderName: message.Sender?.DisplayName,
+                    ScopeId: scopeId,
+                    NyxIdAccessToken: userToken);
+
+                if (dayOneBridge.ShouldHandle(bridgeRequest))
+                {
+                    logger.LogInformation(
+                        "Relay Day One bridge owning message: platform={Platform}, conversation={ConversationId}, message_id={MessageId}",
+                        platform, conversationId, message.MessageId);
+
+                    _ = FinalizeDayOneBridgeReplyAsync(
+                            dayOneBridge,
+                            bridgeRequest,
+                            userToken,
+                            message.MessageId!,
+                            nyxClient,
+                            logger)
+                        .ContinueWith(
+                            task => logger.LogError(
+                                task.Exception,
+                                "Relay Day One bridge reply pipeline failed for message {MessageId}",
+                                message.MessageId),
+                            TaskContinuationOptions.OnlyOnFaulted);
+
+                    return Results.Accepted(value: new
+                    {
+                        status = "accepted",
+                        bridge = "day_one_command",
+                        message_id = message.MessageId,
+                    });
+                }
+            }
+
             // ─── Get or create actor ───
             // Relay follows the same strict lifecycle contract as create:
             // registry persistence via IGAgentActorStore is mandatory, and
@@ -1008,6 +1057,52 @@ public static class NyxIdChatEndpoints
         }
 
         return false;
+    }
+
+    private static async Task FinalizeDayOneBridgeReplyAsync(
+        INyxRelayDayOneBridge bridge,
+        NyxRelayBridgeRequest request,
+        string relayToken,
+        string messageId,
+        NyxIdApiClient nyxClient,
+        ILogger logger)
+    {
+        string replyText;
+        try
+        {
+            replyText = await bridge.HandleAsync(request, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(
+                ex,
+                "Relay Day One bridge handler threw: messageId={MessageId}",
+                messageId);
+            replyText = "Sorry, something went wrong while handling that command. Please try again.";
+        }
+
+        if (string.IsNullOrWhiteSpace(replyText))
+            replyText = "Sorry, I wasn't able to generate a response.";
+
+        using var deliveryCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var delivery = await nyxClient.SendChannelRelayTextReplyAsync(
+            relayToken,
+            messageId,
+            replyText,
+            deliveryCts.Token);
+        if (!delivery.Succeeded)
+        {
+            logger.LogError(
+                "Relay Day One bridge reply delivery failed: messageId={MessageId}, detail={Detail}",
+                messageId,
+                delivery.Detail);
+            return;
+        }
+
+        logger.LogInformation(
+            "Relay Day One bridge reply delivered: messageId={MessageId}, platformMessageId={PlatformMessageId}",
+            delivery.MessageId,
+            delivery.PlatformMessageId);
     }
 
     private static async Task FinalizeRelayReplyAsync(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -6,6 +6,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Deduplication;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgents.NyxidChat.Relay;
 using Google.Protobuf.WellKnownTypes;
@@ -860,6 +861,30 @@ public static class NyxIdChatEndpoints
 
                 if (dayOneBridge.ShouldHandle(bridgeRequest))
                 {
+                    // Dedupe at the Nyx-relay callback boundary so retried webhooks with the
+                    // same message_id do not double-fire AgentBuilderTool side effects (a single
+                    // `/daily` would otherwise create multiple agents + API keys on retry). The
+                    // LLM fallback path relies on the actor's session for equivalent dedupe; the
+                    // bridge skips the actor entirely, so it must guard itself here.
+                    var deduplicator = http.RequestServices.GetService<IEventDeduplicator>();
+                    var dedupeKey = BuildBridgeDedupeKey(scopeId, message.MessageId!);
+                    var firstDelivery = deduplicator is null
+                                        || await deduplicator.TryRecordAsync(dedupeKey);
+                    if (!firstDelivery)
+                    {
+                        logger.LogInformation(
+                            "Relay Day One bridge duplicate callback suppressed: message_id={MessageId}, dedupe_key={DedupeKey}",
+                            message.MessageId,
+                            dedupeKey);
+                        return Results.Accepted(value: new
+                        {
+                            status = "accepted",
+                            bridge = "day_one_command",
+                            dedupe = "duplicate",
+                            message_id = message.MessageId,
+                        });
+                    }
+
                     logger.LogInformation(
                         "Relay Day One bridge owning message: platform={Platform}, conversation={ConversationId}, message_id={MessageId}",
                         platform, conversationId, message.MessageId);
@@ -1058,6 +1083,9 @@ public static class NyxIdChatEndpoints
 
         return false;
     }
+
+    private static string BuildBridgeDedupeKey(string scopeId, string messageId) =>
+        $"nyxid-relay-bridge:{scopeId}:{messageId}";
 
     private static async Task FinalizeDayOneBridgeReplyAsync(
         INyxRelayDayOneBridge bridge,

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -6,7 +6,6 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Deduplication;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgents.NyxidChat.Relay;
 using Google.Protobuf.WellKnownTypes;
@@ -864,12 +863,14 @@ public static class NyxIdChatEndpoints
                     // Dedupe at the Nyx-relay callback boundary so retried webhooks with the
                     // same message_id do not double-fire AgentBuilderTool side effects (a single
                     // `/daily` would otherwise create multiple agents + API keys on retry). The
-                    // LLM fallback path relies on the actor's session for equivalent dedupe; the
-                    // bridge skips the actor entirely, so it must guard itself here.
-                    var deduplicator = http.RequestServices.GetService<IEventDeduplicator>();
+                    // LLM fallback path relies on the actor's serialized mailbox for equivalent
+                    // dedupe; the bridge skips the actor entirely, so it must use an atomic
+                    // first-writer-wins guard here — a non-atomic TryGet+Set pair would let
+                    // concurrent deliveries both observe the key as absent and both pass.
+                    var idempotencyGuard = http.RequestServices.GetService<INyxRelayBridgeIdempotencyGuard>();
                     var dedupeKey = BuildBridgeDedupeKey(scopeId, message.MessageId!);
-                    var firstDelivery = deduplicator is null
-                                        || await deduplicator.TryRecordAsync(dedupeKey);
+                    var firstDelivery = idempotencyGuard is null
+                                        || idempotencyGuard.TryClaim(dedupeKey);
                     if (!firstDelivery)
                     {
                         logger.LogInformation(

--- a/agents/Aevatar.GAgents.NyxidChat/Relay/INyxRelayBridgeIdempotencyGuard.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/Relay/INyxRelayBridgeIdempotencyGuard.cs
@@ -30,6 +30,8 @@ internal sealed class NyxRelayBridgeIdempotencyGuard : INyxRelayBridgeIdempotenc
     private readonly ConcurrentDictionary<string, DateTimeOffset> _claims = new(StringComparer.Ordinal);
     private readonly TimeSpan _ttl;
     private readonly TimeProvider _timeProvider;
+    private readonly long _sweepIntervalTicks;
+    private long _lastSweepTicks;
 
     public NyxRelayBridgeIdempotencyGuard()
         : this(TimeSpan.FromMinutes(10), TimeProvider.System)
@@ -42,13 +44,21 @@ internal sealed class NyxRelayBridgeIdempotencyGuard : INyxRelayBridgeIdempotenc
             throw new ArgumentOutOfRangeException(nameof(ttl), "TTL must be positive.");
         _ttl = ttl;
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _sweepIntervalTicks = Math.Max(TimeSpan.TicksPerSecond, _ttl.Ticks / 4);
+        _lastSweepTicks = _timeProvider.GetUtcNow().UtcTicks;
     }
+
+    // Exposed for tests (and diagnostics) so eviction behavior can be verified without
+    // observing memory pressure directly.
+    internal int ClaimCount => _claims.Count;
 
     public bool TryClaim(string key)
     {
         ArgumentException.ThrowIfNullOrEmpty(key);
 
         var now = _timeProvider.GetUtcNow();
+        MaybeSweepExpired(now);
+
         var newExpiry = now + _ttl;
 
         // Hot path: key absent. TryAdd is atomic — only one concurrent caller succeeds.
@@ -71,5 +81,25 @@ internal sealed class NyxRelayBridgeIdempotencyGuard : INyxRelayBridgeIdempotenc
 
         // Entry vanished between TryAdd and TryGetValue (concurrent eviction). Try fresh add.
         return _claims.TryAdd(key, newExpiry);
+    }
+
+    // Opportunistic sweep to bound memory. Eviction cost is folded into callers that cross
+    // the sweep interval, so a quiet host does no work and a busy host sweeps at a rate
+    // governed by wall-clock time (not per-call), keeping the amortized cost tiny.
+    private void MaybeSweepExpired(DateTimeOffset now)
+    {
+        var lastSweep = Interlocked.Read(ref _lastSweepTicks);
+        if (now.UtcTicks - lastSweep < _sweepIntervalTicks)
+            return;
+
+        // CAS-claim the sweep slot so concurrent callers do not duplicate the walk.
+        if (Interlocked.CompareExchange(ref _lastSweepTicks, now.UtcTicks, lastSweep) != lastSweep)
+            return;
+
+        foreach (var kvp in _claims)
+        {
+            if (kvp.Value <= now)
+                _claims.TryRemove(kvp);
+        }
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/Relay/INyxRelayBridgeIdempotencyGuard.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/Relay/INyxRelayBridgeIdempotencyGuard.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+
+namespace Aevatar.GAgents.NyxidChat.Relay;
+
+/// <summary>
+/// Atomic, boundary-level first-writer-wins guard for Nyx relay bridge callbacks.
+///
+/// Unlike <c>IEventDeduplicator</c>, whose <c>MemoryCacheDeduplicator</c> implementation
+/// performs a non-atomic <c>TryGetValue</c> + <c>Set</c> pair (safe inside a serialized
+/// grain mailbox, unsafe at a concurrent HTTP boundary), this guard uses
+/// <c>ConcurrentDictionary.TryAdd</c> / <c>TryUpdate</c> so that two simultaneous
+/// deliveries of the same webhook cannot both claim first-seen within a single process.
+///
+/// The guard is per-process: Nyx typically routes retries of the same callback to the
+/// same Aevatar host, so node-local atomicity covers the observed retry pattern. Cross-
+/// node replays would still need an upstream idempotency layer, but that is outside the
+/// scope of this bridge.
+/// </summary>
+public interface INyxRelayBridgeIdempotencyGuard
+{
+    /// <summary>
+    /// Atomically claim <paramref name="key"/>. Returns true only for the first caller to
+    /// observe the key as absent (or expired); every concurrent caller sees false.
+    /// </summary>
+    bool TryClaim(string key);
+}
+
+internal sealed class NyxRelayBridgeIdempotencyGuard : INyxRelayBridgeIdempotencyGuard
+{
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _claims = new(StringComparer.Ordinal);
+    private readonly TimeSpan _ttl;
+    private readonly TimeProvider _timeProvider;
+
+    public NyxRelayBridgeIdempotencyGuard()
+        : this(TimeSpan.FromMinutes(10), TimeProvider.System)
+    {
+    }
+
+    internal NyxRelayBridgeIdempotencyGuard(TimeSpan ttl, TimeProvider timeProvider)
+    {
+        if (ttl <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(ttl), "TTL must be positive.");
+        _ttl = ttl;
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public bool TryClaim(string key)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        var now = _timeProvider.GetUtcNow();
+        var newExpiry = now + _ttl;
+
+        // Hot path: key absent. TryAdd is atomic — only one concurrent caller succeeds.
+        if (_claims.TryAdd(key, newExpiry))
+            return true;
+
+        // Cold path: key present. Only replace if expired; do so atomically.
+        while (_claims.TryGetValue(key, out var existing))
+        {
+            if (existing > now)
+                return false;
+
+            // Expired. TryUpdate succeeds only if the current value still equals `existing`,
+            // so another concurrent claimant cannot also succeed.
+            if (_claims.TryUpdate(key, newExpiry, existing))
+                return true;
+
+            // Someone else mutated the entry between our read and update; loop and retry.
+        }
+
+        // Entry vanished between TryAdd and TryGetValue (concurrent eviction). Try fresh add.
+        return _claims.TryAdd(key, newExpiry);
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/Relay/INyxRelayDayOneBridge.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/Relay/INyxRelayDayOneBridge.cs
@@ -1,0 +1,41 @@
+namespace Aevatar.GAgents.NyxidChat.Relay;
+
+/// <summary>
+/// Deterministic Day One slash-command bridge for Nyx relay callbacks.
+///
+/// The bridge is a disposable helper for the Nyx relay production path. It lets the
+/// endpoint resolve Day One text commands (<c>/daily</c>, <c>/social-media</c>,
+/// <c>/agents</c>, …) without going through the LLM, while free-text still falls
+/// through to the existing chat agent. Reply capability is scoped to the current
+/// callback token — the bridge must not introduce long-term state, durable
+/// reply-token cache, or any outbound credential persistence.
+/// </summary>
+public interface INyxRelayDayOneBridge
+{
+    /// <summary>
+    /// Synchronous check: should the bridge own this message instead of the
+    /// LLM path? Returns true for slash-prefixed text in non-device conversations.
+    /// </summary>
+    bool ShouldHandle(NyxRelayBridgeRequest request);
+
+    /// <summary>
+    /// Resolve the deterministic reply text for a bridge-owned message. The
+    /// caller is responsible for delivering the result via the current
+    /// callback's relay reply channel.
+    /// </summary>
+    Task<string> HandleAsync(NyxRelayBridgeRequest request, CancellationToken ct);
+}
+
+/// <summary>
+/// Normalized relay callback inputs consumed by <see cref="INyxRelayDayOneBridge"/>.
+/// </summary>
+public sealed record NyxRelayBridgeRequest(
+    string Text,
+    string? ConversationType,
+    string? ConversationId,
+    string? MessageId,
+    string? Platform,
+    string? SenderId,
+    string? SenderName,
+    string ScopeId,
+    string NyxIdAccessToken);

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Aevatar.GAgents.NyxidChat.Relay;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -14,6 +15,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient();
         services.TryAddSingleton(BindRelayOptions(configuration));
         services.TryAddSingleton<NyxRelayJwtValidator>();
+        services.TryAddSingleton<INyxRelayBridgeIdempotencyGuard, NyxRelayBridgeIdempotencyGuard>();
 
         return services;
     }

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -218,7 +218,7 @@ Use `agent_builder` when the user wants a persistent Day One automation agent in
 - `create_agent` will create a persistent agent plus a non-expiring NyxID API key for outbound delivery
 - `daily_report` is a `SkillRunnerGAgent` that sends plain-text GitHub summaries back into the current private chat
 - `social_media` is a workflow-backed scheduled agent that generates one draft and routes approval through the current supported human-interaction surface
-- The Nyx relay path supports text commands such as `/daily-report ...`, `/social-media ...`, `/agents`, `/agent-status <agent_id>`
+- The Nyx relay path supports text commands such as `/daily ...`, `/social-media ...`, `/agents`, `/agent-status <agent_id>`
 - `list_agents` and `agent_status` read the registry-backed current state
 - `run_agent` only works when the agent is enabled
 - `disable_agent` pauses scheduled execution without deleting the agent or revoking its API key

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -13,6 +13,7 @@ using Aevatar.Authentication.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgents.NyxidChat;
+using Aevatar.GAgents.NyxidChat.Relay;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
@@ -760,7 +761,7 @@ public class NyxIdChatEndpointsCoverageTests
         const string conversationId = "conv-daily";
         const string messageId = "msg-daily-1";
         const string dailyReportPrompt =
-            "/daily-report github_username=alice schedule_time=09:00 repositories=owner/repo";
+            "/daily github_username=alice schedule_time=09:00 repositories=owner/repo";
 
         var relay = CreateRelayInvocationDependencies(scopeId: scopeId, relayApiKeyId: scopeId);
         var payload = """
@@ -769,7 +770,7 @@ public class NyxIdChatEndpointsCoverageTests
               "platform":"lark",
               "agent":{"api_key_id":"scope-daily"},
               "conversation":{"id":"conv-daily","platform_id":"chat-daily"},
-              "content":{"text":"/daily-report github_username=alice schedule_time=09:00 repositories=owner/repo"}
+              "content":{"text":"/daily github_username=alice schedule_time=09:00 repositories=owner/repo"}
             }
             """;
 
@@ -839,6 +840,129 @@ public class NyxIdChatEndpointsCoverageTests
         requests.Should().HaveCount(2);
         requests.Select(request => request.Prompt).Should().OnlyContain(prompt => prompt == dailyReportPrompt);
         requests.Select(request => request.SessionId).Should().OnlyContain(sessionId => sessionId == $"{conversationId}-{messageId}");
+    }
+
+    [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldInterceptSlashCommand_WhenDayOneBridgeOwns()
+    {
+        var relay = CreateRelayInvocationDependencies(scopeId: "scope-bridge", relayApiKeyId: "scope-bridge");
+        var payload = """
+            {
+              "message_id":"msg-slash",
+              "platform":"lark",
+              "agent":{"api_key_id":"scope-bridge"},
+              "conversation":{"id":"conv-1","platform_id":"chat-1","type":"private"},
+              "sender":{"platform_id":"sender-1","display_name":"Sender"},
+              "content":{"text":"/daily alice"}
+            }
+            """;
+        var bridge = new StubDayOneBridge { ShouldHandleResult = true, ReplyText = "stub reply" };
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .AddSingleton<INyxRelayDayOneBridge>(bridge)
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Headers["X-NyxID-User-Token"] = relay.Token;
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+        var runtime = new StubActorRuntime();
+        var result = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            runtime,
+            new StubSubscriptionProvider(),
+            new StubGAgentActorStore(),
+            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
+            relay.Validator,
+            relay.Client,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        response.Body.Should().Contain("day_one_command");
+        response.Body.Should().Contain("msg-slash");
+
+        bridge.ShouldHandleCalls.Should().ContainSingle();
+        bridge.ShouldHandleCalls[0].Text.Should().Be("/daily alice");
+        bridge.ShouldHandleCalls[0].ConversationType.Should().Be("private");
+        bridge.ShouldHandleCalls[0].ScopeId.Should().Be("scope-bridge");
+        bridge.ShouldHandleCalls[0].NyxIdAccessToken.Should().Be(relay.Token);
+
+        runtime.CreateCalls.Should().BeEmpty(
+            because: "bridge-owned slash commands must not allocate a chat actor");
+        runtime.Actors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldDispatchToActor_WhenDayOneBridgeDefers()
+    {
+        var relay = CreateRelayInvocationDependencies(scopeId: "scope-defer", relayApiKeyId: "scope-defer");
+        var payload = """
+            {
+              "message_id":"msg-freetext",
+              "platform":"lark",
+              "agent":{"api_key_id":"scope-defer"},
+              "conversation":{"id":"conv-1","platform_id":"chat-1","type":"private"},
+              "content":{"text":"hello there"}
+            }
+            """;
+        var bridge = new StubDayOneBridge { ShouldHandleResult = false };
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .AddSingleton<INyxRelayDayOneBridge>(bridge)
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Headers["X-NyxID-User-Token"] = relay.Token;
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+        var runtime = new StubActorRuntime();
+        var result = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            runtime,
+            new StubSubscriptionProvider(),
+            new StubGAgentActorStore(),
+            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
+            relay.Validator,
+            relay.Client,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        response.Body.Should().NotContain("day_one_command");
+
+        bridge.ShouldHandleCalls.Should().ContainSingle();
+        bridge.HandleCalls.Should().BeEmpty(
+            because: "bridge defers free-text to the LLM path");
+        runtime.Actors.Should().ContainKey("nyxid-relay-conv-1");
+    }
+
+    private sealed class StubDayOneBridge : INyxRelayDayOneBridge
+    {
+        public bool ShouldHandleResult { get; set; } = true;
+        public string ReplyText { get; set; } = "stub reply";
+        public List<NyxRelayBridgeRequest> ShouldHandleCalls { get; } = new();
+        public List<NyxRelayBridgeRequest> HandleCalls { get; } = new();
+
+        public bool ShouldHandle(NyxRelayBridgeRequest request)
+        {
+            ShouldHandleCalls.Add(request);
+            return ShouldHandleResult;
+        }
+
+        public Task<string> HandleAsync(NyxRelayBridgeRequest request, CancellationToken ct)
+        {
+            HandleCalls.Add(request);
+            return Task.FromResult(ReplyText);
+        }
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.Foundation.Abstractions.Deduplication;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -887,11 +886,11 @@ public class NyxIdChatEndpointsCoverageTests
         response.Body.Should().Contain("day_one_command");
         response.Body.Should().Contain("msg-slash");
 
-        bridge.ShouldHandleCalls.Should().ContainSingle();
-        bridge.ShouldHandleCalls[0].Text.Should().Be("/daily alice");
-        bridge.ShouldHandleCalls[0].ConversationType.Should().Be("private");
-        bridge.ShouldHandleCalls[0].ScopeId.Should().Be("scope-bridge");
-        bridge.ShouldHandleCalls[0].NyxIdAccessToken.Should().Be(relay.Token);
+        var captured = bridge.ShouldHandleCalls.Should().ContainSingle().Subject;
+        captured.Text.Should().Be("/daily alice");
+        captured.ConversationType.Should().Be("private");
+        captured.ScopeId.Should().Be("scope-bridge");
+        captured.NyxIdAccessToken.Should().Be(relay.Token);
 
         runtime.CreateCalls.Should().BeEmpty(
             because: "bridge-owned slash commands must not allocate a chat actor");
@@ -947,10 +946,11 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
-    public async Task HandleRelayWebhookAsync_ShouldDedupeBridgeSideEffects_ForDuplicateMessageId()
+    public async Task HandleRelayWebhookAsync_ShouldDedupeBridgeSideEffects_UnderConcurrentRetries()
     {
         const string scopeId = "scope-dedupe";
         const string messageId = "msg-dedupe-1";
+        const int concurrentDeliveries = 8;
         var relay = CreateRelayInvocationDependencies(scopeId: scopeId, relayApiKeyId: scopeId);
         var payload = $$"""
             {
@@ -962,11 +962,11 @@ public class NyxIdChatEndpointsCoverageTests
             }
             """;
         var bridge = new StubDayOneBridge { ShouldHandleResult = true };
-        var deduplicator = new StubEventDeduplicator();
+        var guard = new NyxRelayBridgeIdempotencyGuard();
         var services = new ServiceCollection()
             .AddLogging()
             .AddSingleton<INyxRelayDayOneBridge>(bridge)
-            .AddSingleton<IEventDeduplicator>(deduplicator)
+            .AddSingleton<INyxRelayBridgeIdempotencyGuard>(guard)
             .BuildServiceProvider();
 
         DefaultHttpContext BuildContext()
@@ -978,87 +978,81 @@ public class NyxIdChatEndpointsCoverageTests
             return context;
         }
 
-        // First delivery: HandleAsync fires in background; the bridge signals via TCS once
-        // it has been invoked so the test can sequence the second (duplicate) delivery
-        // without a polling wait.
-        var firstResult = await InvokeResultAsync(
-            "HandleRelayWebhookAsync",
-            BuildContext(),
-            new StubActorRuntime(),
-            new StubSubscriptionProvider(),
-            new StubGAgentActorStore(),
-            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
-            relay.Validator,
-            relay.Client,
-            NullLoggerFactory.Instance,
-            CancellationToken.None);
-        var firstResponse = await ExecuteResultAsync(firstResult);
+        // Release all deliveries simultaneously so every thread observes the dedupe key as
+        // absent in the same time window — this is exactly the race the sequential test
+        // could not surface.
+        using var releaseGate = new ManualResetEventSlim(false);
+        async Task<(int Status, string Body)> FireOnceAsync()
+        {
+            await Task.Yield();
+            releaseGate.Wait();
+            var result = await InvokeResultAsync(
+                "HandleRelayWebhookAsync",
+                BuildContext(),
+                new StubActorRuntime(),
+                new StubSubscriptionProvider(),
+                new StubGAgentActorStore(),
+                new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
+                relay.Validator,
+                relay.Client,
+                NullLoggerFactory.Instance,
+                CancellationToken.None);
+            return await ExecuteResultAsync(result);
+        }
+
+        var deliveryTasks = Enumerable
+            .Range(0, concurrentDeliveries)
+            .Select(_ => Task.Run(FireOnceAsync))
+            .ToArray();
+        releaseGate.Set();
+        var responses = await Task.WhenAll(deliveryTasks);
+
+        // Wait for the winner's fire-and-forget HandleAsync to record the call so the
+        // count assertion is deterministic (no polling wait).
         await bridge.FirstHandleStarted;
 
-        var secondResult = await InvokeResultAsync(
-            "HandleRelayWebhookAsync",
-            BuildContext(),
-            new StubActorRuntime(),
-            new StubSubscriptionProvider(),
-            new StubGAgentActorStore(),
-            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
-            relay.Validator,
-            relay.Client,
-            NullLoggerFactory.Instance,
-            CancellationToken.None);
-        var secondResponse = await ExecuteResultAsync(secondResult);
+        responses.Should().OnlyContain(r => r.Status == StatusCodes.Status202Accepted);
+        responses.Count(r => r.Body.Contains("\"dedupe\":\"duplicate\"", StringComparison.Ordinal))
+            .Should().Be(concurrentDeliveries - 1,
+                because: "exactly one concurrent delivery wins the atomic claim, the rest must be reported as duplicates");
+        responses.Count(r => !r.Body.Contains("\"dedupe\":\"duplicate\"", StringComparison.Ordinal))
+            .Should().Be(1);
 
-        firstResponse.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        secondResponse.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        firstResponse.Body.Should().NotContain("duplicate");
-        secondResponse.Body.Should().Contain("\"dedupe\":\"duplicate\"",
-            because: "retried callbacks for the same message_id must be reported as duplicates");
-
-        bridge.ShouldHandleCalls.Should().HaveCount(2);
-        deduplicator.RecordedKeys.Should().OnlyContain(k => k == $"nyxid-relay-bridge:{scopeId}:{messageId}");
-        deduplicator.RecordedKeys.Should().HaveCount(2,
-            because: "both callbacks query the deduplicator, but only the first gets first-seen");
+        bridge.ShouldHandleCalls.Should().HaveCount(concurrentDeliveries,
+            because: "every delivery enters the bridge gate before the dedupe check");
         bridge.HandleCalls.Should().ContainSingle(
-            because: "only the first-seen callback should fire AgentBuilder side effects");
+            because: "only the winning delivery should fire AgentBuilder side effects");
     }
 
     private sealed class StubDayOneBridge : INyxRelayDayOneBridge
     {
+        // ConcurrentBag is used so the concurrent-retry test can safely record overlapping
+        // calls from many threads without lock contention skewing the race we are testing.
+        private readonly System.Collections.Concurrent.ConcurrentBag<NyxRelayBridgeRequest> _shouldHandleCalls = new();
+        private readonly System.Collections.Concurrent.ConcurrentBag<NyxRelayBridgeRequest> _handleCalls = new();
         private readonly TaskCompletionSource _firstHandleStarted =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public bool ShouldHandleResult { get; set; } = true;
         public string ReplyText { get; set; } = "stub reply";
-        public List<NyxRelayBridgeRequest> ShouldHandleCalls { get; } = new();
-        public List<NyxRelayBridgeRequest> HandleCalls { get; } = new();
+        public IReadOnlyCollection<NyxRelayBridgeRequest> ShouldHandleCalls => _shouldHandleCalls;
+        public IReadOnlyCollection<NyxRelayBridgeRequest> HandleCalls => _handleCalls;
         public Task FirstHandleStarted => _firstHandleStarted.Task;
 
         public bool ShouldHandle(NyxRelayBridgeRequest request)
         {
-            ShouldHandleCalls.Add(request);
+            _shouldHandleCalls.Add(request);
             return ShouldHandleResult;
         }
 
         public Task<string> HandleAsync(NyxRelayBridgeRequest request, CancellationToken ct)
         {
-            HandleCalls.Add(request);
+            _handleCalls.Add(request);
             _firstHandleStarted.TrySetResult();
             return Task.FromResult(ReplyText);
         }
     }
 
-    private sealed class StubEventDeduplicator : IEventDeduplicator
-    {
-        private readonly HashSet<string> _seen = new(StringComparer.Ordinal);
-
-        public List<string> RecordedKeys { get; } = new();
-
-        public Task<bool> TryRecordAsync(string eventId)
-        {
-            RecordedKeys.Add(eventId);
-            return Task.FromResult(_seen.Add(eventId));
-        }
-    }
 
     [Fact]
     public async Task HandleRelayWebhookAsync_ShouldRejectMismatchedRelayApiKeyId()

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions.Deduplication;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -945,12 +946,92 @@ public class NyxIdChatEndpointsCoverageTests
         runtime.Actors.Should().ContainKey("nyxid-relay-conv-1");
     }
 
+    [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldDedupeBridgeSideEffects_ForDuplicateMessageId()
+    {
+        const string scopeId = "scope-dedupe";
+        const string messageId = "msg-dedupe-1";
+        var relay = CreateRelayInvocationDependencies(scopeId: scopeId, relayApiKeyId: scopeId);
+        var payload = $$"""
+            {
+              "message_id":"{{messageId}}",
+              "platform":"lark",
+              "agent":{"api_key_id":"{{scopeId}}"},
+              "conversation":{"id":"conv-d","platform_id":"chat-d","type":"private"},
+              "content":{"text":"/daily alice"}
+            }
+            """;
+        var bridge = new StubDayOneBridge { ShouldHandleResult = true };
+        var deduplicator = new StubEventDeduplicator();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<INyxRelayDayOneBridge>(bridge)
+            .AddSingleton<IEventDeduplicator>(deduplicator)
+            .BuildServiceProvider();
+
+        DefaultHttpContext BuildContext()
+        {
+            var context = new DefaultHttpContext { RequestServices = services };
+            context.Request.ContentType = "application/json";
+            context.Request.Headers["X-NyxID-User-Token"] = relay.Token;
+            context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+            return context;
+        }
+
+        // First delivery: HandleAsync fires in background; the bridge signals via TCS once
+        // it has been invoked so the test can sequence the second (duplicate) delivery
+        // without a polling wait.
+        var firstResult = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            BuildContext(),
+            new StubActorRuntime(),
+            new StubSubscriptionProvider(),
+            new StubGAgentActorStore(),
+            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
+            relay.Validator,
+            relay.Client,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var firstResponse = await ExecuteResultAsync(firstResult);
+        await bridge.FirstHandleStarted;
+
+        var secondResult = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            BuildContext(),
+            new StubActorRuntime(),
+            new StubSubscriptionProvider(),
+            new StubGAgentActorStore(),
+            new NyxIdRelayOptions { ResponseTimeoutSeconds = 0 },
+            relay.Validator,
+            relay.Client,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var secondResponse = await ExecuteResultAsync(secondResult);
+
+        firstResponse.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        secondResponse.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        firstResponse.Body.Should().NotContain("duplicate");
+        secondResponse.Body.Should().Contain("\"dedupe\":\"duplicate\"",
+            because: "retried callbacks for the same message_id must be reported as duplicates");
+
+        bridge.ShouldHandleCalls.Should().HaveCount(2);
+        deduplicator.RecordedKeys.Should().OnlyContain(k => k == $"nyxid-relay-bridge:{scopeId}:{messageId}");
+        deduplicator.RecordedKeys.Should().HaveCount(2,
+            because: "both callbacks query the deduplicator, but only the first gets first-seen");
+        bridge.HandleCalls.Should().ContainSingle(
+            because: "only the first-seen callback should fire AgentBuilder side effects");
+    }
+
     private sealed class StubDayOneBridge : INyxRelayDayOneBridge
     {
+        private readonly TaskCompletionSource _firstHandleStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public bool ShouldHandleResult { get; set; } = true;
         public string ReplyText { get; set; } = "stub reply";
         public List<NyxRelayBridgeRequest> ShouldHandleCalls { get; } = new();
         public List<NyxRelayBridgeRequest> HandleCalls { get; } = new();
+        public Task FirstHandleStarted => _firstHandleStarted.Task;
 
         public bool ShouldHandle(NyxRelayBridgeRequest request)
         {
@@ -961,7 +1042,21 @@ public class NyxIdChatEndpointsCoverageTests
         public Task<string> HandleAsync(NyxRelayBridgeRequest request, CancellationToken ct)
         {
             HandleCalls.Add(request);
+            _firstHandleStarted.TrySetResult();
             return Task.FromResult(ReplyText);
+        }
+    }
+
+    private sealed class StubEventDeduplicator : IEventDeduplicator
+    {
+        private readonly HashSet<string> _seen = new(StringComparer.Ordinal);
+
+        public List<string> RecordedKeys { get; } = new();
+
+        public Task<bool> TryRecordAsync(string eventId)
+        {
+            RecordedKeys.Add(eventId);
+            return Task.FromResult(_seen.Add(eventId));
         }
     }
 

--- a/test/Aevatar.AI.Tests/NyxRelayBridgeIdempotencyGuardTests.cs
+++ b/test/Aevatar.AI.Tests/NyxRelayBridgeIdempotencyGuardTests.cs
@@ -61,6 +61,28 @@ public sealed class NyxRelayBridgeIdempotencyGuardTests
             .BeTrue(because: "TTL has elapsed, a later retry is a fresh callback, not a duplicate");
     }
 
+    [Fact]
+    public void TryClaim_ShouldEvictExpiredEntries_ToBoundMemory()
+    {
+        // Without active eviction, every processed message_id stays in the guard forever.
+        // Verify that crossing the sweep interval purges expired keys from the underlying
+        // map, so memory is bounded by recent-traffic * TTL rather than total-traffic.
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 4, 23, 0, 0, 0, TimeSpan.Zero));
+        var guard = new NyxRelayBridgeIdempotencyGuard(TimeSpan.FromMinutes(10), timeProvider);
+
+        for (var i = 0; i < 500; i++)
+            guard.TryClaim($"msg-{i}").Should().BeTrue();
+
+        guard.ClaimCount.Should().Be(500);
+
+        // Past TTL + sweep interval; the next claim must trigger the opportunistic sweep.
+        timeProvider.Advance(TimeSpan.FromMinutes(15));
+        guard.TryClaim("msg-after").Should().BeTrue();
+
+        guard.ClaimCount.Should().Be(1,
+            because: "all 500 expired entries must have been swept, leaving only the fresh claim");
+    }
+
     private sealed class MutableTimeProvider : TimeProvider
     {
         private DateTimeOffset _now;

--- a/test/Aevatar.AI.Tests/NyxRelayBridgeIdempotencyGuardTests.cs
+++ b/test/Aevatar.AI.Tests/NyxRelayBridgeIdempotencyGuardTests.cs
@@ -1,0 +1,74 @@
+using Aevatar.GAgents.NyxidChat.Relay;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class NyxRelayBridgeIdempotencyGuardTests
+{
+    [Fact]
+    public void TryClaim_ShouldReturnTrueOnFirstCallAndFalseOnSecond()
+    {
+        var guard = new NyxRelayBridgeIdempotencyGuard();
+
+        guard.TryClaim("key-1").Should().BeTrue();
+        guard.TryClaim("key-1").Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryClaim_ShouldAdmitDistinctKeys()
+    {
+        var guard = new NyxRelayBridgeIdempotencyGuard();
+
+        guard.TryClaim("key-a").Should().BeTrue();
+        guard.TryClaim("key-b").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TryClaim_UnderConcurrentCallers_SucceedsExactlyOnce()
+    {
+        var guard = new NyxRelayBridgeIdempotencyGuard();
+        const int callers = 32;
+        using var gate = new ManualResetEventSlim(false);
+
+        async Task<bool> ClaimOnceAsync()
+        {
+            await Task.Yield();
+            gate.Wait();
+            return guard.TryClaim("shared-key");
+        }
+
+        var tasks = Enumerable.Range(0, callers).Select(_ => Task.Run(ClaimOnceAsync)).ToArray();
+        gate.Set();
+        var results = await Task.WhenAll(tasks);
+
+        results.Count(won => won).Should().Be(1,
+            because: "exactly one concurrent caller must win the atomic first-writer claim");
+    }
+
+    [Fact]
+    public void TryClaim_ShouldReclaimAfterTtlExpiry()
+    {
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 4, 23, 0, 0, 0, TimeSpan.Zero));
+        var guard = new NyxRelayBridgeIdempotencyGuard(TimeSpan.FromMinutes(5), timeProvider);
+
+        guard.TryClaim("ephemeral").Should().BeTrue();
+        guard.TryClaim("ephemeral").Should().BeFalse();
+
+        timeProvider.Advance(TimeSpan.FromMinutes(6));
+
+        guard.TryClaim("ephemeral").Should()
+            .BeTrue(because: "TTL has elapsed, a later retry is a fresh callback, not a duplicate");
+    }
+
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+
+        public MutableTimeProvider(DateTimeOffset initial) => _now = initial;
+
+        public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTurnRunnerTests.cs
@@ -116,7 +116,7 @@ public sealed class LarkConversationTurnRunnerTests
 
         var result = await runner.RunInboundAsync(
             BuildInboundActivity(
-                "/daily-report alice",
+                "/daily alice",
                 "msg-slash-1",
                 ConversationScope.DirectMessage,
                 "oc_p2p_chat_1"),

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
@@ -12,7 +12,7 @@ public sealed class NyxRelayAgentBuilderFlowTests
         var inbound = new ChannelInboundEvent
         {
             ChatType = "p2p",
-            Text = "/daily-report",
+            Text = "/daily",
         };
 
         var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
@@ -21,7 +21,7 @@ public sealed class NyxRelayAgentBuilderFlowTests
         decision.Should().NotBeNull();
         decision!.RequiresToolExecution.Should().BeFalse();
         decision.ReplyPayload.Should().Contain("Daily report agent command");
-        decision.ReplyPayload.Should().Contain("/daily-report github_username=alice");
+        decision.ReplyPayload.Should().Contain("/daily github_username=alice");
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public sealed class NyxRelayAgentBuilderFlowTests
         {
             ChatType = "p2p",
             ConversationId = "oc_8a70aeefbdb4340e1fa5f575b4c794eb",
-            Text = "/daily-report eanzhao",
+            Text = "/daily eanzhao",
         };
 
         var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
@@ -49,8 +49,8 @@ public sealed class NyxRelayAgentBuilderFlowTests
     }
 
     [Theory]
-    [InlineData("/daily-report =broken")]
-    [InlineData("/daily-report github_username=")]
+    [InlineData("/daily =broken")]
+    [InlineData("/daily github_username=")]
     public void TryResolve_ShouldNotTreatMalformedKeyValueTokenAsPositional(string text)
     {
         var inbound = new ChannelInboundEvent
@@ -154,5 +154,88 @@ public sealed class NyxRelayAgentBuilderFlowTests
         decision.Should().NotBeNull();
         decision!.RequiresToolExecution.Should().BeFalse();
         decision.ReplyPayload.Should().Contain("/delete-agent agent-1 confirm");
+    }
+
+    [Fact]
+    public void TryResolve_ShouldReturnUnknownCommandUsage_ForUnknownSlash()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            Text = "/daily_report alice",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeFalse();
+        decision.ReplyPayload.Should().Contain("Unknown command: /daily_report");
+        decision.ReplyPayload.Should().Contain("/daily github_username=alice");
+    }
+
+    [Fact]
+    public void TryResolve_ShouldReturnUnknownCommandUsage_ForNonsenseSlash()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            Text = "/foobar",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeFalse();
+        decision.ReplyPayload.Should().Contain("Unknown command: /foobar");
+    }
+
+    [Fact]
+    public void TryResolve_ShouldReturnPrivateChatRestriction_ForKnownCommandInGroup()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "group",
+            Text = "/daily alice",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeFalse();
+        decision.ReplyPayload.Should().Contain("private chat");
+        decision.ReplyPayload.Should().Contain("/daily");
+    }
+
+    [Fact]
+    public void TryResolve_ShouldFallThrough_ForNonSlashText()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            Text = "hello there",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeFalse();
+        decision.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryResolve_ShouldFallThrough_ForEmptyText()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            Text = "   ",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeFalse();
+        decision.Should().BeNull();
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayDayOneBridgeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayDayOneBridgeTests.cs
@@ -1,0 +1,103 @@
+using Aevatar.GAgents.NyxidChat.Relay;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class NyxRelayDayOneBridgeTests
+{
+    [Theory]
+    [InlineData("/daily alice", "private", true)]
+    [InlineData("/daily alice", "group", true)]
+    [InlineData("/daily alice", "channel", true)]
+    [InlineData("/daily alice", null, true)]
+    [InlineData("  /daily  ", "private", true)]
+    [InlineData("/foobar", "private", true)]
+    [InlineData("hello there", "private", false)]
+    [InlineData("", "private", false)]
+    [InlineData("   ", "private", false)]
+    [InlineData("/daily alice", "device", false)]
+    public void ShouldHandle_ReturnsExpectedGating(string text, string? conversationType, bool expected)
+    {
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest(text, conversationType);
+
+        bridge.ShouldHandle(request).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForUnknownSlash_ReturnsUnknownCommandUsage()
+    {
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest("/daily_report alice", conversationType: "private");
+
+        var reply = await bridge.HandleAsync(request, CancellationToken.None);
+
+        reply.Should().Contain("Unknown command: /daily_report");
+        reply.Should().Contain("/daily github_username=alice");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForKnownCommandInGroup_ReturnsPrivateChatRestriction()
+    {
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest("/daily alice", conversationType: "group");
+
+        var reply = await bridge.HandleAsync(request, CancellationToken.None);
+
+        reply.Should().Contain("private chat");
+        reply.Should().Contain("/daily");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForKnownCommandInChannel_ReturnsPrivateChatRestriction()
+    {
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest("/daily alice", conversationType: "channel");
+
+        var reply = await bridge.HandleAsync(request, CancellationToken.None);
+
+        reply.Should().Contain("private chat");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForKnownCommandWithoutArguments_ReturnsHelpText()
+    {
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest("/daily", conversationType: "private");
+
+        var reply = await bridge.HandleAsync(request, CancellationToken.None);
+
+        reply.Should().Contain("Daily report agent command");
+        reply.Should().Contain("/daily github_username=alice");
+    }
+
+    [Fact]
+    public async Task HandleAsync_ForCreateDailyWithArguments_InvokesAgentBuilderTool()
+    {
+        // No AgentBuilder runtime services wired → tool returns the expected DI-not-registered
+        // error payload, which the bridge surfaces via the formatted tool-result helper. This
+        // covers the full "decision.RequiresToolExecution" branch end-to-end.
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest(
+            "/daily github_username=alice schedule_time=09:00 repositories=owner/repo",
+            conversationType: "private");
+
+        var reply = await bridge.HandleAsync(request, CancellationToken.None);
+
+        reply.Should().Contain("Create daily report agent failed");
+    }
+
+    private static NyxRelayBridgeRequest BuildRequest(string text, string? conversationType) =>
+        new(
+            Text: text,
+            ConversationType: conversationType,
+            ConversationId: "conv-1",
+            MessageId: "msg-1",
+            Platform: "lark",
+            SenderId: "sender-1",
+            SenderName: "Sender Name",
+            ScopeId: "scope-1",
+            NyxIdAccessToken: "token-1");
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayDayOneBridgeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayDayOneBridgeTests.cs
@@ -61,6 +61,21 @@ public sealed class NyxRelayDayOneBridgeTests
         reply.Should().Contain("private chat");
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("unknown-future-type")]
+    public async Task HandleAsync_ForMissingOrUnknownConversationType_FailsClosedWithRestriction(string? conversationType)
+    {
+        var bridge = new NyxRelayDayOneBridge(new ServiceCollection().BuildServiceProvider());
+        var request = BuildRequest("/daily alice", conversationType);
+
+        var reply = await bridge.HandleAsync(request, CancellationToken.None);
+
+        reply.Should().Contain("private chat",
+            because: "missing or unrecognized conversation.type must not be treated as p2p");
+    }
+
     [Fact]
     public async Task HandleAsync_ForKnownCommandWithoutArguments_ReturnsHelpText()
     {


### PR DESCRIPTION
Resolves aevatarAI/aevatar#341.

## Summary
- Intercept Day One slash commands (`/daily`, `/social-media`, `/agents`, …) on the Nyx relay production path before they reach the LLM. Free-text keeps falling through to the existing `NyxIdChatGAgent` flow.
- Rename `/daily-report` → `/daily` across the bridge flow, card flow, help text, system prompt and tests. `/create-daily-report` alias dropped per the deletion-first rule.
- Widen `NyxRelayAgentBuilderFlow.TryResolve` to gate on slash prefix first, then `chat_type`:
  - known command in `group`/`channel` → deterministic private-chat restriction
  - unknown `/foobar`, `/daily_report`, etc. → deterministic unknown-command usage
  - non-slash text → fall through to LLM
- Add `INyxRelayDayOneBridge` (NyxidChat) with sync `ShouldHandle` gate + async `HandleAsync` resolver, implemented by `NyxRelayDayOneBridge` (ChannelRuntime). Maps Nyx callback `conversation.type` → `channel.chat_type` (`private → p2p`, `group/channel → group`, `device → skip`) and reuses `AgentBuilderTool` with a per-request `AgentToolRequestContext`.
- Wire the bridge into `/api/webhooks/nyxid-relay`: when the bridge owns a message the endpoint skips actor dispatch, returns `202` with `bridge=day_one_command`, and delivers the reply through the current callback's relay reply channel.

## Non-goals (from #341)
- No Aevatar-side storage of the Nyx agent `full_key`.
- No long-term reply-credential cache, no projection/read-model write for callback tokens, no durable async-reply continuation.
- Bridge stays a disposable helper so `#328` can absorb or remove it once `NyxID#469` (or equivalent) unlocks the proper outbound credential story.

## Comment follow-ups
- Bridge is an extractable flow (dedicated class, thin endpoint wiring) so a future unified inbound backbone can lift it without rewriting from scratch.
- Slash surface stays text-first. Bootstrap-card UX for first-time `/daily` without saved GitHub username is intentionally **not** added here — it needs owner-scoped Day One preference storage (not conversation-scoped), which belongs with `#336` / the unified backbone rather than in this bridge.
- Group/channel known slash returns a deterministic DM handoff instead of letting the LLM make something up.

## Test plan
- [x] `dotnet build aevatar.slnx` — 0 errors
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests` — 193 pass (2 pre-existing `ServiceCollectionExtensionsTests` failures unrelated to this PR, verified by stashing)
- [x] `dotnet test test/Aevatar.AI.Tests --filter NyxIdChatEndpointsCoverageTests` — 40/40 pass (includes new bridge-intercept + defer-to-actor coverage)
- [x] `bash tools/ci/architecture_guards.sh` — pass
- [x] `bash tools/ci/test_stability_guards.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)