### PR TITLE
Harden NyxId scoped chat guard

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
+++ b/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\Aevatar.AI.LLMProviders.NyxId\Aevatar.AI.LLMProviders.NyxId.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Hosting\Aevatar.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Presentation.AGUI\Aevatar.Presentation.AGUI.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Studio.Application\Aevatar.Studio.Application.csproj" />

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
@@ -3,7 +3,6 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Hosting;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -20,7 +19,6 @@ public static partial class NyxIdChatEndpoints
         string actorId,
         NyxIdChatStreamRequest request,
         [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IGAgentActorStore actorStore,
         [FromServices] IActorEventSubscriptionProvider subscriptionProvider,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -49,7 +47,7 @@ public static partial class NyxIdChatEndpoints
                 return;
             }
 
-            if (!await IsConversationRegisteredAsync(scopeId, actorId, actorStore, ct))
+            if (!IsConversationBoundToScope(scopeId, actorId))
             {
                 await ConversationNotFoundResult().ExecuteAsync(http);
                 return;
@@ -201,7 +199,6 @@ public static partial class NyxIdChatEndpoints
         string actorId,
         NyxIdApprovalRequest request,
         [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IGAgentActorStore actorStore,
         [FromServices] IActorEventSubscriptionProvider subscriptionProvider,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -227,7 +224,7 @@ public static partial class NyxIdChatEndpoints
                 return;
             }
 
-            if (!await IsConversationRegisteredAsync(scopeId, actorId, actorStore, ct))
+            if (!IsConversationBoundToScope(scopeId, actorId))
             {
                 await ConversationNotFoundResult().ExecuteAsync(http);
                 return;

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
@@ -2,6 +2,8 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Hosting;
+using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +20,7 @@ public static partial class NyxIdChatEndpoints
         string actorId,
         NyxIdChatStreamRequest request,
         [FromServices] IActorRuntime actorRuntime,
+        [FromServices] IGAgentActorStore actorStore,
         [FromServices] IActorEventSubscriptionProvider subscriptionProvider,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -29,6 +32,9 @@ public static partial class NyxIdChatEndpoints
 
         try
         {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
             accessToken = ExtractBearerToken(http);
             if (string.IsNullOrWhiteSpace(accessToken))
             {
@@ -40,6 +46,12 @@ public static partial class NyxIdChatEndpoints
             if (string.IsNullOrWhiteSpace(prompt) && request.InputParts is not { Count: > 0 })
             {
                 http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return;
+            }
+
+            if (!await IsConversationRegisteredAsync(scopeId, actorId, actorStore, ct))
+            {
+                await ConversationNotFoundResult().ExecuteAsync(http);
                 return;
             }
 
@@ -189,6 +201,7 @@ public static partial class NyxIdChatEndpoints
         string actorId,
         NyxIdApprovalRequest request,
         [FromServices] IActorRuntime actorRuntime,
+        [FromServices] IGAgentActorStore actorStore,
         [FromServices] IActorEventSubscriptionProvider subscriptionProvider,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -198,6 +211,9 @@ public static partial class NyxIdChatEndpoints
 
         try
         {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
             var accessToken = ExtractBearerToken(http);
             if (string.IsNullOrWhiteSpace(accessToken))
             {
@@ -208,6 +224,12 @@ public static partial class NyxIdChatEndpoints
             if (string.IsNullOrWhiteSpace(request.RequestId))
             {
                 http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return;
+            }
+
+            if (!await IsConversationRegisteredAsync(scopeId, actorId, actorStore, ct))
+            {
+                await ConversationNotFoundResult().ExecuteAsync(http);
                 return;
             }
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Hosting;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -84,6 +85,9 @@ public static partial class NyxIdChatEndpoints
         [FromServices] IGAgentActorStore actorStore,
         CancellationToken ct)
     {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
         // Conversation creation is fail-fast on IGAgentActorStore persistence.
         // NyxId chat depends on the registry being available; there is no
         // degraded mode where a conversation can run without being registered.
@@ -98,6 +102,9 @@ public static partial class NyxIdChatEndpoints
         [FromServices] IGAgentActorStore actorStore,
         CancellationToken ct)
     {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
         try
         {
             var groups = await actorStore.GetAsync(scopeId, ct);
@@ -121,6 +128,12 @@ public static partial class NyxIdChatEndpoints
         [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
+        if (!await IsConversationRegisteredAsync(scopeId, actorId, actorStore, ct))
+            return ConversationNotFoundResult();
+
         await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
         try
         {
@@ -134,6 +147,27 @@ public static partial class NyxIdChatEndpoints
 
         return Results.Ok();
     }
+
+    private static async Task<bool> IsConversationRegisteredAsync(
+        string scopeId,
+        string actorId,
+        IGAgentActorStore actorStore,
+        CancellationToken ct)
+    {
+        var groups = await actorStore.GetAsync(scopeId, ct);
+        return groups.Any(group =>
+            string.Equals(group.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal) &&
+            group.ActorIds.Any(registeredActorId => string.Equals(registeredActorId, actorId, StringComparison.Ordinal)));
+    }
+
+    private static IResult ConversationNotFoundResult() =>
+        Results.Json(
+            new
+            {
+                code = "NYXID_CHAT_CONVERSATION_NOT_FOUND",
+                message = "NyxID chat conversation is not registered in the requested scope.",
+            },
+            statusCode: StatusCodes.Status404NotFound);
 
     private static async Task TryRestoreConversationRegistrationAsync(
         HttpContext http,

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -91,7 +91,7 @@ public static partial class NyxIdChatEndpoints
         // Conversation creation is fail-fast on IGAgentActorStore persistence.
         // NyxId chat depends on the registry being available; there is no
         // degraded mode where a conversation can run without being registered.
-        var actorId = NyxIdChatServiceDefaults.GenerateActorId();
+        var actorId = NyxIdChatServiceDefaults.GenerateActorId(scopeId);
         await actorStore.AddActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
         return Results.Ok(new { actorId });
     }
@@ -131,7 +131,7 @@ public static partial class NyxIdChatEndpoints
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
-        if (!await IsConversationRegisteredAsync(scopeId, actorId, actorStore, ct))
+        if (!IsConversationBoundToScope(scopeId, actorId))
             return ConversationNotFoundResult();
 
         await actorStore.RemoveActorAsync(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId, ct);
@@ -148,17 +148,10 @@ public static partial class NyxIdChatEndpoints
         return Results.Ok();
     }
 
-    private static async Task<bool> IsConversationRegisteredAsync(
+    private static bool IsConversationBoundToScope(
         string scopeId,
-        string actorId,
-        IGAgentActorStore actorStore,
-        CancellationToken ct)
-    {
-        var groups = await actorStore.GetAsync(scopeId, ct);
-        return groups.Any(group =>
-            string.Equals(group.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal) &&
-            group.ActorIds.Any(registeredActorId => string.Equals(registeredActorId, actorId, StringComparison.Ordinal)));
-    }
+        string actorId) =>
+        NyxIdChatServiceDefaults.IsActorIdForScope(actorId, scopeId);
 
     private static IResult ConversationNotFoundResult() =>
         Results.Json(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatServiceDefaults.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatServiceDefaults.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Aevatar.GAgents.NyxidChat;
 
 public static class NyxIdChatServiceDefaults
@@ -9,6 +12,23 @@ public static class NyxIdChatServiceDefaults
     public const string ActorsFileName = "actors";
     public const string ProviderName = "nyxid";
 
-    public static string GenerateActorId() =>
-        $"{ActorIdPrefix}-{Guid.NewGuid():N}";
+    public static string GenerateActorId(string scopeId) =>
+        $"{ActorIdPrefix}-{Guid.NewGuid():N}:scope:{ComputeScopeHash(scopeId)}";
+
+    public static bool IsActorIdForScope(string? actorId, string? scopeId)
+    {
+        if (string.IsNullOrWhiteSpace(actorId) || string.IsNullOrWhiteSpace(scopeId))
+            return false;
+
+        var suffix = $":scope:{ComputeScopeHash(scopeId)}";
+        return actorId.Trim().StartsWith($"{ActorIdPrefix}-", StringComparison.Ordinal) &&
+               actorId.Trim().EndsWith(suffix, StringComparison.Ordinal);
+    }
+
+    private static string ComputeScopeHash(string scopeId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scopeId);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim())))
+            .ToLowerInvariant();
+    }
 }

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -139,7 +139,7 @@ public class NyxIdChatEndpointsCoverageTests
         var actorStore = new StubGAgentActorStore();
         var result = await InvokeResultAsync(
             "HandleCreateConversationAsync",
-            new DefaultHttpContext(),
+            CreateScopedHttpContext(),
             "scope-a",
             actorStore,
             CancellationToken.None);
@@ -158,6 +158,23 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleCreateConversationAsync_ShouldRejectMismatchedAuthenticatedScope()
+    {
+        var actorStore = new StubGAgentActorStore();
+        var result = await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            CreateScopedHttpContext("scope-b"),
+            "scope-a",
+            actorStore,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        response.Body.Should().Contain("SCOPE_ACCESS_DENIED");
+        actorStore.AddedActors.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleCreateConversationAsync_ShouldBubbleFailure_WhenActorRegistrationFails()
     {
         var actorStore = new StubGAgentActorStore
@@ -167,7 +184,7 @@ public class NyxIdChatEndpointsCoverageTests
 
         var act = async () => await InvokeResultAsync(
             "HandleCreateConversationAsync",
-            new DefaultHttpContext(),
+            CreateScopedHttpContext(),
             "scope-a",
             actorStore,
             CancellationToken.None);
@@ -189,7 +206,7 @@ public class NyxIdChatEndpointsCoverageTests
         };
         var result = await InvokeResultAsync(
             "HandleListConversationsAsync",
-            new DefaultHttpContext(),
+            CreateScopedHttpContext(),
             "scope-a",
             actorStore,
             CancellationToken.None);
@@ -206,11 +223,17 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldReturnOk_AndRemoveActor()
     {
-        var actorStore = new StubGAgentActorStore();
+        var actorStore = new StubGAgentActorStore
+        {
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+            ],
+        };
         var historyStore = new StubChatHistoryStore();
         var result = await InvokeResultAsync(
             "HandleDeleteConversationAsync",
-            new DefaultHttpContext(),
+            CreateScopedHttpContext(),
             "scope-a",
             "actor-1",
             actorStore,
@@ -229,17 +252,48 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleDeleteConversationAsync_ShouldReturnNotFound_WhenConversationIsNotRegisteredInScope()
+    {
+        var actorStore = new StubGAgentActorStore
+        {
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-other"]),
+            ],
+        };
+        var historyStore = new StubChatHistoryStore();
+        var result = await InvokeResultAsync(
+            "HandleDeleteConversationAsync",
+            CreateScopedHttpContext(),
+            "scope-a",
+            "actor-1",
+            actorStore,
+            historyStore,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        response.Body.Should().Contain("NYXID_CHAT_CONVERSATION_NOT_FOUND");
+        actorStore.RemovedActors.Should().BeEmpty();
+        historyStore.DeletedConversations.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleDeleteConversationAsync_ShouldBubbleFailure_WhenActorRemovalFails()
     {
         var actorStore = new StubGAgentActorStore
         {
             RemoveActorException = new InvalidOperationException("actor store unavailable"),
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+            ],
         };
         var historyStore = new StubChatHistoryStore();
 
         var act = async () => await InvokeResultAsync(
             "HandleDeleteConversationAsync",
-            new DefaultHttpContext(),
+            CreateScopedHttpContext(),
             "scope-a",
             "actor-1",
             actorStore,
@@ -254,7 +308,13 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldRestoreActorRegistration_WhenHistoryDeleteFails()
     {
-        var actorStore = new StubGAgentActorStore();
+        var actorStore = new StubGAgentActorStore
+        {
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+            ],
+        };
         var historyStore = new StubChatHistoryStore
         {
             DeleteConversationException = new InvalidOperationException("history unavailable"),
@@ -262,7 +322,7 @@ public class NyxIdChatEndpointsCoverageTests
 
         var act = async () => await InvokeResultAsync(
             "HandleDeleteConversationAsync",
-            new DefaultHttpContext(),
+            CreateScopedHttpContext(),
             "scope-a",
             "actor-1",
             actorStore,
@@ -284,7 +344,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleStreamMessageAsync_ShouldRejectWithoutAuthorization()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer";
         var runtime = new StubActorRuntime();
         var subscriptions = new StubSubscriptionProvider();
@@ -296,6 +356,7 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
+            new StubGAgentActorStore(),
             subscriptions,
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -303,9 +364,69 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleStreamMessageAsync_ShouldRejectMismatchedAuthenticatedScope()
+    {
+        var context = CreateScopedHttpContext("scope-b");
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        var runtime = new StubActorRuntime();
+        var actorStore = new StubGAgentActorStore
+        {
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+            ],
+        };
+
+        await InvokeTaskAsync(
+            "HandleStreamMessageAsync",
+            context,
+            "scope-a",
+            "actor-1",
+            new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
+            runtime,
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleStreamMessageAsync_ShouldReturnNotFound_WhenConversationIsNotRegisteredInScope()
+    {
+        var context = CreateScopedHttpContext();
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        var runtime = new StubActorRuntime();
+        var actorStore = new StubGAgentActorStore
+        {
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-other"]),
+            ],
+        };
+
+        await InvokeTaskAsync(
+            "HandleStreamMessageAsync",
+            context,
+            "scope-a",
+            "actor-1",
+            new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
+            runtime,
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleStreamMessageAsync_ShouldRejectWhenNoPromptAndNoInputParts()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         var runtime = new StubActorRuntime();
 
@@ -316,6 +437,7 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest(null),
             runtime,
+            new StubGAgentActorStore(),
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -325,7 +447,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleApproveAsync_ShouldRejectWithoutAuthorization()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer";
         var runtime = new StubActorRuntime();
 
@@ -336,6 +458,7 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
             runtime,
+            new StubGAgentActorStore(),
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -343,9 +466,40 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleApproveAsync_ShouldReturnNotFound_WhenConversationIsNotRegisteredInScope()
+    {
+        var context = CreateScopedHttpContext();
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        var runtime = new StubActorRuntime();
+        runtime.Actors["actor-1"] = new StubActor("actor-1");
+        var actorStore = new StubGAgentActorStore
+        {
+            GroupsToReturn =
+            [
+                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-other"]),
+            ],
+        };
+
+        await InvokeTaskAsync(
+            "HandleApproveAsync",
+            context,
+            "scope-a",
+            "actor-1",
+            new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
+            runtime,
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject.HandledEnvelopes.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleApproveAsync_ShouldRejectWhenRequestIdMissing()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         var runtime = new StubActorRuntime();
 
@@ -356,6 +510,7 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest(null),
             runtime,
+            new StubGAgentActorStore(),
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -365,14 +520,11 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleStreamMessageAsync_ShouldDispatchChatRequest_AndWriteRunFinished()
     {
-        var context = new DefaultHttpContext
-        {
-            RequestServices = new ServiceCollection()
+        var context = CreateScopedHttpContext(
+            services => services
                 .AddLogging()
                 .AddSingleton<INyxIdUserLlmPreferencesStore>(new StubPreferencesStore("relay-model", "/relay-route", 7))
-                .AddSingleton<IUserMemoryStore>(new StubUserMemoryStore("remember this"))
-                .BuildServiceProvider(),
-        };
+                .AddSingleton<IUserMemoryStore>(new StubUserMemoryStore("remember this")));
         context.Request.Headers.Authorization = "Bearer valid-token";
         context.Request.Headers["X-Nyx-Refresh-Token"] = "refresh-token";
         context.Response.Body = new MemoryStream();
@@ -395,6 +547,13 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello there"),
             runtime,
+            new StubGAgentActorStore
+            {
+                GroupsToReturn =
+                [
+                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+                ],
+            },
             subscriptions,
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -425,7 +584,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleStreamMessageAsync_ShouldReturn500_WhenFailureOccursBeforeWriterStarts()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
 
         await InvokeTaskAsync(
@@ -435,6 +594,13 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             new ThrowingActorRuntime(new InvalidOperationException("runtime failed")),
+            new StubGAgentActorStore
+            {
+                GroupsToReturn =
+                [
+                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+                ],
+            },
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -445,7 +611,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleStreamMessageAsync_ShouldWriteRunError_WhenFailureOccursAfterWriterStarts()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         context.Response.Body = new MemoryStream();
 
@@ -459,6 +625,13 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
+            new StubGAgentActorStore
+            {
+                GroupsToReturn =
+                [
+                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+                ],
+            },
             new ThrowingSubscriptionProvider(new InvalidOperationException("subscription failed")),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -474,7 +647,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleApproveAsync_ShouldDispatchDecision_AndWriteRunFinished()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         context.Response.Body = new MemoryStream();
 
@@ -496,6 +669,13 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1", Approved: false, Reason: "deny", SessionId: "session-1"),
             runtime,
+            new StubGAgentActorStore
+            {
+                GroupsToReturn =
+                [
+                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+                ],
+            },
             subscriptions,
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -517,7 +697,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleApproveAsync_ShouldReturn500_WhenFailureOccursBeforeWriterStarts()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
 
         await InvokeTaskAsync(
@@ -527,6 +707,13 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1"),
             new ThrowingActorRuntime(new InvalidOperationException("runtime failed")),
+            new StubGAgentActorStore
+            {
+                GroupsToReturn =
+                [
+                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+                ],
+            },
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -537,7 +724,7 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleApproveAsync_ShouldWriteRunError_WhenFailureOccursAfterWriterStarts()
     {
-        var context = new DefaultHttpContext();
+        var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         context.Response.Body = new MemoryStream();
 
@@ -551,6 +738,13 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1"),
             runtime,
+            new StubGAgentActorStore
+            {
+                GroupsToReturn =
+                [
+                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
+                ],
+            },
             new ThrowingSubscriptionProvider(new InvalidOperationException("approval subscription failed")),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -1369,6 +1563,40 @@ public class NyxIdChatEndpointsCoverageTests
         await endpoint.RequestDelegate!(context);
         context.Response.Body.Position = 0;
         return (context.Response.StatusCode, await new StreamReader(context.Response.Body).ReadToEndAsync());
+    }
+
+    private static DefaultHttpContext CreateScopedHttpContext(
+        string claimedScopeId = "scope-a",
+        Action<IServiceCollection>? configureServices = null)
+    {
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddSingleton<IHostEnvironment>(new TestHostEnvironment());
+        configureServices?.Invoke(services);
+
+        return new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            User = new ClaimsPrincipal(
+                new ClaimsIdentity(
+                [
+                    new Claim("scope_id", claimedScopeId),
+                ],
+                authenticationType: "TestAuth")),
+        };
+    }
+
+    private static DefaultHttpContext CreateScopedHttpContext(Action<IServiceCollection> configureServices) =>
+        CreateScopedHttpContext("scope-a", configureServices);
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "NyxIdChatEndpointsCoverageTests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
     }
 
     private static int GetFreeTcpPort()

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -151,6 +151,7 @@ public class NyxIdChatEndpointsCoverageTests
         doc.RootElement.TryGetProperty("createdAt", out _).Should().BeFalse();
         var createdActorId = actorId.GetString();
         createdActorId.Should().NotBeNullOrWhiteSpace();
+        NyxIdChatServiceDefaults.IsActorIdForScope(createdActorId, "scope-a").Should().BeTrue();
         actorStore.AddedActors.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
@@ -223,19 +224,14 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldReturnOk_AndRemoveActor()
     {
-        var actorStore = new StubGAgentActorStore
-        {
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-            ],
-        };
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "delete");
+        var actorStore = new StubGAgentActorStore();
         var historyStore = new StubChatHistoryStore();
         var result = await InvokeResultAsync(
             "HandleDeleteConversationAsync",
             CreateScopedHttpContext(),
             "scope-a",
-            "actor-1",
+            actorId,
             actorStore,
             historyStore,
             CancellationToken.None);
@@ -245,22 +241,16 @@ public class NyxIdChatEndpointsCoverageTests
         actorStore.RemovedActors.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
-            entry.ActorId == "actor-1");
+            entry.ActorId == actorId);
         historyStore.DeletedConversations.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
-            entry.ConversationId == "actor-1");
+            entry.ConversationId == actorId);
     }
 
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldReturnNotFound_WhenConversationIsNotRegisteredInScope()
     {
-        var actorStore = new StubGAgentActorStore
-        {
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-other"]),
-            ],
-        };
+        var actorStore = new StubGAgentActorStore();
         var historyStore = new StubChatHistoryStore();
         var result = await InvokeResultAsync(
             "HandleDeleteConversationAsync",
@@ -281,13 +271,10 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldBubbleFailure_WhenActorRemovalFails()
     {
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "remove-failure");
         var actorStore = new StubGAgentActorStore
         {
             RemoveActorException = new InvalidOperationException("actor store unavailable"),
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-            ],
         };
         var historyStore = new StubChatHistoryStore();
 
@@ -295,7 +282,7 @@ public class NyxIdChatEndpointsCoverageTests
             "HandleDeleteConversationAsync",
             CreateScopedHttpContext(),
             "scope-a",
-            "actor-1",
+            actorId,
             actorStore,
             historyStore,
             CancellationToken.None);
@@ -308,13 +295,8 @@ public class NyxIdChatEndpointsCoverageTests
     [Fact]
     public async Task HandleDeleteConversationAsync_ShouldRestoreActorRegistration_WhenHistoryDeleteFails()
     {
-        var actorStore = new StubGAgentActorStore
-        {
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-            ],
-        };
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "restore");
+        var actorStore = new StubGAgentActorStore();
         var historyStore = new StubChatHistoryStore
         {
             DeleteConversationException = new InvalidOperationException("history unavailable"),
@@ -324,7 +306,7 @@ public class NyxIdChatEndpointsCoverageTests
             "HandleDeleteConversationAsync",
             CreateScopedHttpContext(),
             "scope-a",
-            "actor-1",
+            actorId,
             actorStore,
             historyStore,
             CancellationToken.None);
@@ -334,11 +316,11 @@ public class NyxIdChatEndpointsCoverageTests
         actorStore.RemovedActors.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
-            entry.ActorId == "actor-1");
+            entry.ActorId == actorId);
         actorStore.AddedActors.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
-            entry.ActorId == "actor-1");
+            entry.ActorId == actorId);
     }
 
     [Fact]
@@ -356,7 +338,6 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
-            new StubGAgentActorStore(),
             subscriptions,
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -369,22 +350,15 @@ public class NyxIdChatEndpointsCoverageTests
         var context = CreateScopedHttpContext("scope-b");
         context.Request.Headers.Authorization = "Bearer valid-token";
         var runtime = new StubActorRuntime();
-        var actorStore = new StubGAgentActorStore
-        {
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-            ],
-        };
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "auth-scope");
 
         await InvokeTaskAsync(
             "HandleStreamMessageAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
-            actorStore,
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -399,13 +373,6 @@ public class NyxIdChatEndpointsCoverageTests
         var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         var runtime = new StubActorRuntime();
-        var actorStore = new StubGAgentActorStore
-        {
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-other"]),
-            ],
-        };
 
         await InvokeTaskAsync(
             "HandleStreamMessageAsync",
@@ -414,7 +381,61 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
-            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleStreamMessageAsync_ShouldAcceptScopeBoundConversation_WhenRegistryProjectionHasNotCaughtUp()
+    {
+        var context = CreateScopedHttpContext();
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        context.Response.Body = new MemoryStream();
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "first-message");
+        var runtime = new StubActorRuntime();
+
+        await InvokeTaskAsync(
+            "HandleStreamMessageAsync",
+            context,
+            "scope-a",
+            actorId,
+            new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
+            runtime,
+            new StubSubscriptionProvider
+            {
+                Messages =
+                {
+                    new EventEnvelope { Payload = Any.Pack(new TextMessageEndEvent { Content = "done" }) },
+                },
+            },
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        runtime.CreateCalls.Should().ContainSingle(call =>
+            call.Type == typeof(NyxIdChatGAgent) &&
+            call.Id == actorId);
+    }
+
+    [Fact]
+    public async Task HandleStreamMessageAsync_ShouldRejectConversationBoundToDifferentScope()
+    {
+        var context = CreateScopedHttpContext();
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        var runtime = new StubActorRuntime();
+        var actorId = BuildScopedNyxIdChatActorId("scope-b", "cross-scope");
+
+        await InvokeTaskAsync(
+            "HandleStreamMessageAsync",
+            context,
+            "scope-a",
+            actorId,
+            new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
+            runtime,
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -437,7 +458,6 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdChatStreamRequest(null),
             runtime,
-            new StubGAgentActorStore(),
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -458,7 +478,6 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
             runtime,
-            new StubGAgentActorStore(),
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -471,29 +490,22 @@ public class NyxIdChatEndpointsCoverageTests
         var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
         var runtime = new StubActorRuntime();
-        runtime.Actors["actor-1"] = new StubActor("actor-1");
-        var actorStore = new StubGAgentActorStore
-        {
-            GroupsToReturn =
-            [
-                new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-other"]),
-            ],
-        };
+        var actorId = BuildScopedNyxIdChatActorId("scope-b", "approval-scope");
+        runtime.Actors[actorId] = new StubActor(actorId);
 
         await InvokeTaskAsync(
             "HandleApproveAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
             runtime,
-            actorStore,
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
-        runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject.HandledEnvelopes.Should().BeEmpty();
+        runtime.Actors[actorId].Should().BeOfType<StubActor>().Subject.HandledEnvelopes.Should().BeEmpty();
     }
 
     [Fact]
@@ -510,7 +522,6 @@ public class NyxIdChatEndpointsCoverageTests
             "actor-1",
             new NyxIdChatEndpoints.NyxIdApprovalRequest(null),
             runtime,
-            new StubGAgentActorStore(),
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -528,6 +539,7 @@ public class NyxIdChatEndpointsCoverageTests
         context.Request.Headers.Authorization = "Bearer valid-token";
         context.Request.Headers["X-Nyx-Refresh-Token"] = "refresh-token";
         context.Response.Body = new MemoryStream();
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "dispatch");
 
         var runtime = new StubActorRuntime();
         var subscriptions = new StubSubscriptionProvider
@@ -544,23 +556,16 @@ public class NyxIdChatEndpointsCoverageTests
             "HandleStreamMessageAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello there"),
             runtime,
-            new StubGAgentActorStore
-            {
-                GroupsToReturn =
-                [
-                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-                ],
-            },
             subscriptions,
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         runtime.CreateCalls.Should().ContainSingle();
-        var actor = runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject;
+        var actor = runtime.Actors[actorId].Should().BeOfType<StubActor>().Subject;
         var chatRequest = actor.HandledEnvelopes.Should().ContainSingle().Subject.Payload.Unpack<ChatRequestEvent>();
         chatRequest.Prompt.Should().Be("hello there");
         chatRequest.ScopeId.Should().Be("scope-a");
@@ -586,21 +591,15 @@ public class NyxIdChatEndpointsCoverageTests
     {
         var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "runtime-failure");
 
         await InvokeTaskAsync(
             "HandleStreamMessageAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             new ThrowingActorRuntime(new InvalidOperationException("runtime failed")),
-            new StubGAgentActorStore
-            {
-                GroupsToReturn =
-                [
-                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-                ],
-            },
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -616,22 +615,16 @@ public class NyxIdChatEndpointsCoverageTests
         context.Response.Body = new MemoryStream();
 
         var runtime = new StubActorRuntime();
-        runtime.Actors["actor-1"] = new StubActor("actor-1");
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "stream-error");
+        runtime.Actors[actorId] = new StubActor(actorId);
 
         await InvokeTaskAsync(
             "HandleStreamMessageAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
-            new StubGAgentActorStore
-            {
-                GroupsToReturn =
-                [
-                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-                ],
-            },
             new ThrowingSubscriptionProvider(new InvalidOperationException("subscription failed")),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -652,7 +645,8 @@ public class NyxIdChatEndpointsCoverageTests
         context.Response.Body = new MemoryStream();
 
         var runtime = new StubActorRuntime();
-        runtime.Actors["actor-1"] = new StubActor("actor-1");
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "approve");
+        runtime.Actors[actorId] = new StubActor(actorId);
         var subscriptions = new StubSubscriptionProvider
         {
             Messages =
@@ -666,22 +660,15 @@ public class NyxIdChatEndpointsCoverageTests
             "HandleApproveAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1", Approved: false, Reason: "deny", SessionId: "session-1"),
             runtime,
-            new StubGAgentActorStore
-            {
-                GroupsToReturn =
-                [
-                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-                ],
-            },
             subscriptions,
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        var actor = runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject;
+        var actor = runtime.Actors[actorId].Should().BeOfType<StubActor>().Subject;
         var decision = actor.HandledEnvelopes.Should().ContainSingle().Subject.Payload.Unpack<ToolApprovalDecisionEvent>();
         decision.RequestId.Should().Be("req-1");
         decision.Approved.Should().BeFalse();
@@ -699,21 +686,15 @@ public class NyxIdChatEndpointsCoverageTests
     {
         var context = CreateScopedHttpContext();
         context.Request.Headers.Authorization = "Bearer valid-token";
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "approval-runtime-failure");
 
         await InvokeTaskAsync(
             "HandleApproveAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1"),
             new ThrowingActorRuntime(new InvalidOperationException("runtime failed")),
-            new StubGAgentActorStore
-            {
-                GroupsToReturn =
-                [
-                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-                ],
-            },
             new StubSubscriptionProvider(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -729,22 +710,16 @@ public class NyxIdChatEndpointsCoverageTests
         context.Response.Body = new MemoryStream();
 
         var runtime = new StubActorRuntime();
-        runtime.Actors["actor-1"] = new StubActor("actor-1");
+        var actorId = BuildScopedNyxIdChatActorId("scope-a", "approval-stream-error");
+        runtime.Actors[actorId] = new StubActor(actorId);
 
         await InvokeTaskAsync(
             "HandleApproveAsync",
             context,
             "scope-a",
-            "actor-1",
+            actorId,
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1"),
             runtime,
-            new StubGAgentActorStore
-            {
-                GroupsToReturn =
-                [
-                    new GAgentActorGroup(NyxIdChatServiceDefaults.GAgentTypeName, ["actor-1"]),
-                ],
-            },
             new ThrowingSubscriptionProvider(new InvalidOperationException("approval subscription failed")),
             NullLoggerFactory.Instance,
             CancellationToken.None);
@@ -1520,6 +1495,13 @@ public class NyxIdChatEndpointsCoverageTests
         var scopeHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim())))
             .ToLowerInvariant();
         return $"channel-conversation:{canonicalKey}:scope:{scopeHash}";
+    }
+
+    private static string BuildScopedNyxIdChatActorId(string scopeId, string suffix)
+    {
+        var scopeHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim())))
+            .ToLowerInvariant();
+        return $"{NyxIdChatServiceDefaults.ActorIdPrefix}-{suffix}:scope:{scopeHash}";
     }
 
     private static async Task<(int StatusCode, string Body)> ExecuteResultAsync(IResult result)


### PR DESCRIPTION
## Problem

NyxID scoped chat endpoints under `/api/scopes/{scopeId}/nyxid-chat/...` accepted the route `scopeId` without using the shared authenticated scope guard, and `stream` / `approve` / `delete` could operate on a conversation by bare `actorId`.

That meant a caller who knew a valid NyxID chat `actorId` could potentially target a conversation outside the requested scope.

## Solution

- Apply `AevatarScopeAccessGuard` to scoped NyxID chat create/list/delete endpoints.
- Require `stream` / `approve` / `delete` to validate `(scopeId, NyxIdChatServiceDefaults.GAgentTypeName, actorId)` through `IGAgentActorStore` before touching the actor or chat history.
- Return `404 NYXID_CHAT_CONVERSATION_NOT_FOUND` when a conversation is not registered under the requested scope.
- Add targeted endpoint coverage for scope mismatch and unregistered conversation paths.

## Impact Paths

- `agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs`
- `agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs`
- `agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj`
- `test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs`

## Validation

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter "FullyQualifiedName~NyxIdChatEndpointsCoverageTests" --nologo` - 42/42 passed
- `bash tools/ci/test_stability_guards.sh` - passed
- `dotnet build agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj --nologo` - 0 errors
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --no-build --nologo` - 487/487 passed
- `git diff --check` - clean

Closes #372