### PR TITLE
Improve Mission Control discovery

### DIFF
--- a/apps/aevatar-console-web/config/routes.ts
+++ b/apps/aevatar-console-web/config/routes.ts
@@ -87,7 +87,7 @@ export default [
     path: "/runtime/runs",
     name: "Event Stream",
     component: "./runs",
-    hideInMenu: true,
+    menuGroupKey: "platform",
   },
   {
     path: "/runtime/mission-control",

--- a/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
+++ b/apps/aevatar-console-web/src/pages/MissionControl/index.tsx
@@ -26,6 +26,9 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import { history } from '@/shared/navigation/history';
+import { buildRuntimeRunsHref } from '@/shared/navigation/runtimeRoutes';
+import { buildTeamDetailHref } from '@/shared/navigation/teamRoutes';
 import { AEVATAR_INTERACTIVE_BUTTON_CLASS } from '@/shared/ui/interactionStandards';
 import { useMissionControlRuntime, type UseMissionControlRuntimeResult } from './hooks/useMissionControlRuntime';
 import InspectorPanel from './InspectorPanel';
@@ -224,6 +227,7 @@ function MissionHeaderBar({
   liveMode,
   loading,
   onRefresh,
+  routeContext,
   snapshot,
   stageView,
   onStageViewChange,
@@ -233,6 +237,7 @@ function MissionHeaderBar({
   liveMode: boolean;
   loading: boolean;
   onRefresh: () => void;
+  routeContext: UseMissionControlRuntimeResult['routeContext'];
   snapshot: MissionControlSnapshot;
   stageView: MissionStageView;
   onStageViewChange: (value: MissionStageView) => void;
@@ -307,7 +312,35 @@ function MissionHeaderBar({
             Sync now
           </Button>
         ) : (
-          <Tag color="default">Attach a live run first</Tag>
+          <>
+            {routeContext.scopeId ? (
+              <Button
+                onClick={() =>
+                  history.push(
+                    buildTeamDetailHref({
+                      scopeId: routeContext.scopeId ?? '',
+                      tab: 'events',
+                    }),
+                  )
+                }
+              >
+                Back to Team
+              </Button>
+            ) : null}
+            <Button
+              type="primary"
+              onClick={() =>
+                history.push(
+                  buildRuntimeRunsHref({
+                    scopeId: routeContext.scopeId,
+                    serviceId: routeContext.serviceId,
+                  }),
+                )
+              }
+            >
+              Open Event Stream
+            </Button>
+          </>
         )}
         {ui.interventionRequired ? (
           <Button type="primary" onClick={ui.openInterventionPanel}>
@@ -767,6 +800,7 @@ function MissionControlCanvas({
         onRefresh={() => {
           void runtime.refresh();
         }}
+        routeContext={runtime.routeContext}
         onStageViewChange={setStageView}
         snapshot={snapshot}
         stageView={stageView}

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -424,7 +424,11 @@ describe("RunsPage", () => {
   });
 
   it("shows the trace workbench and primary run actions after the run starts", async () => {
-    window.history.replaceState({}, "", "/runtime/runs?scopeId=scope-1");
+    window.history.replaceState(
+      {},
+      "",
+      "/runtime/runs?scopeId=scope-1&prompt=Watch%20this%20run",
+    );
     mockSession.status = "running";
     mockSession.runId = "run-1";
     mockSession.context = {
@@ -445,6 +449,8 @@ describe("RunsPage", () => {
     expect(window.location.pathname).toBe("/runtime/mission-control");
     const params = new URLSearchParams(window.location.search);
     expect(params.get("actorId")).toBe("actor-1");
+    expect(params.get("autoStream")).toBe("true");
+    expect(params.get("prompt")).toBe("Watch this run");
     expect(params.get("runId")).toBe("run-1");
     expect(params.get("scopeId")).toBe("scope-1");
   });

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -15,7 +15,22 @@ import RunsPage from "./index";
 
 const mockDispatch = jest.fn();
 const mockReset = jest.fn();
-const mockSession = {
+type MockRunSession = {
+  activeSteps: Set<string>;
+  context?: {
+    actorId?: string;
+    commandId?: string;
+    workflowName?: string;
+  };
+  error?: string;
+  events: unknown[];
+  messages: unknown[];
+  pendingHumanInput?: unknown;
+  runId: string;
+  status: string;
+};
+
+const mockSession: MockRunSession = {
   context: undefined,
   status: "idle",
   messages: [],
@@ -331,6 +346,9 @@ describe("RunsPage", () => {
       screen.getByRole("button", { name: "Actor explorer" })
     ).toBeTruthy();
     expect(
+      screen.getByRole("button", { name: "Mission Control" })
+    ).toBeDisabled();
+    expect(
       screen.queryByRole("button", { name: "Open observability hub" })
     ).toBeNull();
     expect(
@@ -406,8 +424,14 @@ describe("RunsPage", () => {
   });
 
   it("shows the trace workbench and primary run actions after the run starts", async () => {
+    window.history.replaceState({}, "", "/runtime/runs?scopeId=scope-1");
     mockSession.status = "running";
     mockSession.runId = "run-1";
+    mockSession.context = {
+      actorId: "actor-1",
+      commandId: "cmd-1",
+      workflowName: "direct",
+    };
 
     const { container } = renderWithQueryClient(React.createElement(RunsPage));
 
@@ -415,6 +439,14 @@ describe("RunsPage", () => {
     expect(screen.queryByRole("button", { name: "Run setup" })).toBeNull();
     expect(screen.getByRole("button", { name: "Details" })).toBeTruthy();
     expect(screen.getByRole("tab", { name: "Conversation" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mission Control" }));
+
+    expect(window.location.pathname).toBe("/runtime/mission-control");
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("actorId")).toBe("actor-1");
+    expect(params.get("runId")).toBe("run-1");
+    expect(params.get("scopeId")).toBe("scope-1");
   });
 
   it("surfaces pending human interaction inline in the main workspace", async () => {

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -13,6 +13,7 @@ import {
 import {
   AppstoreOutlined,
   ArrowLeftOutlined,
+  ControlOutlined,
   DeploymentUnitOutlined,
   InfoCircleOutlined,
   SendOutlined,
@@ -27,6 +28,7 @@ import { sanitizeReturnTo } from "@/shared/auth/session";
 import { buildTeamDetailHref } from "@/shared/navigation/teamRoutes";
 import {
   buildRuntimeExplorerHref,
+  buildRuntimeMissionControlHref,
   buildRuntimeWorkflowsHref,
 } from "@/shared/navigation/runtimeRoutes";
 import {
@@ -1203,6 +1205,30 @@ const RunsPage: React.FC = () => {
   ]);
   const actorId = session.context?.actorId;
   const commandId = session.context?.commandId ?? "";
+  const canOpenMissionControl = Boolean(activeScopeId.trim() && session.runId);
+  const handleOpenMissionControl = useCallback(() => {
+    const runId = session.runId?.trim();
+    const scopeId = activeScopeId.trim();
+    if (!scopeId || !runId) {
+      return;
+    }
+
+    history.push(
+      buildRuntimeMissionControlHref({
+        actorId: actorId || undefined,
+        endpointId: activeEndpointId || undefined,
+        runId,
+        scopeId,
+        serviceId: activeServiceOverrideId || undefined,
+      }),
+    );
+  }, [
+    activeEndpointId,
+    activeScopeId,
+    activeServiceOverrideId,
+    actorId,
+    session.runId,
+  ]);
   const payloadTypeUrl =
     activePayloadTypeUrl.trim() ||
     composerFormRef.current?.getFieldValue("payloadTypeUrl")?.trim?.() ||
@@ -2145,6 +2171,14 @@ const RunsPage: React.FC = () => {
               }
             >
               Actor explorer
+            </Button>
+            <Button
+              className={`${runsWorkbenchHeaderButtonClassName} ${runsWorkbenchHeaderButtonAccentClassName}`}
+              disabled={!canOpenMissionControl}
+              icon={<ControlOutlined />}
+              onClick={handleOpenMissionControl}
+            >
+              Mission Control
             </Button>
           </div>
         </div>

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -1213,10 +1213,14 @@ const RunsPage: React.FC = () => {
       return;
     }
 
+    const prompt = activePrompt.trim();
+
     history.push(
       buildRuntimeMissionControlHref({
         actorId: actorId || undefined,
+        autoStream: true,
         endpointId: activeEndpointId || undefined,
+        prompt: prompt || undefined,
         runId,
         scopeId,
         serviceId: activeServiceOverrideId || undefined,
@@ -1224,6 +1228,7 @@ const RunsPage: React.FC = () => {
     );
   }, [
     activeEndpointId,
+    activePrompt,
     activeScopeId,
     activeServiceOverrideId,
     actorId,

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -907,6 +907,24 @@ describe("TeamDetailPage", () => {
     expect(params.get("serviceId")).toBe("default");
   });
 
+  it("opens Mission Control from the team event stream with run context", async () => {
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "服务映射" });
+    fireEvent.click(screen.getByRole("button", { name: "事件流" }));
+    await screen.findByText("当前任务事件流");
+    fireEvent.click(await screen.findByRole("button", { name: "打开 Mission Control" }));
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/runtime/mission-control");
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("actorId")).toBe("actor-intake");
+    expect(params.get("runId")).toBe("run-current");
+    expect(params.get("scopeId")).toBe("scope-1");
+    expect(params.get("serviceId")).toBe("default");
+  });
+
   it("updates the topology depth selection when the focus member is available", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -913,6 +913,7 @@ describe("TeamDetailPage", () => {
     await screen.findByRole("button", { name: "服务映射" });
     fireEvent.click(screen.getByRole("button", { name: "事件流" }));
     await screen.findByText("当前任务事件流");
+    await screen.findByText(/Current playback is centered on risk_review/);
     fireEvent.click(await screen.findByRole("button", { name: "打开 Mission Control" }));
 
     await waitFor(() => {
@@ -920,6 +921,8 @@ describe("TeamDetailPage", () => {
     });
     const params = new URLSearchParams(window.location.search);
     expect(params.get("actorId")).toBe("actor-intake");
+    expect(params.get("autoStream")).toBe("true");
+    expect(params.get("prompt")).toBe("hello");
     expect(params.get("runId")).toBe("run-current");
     expect(params.get("scopeId")).toBe("scope-1");
     expect(params.get("serviceId")).toBe("default");

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/shared/navigation/teamRoutes";
 import {
   buildRuntimeExplorerHref,
+  buildRuntimeMissionControlHref,
   buildRuntimeRunsHref,
 } from "@/shared/navigation/runtimeRoutes";
 import { saveObservedRunSessionPayload } from "@/shared/runs/draftRunSession";
@@ -1485,6 +1486,38 @@ const TeamDetailPage: React.FC = () => {
     [lens.playback.currentRunId, lens.playback.rootActorId, runtimeServiceId, scopeId],
   );
 
+  const handleOpenMissionControl = React.useCallback(() => {
+    const runId =
+      trimText(lens.currentRun?.runId) || trimText(lens.playback.currentRunId);
+    if (!scopeId || !runId) {
+      return;
+    }
+
+    const actorId =
+      trimText(lens.currentRun?.actorId) ||
+      trimText(lens.playback.rootActorId) ||
+      trimText(lens.graph.focusActorId) ||
+      undefined;
+
+    history.push(
+      buildRuntimeMissionControlHref({
+        actorId,
+        endpointId: "chat",
+        runId,
+        scopeId,
+        serviceId: runtimeServiceId,
+      }),
+    );
+  }, [
+    lens.currentRun?.actorId,
+    lens.currentRun?.runId,
+    lens.graph.focusActorId,
+    lens.playback.currentRunId,
+    lens.playback.rootActorId,
+    runtimeServiceId,
+    scopeId,
+  ]);
+
   const teamHeading = resolveTeamHeading({
     scopeId,
     workflowId: activeWorkflowSummary?.workflowId,
@@ -1532,7 +1565,10 @@ const TeamDetailPage: React.FC = () => {
         ? "来自 workflow 更新时间"
         : "当前还没有可见更新时间";
   const activeRunId =
-    lens.currentRun?.runId || focusedOperationalUnit?.latestRun?.runId || "";
+    lens.currentRun?.runId ||
+    lens.playback.currentRunId ||
+    focusedOperationalUnit?.latestRun?.runId ||
+    "";
   const currentRevisionId = trimText(lens.activeRevision?.revisionId) || "--";
   const currentRevisionStatus =
     trimText(lens.activeRevision?.servingState) ||
@@ -3370,6 +3406,7 @@ const TeamDetailPage: React.FC = () => {
         onOpenAudit={() =>
           handleOpenPlaybackActor(lens.currentRun?.actorId, activeRunId)
         }
+        onOpenMissionControl={handleOpenMissionControl}
         onSelectRun={handleSelectRun}
         openAuditButtonStyle={resolveActionButtonStyle(token)}
         playbackSummary={formatPlaybackSummary(lens.playback.summary)}
@@ -3377,6 +3414,7 @@ const TeamDetailPage: React.FC = () => {
         provenanceStyle={resolveObservationPillStyle(token, playbackProvenance.status)}
         runSwitchOptions={runSwitchDisplayOptions}
         showOpenAudit={Boolean(activeRunId)}
+        showOpenMissionControl={Boolean(activeRunId)}
       />
     );
   };

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1486,6 +1486,11 @@ const TeamDetailPage: React.FC = () => {
     [lens.playback.currentRunId, lens.playback.rootActorId, runtimeServiceId, scopeId],
   );
 
+  const missionControlPrompt =
+    trimText(lens.currentRunAudit?.audit.input) ||
+    trimText(lens.playback.launchPrompt) ||
+    trimText(lens.playback.prompt);
+
   const handleOpenMissionControl = React.useCallback(() => {
     const runId =
       trimText(lens.currentRun?.runId) || trimText(lens.playback.currentRunId);
@@ -1502,7 +1507,9 @@ const TeamDetailPage: React.FC = () => {
     history.push(
       buildRuntimeMissionControlHref({
         actorId,
+        autoStream: Boolean(missionControlPrompt),
         endpointId: "chat",
+        prompt: missionControlPrompt || undefined,
         runId,
         scopeId,
         serviceId: runtimeServiceId,
@@ -1514,6 +1521,7 @@ const TeamDetailPage: React.FC = () => {
     lens.graph.focusActorId,
     lens.playback.currentRunId,
     lens.playback.rootActorId,
+    missionControlPrompt,
     runtimeServiceId,
     scopeId,
   ]);
@@ -3414,7 +3422,7 @@ const TeamDetailPage: React.FC = () => {
         provenanceStyle={resolveObservationPillStyle(token, playbackProvenance.status)}
         runSwitchOptions={runSwitchDisplayOptions}
         showOpenAudit={Boolean(activeRunId)}
-        showOpenMissionControl={Boolean(activeRunId)}
+        showOpenMissionControl={Boolean(activeRunId && missionControlPrompt)}
       />
     );
   };

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamEventsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamEventsTab.tsx
@@ -50,6 +50,7 @@ type TeamEventsTabProps = {
   readonly isRunsLoading: boolean;
   readonly memberMappingRows: readonly MemberMappingRow[];
   readonly onOpenAudit: () => void;
+  readonly onOpenMissionControl: () => void;
   readonly onSelectRun: (runId: string) => void;
   readonly openAuditButtonStyle: React.CSSProperties;
   readonly playbackSummary: string;
@@ -57,6 +58,7 @@ type TeamEventsTabProps = {
   readonly provenanceStyle: React.CSSProperties;
   readonly runSwitchOptions: readonly RunSwitchOption[];
   readonly showOpenAudit: boolean;
+  readonly showOpenMissionControl: boolean;
 };
 
 const TeamEventsTab: React.FC<TeamEventsTabProps> = ({
@@ -69,6 +71,7 @@ const TeamEventsTab: React.FC<TeamEventsTabProps> = ({
   isRunsLoading,
   memberMappingRows,
   onOpenAudit,
+  onOpenMissionControl,
   onSelectRun,
   openAuditButtonStyle,
   playbackSummary,
@@ -76,6 +79,7 @@ const TeamEventsTab: React.FC<TeamEventsTabProps> = ({
   provenanceStyle,
   runSwitchOptions,
   showOpenAudit,
+  showOpenMissionControl,
 }) => {
   const { token } = theme.useToken();
 
@@ -166,11 +170,22 @@ const TeamEventsTab: React.FC<TeamEventsTabProps> = ({
                   </div>
                 ) : null}
               </div>
-              {showOpenAudit ? (
+              {showOpenAudit || showOpenMissionControl ? (
                 <Space wrap>
-                  <Button onClick={onOpenAudit} style={openAuditButtonStyle}>
-                    打开完整审计
-                  </Button>
+                  {showOpenMissionControl ? (
+                    <Button
+                      onClick={onOpenMissionControl}
+                      style={openAuditButtonStyle}
+                      type="primary"
+                    >
+                      打开 Mission Control
+                    </Button>
+                  ) : null}
+                  {showOpenAudit ? (
+                    <Button onClick={onOpenAudit} style={openAuditButtonStyle}>
+                      打开完整审计
+                    </Button>
+                  ) : null}
                 </Space>
               ) : null}
             </div>

--- a/apps/aevatar-console-web/src/routesConfig.test.ts
+++ b/apps/aevatar-console-web/src/routesConfig.test.ts
@@ -48,7 +48,8 @@ describe("console routes", () => {
     expect(findRoute(routes, "/teams").hideInMenu).toBe(false);
     expect(findRoute(routes, "/studio").hideInMenu).toBe(true);
     expect(findRoute(routes, "/chat").hideInMenu).toBe(true);
-    expect(findRoute(routes, "/runtime/runs").hideInMenu).toBe(true);
+    expect(findRoute(routes, "/runtime/runs").hideInMenu).toBeUndefined();
+    expect(findRoute(routes, "/runtime/runs").menuGroupKey).toBe("platform");
     expect(findRoute(routes, "/scopes/overview").hideInMenu).toBe(true);
     expect(findRoute(routes, "/teams").name).toBe("My Teams");
     expect(findRoute(routes, "/teams").component).toBe("./teams");
@@ -71,6 +72,7 @@ describe("console routes", () => {
     expect(findRoute(routes, "/gagents").redirect).toBe("/runtime/gagents");
     expect(hasRoute(routes, "/mission-control")).toBe(true);
     expect(findRoute(routes, "/mission-control").redirect).toBe("/runtime/mission-control");
+    expect(findRoute(routes, "/runtime/mission-control").hideInMenu).toBe(true);
     expect(findRoute(routes, "/runtime/explorer").menuGroupKey).toBe("platform");
     expect(findRoute(routes, "/runtime/explorer/detail").hideInMenu).toBe(true);
     expect(findRoute(routes, "/runtime/explorer/detail").parentKeys).toEqual([

--- a/apps/aevatar-console-web/src/shared/navigation/runtimeRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/runtimeRoutes.test.ts
@@ -1,5 +1,6 @@
 import {
   buildRuntimeExplorerHref,
+  buildRuntimeMissionControlHref,
   buildRuntimeRunsHref,
 } from './runtimeRoutes';
 
@@ -33,5 +34,30 @@ describe('runtimeRoutes', () => {
     ).toContain(
       'returnTo=%2Fruntime%2Fexplorer%2Fdetail%3FactorId%3Dactor%253A%252F%252Fselected%26runId%3Drun-1',
     );
+  });
+
+  it('builds Mission Control deep links with live run context', () => {
+    expect(
+      buildRuntimeMissionControlHref({
+        actorId: 'actor://selected',
+        autoStream: false,
+        endpointId: 'chat',
+        prompt: 'inspect this run',
+        runId: 'run-1',
+        scopeId: 'scope-a',
+        serviceId: 'draft',
+      }),
+    ).toBe(
+      '/runtime/mission-control?actorId=actor%3A%2F%2Fselected&autoStream=false&endpointId=chat&prompt=inspect+this+run&runId=run-1&scopeId=scope-a&serviceId=draft',
+    );
+  });
+
+  it('omits empty Mission Control query values', () => {
+    expect(
+      buildRuntimeMissionControlHref({
+        runId: 'run-1',
+        scopeId: 'scope-a',
+      }),
+    ).toBe('/runtime/mission-control?runId=run-1&scopeId=scope-a');
   });
 });

--- a/apps/aevatar-console-web/src/shared/navigation/runtimeRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/runtimeRoutes.ts
@@ -2,6 +2,7 @@ const runtimePaths = {
   workflows: "/runtime/workflows",
   primitives: "/runtime/primitives",
   runs: "/runtime/runs",
+  missionControl: "/runtime/mission-control",
   explorer: "/runtime/explorer",
   explorerDetail: "/runtime/explorer/detail",
   gagents: "/runtime/gagents",
@@ -72,6 +73,28 @@ export function buildRuntimeRunsHref(options?: {
     actorId: options?.actorId,
     draftKey: options?.draftKey,
     returnTo: options?.returnTo,
+  });
+}
+
+export function buildRuntimeMissionControlHref(options?: {
+  actorId?: string;
+  autoStream?: boolean;
+  endpointId?: string;
+  prompt?: string;
+  runId?: string;
+  scopeId?: string;
+  serviceId?: string;
+  serviceOverrideId?: string;
+}): string {
+  return buildHref(runtimePaths.missionControl, {
+    actorId: options?.actorId,
+    autoStream:
+      options?.autoStream === undefined ? undefined : String(options.autoStream),
+    endpointId: options?.endpointId,
+    prompt: options?.prompt,
+    runId: options?.runId,
+    scopeId: options?.scopeId,
+    serviceId: options?.serviceId ?? options?.serviceOverrideId,
   });
 }
 


### PR DESCRIPTION
## Summary
- Promote Event Stream into the Platform navigation as the main runtime operator entry.
- Add Mission Control deep-link helpers and contextual entry points from Team Detail and active Event Stream runs.
- Add Mission Control recovery actions back to Event Stream or Team context when opened without a live run.

## Validation
- npm --prefix apps/aevatar-console-web test -- --runTestsByPath src/shared/navigation/runtimeRoutes.test.ts src/routesConfig.test.ts src/pages/runs/index.test.tsx src/pages/teams/detail.test.tsx --runInBand
- npm --prefix apps/aevatar-console-web run tsc

## Related Issue
Closes #318