### PR TITLE
Close projection provider partial-registration gaps

### DIFF
--- a/src/Aevatar.Scripting.Hosting/DependencyInjection/ScriptingProjectionProviderServiceCollectionExtensions.cs
+++ b/src/Aevatar.Scripting.Hosting/DependencyInjection/ScriptingProjectionProviderServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<ScriptReadModelDocument, string>)))
+        if (HasAllScriptingDocumentReaders(services))
             return services;
 
         if (configuration == null)
@@ -58,32 +58,27 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
 
         if (enableElasticsearchDocument)
         {
-            services.AddElasticsearchDocumentProjectionStore<ScriptDefinitionSnapshotDocument, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ScriptDefinitionSnapshotDocument>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ScriptCatalogEntryDocument, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ScriptCatalogEntryDocument>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ScriptReadModelDocument, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ScriptReadModelDocument>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ScriptEvolutionReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ScriptEvolutionReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ScriptNativeDocumentReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ScriptNativeDocumentReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                indexScopeSelector: readModel => readModel.DocumentIndexScope);
+            TryAddElasticsearchDocumentStore<ScriptDefinitionSnapshotDocument>(
+                services,
+                configuration,
+                static readModel => readModel.Id);
+            TryAddElasticsearchDocumentStore<ScriptCatalogEntryDocument>(
+                services,
+                configuration,
+                static readModel => readModel.Id);
+            TryAddElasticsearchDocumentStore<ScriptReadModelDocument>(
+                services,
+                configuration,
+                static readModel => readModel.Id);
+            TryAddElasticsearchDocumentStore<ScriptEvolutionReadModel>(
+                services,
+                configuration,
+                static readModel => readModel.Id);
+            TryAddElasticsearchDocumentStore<ScriptNativeDocumentReadModel>(
+                services,
+                configuration,
+                static readModel => readModel.Id,
+                static readModel => readModel.DocumentIndexScope);
         }
         else
         {
@@ -105,24 +100,56 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
 
     private static void AddInMemoryDocumentStores(IServiceCollection services)
     {
-        services.AddInMemoryDocumentProjectionStore<ScriptDefinitionSnapshotDocument, string>(
-            keySelector: static readModel => readModel.Id,
+        TryAddInMemoryDocumentStore<ScriptDefinitionSnapshotDocument>(services, static readModel => readModel.Id);
+        TryAddInMemoryDocumentStore<ScriptCatalogEntryDocument>(services, static readModel => readModel.Id);
+        TryAddInMemoryDocumentStore<ScriptReadModelDocument>(services, static readModel => readModel.Id);
+        TryAddInMemoryDocumentStore<ScriptEvolutionReadModel>(services, static readModel => readModel.Id);
+        TryAddInMemoryDocumentStore<ScriptNativeDocumentReadModel>(services, static readModel => readModel.Id);
+    }
+
+    private static bool HasAllScriptingDocumentReaders(IServiceCollection services)
+    {
+        return HasDocumentReader<ScriptDefinitionSnapshotDocument>(services)
+               && HasDocumentReader<ScriptCatalogEntryDocument>(services)
+               && HasDocumentReader<ScriptReadModelDocument>(services)
+               && HasDocumentReader<ScriptEvolutionReadModel>(services)
+               && HasDocumentReader<ScriptNativeDocumentReadModel>(services);
+    }
+
+    private static bool HasDocumentReader<TDocument>(IServiceCollection services)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TDocument, string>));
+    }
+
+    private static void TryAddElasticsearchDocumentStore<TDocument>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        Func<TDocument, string> keySelector,
+        Func<TDocument, string?>? indexScopeSelector = null)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        if (HasDocumentReader<TDocument>(services))
+            return;
+
+        services.AddElasticsearchDocumentProjectionStore<TDocument, string>(
+            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDocument>>().Metadata,
+            keySelector: keySelector,
             keyFormatter: static key => key,
-            defaultSortSelector: static readModel => readModel.UpdatedAt);
-        services.AddInMemoryDocumentProjectionStore<ScriptCatalogEntryDocument, string>(
-            keySelector: static readModel => readModel.Id,
-            keyFormatter: static key => key,
-            defaultSortSelector: static readModel => readModel.UpdatedAt);
-        services.AddInMemoryDocumentProjectionStore<ScriptReadModelDocument, string>(
-            keySelector: static readModel => readModel.Id,
-            keyFormatter: static key => key,
-            defaultSortSelector: static readModel => readModel.UpdatedAt);
-        services.AddInMemoryDocumentProjectionStore<ScriptEvolutionReadModel, string>(
-            keySelector: static readModel => readModel.Id,
-            keyFormatter: static key => key,
-            defaultSortSelector: static readModel => readModel.UpdatedAt);
-        services.AddInMemoryDocumentProjectionStore<ScriptNativeDocumentReadModel, string>(
-            keySelector: static readModel => readModel.Id,
+            indexScopeSelector: indexScopeSelector);
+    }
+
+    private static void TryAddInMemoryDocumentStore<TDocument>(
+        IServiceCollection services,
+        Func<TDocument, string> keySelector)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        if (HasDocumentReader<TDocument>(services))
+            return;
+
+        services.AddInMemoryDocumentProjectionStore<TDocument, string>(
+            keySelector: keySelector,
             keyFormatter: static key => key,
             defaultSortSelector: static readModel => readModel.UpdatedAt);
     }

--- a/src/Aevatar.Scripting.Hosting/DependencyInjection/ScriptingProjectionProviderServiceCollectionExtensions.cs
+++ b/src/Aevatar.Scripting.Hosting/DependencyInjection/ScriptingProjectionProviderServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Providers.Neo4j.Configuration;
 using Aevatar.CQRS.Projection.Providers.Neo4j.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
@@ -18,11 +20,11 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        if (HasAllScriptingDocumentReaders(services))
-            return services;
-
         if (configuration == null)
         {
+            if (HasAllScriptingDocumentReaders(services, DocumentProviderKind.InMemory))
+                return services;
+
             AddInMemoryDocumentStores(services);
             services.AddInMemoryGraphProjectionStore();
             return services;
@@ -48,6 +50,12 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
             throw new InvalidOperationException(
                 "Exactly one document projection provider must be enabled. Configure either Projection:Document:Providers:Elasticsearch:Enabled=true or Projection:Document:Providers:InMemory:Enabled=true.");
         }
+
+        var selectedDocumentProvider = enableElasticsearchDocument
+            ? DocumentProviderKind.Elasticsearch
+            : DocumentProviderKind.InMemory;
+        if (HasAllScriptingDocumentReaders(services, selectedDocumentProvider))
+            return services;
 
         var graphProviderCount = (enableNeo4jGraph ? 1 : 0) + (enableInMemoryGraph ? 1 : 0);
         if (graphProviderCount != 1)
@@ -107,19 +115,48 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         TryAddInMemoryDocumentStore<ScriptNativeDocumentReadModel>(services, static readModel => readModel.Id);
     }
 
-    private static bool HasAllScriptingDocumentReaders(IServiceCollection services)
+    private static bool HasAllScriptingDocumentReaders(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
     {
-        return HasDocumentReader<ScriptDefinitionSnapshotDocument>(services)
-               && HasDocumentReader<ScriptCatalogEntryDocument>(services)
-               && HasDocumentReader<ScriptReadModelDocument>(services)
-               && HasDocumentReader<ScriptEvolutionReadModel>(services)
-               && HasDocumentReader<ScriptNativeDocumentReadModel>(services);
+        return HasDocumentReaderForProvider<ScriptDefinitionSnapshotDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ScriptCatalogEntryDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ScriptReadModelDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ScriptEvolutionReadModel>(services, providerKind)
+               && HasDocumentReaderForProvider<ScriptNativeDocumentReadModel>(services, providerKind);
     }
 
-    private static bool HasDocumentReader<TDocument>(IServiceCollection services)
+    private static bool HasAnyDocumentReader<TDocument>(IServiceCollection services)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
         return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TDocument, string>));
+    }
+
+    private static bool HasDocumentReaderForProvider<TDocument>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        return providerKind switch
+        {
+            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDocument, string>)),
+            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDocument, string>)),
+            _ => false,
+        };
+    }
+
+    private static void EnsureCompatibleDocumentReaderProvider<TDocument>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        if (!HasAnyDocumentReader<TDocument>(services))
+            return;
+        if (HasDocumentReaderForProvider<TDocument>(services, providerKind))
+            return;
+
+        throw new InvalidOperationException(
+            $"Projection document reader for {typeof(TDocument).Name} is already registered with a different provider.");
     }
 
     private static void TryAddElasticsearchDocumentStore<TDocument>(
@@ -129,7 +166,8 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         Func<TDocument, string?>? indexScopeSelector = null)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        if (HasDocumentReader<TDocument>(services))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.Elasticsearch);
+        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TDocument, string>(
@@ -145,7 +183,8 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         Func<TDocument, string> keySelector)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        if (HasDocumentReader<TDocument>(services))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.InMemory);
+        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TDocument, string>(
@@ -271,5 +310,11 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
             throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
 
         return parsed;
+    }
+
+    private enum DocumentProviderKind
+    {
+        InMemory,
+        Elasticsearch,
     }
 }

--- a/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
@@ -37,8 +37,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        // Idempotency guard: pick a Studio-specific readmodel as canary.
-        if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<RoleCatalogCurrentStateDocument, string>)))
+        if (HasAllStudioDocumentReaders(services))
             return services;
 
         var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
@@ -83,6 +82,9 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         IConfiguration configuration)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
+        if (HasDocumentReader<TDoc>(services))
+            return;
+
         services.AddElasticsearchDocumentProjectionStore<TDoc, string>(
             optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
             metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDoc>>().Metadata,
@@ -95,10 +97,31 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         IServiceCollection services)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
+        if (HasDocumentReader<TDoc>(services))
+            return;
+
         services.AddInMemoryDocumentProjectionStore<TDoc, string>(
             keySelector: readModel => readModel.ActorId,
             keyFormatter: key => key,
             defaultSortSelector: readModel => readModel.UpdatedAt);
+    }
+
+    private static bool HasAllStudioDocumentReaders(IServiceCollection services)
+    {
+        return HasDocumentReader<RoleCatalogCurrentStateDocument>(services)
+               && HasDocumentReader<ConnectorCatalogCurrentStateDocument>(services)
+               && HasDocumentReader<ChatHistoryIndexCurrentStateDocument>(services)
+               && HasDocumentReader<ChatConversationCurrentStateDocument>(services)
+               && HasDocumentReader<GAgentRegistryCurrentStateDocument>(services)
+               && HasDocumentReader<UserMemoryCurrentStateDocument>(services)
+               && HasDocumentReader<StreamingProxyParticipantCurrentStateDocument>(services)
+               && HasDocumentReader<UserConfigCurrentStateDocument>(services);
+    }
+
+    private static bool HasDocumentReader<TDoc>(IServiceCollection services)
+        where TDoc : class, IProjectionReadModel<TDoc>, new()
+    {
+        return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TDoc, string>));
     }
 
     private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)

--- a/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgents.ChatHistory;
 using Aevatar.GAgents.ConnectorCatalog;
@@ -37,9 +39,6 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        if (HasAllStudioDocumentReaders(services))
-            return services;
-
         var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
         var inMemoryEnabled = ResolveOptionalBool(
             configuration["Projection:Document:Providers:InMemory:Enabled"],
@@ -50,6 +49,12 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             throw new InvalidOperationException(
                 "Exactly one document projection provider must be enabled for Studio.");
         }
+
+        var selectedDocumentProvider = elasticsearchEnabled
+            ? DocumentProviderKind.Elasticsearch
+            : DocumentProviderKind.InMemory;
+        if (HasAllStudioDocumentReaders(services, selectedDocumentProvider))
+            return services;
 
         if (elasticsearchEnabled)
         {
@@ -82,7 +87,8 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         IConfiguration configuration)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
-        if (HasDocumentReader<TDoc>(services))
+        EnsureCompatibleDocumentReaderProvider<TDoc>(services, DocumentProviderKind.Elasticsearch);
+        if (HasDocumentReaderForProvider<TDoc>(services, DocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TDoc, string>(
@@ -97,7 +103,8 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         IServiceCollection services)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
-        if (HasDocumentReader<TDoc>(services))
+        EnsureCompatibleDocumentReaderProvider<TDoc>(services, DocumentProviderKind.InMemory);
+        if (HasDocumentReaderForProvider<TDoc>(services, DocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TDoc, string>(
@@ -106,22 +113,51 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             defaultSortSelector: readModel => readModel.UpdatedAt);
     }
 
-    private static bool HasAllStudioDocumentReaders(IServiceCollection services)
+    private static bool HasAllStudioDocumentReaders(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
     {
-        return HasDocumentReader<RoleCatalogCurrentStateDocument>(services)
-               && HasDocumentReader<ConnectorCatalogCurrentStateDocument>(services)
-               && HasDocumentReader<ChatHistoryIndexCurrentStateDocument>(services)
-               && HasDocumentReader<ChatConversationCurrentStateDocument>(services)
-               && HasDocumentReader<GAgentRegistryCurrentStateDocument>(services)
-               && HasDocumentReader<UserMemoryCurrentStateDocument>(services)
-               && HasDocumentReader<StreamingProxyParticipantCurrentStateDocument>(services)
-               && HasDocumentReader<UserConfigCurrentStateDocument>(services);
+        return HasDocumentReaderForProvider<RoleCatalogCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ConnectorCatalogCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ChatHistoryIndexCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<ChatConversationCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<GAgentRegistryCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<UserMemoryCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<StreamingProxyParticipantCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind);
     }
 
-    private static bool HasDocumentReader<TDoc>(IServiceCollection services)
+    private static bool HasAnyDocumentReader<TDoc>(IServiceCollection services)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
         return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TDoc, string>));
+    }
+
+    private static bool HasDocumentReaderForProvider<TDoc>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TDoc : class, IProjectionReadModel<TDoc>, new()
+    {
+        return providerKind switch
+        {
+            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDoc, string>)),
+            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDoc, string>)),
+            _ => false,
+        };
+    }
+
+    private static void EnsureCompatibleDocumentReaderProvider<TDoc>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TDoc : class, IProjectionReadModel<TDoc>, new()
+    {
+        if (!HasAnyDocumentReader<TDoc>(services))
+            return;
+        if (HasDocumentReaderForProvider<TDoc>(services, providerKind))
+            return;
+
+        throw new InvalidOperationException(
+            $"Projection document reader for {typeof(TDoc).Name} is already registered with a different provider.");
     }
 
     private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
@@ -171,5 +207,11 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             StreamingProxyParticipantGAgentState.Descriptor,
             ChatHistoryIndexState.Descriptor,
             ChatConversationState.Descriptor);
+    }
+
+    private enum DocumentProviderKind
+    {
+        InMemory,
+        Elasticsearch,
     }
 }

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -87,7 +87,7 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<ServiceCatalogReadModel, string>)))
+        if (HasAllGAgentServiceProjectionReaders(services))
             return services;
         var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
         var inMemoryEnabled = ResolveOptionalBool(
@@ -102,84 +102,76 @@ public static class ServiceCollectionExtensions
 
         if (elasticsearchEnabled)
         {
-            services.AddElasticsearchDocumentProjectionStore<ServiceCatalogReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceCatalogReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ServiceRevisionCatalogReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceRevisionCatalogReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ServiceDeploymentCatalogReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceDeploymentCatalogReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ServiceServingSetReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceServingSetReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ServiceRolloutReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceRolloutReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ServiceRolloutCommandObservationReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceRolloutCommandObservationReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<ServiceTrafficViewReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceTrafficViewReadModel>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
-            services.AddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<UserConfigCurrentStateDocument>>().Metadata,
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key);
+            TryAddElasticsearchDocumentProjectionStore<ServiceCatalogReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceRevisionCatalogReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceDeploymentCatalogReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceServingSetReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceRolloutReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceRolloutCommandObservationReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<ServiceTrafficViewReadModel>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
         }
         else
         {
-            services.AddInMemoryDocumentProjectionStore<ServiceCatalogReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<ServiceRevisionCatalogReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<ServiceDeploymentCatalogReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<ServiceServingSetReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<ServiceRolloutReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<ServiceRolloutCommandObservationReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<ServiceTrafficViewReadModel, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
-            services.AddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument, string>(
-                keySelector: readModel => readModel.Id,
-                keyFormatter: key => key,
-                defaultSortSelector: readModel => readModel.UpdatedAt);
+            TryAddInMemoryDocumentProjectionStore<ServiceCatalogReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceRevisionCatalogReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceDeploymentCatalogReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceServingSetReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceRolloutReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceRolloutCommandObservationReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<ServiceTrafficViewReadModel>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services, static readModel => readModel.Id);
         }
 
         return services;
+    }
+
+    private static bool HasAllGAgentServiceProjectionReaders(IServiceCollection services)
+    {
+        return HasProjectionDocumentReader<ServiceCatalogReadModel>(services)
+               && HasProjectionDocumentReader<ServiceRevisionCatalogReadModel>(services)
+               && HasProjectionDocumentReader<ServiceDeploymentCatalogReadModel>(services)
+               && HasProjectionDocumentReader<ServiceServingSetReadModel>(services)
+               && HasProjectionDocumentReader<ServiceRolloutReadModel>(services)
+               && HasProjectionDocumentReader<ServiceRolloutCommandObservationReadModel>(services)
+               && HasProjectionDocumentReader<ServiceTrafficViewReadModel>(services)
+               && HasProjectionDocumentReader<UserConfigCurrentStateDocument>(services);
+    }
+
+    private static bool HasProjectionDocumentReader<TReadModel>(IServiceCollection services)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TReadModel, string>));
+    }
+
+    private static void TryAddElasticsearchDocumentProjectionStore<TReadModel>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        Func<TReadModel, string> keySelector)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        if (HasProjectionDocumentReader<TReadModel>(services))
+            return;
+
+        services.AddElasticsearchDocumentProjectionStore<TReadModel, string>(
+            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TReadModel>>().Metadata,
+            keySelector: keySelector,
+            keyFormatter: static key => key);
+    }
+
+    private static void TryAddInMemoryDocumentProjectionStore<TReadModel>(
+        IServiceCollection services,
+        Func<TReadModel, string> keySelector)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        if (HasProjectionDocumentReader<TReadModel>(services))
+            return;
+
+        services.AddInMemoryDocumentProjectionStore<TReadModel, string>(
+            keySelector: keySelector,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
     }
 
     private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Application.Bindings;
@@ -87,8 +89,6 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        if (HasAllGAgentServiceProjectionReaders(services))
-            return services;
         var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
         var inMemoryEnabled = ResolveOptionalBool(
             configuration["Projection:Document:Providers:InMemory:Enabled"],
@@ -99,6 +99,12 @@ public static class ServiceCollectionExtensions
             throw new InvalidOperationException(
                 "Exactly one document projection provider must be enabled for GAgentService.");
         }
+
+        var selectedDocumentProvider = elasticsearchEnabled
+            ? DocumentProviderKind.Elasticsearch
+            : DocumentProviderKind.InMemory;
+        if (HasAllGAgentServiceProjectionReaders(services, selectedDocumentProvider))
+            return services;
 
         if (elasticsearchEnabled)
         {
@@ -126,22 +132,51 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    private static bool HasAllGAgentServiceProjectionReaders(IServiceCollection services)
+    private static bool HasAllGAgentServiceProjectionReaders(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
     {
-        return HasProjectionDocumentReader<ServiceCatalogReadModel>(services)
-               && HasProjectionDocumentReader<ServiceRevisionCatalogReadModel>(services)
-               && HasProjectionDocumentReader<ServiceDeploymentCatalogReadModel>(services)
-               && HasProjectionDocumentReader<ServiceServingSetReadModel>(services)
-               && HasProjectionDocumentReader<ServiceRolloutReadModel>(services)
-               && HasProjectionDocumentReader<ServiceRolloutCommandObservationReadModel>(services)
-               && HasProjectionDocumentReader<ServiceTrafficViewReadModel>(services)
-               && HasProjectionDocumentReader<UserConfigCurrentStateDocument>(services);
+        return HasProjectionDocumentReaderForProvider<ServiceCatalogReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceRevisionCatalogReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceDeploymentCatalogReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceServingSetReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceRolloutReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceRolloutCommandObservationReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<ServiceTrafficViewReadModel>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind);
     }
 
-    private static bool HasProjectionDocumentReader<TReadModel>(IServiceCollection services)
+    private static bool HasAnyProjectionDocumentReader<TReadModel>(IServiceCollection services)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
         return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TReadModel, string>));
+    }
+
+    private static bool HasProjectionDocumentReaderForProvider<TReadModel>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        return providerKind switch
+        {
+            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TReadModel, string>)),
+            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TReadModel, string>)),
+            _ => false,
+        };
+    }
+
+    private static void EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TReadModel : class, IProjectionReadModel<TReadModel>, new()
+    {
+        if (!HasAnyProjectionDocumentReader<TReadModel>(services))
+            return;
+        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, providerKind))
+            return;
+
+        throw new InvalidOperationException(
+            $"Projection document reader for {typeof(TReadModel).Name} is already registered with a different provider.");
     }
 
     private static void TryAddElasticsearchDocumentProjectionStore<TReadModel>(
@@ -150,7 +185,8 @@ public static class ServiceCollectionExtensions
         Func<TReadModel, string> keySelector)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
-        if (HasProjectionDocumentReader<TReadModel>(services))
+        EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(services, DocumentProviderKind.Elasticsearch);
+        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, DocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TReadModel, string>(
@@ -165,7 +201,8 @@ public static class ServiceCollectionExtensions
         Func<TReadModel, string> keySelector)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
-        if (HasProjectionDocumentReader<TReadModel>(services))
+        EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(services, DocumentProviderKind.InMemory);
+        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, DocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TReadModel, string>(
@@ -208,5 +245,11 @@ public static class ServiceCollectionExtensions
             throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
 
         return parsed;
+    }
+
+    private enum DocumentProviderKind
+    {
+        InMemory,
+        Elasticsearch,
     }
 }

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<WorkflowExecutionCurrentStateDocument, string>)))
+        if (HasAllWorkflowDocumentReaders(services))
             return services;
 
         EnsureLegacyProviderOptionsNotUsed(configuration);
@@ -76,49 +76,87 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         IServiceCollection services,
         IConfiguration configuration)
     {
-        services.AddElasticsearchDocumentProjectionStore<WorkflowExecutionCurrentStateDocument, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<WorkflowExecutionCurrentStateDocument>>().Metadata,
-            keySelector: static document => document.RootActorId,
-            keyFormatter: static key => key);
-        services.AddElasticsearchDocumentProjectionStore<WorkflowRunTimelineDocument, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<WorkflowRunTimelineDocument>>().Metadata,
-            keySelector: static document => document.RootActorId,
-            keyFormatter: static key => key);
-        services.AddElasticsearchDocumentProjectionStore<WorkflowRunInsightReportDocument, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<WorkflowRunInsightReportDocument>>().Metadata,
-            keySelector: static report => report.RootActorId,
-            keyFormatter: static key => key);
-        services.AddElasticsearchDocumentProjectionStore<WorkflowActorBindingDocument, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
-            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<WorkflowActorBindingDocument>>().Metadata,
-            keySelector: static document => document.Id,
-            keyFormatter: static key => key);
+        TryAddElasticsearchDocumentStore<WorkflowExecutionCurrentStateDocument>(
+            services,
+            configuration,
+            static document => document.RootActorId);
+        TryAddElasticsearchDocumentStore<WorkflowRunTimelineDocument>(
+            services,
+            configuration,
+            static document => document.RootActorId);
+        TryAddElasticsearchDocumentStore<WorkflowRunInsightReportDocument>(
+            services,
+            configuration,
+            static report => report.RootActorId);
+        TryAddElasticsearchDocumentStore<WorkflowActorBindingDocument>(
+            services,
+            configuration,
+            static document => document.Id);
     }
 
     private static void AddInMemoryDocumentStores(IServiceCollection services)
     {
-        services.AddInMemoryDocumentProjectionStore<WorkflowExecutionCurrentStateDocument, string>(
-            keySelector: static document => document.RootActorId,
+        TryAddInMemoryDocumentStore<WorkflowExecutionCurrentStateDocument>(
+            services,
+            static document => document.RootActorId,
+            static document => document.UpdatedAt);
+        TryAddInMemoryDocumentStore<WorkflowRunTimelineDocument>(
+            services,
+            static document => document.RootActorId,
+            static document => document.UpdatedAt);
+        TryAddInMemoryDocumentStore<WorkflowRunInsightReportDocument>(
+            services,
+            static report => report.RootActorId,
+            static report => report.CreatedAt);
+        TryAddInMemoryDocumentStore<WorkflowActorBindingDocument>(
+            services,
+            static document => document.Id,
+            static document => document.UpdatedAt);
+    }
+
+    private static bool HasAllWorkflowDocumentReaders(IServiceCollection services)
+    {
+        return HasDocumentReader<WorkflowExecutionCurrentStateDocument>(services)
+               && HasDocumentReader<WorkflowRunTimelineDocument>(services)
+               && HasDocumentReader<WorkflowRunInsightReportDocument>(services)
+               && HasDocumentReader<WorkflowActorBindingDocument>(services);
+    }
+
+    private static bool HasDocumentReader<TDocument>(IServiceCollection services)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TDocument, string>));
+    }
+
+    private static void TryAddElasticsearchDocumentStore<TDocument>(
+        IServiceCollection services,
+        IConfiguration configuration,
+        Func<TDocument, string> keySelector)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        if (HasDocumentReader<TDocument>(services))
+            return;
+
+        services.AddElasticsearchDocumentProjectionStore<TDocument, string>(
+            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDocument>>().Metadata,
+            keySelector: keySelector,
+            keyFormatter: static key => key);
+    }
+
+    private static void TryAddInMemoryDocumentStore<TDocument>(
+        IServiceCollection services,
+        Func<TDocument, string> keySelector,
+        Func<TDocument, object?> defaultSortSelector)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        if (HasDocumentReader<TDocument>(services))
+            return;
+
+        services.AddInMemoryDocumentProjectionStore<TDocument, string>(
+            keySelector: keySelector,
             keyFormatter: static key => key,
-            defaultSortSelector: static document => document.UpdatedAt,
-            queryTakeMax: 200);
-        services.AddInMemoryDocumentProjectionStore<WorkflowRunTimelineDocument, string>(
-            keySelector: static document => document.RootActorId,
-            keyFormatter: static key => key,
-            defaultSortSelector: static document => document.UpdatedAt,
-            queryTakeMax: 200);
-        services.AddInMemoryDocumentProjectionStore<WorkflowRunInsightReportDocument, string>(
-            keySelector: static report => report.RootActorId,
-            keyFormatter: static key => key,
-            defaultSortSelector: static report => report.CreatedAt,
-            queryTakeMax: 200);
-        services.AddInMemoryDocumentProjectionStore<WorkflowActorBindingDocument, string>(
-            keySelector: static document => document.Id,
-            keyFormatter: static key => key,
-            defaultSortSelector: static document => document.UpdatedAt,
+            defaultSortSelector: defaultSortSelector,
             queryTakeMax: 200);
     }
 

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Providers.Neo4j.Configuration;
 using Aevatar.CQRS.Projection.Providers.Neo4j.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
@@ -18,9 +20,6 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
-
-        if (HasAllWorkflowDocumentReaders(services))
-            return services;
 
         EnsureLegacyProviderOptionsNotUsed(configuration);
 
@@ -42,6 +41,12 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             throw new InvalidOperationException(
                 "Exactly one document projection provider must be enabled. Configure either Projection:Document:Providers:Elasticsearch:Enabled=true or Projection:Document:Providers:InMemory:Enabled=true.");
         }
+
+        var selectedDocumentProvider = enableElasticsearchDocument
+            ? DocumentProviderKind.Elasticsearch
+            : DocumentProviderKind.InMemory;
+        if (HasAllWorkflowDocumentReaders(services, selectedDocumentProvider))
+            return services;
 
         var graphProviderCount = (enableNeo4jGraph ? 1 : 0) + (enableInMemoryGraph ? 1 : 0);
         if (graphProviderCount != 1)
@@ -114,18 +119,47 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             static document => document.UpdatedAt);
     }
 
-    private static bool HasAllWorkflowDocumentReaders(IServiceCollection services)
+    private static bool HasAllWorkflowDocumentReaders(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
     {
-        return HasDocumentReader<WorkflowExecutionCurrentStateDocument>(services)
-               && HasDocumentReader<WorkflowRunTimelineDocument>(services)
-               && HasDocumentReader<WorkflowRunInsightReportDocument>(services)
-               && HasDocumentReader<WorkflowActorBindingDocument>(services);
+        return HasDocumentReaderForProvider<WorkflowExecutionCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<WorkflowRunTimelineDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<WorkflowRunInsightReportDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<WorkflowActorBindingDocument>(services, providerKind);
     }
 
-    private static bool HasDocumentReader<TDocument>(IServiceCollection services)
+    private static bool HasAnyDocumentReader<TDocument>(IServiceCollection services)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
         return services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<TDocument, string>));
+    }
+
+    private static bool HasDocumentReaderForProvider<TDocument>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        return providerKind switch
+        {
+            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDocument, string>)),
+            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDocument, string>)),
+            _ => false,
+        };
+    }
+
+    private static void EnsureCompatibleDocumentReaderProvider<TDocument>(
+        IServiceCollection services,
+        DocumentProviderKind providerKind)
+        where TDocument : class, IProjectionReadModel<TDocument>, new()
+    {
+        if (!HasAnyDocumentReader<TDocument>(services))
+            return;
+        if (HasDocumentReaderForProvider<TDocument>(services, providerKind))
+            return;
+
+        throw new InvalidOperationException(
+            $"Projection document reader for {typeof(TDocument).Name} is already registered with a different provider.");
     }
 
     private static void TryAddElasticsearchDocumentStore<TDocument>(
@@ -134,7 +168,8 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         Func<TDocument, string> keySelector)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        if (HasDocumentReader<TDocument>(services))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.Elasticsearch);
+        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TDocument, string>(
@@ -150,7 +185,8 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         Func<TDocument, object?> defaultSortSelector)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        if (HasDocumentReader<TDocument>(services))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.InMemory);
+        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TDocument, string>(
@@ -285,5 +321,11 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
 
         return parsed;
+    }
+
+    private enum DocumentProviderKind
+    {
+        InMemory,
+        Elasticsearch,
     }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -268,6 +268,31 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddGAgentServiceProjectionReadModelProviders_ShouldRejectPartialRegistrationFromDifferentProvider()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+                ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://localhost:9200",
+                ["Projection:Document:Providers:InMemory:Enabled"] = "false",
+            })
+            .Build();
+
+        services.AddGAgentServiceProjection();
+        services.AddInMemoryDocumentProjectionStore<ServiceCatalogReadModel, string>(
+            keySelector: static readModel => readModel.Id,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
+
+        var act = () => services.AddGAgentServiceProjectionReadModelProviders(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ServiceCatalogReadModel*different provider*");
+    }
+
+    [Fact]
     public void AddGAgentServiceProjectionReadModelProviders_ShouldRegisterElasticsearchStores_WhenConfigured()
     {
         var services = new ServiceCollection();

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -15,7 +15,9 @@ using Aevatar.GAgentService.Projection.DependencyInjection;
 using Aevatar.GAgentService.Infrastructure.Adapters;
 using Aevatar.Hosting;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
@@ -243,6 +245,26 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         services.AddGAgentServiceProjectionReadModelProviders(configuration);
 
         services.Count.Should().Be(afterFirstRegistration);
+    }
+
+    [Fact]
+    public void AddGAgentServiceProjectionReadModelProviders_ShouldFillMissingReadersWhenPartialRegistrationExists()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddGAgentServiceProjection();
+        services.AddInMemoryDocumentProjectionStore<ServiceCatalogReadModel, string>(
+            keySelector: static readModel => readModel.Id,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
+
+        services.AddGAgentServiceProjectionReadModelProviders(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<UserConfigCurrentStateDocument, string>>().Should().NotBeNull();
+        services.Count(x => x.ServiceType == typeof(IProjectionDocumentReader<ServiceCatalogReadModel, string>)).Should().Be(1);
     }
 
     [Fact]

--- a/test/Aevatar.Hosting.Tests/ScriptCapabilityHostExtensionsTests.cs
+++ b/test/Aevatar.Hosting.Tests/ScriptCapabilityHostExtensionsTests.cs
@@ -131,6 +131,32 @@ public class ScriptCapabilityHostExtensionsTests
     }
 
     [Fact]
+    public void AddScriptingProjectionReadModelProviders_ShouldRejectPartialRegistrationFromDifferentProvider()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+                ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://localhost:9200",
+                ["Projection:Document:Providers:InMemory:Enabled"] = "false",
+                ["Projection:Graph:Providers:InMemory:Enabled"] = "true",
+                ["Projection:Graph:Providers:Neo4j:Enabled"] = "false",
+            })
+            .Build();
+
+        services.AddInMemoryDocumentProjectionStore<ScriptReadModelDocument, string>(
+            keySelector: static readModel => readModel.Id,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
+
+        var act = () => services.AddScriptingProjectionReadModelProviders(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ScriptReadModelDocument*different provider*");
+    }
+
+    [Fact]
     public void AddScriptingCapabilityBundle_ShouldMapEvolutionAndReadModelEndpoints()
     {
         var builder = WebApplication.CreateBuilder();

--- a/test/Aevatar.Hosting.Tests/ScriptCapabilityHostExtensionsTests.cs
+++ b/test/Aevatar.Hosting.Tests/ScriptCapabilityHostExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.Hosting;
 using Aevatar.Foundation.Runtime.Implementations.Local.DependencyInjection;
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.Stores;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
@@ -108,6 +109,25 @@ public class ScriptCapabilityHostExtensionsTests
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*Invalid boolean value*");
+    }
+
+    [Fact]
+    public void AddScriptingProjectionReadModelProviders_ShouldFillMissingReadersWhenPartialRegistrationExists()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddInMemoryDocumentProjectionStore<ScriptReadModelDocument, string>(
+            keySelector: static readModel => readModel.Id,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
+
+        services.AddScriptingProjectionReadModelProviders(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IProjectionDocumentReader<ScriptEvolutionReadModel, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<ScriptNativeDocumentReadModel, string>>().Should().NotBeNull();
+        services.Count(x => x.ServiceType == typeof(IProjectionDocumentReader<ScriptReadModelDocument, string>)).Should().Be(1);
     }
 
     [Fact]

--- a/test/Aevatar.Tools.Cli.Tests/StudioProjectionReadModelServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/StudioProjectionReadModelServiceCollectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.Studio.Hosting;
 using Aevatar.Studio.Projection.ReadModels;
 using FluentAssertions;
@@ -29,6 +30,7 @@ public sealed class StudioProjectionReadModelServiceCollectionExtensionsTests
         typeof(GAgentRegistryCurrentStateDocument),
         typeof(UserMemoryCurrentStateDocument),
         typeof(StreamingProxyParticipantCurrentStateDocument),
+        typeof(UserConfigCurrentStateDocument),
     ];
 
     [Fact]
@@ -167,9 +169,26 @@ public sealed class StudioProjectionReadModelServiceCollectionExtensionsTests
         var countAfterFirstCall = services.Count;
         services.AddStudioProjectionReadModelProviders(configuration);
 
-        // Second call must short-circuit via the canary check on
-        // IProjectionDocumentReader<RoleCatalogCurrentStateDocument, string>.
+        // Second call must short-circuit once the full Studio reader set is present.
         services.Count.Should().Be(countAfterFirstCall);
+    }
+
+    [Fact]
+    public void AddStudioProjectionReadModelProviders_WhenPartialRegistrationExists_ShouldFillMissingReaders()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration();
+
+        services.AddInMemoryDocumentProjectionStore<RoleCatalogCurrentStateDocument, string>(
+            keySelector: static readModel => readModel.ActorId,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
+
+        services.AddStudioProjectionReadModelProviders(configuration);
+
+        AssertReaderAndWriterRegistered(services, typeof(ChatConversationCurrentStateDocument));
+        AssertReaderAndWriterRegistered(services, typeof(UserConfigCurrentStateDocument));
+        services.Count(descriptor => descriptor.ServiceType == typeof(IProjectionDocumentReader<RoleCatalogCurrentStateDocument, string>)).Should().Be(1);
     }
 
     [Fact]

--- a/test/Aevatar.Tools.Cli.Tests/StudioProjectionReadModelServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/StudioProjectionReadModelServiceCollectionExtensionsTests.cs
@@ -192,6 +192,28 @@ public sealed class StudioProjectionReadModelServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddStudioProjectionReadModelProviders_WhenPartialRegistrationUsesDifferentProvider_ShouldThrow()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+            ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://localhost:9200",
+            ["Projection:Document:Providers:InMemory:Enabled"] = "false",
+        });
+
+        services.AddInMemoryDocumentProjectionStore<RoleCatalogCurrentStateDocument, string>(
+            keySelector: static readModel => readModel.ActorId,
+            keyFormatter: static key => key,
+            defaultSortSelector: static readModel => readModel.UpdatedAt);
+
+        Action act = () => services.AddStudioProjectionReadModelProviders(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*RoleCatalogCurrentStateDocument*different provider*");
+    }
+
+    [Fact]
     public void AddStudioProjectionReadModelProviders_WhenElasticsearchEnabled_ShouldNotRegisterInMemoryStore()
     {
         var services = new ServiceCollection();

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHostingExtensionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHostingExtensionsCoverageTests.cs
@@ -4,6 +4,7 @@ using Aevatar.AI.ToolProviders.MCP;
 using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Hosting;
 using Aevatar.Workflow.Core;
@@ -358,6 +359,26 @@ public sealed class WorkflowHostingExtensionsCoverageTests
         services.AddWorkflowProjectionReadModelProviders(configuration);
 
         services.Count.Should().Be(afterFirstRegistration);
+    }
+
+    [Fact]
+    public void AddWorkflowProjectionReadModelProviders_ShouldFillMissingReadersWhenPartialRegistrationExists()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddInMemoryDocumentProjectionStore<WorkflowExecutionCurrentStateDocument, string>(
+            keySelector: static document => document.RootActorId,
+            keyFormatter: static key => key,
+            defaultSortSelector: static document => document.UpdatedAt,
+            queryTakeMax: 200);
+
+        services.AddWorkflowProjectionReadModelProviders(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowRunInsightReportDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowActorBindingDocument, string>>().Should().NotBeNull();
+        services.Count(x => x.ServiceType == typeof(IProjectionDocumentReader<WorkflowExecutionCurrentStateDocument, string>)).Should().Be(1);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHostingExtensionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHostingExtensionsCoverageTests.cs
@@ -382,6 +382,33 @@ public sealed class WorkflowHostingExtensionsCoverageTests
     }
 
     [Fact]
+    public void AddWorkflowProjectionReadModelProviders_ShouldRejectPartialRegistrationFromDifferentProvider()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+                ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://localhost:9200",
+                ["Projection:Document:Providers:InMemory:Enabled"] = "false",
+                ["Projection:Graph:Providers:InMemory:Enabled"] = "true",
+                ["Projection:Graph:Providers:Neo4j:Enabled"] = "false",
+            })
+            .Build();
+
+        services.AddInMemoryDocumentProjectionStore<WorkflowExecutionCurrentStateDocument, string>(
+            keySelector: static document => document.RootActorId,
+            keyFormatter: static key => key,
+            defaultSortSelector: static document => document.UpdatedAt,
+            queryTakeMax: 200);
+
+        var act = () => services.AddWorkflowProjectionReadModelProviders(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*WorkflowExecutionCurrentStateDocument*different provider*");
+    }
+
+    [Fact]
     public async Task AddWorkflowProjectionReadModelProviders_ShouldResolveWorkflowActorBindingDocumentStore()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## 问题
上一条修复只补了 `ServiceRolloutCommandObservationReadModel` 的漏注册，但同类 projection provider 还存在一个系统性缺陷：

- 多个 capability 的 read-model provider 都用单个 `IProjectionDocumentReader<...>` 当幂等 canary
- 一旦某个 reader 已经存在、但同组其余 reader 缺失，provider 会直接提前返回
- 结果就是容器进入“部分注册”状态，宿主只会在后续解析某个缺失 reader/query reader 时才启动失败

这类风险不只在 `Aevatar.GAgentService.Hosting`，还存在于 `Workflow`、`Scripting`、`Studio` 的 projection provider 注册路径。

## 方案
- 把 GAgentService / Workflow / Scripting / Studio 的 projection provider 幂等判断统一改成“整组 reader 是否都已存在”
- 对每个 document store 注册改成按 read-model 粒度 `TryAdd`，缺哪个补哪个，已有的不重复注册
- 增加回归测试，覆盖“部分注册后再次调用 provider 仍会补齐缺失 reader”的场景
- 补齐 `Studio` 这组测试里遗漏的 `UserConfigCurrentStateDocument` 覆盖

## 影响
- 避免 host 因 projection document store 处于 partial-registration 状态而在启动时或首次解析 query reader 时崩溃
- 让同类 capability bundle 的 provider 注册语义一致：幂等，但不会吞掉缺失的 reader
- 收敛同类问题，避免后续继续按 read-model 一个个补漏

## 验证
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests"`
- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/Aevatar.Workflow.Host.Api.Tests.csproj --nologo --filter "FullyQualifiedName~WorkflowHostingExtensionsCoverageTests"`
- `dotnet test test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj --nologo --filter "FullyQualifiedName~ScriptCapabilityHostExtensionsTests"`
- `dotnet test test/Aevatar.Tools.Cli.Tests/Aevatar.Tools.Cli.Tests.csproj --nologo --filter "FullyQualifiedName~StudioProjectionReadModelServiceCollectionExtensionsTests"`
- `dotnet build src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj --nologo`
- `bash tools/ci/test_stability_guards.sh`

结果：
- GAgentService hosting integration tests: 19 passed
- Workflow hosting coverage tests: 19 passed
- Script capability host tests: 6 passed
- Studio projection hosting tests: 12 passed
- Mainnet host build: passed
- Stability guard: passed