### PR TITLE
Register rollout observation read model store

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -127,6 +127,11 @@ public static class ServiceCollectionExtensions
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceRolloutReadModel>>().Metadata,
                 keySelector: readModel => readModel.Id,
                 keyFormatter: key => key);
+            services.AddElasticsearchDocumentProjectionStore<ServiceRolloutCommandObservationReadModel, string>(
+                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceRolloutCommandObservationReadModel>>().Metadata,
+                keySelector: readModel => readModel.Id,
+                keyFormatter: key => key);
             services.AddElasticsearchDocumentProjectionStore<ServiceTrafficViewReadModel, string>(
                 optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceTrafficViewReadModel>>().Metadata,
@@ -157,6 +162,10 @@ public static class ServiceCollectionExtensions
                 keyFormatter: key => key,
                 defaultSortSelector: readModel => readModel.UpdatedAt);
             services.AddInMemoryDocumentProjectionStore<ServiceRolloutReadModel, string>(
+                keySelector: readModel => readModel.Id,
+                keyFormatter: key => key,
+                defaultSortSelector: readModel => readModel.UpdatedAt);
+            services.AddInMemoryDocumentProjectionStore<ServiceRolloutCommandObservationReadModel, string>(
                 keySelector: readModel => readModel.Id,
                 keyFormatter: key => key,
                 defaultSortSelector: readModel => readModel.UpdatedAt);

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -58,6 +58,9 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         services.Should().Contain(x => x.ImplementationType == typeof(StaticServiceImplementationAdapter));
         services.Should().Contain(x => x.ImplementationType == typeof(ScriptingServiceImplementationAdapter));
         services.Should().Contain(x => x.ImplementationType == typeof(WorkflowServiceImplementationAdapter));
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IServiceRolloutCommandObservationQueryReader>().Should().NotBeNull();
     }
 
     [Fact]
@@ -262,6 +265,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         provider.GetRequiredService<IProjectionWriteDispatcher<ServiceRevisionCatalogReadModel>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<ServiceCatalogReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRevisionCatalogReadModel, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## 问题
`Aevatar.Mainnet.Host.Api` 启动时会解析 `ServiceServingQueryApplicationService`，它依赖 `IServiceRolloutCommandObservationQueryReader`。这条 query reader 又要求 `IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>`，但 `Aevatar.GAgentService.Hosting` 在装配 projection document stores 时漏掉了 `ServiceRolloutCommandObservationReadModel` 的注册，导致 host 在启动期直接因为 DI 失败而退出。

## 方案
- 在 `Aevatar.GAgentService.Hosting` 的 projection read model provider 注册里补齐 `ServiceRolloutCommandObservationReadModel` 的 Elasticsearch store
- 同时补齐 InMemory store，保持两条 provider 路径一致
- 增加回归测试，直接校验 capability bundle 和 Elasticsearch provider 都能解析 rollout observation 的 document reader / query reader

## 影响
- 修复 `Aevatar.Mainnet.Host.Api` 启动期的 DI 断裂
- `ServiceRolloutCommandObservationQueryReader` 现在能被正常构造，rollout command observation query 路径可用

## 验证
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests"`
- `dotnet build src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj --nologo`
- `bash tools/ci/test_stability_guards.sh`

结果：
- GAgentService hosting integration tests: 18 passed
- Mainnet host build: passed
- Stability guard: passed