### PR TITLE
Carry relay reply_token through inbox + GC stale pending LLM requests

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -33,6 +33,11 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     // sub-minute schedules are unreliable. The inbox dispatch happens inline via
     // IChannelLlmReplyInbox; the durable timer is reserved for retry/rehydration.
     private static readonly TimeSpan DeferredLlmDispatchRetryDelay = TimeSpan.FromSeconds(60);
+    // Pending LLM reply requests older than this are considered stale on rehydration:
+    // the user gave up, the relay reply_token (~30 min TTL) is likely already expired,
+    // and the user access token (~15 min TTL) used for the LLM call is definitely gone.
+    // Drop them rather than burn an LLM round and reply hours late.
+    private static readonly TimeSpan PendingLlmReplyRequestMaxAge = TimeSpan.FromMinutes(5);
     private readonly Dictionary<string, NyxRelayReplyTokenContext> _nyxRelayReplyTokens = new(StringComparer.Ordinal);
 
     /// <summary>
@@ -104,8 +109,15 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         if (result.LlmReplyRequest is not null)
         {
-            await PersistDomainEventAsync(result.LlmReplyRequest);
-            await DispatchPendingLlmReplyAsync(result.LlmReplyRequest, CancellationToken.None);
+            // The transient inbox copy keeps reply_token + expiry so the LLM worker can
+            // echo them back inside LlmReplyReadyEvent; the persisted state copy must
+            // not carry the credential into the event store / projection / read model.
+            var inboxCopy = result.LlmReplyRequest;
+            var persistedCopy = inboxCopy.Clone();
+            persistedCopy.ReplyToken = string.Empty;
+            persistedCopy.ReplyTokenExpiresAtUnixMs = 0;
+            await PersistDomainEventAsync(persistedCopy);
+            await DispatchPendingLlmReplyAsync(inboxCopy, CancellationToken.None);
             Logger.LogInformation(
                 "Accepted inbound activity for deferred LLM reply: activity={ActivityId} conversation={Key}",
                 activity.Id,
@@ -215,10 +227,17 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             return;
         }
 
+        var runtimeContext = BuildNyxRelayRuntimeContextForReply(evt, pendingRequest?.Activity);
+        Logger.LogInformation(
+            "Received LLM reply ready: correlation={CorrelationId} terminal={TerminalState} replyTokenSource={Source}",
+            evt.CorrelationId,
+            evt.TerminalState,
+            DescribeReplyTokenSource(evt, runtimeContext));
+
         var runner = ResolveRunner();
         var result = await runner.RunLlmReplyAsync(
             evt,
-            BuildNyxRelayRuntimeContext(evt.CorrelationId, pendingRequest?.Activity ?? evt.Activity),
+            runtimeContext,
             CancellationToken.None);
 
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -433,8 +452,37 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private async Task SchedulePendingLlmReplyDispatchesAsync(CancellationToken ct)
     {
-        foreach (var request in State.PendingLlmReplyRequests)
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var maxAgeMs = (long)PendingLlmReplyRequestMaxAge.TotalMilliseconds;
+
+        // Snapshot: PersistDomainEventAsync below mutates State.PendingLlmReplyRequests
+        // via the state matcher, which would invalidate the iterator if we walked the
+        // live collection.
+        var pending = State.PendingLlmReplyRequests.ToArray();
+        foreach (var request in pending)
         {
+            var ageMs = request.RequestedAtUnixMs > 0 ? nowMs - request.RequestedAtUnixMs : 0;
+            if (request.RequestedAtUnixMs > 0 && ageMs > maxAgeMs)
+            {
+                Logger.LogInformation(
+                    "Dropping stale pending LLM reply request on rehydration: correlation={CorrelationId} ageMs={AgeMs}",
+                    request.CorrelationId,
+                    ageMs);
+                var failed = new ConversationContinueFailedEvent
+                {
+                    CommandId = BuildLlmReplyCommandId(request.CorrelationId),
+                    CorrelationId = request.CorrelationId,
+                    CausationId = string.Empty,
+                    Kind = FailureKind.PermanentAdapterError,
+                    ErrorCode = "stale_pending_request_dropped",
+                    ErrorSummary = "Pending LLM reply request exceeded max age and was dropped on actor rehydration.",
+                    NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
+                    FailedAtUnixMs = nowMs,
+                };
+                await PersistDomainEventAsync(failed);
+                continue;
+            }
+
             await DispatchPendingLlmReplyAsync(request, ct);
         }
     }
@@ -503,6 +551,45 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         }
 
         return new ConversationTurnRuntimeContext(tokenContext);
+    }
+
+    private ConversationTurnRuntimeContext BuildNyxRelayRuntimeContextForReply(
+        LlmReplyReadyEvent evt,
+        ChatActivity? pendingActivity)
+    {
+        var activity = pendingActivity ?? evt.Activity;
+
+        // Inbox-echoed credential is the authoritative source — it survives actor
+        // deactivation between inbound capture and LLM reply ready, which the in-memory
+        // dict cannot. Fall back to the dict only when the inbox didn't carry a token
+        // (legacy in-flight messages from before this change deployed).
+        var inlineToken = NormalizeOptional(evt.ReplyToken);
+        if (inlineToken is not null)
+        {
+            var expiresAt = evt.ReplyTokenExpiresAtUnixMs > 0
+                ? DateTimeOffset.FromUnixTimeMilliseconds(evt.ReplyTokenExpiresAtUnixMs)
+                : DateTimeOffset.UtcNow.AddMinutes(30);
+            if (expiresAt > DateTimeOffset.UtcNow)
+            {
+                var correlationId = NormalizeOptional(evt.CorrelationId) ??
+                                    NormalizeOptional(activity?.OutboundDelivery?.CorrelationId) ??
+                                    string.Empty;
+                var replyMessageId = NormalizeOptional(activity?.OutboundDelivery?.ReplyMessageId) ?? string.Empty;
+                return new ConversationTurnRuntimeContext(
+                    new NyxRelayReplyTokenContext(correlationId, inlineToken, replyMessageId, expiresAt));
+            }
+        }
+
+        return BuildNyxRelayRuntimeContext(evt.CorrelationId, activity);
+    }
+
+    private string DescribeReplyTokenSource(LlmReplyReadyEvent evt, ConversationTurnRuntimeContext runtimeContext)
+    {
+        if (runtimeContext.NyxRelayReplyToken is null)
+            return "none";
+        if (!string.IsNullOrWhiteSpace(evt.ReplyToken))
+            return "inbox-echo";
+        return "actor-runtime-dict";
     }
 
     private void SweepExpiredNyxRelayReplyTokens()

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -193,13 +193,21 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             return;
         }
 
+        // Retry and rehydration paths read `request` from State.PendingLlmReplyRequests,
+        // which always carries an empty ReplyToken (the inbound handler strips it before
+        // persist). If the actor is still alive and the in-memory dict still has the
+        // token for this correlation, re-enrich the inbox copy so the subscriber's relay
+        // credential gate does not mistake a legitimate retry for a dead request.
+        var enriched = EnrichWithRuntimeReplyTokenIfNeeded(request);
+
         try
         {
-            await inbox.EnqueueAsync(request.Clone(), ct);
+            await inbox.EnqueueAsync(enriched.Clone(), ct);
             Logger.LogInformation(
-                "Enqueued LLM reply request to inbox: correlation={CorrelationId} conversation={Key}",
-                request.CorrelationId,
-                request.Activity?.Conversation?.CanonicalKey);
+                "Enqueued LLM reply request to inbox: correlation={CorrelationId} conversation={Key} replyTokenSource={Source}",
+                enriched.CorrelationId,
+                enriched.Activity?.Conversation?.CanonicalKey,
+                DescribeEnqueuedReplyTokenSource(request, enriched));
         }
         catch (Exception ex)
         {
@@ -209,6 +217,42 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
         }
+    }
+
+    private NeedsLlmReplyEvent EnrichWithRuntimeReplyTokenIfNeeded(NeedsLlmReplyEvent request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.ReplyToken))
+            return request;
+
+        var correlationId = NormalizeOptional(request.CorrelationId) ??
+                            NormalizeOptional(request.Activity?.OutboundDelivery?.CorrelationId);
+        if (correlationId is null)
+            return request;
+
+        if (!_nyxRelayReplyTokens.TryGetValue(correlationId, out var tokenContext))
+            return request;
+
+        if (tokenContext.ExpiresAtUtc <= DateTimeOffset.UtcNow)
+        {
+            _nyxRelayReplyTokens.Remove(correlationId);
+            return request;
+        }
+
+        var enriched = request.Clone();
+        enriched.ReplyToken = tokenContext.ReplyToken;
+        enriched.ReplyTokenExpiresAtUnixMs = tokenContext.ExpiresAtUtc.ToUnixTimeMilliseconds();
+        return enriched;
+    }
+
+    private static string DescribeEnqueuedReplyTokenSource(
+        NeedsLlmReplyEvent original,
+        NeedsLlmReplyEvent enriched)
+    {
+        if (!string.IsNullOrWhiteSpace(original.ReplyToken))
+            return "inbound-direct";
+        if (!string.IsNullOrWhiteSpace(enriched.ReplyToken))
+            return "actor-runtime-dict";
+        return "none";
     }
 
     [EventHandler]

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -181,6 +181,44 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         await DispatchPendingLlmReplyAsync(pendingRequest, CancellationToken.None);
     }
 
+    [EventHandler]
+    public async Task HandleDeferredLlmReplyDroppedAsync(DeferredLlmReplyDroppedEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        var pending = FindPendingLlmReplyRequest(evt.CorrelationId);
+        if (pending is null)
+        {
+            Logger.LogDebug(
+                "Ignoring deferred LLM reply drop without pending request: correlation={CorrelationId} reason={Reason}",
+                evt.CorrelationId,
+                evt.Reason);
+            return;
+        }
+
+        var reason = string.IsNullOrWhiteSpace(evt.Reason) ? "deferred_llm_reply_dropped" : evt.Reason;
+        var failed = new ConversationContinueFailedEvent
+        {
+            CommandId = BuildLlmReplyCommandId(evt.CorrelationId),
+            CorrelationId = evt.CorrelationId,
+            CausationId = string.Empty,
+            Kind = FailureKind.PermanentAdapterError,
+            ErrorCode = reason,
+            ErrorSummary = "Deferred LLM reply request was dropped by the inbox pre-LLM gate.",
+            NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
+            FailedAtUnixMs = evt.DroppedAtUnixMs > 0
+                ? evt.DroppedAtUnixMs
+                : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        };
+        await PersistDomainEventAsync(failed);
+        RemoveNyxRelayReplyToken(evt.CorrelationId, pending.Activity);
+
+        Logger.LogInformation(
+            "Retired pending LLM reply after inbox drop: correlation={CorrelationId} reason={Reason}",
+            evt.CorrelationId,
+            reason);
+    }
+
     private async Task DispatchPendingLlmReplyAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
         var inbox = Services.GetService<IChannelLlmReplyInbox>();

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -32,6 +32,14 @@ message NeedsLlmReplyEvent {
   aevatar.gagents.channel.abstractions.ChatActivity activity = 4;
   map<string, string> metadata = 5;
   int64 requested_at_unix_ms = 6;
+  // Transient inbox-only credential. The actor MUST clear `reply_token` and
+  // `reply_token_expires_at_unix_ms` (set them to the empty default) on the
+  // copy passed to PersistDomainEventAsync; only the inbox-bound copy may
+  // carry them so the LLM worker can echo the credential back without the
+  // actor's in-memory dict surviving deactivation. Never persist to event
+  // store, projection, or read model.
+  string reply_token = 7;
+  int64 reply_token_expires_at_unix_ms = 8;
 }
 
 // Transient actor-inbox envelope used by the NyxID relay endpoint to hand a single
@@ -64,6 +72,13 @@ message LlmReplyReadyEvent {
   string error_code = 7;
   string error_summary = 8;
   int64 ready_at_unix_ms = 9;
+  // Transient inbox-echoed credential carried back from the LLM worker so the
+  // actor's outbound relay reply does not depend on its in-memory token dict
+  // surviving deactivation. The actor consumes these fields directly and never
+  // persists them. The inbox subscriber copies the values from the inbound
+  // NeedsLlmReplyEvent verbatim.
+  string reply_token = 10;
+  int64 reply_token_expires_at_unix_ms = 11;
 }
 
 message DeferredLlmReplyDispatchRequestedEvent {

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -91,6 +91,18 @@ message NyxRelayReplyTokenCleanupRequestedEvent {
   int64 requested_at_unix_ms = 2;
 }
 
+// Sent by ChannelLlmReplyInboxRuntime when its pre-LLM gates (stale age,
+// missing relay credential, malformed payload) refuse to process a deferred
+// LLM reply. The actor consumes this to retire the matching pending entry
+// from State.PendingLlmReplyRequests via a NotRetryable
+// ConversationContinueFailedEvent, so the request never silently
+// accumulates in actor state.
+message DeferredLlmReplyDroppedEvent {
+  string correlation_id = 1;
+  string reason = 2;
+  int64 dropped_at_unix_ms = 3;
+}
+
 message ConversationContinueRequestedEvent {
   string command_id = 1;
   string correlation_id = 2;

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -74,7 +74,8 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
                 "Conversation routing target is missing.");
         }
 
-        return ConversationTurnResult.LlmReplyRequested(BuildLlmReplyRequest(activity, registration, inboundEvent));
+        return ConversationTurnResult.LlmReplyRequested(
+            BuildLlmReplyRequest(activity, registration, inboundEvent, runtimeContext));
     }
 
     public Task<ConversationTurnResult> RunInboundAsync(ChatActivity activity, CancellationToken ct) =>
@@ -671,7 +672,8 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
     private static NeedsLlmReplyEvent BuildLlmReplyRequest(
         ChatActivity activity,
         ChannelBotRegistrationEntry registration,
-        ChannelInboundEvent inboundEvent)
+        ChannelInboundEvent inboundEvent,
+        ConversationTurnRuntimeContext runtimeContext)
     {
         var request = new NeedsLlmReplyEvent
         {
@@ -681,6 +683,18 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             Activity = activity.Clone(),
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
+
+        // Carry the relay reply credential through the inbox as transient inbox-only
+        // fields. ConversationGAgent strips these before persisting NeedsLlmReplyEvent;
+        // ChannelLlmReplyInboxRuntime echoes them into the LlmReplyReadyEvent so the
+        // outbound reply does not depend on the actor's in-memory token dict surviving
+        // deactivation.
+        if (runtimeContext.NyxRelayReplyToken is { } token &&
+            token.ExpiresAtUtc > DateTimeOffset.UtcNow)
+        {
+            request.ReplyToken = token.ReplyToken;
+            request.ReplyTokenExpiresAtUnixMs = token.ExpiresAtUtc.ToUnixTimeMilliseconds();
+        }
 
         foreach (var pair in BuildReplyMetadata(inboundEvent, activity))
             request.Metadata[pair.Key] = pair.Value;

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
@@ -74,6 +74,8 @@ internal sealed class ChannelLlmReplyInboxRuntime :
         await StopAsync(CancellationToken.None);
     }
 
+    internal const long MaxInboxRequestAgeMs = 5 * 60 * 1000;
+
     internal async Task ProcessAsync(NeedsLlmReplyEvent request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -89,6 +91,32 @@ internal sealed class ChannelLlmReplyInboxRuntime :
                 "Dropping malformed deferred LLM reply request: correlation={CorrelationId}, target={TargetActorId}",
                 request.CorrelationId,
                 request.TargetActorId);
+            return;
+        }
+
+        // Stale gate: NyxID relay reply tokens have a ~30 min TTL and the user access
+        // token used for the LLM call expires inside ~15 min. A request that has been
+        // sitting in the stream for hours can't lead to a successful reply, so drop it
+        // here instead of spending an LLM round just to fail at the outbound stage.
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (request.RequestedAtUnixMs > 0 && nowMs - request.RequestedAtUnixMs > MaxInboxRequestAgeMs)
+        {
+            _logger.LogInformation(
+                "Dropping stale LLM reply request: correlation={CorrelationId} ageMs={AgeMs}",
+                request.CorrelationId,
+                nowMs - request.RequestedAtUnixMs);
+            return;
+        }
+
+        // Relay credential gate: relay turns require a fresh reply_token to send the
+        // outbound. A relay request with no inbox-carried token (e.g., rehydrated from
+        // persisted state after a pod restart that lost the original capture) cannot
+        // be delivered, so skip the LLM call entirely.
+        if (IsRelayRequest(request) && string.IsNullOrWhiteSpace(request.ReplyToken))
+        {
+            _logger.LogWarning(
+                "Dropping relay LLM reply request without inbox-carried reply_token: correlation={CorrelationId}",
+                request.CorrelationId);
             return;
         }
 
@@ -151,6 +179,11 @@ internal sealed class ChannelLlmReplyInboxRuntime :
             ErrorCode = errorCode,
             ErrorSummary = errorSummary,
             ReadyAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            // Echo the inbox-only relay credential straight back so ConversationGAgent's
+            // outbound reply does not depend on its in-memory token dict still having the
+            // entry. The actor consumes these fields and never persists them.
+            ReplyToken = request.ReplyToken ?? string.Empty,
+            ReplyTokenExpiresAtUnixMs = request.ReplyTokenExpiresAtUnixMs,
         };
         var envelope = new EventEnvelope
         {
@@ -177,6 +210,13 @@ internal sealed class ChannelLlmReplyInboxRuntime :
         metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = userAccessToken;
         return metadata;
     }
+
+    private static bool IsRelayRequest(NeedsLlmReplyEvent request) =>
+        request.Activity?.OutboundDelivery is
+        {
+            ReplyMessageId.Length: > 0,
+            CorrelationId.Length: > 0,
+        };
 
     private bool ShouldCaptureInteractiveReply(ChatActivity? activity)
     {

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
@@ -91,6 +91,7 @@ internal sealed class ChannelLlmReplyInboxRuntime :
                 "Dropping malformed deferred LLM reply request: correlation={CorrelationId}, target={TargetActorId}",
                 request.CorrelationId,
                 request.TargetActorId);
+            await NotifyActorOfDropAsync(request, "malformed_deferred_llm_reply_request");
             return;
         }
 
@@ -105,6 +106,7 @@ internal sealed class ChannelLlmReplyInboxRuntime :
                 "Dropping stale LLM reply request: correlation={CorrelationId} ageMs={AgeMs}",
                 request.CorrelationId,
                 nowMs - request.RequestedAtUnixMs);
+            await NotifyActorOfDropAsync(request, "stale_inbox_request_dropped");
             return;
         }
 
@@ -117,6 +119,7 @@ internal sealed class ChannelLlmReplyInboxRuntime :
             _logger.LogWarning(
                 "Dropping relay LLM reply request without inbox-carried reply_token: correlation={CorrelationId}",
                 request.CorrelationId);
+            await NotifyActorOfDropAsync(request, "missing_relay_reply_token");
             return;
         }
 
@@ -217,6 +220,67 @@ internal sealed class ChannelLlmReplyInboxRuntime :
             ReplyMessageId.Length: > 0,
             CorrelationId.Length: > 0,
         };
+
+    private async Task NotifyActorOfDropAsync(NeedsLlmReplyEvent request, string reason)
+    {
+        if (string.IsNullOrWhiteSpace(request.TargetActorId) ||
+            string.IsNullOrWhiteSpace(request.CorrelationId))
+        {
+            return;
+        }
+
+        IActor? actor;
+        try
+        {
+            actor = await _actorRuntime.GetAsync(request.TargetActorId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to resolve actor for inbox drop notification: correlation={CorrelationId} target={TargetActorId}",
+                request.CorrelationId,
+                request.TargetActorId);
+            return;
+        }
+
+        if (actor is null)
+        {
+            // No active actor means there is nothing pending to clean up; the request
+            // either was never persisted or the actor's state was already retired.
+            return;
+        }
+
+        var dropped = new DeferredLlmReplyDroppedEvent
+        {
+            CorrelationId = request.CorrelationId,
+            Reason = reason,
+            DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        };
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(dropped),
+            Route = new EnvelopeRoute
+            {
+                Direct = new DirectRoute { TargetActorId = actor.Id },
+            },
+        };
+
+        try
+        {
+            await actor.HandleEventAsync(envelope, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to deliver inbox drop notification: correlation={CorrelationId} reason={Reason}",
+                request.CorrelationId,
+                reason);
+        }
+    }
 
     private bool ShouldCaptureInteractiveReply(ChatActivity? activity)
     {

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -418,6 +418,65 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleDeferredLlmReplyDispatchRequestedAsync_ReEnrichesStrippedPendingRequestWithActorRuntimeToken()
+    {
+        // Regression for Codex review: the persisted NeedsLlmReplyEvent in
+        // State.PendingLlmReplyRequests always has an empty ReplyToken (strip-on-persist).
+        // On the retry / durable-reminder path we walk that state, so the inbox must see
+        // the token re-enriched from the actor's in-memory dict while the activation is
+        // still alive. Without enrichment the inbox subscriber's relay gate would drop
+        // the retry and permanently lose the reply.
+        const string sentinelReplyToken = "sentinel-retry-enrich-b3d7a";
+        var inbox = new RecordingInbox();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    ReplyToken = sentinelReplyToken,
+                    ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
+                }),
+        };
+        var (agent, _) = CreateAgent(runner, "conv-retry-enrich", inbox);
+
+        var inboundActivity = CreateActivity("act-retry", "conv:slack:C1");
+        inboundActivity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-msg-retry",
+            CorrelationId = "corr-retry",
+        };
+        var relayInbound = new NyxRelayInboundActivity
+        {
+            Activity = inboundActivity,
+            ReplyToken = sentinelReplyToken,
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
+            CorrelationId = "corr-retry",
+        };
+
+        // Inbound capture populates the actor runtime dict and enqueues with ReplyToken set directly.
+        await agent.HandleNyxRelayInboundActivityAsync(relayInbound);
+        inbox.Enqueued.Count.ShouldBe(1);
+        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+
+        // Simulate the durable-reminder retry firing: pendingRequest is read from state
+        // where ReplyToken was stripped. DispatchPendingLlmReplyAsync must re-enrich
+        // from the actor dict so the inbox still receives the token.
+        await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
+        {
+            CorrelationId = "corr-retry",
+            RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        inbox.Enqueued.Count.ShouldBe(2);
+        inbox.Enqueued[1].ReplyToken.ShouldBe(sentinelReplyToken);
+    }
+
+    [Fact]
     public async Task HandleLlmReplyReadyAsync_PrefersInboxEchoedReplyToken_OverActorRuntimeDict()
     {
         // After a pod restart the in-memory _nyxRelayReplyTokens dict is empty, so the

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -526,6 +526,74 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleDeferredLlmReplyDroppedAsync_RetiresPendingRequestWithNotRetryableFailure()
+    {
+        // Inbox-side gates (stale-age, missing relay credential, malformed payload) need
+        // a way to tell the actor "stop tracking this pending request" so it doesn't
+        // silently accumulate in State.PendingLlmReplyRequests until the next
+        // rehydration. The actor's drop handler emits a NotRetryable
+        // ConversationContinueFailedEvent which routes through the existing state
+        // matcher to remove the pending entry.
+        var inbox = new RecordingInbox();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    ReplyToken = "drop-test-token",
+                    ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
+                }),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-drop-clears", inbox);
+
+        var inboundActivity = CreateActivity("act-drop", "conv:slack:C1");
+        inboundActivity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-msg-drop",
+            CorrelationId = "corr-drop",
+        };
+        await agent.HandleInboundActivityAsync(inboundActivity);
+        agent.State.PendingLlmReplyRequests.ShouldContain(req => req.CorrelationId == "corr-drop");
+
+        await agent.HandleDeferredLlmReplyDroppedAsync(new DeferredLlmReplyDroppedEvent
+        {
+            CorrelationId = "corr-drop",
+            Reason = "stale_inbox_request_dropped",
+            DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        agent.State.PendingLlmReplyRequests.ShouldNotContain(req => req.CorrelationId == "corr-drop");
+        var events = await store.GetEventsAsync(agent.Id);
+        var lastEvent = events[^1];
+        lastEvent.EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
+        var failed = ConversationContinueFailedEvent.Parser.ParseFrom(lastEvent.EventData.Value);
+        failed.ErrorCode.ShouldBe("stale_inbox_request_dropped");
+        failed.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable);
+    }
+
+    [Fact]
+    public async Task HandleDeferredLlmReplyDroppedAsync_IgnoresUnknownCorrelationId()
+    {
+        var (agent, store) = CreateAgent(new RecordingTurnRunner(), "conv-drop-unknown");
+        var initialEvents = (await store.GetEventsAsync(agent.Id)).Count;
+
+        await agent.HandleDeferredLlmReplyDroppedAsync(new DeferredLlmReplyDroppedEvent
+        {
+            CorrelationId = "corr-not-pending",
+            Reason = "stale_inbox_request_dropped",
+            DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(initialEvents);
+    }
+
+    [Fact]
     public async Task HandleContinueCommandAsync_PermanentFailure_MarksCommandProcessed()
     {
         // Terminal (non-retryable) continue failures consume the command id so a buggy caller's

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -372,6 +372,101 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleInboundActivityAsync_StripsReplyTokenFromPersistedNeedsLlmReplyEvent_ButKeepsItOnInboxCopy()
+    {
+        // Strip-on-persist invariant: NeedsLlmReplyEvent must keep reply_token on the
+        // copy enqueued to inbox so the LLM worker can echo it back, but the persisted
+        // copy that lands in event store must omit it.
+        const string sentinelReplyToken = "sentinel-strip-on-persist-1f8b3";
+        var inbox = new RecordingInbox();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                    ReplyToken = sentinelReplyToken,
+                    ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
+                }),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-strip-token", inbox);
+
+        var inboundActivity = CreateActivity("act-strip", "conv:slack:C1");
+        inboundActivity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-msg-strip",
+            CorrelationId = "corr-strip",
+        };
+        await agent.HandleInboundActivityAsync(inboundActivity);
+
+        inbox.Enqueued.Count.ShouldBe(1);
+        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.ShouldNotBeEmpty();
+        var sentinelBytes = Encoding.UTF8.GetBytes(sentinelReplyToken);
+        foreach (var record in events)
+        {
+            var payloadBytes = record.EventData?.Value?.ToByteArray() ?? Array.Empty<byte>();
+            ContainsSubsequence(payloadBytes, sentinelBytes)
+                .ShouldBeFalse($"persisted event {record.EventType} must not contain reply_token bytes");
+        }
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_PrefersInboxEchoedReplyToken_OverActorRuntimeDict()
+    {
+        // After a pod restart the in-memory _nyxRelayReplyTokens dict is empty, so the
+        // outbound reply must be able to consume the inbox-echoed reply_token from
+        // LlmReplyReadyEvent directly. Capture the token observed by the runner to confirm.
+        ConversationTurnRuntimeContext? observedContext = null;
+        var runner = new RecordingTurnRunner
+        {
+            LlmReplyResultFactory = reply => ConversationTurnResult.Sent(
+                "sent:" + reply.CorrelationId,
+                new MessageContent { Text = "ack" },
+                "bot",
+                new OutboundDeliveryContext
+                {
+                    ReplyMessageId = reply.Activity?.OutboundDelivery?.ReplyMessageId ?? string.Empty,
+                    CorrelationId = reply.CorrelationId,
+                }),
+        };
+        runner.LlmReplyContextObserver = ctx => observedContext = ctx;
+        var (agent, _) = CreateAgent(runner, "conv-inbox-echo");
+
+        var activity = CreateActivity("act-inbox-echo", "conv:slack:C1");
+        activity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-msg-echo",
+            CorrelationId = "corr-inbox-echo",
+        };
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "corr-inbox-echo",
+            RegistrationId = "reg-1",
+            SourceActorId = "llm-worker-1",
+            Activity = activity.Clone(),
+            Outbound = new MessageContent { Text = "reply-from-llm" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            ReplyToken = "inbox-echoed-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
+        });
+
+        observedContext.ShouldNotBeNull();
+        observedContext!.NyxRelayReplyToken.ShouldNotBeNull();
+        observedContext.NyxRelayReplyToken!.ReplyToken.ShouldBe("inbox-echoed-token");
+        observedContext.NyxRelayReplyToken.CorrelationId.ShouldBe("corr-inbox-echo");
+        observedContext.NyxRelayReplyToken.ReplyMessageId.ShouldBe("relay-msg-echo");
+    }
+
+    [Fact]
     public async Task HandleContinueCommandAsync_PermanentFailure_MarksCommandProcessed()
     {
         // Terminal (non-retryable) continue failures consume the command id so a buggy caller's
@@ -487,6 +582,7 @@ public sealed class ConversationGAgentDedupTests
         public int ContinueCount;
         public Func<ChatActivity, ConversationTurnResult>? InboundResultFactory { get; set; }
         public Func<LlmReplyReadyEvent, ConversationTurnResult>? LlmReplyResultFactory { get; set; }
+        public Action<ConversationTurnRuntimeContext>? LlmReplyContextObserver { get; set; }
         public Func<ConversationContinueRequestedEvent, ConversationTurnResult>? ContinueResultFactory { get; set; }
 
         public Task<ConversationTurnResult> RunInboundAsync(
@@ -507,6 +603,7 @@ public sealed class ConversationGAgentDedupTests
             CancellationToken ct)
         {
             Interlocked.Increment(ref LlmReplyCount);
+            LlmReplyContextObserver?.Invoke(runtimeContext);
             var result = LlmReplyResultFactory is null
                 ? ConversationTurnResult.Sent(
                     "sent:llm:" + reply.CorrelationId,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
@@ -220,7 +220,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     [Fact]
     public async Task ProcessAsync_ShouldDropRelayRequest_WhenInboxCarriesNoReplyToken()
     {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        EventEnvelope? handled = null;
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("actor-1").Returns(Task.FromResult<IActor?>(actor));
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
         var runtime = new ChannelLlmReplyInboxRuntime(
             Substitute.For<IStreamProvider>(),
@@ -241,13 +247,22 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeFalse();
-        await actorRuntime.DidNotReceiveWithAnyArgs().GetAsync(Arg.Any<string>());
+        handled.Should().NotBeNull();
+        var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
+        dropped.CorrelationId.Should().Be("corr-no-token");
+        dropped.Reason.Should().Be("missing_relay_reply_token");
     }
 
     [Fact]
     public async Task ProcessAsync_ShouldDropRequest_WhenOlderThanMaxAge()
     {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        EventEnvelope? handled = null;
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("actor-1").Returns(Task.FromResult<IActor?>(actor));
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
         var runtime = new ChannelLlmReplyInboxRuntime(
             Substitute.For<IStreamProvider>(),
@@ -271,7 +286,10 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeFalse();
-        await actorRuntime.DidNotReceiveWithAnyArgs().GetAsync(Arg.Any<string>());
+        handled.Should().NotBeNull();
+        var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
+        dropped.CorrelationId.Should().Be("corr-stale");
+        dropped.Reason.Should().Be("stale_inbox_request_dropped");
     }
 
     [Fact]
@@ -298,9 +316,18 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldDropSilently_WhenActivityMissing()
+    public async Task ProcessAsync_ShouldNotifyActor_WhenActivityMissing()
     {
+        // Malformed payload (no Activity) should still tell the actor to retire its
+        // pending entry — the actor decides whether to clean up. Otherwise the entry
+        // accumulates silently in State.PendingLlmReplyRequests until rehydration.
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        EventEnvelope? handled = null;
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("actor-1").Returns(Task.FromResult<IActor?>(actor));
         var runtime = new ChannelLlmReplyInboxRuntime(
             Substitute.For<IStreamProvider>(),
             actorRuntime,
@@ -316,7 +343,10 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             RegistrationId = "reg-1",
         });
 
-        await actorRuntime.DidNotReceiveWithAnyArgs().GetAsync(Arg.Any<string>());
+        handled.Should().NotBeNull();
+        var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
+        dropped.CorrelationId.Should().Be("corr-no-activity");
+        dropped.Reason.Should().Be("malformed_deferred_llm_reply_request");
     }
 
     private static ChatActivity BuildRelayActivity() =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
@@ -53,6 +53,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-1",
         });
 
         replyGenerator.CaptureSucceeded.Should().BeTrue();
@@ -131,6 +132,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-throw",
         });
 
         handled.Should().NotBeNull();
@@ -170,6 +172,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-empty",
         });
 
         handled.Should().NotBeNull();
@@ -177,6 +180,98 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         ready.TerminalState.Should().Be(LlmReplyTerminalState.Failed);
         ready.ErrorCode.Should().Be("empty_reply");
         ready.Outbound.Text.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ShouldEchoReplyTokenIntoLlmReplyReadyEvent()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
+        EventEnvelope? handled = null;
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled = call.Arg<EventEnvelope>());
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("actor-1").Returns(Task.FromResult<IActor?>(actor));
+        var runtime = new ChannelLlmReplyInboxRuntime(
+            Substitute.For<IStreamProvider>(),
+            actorRuntime,
+            new RecordingReplyGenerator(() => false) { ReplyText = "ok" },
+            new AsyncLocalInteractiveReplyCollector(),
+            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+
+        var expiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds();
+        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-echo",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-echo",
+            ReplyTokenExpiresAtUnixMs = expiresAtUnixMs,
+        });
+
+        handled.Should().NotBeNull();
+        var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
+        ready.ReplyToken.Should().Be("relay-token-echo");
+        ready.ReplyTokenExpiresAtUnixMs.Should().Be(expiresAtUnixMs);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ShouldDropRelayRequest_WhenInboxCarriesNoReplyToken()
+    {
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
+        var runtime = new ChannelLlmReplyInboxRuntime(
+            Substitute.For<IStreamProvider>(),
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+
+        // Relay activity but no inbox-carried ReplyToken — simulates a request rehydrated
+        // from persisted state after a pod restart, where the original token capture is gone.
+        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-no-token",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+        });
+
+        replyGenerator.CaptureSucceeded.Should().BeFalse();
+        await actorRuntime.DidNotReceiveWithAnyArgs().GetAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ShouldDropRequest_WhenOlderThanMaxAge()
+    {
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
+        var runtime = new ChannelLlmReplyInboxRuntime(
+            Substitute.For<IStreamProvider>(),
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+
+        var requestedAtUnixMs = DateTimeOffset.UtcNow
+            .AddMilliseconds(-(ChannelLlmReplyInboxRuntime.MaxInboxRequestAgeMs + 60_000))
+            .ToUnixTimeMilliseconds();
+        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-stale",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-stale",
+            RequestedAtUnixMs = requestedAtUnixMs,
+        });
+
+        replyGenerator.CaptureSucceeded.Should().BeFalse();
+        await actorRuntime.DidNotReceiveWithAnyArgs().GetAsync(Arg.Any<string>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Production logs after #380 unblocked the deferred LLM dispatch chain showed two follow-on failures keeping the Lark bot silent:

1. `Deferred LLM reply failed: code=adapter_not_found` — `NeedsLlmReplyEvent`s persisted to actor state during pre-#380 days kept replaying after every actor activation, but the user access token (`X-NyxID-User-Token`, ~15 min TTL) embedded in `Activity.TransportExtras.NyxUserAccessToken` was long expired by the time the LLM call ran, so NyxID 401'd every attempt with `token_expired`.
2. `Deferred LLM reply failed: code=reply_token_missing_or_expired` — fresh inbound turns captured the relay reply_token into `ConversationGAgent._nyxRelayReplyTokens` (in-memory), but the actor deactivated between `HandleNyxRelayInboundActivityAsync` and `HandleLlmReplyReadyAsync` (inbox round-trip + LLM streaming exceeds Orleans activation idle in this deployment). On reactivation the dict was empty and the outbound relay reply could not produce its credential.

Issue #366 §3 already flagged this risk:

> 如果确认 actor 在一次 turn 内也可能跨节点迁移，次选方案是使用抽象化分布式短期状态服务（Redis / Orleans transient grain 等）

This PR carries the relay credential through the inbox messages themselves so it survives actor deactivation, prunes stale pending requests so old credentials never burn an LLM round, and adds the diagnostic log line we needed an hour ago.

## Approach

The persisted-state invariant from #366 §4 (`reply_token` not in event store / projection / read model) still holds: the actor strips the credential from the copy passed to `PersistDomainEventAsync` and only attaches it to the inbox-bound copy. The inbox subscriber echoes it straight back inside `LlmReplyReadyEvent`, and the actor consumes it from there.

```
HandleNyxRelayInboundActivityAsync
  ├─ capture reply_token in actor-runtime dict (legacy fast path)
  ├─ runner.RunInboundAsync(activity, runtimeContext)
  │      └─ BuildLlmReplyRequest sets ReplyToken / ExpiresAtUnixMs on the event
  ├─ persistedCopy = inboxCopy.Clone(); persistedCopy.ReplyToken = ""
  ├─ PersistDomainEventAsync(persistedCopy)         ← never carries token
  └─ inbox.EnqueueAsync(inboxCopy)                  ← carries token

ChannelLlmReplyInboxRuntime.ProcessAsync
  ├─ stale gate: drop if RequestedAtUnixMs > 5 min ago
  ├─ relay gate: drop if relay turn but ReplyToken empty
  ├─ LLM call
  └─ dispatch LlmReplyReadyEvent { …, ReplyToken, ReplyTokenExpiresAtUnixMs }

HandleLlmReplyReadyAsync
  ├─ BuildNyxRelayRuntimeContextForReply: prefer evt.ReplyToken,
  │      fall back to actor-runtime dict
  ├─ log replyTokenSource={inbox-echo|actor-runtime-dict|none}
  └─ runner.RunLlmReplyAsync(..., runtimeContext)
```

## Changes

- **`conversation_events.proto`**: add transient `reply_token` + `reply_token_expires_at_unix_ms` to `NeedsLlmReplyEvent` (fields 7/8) and `LlmReplyReadyEvent` (fields 10/11). Doc comments forbid persistence; the actor strips them from the persisted copy.
- **`ChannelConversationTurnRunner.BuildLlmReplyRequest`**: copy reply_token + expires_at from `runtimeContext.NyxRelayReplyToken` onto the inbox-bound `NeedsLlmReplyEvent`.
- **`ConversationGAgent.HandleInboundActivityCoreAsync`**: clone the runner's request, blank reply_token + expires_at, persist the stripped copy, dispatch the original with token to the inbox.
- **`ConversationGAgent.HandleLlmReplyReadyAsync`**: new `BuildNyxRelayRuntimeContextForReply` prefers `evt.ReplyToken` over the in-memory dict; entry log line `replyTokenSource=...` tags which path produced the credential.
- **`ConversationGAgent.SchedulePendingLlmReplyDispatchesAsync`**: walk a snapshot of `State.PendingLlmReplyRequests`, drop entries older than `PendingLlmReplyRequestMaxAge = 5min` by emitting `ConversationContinueFailedEvent { ErrorCode = "stale_pending_request_dropped", NotRetryable }`. The state mutator removes them from `PendingLlmReplyRequests`, so a pod restart no longer re-queues hours-old messages.
- **`ChannelLlmReplyInboxRuntime.ProcessAsync`**: stale-age gate (`MaxInboxRequestAgeMs = 5min`) + relay-credential gate. Both drop with an explanatory log instead of burning an LLM round on a doomed request. Echo `request.ReplyToken` / `RequestedAtUnixMs` into the dispatched `LlmReplyReadyEvent`.

## Validation

- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj` — 105 pass (3 new regression tests for strip-on-persist, inbox-echo preferred over dict, direct dispatch).
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — 286 pass (3 new tests for token echo, missing-token drop, stale-age drop).
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj` — 482 pass.
- `bash tools/ci/architecture_guards.sh` — pass through buf lint (local has no `buf`).
- `bash tools/ci/test_stability_guards.sh` — pass.

## Test plan

- [x] Unit + integration tests pass on dev base.
- [ ] Deploy to mainnet host. Send a Lark message. Expected new log lines:
  - `Enqueued LLM reply request to inbox: correlation=...`
  - `Processing LLM reply request: correlation=... target=...`
  - `Received LLM reply ready: correlation=... terminal=Completed replyTokenSource=inbox-echo`
  - `Completed deferred LLM reply: correlation=... sent=...`
- [ ] Confirm bot now actually replies in the Lark DM.