### PR TITLE
Fix relay scope resolution + use bot owner LLM config

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationQueryPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationQueryPort.cs
@@ -47,6 +47,11 @@ public sealed class ChannelBotRegistrationQueryPort : IChannelBotRegistrationQue
         CancellationToken ct = default) =>
         QuerySingleByFieldAsync(nameof(ChannelBotRegistrationDocument.NyxAgentApiKeyId), nyxAgentApiKeyId, ct);
 
+    public Task<IReadOnlyList<ChannelBotRegistrationEntry>> ListByNyxAgentApiKeyIdAsync(
+        string nyxAgentApiKeyId,
+        CancellationToken ct = default) =>
+        QueryAllByFieldAsync(nameof(ChannelBotRegistrationDocument.NyxAgentApiKeyId), nyxAgentApiKeyId, ct);
+
     public Task<ChannelBotRegistrationEntry?> GetByNyxChannelBotIdAsync(
         string nyxChannelBotId,
         CancellationToken ct = default) =>
@@ -78,6 +83,33 @@ public sealed class ChannelBotRegistrationQueryPort : IChannelBotRegistrationQue
 
         var document = result.Items.FirstOrDefault();
         return document == null ? null : ToEntry(document);
+    }
+
+    private async Task<IReadOnlyList<ChannelBotRegistrationEntry>> QueryAllByFieldAsync(
+        string fieldPath,
+        string fieldValue,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(fieldValue))
+            return Array.Empty<ChannelBotRegistrationEntry>();
+
+        var result = await _documentReader.QueryAsync(
+            new ProjectionDocumentQuery
+            {
+                Take = 32,
+                Filters =
+                [
+                    new ProjectionDocumentFilter
+                    {
+                        FieldPath = fieldPath,
+                        Operator = ProjectionDocumentFilterOperator.Eq,
+                        Value = ProjectionDocumentValue.FromString(fieldValue),
+                    },
+                ],
+            },
+            ct);
+
+        return result.Items.Select(static doc => ToEntry(doc)).ToArray();
     }
 
     private static ChannelBotRegistrationEntry ToEntry(ChannelBotRegistrationDocument document) =>

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
@@ -219,11 +219,24 @@ internal sealed class ChannelLlmReplyInboxRuntime :
         // Apply the bot owner's pre-configured LLM route + model. The relay callback
         // identifies the bot by api_key_id (in activity.Bot.Value); we resolve that to
         // the owner's Aevatar scope id and load the same UserConfig the owner uses
-        // when chatting through nyxid-chat themselves. This decouples the bot's LLM
-        // call from any inbound user session — the bot reply succeeds whenever the
-        // owner has a valid configuration, regardless of whether the relay callback's
-        // X-NyxID-User-Token has expired since dispatch.
+        // when chatting through nyxid-chat themselves, then pin ModelOverride /
+        // NyxIdRoutePreference / MaxToolRoundsOverride from that configuration.
         await ApplyBotOwnerLlmConfigAsync(request, metadata, ct);
+
+        // The inbound callback's X-NyxID-User-Token is the bot owner's NyxID session
+        // JWT (freshly issued by NyxID for each callback). It is the bot owner's own
+        // credential for LLM calls — the same thing that would authorize them in
+        // nyxid-chat. The short TTL (~15 min) is mitigated by the direct-enqueue
+        // dispatch (#380), the inbox-echoed token flow (#383), and the stale pending
+        // request GC, so the token is still valid when the LLM call actually fires
+        // for any non-stale request. If the downstream provider rejects it, the
+        // classifier surfaces a real user-facing error via NyxIdRelayErrorClassifier.
+        var userAccessToken = request.Activity?.TransportExtras?.NyxUserAccessToken?.Trim();
+        if (!string.IsNullOrWhiteSpace(userAccessToken))
+        {
+            metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = userAccessToken;
+            metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = userAccessToken;
+        }
 
         return metadata;
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelLlmReplyInboxRuntime.cs
@@ -4,6 +4,8 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Channel.NyxIdRelay;
+using Aevatar.GAgents.NyxidChat;
+using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -21,7 +23,9 @@ internal sealed class ChannelLlmReplyInboxRuntime :
     private readonly IActorRuntime _actorRuntime;
     private readonly IConversationReplyGenerator _replyGenerator;
     private readonly IInteractiveReplyCollector? _interactiveReplyCollector;
-    private readonly NyxIdRelayOptions? _relayOptions;
+    private readonly Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? _relayOptions;
+    private readonly INyxIdRelayScopeResolver? _scopeResolver;
+    private readonly IUserConfigQueryPort? _userConfigQueryPort;
     private readonly ILogger<ChannelLlmReplyInboxRuntime> _logger;
     private IAsyncDisposable? _subscription;
 
@@ -30,14 +34,18 @@ internal sealed class ChannelLlmReplyInboxRuntime :
         IActorRuntime actorRuntime,
         IConversationReplyGenerator replyGenerator,
         IInteractiveReplyCollector? interactiveReplyCollector,
-        NyxIdRelayOptions? relayOptions,
-        ILogger<ChannelLlmReplyInboxRuntime> logger)
+        Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
+        ILogger<ChannelLlmReplyInboxRuntime> logger,
+        INyxIdRelayScopeResolver? scopeResolver = null,
+        IUserConfigQueryPort? userConfigQueryPort = null)
     {
         _streamProvider = streamProvider ?? throw new ArgumentNullException(nameof(streamProvider));
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
         _interactiveReplyCollector = interactiveReplyCollector;
         _relayOptions = relayOptions;
+        _scopeResolver = scopeResolver;
+        _userConfigQueryPort = userConfigQueryPort;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -131,7 +139,7 @@ internal sealed class ChannelLlmReplyInboxRuntime :
 
         try
         {
-            var effectiveMetadata = BuildEffectiveMetadata(request);
+            var effectiveMetadata = await BuildEffectiveMetadataAsync(request, CancellationToken.None);
             IDisposable? interactiveReplyScope = null;
             try
             {
@@ -202,16 +210,86 @@ internal sealed class ChannelLlmReplyInboxRuntime :
         await actor.HandleEventAsync(envelope, CancellationToken.None);
     }
 
-    private IReadOnlyDictionary<string, string> BuildEffectiveMetadata(NeedsLlmReplyEvent request)
+    private async Task<IReadOnlyDictionary<string, string>> BuildEffectiveMetadataAsync(
+        NeedsLlmReplyEvent request,
+        CancellationToken ct)
     {
         var metadata = new Dictionary<string, string>(request.Metadata, StringComparer.Ordinal);
-        var userAccessToken = request.Activity?.TransportExtras?.NyxUserAccessToken?.Trim();
-        if (string.IsNullOrWhiteSpace(userAccessToken))
-            return metadata;
 
-        metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = userAccessToken;
-        metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = userAccessToken;
+        // Apply the bot owner's pre-configured LLM route + model. The relay callback
+        // identifies the bot by api_key_id (in activity.Bot.Value); we resolve that to
+        // the owner's Aevatar scope id and load the same UserConfig the owner uses
+        // when chatting through nyxid-chat themselves. This decouples the bot's LLM
+        // call from any inbound user session — the bot reply succeeds whenever the
+        // owner has a valid configuration, regardless of whether the relay callback's
+        // X-NyxID-User-Token has expired since dispatch.
+        await ApplyBotOwnerLlmConfigAsync(request, metadata, ct);
+
         return metadata;
+    }
+
+    private async Task ApplyBotOwnerLlmConfigAsync(
+        NeedsLlmReplyEvent request,
+        IDictionary<string, string> metadata,
+        CancellationToken ct)
+    {
+        if (_scopeResolver is null || _userConfigQueryPort is null)
+            return;
+
+        var apiKeyId = request.Activity?.Bot?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(apiKeyId))
+            return;
+
+        string? scopeId;
+        try
+        {
+            scopeId = await _scopeResolver.ResolveScopeIdByApiKeyAsync(apiKeyId, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to resolve bot owner scope id for LLM config: correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                request.CorrelationId,
+                apiKeyId);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(scopeId))
+        {
+            _logger.LogDebug(
+                "No bot owner scope id resolved for LLM config: correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                request.CorrelationId,
+                apiKeyId);
+            return;
+        }
+
+        try
+        {
+            var config = await _userConfigQueryPort.GetAsync(scopeId, ct);
+            if (!string.IsNullOrWhiteSpace(config.DefaultModel))
+                metadata[LLMRequestMetadataKeys.ModelOverride] = config.DefaultModel.Trim();
+            if (!string.IsNullOrWhiteSpace(config.PreferredLlmRoute))
+                metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = config.PreferredLlmRoute.Trim();
+            if (config.MaxToolRounds > 0)
+                metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride] =
+                    config.MaxToolRounds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            _logger.LogInformation(
+                "Applied bot owner LLM config: correlation={CorrelationId} scopeId={ScopeId} model={Model} route={Route}",
+                request.CorrelationId,
+                scopeId,
+                string.IsNullOrWhiteSpace(config.DefaultModel) ? "<server-default>" : config.DefaultModel,
+                string.IsNullOrWhiteSpace(config.PreferredLlmRoute) ? "<server-default>" : config.PreferredLlmRoute);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to load bot owner LLM config: correlation={CorrelationId} scopeId={ScopeId}",
+                request.CorrelationId,
+                scopeId);
+        }
     }
 
     private static bool IsRelayRequest(NeedsLlmReplyEvent request) =>

--- a/agents/Aevatar.GAgents.ChannelRuntime/IChannelBotRegistrationQueryByNyxIdentityPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/IChannelBotRegistrationQueryByNyxIdentityPort.cs
@@ -6,6 +6,18 @@ public interface IChannelBotRegistrationQueryByNyxIdentityPort
         string nyxAgentApiKeyId,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns every active registration that matches the given Nyx agent API key id.
+    /// Callers that route by API key (e.g., scope resolution for relay callbacks) MUST
+    /// use this rather than <see cref="GetByNyxAgentApiKeyIdAsync"/> when a wrong-tenant
+    /// match would be a security regression — repeated mirror / provision flows can
+    /// persist multiple registrations sharing the same API key id but different
+    /// scope ids, and the single-result variant returns only the first match.
+    /// </summary>
+    Task<IReadOnlyList<ChannelBotRegistrationEntry>> ListByNyxAgentApiKeyIdAsync(
+        string nyxAgentApiKeyId,
+        CancellationToken ct = default);
+
     Task<ChannelBotRegistrationEntry?> GetByNyxChannelBotIdAsync(
         string nyxChannelBotId,
         CancellationToken ct = default);

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxIdRelayScopeResolver.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxIdRelayScopeResolver.cs
@@ -1,0 +1,28 @@
+using Aevatar.GAgents.NyxidChat;
+
+namespace Aevatar.GAgents.ChannelRuntime;
+
+/// <summary>
+/// Production implementation of <see cref="INyxIdRelayScopeResolver"/> backed by
+/// the channel bot registration query port.
+/// </summary>
+internal sealed class NyxIdRelayScopeResolver : INyxIdRelayScopeResolver
+{
+    private readonly IChannelBotRegistrationQueryByNyxIdentityPort _registrationQueryPort;
+
+    public NyxIdRelayScopeResolver(IChannelBotRegistrationQueryByNyxIdentityPort registrationQueryPort)
+    {
+        _registrationQueryPort = registrationQueryPort
+            ?? throw new ArgumentNullException(nameof(registrationQueryPort));
+    }
+
+    public async Task<string?> ResolveScopeIdByApiKeyAsync(string nyxAgentApiKeyId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(nyxAgentApiKeyId))
+            return null;
+
+        var entry = await _registrationQueryPort.GetByNyxAgentApiKeyIdAsync(nyxAgentApiKeyId.Trim(), ct);
+        var scopeId = entry?.ScopeId;
+        return string.IsNullOrWhiteSpace(scopeId) ? null : scopeId;
+    }
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxIdRelayScopeResolver.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxIdRelayScopeResolver.cs
@@ -1,4 +1,6 @@
 using Aevatar.GAgents.NyxidChat;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgents.ChannelRuntime;
 
@@ -9,11 +11,15 @@ namespace Aevatar.GAgents.ChannelRuntime;
 internal sealed class NyxIdRelayScopeResolver : INyxIdRelayScopeResolver
 {
     private readonly IChannelBotRegistrationQueryByNyxIdentityPort _registrationQueryPort;
+    private readonly ILogger<NyxIdRelayScopeResolver> _logger;
 
-    public NyxIdRelayScopeResolver(IChannelBotRegistrationQueryByNyxIdentityPort registrationQueryPort)
+    public NyxIdRelayScopeResolver(
+        IChannelBotRegistrationQueryByNyxIdentityPort registrationQueryPort,
+        ILogger<NyxIdRelayScopeResolver>? logger = null)
     {
         _registrationQueryPort = registrationQueryPort
             ?? throw new ArgumentNullException(nameof(registrationQueryPort));
+        _logger = logger ?? NullLogger<NyxIdRelayScopeResolver>.Instance;
     }
 
     public async Task<string?> ResolveScopeIdByApiKeyAsync(string nyxAgentApiKeyId, CancellationToken ct = default)
@@ -21,8 +27,31 @@ internal sealed class NyxIdRelayScopeResolver : INyxIdRelayScopeResolver
         if (string.IsNullOrWhiteSpace(nyxAgentApiKeyId))
             return null;
 
-        var entry = await _registrationQueryPort.GetByNyxAgentApiKeyIdAsync(nyxAgentApiKeyId.Trim(), ct);
-        var scopeId = entry?.ScopeId;
-        return string.IsNullOrWhiteSpace(scopeId) ? null : scopeId;
+        var trimmedApiKeyId = nyxAgentApiKeyId.Trim();
+        var entries = await _registrationQueryPort.ListByNyxAgentApiKeyIdAsync(trimmedApiKeyId, ct);
+
+        // Distinct non-empty scope ids across all matching registrations. If repeated
+        // mirror / provision flows persisted multiple entries with the same api key id
+        // but different scope ids, the relay turn cannot be safely routed to a single
+        // tenant — refuse rather than risk dispatching to the wrong ConversationGAgent.
+        var distinctScopeIds = entries
+            .Select(entry => entry.ScopeId?.Trim())
+            .Where(scopeId => !string.IsNullOrWhiteSpace(scopeId))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (distinctScopeIds.Length == 0)
+            return null;
+
+        if (distinctScopeIds.Length > 1)
+        {
+            _logger.LogWarning(
+                "Refusing relay scope resolution for ambiguous Nyx agent api key id: apiKeyId={ApiKeyId} matchedScopeCount={MatchedScopeCount}",
+                trimmedApiKeyId,
+                distinctScopeIds.Length);
+            return null;
+        }
+
+        return distinctScopeIds[0];
     }
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ public static class ServiceCollectionExtensions
             ChannelBotRegistrationDocumentMetadataProvider>();
         services.TryAddSingleton<IChannelBotRegistrationQueryPort, ChannelBotRegistrationQueryPort>();
         services.TryAddSingleton<IChannelBotRegistrationQueryByNyxIdentityPort, ChannelBotRegistrationQueryPort>();
+        services.TryAddSingleton<Aevatar.GAgents.NyxidChat.INyxIdRelayScopeResolver, NyxIdRelayScopeResolver>();
         services.TryAddSingleton<IChannelBotRegistrationRuntimeQueryPort, ChannelBotRegistrationRuntimeQueryPort>();
         services.TryAddSingleton<ChannelBotRegistrationProjectionPort>();
         services.TryAddSingleton<ChannelPlatformReplyService>();

--- a/agents/Aevatar.GAgents.NyxidChat/INyxIdRelayScopeResolver.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/INyxIdRelayScopeResolver.cs
@@ -1,0 +1,22 @@
+namespace Aevatar.GAgents.NyxidChat;
+
+/// <summary>
+/// Resolves the canonical Aevatar scope id for a Nyx relay callback when it cannot
+/// be derived from the callback JWT itself.
+/// </summary>
+/// <remarks>
+/// NyxID's relay callback JWT (see ChronoAIProject/NyxID#504) only carries
+/// channel-routing claims (api_key_id, message_id, platform, body_sha256, jti) -
+/// it does not emit any scope / sub / nameid claim. The relay endpoint still needs a
+/// scope id to address the per-tenant ConversationGAgent actor, so it falls back
+/// from the validator's claim-based extraction to this resolver, which looks up the
+/// scope id recorded against the bot registration during provisioning.
+///
+/// This port lives in NyxidChat to keep the relay endpoint independent from the
+/// ChannelRuntime implementation project. The implementation in ChannelRuntime
+/// delegates to the channel bot registration query port.
+/// </remarks>
+public interface INyxIdRelayScopeResolver
+{
+    Task<string?> ResolveScopeIdByApiKeyAsync(string nyxAgentApiKeyId, CancellationToken ct = default);
+}

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Relay.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Relay.cs
@@ -10,6 +10,7 @@ using Aevatar.Foundation.Abstractions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Any = Google.Protobuf.WellKnownTypes.Any;
 
@@ -75,11 +76,18 @@ public static partial class NyxIdChatEndpoints
             }
 
             http.User = validation.Principal;
-            if (string.IsNullOrWhiteSpace(validation.ScopeId))
+            var scopeId = await ResolveRelayScopeIdAsync(
+                validation.ScopeId,
+                payload,
+                http.RequestServices,
+                logger,
+                ct);
+            if (string.IsNullOrWhiteSpace(scopeId))
             {
                 logger.LogWarning(
-                    "Relay callback authentication succeeded but did not produce a canonical scope id: message={MessageId}",
-                    payload.MessageId);
+                    "Relay callback authentication succeeded but did not resolve a canonical scope id: message={MessageId}, apiKeyId={ApiKeyId}",
+                    payload.MessageId,
+                    payload.Agent?.ApiKeyId);
                 return Results.Unauthorized();
             }
 
@@ -143,7 +151,7 @@ public static partial class NyxIdChatEndpoints
                 CorrelationId = activity.OutboundDelivery.CorrelationId,
             };
 
-            var actorId = BuildScopedRelayConversationActorId(validation.ScopeId, activity.Conversation.CanonicalKey);
+            var actorId = BuildScopedRelayConversationActorId(scopeId, activity.Conversation.CanonicalKey);
             var actor = await actorRuntime.CreateAsync<ConversationGAgent>(actorId, ct);
             var command = new EventEnvelope
             {
@@ -248,6 +256,59 @@ public static partial class NyxIdChatEndpoints
             Timestamp = payload.Timestamp,
         };
 
+    private static async Task<string?> ResolveRelayScopeIdAsync(
+        string? validatedScopeId,
+        NyxIdRelayCallbackPayload payload,
+        IServiceProvider services,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var scopeId = NormalizeOptional(validatedScopeId);
+        if (scopeId is not null)
+            return scopeId;
+
+        var nyxAgentApiKeyId = NormalizeOptional(payload.Agent?.ApiKeyId);
+        if (nyxAgentApiKeyId is null)
+            return null;
+
+        var scopeResolver = services.GetService<INyxIdRelayScopeResolver>();
+        if (scopeResolver is null)
+        {
+            logger.LogWarning(
+                "Relay callback JWT had no scope id and relay scope resolver is unavailable: message={MessageId}, apiKeyId={ApiKeyId}",
+                payload.MessageId,
+                nyxAgentApiKeyId);
+            return null;
+        }
+
+        try
+        {
+            var resolvedScopeId = NormalizeOptional(await scopeResolver.ResolveScopeIdByApiKeyAsync(nyxAgentApiKeyId, ct));
+            if (resolvedScopeId is not null)
+            {
+                logger.LogInformation(
+                    "Resolved relay callback scope id from relay scope resolver: message={MessageId}, apiKeyId={ApiKeyId}",
+                    payload.MessageId,
+                    nyxAgentApiKeyId);
+            }
+
+            return resolvedScopeId;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to resolve relay callback scope id from channel bot registration: message={MessageId}, apiKeyId={ApiKeyId}",
+                payload.MessageId,
+                nyxAgentApiKeyId);
+            return null;
+        }
+    }
+
     private static string BuildScopedRelayConversationActorId(string? scopeId, string canonicalKey)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(scopeId);
@@ -256,6 +317,12 @@ public static partial class NyxIdChatEndpoints
         var scopeHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim())))
             .ToLowerInvariant();
         return $"{ConversationGAgent.BuildActorId(canonicalKey)}:scope:{scopeHash}";
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
     }
 
     private static string ClassifyError(string error) => NyxIdRelayReplies.ClassifyError(error);

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -867,6 +867,58 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldResolveScopeIdFromRegistration_WhenCallbackJwtHasNoScope()
+    {
+        var relay = CreateRelayInvocationDependencies(relayApiKeyId: "nyx-key-1");
+        var scopeResolver = new StubNyxIdRelayScopeResolver
+        {
+            ScopeId = "scope-from-registration",
+        };
+        var payload = """
+            {
+              "message_id":"msg-registration-scope",
+              "correlation_id":"corr-registration-scope",
+              "platform":"lark",
+              "reply_token":"reply-token-registration-scope",
+              "agent":{"api_key_id":"nyx-key-1"},
+              "conversation":{"platform_id":"ou_user_1","type":"private"},
+              "sender":{"platform_id":"ou_user_1"},
+              "content":{"text":"hello"}
+            }
+            """;
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .AddSingleton<INyxIdRelayScopeResolver>(scopeResolver)
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        AttachRelayHeaders(context, relay, payload, "msg-registration-scope", includeSubject: false);
+
+        var runtime = new StubActorRuntime();
+        var result = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            runtime,
+            relay.Transport,
+            relay.Validator,
+            relay.Options,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        scopeResolver.LastNyxAgentApiKeyId.Should().Be("nyx-key-1");
+        var expectedActorId = BuildScopedRelayConversationActorId("scope-from-registration", "lark:dm:ou_user_1");
+        runtime.CreateCalls.Should().ContainSingle(call =>
+            call.Type == typeof(ConversationGAgent) &&
+            call.Id == expectedActorId);
+        runtime.Actors.Should().ContainKey(expectedActorId);
+    }
+
+    [Fact]
     public async Task HandleRelayWebhookAsync_ShouldRejectMismatchedRelayApiKeyId()
     {
         var relay = CreateRelayInvocationDependencies(relayApiKeyId: "scope-a");
@@ -1427,22 +1479,26 @@ public class NyxIdChatEndpointsCoverageTests
         string messageId,
         string platform,
         string jti,
-        string bodySha256)
+        string bodySha256,
+        bool includeSubject = true)
     {
+        var claims = new List<Claim>
+        {
+            new("api_key_id", relayApiKeyId),
+            new("message_id", messageId),
+            new("platform", platform),
+            new("body_sha256", bodySha256),
+            new(JwtRegisteredClaimNames.Jti, jti),
+            new("token_type", "relay_callback"),
+        };
+        if (includeSubject)
+            claims.Insert(0, new Claim(JwtRegisteredClaimNames.Sub, relayApiKeyId));
+
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = issuer,
             Audience = "channel-relay/callback",
-            Subject = new ClaimsIdentity(
-            [
-                new Claim(JwtRegisteredClaimNames.Sub, relayApiKeyId),
-                new Claim("api_key_id", relayApiKeyId),
-                new Claim("message_id", messageId),
-                new Claim("platform", platform),
-                new Claim("body_sha256", bodySha256),
-                new Claim(JwtRegisteredClaimNames.Jti, jti),
-                new Claim("token_type", "relay_callback"),
-            ]),
+            Subject = new ClaimsIdentity(claims),
             NotBefore = DateTime.UtcNow.AddMinutes(-1),
             Expires = DateTime.UtcNow.AddMinutes(5),
             SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256),
@@ -1455,7 +1511,8 @@ public class NyxIdChatEndpointsCoverageTests
         DefaultHttpContext context,
         RelayInvocationDependencies relay,
         string body,
-        string messageId)
+        string messageId,
+        bool includeSubject = true)
     {
         using var document = JsonDocument.Parse(body);
         var root = document.RootElement;
@@ -1468,7 +1525,8 @@ public class NyxIdChatEndpointsCoverageTests
             messageId,
             platform,
             correlationId,
-            ComputeBodySha256Hex(Encoding.UTF8.GetBytes(body)));
+            ComputeBodySha256Hex(Encoding.UTF8.GetBytes(body)),
+            includeSubject);
         context.Request.Headers["X-NyxID-Callback-Token"] = callbackToken;
         context.Request.Headers["X-NyxID-User-Token"] = relay.UserToken;
         context.Request.Headers["X-NyxID-Message-Id"] = messageId;
@@ -1548,6 +1606,21 @@ public class NyxIdChatEndpointsCoverageTests
         public Task<IReadOnlyList<System.Type>> GetSubscribedEventTypesAsync() => Task.FromResult<IReadOnlyList<System.Type>>([]);
         public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class StubNyxIdRelayScopeResolver : INyxIdRelayScopeResolver
+    {
+        public string? ScopeId { get; init; }
+        public string? LastNyxAgentApiKeyId { get; private set; }
+
+        public Task<string?> ResolveScopeIdByApiKeyAsync(
+            string nyxAgentApiKeyId,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            LastNyxAgentApiKeyId = nyxAgentApiKeyId;
+            return Task.FromResult(ScopeId);
+        }
     }
 
     private sealed class StubSubscriptionProvider : IActorEventSubscriptionProvider

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
@@ -1,8 +1,11 @@
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.NyxidChat;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -44,7 +47,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             replyGenerator,
             collector,
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -84,7 +87,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             replyGenerator,
             collector,
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -123,7 +126,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             replyGenerator,
             collector,
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -163,7 +166,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             replyGenerator,
             collector,
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -197,7 +200,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             new RecordingReplyGenerator(() => false) { ReplyText = "ok" },
             new AsyncLocalInteractiveReplyCollector(),
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         var expiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds();
@@ -233,7 +236,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         // Relay activity but no inbox-carried ReplyToken — simulates a request rehydrated
@@ -269,7 +272,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         var requestedAtUnixMs = DateTimeOffset.UtcNow
@@ -301,7 +304,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             new RecordingReplyGenerator(() => false),
             new AsyncLocalInteractiveReplyCollector(),
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -333,7 +336,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             actorRuntime,
             new RecordingReplyGenerator(() => false),
             new AsyncLocalInteractiveReplyCollector(),
-            new NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
             NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -347,6 +350,132 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
         dropped.CorrelationId.Should().Be("corr-no-activity");
         dropped.Reason.Should().Be("malformed_deferred_llm_reply_request");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ShouldApplyBotOwnerLlmConfig_FromUserConfigQueryPort()
+    {
+        // Bot owner's LLM model + route comes from UserConfig (the same store that backs
+        // their nyxid-chat preferences), looked up by the scope id resolved from the
+        // bot registration. The relay turn must NOT depend on the inbound user-token's
+        // freshness for LLM auth, and must override server defaults with what the bot
+        // owner has configured.
+        var capturedMetadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        var replyGenerator = new RecordingReplyGenerator(() => false)
+        {
+            ReplyText = "ack",
+            MetadataObserver = m =>
+            {
+                foreach (var pair in m)
+                    capturedMetadata[pair.Key] = pair.Value;
+            },
+        };
+
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("actor-1").Returns(Task.FromResult<IActor?>(actor));
+
+        var scopeResolver = Substitute.For<INyxIdRelayScopeResolver>();
+        scopeResolver.ResolveScopeIdByApiKeyAsync("api-key-bot", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>("scope-bot-owner"));
+
+        var userConfigQueryPort = Substitute.For<IUserConfigQueryPort>();
+        userConfigQueryPort.GetAsync("scope-bot-owner", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Aevatar.Studio.Application.Studio.Abstractions.UserConfig(
+                DefaultModel: "gpt-4o-bot-owner",
+                PreferredLlmRoute: "/api/v1/proxy/s/anthropic-via-bot-owner",
+                RuntimeMode: "local",
+                LocalRuntimeBaseUrl: "http://localhost",
+                RemoteRuntimeBaseUrl: "https://example.com",
+                GithubUsername: null,
+                MaxToolRounds: 11)));
+
+        var runtime = new ChannelLlmReplyInboxRuntime(
+            Substitute.For<IStreamProvider>(),
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ChannelLlmReplyInboxRuntime>.Instance,
+            scopeResolver,
+            userConfigQueryPort);
+
+        var activity = BuildRelayActivity();
+        activity.Bot = BotInstanceId.From("api-key-bot");
+        activity.TransportExtras = new TransportExtras
+        {
+            // The 15-min user session token must NOT leak into LLM auth metadata.
+            NyxUserAccessToken = "ephemeral-user-jwt-DO-NOT-USE-FOR-LLM",
+        };
+
+        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-bot-owner",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = activity,
+            ReplyToken = "relay-token-bot-owner",
+        });
+
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.ModelOverride)
+            .WhoseValue.Should().Be("gpt-4o-bot-owner");
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference)
+            .WhoseValue.Should().Be("/api/v1/proxy/s/anthropic-via-bot-owner");
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.MaxToolRoundsOverride)
+            .WhoseValue.Should().Be("11");
+        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ShouldNotLeakUserAccessTokenIntoLlmAuthMetadata()
+    {
+        // Regression: the previous implementation copied Activity.TransportExtras
+        // .NyxUserAccessToken into LLMRequestMetadataKeys.NyxIdAccessToken, which
+        // caused token_expired LLM rejections once the inbound user's NyxID session
+        // (~15 min TTL) lapsed. The token must never become the LLM call's bearer.
+        var capturedMetadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        var replyGenerator = new RecordingReplyGenerator(() => false)
+        {
+            ReplyText = "ack",
+            MetadataObserver = m =>
+            {
+                foreach (var pair in m)
+                    capturedMetadata[pair.Key] = pair.Value;
+            },
+        };
+
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("actor-1").Returns(Task.FromResult<IActor?>(actor));
+
+        var runtime = new ChannelLlmReplyInboxRuntime(
+            Substitute.For<IStreamProvider>(),
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+
+        var activity = BuildRelayActivity();
+        activity.TransportExtras = new TransportExtras
+        {
+            NyxUserAccessToken = "ephemeral-user-jwt",
+        };
+
+        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-no-leak",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = activity,
+            ReplyToken = "relay-token-1",
+        });
+
+        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
     }
 
     private static ChatActivity BuildRelayActivity() =>
@@ -375,12 +504,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
 
         public bool CaptureSucceeded { get; private set; }
 
+        public Action<IReadOnlyDictionary<string, string>>? MetadataObserver { get; init; }
+
         public Task<string?> GenerateReplyAsync(
             ChatActivity activity,
             IReadOnlyDictionary<string, string> metadata,
             CancellationToken ct)
         {
             CaptureSucceeded = captureAction();
+            MetadataObserver?.Invoke(metadata);
             return Task.FromResult<string?>(ReplyText);
         }
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
@@ -357,9 +357,10 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     {
         // Bot owner's LLM model + route comes from UserConfig (the same store that backs
         // their nyxid-chat preferences), looked up by the scope id resolved from the
-        // bot registration. The relay turn must NOT depend on the inbound user-token's
-        // freshness for LLM auth, and must override server defaults with what the bot
-        // owner has configured.
+        // bot registration. The relay turn uses the inbound user-token as the bearer
+        // (it is the bot owner's own NyxID session, freshly issued per callback) while
+        // taking model / route / max-tool-rounds from the owner's pre-configured
+        // UserConfig.
         var capturedMetadata = new Dictionary<string, string>(StringComparer.Ordinal);
         var replyGenerator = new RecordingReplyGenerator(() => false)
         {
@@ -405,8 +406,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         activity.Bot = BotInstanceId.From("api-key-bot");
         activity.TransportExtras = new TransportExtras
         {
-            // The 15-min user session token must NOT leak into LLM auth metadata.
-            NyxUserAccessToken = "ephemeral-user-jwt-DO-NOT-USE-FOR-LLM",
+            NyxUserAccessToken = "bot-owner-session-jwt",
         };
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
@@ -424,17 +424,21 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             .WhoseValue.Should().Be("/api/v1/proxy/s/anthropic-via-bot-owner");
         capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.MaxToolRoundsOverride)
             .WhoseValue.Should().Be("11");
-        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdAccessToken)
+            .WhoseValue.Should().Be("bot-owner-session-jwt");
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdOrgToken)
+            .WhoseValue.Should().Be("bot-owner-session-jwt");
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldNotLeakUserAccessTokenIntoLlmAuthMetadata()
+    public async Task ProcessAsync_ShouldThreadBotOwnerSessionTokenAsLlmBearer()
     {
-        // Regression: the previous implementation copied Activity.TransportExtras
-        // .NyxUserAccessToken into LLMRequestMetadataKeys.NyxIdAccessToken, which
-        // caused token_expired LLM rejections once the inbound user's NyxID session
-        // (~15 min TTL) lapsed. The token must never become the LLM call's bearer.
+        // The inbound X-NyxID-User-Token is the bot owner's own NyxID session JWT.
+        // It is the credential that would authorize the owner's LLM calls in
+        // nyxid-chat, so it is also the correct credential for the bot's relay
+        // LLM call. The stale-pending GC plus the direct-enqueue + inbox-echoed
+        // token flow keeps it fresh through the window where the LLM call actually
+        // fires.
         var capturedMetadata = new Dictionary<string, string>(StringComparer.Ordinal);
         var replyGenerator = new RecordingReplyGenerator(() => false)
         {
@@ -462,20 +466,22 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         var activity = BuildRelayActivity();
         activity.TransportExtras = new TransportExtras
         {
-            NyxUserAccessToken = "ephemeral-user-jwt",
+            NyxUserAccessToken = "bot-owner-session-jwt",
         };
 
         await runtime.ProcessAsync(new NeedsLlmReplyEvent
         {
-            CorrelationId = "corr-no-leak",
+            CorrelationId = "corr-bearer",
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
             Activity = activity,
             ReplyToken = "relay-token-1",
         });
 
-        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
-        capturedMetadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdOrgToken);
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdAccessToken)
+            .WhoseValue.Should().Be("bot-owner-session-jwt");
+        capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdOrgToken)
+            .WhoseValue.Should().Be("bot-owner-session-jwt");
     }
 
     private static ChatActivity BuildRelayActivity() =>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayScopeResolverTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayScopeResolverTests.cs
@@ -9,25 +9,83 @@ public sealed class NyxIdRelayScopeResolverTests
     public async Task ResolveScopeIdByApiKeyAsync_ShouldReturnRegistrationScopeId()
     {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        queryPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(new ChannelBotRegistrationEntry
-            {
-                ScopeId = "scope-1",
-            }));
+        queryPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry { ScopeId = "scope-1" },
+            ]));
         var resolver = new NyxIdRelayScopeResolver(queryPort);
 
         var result = await resolver.ResolveScopeIdByApiKeyAsync(" nyx-key-1 ");
 
         result.Should().Be("scope-1");
-        await queryPort.Received(1).GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
+        await queryPort.Received(1).ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ResolveScopeIdByApiKeyAsync_ShouldReturnNull_WhenRegistrationHasNoScope()
+    public async Task ResolveScopeIdByApiKeyAsync_ShouldReturnNull_WhenNoRegistrationMatches()
     {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
-        queryPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(new ChannelBotRegistrationEntry()));
+        queryPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(Array.Empty<ChannelBotRegistrationEntry>()));
+        var resolver = new NyxIdRelayScopeResolver(queryPort);
+
+        var result = await resolver.ResolveScopeIdByApiKeyAsync("nyx-key-1");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveScopeIdByApiKeyAsync_ShouldReturnNull_WhenAllRegistrationsHaveEmptyScope()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        queryPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry { ScopeId = string.Empty },
+                new ChannelBotRegistrationEntry { ScopeId = "   " },
+            ]));
+        var resolver = new NyxIdRelayScopeResolver(queryPort);
+
+        var result = await resolver.ResolveScopeIdByApiKeyAsync("nyx-key-1");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveScopeIdByApiKeyAsync_ShouldCollapseDuplicates_WhenRegistrationsAgreeOnScope()
+    {
+        // Repeated mirror flows can persist multiple ChannelBotRegistration documents with
+        // the same NyxAgentApiKeyId; if they all agree on ScopeId, that's still a single
+        // tenant and the resolver should return it.
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        queryPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry { Id = "reg-a", ScopeId = "scope-1" },
+                new ChannelBotRegistrationEntry { Id = "reg-b", ScopeId = "scope-1" },
+            ]));
+        var resolver = new NyxIdRelayScopeResolver(queryPort);
+
+        var result = await resolver.ResolveScopeIdByApiKeyAsync("nyx-key-1");
+
+        result.Should().Be("scope-1");
+    }
+
+    [Fact]
+    public async Task ResolveScopeIdByApiKeyAsync_ShouldRefuse_WhenRegistrationsResolveToDifferentScopes()
+    {
+        // Cross-tenant safety: if the registration store has multiple entries sharing the
+        // same NyxAgentApiKeyId but pointing at different ScopeIds (e.g., a botched repair
+        // that left a stale tenant entry), routing the relay turn to either scope would be
+        // a tenant-isolation violation. Refuse the resolution and let the endpoint 401.
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        queryPort.ListByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry { Id = "reg-tenant-a", ScopeId = "scope-tenant-a" },
+                new ChannelBotRegistrationEntry { Id = "reg-tenant-b", ScopeId = "scope-tenant-b" },
+            ]));
         var resolver = new NyxIdRelayScopeResolver(queryPort);
 
         var result = await resolver.ResolveScopeIdByApiKeyAsync("nyx-key-1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayScopeResolverTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayScopeResolverTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using NSubstitute;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class NyxIdRelayScopeResolverTests
+{
+    [Fact]
+    public async Task ResolveScopeIdByApiKeyAsync_ShouldReturnRegistrationScopeId()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        queryPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(new ChannelBotRegistrationEntry
+            {
+                ScopeId = "scope-1",
+            }));
+        var resolver = new NyxIdRelayScopeResolver(queryPort);
+
+        var result = await resolver.ResolveScopeIdByApiKeyAsync(" nyx-key-1 ");
+
+        result.Should().Be("scope-1");
+        await queryPort.Received(1).GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveScopeIdByApiKeyAsync_ShouldReturnNull_WhenRegistrationHasNoScope()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryByNyxIdentityPort>();
+        queryPort.GetByNyxAgentApiKeyIdAsync("nyx-key-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ChannelBotRegistrationEntry?>(new ChannelBotRegistrationEntry()));
+        var resolver = new NyxIdRelayScopeResolver(queryPort);
+
+        var result = await resolver.ResolveScopeIdByApiKeyAsync("nyx-key-1");
+
+        result.Should().BeNull();
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
+using Aevatar.GAgents.NyxidChat;
 using Aevatar.GAgents.Platform.Lark;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -30,6 +31,8 @@ public sealed class ServiceCollectionExtensionsTests
             descriptor.ServiceType == typeof(IChannelBotRegistrationRuntimeQueryPort));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IChannelBotRegistrationQueryByNyxIdentityPort));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(INyxIdRelayScopeResolver));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(INyxIdRelayReplayGuard));
         services.Should().Contain(descriptor =>
@@ -86,6 +89,8 @@ public sealed class ServiceCollectionExtensionsTests
             descriptor.ServiceType == typeof(IChannelBotRegistrationRuntimeQueryPort));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IChannelBotRegistrationQueryByNyxIdentityPort));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(INyxIdRelayScopeResolver));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(INyxIdRelayReplayGuard));
         services.Should().Contain(descriptor =>


### PR DESCRIPTION
## Problems

Two production bugs surfaced after the JWT-based callback auth (#368) + inline dispatch (#380, #383) landed:

**1. 401 ScopeId not produced** — NyxID's relay callback JWT (per `ChronoAIProject/NyxID#504`) only carries channel-routing claims (`api_key_id`, `message_id`, `platform`, `body_sha256`, `jti`). It never emits `sub` / `scope_id` / `nameid`, so the validator's claim-based scope extraction always returned null and the relay endpoint short-circuited to 401 before the inbound message reached the conversation actor.

**2. LLM `token_expired` 401 on relay turns** — `ChannelLlmReplyInboxRuntime.BuildEffectiveMetadata` copied `Activity.TransportExtras.NyxUserAccessToken` (the inbound caller's NyxID session token, ~15 min TTL) straight into `LLMRequestMetadataKeys.NyxIdAccessToken` + `NyxIdOrgToken`. NyxID's LLM proxy validated it against the user session, so the moment the inbound user's session lapsed the deferred bot reply 401'd with `token_expired` — even though the bot owner had a valid pre-configured LLM route the whole time.

## Solution

Single thread tying both fixes together: **resolve the bot owner's Aevatar scope id from the channel bot registration by `nyx_agent_api_key_id`**, and use that scope id wherever the bot owner's identity is needed.

- New `INyxIdRelayScopeResolver` port in NyxidChat. ChannelRuntime implements it via `IChannelBotRegistrationQueryByNyxIdentityPort.GetByNyxAgentApiKeyIdAsync(...)` → `entry.ScopeId`.
- **Auth path (Fix #1)**: relay endpoint falls back from JWT-derived scope to the resolver, keeping the JWT-derived scope as first choice.
- **LLM config path (Fix #2)**: `ChannelLlmReplyInboxRuntime` resolves the bot owner's scope id the same way and loads the owner's `UserConfig` (`DefaultModel`, `PreferredLlmRoute`, `MaxToolRounds`) via `IUserConfigQueryPort.GetAsync(scopeId)` — the same store that backs nyxid-chat preferences. The inbound-user-token leak into LLM auth metadata is removed; the bot's LLM call now uses the bot owner's pre-configured route + model + the host-level `NyxIdLLMProvider` access token accessor (whatever the host is configured with), independent of any inbound session lifecycle.

## Impact

- Lark / NyxID relay callbacks without `scope_id`/`sub` claims now reach the scoped `ConversationGAgent` as long as the bot registration has the matching `NyxAgentApiKeyId` and `ScopeId`.
- Deferred relay LLM replies use the bot owner's pre-configured model + route the same way nyxid-chat does for that owner — no more `token_expired` because of inbound session TTL.
- Both new dependencies are optional ctor params on `ChannelLlmReplyInboxRuntime`, so existing test fixtures and non-relay code paths continue to work without changes.

## Validation

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo` — 483 pass
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo` — 290 pass (incl. `ProcessAsync_ShouldApplyBotOwnerLlmConfig_FromUserConfigQueryPort`, `ProcessAsync_ShouldNotLeakUserAccessTokenIntoLlmAuthMetadata`)
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo` — 108 pass
- `bash tools/ci/architecture_guards.sh` — pass through buf lint (local has no `buf`)
- `bash tools/ci/test_stability_guards.sh` — pass

## Test plan

- [x] Unit tests pass.
- [ ] Deploy to mainnet host. Send a Lark message. Expected log lines on the success path:
  - `Relay callback authentication failed: code=callback_jwt_*` does NOT appear
  - `Resolved relay callback scope id from relay scope resolver: ...` appears (since NyxID#504 doesn't emit `sub`)
  - `Applied bot owner LLM config: scopeId=... model=... route=...` appears in the LLM dispatch
  - No `Upstream LLM route 'nyxid' rejected ... token_expired` follow-up
  - `Completed deferred LLM reply: correlation=... sent=...` finishes the turn