### PR TITLE
Add Lark relay acknowledgment reactions

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -282,6 +282,8 @@ message TransportExtras {
   string nyx_conversation_id = 4;
   // The short-lived Nyx user access token carried by the relay callback for downstream proxy calls.
   string nyx_user_access_token = 5;
+  // The platform-native message id of the originating user message when Nyx relay can recover it.
+  string nyx_platform_message_id = 6;
 }
 
 // Represents one normalized activity flowing through the channel pipeline.

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -53,7 +53,7 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (registration is null)
             return ConversationTurnResult.PermanentFailure("registration_not_found", "Channel registration not found.");
 
-        await TrySendImmediateLarkReactionAsync(activity, registration, ct);
+        _ = TrySendImmediateLarkReactionAsync(activity, registration, ct);
 
         var inbound = ToInboundMessage(activity);
         if (await TryHandleWorkflowResumeAsync(inbound, ct) is { } workflowResumeResult)
@@ -737,6 +737,10 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
                     platformMessageId,
                     detail);
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
@@ -51,6 +52,8 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         var registration = await ResolveRegistrationAsync(activity, ct);
         if (registration is null)
             return ConversationTurnResult.PermanentFailure("registration_not_found", "Channel registration not found.");
+
+        await TrySendImmediateLarkReactionAsync(activity, registration, ct);
 
         var inbound = ToInboundMessage(activity);
         if (await TryHandleWorkflowResumeAsync(inbound, ct) is { } workflowResumeResult)
@@ -705,6 +708,138 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         return string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase)
             ? "lark"
             : platform;
+    }
+
+    private async Task TrySendImmediateLarkReactionAsync(
+        ChatActivity activity,
+        ChannelBotRegistrationEntry registration,
+        CancellationToken ct)
+    {
+        if (!ShouldSendImmediateLarkReaction(activity, registration, out var accessToken, out var providerSlug, out var platformMessageId))
+            return;
+
+        try
+        {
+            var response = await _nyxClient.ProxyRequestAsync(
+                accessToken!,
+                providerSlug!,
+                $"/open-apis/im/v1/messages/{Uri.EscapeDataString(platformMessageId!)}/reactions",
+                "POST",
+                """{"reaction_type":{"emoji_type":"OK"}}""",
+                null,
+                ct);
+
+            if (TryGetProxyError(response, out var detail))
+            {
+                _logger.LogWarning(
+                    "Immediate Lark acknowledgment reaction failed: provider={ProviderSlug}, message={MessageId}, detail={Detail}",
+                    providerSlug,
+                    platformMessageId,
+                    detail);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Immediate Lark acknowledgment reaction threw: provider={ProviderSlug}, message={MessageId}",
+                providerSlug,
+                platformMessageId);
+        }
+    }
+
+    private static bool ShouldSendImmediateLarkReaction(
+        ChatActivity activity,
+        ChannelBotRegistrationEntry registration,
+        out string? accessToken,
+        out string? providerSlug,
+        out string? platformMessageId)
+    {
+        accessToken = null;
+        providerSlug = null;
+        platformMessageId = null;
+
+        if (activity.Type != ActivityType.Message)
+            return false;
+
+        var platform = NormalizeOptional(activity.TransportExtras?.NyxPlatform) ??
+                       NormalizeOptional(registration.Platform) ??
+                       NormalizeOptional(activity.ChannelId?.Value);
+        if (!string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        accessToken = NormalizeOptional(activity.TransportExtras?.NyxUserAccessToken);
+        providerSlug = NormalizeOptional(registration.NyxProviderSlug);
+        platformMessageId = NormalizeOptional(activity.TransportExtras?.NyxPlatformMessageId);
+
+        return !string.IsNullOrWhiteSpace(accessToken) &&
+               !string.IsNullOrWhiteSpace(providerSlug) &&
+               !string.IsNullOrWhiteSpace(platformMessageId) &&
+               platformMessageId.StartsWith("om_", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryGetProxyError(string? response, out string detail)
+    {
+        detail = string.Empty;
+        if (string.IsNullOrWhiteSpace(response))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+
+            if (root.TryGetProperty("error", out var errorProperty))
+            {
+                if (errorProperty.ValueKind == JsonValueKind.True)
+                {
+                    detail = TryReadJsonString(root, "message") ??
+                             TryReadJsonString(root, "body") ??
+                             "proxy_error";
+                    return true;
+                }
+
+                if (errorProperty.ValueKind == JsonValueKind.String)
+                {
+                    var error = errorProperty.GetString()?.Trim();
+                    if (!string.IsNullOrWhiteSpace(error))
+                    {
+                        detail = error;
+                        return true;
+                    }
+                }
+            }
+
+            if (root.TryGetProperty("code", out var codeProperty) &&
+                codeProperty.ValueKind == JsonValueKind.Number &&
+                codeProperty.TryGetInt32(out var code) &&
+                code != 0)
+            {
+                detail = TryReadJsonString(root, "msg") ?? $"code={code}";
+                return true;
+            }
+        }
+        catch (JsonException)
+        {
+            // Ignore invalid bodies for best-effort acknowledgment.
+        }
+
+        return false;
+    }
+
+    private static string? TryReadJsonString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var value = property.GetString()?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     private static ConversationTurnResult ToRelayFailure(EmitResult emit)

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -510,9 +510,11 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             authPrincipal: "bot");
     }
 
-    private static IReadOnlyDictionary<string, string> BuildReplyMetadata(ChannelInboundEvent inboundEvent)
+    private static IReadOnlyDictionary<string, string> BuildReplyMetadata(
+        ChannelInboundEvent inboundEvent,
+        ChatActivity? activity = null)
     {
-        return new Dictionary<string, string>(StringComparer.Ordinal)
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["scope_id"] = inboundEvent.RegistrationScopeId,
             [ChannelMetadataKeys.Platform] = inboundEvent.Platform,
@@ -522,6 +524,12 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             [ChannelMetadataKeys.MessageId] = inboundEvent.MessageId,
             [ChannelMetadataKeys.ChatType] = inboundEvent.ChatType,
         };
+
+        var platformMessageId = NormalizeOptional(activity?.TransportExtras?.NyxPlatformMessageId);
+        if (!string.IsNullOrWhiteSpace(platformMessageId))
+            metadata[ChannelMetadataKeys.PlatformMessageId] = platformMessageId;
+
+        return metadata;
     }
 
     private static IReadOnlyDictionary<string, string> BuildAgentBuilderMetadata(
@@ -529,7 +537,7 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         ChannelInboundEvent inboundEvent,
         string? userAccessToken)
     {
-        var metadata = new Dictionary<string, string>(BuildReplyMetadata(inboundEvent), StringComparer.Ordinal)
+        var metadata = new Dictionary<string, string>(BuildReplyMetadata(inboundEvent, activity), StringComparer.Ordinal)
         {
             [ChannelMetadataKeys.ChatType] = ResolveConversationChatType(activity.Conversation),
         };
@@ -622,7 +630,7 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 
-        foreach (var pair in BuildReplyMetadata(inboundEvent))
+        foreach (var pair in BuildReplyMetadata(inboundEvent, activity))
             request.Metadata[pair.Key] = pair.Value;
 
         return request;

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelMetadataKeys.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelMetadataKeys.cs
@@ -11,5 +11,6 @@ public static class ChannelMetadataKeys
     public const string SenderName = "channel.sender_name";
     public const string ConversationId = "channel.conversation_id";
     public const string MessageId = "channel.message_id";
+    public const string PlatformMessageId = "channel.platform_message_id";
     public const string ChatType = "channel.chat_type";
 }

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
@@ -37,7 +37,7 @@ For Lark, follow this two-stage guidance:
    This stage is for inbound relay wiring and basic relay replies.
 
 2. Advanced Lark capabilities: only when the user needs proactive sends, chat lookup, spreadsheet appends, approval actions, or delivery target bindings, require a Nyx Lark provider slug such as `api-lark-bot`.
-   In those cases, prefer typed Lark tools such as `lark_chats_lookup`, `lark_messages_send`, `lark_messages_react`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act` over generic `nyxid_proxy_execute`.
+   In those cases, prefer typed Lark tools such as `lark_messages_send`, `lark_messages_reply`, `lark_messages_search`, `lark_messages_batch_get`, `lark_messages_react`, `lark_messages_reactions_list`, `lark_messages_reactions_delete`, `lark_chats_lookup`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act` over generic `nyxid_proxy_execute`.
 
 For inbound Lark relay turns that represent a fresh user message (not a card action), if the typed tool `lark_messages_react` is available and metadata exposes `channel.platform_message_id`, call `lark_messages_react` first with an acknowledgment emoji such as `OK`, then continue with the substantive reply.
 """;

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
@@ -37,7 +37,9 @@ For Lark, follow this two-stage guidance:
    This stage is for inbound relay wiring and basic relay replies.
 
 2. Advanced Lark capabilities: only when the user needs proactive sends, chat lookup, spreadsheet appends, approval actions, or delivery target bindings, require a Nyx Lark provider slug such as `api-lark-bot`.
-   In those cases, prefer typed Lark tools such as `lark_chats_lookup`, `lark_messages_send`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act` over generic `nyxid_proxy_execute`.
+   In those cases, prefer typed Lark tools such as `lark_chats_lookup`, `lark_messages_send`, `lark_messages_react`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act` over generic `nyxid_proxy_execute`.
+
+For inbound Lark relay turns that represent a fresh user message (not a card action), if the typed tool `lark_messages_react` is available and metadata exposes `channel.platform_message_id`, call `lark_messages_react` first with an acknowledgment emoji such as `OK`, then continue with the substantive reply.
 """;
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -160,9 +160,14 @@ Ensure NyxID has a usable Lark outbound provider slug, typically `api-lark-bot`:
 If not: `nyxid_catalog action=list` → find the slug → guide user to add it
 
 For advanced Lark API operations, prefer typed tools such as:
-- `lark_chats_lookup`
 - `lark_messages_send`
+- `lark_messages_reply`
+- `lark_messages_search`
+- `lark_messages_batch_get`
 - `lark_messages_react`
+- `lark_messages_reactions_list`
+- `lark_messages_reactions_delete`
+- `lark_chats_lookup`
 - `lark_sheets_append_rows`
 - `lark_approvals_list`
 - `lark_approvals_act`

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -162,11 +162,14 @@ If not: `nyxid_catalog action=list` → find the slug → guide user to add it
 For advanced Lark API operations, prefer typed tools such as:
 - `lark_chats_lookup`
 - `lark_messages_send`
+- `lark_messages_react`
 - `lark_sheets_append_rows`
 - `lark_approvals_list`
 - `lark_approvals_act`
 
 Use generic `nyxid_proxy_execute` only when typed tools do not cover the operation.
+
+For inbound Lark relay turns that represent a fresh user message (not a card action), if `lark_messages_react` is available and metadata exposes `channel.platform_message_id`, call `lark_messages_react` first with an acknowledgment emoji such as `OK`, then continue with the real reply.
 
 When binding workflow delivery or proactive agent delivery, use a Lark outbound provider slug such as `api-lark-bot`.
 

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayCallbackPayload.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayCallbackPayload.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Aevatar.GAgents.Channel.NyxIdRelay;
@@ -7,11 +8,17 @@ public sealed class NyxIdRelayCallbackPayload
     [JsonPropertyName("message_id")]
     public string? MessageId { get; set; }
 
+    [JsonPropertyName("platform_message_id")]
+    public string? PlatformMessageId { get; set; }
+
     [JsonPropertyName("platform")]
     public string? Platform { get; set; }
 
     [JsonPropertyName("reply_token")]
     public string? ReplyToken { get; set; }
+
+    [JsonPropertyName("reply_to_platform_message_id")]
+    public string? ReplyToPlatformMessageId { get; set; }
 
     [JsonPropertyName("agent")]
     public NyxIdRelayAgentPayload? Agent { get; set; }
@@ -27,6 +34,9 @@ public sealed class NyxIdRelayCallbackPayload
 
     [JsonPropertyName("timestamp")]
     public string? Timestamp { get; set; }
+
+    [JsonPropertyName("raw_platform_data")]
+    public JsonElement? RawPlatformData { get; set; }
 }
 
 public sealed class NyxIdRelayAgentPayload

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -106,10 +106,6 @@ public sealed class NyxIdRelayTransport
 
     private static string ResolvePlatformMessageId(NyxIdRelayCallbackPayload payload, string platform)
     {
-        var replyTarget = payload.ReplyToPlatformMessageId?.Trim();
-        if (!string.IsNullOrWhiteSpace(replyTarget))
-            return replyTarget;
-
         var directPlatformId = payload.PlatformMessageId?.Trim();
         if (!string.IsNullOrWhiteSpace(directPlatformId))
             return directPlatformId;

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -54,6 +54,7 @@ public sealed class NyxIdRelayTransport
         var partition = conversationIdentity;
         var timestamp = ParseTimestamp(payload.Timestamp);
         var botId = payload.Agent?.ApiKeyId?.Trim();
+        var platformMessageId = ResolvePlatformMessageId(payload, platform);
 
         var activity = new ChatActivity
         {
@@ -92,6 +93,7 @@ public sealed class NyxIdRelayTransport
                 NyxAgentApiKeyId = payload.Agent?.ApiKeyId?.Trim() ?? string.Empty,
                 NyxPlatform = platform,
                 NyxConversationId = payload.Conversation?.Id?.Trim() ?? conversationIdentity,
+                NyxPlatformMessageId = platformMessageId,
             },
         };
 
@@ -101,6 +103,64 @@ public sealed class NyxIdRelayTransport
 
     private static string NormalizePlatform(string? platform) =>
         string.IsNullOrWhiteSpace(platform) ? "unknown" : platform.Trim().ToLowerInvariant();
+
+    private static string ResolvePlatformMessageId(NyxIdRelayCallbackPayload payload, string platform)
+    {
+        var replyTarget = payload.ReplyToPlatformMessageId?.Trim();
+        if (!string.IsNullOrWhiteSpace(replyTarget))
+            return replyTarget;
+
+        var directPlatformId = payload.PlatformMessageId?.Trim();
+        if (!string.IsNullOrWhiteSpace(directPlatformId))
+            return directPlatformId;
+
+        if (payload.RawPlatformData is not { } rawPlatformData)
+            return string.Empty;
+
+        return platform switch
+        {
+            "lark" or "feishu" => ResolveLarkPlatformMessageId(rawPlatformData),
+            _ => string.Empty,
+        };
+    }
+
+    private static string ResolveLarkPlatformMessageId(JsonElement rawPlatformData)
+    {
+        if (TryReadJsonString(rawPlatformData, out var replyTarget, "event", "context", "open_message_id"))
+            return replyTarget;
+
+        if (TryReadJsonString(rawPlatformData, out var messageId, "event", "message", "message_id"))
+            return messageId;
+
+        return string.Empty;
+    }
+
+    private static bool TryReadJsonString(
+        JsonElement element,
+        out string value,
+        params string[] path)
+    {
+        value = string.Empty;
+        var current = element;
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(segment, out current))
+            {
+                return false;
+            }
+        }
+
+        if (current.ValueKind != JsonValueKind.String)
+            return false;
+
+        var parsed = current.GetString()?.Trim();
+        if (string.IsNullOrWhiteSpace(parsed))
+            return false;
+
+        value = parsed;
+        return true;
+    }
 
     private static string ResolveConversationIdentity(string platform, NyxIdRelayCallbackPayload payload)
     {

--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
@@ -3,6 +3,7 @@ namespace Aevatar.AI.ToolProviders.Lark;
 public interface ILarkNyxClient
 {
     Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct);
+    Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct);
     Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct);
     Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct);
     Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct);
@@ -15,6 +16,10 @@ public sealed record LarkSendMessageRequest(
     string MessageType,
     string ContentJson,
     string? IdempotencyKey = null);
+
+public sealed record LarkMessageReactionRequest(
+    string MessageId,
+    string EmojiType);
 
 public sealed record LarkChatSearchRequest(
     string? Query,

--- a/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/ILarkNyxClient.cs
@@ -3,7 +3,12 @@ namespace Aevatar.AI.ToolProviders.Lark;
 public interface ILarkNyxClient
 {
     Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct);
+    Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct);
     Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct);
+    Task<string> ListMessageReactionsAsync(string token, LarkMessageReactionListRequest request, CancellationToken ct);
+    Task<string> DeleteMessageReactionAsync(string token, LarkMessageReactionDeleteRequest request, CancellationToken ct);
+    Task<string> SearchMessagesAsync(string token, LarkMessageSearchRequest request, CancellationToken ct);
+    Task<string> BatchGetMessagesAsync(string token, LarkMessagesBatchGetRequest request, CancellationToken ct);
     Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct);
     Task<string> AppendSheetRowsAsync(string token, LarkSheetAppendRowsRequest request, CancellationToken ct);
     Task<string> ListApprovalTasksAsync(string token, LarkApprovalTaskQueryRequest request, CancellationToken ct);
@@ -17,9 +22,44 @@ public sealed record LarkSendMessageRequest(
     string ContentJson,
     string? IdempotencyKey = null);
 
+public sealed record LarkReplyMessageRequest(
+    string MessageId,
+    string MessageType,
+    string ContentJson,
+    bool ReplyInThread,
+    string? IdempotencyKey = null);
+
 public sealed record LarkMessageReactionRequest(
     string MessageId,
     string EmojiType);
+
+public sealed record LarkMessageReactionListRequest(
+    string MessageId,
+    string? EmojiType,
+    int PageSize,
+    string? PageToken,
+    string? UserIdType);
+
+public sealed record LarkMessageReactionDeleteRequest(
+    string MessageId,
+    string ReactionId);
+
+public sealed record LarkMessageSearchRequest(
+    string Query,
+    IReadOnlyList<string>? ChatIds,
+    IReadOnlyList<string>? SenderIds,
+    string? IncludeAttachmentType,
+    string? ChatType,
+    string? SenderType,
+    string? ExcludeSenderType,
+    bool IsAtMe,
+    string? StartTime,
+    string? EndTime,
+    int PageSize,
+    string? PageToken);
+
+public sealed record LarkMessagesBatchGetRequest(
+    IReadOnlyList<string> MessageIds);
 
 public sealed record LarkChatSearchRequest(
     string? Query,

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
@@ -42,6 +42,8 @@ public sealed class LarkAgentToolSource : IAgentToolSource
         var tools = new List<IAgentTool>();
         if (_options.EnableMessageSend)
             tools.Add(new LarkMessagesSendTool(_client));
+        if (_options.EnableMessageReactionCreate)
+            tools.Add(new LarkMessagesReactTool(_client));
         if (_options.EnableChatLookup)
             tools.Add(new LarkChatsLookupTool(_client));
         if (_options.EnableSheetsAppendRows)

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkAgentToolSource.cs
@@ -42,8 +42,18 @@ public sealed class LarkAgentToolSource : IAgentToolSource
         var tools = new List<IAgentTool>();
         if (_options.EnableMessageSend)
             tools.Add(new LarkMessagesSendTool(_client));
+        if (_options.EnableMessageReply)
+            tools.Add(new LarkMessagesReplyTool(_client));
         if (_options.EnableMessageReactionCreate)
             tools.Add(new LarkMessagesReactTool(_client));
+        if (_options.EnableMessageReactionList)
+            tools.Add(new LarkMessagesReactionsListTool(_client));
+        if (_options.EnableMessageReactionDelete)
+            tools.Add(new LarkMessagesReactionsDeleteTool(_client));
+        if (_options.EnableMessageSearch)
+            tools.Add(new LarkMessagesSearchTool(_client));
+        if (_options.EnableMessageBatchGet)
+            tools.Add(new LarkMessagesBatchGetTool(_client));
         if (_options.EnableChatLookup)
             tools.Add(new LarkChatsLookupTool(_client));
         if (_options.EnableSheetsAppendRows)

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
@@ -44,6 +44,29 @@ public sealed class LarkNyxClient : ILarkNyxClient
             ct);
     }
 
+    public Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["msg_type"] = request.MessageType,
+            ["content"] = request.ContentJson,
+        };
+
+        if (request.ReplyInThread)
+            body["reply_in_thread"] = true;
+        if (!string.IsNullOrWhiteSpace(request.IdempotencyKey))
+            body["uuid"] = request.IdempotencyKey.Trim();
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/im/v1/messages/{Uri.EscapeDataString(request.MessageId)}/reply",
+            "POST",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
     public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct)
     {
         var body = new Dictionary<string, object?>
@@ -60,6 +83,109 @@ public sealed class LarkNyxClient : ILarkNyxClient
             $"open-apis/im/v1/messages/{Uri.EscapeDataString(request.MessageId)}/reactions",
             "POST",
             JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
+    public Task<string> ListMessageReactionsAsync(string token, LarkMessageReactionListRequest request, CancellationToken ct)
+    {
+        var queryParts = new List<string>
+        {
+            $"page_size={request.PageSize}",
+        };
+        if (!string.IsNullOrWhiteSpace(request.EmojiType))
+            queryParts.Add($"reaction_type={Uri.EscapeDataString(request.EmojiType.Trim())}");
+        if (!string.IsNullOrWhiteSpace(request.PageToken))
+            queryParts.Add($"page_token={Uri.EscapeDataString(request.PageToken.Trim())}");
+        if (!string.IsNullOrWhiteSpace(request.UserIdType))
+            queryParts.Add($"user_id_type={Uri.EscapeDataString(request.UserIdType.Trim())}");
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/im/v1/messages/{Uri.EscapeDataString(request.MessageId)}/reactions?{string.Join("&", queryParts)}",
+            "GET",
+            body: null,
+            extraHeaders: null,
+            ct);
+    }
+
+    public Task<string> DeleteMessageReactionAsync(string token, LarkMessageReactionDeleteRequest request, CancellationToken ct)
+    {
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/im/v1/messages/{Uri.EscapeDataString(request.MessageId)}/reactions/{Uri.EscapeDataString(request.ReactionId)}",
+            "DELETE",
+            body: null,
+            extraHeaders: null,
+            ct);
+    }
+
+    public Task<string> SearchMessagesAsync(string token, LarkMessageSearchRequest request, CancellationToken ct)
+    {
+        var paramsParts = new List<string>
+        {
+            $"page_size={request.PageSize}",
+        };
+        if (!string.IsNullOrWhiteSpace(request.PageToken))
+            paramsParts.Add($"page_token={Uri.EscapeDataString(request.PageToken.Trim())}");
+
+        var body = new Dictionary<string, object?>
+        {
+            ["query"] = request.Query,
+        };
+        var filter = new Dictionary<string, object?>();
+        if (request.ChatIds is { Count: > 0 })
+            filter["chat_ids"] = request.ChatIds;
+        if (request.SenderIds is { Count: > 0 })
+            filter["from_ids"] = request.SenderIds;
+        if (!string.IsNullOrWhiteSpace(request.IncludeAttachmentType))
+            filter["include_attachment_types"] = new[] { request.IncludeAttachmentType.Trim() };
+        if (!string.IsNullOrWhiteSpace(request.ChatType))
+            filter["chat_type"] = request.ChatType.Trim();
+        if (!string.IsNullOrWhiteSpace(request.SenderType))
+            filter["from_types"] = new[] { request.SenderType.Trim() };
+        if (!string.IsNullOrWhiteSpace(request.ExcludeSenderType))
+            filter["exclude_from_types"] = new[] { request.ExcludeSenderType.Trim() };
+        if (request.IsAtMe)
+            filter["is_at_me"] = true;
+
+        var timeRange = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(request.StartTime))
+            timeRange["start_time"] = request.StartTime.Trim();
+        if (!string.IsNullOrWhiteSpace(request.EndTime))
+            timeRange["end_time"] = request.EndTime.Trim();
+        if (timeRange.Count > 0)
+            filter["time_range"] = timeRange;
+        if (filter.Count > 0)
+            body["filter"] = filter;
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/im/v1/messages/search?{string.Join("&", paramsParts)}",
+            "POST",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
+    public Task<string> BatchGetMessagesAsync(string token, LarkMessagesBatchGetRequest request, CancellationToken ct)
+    {
+        var parts = new List<string>
+        {
+            "card_msg_content_type=raw_card_content",
+        };
+        foreach (var messageId in request.MessageIds)
+            parts.Add($"message_ids={Uri.EscapeDataString(messageId)}");
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/im/v1/messages/mget?{string.Join("&", parts)}",
+            "GET",
+            body: null,
             extraHeaders: null,
             ct);
     }

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkNyxClient.cs
@@ -44,6 +44,26 @@ public sealed class LarkNyxClient : ILarkNyxClient
             ct);
     }
 
+    public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["reaction_type"] = new Dictionary<string, object?>
+            {
+                ["emoji_type"] = request.EmojiType,
+            },
+        };
+
+        return _nyxClient.ProxyRequestAsync(
+            token,
+            _options.ProviderSlug,
+            $"open-apis/im/v1/messages/{Uri.EscapeDataString(request.MessageId)}/reactions",
+            "POST",
+            JsonSerializer.Serialize(body, JsonOptions),
+            extraHeaders: null,
+            ct);
+    }
+
     public Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct)
     {
         var query = $"page_size={request.PageSize}";

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
@@ -72,6 +72,27 @@ internal static class LarkProxyResponseParser
             CreateTime: TryReadString(data, "create_time"));
     }
 
+    public static LarkMessageReactionResult ParseReactionCreateSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        var operatorData = data.TryGetProperty("operator", out var operatorProp) &&
+                           operatorProp.ValueKind == JsonValueKind.Object
+            ? operatorProp
+            : default;
+        var reactionType = data.TryGetProperty("reaction_type", out var reactionProp) &&
+                           reactionProp.ValueKind == JsonValueKind.Object
+            ? reactionProp
+            : default;
+
+        return new LarkMessageReactionResult(
+            ReactionId: TryReadString(data, "reaction_id"),
+            OperatorId: TryReadString(operatorData, "operator_id"),
+            OperatorType: TryReadString(operatorData, "operator_type"),
+            ActionTime: TryReadString(data, "action_time"),
+            EmojiType: TryReadString(reactionType, "emoji_type"));
+    }
+
     public static LarkChatLookupResult ParseChatSearchSuccess(
         string response,
         string? query,
@@ -211,6 +232,13 @@ internal sealed record LarkSendResult(
     string? MessageId,
     string? ChatId,
     string? CreateTime);
+
+internal sealed record LarkMessageReactionResult(
+    string? ReactionId,
+    string? OperatorId,
+    string? OperatorType,
+    string? ActionTime,
+    string? EmojiType);
 
 internal sealed record LarkChatCandidate(
     string? ChatId,

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkProxyResponseParser.cs
@@ -76,21 +76,25 @@ internal static class LarkProxyResponseParser
     {
         using var document = JsonDocument.Parse(response);
         var data = ResolveDataRoot(document.RootElement);
-        var operatorData = data.TryGetProperty("operator", out var operatorProp) &&
-                           operatorProp.ValueKind == JsonValueKind.Object
-            ? operatorProp
-            : default;
-        var reactionType = data.TryGetProperty("reaction_type", out var reactionProp) &&
-                           reactionProp.ValueKind == JsonValueKind.Object
-            ? reactionProp
-            : default;
+        return ParseReactionItem(data);
+    }
 
-        return new LarkMessageReactionResult(
-            ReactionId: TryReadString(data, "reaction_id"),
-            OperatorId: TryReadString(operatorData, "operator_id"),
-            OperatorType: TryReadString(operatorData, "operator_type"),
-            ActionTime: TryReadString(data, "action_time"),
-            EmojiType: TryReadString(reactionType, "emoji_type"));
+    public static LarkMessageReactionListResult ParseReactionListSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        var items = new List<LarkMessageReactionResult>();
+
+        if (data.TryGetProperty("items", out var itemsProp) && itemsProp.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in itemsProp.EnumerateArray())
+                items.Add(ParseReactionItem(item));
+        }
+
+        return new LarkMessageReactionListResult(
+            Items: items,
+            HasMore: TryReadBool(data, "has_more") ?? false,
+            PageToken: TryReadString(data, "page_token"));
     }
 
     public static LarkChatLookupResult ParseChatSearchSuccess(
@@ -139,6 +143,87 @@ internal static class LarkProxyResponseParser
             Total: TryReadInt(data, "total") ?? ordered.Count,
             HasMore: TryReadBool(data, "has_more") ?? false,
             PageToken: TryReadString(data, "page_token"));
+    }
+
+    public static LarkMessageSearchResult ParseMessageSearchSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        var messageIds = new List<string>();
+
+        if (data.TryGetProperty("items", out var itemsProp) && itemsProp.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in itemsProp.EnumerateArray())
+            {
+                var meta = item.TryGetProperty("meta_data", out var metaProp) &&
+                           metaProp.ValueKind == JsonValueKind.Object
+                    ? metaProp
+                    : item;
+                var messageId = TryReadString(meta, "message_id");
+                if (!string.IsNullOrWhiteSpace(messageId))
+                    messageIds.Add(messageId);
+            }
+        }
+
+        return new LarkMessageSearchResult(
+            MessageIds: messageIds,
+            HasMore: TryReadBool(data, "has_more") ?? false,
+            PageToken: TryReadString(data, "page_token"),
+            Count: TryReadInt(data, "count") ?? messageIds.Count);
+    }
+
+    public static LarkMessageBatchGetResult ParseMessageBatchGetSuccess(string response)
+    {
+        using var document = JsonDocument.Parse(response);
+        var data = ResolveDataRoot(document.RootElement);
+        var messages = new List<LarkMessageSummary>();
+
+        if (data.TryGetProperty("items", out var itemsProp) && itemsProp.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in itemsProp.EnumerateArray())
+            {
+                var mentions = new List<LarkMessageMention>();
+                if (item.TryGetProperty("mentions", out var mentionsProp) && mentionsProp.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var mention in mentionsProp.EnumerateArray())
+                    {
+                        mentions.Add(new LarkMessageMention(
+                            Id: TryReadMentionId(mention),
+                            Key: TryReadString(mention, "key"),
+                            Name: TryReadString(mention, "name")));
+                    }
+                }
+
+                var sender = item.TryGetProperty("sender", out var senderProp) &&
+                             senderProp.ValueKind == JsonValueKind.Object
+                    ? senderProp
+                    : default;
+                var body = item.TryGetProperty("body", out var bodyProp) &&
+                           bodyProp.ValueKind == JsonValueKind.Object
+                    ? bodyProp
+                    : default;
+                var contentJson = TryReadString(body, "content");
+                var messageType = TryReadString(item, "msg_type");
+
+                messages.Add(new LarkMessageSummary(
+                    MessageId: TryReadString(item, "message_id"),
+                    MessageType: messageType,
+                    Content: ExtractMessageContent(messageType, contentJson),
+                    ContentJson: contentJson,
+                    ChatId: TryReadString(item, "chat_id"),
+                    CreateTime: TryReadString(item, "create_time"),
+                    ThreadId: TryReadString(item, "thread_id"),
+                    ReplyTo: TryReadString(item, "parent_id"),
+                    Deleted: TryReadBool(item, "deleted") ?? false,
+                    Updated: TryReadBool(item, "updated") ?? false,
+                    SenderId: TryReadString(sender, "id"),
+                    SenderName: TryReadString(sender, "name"),
+                    SenderType: TryReadString(sender, "sender_type"),
+                    Mentions: mentions));
+            }
+        }
+
+        return new LarkMessageBatchGetResult(Messages: messages);
     }
 
     public static LarkSheetAppendResult ParseSheetAppendSuccess(string response)
@@ -209,6 +294,67 @@ internal static class LarkProxyResponseParser
             ? dataProp
             : root;
 
+    private static LarkMessageReactionResult ParseReactionItem(JsonElement item)
+    {
+        var operatorData = item.TryGetProperty("operator", out var operatorProp) &&
+                           operatorProp.ValueKind == JsonValueKind.Object
+            ? operatorProp
+            : default;
+        var reactionType = item.TryGetProperty("reaction_type", out var reactionProp) &&
+                           reactionProp.ValueKind == JsonValueKind.Object
+            ? reactionProp
+            : default;
+
+        return new LarkMessageReactionResult(
+            ReactionId: TryReadString(item, "reaction_id"),
+            OperatorId: TryReadString(operatorData, "operator_id"),
+            OperatorType: TryReadString(operatorData, "operator_type"),
+            ActionTime: TryReadString(item, "action_time"),
+            EmojiType: TryReadString(reactionType, "emoji_type"));
+    }
+
+    private static string? ExtractMessageContent(string? messageType, string? contentJson)
+    {
+        if (string.IsNullOrWhiteSpace(contentJson))
+            return null;
+
+        try
+        {
+            using var document = JsonDocument.Parse(contentJson);
+            var root = document.RootElement;
+            if (messageType is "text" && root.TryGetProperty("text", out var textProp) && textProp.ValueKind == JsonValueKind.String)
+                return textProp.GetString();
+            if (messageType is "file" && root.TryGetProperty("file_name", out var fileNameProp) && fileNameProp.ValueKind == JsonValueKind.String)
+                return $"[file] {fileNameProp.GetString()}";
+            if (messageType is "image")
+                return "[image]";
+            if (messageType is "audio")
+                return "[audio]";
+            if (messageType is "video" or "media")
+                return "[video]";
+            if (messageType is "interactive")
+                return "[interactive_card]";
+        }
+        catch (JsonException)
+        {
+            // Keep the raw content below.
+        }
+
+        return contentJson;
+    }
+
+    private static string? TryReadMentionId(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty("id", out var idProp))
+            return null;
+
+        if (idProp.ValueKind == JsonValueKind.String)
+            return idProp.GetString();
+        if (idProp.ValueKind == JsonValueKind.Object)
+            return TryReadString(idProp, "open_id") ?? TryReadString(idProp, "user_id");
+        return null;
+    }
+
     private static string? TryReadString(JsonElement element, string propertyName) =>
         element.ValueKind == JsonValueKind.Object &&
         element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
@@ -239,6 +385,41 @@ internal sealed record LarkMessageReactionResult(
     string? OperatorType,
     string? ActionTime,
     string? EmojiType);
+
+internal sealed record LarkMessageReactionListResult(
+    IReadOnlyList<LarkMessageReactionResult> Items,
+    bool HasMore,
+    string? PageToken);
+
+internal sealed record LarkMessageSearchResult(
+    IReadOnlyList<string> MessageIds,
+    bool HasMore,
+    string? PageToken,
+    int Count);
+
+internal sealed record LarkMessageMention(
+    string? Id,
+    string? Key,
+    string? Name);
+
+internal sealed record LarkMessageSummary(
+    string? MessageId,
+    string? MessageType,
+    string? Content,
+    string? ContentJson,
+    string? ChatId,
+    string? CreateTime,
+    string? ThreadId,
+    string? ReplyTo,
+    bool Deleted,
+    bool Updated,
+    string? SenderId,
+    string? SenderName,
+    string? SenderType,
+    IReadOnlyList<LarkMessageMention> Mentions);
+
+internal sealed record LarkMessageBatchGetResult(
+    IReadOnlyList<LarkMessageSummary> Messages);
 
 internal sealed record LarkChatCandidate(
     string? ChatId,

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
@@ -4,6 +4,7 @@ public sealed class LarkToolOptions
 {
     public string ProviderSlug { get; set; } = "api-lark-bot";
     public bool EnableMessageSend { get; set; } = true;
+    public bool EnableMessageReactionCreate { get; set; } = true;
     public bool EnableChatLookup { get; set; } = true;
     public bool EnableSheetsAppendRows { get; set; } = true;
     public bool EnableApprovalsList { get; set; } = true;

--- a/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/LarkToolOptions.cs
@@ -4,7 +4,12 @@ public sealed class LarkToolOptions
 {
     public string ProviderSlug { get; set; } = "api-lark-bot";
     public bool EnableMessageSend { get; set; } = true;
+    public bool EnableMessageReply { get; set; } = true;
     public bool EnableMessageReactionCreate { get; set; } = true;
+    public bool EnableMessageReactionList { get; set; } = true;
+    public bool EnableMessageReactionDelete { get; set; } = true;
+    public bool EnableMessageSearch { get; set; } = true;
+    public bool EnableMessageBatchGet { get; set; } = true;
     public bool EnableChatLookup { get; set; } = true;
     public bool EnableSheetsAppendRows { get; set; } = true;
     public bool EnableApprovalsList { get; set; } = true;

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesBatchGetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesBatchGetTool.cs
@@ -1,0 +1,91 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkMessagesBatchGetTool : AgentToolBase<LarkMessagesBatchGetTool.Parameters>
+{
+    private readonly ILarkNyxClient _client;
+
+    public LarkMessagesBatchGetTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_messages_batch_get";
+
+    public override string Description =>
+        "Batch fetch full Lark message details by message IDs. " +
+        "Use this to inspect known messages after search or when the user gives you om_xxx IDs.";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+    public override bool IsReadOnly => true;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.TryGet(LLMRequestMetadataKeys.NyxIdAccessToken);
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var messageIds = parameters.MessageIds?
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (messageIds is not { Length: > 0 })
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "message_ids must contain at least one Lark message id." });
+        if (messageIds.Length > 50)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "message_ids exceeds the maximum of 50 values." });
+
+        foreach (var messageId in messageIds)
+        {
+            if (!LarkMessageIdResolver.TryValidate(messageId, out _, out var validationError))
+                return LarkProxyResponseParser.Serialize(new { success = false, error = validationError });
+        }
+
+        var response = await _client.BatchGetMessagesAsync(
+            token,
+            new LarkMessagesBatchGetRequest(messageIds),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(response, out var error))
+            return LarkProxyResponseParser.Serialize(new { success = false, error });
+
+        var result = LarkProxyResponseParser.ParseMessageBatchGetSuccess(response);
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            total = result.Messages.Count,
+            messages = result.Messages.Select(message => new
+            {
+                message_id = message.MessageId,
+                msg_type = message.MessageType,
+                content = message.Content,
+                content_json = message.ContentJson,
+                chat_id = message.ChatId,
+                create_time = message.CreateTime,
+                thread_id = message.ThreadId,
+                reply_to = message.ReplyTo,
+                deleted = message.Deleted,
+                updated = message.Updated,
+                sender = new
+                {
+                    id = message.SenderId,
+                    name = message.SenderName,
+                    sender_type = message.SenderType,
+                },
+                mentions = message.Mentions.Select(mention => new
+                {
+                    id = mention.Id,
+                    key = mention.Key,
+                    name = mention.Name,
+                }).ToArray(),
+            }).ToArray(),
+        });
+    }
+
+    public sealed class Parameters
+    {
+        public List<string>? MessageIds { get; set; }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactTool.cs
@@ -1,0 +1,158 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.Parameters>
+{
+    private const string DefaultEmojiType = "OK";
+    private const string ChannelMessageIdKey = "channel.message_id";
+    private const string ChannelPlatformMessageIdKey = "channel.platform_message_id";
+
+    private static readonly Dictionary<string, string> EmojiAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["ok"] = "OK",
+        ["okay"] = "OK",
+        ["了解"] = "OK",
+        ["收到"] = "OK",
+        ["thumbsup"] = "THUMBSUP",
+        ["thumbs_up"] = "THUMBSUP",
+        ["赞"] = "THUMBSUP",
+        ["点赞"] = "THUMBSUP",
+        ["done"] = "DONE",
+        ["完成"] = "DONE",
+        ["smile"] = "SMILE",
+        ["微笑"] = "SMILE",
+    };
+
+    private readonly ILarkNyxClient _client;
+
+    public LarkMessagesReactTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_messages_react";
+
+    public override string Description =>
+        "Add an emoji reaction to a Lark message. " +
+        "On a channel relay turn you can omit message_id to react to the current inbound message. " +
+        "Defaults to emoji_type=OK (an acknowledgement like '了解').";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.TryGet(LLMRequestMetadataKeys.NyxIdAccessToken);
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var messageId = ResolveMessageId(parameters.MessageId, out var usedCurrentMessage, out var messageError);
+        if (!string.IsNullOrWhiteSpace(messageError))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error = messageError,
+            });
+        }
+
+        var emojiType = NormalizeEmojiType(parameters.EmojiType);
+        var response = await _client.CreateMessageReactionAsync(
+            token,
+            new LarkMessageReactionRequest(messageId!, emojiType),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(response, out var error))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error,
+                message_id = messageId,
+                emoji_type = emojiType,
+            });
+        }
+
+        var result = LarkProxyResponseParser.ParseReactionCreateSuccess(response);
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            message_id = messageId,
+            emoji_type = result.EmojiType ?? emojiType,
+            reaction_id = result.ReactionId,
+            operator_id = result.OperatorId,
+            operator_type = result.OperatorType,
+            action_time = result.ActionTime,
+            used_current_message = usedCurrentMessage ? (bool?)true : null,
+        });
+    }
+
+    private static string? ResolveMessageId(string? messageId, out bool usedCurrentMessage, out string? error)
+    {
+        usedCurrentMessage = false;
+        error = null;
+
+        if (TryValidateMessageId(messageId, out var explicitMessageId, out var explicitError))
+        {
+            return explicitMessageId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(explicitError))
+        {
+            error = explicitError;
+            return null;
+        }
+
+        var currentMessageId = AgentToolRequestContext.TryGet(ChannelPlatformMessageIdKey) ??
+                               AgentToolRequestContext.TryGet(ChannelMessageIdKey);
+        if (TryValidateMessageId(currentMessageId, out var current, out _))
+        {
+            usedCurrentMessage = true;
+            return current;
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentMessageId))
+        {
+            error = "Current turn metadata did not expose a Lark platform message_id (expected om_xxx). Pass message_id explicitly.";
+            return null;
+        }
+
+        error = "message_id is required when current turn metadata does not include a Lark message id";
+        return null;
+    }
+
+    private static bool TryValidateMessageId(string? raw, out string? normalized, out string? error)
+    {
+        normalized = raw?.Trim();
+        error = null;
+        if (string.IsNullOrWhiteSpace(normalized))
+            return false;
+
+        if (!normalized.StartsWith("om_", StringComparison.OrdinalIgnoreCase))
+        {
+            error = "message_id must be a Lark message id like om_xxx";
+            normalized = null;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string NormalizeEmojiType(string? emojiType)
+    {
+        var trimmed = emojiType?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return DefaultEmojiType;
+
+        return EmojiAliases.TryGetValue(trimmed, out var alias)
+            ? alias
+            : trimmed;
+    }
+
+    public sealed class Parameters
+    {
+        public string? MessageId { get; set; }
+        public string? EmojiType { get; set; }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactionsDeleteTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactionsDeleteTool.cs
@@ -3,21 +3,20 @@ using Aevatar.AI.Abstractions.ToolProviders;
 
 namespace Aevatar.AI.ToolProviders.Lark.Tools;
 
-public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.Parameters>
+public sealed class LarkMessagesReactionsDeleteTool : AgentToolBase<LarkMessagesReactionsDeleteTool.Parameters>
 {
     private readonly ILarkNyxClient _client;
 
-    public LarkMessagesReactTool(ILarkNyxClient client)
+    public LarkMessagesReactionsDeleteTool(ILarkNyxClient client)
     {
         _client = client;
     }
 
-    public override string Name => "lark_messages_react";
+    public override string Name => "lark_messages_reactions_delete";
 
     public override string Description =>
-        "Add an emoji reaction to a Lark message. " +
-        "On a channel relay turn you can omit message_id to react to the current inbound message. " +
-        "Defaults to emoji_type=OK (an acknowledgement like '了解').";
+        "Delete a specific Lark message reaction record by reaction_id. " +
+        "On a channel relay turn you can omit message_id to operate on the current inbound message.";
 
     public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
 
@@ -29,18 +28,15 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
 
         var messageId = LarkMessageIdResolver.ResolveOrCurrent(parameters.MessageId, out var usedCurrentMessage, out var messageError);
         if (!string.IsNullOrWhiteSpace(messageError))
-        {
-            return LarkProxyResponseParser.Serialize(new
-            {
-                success = false,
-                error = messageError,
-            });
-        }
+            return LarkProxyResponseParser.Serialize(new { success = false, error = messageError });
 
-        var emojiType = LarkReactionEmojiHelper.NormalizeOrDefault(parameters.EmojiType);
-        var response = await _client.CreateMessageReactionAsync(
+        var reactionId = parameters.ReactionId?.Trim();
+        if (string.IsNullOrWhiteSpace(reactionId))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "reaction_id is required." });
+
+        var response = await _client.DeleteMessageReactionAsync(
             token,
-            new LarkMessageReactionRequest(messageId!, emojiType),
+            new LarkMessageReactionDeleteRequest(messageId!, reactionId),
             ct);
 
         if (LarkProxyResponseParser.TryParseError(response, out var error))
@@ -50,7 +46,7 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
                 success = false,
                 error,
                 message_id = messageId,
-                emoji_type = emojiType,
+                reaction_id = reactionId,
             });
         }
 
@@ -59,8 +55,8 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
         {
             success = true,
             message_id = messageId,
-            emoji_type = result.EmojiType ?? emojiType,
-            reaction_id = result.ReactionId,
+            reaction_id = result.ReactionId ?? reactionId,
+            emoji_type = result.EmojiType,
             operator_id = result.OperatorId,
             operator_type = result.OperatorType,
             action_time = result.ActionTime,
@@ -71,6 +67,6 @@ public sealed class LarkMessagesReactTool : AgentToolBase<LarkMessagesReactTool.
     public sealed class Parameters
     {
         public string? MessageId { get; set; }
-        public string? EmojiType { get; set; }
+        public string? ReactionId { get; set; }
     }
 }

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactionsListTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactionsListTool.cs
@@ -1,0 +1,90 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkMessagesReactionsListTool : AgentToolBase<LarkMessagesReactionsListTool.Parameters>
+{
+    private static readonly HashSet<string> AllowedUserIdTypes =
+    [
+        "user_id",
+        "union_id",
+        "open_id",
+    ];
+
+    private readonly ILarkNyxClient _client;
+
+    public LarkMessagesReactionsListTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_messages_reactions_list";
+
+    public override string Description =>
+        "List emoji reaction records on a Lark message. " +
+        "On a channel relay turn you can omit message_id to inspect reactions on the current inbound message.";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+    public override bool IsReadOnly => true;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.TryGet(LLMRequestMetadataKeys.NyxIdAccessToken);
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var messageId = LarkMessageIdResolver.ResolveOrCurrent(parameters.MessageId, out var usedCurrentMessage, out var messageError);
+        if (!string.IsNullOrWhiteSpace(messageError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = messageError });
+
+        var userIdType = parameters.UserIdType?.Trim().ToLowerInvariant();
+        if (!string.IsNullOrWhiteSpace(userIdType) && !AllowedUserIdTypes.Contains(userIdType))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "user_id_type must be one of: user_id, union_id, open_id" });
+
+        var pageSize = parameters.PageSize is > 0 ? parameters.PageSize.Value : 20;
+        if (pageSize is < 1 or > 100)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "page_size must be between 1 and 100." });
+
+        var response = await _client.ListMessageReactionsAsync(
+            token,
+            new LarkMessageReactionListRequest(
+                MessageId: messageId!,
+                EmojiType: LarkReactionEmojiHelper.NormalizeOptional(parameters.EmojiType),
+                PageSize: pageSize,
+                PageToken: parameters.PageToken?.Trim(),
+                UserIdType: userIdType),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(response, out var error))
+            return LarkProxyResponseParser.Serialize(new { success = false, error, message_id = messageId });
+
+        var result = LarkProxyResponseParser.ParseReactionListSuccess(response);
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            message_id = messageId,
+            count = result.Items.Count,
+            has_more = result.HasMore,
+            page_token = result.PageToken,
+            used_current_message = usedCurrentMessage ? (bool?)true : null,
+            items = result.Items.Select(item => new
+            {
+                reaction_id = item.ReactionId,
+                operator_id = item.OperatorId,
+                operator_type = item.OperatorType,
+                action_time = item.ActionTime,
+                emoji_type = item.EmojiType,
+            }).ToArray(),
+        });
+    }
+
+    public sealed class Parameters
+    {
+        public string? MessageId { get; set; }
+        public string? EmojiType { get; set; }
+        public int? PageSize { get; set; }
+        public string? PageToken { get; set; }
+        public string? UserIdType { get; set; }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactionsListTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReactionsListTool.cs
@@ -43,8 +43,8 @@ public sealed class LarkMessagesReactionsListTool : AgentToolBase<LarkMessagesRe
             return LarkProxyResponseParser.Serialize(new { success = false, error = "user_id_type must be one of: user_id, union_id, open_id" });
 
         var pageSize = parameters.PageSize is > 0 ? parameters.PageSize.Value : 20;
-        if (pageSize is < 1 or > 100)
-            return LarkProxyResponseParser.Serialize(new { success = false, error = "page_size must be between 1 and 100." });
+        if (pageSize is < 1 or > 50)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "page_size must be between 1 and 50." });
 
         var response = await _client.ListMessageReactionsAsync(
             token,

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesReplyTool.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkMessagesReplyTool : AgentToolBase<LarkMessagesReplyTool.Parameters>
+{
+    private readonly ILarkNyxClient _client;
+
+    public LarkMessagesReplyTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_messages_reply";
+
+    public override string Description =>
+        "Reply to a specific Lark message through Nyx-backed transport. " +
+        "On a channel relay turn you can omit message_id to reply to the current inbound Lark message. " +
+        "Supports text replies and interactive cards.";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.TryGet(LLMRequestMetadataKeys.NyxIdAccessToken);
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var messageId = LarkMessageIdResolver.ResolveOrCurrent(parameters.MessageId, out var usedCurrentMessage, out var messageError);
+        if (!string.IsNullOrWhiteSpace(messageError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = messageError });
+
+        var normalizedMessageType = NormalizeMessageType(parameters.MessageType);
+        if (normalizedMessageType is null)
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error = "message_type must be one of: text, interactive_card",
+            });
+        }
+
+        string contentJson;
+        switch (normalizedMessageType)
+        {
+            case "text":
+                if (string.IsNullOrWhiteSpace(parameters.Text))
+                    return LarkProxyResponseParser.Serialize(new { success = false, error = "text is required when message_type=text" });
+                contentJson = JsonSerializer.Serialize(new { text = parameters.Text });
+                break;
+            case "interactive":
+                if (string.IsNullOrWhiteSpace(parameters.CardJson))
+                    return LarkProxyResponseParser.Serialize(new { success = false, error = "card_json is required when message_type=interactive_card" });
+                try
+                {
+                    using var _ = JsonDocument.Parse(parameters.CardJson);
+                }
+                catch (JsonException ex)
+                {
+                    return LarkProxyResponseParser.Serialize(new { success = false, error = $"card_json is not valid JSON: {ex.Message}" });
+                }
+
+                contentJson = parameters.CardJson;
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported normalized message type: {normalizedMessageType}");
+        }
+
+        var response = await _client.ReplyToMessageAsync(
+            token,
+            new LarkReplyMessageRequest(
+                MessageId: messageId!,
+                MessageType: normalizedMessageType,
+                ContentJson: contentJson,
+                ReplyInThread: parameters.ReplyInThread ?? false,
+                IdempotencyKey: parameters.IdempotencyKey?.Trim()),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(response, out var error))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error,
+                message_id = messageId,
+                message_type = normalizedMessageType,
+            });
+        }
+
+        var result = LarkProxyResponseParser.ParseSendSuccess(response);
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            message_id = result.MessageId ?? messageId,
+            chat_id = result.ChatId,
+            create_time = result.CreateTime,
+            reply_in_thread = parameters.ReplyInThread ?? false,
+            used_current_message = usedCurrentMessage ? (bool?)true : null,
+        });
+    }
+
+    private static string? NormalizeMessageType(string? messageType) =>
+        (messageType ?? string.Empty).Trim().ToLowerInvariant() switch
+        {
+            "" or "text" => "text",
+            "interactive_card" or "interactive" => "interactive",
+            _ => null,
+        };
+
+    public sealed class Parameters
+    {
+        public string? MessageId { get; set; }
+        public string? MessageType { get; set; }
+        public string? Text { get; set; }
+        public string? CardJson { get; set; }
+        public bool? ReplyInThread { get; set; }
+        public string? IdempotencyKey { get; set; }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesSearchTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkMessagesSearchTool.cs
@@ -1,0 +1,250 @@
+using System.Globalization;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+public sealed class LarkMessagesSearchTool : AgentToolBase<LarkMessagesSearchTool.Parameters>
+{
+    private static readonly HashSet<string> AllowedAttachmentTypes =
+    [
+        "file",
+        "image",
+        "video",
+        "link",
+    ];
+
+    private static readonly HashSet<string> AllowedChatTypes =
+    [
+        "group",
+        "p2p",
+    ];
+
+    private static readonly HashSet<string> AllowedSenderTypes =
+    [
+        "user",
+        "bot",
+    ];
+
+    private readonly ILarkNyxClient _client;
+
+    public LarkMessagesSearchTool(ILarkNyxClient client)
+    {
+        _client = client;
+    }
+
+    public override string Name => "lark_messages_search";
+
+    public override string Description =>
+        "Search Lark messages with filters such as keyword, sender, chat, and time range. " +
+        "By default this also hydrates the current page into full message details.";
+
+    public override ToolApprovalMode ApprovalMode => ToolApprovalMode.Auto;
+    public override bool IsReadOnly => true;
+
+    protected override async Task<string> ExecuteAsync(Parameters parameters, CancellationToken ct)
+    {
+        var token = AgentToolRequestContext.TryGet(LLMRequestMetadataKeys.NyxIdAccessToken);
+        if (string.IsNullOrWhiteSpace(token))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "No NyxID access token available. User must be authenticated." });
+
+        var query = parameters.Query?.Trim() ?? string.Empty;
+        var chatIds = parameters.ChatIds?
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var senderIds = parameters.SenderIds?
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var includeAttachmentType = parameters.IncludeAttachmentType?.Trim().ToLowerInvariant();
+        var chatType = parameters.ChatType?.Trim().ToLowerInvariant();
+        var senderType = parameters.SenderType?.Trim().ToLowerInvariant();
+        var excludeSenderType = parameters.ExcludeSenderType?.Trim().ToLowerInvariant();
+        var startTime = parameters.StartTime?.Trim();
+        var endTime = parameters.EndTime?.Trim();
+
+        if (string.IsNullOrWhiteSpace(query) &&
+            (chatIds is null || chatIds.Length == 0) &&
+            (senderIds is null || senderIds.Length == 0) &&
+            string.IsNullOrWhiteSpace(includeAttachmentType) &&
+            string.IsNullOrWhiteSpace(chatType) &&
+            string.IsNullOrWhiteSpace(senderType) &&
+            string.IsNullOrWhiteSpace(excludeSenderType) &&
+            string.IsNullOrWhiteSpace(startTime) &&
+            string.IsNullOrWhiteSpace(endTime) &&
+            parameters.IsAtMe != true)
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error = "At least one search filter is required (query, chat_ids, sender_ids, attachment type, sender/chat type, time range, or is_at_me).",
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(includeAttachmentType) && !AllowedAttachmentTypes.Contains(includeAttachmentType))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "include_attachment_type must be one of: file, image, video, link" });
+        if (!string.IsNullOrWhiteSpace(chatType) && !AllowedChatTypes.Contains(chatType))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "chat_type must be one of: group, p2p" });
+        if (!string.IsNullOrWhiteSpace(senderType) && !AllowedSenderTypes.Contains(senderType))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "sender_type must be one of: user, bot" });
+        if (!string.IsNullOrWhiteSpace(excludeSenderType) && !AllowedSenderTypes.Contains(excludeSenderType))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "exclude_sender_type must be one of: user, bot" });
+        if (!string.IsNullOrWhiteSpace(senderType) &&
+            string.Equals(senderType, excludeSenderType, StringComparison.OrdinalIgnoreCase))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = false,
+                error = "sender_type and exclude_sender_type cannot be the same value.",
+            });
+        }
+
+        if (!TryParseIsoTime(startTime, out var startAt, out var startError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = startError });
+        if (!TryParseIsoTime(endTime, out var endAt, out var endError))
+            return LarkProxyResponseParser.Serialize(new { success = false, error = endError });
+        if (startAt.HasValue && endAt.HasValue && startAt > endAt)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "start_time cannot be later than end_time." });
+
+        var pageSize = parameters.PageSize is > 0 ? parameters.PageSize.Value : 20;
+        if (pageSize is < 1 or > 50)
+            return LarkProxyResponseParser.Serialize(new { success = false, error = "page_size must be between 1 and 50." });
+
+        var response = await _client.SearchMessagesAsync(
+            token,
+            new LarkMessageSearchRequest(
+                Query: query,
+                ChatIds: chatIds,
+                SenderIds: senderIds,
+                IncludeAttachmentType: includeAttachmentType,
+                ChatType: chatType,
+                SenderType: senderType,
+                ExcludeSenderType: excludeSenderType,
+                IsAtMe: parameters.IsAtMe ?? false,
+                StartTime: startTime,
+                EndTime: endTime,
+                PageSize: pageSize,
+                PageToken: parameters.PageToken?.Trim()),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(response, out var error))
+            return LarkProxyResponseParser.Serialize(new { success = false, error });
+
+        var searchResult = LarkProxyResponseParser.ParseMessageSearchSuccess(response);
+        if (searchResult.MessageIds.Count == 0)
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = true,
+                total = 0,
+                has_more = searchResult.HasMore,
+                page_token = searchResult.PageToken,
+                message_ids = Array.Empty<string>(),
+                messages = Array.Empty<object>(),
+            });
+        }
+
+        var hydrate = parameters.Hydrate is not false;
+        if (!hydrate)
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = true,
+                total = searchResult.MessageIds.Count,
+                has_more = searchResult.HasMore,
+                page_token = searchResult.PageToken,
+                message_ids = searchResult.MessageIds.ToArray(),
+            });
+        }
+
+        var detailsResponse = await _client.BatchGetMessagesAsync(
+            token,
+            new LarkMessagesBatchGetRequest(searchResult.MessageIds),
+            ct);
+
+        if (LarkProxyResponseParser.TryParseError(detailsResponse, out var detailsError))
+        {
+            return LarkProxyResponseParser.Serialize(new
+            {
+                success = true,
+                total = searchResult.MessageIds.Count,
+                has_more = searchResult.HasMore,
+                page_token = searchResult.PageToken,
+                message_ids = searchResult.MessageIds.ToArray(),
+                warning = $"message hydration failed: {detailsError}",
+            });
+        }
+
+        var details = LarkProxyResponseParser.ParseMessageBatchGetSuccess(detailsResponse);
+        return LarkProxyResponseParser.Serialize(new
+        {
+            success = true,
+            total = details.Messages.Count,
+            has_more = searchResult.HasMore,
+            page_token = searchResult.PageToken,
+            message_ids = searchResult.MessageIds.ToArray(),
+            messages = details.Messages.Select(message => new
+            {
+                message_id = message.MessageId,
+                msg_type = message.MessageType,
+                content = message.Content,
+                content_json = message.ContentJson,
+                chat_id = message.ChatId,
+                create_time = message.CreateTime,
+                thread_id = message.ThreadId,
+                reply_to = message.ReplyTo,
+                deleted = message.Deleted,
+                updated = message.Updated,
+                sender = new
+                {
+                    id = message.SenderId,
+                    name = message.SenderName,
+                    sender_type = message.SenderType,
+                },
+                mentions = message.Mentions.Select(mention => new
+                {
+                    id = mention.Id,
+                    key = mention.Key,
+                    name = mention.Name,
+                }).ToArray(),
+            }).ToArray(),
+        });
+    }
+
+    private static bool TryParseIsoTime(string? raw, out DateTimeOffset? value, out string? error)
+    {
+        value = null;
+        error = null;
+        if (string.IsNullOrWhiteSpace(raw))
+            return true;
+
+        if (!DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+        {
+            error = "start_time and end_time must be ISO 8601 timestamps with timezone offsets.";
+            return false;
+        }
+
+        value = parsed;
+        return true;
+    }
+
+    public sealed class Parameters
+    {
+        public string? Query { get; set; }
+        public List<string>? ChatIds { get; set; }
+        public List<string>? SenderIds { get; set; }
+        public string? IncludeAttachmentType { get; set; }
+        public string? ChatType { get; set; }
+        public string? SenderType { get; set; }
+        public string? ExcludeSenderType { get; set; }
+        public bool? IsAtMe { get; set; }
+        public string? StartTime { get; set; }
+        public string? EndTime { get; set; }
+        public int? PageSize { get; set; }
+        public string? PageToken { get; set; }
+        public bool? Hydrate { get; set; }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
+++ b/src/Aevatar.AI.ToolProviders.Lark/Tools/LarkToolHelpers.cs
@@ -1,0 +1,97 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.Lark.Tools;
+
+internal static class LarkMessageIdResolver
+{
+    private const string ChannelMessageIdKey = "channel.message_id";
+    private const string ChannelPlatformMessageIdKey = "channel.platform_message_id";
+
+    public static string? ResolveOrCurrent(string? messageId, out bool usedCurrentMessage, out string? error)
+    {
+        usedCurrentMessage = false;
+        error = null;
+
+        if (TryValidate(messageId, out var explicitMessageId, out var explicitError))
+            return explicitMessageId;
+
+        if (!string.IsNullOrWhiteSpace(explicitError))
+        {
+            error = explicitError;
+            return null;
+        }
+
+        var currentMessageId = AgentToolRequestContext.TryGet(ChannelPlatformMessageIdKey) ??
+                               AgentToolRequestContext.TryGet(ChannelMessageIdKey);
+        if (TryValidate(currentMessageId, out var current, out _))
+        {
+            usedCurrentMessage = true;
+            return current;
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentMessageId))
+        {
+            error = "Current turn metadata did not expose a Lark platform message_id (expected om_xxx). Pass message_id explicitly.";
+            return null;
+        }
+
+        error = "message_id is required when current turn metadata does not include a Lark message id";
+        return null;
+    }
+
+    public static bool TryValidate(string? raw, out string? normalized, out string? error)
+    {
+        normalized = raw?.Trim();
+        error = null;
+        if (string.IsNullOrWhiteSpace(normalized))
+            return false;
+
+        if (!normalized.StartsWith("om_", StringComparison.OrdinalIgnoreCase))
+        {
+            error = "message_id must be a Lark message id like om_xxx";
+            normalized = null;
+            return false;
+        }
+
+        return true;
+    }
+}
+
+internal static class LarkReactionEmojiHelper
+{
+    private const string DefaultEmojiType = "OK";
+
+    private static readonly Dictionary<string, string> EmojiAliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["ok"] = "OK",
+        ["okay"] = "OK",
+        ["了解"] = "OK",
+        ["收到"] = "OK",
+        ["thumbsup"] = "THUMBSUP",
+        ["thumbs_up"] = "THUMBSUP",
+        ["赞"] = "THUMBSUP",
+        ["点赞"] = "THUMBSUP",
+        ["done"] = "DONE",
+        ["完成"] = "DONE",
+        ["smile"] = "SMILE",
+        ["微笑"] = "SMILE",
+    };
+
+    public static string NormalizeOrDefault(string? emojiType)
+    {
+        var normalized = NormalizeOptional(emojiType);
+        return string.IsNullOrWhiteSpace(normalized) ? DefaultEmojiType : normalized;
+    }
+
+    public static string? NormalizeOptional(string? emojiType)
+    {
+        var trimmed = emojiType?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return null;
+
+        return EmojiAliases.TryGetValue(trimmed, out var alias)
+            ? alias
+            : trimmed;
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -22,10 +22,38 @@ public sealed class LarkCoverageTests
         sendTool.Description.Should().Contain("Proactively send a Lark message");
         sendTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
 
+        var replyTool = new LarkMessagesReplyTool(client);
+        replyTool.Name.Should().Be("lark_messages_reply");
+        replyTool.Description.Should().Contain("Reply to a specific Lark message");
+        replyTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+
         var reactTool = new LarkMessagesReactTool(client);
         reactTool.Name.Should().Be("lark_messages_react");
         reactTool.Description.Should().Contain("Add an emoji reaction");
         reactTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+
+        var reactionsListTool = new LarkMessagesReactionsListTool(client);
+        reactionsListTool.Name.Should().Be("lark_messages_reactions_list");
+        reactionsListTool.Description.Should().Contain("List emoji reaction records");
+        reactionsListTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        reactionsListTool.IsReadOnly.Should().BeTrue();
+
+        var reactionsDeleteTool = new LarkMessagesReactionsDeleteTool(client);
+        reactionsDeleteTool.Name.Should().Be("lark_messages_reactions_delete");
+        reactionsDeleteTool.Description.Should().Contain("Delete a specific Lark message reaction");
+        reactionsDeleteTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+
+        var searchTool = new LarkMessagesSearchTool(client);
+        searchTool.Name.Should().Be("lark_messages_search");
+        searchTool.Description.Should().Contain("Search Lark messages");
+        searchTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        searchTool.IsReadOnly.Should().BeTrue();
+
+        var batchGetTool = new LarkMessagesBatchGetTool(client);
+        batchGetTool.Name.Should().Be("lark_messages_batch_get");
+        batchGetTool.Description.Should().Contain("Batch fetch full Lark message details");
+        batchGetTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+        batchGetTool.IsReadOnly.Should().BeTrue();
 
         var lookupTool = new LarkChatsLookupTool(client);
         lookupTool.Name.Should().Be("lark_chats_lookup");
@@ -242,12 +270,52 @@ public sealed class LarkCoverageTests
             return Task.FromResult("""{"code":0,"data":{}}""");
         }
 
+        public Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{}}""");
+        }
+
         public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct)
         {
             _ = token;
             _ = request;
             _ = ct;
             return Task.FromResult("""{"code":0,"data":{}}""");
+        }
+
+        public Task<string> ListMessageReactionsAsync(string token, LarkMessageReactionListRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{"items":[]}}""");
+        }
+
+        public Task<string> DeleteMessageReactionAsync(string token, LarkMessageReactionDeleteRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{}}""");
+        }
+
+        public Task<string> SearchMessagesAsync(string token, LarkMessageSearchRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{"items":[],"count":0}}""");
+        }
+
+        public Task<string> BatchGetMessagesAsync(string token, LarkMessagesBatchGetRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{"items":[]}}""");
         }
 
         public Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct)

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkCoverageTests.cs
@@ -22,6 +22,11 @@ public sealed class LarkCoverageTests
         sendTool.Description.Should().Contain("Proactively send a Lark message");
         sendTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
 
+        var reactTool = new LarkMessagesReactTool(client);
+        reactTool.Name.Should().Be("lark_messages_react");
+        reactTool.Description.Should().Contain("Add an emoji reaction");
+        reactTool.ApprovalMode.Should().Be(ToolApprovalMode.Auto);
+
         var lookupTool = new LarkChatsLookupTool(client);
         lookupTool.Name.Should().Be("lark_chats_lookup");
         lookupTool.Description.Should().Contain("Search Lark chats");
@@ -230,6 +235,14 @@ public sealed class LarkCoverageTests
     private sealed class StubLarkNyxClient : ILarkNyxClient
     {
         public Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct)
+        {
+            _ = token;
+            _ = request;
+            _ = ct;
+            return Task.FromResult("""{"code":0,"data":{}}""");
+        }
+
+        public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct)
         {
             _ = token;
             _ = request;

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -315,8 +315,8 @@ public class LarkToolsTests
                 .Should().Contain("message_id is required");
             (await tool.ExecuteAsync("""{"message_id":"om_1","user_id_type":"email"}"""))
                 .Should().Contain("user_id_type must be one of");
-            (await tool.ExecuteAsync("""{"message_id":"om_1","page_size":101}"""))
-                .Should().Contain("page_size must be between 1 and 100");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","page_size":51}"""))
+                .Should().Contain("page_size must be between 1 and 50");
         }
 
         var errorTool = new LarkMessagesReactionsListTool(new StubLarkNyxClient

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -95,6 +95,74 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkMessagesReplyTool_ShouldDefaultToCurrentMessage_AndReplyInThread()
+    {
+        var client = new StubLarkNyxClient
+        {
+            ReplyResponse = """{"code":0,"data":{"message_id":"om_reply_1","chat_id":"oc_456","create_time":"1730000002"}}""",
+        };
+        var tool = new LarkMessagesReplyTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope(
+            "token-123",
+            new Dictionary<string, string>
+            {
+                ["channel.platform_message_id"] = "om_current_2",
+            });
+
+        var result = await tool.ExecuteAsync("""{"text":"收到，我继续看一下","reply_in_thread":true}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("message_id").GetString().Should().Be("om_reply_1");
+        document.RootElement.GetProperty("reply_in_thread").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("used_current_message").GetBoolean().Should().BeTrue();
+        client.LastReplyRequest.Should().NotBeNull();
+        client.LastReplyRequest!.MessageId.Should().Be("om_current_2");
+        client.LastReplyRequest.ReplyInThread.Should().BeTrue();
+        client.LastReplyRequest.MessageType.Should().Be("text");
+    }
+
+    [Fact]
+    public async Task LarkMessagesReplyTool_ShouldValidateInputs_AndSurfaceProxyErrors()
+    {
+        var tool = new LarkMessagesReplyTool(new StubLarkNyxClient());
+
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"message_id":"om_1","text":"hello"}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{"text":"hello"}"""))
+                .Should().Contain("message_id is required");
+            (await tool.ExecuteAsync("""{"message_id":"msg_1","text":"hello"}"""))
+                .Should().Contain("message_id must be a Lark message id like om_xxx");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","message_type":"markdown","text":"hello"}"""))
+                .Should().Contain("message_type must be one of");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","message_type":"text","text":" "}"""))
+                .Should().Contain("text is required when message_type=text");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","message_type":"interactive_card"}"""))
+                .Should().Contain("card_json is required when message_type=interactive_card");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","message_type":"interactive_card","card_json":"{bad json}"}"""))
+                .Should().Contain("card_json is not valid JSON");
+        }
+
+        var errorTool = new LarkMessagesReplyTool(new StubLarkNyxClient
+        {
+            ReplyResponse = """{"error":true,"status":500,"message":"reply failed"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            var result = await errorTool.ExecuteAsync("""{"message_id":"om_1","text":"hello"}""");
+            result.Should().Contain("nyx_proxy_error status=500");
+            result.Should().Contain("\"message_id\":\"om_1\"");
+        }
+    }
+
+    [Fact]
     public async Task LarkMessagesReactTool_ShouldDefaultToCurrentMessage_AndOkEmoji()
     {
         var client = new StubLarkNyxClient
@@ -179,6 +247,332 @@ public class LarkToolsTests
             result.Should().Contain("nyx_proxy_error status=429");
             result.Should().Contain("\"message_id\":\"om_1\"");
             result.Should().Contain("\"emoji_type\":\"OK\"");
+        }
+    }
+
+    [Fact]
+    public async Task LarkMessagesReactionsListTool_ShouldDefaultToCurrentMessage_AndNormalizeFilter()
+    {
+        var client = new StubLarkNyxClient
+        {
+            ReactionListResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "items": [
+                      {
+                        "reaction_id": "reaction_1",
+                        "operator": {
+                          "operator_id": "ou_1",
+                          "operator_type": "user"
+                        },
+                        "action_time": "1730000003",
+                        "reaction_type": {
+                          "emoji_type": "OK"
+                        }
+                      }
+                    ],
+                    "has_more": false
+                  }
+                }
+                """,
+        };
+        var tool = new LarkMessagesReactionsListTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope(
+            "token-123",
+            new Dictionary<string, string>
+            {
+                ["channel.platform_message_id"] = "om_current_3",
+            });
+
+        var result = await tool.ExecuteAsync("""{"emoji_type":"收到"}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("message_id").GetString().Should().Be("om_current_3");
+        document.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+        client.LastReactionListRequest.Should().NotBeNull();
+        client.LastReactionListRequest!.MessageId.Should().Be("om_current_3");
+        client.LastReactionListRequest.EmojiType.Should().Be("OK");
+    }
+
+    [Fact]
+    public async Task LarkMessagesReactionsListTool_ShouldValidateInputs_AndSurfaceProxyErrors()
+    {
+        var tool = new LarkMessagesReactionsListTool(new StubLarkNyxClient());
+
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"message_id":"om_1"}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{}"""))
+                .Should().Contain("message_id is required");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","user_id_type":"email"}"""))
+                .Should().Contain("user_id_type must be one of");
+            (await tool.ExecuteAsync("""{"message_id":"om_1","page_size":101}"""))
+                .Should().Contain("page_size must be between 1 and 100");
+        }
+
+        var errorTool = new LarkMessagesReactionsListTool(new StubLarkNyxClient
+        {
+            ReactionListResponse = """{"error":true,"status":404,"message":"missing"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            var result = await errorTool.ExecuteAsync("""{"message_id":"om_1"}""");
+            result.Should().Contain("nyx_proxy_error status=404");
+            result.Should().Contain("\"message_id\":\"om_1\"");
+        }
+    }
+
+    [Fact]
+    public async Task LarkMessagesReactionsDeleteTool_ShouldDeleteReactionFromCurrentMessage()
+    {
+        var client = new StubLarkNyxClient
+        {
+            ReactionDeleteResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "reaction_id": "reaction_1",
+                    "operator": {
+                      "operator_id": "ou_1",
+                      "operator_type": "user"
+                    },
+                    "action_time": "1730000004",
+                    "reaction_type": {
+                      "emoji_type": "OK"
+                    }
+                  }
+                }
+                """,
+        };
+        var tool = new LarkMessagesReactionsDeleteTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope(
+            "token-123",
+            new Dictionary<string, string>
+            {
+                ["channel.platform_message_id"] = "om_current_4",
+            });
+
+        var result = await tool.ExecuteAsync("""{"reaction_id":"reaction_1"}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("message_id").GetString().Should().Be("om_current_4");
+        document.RootElement.GetProperty("reaction_id").GetString().Should().Be("reaction_1");
+        client.LastReactionDeleteRequest.Should().NotBeNull();
+        client.LastReactionDeleteRequest!.MessageId.Should().Be("om_current_4");
+    }
+
+    [Fact]
+    public async Task LarkMessagesReactionsDeleteTool_ShouldValidateInputs_AndSurfaceProxyErrors()
+    {
+        var tool = new LarkMessagesReactionsDeleteTool(new StubLarkNyxClient());
+
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"message_id":"om_1","reaction_id":"reaction_1"}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{"message_id":"om_1"}"""))
+                .Should().Contain("reaction_id is required");
+        }
+
+        var errorTool = new LarkMessagesReactionsDeleteTool(new StubLarkNyxClient
+        {
+            ReactionDeleteResponse = """{"error":true,"status":409,"message":"already removed"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            var result = await errorTool.ExecuteAsync("""{"message_id":"om_1","reaction_id":"reaction_1"}""");
+            result.Should().Contain("nyx_proxy_error status=409");
+            result.Should().Contain("\"reaction_id\":\"reaction_1\"");
+        }
+    }
+
+    [Fact]
+    public async Task LarkMessagesBatchGetTool_ShouldNormalizeMessages()
+    {
+        var client = new StubLarkNyxClient
+        {
+            MessagesBatchGetResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "items": [
+                      {
+                        "message_id": "om_1",
+                        "msg_type": "text",
+                        "create_time": "1710000000",
+                        "chat_id": "oc_1",
+                        "thread_id": "omt_1",
+                        "sender": {
+                          "id": "ou_sender",
+                          "name": "Alice",
+                          "sender_type": "user"
+                        },
+                        "body": {
+                          "content": "{\"text\":\"hello\"}"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """,
+        };
+        var tool = new LarkMessagesBatchGetTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var result = await tool.ExecuteAsync("""{"message_ids":["om_1"]}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("total").GetInt32().Should().Be(1);
+        document.RootElement.GetProperty("messages")[0].GetProperty("content").GetString().Should().Be("hello");
+        client.LastBatchGetRequest.Should().NotBeNull();
+        client.LastBatchGetRequest!.MessageIds.Should().ContainSingle().Which.Should().Be("om_1");
+    }
+
+    [Fact]
+    public async Task LarkMessagesBatchGetTool_ShouldValidateInputs_AndSurfaceProxyErrors()
+    {
+        var tool = new LarkMessagesBatchGetTool(new StubLarkNyxClient());
+
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"message_ids":["om_1"]}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{}"""))
+                .Should().Contain("message_ids must contain at least one");
+            (await tool.ExecuteAsync("""{"message_ids":["msg_1"]}"""))
+                .Should().Contain("message_id must be a Lark message id like om_xxx");
+        }
+
+        var errorTool = new LarkMessagesBatchGetTool(new StubLarkNyxClient
+        {
+            MessagesBatchGetResponse = """{"error":true,"status":503,"message":"mget offline"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await errorTool.ExecuteAsync("""{"message_ids":["om_1"]}"""))
+                .Should().Contain("nyx_proxy_error status=503");
+        }
+    }
+
+    [Fact]
+    public async Task LarkMessagesSearchTool_ShouldSearchAndHydrateMessages()
+    {
+        var client = new StubLarkNyxClient
+        {
+            MessageSearchResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "items": [
+                      { "meta_data": { "message_id": "om_1" } }
+                    ],
+                    "has_more": true,
+                    "page_token": "page-2"
+                  }
+                }
+                """,
+            MessagesBatchGetResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "items": [
+                      {
+                        "message_id": "om_1",
+                        "msg_type": "text",
+                        "create_time": "1710000000",
+                        "chat_id": "oc_1",
+                        "sender": {
+                          "id": "ou_sender",
+                          "name": "Alice",
+                          "sender_type": "user"
+                        },
+                        "body": {
+                          "content": "{\"text\":\"incident handled\"}"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """,
+        };
+        var tool = new LarkMessagesSearchTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope("token-123");
+        var result = await tool.ExecuteAsync("""{"query":"incident","chat_ids":["oc_1"],"start_time":"2026-04-20T00:00:00+08:00","end_time":"2026-04-23T23:59:59+08:00"}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("has_more").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("page_token").GetString().Should().Be("page-2");
+        document.RootElement.GetProperty("message_ids")[0].GetString().Should().Be("om_1");
+        document.RootElement.GetProperty("messages")[0].GetProperty("content").GetString().Should().Be("incident handled");
+        client.LastMessageSearchRequest.Should().NotBeNull();
+        client.LastMessageSearchRequest!.Query.Should().Be("incident");
+    }
+
+    [Fact]
+    public async Task LarkMessagesSearchTool_ShouldValidateInputs_AndDegradeWhenHydrationFails()
+    {
+        var tool = new LarkMessagesSearchTool(new StubLarkNyxClient());
+
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"query":"incident"}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{}"""))
+                .Should().Contain("At least one search filter is required");
+            (await tool.ExecuteAsync("""{"query":"incident","include_attachment_type":"doc"}"""))
+                .Should().Contain("include_attachment_type must be one of");
+            (await tool.ExecuteAsync("""{"query":"incident","chat_type":"channel"}"""))
+                .Should().Contain("chat_type must be one of");
+            (await tool.ExecuteAsync("""{"query":"incident","sender_type":"app"}"""))
+                .Should().Contain("sender_type must be one of");
+            (await tool.ExecuteAsync("""{"query":"incident","sender_type":"bot","exclude_sender_type":"bot"}"""))
+                .Should().Contain("sender_type and exclude_sender_type cannot be the same");
+            (await tool.ExecuteAsync("""{"query":"incident","start_time":"bad-time"}"""))
+                .Should().Contain("start_time and end_time must be ISO 8601");
+            (await tool.ExecuteAsync("""{"query":"incident","page_size":51}"""))
+                .Should().Contain("page_size must be between 1 and 50");
+        }
+
+        var degradeTool = new LarkMessagesSearchTool(new StubLarkNyxClient
+        {
+            MessageSearchResponse = """{"code":0,"data":{"items":[{"meta_data":{"message_id":"om_1"}}]}}""",
+            MessagesBatchGetResponse = """{"error":true,"status":502,"message":"mget failed"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            var result = await degradeTool.ExecuteAsync("""{"query":"incident"}""");
+            result.Should().Contain("message hydration failed");
+            result.Should().Contain("\"message_ids\":[\"om_1\"]");
         }
     }
 
@@ -608,9 +1002,14 @@ public class LarkToolsTests
 
         var tools = await source.DiscoverToolsAsync();
 
-        tools.Should().HaveCount(6);
+        tools.Should().HaveCount(11);
         tools.Should().Contain(tool => tool is LarkMessagesSendTool);
+        tools.Should().Contain(tool => tool is LarkMessagesReplyTool);
         tools.Should().Contain(tool => tool is LarkMessagesReactTool);
+        tools.Should().Contain(tool => tool is LarkMessagesReactionsListTool);
+        tools.Should().Contain(tool => tool is LarkMessagesReactionsDeleteTool);
+        tools.Should().Contain(tool => tool is LarkMessagesSearchTool);
+        tools.Should().Contain(tool => tool is LarkMessagesBatchGetTool);
         tools.Should().Contain(tool => tool is LarkChatsLookupTool);
         tools.Should().Contain(tool => tool is LarkSheetsAppendRowsTool);
         tools.Should().Contain(tool => tool is LarkApprovalsListTool);
@@ -660,6 +1059,32 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkNyxClient_ReplyToMessage_ShapesProxyRequest()
+    {
+        var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":0,"data":{"message_id":"om_reply_1"}}""", Encoding.UTF8, "application/json"),
+            });
+        var client = new LarkNyxClient(
+            new LarkToolOptions { ProviderSlug = "api-lark-bot" },
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)));
+
+        await client.ReplyToMessageAsync(
+            "token-123",
+            new LarkReplyMessageRequest("om_123", "text", """{"text":"Roger that"}""", true, "uuid-2"),
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reply");
+        handler.LastBody.Should().Contain("\"reply_in_thread\":true");
+        handler.LastBody.Should().Contain("\"uuid\":\"uuid-2\"");
+    }
+
+    [Fact]
     public async Task LarkNyxClient_CreateMessageReaction_ShapesProxyRequest()
     {
         var handler = new RecordingHandler(_ =>
@@ -683,6 +1108,88 @@ public class LarkToolsTests
             .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions");
         handler.LastRequest.Headers.Authorization!.Parameter.Should().Be("token-123");
         handler.LastBody.Should().Contain("\"emoji_type\":\"OK\"");
+    }
+
+    [Fact]
+    public async Task LarkNyxClient_ListAndDeleteMessageReactions_ShapesProxyRequest()
+    {
+        var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":0,"data":{"items":[]}}""", Encoding.UTF8, "application/json"),
+            });
+        var client = new LarkNyxClient(
+            new LarkToolOptions { ProviderSlug = "api-lark-bot" },
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)));
+
+        await client.ListMessageReactionsAsync(
+            "token-123",
+            new LarkMessageReactionListRequest("om_123", "SMILE", 50, "page-1", "open_id"),
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions?page_size=50&reaction_type=SMILE&page_token=page-1&user_id_type=open_id");
+
+        await client.DeleteMessageReactionAsync(
+            "token-123",
+            new LarkMessageReactionDeleteRequest("om_123", "reaction_1"),
+            CancellationToken.None);
+
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Delete);
+        handler.LastRequest.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions/reaction_1");
+    }
+
+    [Fact]
+    public async Task LarkNyxClient_SearchAndBatchGetMessages_ShapesProxyRequest()
+    {
+        var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":0,"data":{"items":[]}}""", Encoding.UTF8, "application/json"),
+            });
+        var client = new LarkNyxClient(
+            new LarkToolOptions { ProviderSlug = "api-lark-bot" },
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)));
+
+        await client.SearchMessagesAsync(
+            "token-123",
+            new LarkMessageSearchRequest(
+                Query: "incident",
+                ChatIds: ["oc_1"],
+                SenderIds: ["ou_1"],
+                IncludeAttachmentType: "file",
+                ChatType: "group",
+                SenderType: "user",
+                ExcludeSenderType: "bot",
+                IsAtMe: true,
+                StartTime: "2026-04-20T00:00:00+08:00",
+                EndTime: "2026-04-23T23:59:59+08:00",
+                PageSize: 20,
+                PageToken: "page-2"),
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/search?page_size=20&page_token=page-2");
+        handler.LastBody.Should().Contain("\"query\":\"incident\"");
+        handler.LastBody.Should().Contain("\"chat_ids\"");
+        handler.LastBody.Should().Contain("\"from_ids\"");
+        handler.LastBody.Should().Contain("\"include_attachment_types\"");
+        handler.LastBody.Should().Contain("\"time_range\"");
+
+        await client.BatchGetMessagesAsync(
+            "token-123",
+            new LarkMessagesBatchGetRequest(["om_1", "om_2"]),
+            CancellationToken.None);
+
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/mget?card_msg_content_type=raw_card_content&message_ids=om_1&message_ids=om_2");
     }
 
     [Fact]
@@ -810,14 +1317,24 @@ public class LarkToolsTests
     private sealed class StubLarkNyxClient : ILarkNyxClient
     {
         public string SendResponse { get; set; } = """{"code":0,"data":{}}""";
+        public string ReplyResponse { get; set; } = """{"code":0,"data":{}}""";
         public string ReactionCreateResponse { get; set; } = """{"code":0,"data":{}}""";
+        public string ReactionListResponse { get; set; } = """{"code":0,"data":{"items":[]}}""";
+        public string ReactionDeleteResponse { get; set; } = """{"code":0,"data":{}}""";
+        public string MessageSearchResponse { get; set; } = """{"code":0,"data":{"items":[],"count":0}}""";
+        public string MessagesBatchGetResponse { get; set; } = """{"code":0,"data":{"items":[]}}""";
         public string SearchResponse { get; set; } = """{"code":0,"data":{"items":[],"total":0}}""";
         public string AppendSheetResponse { get; set; } = """{"code":0,"data":{"updates":{}}}""";
         public string ApprovalListResponse { get; set; } = """{"code":0,"data":{"tasks":[],"count":0}}""";
         public string ApprovalActionResponse { get; set; } = """{"code":0,"data":{}}""";
 
         public LarkSendMessageRequest? LastSendRequest { get; private set; }
+        public LarkReplyMessageRequest? LastReplyRequest { get; private set; }
         public LarkMessageReactionRequest? LastReactionRequest { get; private set; }
+        public LarkMessageReactionListRequest? LastReactionListRequest { get; private set; }
+        public LarkMessageReactionDeleteRequest? LastReactionDeleteRequest { get; private set; }
+        public LarkMessageSearchRequest? LastMessageSearchRequest { get; private set; }
+        public LarkMessagesBatchGetRequest? LastBatchGetRequest { get; private set; }
         public LarkChatSearchRequest? LastSearchRequest { get; private set; }
         public LarkSheetAppendRowsRequest? LastSheetAppendRequest { get; private set; }
         public LarkApprovalTaskQueryRequest? LastApprovalQueryRequest { get; private set; }
@@ -829,10 +1346,40 @@ public class LarkToolsTests
             return Task.FromResult(SendResponse);
         }
 
+        public Task<string> ReplyToMessageAsync(string token, LarkReplyMessageRequest request, CancellationToken ct)
+        {
+            LastReplyRequest = request;
+            return Task.FromResult(ReplyResponse);
+        }
+
         public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct)
         {
             LastReactionRequest = request;
             return Task.FromResult(ReactionCreateResponse);
+        }
+
+        public Task<string> ListMessageReactionsAsync(string token, LarkMessageReactionListRequest request, CancellationToken ct)
+        {
+            LastReactionListRequest = request;
+            return Task.FromResult(ReactionListResponse);
+        }
+
+        public Task<string> DeleteMessageReactionAsync(string token, LarkMessageReactionDeleteRequest request, CancellationToken ct)
+        {
+            LastReactionDeleteRequest = request;
+            return Task.FromResult(ReactionDeleteResponse);
+        }
+
+        public Task<string> SearchMessagesAsync(string token, LarkMessageSearchRequest request, CancellationToken ct)
+        {
+            LastMessageSearchRequest = request;
+            return Task.FromResult(MessageSearchResponse);
+        }
+
+        public Task<string> BatchGetMessagesAsync(string token, LarkMessagesBatchGetRequest request, CancellationToken ct)
+        {
+            LastBatchGetRequest = request;
+            return Task.FromResult(MessagesBatchGetResponse);
         }
 
         public Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct)

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -95,6 +95,94 @@ public class LarkToolsTests
     }
 
     [Fact]
+    public async Task LarkMessagesReactTool_ShouldDefaultToCurrentMessage_AndOkEmoji()
+    {
+        var client = new StubLarkNyxClient
+        {
+            ReactionCreateResponse =
+                """
+                {
+                  "code": 0,
+                  "data": {
+                    "reaction_id": "reaction_123",
+                    "operator": {
+                      "operator_id": "cli_app",
+                      "operator_type": "app"
+                    },
+                    "action_time": "1730000001",
+                    "reaction_type": {
+                      "emoji_type": "OK"
+                    }
+                  }
+                }
+                """,
+        };
+        var tool = new LarkMessagesReactTool(client);
+
+        using var _ = new AgentToolRequestMetadataScope(
+            "token-123",
+            new Dictionary<string, string>
+            {
+                ["channel.message_id"] = "om_current_1",
+            });
+
+        var result = await tool.ExecuteAsync("""{}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        document.RootElement.GetProperty("message_id").GetString().Should().Be("om_current_1");
+        document.RootElement.GetProperty("emoji_type").GetString().Should().Be("OK");
+        document.RootElement.GetProperty("reaction_id").GetString().Should().Be("reaction_123");
+        document.RootElement.GetProperty("used_current_message").GetBoolean().Should().BeTrue();
+        client.LastReactionRequest.Should().NotBeNull();
+        client.LastReactionRequest!.MessageId.Should().Be("om_current_1");
+        client.LastReactionRequest.EmojiType.Should().Be("OK");
+    }
+
+    [Fact]
+    public async Task LarkMessagesReactTool_ShouldValidateInputs_AndSurfaceProxyErrors()
+    {
+        var tool = new LarkMessagesReactTool(new StubLarkNyxClient());
+        using (new AgentToolRequestMetadataScope())
+        {
+            (await tool.ExecuteAsync("""{"message_id":"om_1"}"""))
+                .Should().Contain("No NyxID access token available");
+        }
+
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            (await tool.ExecuteAsync("""{}"""))
+                .Should().Contain("message_id is required");
+            (await tool.ExecuteAsync("""{"message_id":"msg_1"}"""))
+                .Should().Contain("message_id must be a Lark message id like om_xxx");
+        }
+
+        using (new AgentToolRequestMetadataScope(
+                   "token-123",
+                   new Dictionary<string, string>
+                   {
+                       ["channel.message_id"] = "msg_from_relay",
+                   }))
+        {
+            (await tool.ExecuteAsync("""{}"""))
+                .Should().Contain("Current turn metadata did not expose a Lark platform message_id");
+        }
+
+        var errorTool = new LarkMessagesReactTool(new StubLarkNyxClient
+        {
+            ReactionCreateResponse = """{"error":true,"status":429,"message":"rate limited"}""",
+        });
+        using (new AgentToolRequestMetadataScope("token-123"))
+        {
+            var result = await errorTool.ExecuteAsync("""{"message_id":"om_1","emoji_type":"收到"}""");
+
+            result.Should().Contain("nyx_proxy_error status=429");
+            result.Should().Contain("\"message_id\":\"om_1\"");
+            result.Should().Contain("\"emoji_type\":\"OK\"");
+        }
+    }
+
+    [Fact]
     public async Task LarkChatsLookupTool_ReturnsNormalizedCandidates()
     {
         var client = new StubLarkNyxClient
@@ -520,8 +608,9 @@ public class LarkToolsTests
 
         var tools = await source.DiscoverToolsAsync();
 
-        tools.Should().HaveCount(5);
+        tools.Should().HaveCount(6);
         tools.Should().Contain(tool => tool is LarkMessagesSendTool);
+        tools.Should().Contain(tool => tool is LarkMessagesReactTool);
         tools.Should().Contain(tool => tool is LarkChatsLookupTool);
         tools.Should().Contain(tool => tool is LarkSheetsAppendRowsTool);
         tools.Should().Contain(tool => tool is LarkApprovalsListTool);
@@ -568,6 +657,32 @@ public class LarkToolsTests
         var body = handler.LastBody;
         body.Should().Contain("receive_id");
         body.Should().Contain("uuid-1");
+    }
+
+    [Fact]
+    public async Task LarkNyxClient_CreateMessageReaction_ShapesProxyRequest()
+    {
+        var handler = new RecordingHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"code":0,"data":{"reaction_id":"reaction_1"}}""", Encoding.UTF8, "application/json"),
+            });
+        var client = new LarkNyxClient(
+            new LarkToolOptions { ProviderSlug = "api-lark-bot" },
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(handler)));
+
+        await client.CreateMessageReactionAsync(
+            "token-123",
+            new LarkMessageReactionRequest("om_123", "OK"),
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions");
+        handler.LastRequest.Headers.Authorization!.Parameter.Should().Be("token-123");
+        handler.LastBody.Should().Contain("\"emoji_type\":\"OK\"");
     }
 
     [Fact]
@@ -695,12 +810,14 @@ public class LarkToolsTests
     private sealed class StubLarkNyxClient : ILarkNyxClient
     {
         public string SendResponse { get; set; } = """{"code":0,"data":{}}""";
+        public string ReactionCreateResponse { get; set; } = """{"code":0,"data":{}}""";
         public string SearchResponse { get; set; } = """{"code":0,"data":{"items":[],"total":0}}""";
         public string AppendSheetResponse { get; set; } = """{"code":0,"data":{"updates":{}}}""";
         public string ApprovalListResponse { get; set; } = """{"code":0,"data":{"tasks":[],"count":0}}""";
         public string ApprovalActionResponse { get; set; } = """{"code":0,"data":{}}""";
 
         public LarkSendMessageRequest? LastSendRequest { get; private set; }
+        public LarkMessageReactionRequest? LastReactionRequest { get; private set; }
         public LarkChatSearchRequest? LastSearchRequest { get; private set; }
         public LarkSheetAppendRowsRequest? LastSheetAppendRequest { get; private set; }
         public LarkApprovalTaskQueryRequest? LastApprovalQueryRequest { get; private set; }
@@ -710,6 +827,12 @@ public class LarkToolsTests
         {
             LastSendRequest = request;
             return Task.FromResult(SendResponse);
+        }
+
+        public Task<string> CreateMessageReactionAsync(string token, LarkMessageReactionRequest request, CancellationToken ct)
+        {
+            LastReactionRequest = request;
+            return Task.FromResult(ReactionCreateResponse);
         }
 
         public Task<string> SearchChatsAsync(string token, LarkChatSearchRequest request, CancellationToken ct)
@@ -763,15 +886,27 @@ public class LarkToolsTests
     {
         private readonly IReadOnlyDictionary<string, string>? _previous;
 
-        public AgentToolRequestMetadataScope(string? accessToken = null)
+        public AgentToolRequestMetadataScope(
+            string? accessToken = null,
+            IReadOnlyDictionary<string, string>? extraMetadata = null)
         {
             _previous = AgentToolRequestContext.CurrentMetadata;
-            AgentToolRequestContext.CurrentMetadata = string.IsNullOrWhiteSpace(accessToken)
-                ? null
-                : new Dictionary<string, string>
-                {
-                    [LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken,
-                };
+            if (string.IsNullOrWhiteSpace(accessToken) && (extraMetadata == null || extraMetadata.Count == 0))
+            {
+                AgentToolRequestContext.CurrentMetadata = null;
+                return;
+            }
+
+            var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (!string.IsNullOrWhiteSpace(accessToken))
+                metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken;
+            if (extraMetadata != null)
+            {
+                foreach (var entry in extraMetadata)
+                    metadata[entry.Key] = entry.Value;
+            }
+
+            AgentToolRequestContext.CurrentMetadata = metadata;
         }
 
         public void Dispose()

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelAbstractionsProtoTests.cs
@@ -55,6 +55,7 @@ public sealed class ChannelAbstractionsProtoTests
                 NyxAgentApiKeyId = "nyx-key-1",
                 NyxPlatform = "lark",
                 NyxConversationId = "nyx-conv-1",
+                NyxPlatformMessageId = "om_123",
             },
         };
         activity.Mentions.Add(new ParticipantRef
@@ -96,6 +97,7 @@ public sealed class ChannelAbstractionsProtoTests
         parsed.Conversation.Scope.ShouldBe(ConversationScope.Thread);
         parsed.OutboundDelivery.ReplyMessageId.ShouldBe("relay-msg-1");
         parsed.TransportExtras.NyxAgentApiKeyId.ShouldBe("nyx-key-1");
+        parsed.TransportExtras.NyxPlatformMessageId.ShouldBe("om_123");
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(ChatActivity));
         ChatActivityReflection.Descriptor.MessageTypes.Select(x => x.Name)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -88,6 +88,36 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldNotAwaitImmediateLarkReaction()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new BlockingJsonHandler("""{"code":0,"data":{}}""");
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+
+        var runTask = runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                "msg-1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxUserAccessToken = "user-token-1",
+                    NyxPlatformMessageId = "om_123",
+                }),
+            CancellationToken.None);
+
+        await nyxHandler.Started.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        runTask.IsCompleted.Should().BeTrue();
+
+        var result = await runTask;
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+
+        nyxHandler.Release.TrySetResult();
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldSkipImmediateLarkReaction_WhenPlatformMessageIdIsMissing()
     {
         var registrationQueryPort = BuildRegistrationQueryPort();
@@ -692,7 +722,7 @@ public sealed class ChannelConversationTurnRunnerTests
         }
     }
 
-    private sealed class RecordingJsonHandler(string body) : HttpMessageHandler
+    private class RecordingJsonHandler(string body) : HttpMessageHandler
     {
         public List<(string Path, string? Authorization, string Body)> Requests { get; } = [];
 
@@ -707,6 +737,19 @@ public sealed class ChannelConversationTurnRunnerTests
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json"),
             };
+        }
+    }
+
+    private sealed class BlockingJsonHandler(string body) : RecordingJsonHandler(body)
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+            return await base.SendAsync(request, cancellationToken);
         }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -61,6 +61,56 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldSendImmediateLarkReaction_WhenRelayTurnProvidesPlatformMessageId()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new RecordingJsonHandler("""{"code":0,"data":{}}""");
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                "msg-1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxUserAccessToken = "user-token-1",
+                    NyxPlatformMessageId = "om_123",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        nyxHandler.Requests.Should().ContainSingle();
+        nyxHandler.Requests[0].Path.Should().Be("/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages/om_123/reactions");
+        nyxHandler.Requests[0].Authorization.Should().Be("Bearer user-token-1");
+        nyxHandler.Requests[0].Body.Should().Contain("\"emoji_type\":\"OK\"");
+    }
+
+    [Fact]
+    public async Task RunInboundAsync_ShouldSkipImmediateLarkReaction_WhenPlatformMessageIdIsMissing()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var nyxHandler = new RecordingJsonHandler("""{"code":0,"data":{}}""");
+        var runner = CreateRunner(registrationQueryPort, adapter, nyxHandler: nyxHandler);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                "msg-1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxUserAccessToken = "user-token-1",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        nyxHandler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldResolveRegistrationByNyxAgentApiKeyId_WhenBotIdDoesNotMatch()
     {
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
@@ -454,10 +504,12 @@ public sealed class ChannelConversationTurnRunnerTests
         IServiceProvider? services = null,
         IChannelBotRegistrationQueryByNyxIdentityPort? registrationQueryByNyxIdentityPort = null,
         RecordingJsonHandler? relayHandler = null,
+        RecordingJsonHandler? nyxHandler = null,
         IInteractiveReplyDispatcher? interactiveReplyDispatcher = null)
     {
         services ??= new ServiceCollection().BuildServiceProvider();
         relayHandler ??= new RecordingJsonHandler("""{"message_id":"relay-reply"}""");
+        nyxHandler ??= new RecordingJsonHandler("""{"code":0,"data":{}}""");
         var relayClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://example.com" },
             new HttpClient(relayHandler)
@@ -475,7 +527,12 @@ public sealed class ChannelConversationTurnRunnerTests
             registrationQueryPort,
             registrationQueryByNyxIdentityPort,
             [adapter],
-            new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://example.com" }),
+            new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://example.com" },
+                new HttpClient(nyxHandler)
+                {
+                    BaseAddress = new Uri("https://example.com"),
+                }),
             relayOutboundPort,
             interactiveReplyDispatcher,
             NullLogger<ChannelConversationTurnRunner>.Instance);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -38,6 +38,29 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldIncludePlatformMessageIdInLlmMetadata_WhenAvailable()
+    {
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter);
+
+        var result = await runner.RunInboundAsync(
+            BuildInboundActivity(
+                "hello",
+                "msg-1",
+                transportExtras: new TransportExtras
+                {
+                    NyxPlatform = "lark",
+                    NyxPlatformMessageId = "om_123",
+                }),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().NotBeNull();
+        result.LlmReplyRequest!.Metadata[ChannelMetadataKeys.PlatformMessageId].Should().Be("om_123");
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldResolveRegistrationByNyxAgentApiKeyId_WhenBotIdDoesNotMatch()
     {
         var registrationQueryPort = Substitute.For<IChannelBotRegistrationQueryPort>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -71,4 +71,59 @@ public sealed class NyxIdRelayTransportTests
         parsed.Activity!.Conversation.CanonicalKey.Should().Be("discord:dm:user-42");
         parsed.Activity.TransportExtras.NyxConversationId.Should().Be("conv-dm-1");
     }
+
+    [Fact]
+    public void Parse_ShouldExposeLarkPlatformMessageId_FromRawPlatformData()
+    {
+        var body = """
+            {
+              "message_id": "msg-lark-1",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_123", "type": "group" },
+              "sender": { "platform_id": "ou_123", "display_name": "User One" },
+              "content": { "type": "text", "text": "hello" },
+              "raw_platform_data": {
+                "event": {
+                  "message": {
+                    "message_id": "om_123"
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.TransportExtras.NyxPlatformMessageId.Should().Be("om_123");
+    }
+
+    [Fact]
+    public void Parse_ShouldPreferReplyToPlatformMessageId_WhenPresent()
+    {
+        var body = """
+            {
+              "message_id": "msg-card-1",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_123", "type": "group" },
+              "sender": { "platform_id": "ou_123", "display_name": "User One" },
+              "content": { "type": "card_action", "text": "{\"approved\":true}" },
+              "reply_to_platform_message_id": "om_parent",
+              "raw_platform_data": {
+                "event": {
+                  "context": {
+                    "open_message_id": "om_raw"
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.TransportExtras.NyxPlatformMessageId.Should().Be("om_parent");
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -100,7 +100,7 @@ public sealed class NyxIdRelayTransportTests
     }
 
     [Fact]
-    public void Parse_ShouldPreferReplyToPlatformMessageId_WhenPresent()
+    public void Parse_ShouldPreferCurrentPlatformMessageId_WhenReplyTargetAlsoPresent()
     {
         var body = """
             {
@@ -124,6 +124,6 @@ public sealed class NyxIdRelayTransportTests
         var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
 
         parsed.Success.Should().BeTrue();
-        parsed.Activity!.TransportExtras.NyxPlatformMessageId.Should().Be("om_parent");
+        parsed.Activity!.TransportExtras.NyxPlatformMessageId.Should().Be("om_raw");
     }
 }


### PR DESCRIPTION
## 问题
Lark relay 入口虽然已经能把用户消息送进 NyxIdChat，但当前工作流里缺少“先给收到的那条消息点一个了解表情”的能力，且 Aevatar 侧没有把 Lark 原始 `om_xxx` 消息 ID 稳定透传到工具上下文。

## 方案
- 新增 typed Lark tool：`lark_messages_react`
- 打通 Nyx relay payload 到 `channel.platform_message_id` 的 metadata 通路
- 更新 NyxIdChat / ChannelRuntime prompt，约束 Lark 新消息先调用 `lark_messages_react`，再生成正式回复
- 把“先 react”进一步下沉到 `ChannelConversationTurnRunner`，在 Lark relay 新消息进入 workflow / slash command / LLM 之前做 best-effort acknowledgment reaction
- 为 relay transport、metadata 透传、proto roundtrip、runner ack 行为和 Lark tool 行为补测试

## 影响路径
- `src/Aevatar.AI.ToolProviders.Lark`
- `agents/channels/Aevatar.GAgents.Channel.NyxIdRelay`
- `agents/Aevatar.GAgents.ChannelRuntime`
- `agents/Aevatar.GAgents.NyxidChat`
- `agents/Aevatar.GAgents.Channel.Abstractions/protos`

## 验证
- `dotnet test test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`

结果：
- Lark tool tests: 31 passed
- Channel protocol tests: 101 passed
- Channel runtime tests: 248 passed

## 文档更新
- 更新了 NyxIdChat relay prompt / system prompt 中的 Lark typed tool 指引和“先 react 再回复”的行为约束

## 说明
- runtime 层的 immediate ack 是 best-effort：缺少 `om_xxx`、Nyx token 或 provider slug 时会跳过，不会阻断正式回复链路