### PR TITLE
Fix relay registration scope backfill

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs
@@ -42,12 +42,22 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
             return;
         }
 
+        if (string.IsNullOrWhiteSpace(cmd.ScopeId))
+        {
+            Logger.LogWarning(
+                "Ignoring channel bot registration without scope id: platform={Platform}, requestedId={RequestedId}, apiKeyId={ApiKeyId}",
+                cmd.Platform,
+                cmd.RequestedId,
+                cmd.NyxAgentApiKeyId);
+            return;
+        }
+
         var entry = new ChannelBotRegistrationEntry
         {
             Id = !string.IsNullOrWhiteSpace(cmd.RequestedId) ? cmd.RequestedId : Guid.NewGuid().ToString("N"),
             Platform = cmd.Platform,
             NyxProviderSlug = cmd.NyxProviderSlug,
-            ScopeId = cmd.ScopeId,
+            ScopeId = cmd.ScopeId.Trim(),
             WebhookUrl = cmd.WebhookUrl,
             NyxChannelBotId = cmd.NyxChannelBotId ?? string.Empty,
             NyxAgentApiKeyId = cmd.NyxAgentApiKeyId ?? string.Empty,

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
@@ -7,6 +7,10 @@ internal sealed record ChannelBotRegistrationScopeBackfillSelection(
     string? NyxAgentApiKeyId = null,
     bool Force = false);
 
+internal sealed record ChannelBotRegistrationScopeBackfillAuthorization(
+    string? AccessToken = null,
+    INyxRelayApiKeyOwnershipVerifier? OwnershipVerifier = null);
+
 internal sealed record ChannelBotRegistrationScopeBackfillResult(
     int EmptyScopeRegistrationsObserved,
     int CandidateRegistrations,
@@ -21,12 +25,14 @@ internal static class ChannelBotRegistrationScopeBackfill
         ChannelBotRegistrationScopeBackfillSelection selection,
         IActorRuntime actorRuntime,
         IActorDispatchPort dispatchPort,
+        ChannelBotRegistrationScopeBackfillAuthorization authorization,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(registrations);
         ArgumentNullException.ThrowIfNull(selection);
         ArgumentNullException.ThrowIfNull(actorRuntime);
         ArgumentNullException.ThrowIfNull(dispatchPort);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         var emptyScopeRegistrations = registrations
             .Where(static entry => string.IsNullOrWhiteSpace(entry.ScopeId))
@@ -61,6 +67,16 @@ internal static class ChannelBotRegistrationScopeBackfill
             .Where(entry => apiKeyId is null || string.Equals(entry.NyxAgentApiKeyId, apiKeyId, StringComparison.Ordinal))
             .ToArray();
 
+        var hasExplicitSelector = registrationId is not null || apiKeyId is not null;
+        if (!hasExplicitSelector)
+        {
+            return new ChannelBotRegistrationScopeBackfillResult(
+                emptyScopeRegistrations.Length,
+                candidates.Length,
+                0,
+                "Empty-scope registrations were observed; pass registration_id or nyx_agent_api_key_id to repair one safely. force=true only applies after a selector matches multiple registrations.");
+        }
+
         if (candidates.Length == 0)
         {
             return new ChannelBotRegistrationScopeBackfillResult(
@@ -70,13 +86,50 @@ internal static class ChannelBotRegistrationScopeBackfill
                 "No empty-scope registration matched the requested repair selector.");
         }
 
-        if (registrationId is null && apiKeyId is null && !selection.Force && candidates.Length != 1)
+        if (!selection.Force && candidates.Length != 1)
         {
             return new ChannelBotRegistrationScopeBackfillResult(
                 emptyScopeRegistrations.Length,
                 candidates.Length,
                 0,
-                "Multiple empty-scope registrations were observed; pass registration_id or nyx_agent_api_key_id to repair one safely.");
+                "Multiple empty-scope registrations matched the repair selector; pass force=true to repair all matched registrations.");
+        }
+
+        var accessToken = NormalizeOptional(authorization.AccessToken);
+        if (accessToken is null || authorization.OwnershipVerifier is null)
+        {
+            return new ChannelBotRegistrationScopeBackfillResult(
+                emptyScopeRegistrations.Length,
+                candidates.Length,
+                0,
+                "Empty-scope registration repair requires NyxID api-key ownership verification.");
+        }
+
+        foreach (var entry in candidates)
+        {
+            var candidateApiKeyId = NormalizeOptional(entry.NyxAgentApiKeyId);
+            if (candidateApiKeyId is null)
+            {
+                return new ChannelBotRegistrationScopeBackfillResult(
+                    emptyScopeRegistrations.Length,
+                    candidates.Length,
+                    0,
+                    $"Empty-scope registration '{entry.Id}' is missing nyx_agent_api_key_id; cannot verify ownership.");
+            }
+
+            var ownership = await authorization.OwnershipVerifier.VerifyAsync(
+                accessToken,
+                normalizedScopeId,
+                candidateApiKeyId,
+                ct);
+            if (!ownership.Succeeded)
+            {
+                return new ChannelBotRegistrationScopeBackfillResult(
+                    emptyScopeRegistrations.Length,
+                    candidates.Length,
+                    0,
+                    $"Empty-scope registration '{entry.Id}' failed NyxID api-key ownership verification: {ownership.Detail}");
+            }
         }
 
         foreach (var entry in candidates)
@@ -102,7 +155,7 @@ internal static class ChannelBotRegistrationScopeBackfill
             emptyScopeRegistrations.Length,
             candidates.Length,
             candidates.Length,
-            "Empty-scope channel bot registrations were backfilled before projection rebuild.");
+            "Empty-scope channel bot registrations were backfilled before projection rebuild; backfill re-registers entries and refreshes created_at.");
     }
 
     private static string? NormalizeOptional(string? value)

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
@@ -1,0 +1,113 @@
+using Aevatar.Foundation.Abstractions;
+
+namespace Aevatar.GAgents.ChannelRuntime;
+
+internal sealed record ChannelBotRegistrationScopeBackfillSelection(
+    string? RegistrationId = null,
+    string? NyxAgentApiKeyId = null,
+    bool Force = false);
+
+internal sealed record ChannelBotRegistrationScopeBackfillResult(
+    int EmptyScopeRegistrationsObserved,
+    int CandidateRegistrations,
+    int BackfilledRegistrations,
+    string Note);
+
+internal static class ChannelBotRegistrationScopeBackfill
+{
+    public static async Task<ChannelBotRegistrationScopeBackfillResult> BackfillAsync(
+        IReadOnlyList<ChannelBotRegistrationEntry> registrations,
+        string? scopeId,
+        ChannelBotRegistrationScopeBackfillSelection selection,
+        IActorRuntime actorRuntime,
+        IActorDispatchPort dispatchPort,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+        ArgumentNullException.ThrowIfNull(selection);
+        ArgumentNullException.ThrowIfNull(actorRuntime);
+        ArgumentNullException.ThrowIfNull(dispatchPort);
+
+        var emptyScopeRegistrations = registrations
+            .Where(static entry => string.IsNullOrWhiteSpace(entry.ScopeId))
+            .Where(static entry => string.Equals(entry.Platform, "lark", StringComparison.OrdinalIgnoreCase))
+            .Where(static entry => !entry.Tombstoned)
+            .Where(static entry => !string.IsNullOrWhiteSpace(entry.Id))
+            .ToArray();
+
+        if (emptyScopeRegistrations.Length == 0)
+        {
+            return new ChannelBotRegistrationScopeBackfillResult(
+                0,
+                0,
+                0,
+                "No empty-scope channel bot registrations were observed.");
+        }
+
+        var normalizedScopeId = NormalizeOptional(scopeId);
+        if (normalizedScopeId is null)
+        {
+            return new ChannelBotRegistrationScopeBackfillResult(
+                emptyScopeRegistrations.Length,
+                0,
+                0,
+                "Empty-scope registrations were observed, but no canonical scope_id was available for repair.");
+        }
+
+        var registrationId = NormalizeOptional(selection.RegistrationId);
+        var apiKeyId = NormalizeOptional(selection.NyxAgentApiKeyId);
+        var candidates = emptyScopeRegistrations
+            .Where(entry => registrationId is null || string.Equals(entry.Id, registrationId, StringComparison.Ordinal))
+            .Where(entry => apiKeyId is null || string.Equals(entry.NyxAgentApiKeyId, apiKeyId, StringComparison.Ordinal))
+            .ToArray();
+
+        if (candidates.Length == 0)
+        {
+            return new ChannelBotRegistrationScopeBackfillResult(
+                emptyScopeRegistrations.Length,
+                0,
+                0,
+                "No empty-scope registration matched the requested repair selector.");
+        }
+
+        if (registrationId is null && apiKeyId is null && !selection.Force && candidates.Length != 1)
+        {
+            return new ChannelBotRegistrationScopeBackfillResult(
+                emptyScopeRegistrations.Length,
+                candidates.Length,
+                0,
+                "Multiple empty-scope registrations were observed; pass registration_id or nyx_agent_api_key_id to repair one safely.");
+        }
+
+        foreach (var entry in candidates)
+        {
+            await ChannelBotRegistrationStoreCommands.DispatchRegisterAsync(
+                actorRuntime,
+                dispatchPort,
+                new ChannelBotRegisterCommand
+                {
+                    RequestedId = entry.Id,
+                    Platform = entry.Platform,
+                    NyxProviderSlug = entry.NyxProviderSlug,
+                    ScopeId = normalizedScopeId,
+                    WebhookUrl = entry.WebhookUrl,
+                    NyxChannelBotId = entry.NyxChannelBotId,
+                    NyxAgentApiKeyId = entry.NyxAgentApiKeyId,
+                    NyxConversationRouteId = entry.NyxConversationRouteId,
+                },
+                ct);
+        }
+
+        return new ChannelBotRegistrationScopeBackfillResult(
+            emptyScopeRegistrations.Length,
+            candidates.Length,
+            candidates.Length,
+            "Empty-scope channel bot registrations were backfilled before projection rebuild.");
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
@@ -190,6 +190,7 @@ public static class ChannelCallbackEndpoints
         [FromServices] IActorRuntime actorRuntime,
         [FromServices] IActorDispatchPort dispatchPort,
         [FromServices] IChannelBotRegistrationQueryPort queryPort,
+        [FromServices] INyxRelayApiKeyOwnershipVerifier? apiKeyOwnershipVerifier,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -204,11 +205,17 @@ public static class ChannelCallbackEndpoints
             logger.LogWarning(ex, "Invalid channel registration rebuild request payload");
             return Results.BadRequest(new { error = "Invalid JSON" });
         }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(ex, "Unsupported channel registration rebuild request content type");
+            return Results.BadRequest(new { error = "Unsupported content type. Use application/json for rebuild request payloads." });
+        }
 
         var scopeResolution = ResolveScopeId(http, request?.ScopeId, required: false);
         if (scopeResolution.Error is not null)
             return Results.BadRequest(new { error = scopeResolution.Error });
 
+        var accessToken = ResolveBearerAccessToken(http);
         int? observedRegistrationsBeforeRebuild = null;
         ChannelBotRegistrationScopeBackfillResult? backfill = null;
         var note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side registrations may take a moment to refresh.";
@@ -226,6 +233,9 @@ public static class ChannelCallbackEndpoints
                     request?.Force ?? false),
                 actorRuntime,
                 dispatchPort,
+                new ChannelBotRegistrationScopeBackfillAuthorization(
+                    accessToken,
+                    apiKeyOwnershipVerifier),
                 ct);
             if (backfill.EmptyScopeRegistrationsObserved > 0)
                 note = $"{note} {backfill.Note}";
@@ -253,6 +263,16 @@ public static class ChannelCallbackEndpoints
             empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
             note,
         });
+    }
+
+    private static string? ResolveBearerAccessToken(HttpContext http)
+    {
+        var accessToken = http.Request.Headers.Authorization.ToString();
+        const string bearerPrefix = "Bearer ";
+        if (accessToken.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+            accessToken = accessToken[bearerPrefix.Length..].Trim();
+
+        return string.IsNullOrWhiteSpace(accessToken) ? null : accessToken;
     }
 
     private static async Task<IResult> HandleDeleteRegistrationAsync(

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
@@ -398,6 +398,7 @@ public static class ChannelCallbackEndpoints
         if (http.Request.Body.CanSeek && http.Request.Body.Length == http.Request.Body.Position)
             return null;
 
+        // ReadFromJsonAsync throws InvalidOperationException for unsupported content types.
         return await http.Request.ReadFromJsonAsync<ChannelRegistrationRebuildRequest>(RegistrationJsonOptions, ct);
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
@@ -117,12 +117,16 @@ public static class ChannelCallbackEndpoints
             return Results.BadRequest(new { error = "webhook_base_url is required for Nyx-backed relay provisioning" });
         }
 
+        var scopeResolution = ResolveScopeId(http, request.ScopeId, required: true);
+        if (scopeResolution.Error is not null)
+            return Results.BadRequest(new { error = scopeResolution.Error });
+
         var result = await provisioningService.ProvisionAsync(
             new NyxChannelBotProvisioningRequest(
                 Platform: platformNormalized,
                 AccessToken: accessToken,
                 WebhookBaseUrl: request.WebhookBaseUrl.Trim(),
-                ScopeId: request.ScopeId?.Trim() ?? string.Empty,
+                ScopeId: scopeResolution.ScopeId!,
                 Label: request.Label?.Trim() ?? string.Empty,
                 NyxProviderSlug: request.NyxProviderSlug?.Trim() ?? string.Empty,
                 Lark: new NyxChannelLarkCredentials(
@@ -182,6 +186,7 @@ public static class ChannelCallbackEndpoints
     }
 
     private static async Task<IResult> HandleRebuildRegistrationsAsync(
+        HttpContext http,
         [FromServices] IActorRuntime actorRuntime,
         [FromServices] IActorDispatchPort dispatchPort,
         [FromServices] IChannelBotRegistrationQueryPort queryPort,
@@ -189,29 +194,63 @@ public static class ChannelCallbackEndpoints
         CancellationToken ct)
     {
         var logger = loggerFactory.CreateLogger("Aevatar.ChannelRuntime.Registration");
-        await ChannelBotRegistrationStoreCommands.DispatchRebuildProjectionAsync(
-            actorRuntime,
-            dispatchPort,
-            "http_api_manual_rebuild",
-            ct);
-
-        int? observedRegistrationsBeforeRebuild = null;
-        var note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side registrations may take a moment to refresh.";
+        ChannelRegistrationRebuildRequest? request;
         try
         {
-            observedRegistrationsBeforeRebuild = (await queryPort.QueryAllAsync(ct)).Count;
+            request = await ReadOptionalRebuildRequestAsync(http, ct);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Invalid channel registration rebuild request payload");
+            return Results.BadRequest(new { error = "Invalid JSON" });
+        }
+
+        var scopeResolution = ResolveScopeId(http, request?.ScopeId, required: false);
+        if (scopeResolution.Error is not null)
+            return Results.BadRequest(new { error = scopeResolution.Error });
+
+        int? observedRegistrationsBeforeRebuild = null;
+        ChannelBotRegistrationScopeBackfillResult? backfill = null;
+        var note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side registrations may take a moment to refresh.";
+
+        try
+        {
+            var registrations = await queryPort.QueryAllAsync(ct);
+            observedRegistrationsBeforeRebuild = registrations.Count;
+            backfill = await ChannelBotRegistrationScopeBackfill.BackfillAsync(
+                registrations,
+                scopeResolution.ScopeId,
+                new ChannelBotRegistrationScopeBackfillSelection(
+                    request?.RegistrationId,
+                    request?.NyxAgentApiKeyId,
+                    request?.Force ?? false),
+                actorRuntime,
+                dispatchPort,
+                ct);
+            if (backfill.EmptyScopeRegistrationsObserved > 0)
+                note = $"{note} {backfill.Note}";
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Channel registration query failed after dispatching a manual rebuild");
+            logger.LogWarning(ex, "Channel registration query failed before dispatching a manual rebuild");
             note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side observation is currently unavailable; registrations may still refresh asynchronously.";
         }
+
+        await ChannelBotRegistrationStoreCommands.DispatchRebuildProjectionAsync(
+            actorRuntime,
+            dispatchPort,
+            string.IsNullOrWhiteSpace(request?.Reason)
+                ? "http_api_manual_rebuild"
+                : request.Reason.Trim(),
+            ct);
 
         return Results.Accepted(value: new
         {
             status = "accepted",
             actor_id = ChannelBotRegistrationGAgent.WellKnownId,
             observed_registrations_before_rebuild = observedRegistrationsBeforeRebuild,
+            empty_scope_registrations_observed = backfill?.EmptyScopeRegistrationsObserved,
+            empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
             note,
         });
     }
@@ -299,7 +338,7 @@ public static class ChannelCallbackEndpoints
         {
             "unsupported_platform" => StatusCodes.Status409Conflict,
             "missing_access_token" => StatusCodes.Status401Unauthorized,
-            "missing_app_id" or "missing_app_secret" or "missing_verification_token" or "missing_webhook_base_url" => StatusCodes.Status400BadRequest,
+            "missing_app_id" or "missing_app_secret" or "missing_verification_token" or "missing_webhook_base_url" or "missing_scope_id" => StatusCodes.Status400BadRequest,
             "nyx_base_url_not_configured" => StatusCodes.Status500InternalServerError,
             _ => StatusCodes.Status502BadGateway,
         };
@@ -329,6 +368,51 @@ public static class ChannelCallbackEndpoints
 
         return serviceMap;
     }
+
+    private static async Task<ChannelRegistrationRebuildRequest?> ReadOptionalRebuildRequestAsync(
+        HttpContext http,
+        CancellationToken ct)
+    {
+        if (http.Request.ContentLength == 0)
+            return null;
+        if (http.Request.Body.CanSeek && http.Request.Body.Length == http.Request.Body.Position)
+            return null;
+
+        return await http.Request.ReadFromJsonAsync<ChannelRegistrationRebuildRequest>(RegistrationJsonOptions, ct);
+    }
+
+    private static ScopeIdResolution ResolveScopeId(HttpContext http, string? explicitScopeId, bool required)
+    {
+        var explicitNormalized = NormalizeOptional(explicitScopeId);
+        var claimNormalized = NormalizeOptional(http.User.FindFirst("scope_id")?.Value);
+        if (explicitNormalized is not null &&
+            claimNormalized is not null &&
+            !string.Equals(explicitNormalized, claimNormalized, StringComparison.Ordinal))
+        {
+            return new ScopeIdResolution(null, "scope_id does not match the authenticated scope");
+        }
+
+        var resolved = explicitNormalized ?? claimNormalized;
+        if (required && resolved is null)
+            return new ScopeIdResolution(null, "scope_id is required");
+
+        return new ScopeIdResolution(resolved, null);
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private sealed record ScopeIdResolution(string? ScopeId, string? Error);
+
+    private sealed record ChannelRegistrationRebuildRequest(
+        string? ScopeId,
+        string? RegistrationId,
+        string? NyxAgentApiKeyId,
+        string? Reason,
+        bool Force);
 
     private sealed record RegistrationRequest(
         string? Platform,

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
@@ -87,7 +87,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
             },
             "force": {
               "type": "boolean",
-              "description": "For rebuild_projection only: repair all matching empty-scope registrations when more than one candidate exists. Prefer registration_id or nyx_agent_api_key_id for targeted repair."
+              "description": "For rebuild_projection only: when registration_id or nyx_agent_api_key_id matches multiple empty-scope registrations, deliberately repair all matched registrations after NyxID ownership verification."
             },
             "registration_id": {
               "type": "string",
@@ -115,7 +115,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
         {
             "list" => await ExecuteWithQueryAsync(queryPort => ListAsync(queryPort, ct)),
             "register_lark_via_nyx" => await RegisterLarkViaNyxAsync(token, root, ct),
-            "rebuild_projection" => await ExecuteWithStoreAsync((queryPort, actorRuntime, dispatchPort) => RebuildProjectionAsync(queryPort, actorRuntime, dispatchPort, root, ct)),
+            "rebuild_projection" => await ExecuteWithStoreAsync((queryPort, actorRuntime, dispatchPort) => RebuildProjectionAsync(queryPort, actorRuntime, dispatchPort, token, root, ct)),
             "repair_lark_mirror" => await RepairLarkMirrorAsync(root, ct),
             "delete" => await ExecuteWithStoreAsync((queryPort, actorRuntime, dispatchPort) => DeleteAsync(queryPort, actorRuntime, dispatchPort, root, ct)),
             "register" => RetiredActionError("Direct callback registration is retired. Use action=register_lark_via_nyx."),
@@ -374,6 +374,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
         IChannelBotRegistrationQueryPort queryPort,
         IActorRuntime actorRuntime,
         IActorDispatchPort dispatchPort,
+        string accessToken,
         JsonElement args,
         CancellationToken ct)
     {
@@ -397,6 +398,9 @@ public sealed class ChannelRegistrationTool : IAgentTool
                     GetBool(args, "force")),
                 actorRuntime,
                 dispatchPort,
+                new ChannelBotRegistrationScopeBackfillAuthorization(
+                    accessToken,
+                    _serviceProvider.GetService<INyxRelayApiKeyOwnershipVerifier>()),
                 ct);
             if (backfill.EmptyScopeRegistrationsObserved > 0)
                 note = $"{note} {backfill.Note}";

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
@@ -29,6 +29,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
         "Actions: list, register_lark_via_nyx, rebuild_projection, repair_lark_mirror, delete. " +
         "Use register_lark_via_nyx for first-time provisioning, rebuild_projection to re-materialize the local registration read model from the authoritative actor state, and repair_lark_mirror when Nyx relay resources already exist but the local Aevatar mirror is missing. " +
         "Legacy direct callback registration and update_token flows are retired because ChannelRuntime no longer stores channel credentials. " +
+        "Do not ask the user for scope_id; it is resolved from the current NyxID request context and should only be supplied explicitly for diagnostics. " +
         "Repair requires verified Nyx bot/api-key state plus an existing relay credential reference that still resolves in the local secrets store.";
 
     public string ParametersSchema => """
@@ -46,7 +47,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
             },
             "scope_id": {
               "type": "string",
-              "description": "Scope ID for multi-tenant isolation (optional)"
+              "description": "Scope ID for multi-tenant isolation. Normally supplied from the current NyxID request context; only pass explicitly for repair/backfill diagnostics."
             },
             "webhook_base_url": {
               "type": "string",
@@ -83,6 +84,10 @@ public sealed class ChannelRegistrationTool : IAgentTool
             "reason": {
               "type": "string",
               "description": "Optional operator reason for rebuild_projection"
+            },
+            "force": {
+              "type": "boolean",
+              "description": "For rebuild_projection only: repair all matching empty-scope registrations when more than one candidate exists. Prefer registration_id or nyx_agent_api_key_id for targeted repair."
             },
             "registration_id": {
               "type": "string",
@@ -147,11 +152,43 @@ public sealed class ChannelRegistrationTool : IAgentTool
             ? value.GetString()
             : null;
 
+    private static bool GetBool(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.True;
+
     private static string ResolveNyxProviderSlug(JsonElement args)
     {
         var slug = GetStr(args, "nyx_provider_slug")?.Trim();
         return string.IsNullOrWhiteSpace(slug) ? DefaultNyxProviderSlug : slug;
     }
+
+    private static ToolScopeResolution ResolveToolScopeId(JsonElement args, bool required)
+    {
+        var explicitScopeId = NormalizeOptional(GetStr(args, "scope_id"));
+        var contextScopeId = NormalizeOptional(AgentToolRequestContext.TryGet("scope_id"));
+        if (explicitScopeId is not null &&
+            contextScopeId is not null &&
+            !string.Equals(explicitScopeId, contextScopeId, StringComparison.Ordinal))
+        {
+            return new ToolScopeResolution(null, "scope_id does not match the current NyxID request scope");
+        }
+
+        var resolved = explicitScopeId ?? contextScopeId;
+        if (required && resolved is null)
+            return new ToolScopeResolution(null, "scope_id is required from the current NyxID request context");
+
+        return new ToolScopeResolution(resolved, null);
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string SerializeError(string error) =>
+        JsonSerializer.Serialize(new { error });
+
+    private sealed record ToolScopeResolution(string? ScopeId, string? Error);
 
     private static string RetiredActionError(string message) =>
         JsonSerializer.Serialize(new
@@ -217,6 +254,10 @@ public sealed class ChannelRegistrationTool : IAgentTool
         if (provisioningService is null)
             return """{"error":"Nyx-backed Lark provisioning service is not registered."}""";
 
+        var scopeResolution = ResolveToolScopeId(args, required: true);
+        if (scopeResolution.Error is not null)
+            return SerializeError(scopeResolution.Error);
+
         var result = await provisioningService.ProvisionAsync(
             new NyxLarkProvisioningRequest(
                 AccessToken: accessToken,
@@ -224,7 +265,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
                 AppSecret: GetStr(args, "app_secret")?.Trim() ?? string.Empty,
                 VerificationToken: GetStr(args, "verification_token")?.Trim() ?? string.Empty,
                 WebhookBaseUrl: GetStr(args, "webhook_base_url")?.Trim() ?? string.Empty,
-                ScopeId: GetStr(args, "scope_id")?.Trim() ?? string.Empty,
+                ScopeId: scopeResolution.ScopeId!,
                 Label: GetStr(args, "label")?.Trim() ?? string.Empty,
                 NyxProviderSlug: GetStr(args, "nyx_provider_slug")?.Trim() ?? string.Empty),
             ct);
@@ -256,30 +297,42 @@ public sealed class ChannelRegistrationTool : IAgentTool
         if (string.IsNullOrWhiteSpace(nyxAgentApiKeyId))
             return """{"error":"'nyx_agent_api_key_id' is required for repair_lark_mirror"}""";
 
+        var scopeResolution = ResolveToolScopeId(args, required: true);
+        if (scopeResolution.Error is not null)
+            return SerializeError(scopeResolution.Error);
+
+        ChannelBotRegistrationEntry? existing = null;
         var queryPort = _serviceProvider.GetService<IChannelBotRegistrationQueryPort>();
         if (queryPort is not null)
         {
             try
             {
                 var registrations = await queryPort.QueryAllAsync(ct);
-                var existing = registrations.FirstOrDefault(entry =>
+                existing = registrations.FirstOrDefault(entry =>
                     string.Equals(entry.Platform, "lark", StringComparison.OrdinalIgnoreCase) &&
                     MatchesNyxIdentity(entry, nyxChannelBotId, nyxAgentApiKeyId, nyxConversationRouteId));
                 if (existing is not null)
                 {
-                    return SerializeLarkRegistrationPayload(
-                        status: "already_registered",
-                        registrationId: existing.Id,
-                        nyxProviderSlug: string.IsNullOrWhiteSpace(existing.NyxProviderSlug)
-                            ? DefaultNyxProviderSlug
-                            : existing.NyxProviderSlug,
-                        nyxChannelBotId: existing.NyxChannelBotId,
-                        nyxAgentApiKeyId: existing.NyxAgentApiKeyId,
-                        nyxConversationRouteId: existing.NyxConversationRouteId,
-                        relayCallbackUrl: string.Empty,
-                        webhookUrl: existing.WebhookUrl,
-                        error: string.Empty,
-                        note: "Matching local Aevatar mirror already exists.");
+                    var existingScopeId = NormalizeOptional(existing.ScopeId);
+                    if (existingScopeId is not null)
+                    {
+                        if (!string.Equals(existingScopeId, scopeResolution.ScopeId, StringComparison.Ordinal))
+                            return SerializeError("matching local Aevatar mirror belongs to a different scope_id");
+
+                        return SerializeLarkRegistrationPayload(
+                            status: "already_registered",
+                            registrationId: existing.Id,
+                            nyxProviderSlug: string.IsNullOrWhiteSpace(existing.NyxProviderSlug)
+                                ? DefaultNyxProviderSlug
+                                : existing.NyxProviderSlug,
+                            nyxChannelBotId: existing.NyxChannelBotId,
+                            nyxAgentApiKeyId: existing.NyxAgentApiKeyId,
+                            nyxConversationRouteId: existing.NyxConversationRouteId,
+                            relayCallbackUrl: string.Empty,
+                            webhookUrl: existing.WebhookUrl,
+                            error: string.Empty,
+                            note: "Matching local Aevatar mirror already exists.");
+                    }
                 }
             }
             catch
@@ -288,11 +341,15 @@ public sealed class ChannelRegistrationTool : IAgentTool
             }
         }
 
+        var requestedRegistrationId = GetStr(args, "registration_id")?.Trim();
+        if (string.IsNullOrWhiteSpace(requestedRegistrationId) && existing is not null)
+            requestedRegistrationId = existing.Id;
+
         var result = await provisioningService.RepairLocalMirrorAsync(
             new NyxLarkMirrorRepairRequest(
                 AccessToken: AgentToolRequestContext.TryGet(LLMRequestMetadataKeys.NyxIdAccessToken) ?? string.Empty,
-                RequestedRegistrationId: GetStr(args, "registration_id")?.Trim() ?? string.Empty,
-                ScopeId: GetStr(args, "scope_id")?.Trim() ?? string.Empty,
+                RequestedRegistrationId: requestedRegistrationId?.Trim() ?? string.Empty,
+                ScopeId: scopeResolution.ScopeId!,
                 NyxProviderSlug: ResolveNyxProviderSlug(args),
                 WebhookBaseUrl: GetStr(args, "webhook_base_url")?.Trim() ?? string.Empty,
                 NyxChannelBotId: nyxChannelBotId,
@@ -320,28 +377,48 @@ public sealed class ChannelRegistrationTool : IAgentTool
         JsonElement args,
         CancellationToken ct)
     {
-        await ChannelBotRegistrationStoreCommands.DispatchRebuildProjectionAsync(
-            actorRuntime,
-            dispatchPort,
-            GetStr(args, "reason")?.Trim() ?? "tool_manual_rebuild",
-            ct);
+        var scopeResolution = ResolveToolScopeId(args, required: false);
+        if (scopeResolution.Error is not null)
+            return SerializeError(scopeResolution.Error);
 
         int? observedRegistrationsBeforeRebuild = null;
+        ChannelBotRegistrationScopeBackfillResult? backfill = null;
         var note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side registrations may take a moment to refresh.";
         try
         {
-            observedRegistrationsBeforeRebuild = (await queryPort.QueryAllAsync(ct)).Count;
+            var registrations = await queryPort.QueryAllAsync(ct);
+            observedRegistrationsBeforeRebuild = registrations.Count;
+            backfill = await ChannelBotRegistrationScopeBackfill.BackfillAsync(
+                registrations,
+                scopeResolution.ScopeId,
+                new ChannelBotRegistrationScopeBackfillSelection(
+                    GetStr(args, "registration_id"),
+                    GetStr(args, "nyx_agent_api_key_id"),
+                    GetBool(args, "force")),
+                actorRuntime,
+                dispatchPort,
+                ct);
+            if (backfill.EmptyScopeRegistrationsObserved > 0)
+                note = $"{note} {backfill.Note}";
         }
         catch
         {
             note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side observation is currently unavailable; registrations may still refresh asynchronously.";
         }
 
+        await ChannelBotRegistrationStoreCommands.DispatchRebuildProjectionAsync(
+            actorRuntime,
+            dispatchPort,
+            GetStr(args, "reason")?.Trim() ?? "tool_manual_rebuild",
+            ct);
+
         return JsonSerializer.Serialize(new
         {
             status = "accepted",
             actor_id = ChannelBotRegistrationGAgent.WellKnownId,
             observed_registrations_before_rebuild = observedRegistrationsBeforeRebuild,
+            empty_scope_registrations_observed = backfill?.EmptyScopeRegistrationsObserved,
+            empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
             note,
         });
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxLarkProvisioningService.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxLarkProvisioningService.cs
@@ -136,6 +136,8 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
             return Failure("missing_app_secret");
         if (string.IsNullOrWhiteSpace(request.WebhookBaseUrl))
             return Failure("missing_webhook_base_url");
+        if (string.IsNullOrWhiteSpace(request.ScopeId))
+            return Failure("missing_scope_id");
         if (string.IsNullOrWhiteSpace(_nyxOptions.BaseUrl))
             return Failure("nyx_base_url_not_configured");
 
@@ -222,6 +224,8 @@ public sealed class NyxLarkProvisioningService : INyxLarkProvisioningService, IN
             return MirrorFailure("missing_access_token");
         if (string.IsNullOrWhiteSpace(request.WebhookBaseUrl))
             return MirrorFailure("missing_webhook_base_url");
+        if (string.IsNullOrWhiteSpace(request.ScopeId))
+            return MirrorFailure("missing_scope_id");
         if (string.IsNullOrWhiteSpace(request.NyxChannelBotId))
             return MirrorFailure("missing_nyx_channel_bot_id");
         if (string.IsNullOrWhiteSpace(request.NyxAgentApiKeyId))

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayApiKeyOwnershipVerifier.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayApiKeyOwnershipVerifier.cs
@@ -1,0 +1,159 @@
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgents.ChannelRuntime;
+
+internal sealed record NyxRelayApiKeyOwnershipVerification(bool Succeeded, string Detail);
+
+internal interface INyxRelayApiKeyOwnershipVerifier
+{
+    Task<NyxRelayApiKeyOwnershipVerification> VerifyAsync(
+        string accessToken,
+        string expectedScopeId,
+        string nyxAgentApiKeyId,
+        CancellationToken ct);
+}
+
+internal sealed class NyxRelayApiKeyOwnershipVerifier : INyxRelayApiKeyOwnershipVerifier
+{
+    private readonly NyxIdApiClient _nyxClient;
+    private readonly ILogger<NyxRelayApiKeyOwnershipVerifier> _logger;
+
+    public NyxRelayApiKeyOwnershipVerifier(
+        NyxIdApiClient nyxClient,
+        ILogger<NyxRelayApiKeyOwnershipVerifier>? logger = null)
+    {
+        _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
+        _logger = logger ?? NullLogger<NyxRelayApiKeyOwnershipVerifier>.Instance;
+    }
+
+    public async Task<NyxRelayApiKeyOwnershipVerification> VerifyAsync(
+        string accessToken,
+        string expectedScopeId,
+        string nyxAgentApiKeyId,
+        CancellationToken ct)
+    {
+        var token = NormalizeOptional(accessToken);
+        var scopeId = NormalizeOptional(expectedScopeId);
+        var apiKeyId = NormalizeOptional(nyxAgentApiKeyId);
+        if (token is null)
+            return Failure("missing_access_token");
+        if (scopeId is null)
+            return Failure("missing_scope_id");
+        if (apiKeyId is null)
+            return Failure("missing_nyx_agent_api_key_id");
+
+        try
+        {
+            var response = await _nyxClient.GetApiKeyAsync(token, apiKeyId, ct);
+            if (TryReadErrorEnvelope(response, out var errorDetail))
+                return Failure($"api_key_lookup_failed {errorDetail}");
+
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            var returnedId = ReadOptionalString(root, "id");
+            if (!string.Equals(returnedId, apiKeyId, StringComparison.Ordinal))
+                return Failure("api_key_id_mismatch");
+
+            var ownerScopeId = await ResolveOwnerScopeIdAsync(token, root, ct);
+            if (ownerScopeId is null)
+                return Failure("api_key_owner_scope_unresolved");
+
+            if (!string.Equals(ownerScopeId, scopeId, StringComparison.Ordinal))
+                return Failure("api_key_owner_scope_mismatch");
+
+            return new NyxRelayApiKeyOwnershipVerification(true, "verified");
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "NyxID api-key ownership verification returned invalid JSON: apiKeyId={ApiKeyId}", apiKeyId);
+            return Failure("invalid_json");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "NyxID api-key ownership verification failed: apiKeyId={ApiKeyId}", apiKeyId);
+            return Failure("verification_exception");
+        }
+    }
+
+    private async Task<string?> ResolveOwnerScopeIdAsync(string accessToken, JsonElement apiKeyRoot, CancellationToken ct)
+    {
+        if (apiKeyRoot.TryGetProperty("credential_source", out var source) &&
+            source.ValueKind == JsonValueKind.Object)
+        {
+            var sourceType = ReadOptionalString(source, "type");
+            if (string.Equals(sourceType, "org", StringComparison.OrdinalIgnoreCase))
+            {
+                var role = ReadOptionalString(source, "role");
+                if (!string.Equals(role, "admin", StringComparison.OrdinalIgnoreCase))
+                    return null;
+
+                return NormalizeOptional(ReadOptionalString(source, "org_id"));
+            }
+        }
+
+        var currentUserResponse = await _nyxClient.GetCurrentUserAsync(accessToken, ct);
+        if (TryReadErrorEnvelope(currentUserResponse, out _))
+            return null;
+
+        using var currentUser = JsonDocument.Parse(currentUserResponse);
+        return NormalizeOptional(ReadOptionalString(currentUser.RootElement, "id"));
+    }
+
+    private static bool TryReadErrorEnvelope(string response, out string detail)
+    {
+        detail = string.Empty;
+        if (string.IsNullOrWhiteSpace(response))
+        {
+            detail = "empty_response";
+            return true;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("error", out var error) ||
+                error.ValueKind != JsonValueKind.True)
+            {
+                return false;
+            }
+
+            var status = root.TryGetProperty("status", out var statusProp) &&
+                         statusProp.ValueKind == JsonValueKind.Number
+                ? statusProp.GetInt32().ToString()
+                : "unknown";
+            var body = ReadOptionalString(root, "body");
+            var message = ReadOptionalString(root, "message");
+            detail = $"nyx_status={status}" +
+                     (body is null ? string.Empty : $" body={body}") +
+                     (message is null ? string.Empty : $" message={message}");
+            return true;
+        }
+        catch (JsonException)
+        {
+            detail = "invalid_error_envelope";
+            return true;
+        }
+    }
+
+    private static string? ReadOptionalString(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var value) && value.ValueKind == JsonValueKind.String
+            ? NormalizeOptional(value.GetString())
+            : null;
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static NyxRelayApiKeyOwnershipVerification Failure(string detail) =>
+        new(false, detail);
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayApiKeyOwnershipVerifier.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayApiKeyOwnershipVerifier.cs
@@ -21,6 +21,8 @@ internal sealed class NyxRelayApiKeyOwnershipVerifier : INyxRelayApiKeyOwnership
     private readonly NyxIdApiClient _nyxClient;
     private readonly ILogger<NyxRelayApiKeyOwnershipVerifier> _logger;
 
+    private sealed record OwnerScopeResolution(string? ScopeId, string? FailureDetail);
+
     public NyxRelayApiKeyOwnershipVerifier(
         NyxIdApiClient nyxClient,
         ILogger<NyxRelayApiKeyOwnershipVerifier>? logger = null)
@@ -57,11 +59,13 @@ internal sealed class NyxRelayApiKeyOwnershipVerifier : INyxRelayApiKeyOwnership
             if (!string.Equals(returnedId, apiKeyId, StringComparison.Ordinal))
                 return Failure("api_key_id_mismatch");
 
-            var ownerScopeId = await ResolveOwnerScopeIdAsync(token, root, ct);
-            if (ownerScopeId is null)
+            var owner = await ResolveOwnerScopeIdAsync(token, root, ct);
+            if (owner.FailureDetail is not null)
+                return Failure(owner.FailureDetail);
+            if (owner.ScopeId is null)
                 return Failure("api_key_owner_scope_unresolved");
 
-            if (!string.Equals(ownerScopeId, scopeId, StringComparison.Ordinal))
+            if (!string.Equals(owner.ScopeId, scopeId, StringComparison.Ordinal))
                 return Failure("api_key_owner_scope_mismatch");
 
             return new NyxRelayApiKeyOwnershipVerification(true, "verified");
@@ -82,7 +86,10 @@ internal sealed class NyxRelayApiKeyOwnershipVerifier : INyxRelayApiKeyOwnership
         }
     }
 
-    private async Task<string?> ResolveOwnerScopeIdAsync(string accessToken, JsonElement apiKeyRoot, CancellationToken ct)
+    private async Task<OwnerScopeResolution> ResolveOwnerScopeIdAsync(
+        string accessToken,
+        JsonElement apiKeyRoot,
+        CancellationToken ct)
     {
         if (apiKeyRoot.TryGetProperty("credential_source", out var source) &&
             source.ValueKind == JsonValueKind.Object)
@@ -92,18 +99,48 @@ internal sealed class NyxRelayApiKeyOwnershipVerifier : INyxRelayApiKeyOwnership
             {
                 var role = ReadOptionalString(source, "role");
                 if (!string.Equals(role, "admin", StringComparison.OrdinalIgnoreCase))
-                    return null;
+                    return Unresolved($"org_role={role ?? "missing"}");
 
-                return NormalizeOptional(ReadOptionalString(source, "org_id"));
+                var orgId = NormalizeOptional(ReadOptionalString(source, "org_id"));
+                return orgId is null
+                    ? Unresolved("org_id_missing")
+                    : Resolved(orgId);
             }
+
+            if (string.Equals(sourceType, "personal", StringComparison.OrdinalIgnoreCase))
+            {
+                return await ResolvePersonalOwnerScopeIdAsync(accessToken, apiKeyRoot, ct);
+            }
+
+            return Unresolved($"source_type={sourceType ?? "missing"}");
         }
 
+        return Unresolved("credential_source_missing");
+    }
+
+    private async Task<OwnerScopeResolution> ResolvePersonalOwnerScopeIdAsync(
+        string accessToken,
+        JsonElement apiKeyRoot,
+        CancellationToken ct)
+    {
+        // Personal key ownership relies on NyxID's read-owner gate; verify key.user_id too when the response exposes it.
         var currentUserResponse = await _nyxClient.GetCurrentUserAsync(accessToken, ct);
-        if (TryReadErrorEnvelope(currentUserResponse, out _))
-            return null;
+        if (TryReadErrorEnvelope(currentUserResponse, out var errorDetail))
+            return Unresolved($"current_user_lookup_failed {errorDetail}");
 
         using var currentUser = JsonDocument.Parse(currentUserResponse);
-        return NormalizeOptional(ReadOptionalString(currentUser.RootElement, "id"));
+        var currentUserId = NormalizeOptional(ReadOptionalString(currentUser.RootElement, "id"));
+        if (currentUserId is null)
+            return Unresolved("current_user_id_missing");
+
+        var keyUserId = NormalizeOptional(ReadOptionalString(apiKeyRoot, "user_id"));
+        if (keyUserId is not null &&
+            !string.Equals(keyUserId, currentUserId, StringComparison.Ordinal))
+        {
+            return new OwnerScopeResolution(null, "api_key_owner_scope_mismatch key_user_id_mismatch");
+        }
+
+        return Resolved(currentUserId);
     }
 
     private static bool TryReadErrorEnvelope(string response, out string detail)
@@ -153,6 +190,12 @@ internal sealed class NyxRelayApiKeyOwnershipVerifier : INyxRelayApiKeyOwnership
         var normalized = value?.Trim();
         return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
     }
+
+    private static OwnerScopeResolution Resolved(string scopeId) =>
+        new(scopeId, null);
+
+    private static OwnerScopeResolution Unresolved(string detail) =>
+        new(null, $"api_key_owner_scope_unresolved {detail}");
 
     private static NyxRelayApiKeyOwnershipVerification Failure(string detail) =>
         new(false, detail);

--- a/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.Channel;
+using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.DependencyInjection;
 using Aevatar.CQRS.Projection.Core.Orchestration;
@@ -105,6 +106,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IChannelBotRegistrationRuntimeQueryPort, ChannelBotRegistrationRuntimeQueryPort>();
         services.TryAddSingleton<ChannelBotRegistrationProjectionPort>();
         services.TryAddSingleton<ChannelPlatformReplyService>();
+        services.TryAddSingleton<NyxIdApiClient>();
+        services.TryAddSingleton<INyxRelayApiKeyOwnershipVerifier, NyxRelayApiKeyOwnershipVerifier>();
         services.TryAddSingleton<INyxLarkProvisioningService, NyxLarkProvisioningService>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<INyxChannelBotProvisioningService, NyxLarkProvisioningService>());
         services.AddHostedService<ChannelBotRegistrationStartupService>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
@@ -81,12 +81,27 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleRegister_RejectsLarkRegistrationWithoutScopeId()
+    {
+        await _agent.HandleRegister(new ChannelBotRegisterCommand
+        {
+            Platform = "lark",
+            NyxProviderSlug = "api-lark-bot",
+            RequestedId = "reg-1",
+            NyxAgentApiKeyId = "key-1",
+        });
+
+        _agent.State.Registrations.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleUnregister_TombstonesEntry()
     {
         await _agent.HandleRegister(new ChannelBotRegisterCommand
         {
             Platform = "lark",
             NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-1",
             RequestedId = "reg-1",
         });
 
@@ -107,6 +122,7 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
         {
             Platform = "lark",
             NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-1",
             RequestedId = "reg-1",
         });
 
@@ -131,6 +147,7 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
         {
             Platform = "lark",
             NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-1",
             RequestedId = "reg-1",
             NyxAgentApiKeyId = "key-1",
         });

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Aevatar.Foundation.Abstractions;
@@ -74,7 +75,8 @@ public sealed class ChannelCallbackEndpointsTests
                 WebhookUrl: "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1")));
 
         var http = CreateJsonHttpContext(
-            """{"platform":"lark","app_id":"cli_123","app_secret":"secret","verification_token":"verify-123","webhook_base_url":"https://aevatar.example.com"}""");
+            """{"platform":"lark","app_id":"cli_123","app_secret":"secret","verification_token":"verify-123","webhook_base_url":"https://aevatar.example.com"}""",
+            "scope-1");
         http.Request.Headers.Authorization = "Bearer test-token";
 
         var result = await InvokeAsync(
@@ -93,11 +95,35 @@ public sealed class ChannelCallbackEndpointsTests
                 request.Platform == "lark" &&
                 request.AccessToken == "test-token" &&
                 request.WebhookBaseUrl == "https://aevatar.example.com" &&
+                request.ScopeId == "scope-1" &&
                 request.Lark != null &&
                 request.Lark.AppId == "cli_123" &&
                 request.Lark.AppSecret == "secret" &&
                 request.Lark.VerificationToken == "verify-123"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRegisterAsync_RejectsLarkProvisioningWithoutScope()
+    {
+        var provisioningService = Substitute.For<INyxChannelBotProvisioningService>();
+        provisioningService.Platform.Returns("lark");
+
+        var http = CreateJsonHttpContext(
+            """{"platform":"lark","app_id":"cli_123","app_secret":"secret","webhook_base_url":"https://aevatar.example.com"}""");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRegisterAsync",
+            http,
+            new[] { provisioningService },
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        response.Body.Should().Contain("scope_id is required");
+        await provisioningService.DidNotReceive().ProvisionAsync(Arg.Any<NyxChannelBotProvisioningRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -113,7 +139,8 @@ public sealed class ChannelCallbackEndpointsTests
                 Error: "channel_bot_id_request_failed nyx_status=401 body=invalid app secret")));
 
         var http = CreateJsonHttpContext(
-            """{"platform":"lark","app_id":"cli_123","app_secret":"bad-secret","webhook_base_url":"https://aevatar.example.com"}""");
+            """{"platform":"lark","app_id":"cli_123","app_secret":"bad-secret","webhook_base_url":"https://aevatar.example.com"}""",
+            "scope-1");
         http.Request.Headers.Authorization = "Bearer test-token";
 
         var result = await InvokeAsync(
@@ -168,19 +195,20 @@ public sealed class ChannelCallbackEndpointsTests
                 },
             ]));
 
-        EventEnvelope? capturedEnvelope = null;
+        List<EventEnvelope> capturedEnvelopes = [];
         var actor = Substitute.For<IActor>();
         var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
         actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
             .Returns(Task.FromResult<IActor?>(actor));
         ((IActorDispatchPort)actorRuntime).DispatchAsync(
                 ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
                 Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
         var result = await InvokeAsync(
             "HandleRebuildRegistrationsAsync",
+            CreateHttpContext("scope-1"),
             actorRuntime,
             (IActorDispatchPort)actorRuntime,
             queryPort,
@@ -191,8 +219,10 @@ public sealed class ChannelCallbackEndpointsTests
         response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         response.Body.Should().Contain("\"status\":\"accepted\"");
         response.Body.Should().Contain("\"observed_registrations_before_rebuild\":1");
-        capturedEnvelope.Should().NotBeNull();
-        capturedEnvelope!.Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
+        response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":1");
+        capturedEnvelopes.Should().HaveCount(2);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
+        capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
     }
 
     [Fact]
@@ -214,6 +244,7 @@ public sealed class ChannelCallbackEndpointsTests
 
         var result = await InvokeAsync(
             "HandleRebuildRegistrationsAsync",
+            CreateHttpContext("scope-1"),
             actorRuntime,
             (IActorDispatchPort)actorRuntime,
             queryPort,
@@ -322,18 +353,26 @@ public sealed class ChannelCallbackEndpointsTests
         response.Body.Should().Contain("\"detail\":\"accepted\"");
     }
 
-    private static HttpContext CreateHttpContext()
+    private static HttpContext CreateHttpContext(string? scopeId = null)
     {
         var builder = WebApplication.CreateBuilder();
         var context = new DefaultHttpContext();
         context.RequestServices = builder.Services.BuildServiceProvider();
         context.Response.Body = new MemoryStream();
+        if (!string.IsNullOrWhiteSpace(scopeId))
+        {
+            context.User = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim("scope_id", scopeId),
+            ], "test"));
+        }
+
         return context;
     }
 
-    private static HttpContext CreateJsonHttpContext(string json)
+    private static HttpContext CreateJsonHttpContext(string json, string? scopeId = null)
     {
-        var context = CreateHttpContext();
+        var context = CreateHttpContext(scopeId);
         context.Request.ContentType = "application/json";
         context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
         return context;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -192,6 +192,7 @@ public sealed class ChannelCallbackEndpointsTests
                 {
                     Id = "reg-1",
                     Platform = "lark",
+                    NyxAgentApiKeyId = "key-1",
                 },
             ]));
 
@@ -205,13 +206,17 @@ public sealed class ChannelCallbackEndpointsTests
                 Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
                 Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
+        var verifier = new RecordingOwnershipVerifier();
+        var http = CreateJsonHttpContext("""{"registration_id":"reg-1"}""", "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
 
         var result = await InvokeAsync(
             "HandleRebuildRegistrationsAsync",
-            CreateHttpContext("scope-1"),
+            http,
             actorRuntime,
             (IActorDispatchPort)actorRuntime,
             queryPort,
+            verifier,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -223,6 +228,106 @@ public sealed class ChannelCallbackEndpointsTests
         capturedEnvelopes.Should().HaveCount(2);
         capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
         capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
+        verifier.Calls.Should().ContainSingle()
+            .Which.Should().Be(("test-token", "scope-1", "key-1"));
+    }
+
+    [Fact]
+    public async Task HandleRebuildRegistrationsAsync_DoesNotBackfillEmptyScopeRegistrationWithoutSelector()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-1",
+                    Platform = "lark",
+                },
+            ]));
+
+        List<EventEnvelope> capturedEnvelopes = [];
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var result = await InvokeAsync(
+            "HandleRebuildRegistrationsAsync",
+            CreateHttpContext("scope-1"),
+            actorRuntime,
+            (IActorDispatchPort)actorRuntime,
+            queryPort,
+            (INyxRelayApiKeyOwnershipVerifier?)null,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        response.Body.Should().Contain("\"empty_scope_registrations_observed\":1");
+        response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":0");
+        response.Body.Should().Contain("pass registration_id");
+        capturedEnvelopes.Should().HaveCount(1);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
+    }
+
+    [Fact]
+    public async Task HandleRebuildRegistrationsAsync_ReturnsBadRequestForUnsupportedContentType()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        var http = CreateHttpContext("scope-1");
+        http.Request.ContentType = "text/plain";
+        http.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("registration_id=reg-1"));
+
+        var result = await InvokeAsync(
+            "HandleRebuildRegistrationsAsync",
+            http,
+            actorRuntime,
+            (IActorDispatchPort)actorRuntime,
+            queryPort,
+            (INyxRelayApiKeyOwnershipVerifier?)null,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        response.Body.Should().Contain("Unsupported content type");
+        await queryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
+        await ((IActorDispatchPort)actorRuntime).DidNotReceive().DispatchAsync(
+            Arg.Any<string>(),
+            Arg.Any<EventEnvelope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRebuildRegistrationsAsync_ReturnsBadRequestWhenBodyScopeConflictsWithClaim()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+
+        var result = await InvokeAsync(
+            "HandleRebuildRegistrationsAsync",
+            CreateJsonHttpContext("""{"scope_id":"scope-2","registration_id":"reg-1"}""", "scope-1"),
+            actorRuntime,
+            (IActorDispatchPort)actorRuntime,
+            queryPort,
+            (INyxRelayApiKeyOwnershipVerifier?)null,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        response.Body.Should().Contain("scope_id does not match");
+        await queryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
+        await ((IActorDispatchPort)actorRuntime).DidNotReceive().DispatchAsync(
+            Arg.Any<string>(),
+            Arg.Any<EventEnvelope>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -248,6 +353,7 @@ public sealed class ChannelCallbackEndpointsTests
             actorRuntime,
             (IActorDispatchPort)actorRuntime,
             queryPort,
+            (INyxRelayApiKeyOwnershipVerifier?)null,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -378,7 +484,7 @@ public sealed class ChannelCallbackEndpointsTests
         return context;
     }
 
-    private static async Task<IResult> InvokeAsync(string methodName, params object[] args)
+    private static async Task<IResult> InvokeAsync(string methodName, params object?[] args)
     {
         var method = typeof(ChannelCallbackEndpoints)
             .GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic)
@@ -389,6 +495,21 @@ public sealed class ChannelCallbackEndpointsTests
             return await resultTask;
 
         throw new InvalidOperationException($"Method '{methodName}' did not return Task<IResult>.");
+    }
+
+    private sealed class RecordingOwnershipVerifier : INyxRelayApiKeyOwnershipVerifier
+    {
+        public List<(string AccessToken, string ExpectedScopeId, string NyxAgentApiKeyId)> Calls { get; } = [];
+
+        public Task<NyxRelayApiKeyOwnershipVerification> VerifyAsync(
+            string accessToken,
+            string expectedScopeId,
+            string nyxAgentApiKeyId,
+            CancellationToken ct)
+        {
+            Calls.Add((accessToken, expectedScopeId, nyxAgentApiKeyId));
+            return Task.FromResult(new NyxRelayApiKeyOwnershipVerification(true, "verified"));
+        }
     }
 
     private static async Task<(int StatusCode, string Body)> ExecuteResultAsync(IResult result)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -233,6 +233,57 @@ public sealed class ChannelCallbackEndpointsTests
     }
 
     [Fact]
+    public async Task HandleRebuildRegistrationsAsync_DoesNotDispatchRegisterWhenOwnershipVerificationFails()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-1",
+                    Platform = "lark",
+                    NyxAgentApiKeyId = "key-1",
+                },
+            ]));
+
+        List<EventEnvelope> capturedEnvelopes = [];
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var verifier = new RecordingOwnershipVerifier
+        {
+            Result = new NyxRelayApiKeyOwnershipVerification(false, "ownership_denied"),
+        };
+        var http = CreateJsonHttpContext("""{"registration_id":"reg-1"}""", "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRebuildRegistrationsAsync",
+            http,
+            actorRuntime,
+            (IActorDispatchPort)actorRuntime,
+            queryPort,
+            verifier,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":0");
+        response.Body.Should().Contain("ownership_denied");
+        capturedEnvelopes.Should().ContainSingle();
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
+        verifier.Calls.Should().ContainSingle()
+            .Which.Should().Be(("test-token", "scope-1", "key-1"));
+    }
+
+    [Fact]
     public async Task HandleRebuildRegistrationsAsync_DoesNotBackfillEmptyScopeRegistrationWithoutSelector()
     {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
@@ -501,6 +552,9 @@ public sealed class ChannelCallbackEndpointsTests
     {
         public List<(string AccessToken, string ExpectedScopeId, string NyxAgentApiKeyId)> Calls { get; } = [];
 
+        public NyxRelayApiKeyOwnershipVerification Result { get; init; } =
+            new(true, "verified");
+
         public Task<NyxRelayApiKeyOwnershipVerification> VerifyAsync(
             string accessToken,
             string expectedScopeId,
@@ -508,7 +562,7 @@ public sealed class ChannelCallbackEndpointsTests
             CancellationToken ct)
         {
             Calls.Add((accessToken, expectedScopeId, nyxAgentApiKeyId));
-            return Task.FromResult(new NyxRelayApiKeyOwnershipVerification(true, "verified"));
+            return Task.FromResult(Result);
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -115,6 +115,7 @@ public sealed class ChannelRegistrationToolTests
         await provisioningService.Received(1).ProvisionAsync(
             Arg.Is<NyxLarkProvisioningRequest>(request =>
                 request.AccessToken == "test-token" &&
+                request.ScopeId == "scope-1" &&
                 request.AppId == "cli_123" &&
                 request.AppSecret == "secret" &&
                 request.VerificationToken == "verify-123" &&
@@ -136,14 +137,14 @@ public sealed class ChannelRegistrationToolTests
                 },
             ]));
 
-        EventEnvelope? capturedEnvelope = null;
+        List<EventEnvelope> capturedEnvelopes = [];
         var actor = Substitute.For<IActor>();
         var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
         actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
             .Returns(Task.FromResult<IActor?>(actor));
         ((IActorDispatchPort)actorRuntime).DispatchAsync(
                 ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
                 Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
 
@@ -160,8 +161,10 @@ public sealed class ChannelRegistrationToolTests
 
         doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
         doc.RootElement.GetProperty("observed_registrations_before_rebuild").GetInt32().Should().Be(1);
-        capturedEnvelope.Should().NotBeNull();
-        capturedEnvelope!.Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+        doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(1);
+        capturedEnvelopes.Should().HaveCount(2);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
+        capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
     }
 
     [Fact]
@@ -233,6 +236,7 @@ public sealed class ChannelRegistrationToolTests
             Arg.Is<NyxLarkMirrorRepairRequest>(request =>
                 request.AccessToken == "test-token" &&
                 request.RequestedRegistrationId == "reg-restore-1" &&
+                request.ScopeId == "scope-1" &&
                 request.WebhookBaseUrl == "https://aevatar.example.com" &&
                 request.NyxChannelBotId == "bot-1" &&
                 request.NyxAgentApiKeyId == "key-1" &&
@@ -273,6 +277,7 @@ public sealed class ChannelRegistrationToolTests
         await provisioningService.Received(1).RepairLocalMirrorAsync(
             Arg.Is<NyxLarkMirrorRepairRequest>(request =>
                 request.RequestedRegistrationId == "reg-restore-1" &&
+                request.ScopeId == "scope-1" &&
                 request.NyxChannelBotId == "bot-1" &&
                 request.NyxAgentApiKeyId == "key-1" &&
                 request.NyxConversationRouteId == "route-1"),
@@ -324,10 +329,78 @@ public sealed class ChannelRegistrationToolTests
         doc.RootElement.GetProperty("registration_id").GetString().Should().Be("reg-restore-1");
         await provisioningService.Received(1).RepairLocalMirrorAsync(
             Arg.Is<NyxLarkMirrorRepairRequest>(request =>
+                request.ScopeId == "scope-1" &&
                 request.NyxChannelBotId == "bot-1" &&
                 request.NyxAgentApiKeyId == "key-1" &&
                 request.NyxConversationRouteId == "route-1"),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RepairLarkMirror_BackfillsExistingEmptyScopeMirror()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-empty-scope",
+                    Platform = "lark",
+                    NyxProviderSlug = "api-lark-bot",
+                    WebhookUrl = "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1",
+                    NyxChannelBotId = "bot-1",
+                    NyxAgentApiKeyId = "key-1",
+                    NyxConversationRouteId = "route-1",
+                },
+            ]));
+
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        provisioningService.RepairLocalMirrorAsync(Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new NyxLarkMirrorRepairResult(
+                Succeeded: true,
+                Status: "accepted",
+                RegistrationId: "reg-empty-scope",
+                NyxChannelBotId: "bot-1",
+                NyxAgentApiKeyId: "key-1",
+                NyxConversationRouteId: "route-1",
+                WebhookUrl: "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1")));
+
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(queryPort)
+            .AddSingleton(provisioningService)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken();
+        var json = await tool.ExecuteAsync(
+            """{"action":"repair_lark_mirror","webhook_base_url":"https://aevatar.example.com","nyx_channel_bot_id":"bot-1","nyx_agent_api_key_id":"key-1","nyx_conversation_route_id":"route-1"}""");
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        doc.RootElement.GetProperty("registration_id").GetString().Should().Be("reg-empty-scope");
+        await provisioningService.Received(1).RepairLocalMirrorAsync(
+            Arg.Is<NyxLarkMirrorRepairRequest>(request =>
+                request.RequestedRegistrationId == "reg-empty-scope" &&
+                request.ScopeId == "scope-1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RegisterLarkViaNyx_RejectsMissingScopeContext()
+    {
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(provisioningService)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken(null);
+        var json = await tool.ExecuteAsync(
+            """{"action":"register_lark_via_nyx","app_id":"cli_123","app_secret":"secret","webhook_base_url":"https://aevatar.example.com"}""");
+
+        json.Should().Contain("scope_id is required");
+        await provisioningService.DidNotReceive().ProvisionAsync(Arg.Any<NyxLarkProvisioningRequest>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -450,13 +523,17 @@ public sealed class ChannelRegistrationToolTests
         doc.RootElement.GetProperty("note").GetString().Should().Contain("projection not yet confirmed");
     }
 
-    private static IDisposable PushNyxToken()
+    private static IDisposable PushNyxToken(string? scopeId = "scope-1")
     {
         var previous = AgentToolRequestContext.CurrentMetadata;
-        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        var next = new Dictionary<string, string>
         {
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "test-token",
         };
+        if (!string.IsNullOrWhiteSpace(scopeId))
+            next["scope_id"] = scopeId;
+
+        AgentToolRequestContext.CurrentMetadata = next;
 
         return new ResetMetadataScope(previous);
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -134,6 +134,7 @@ public sealed class ChannelRegistrationToolTests
                 {
                     Id = "reg-1",
                     Platform = "lark",
+                    NyxAgentApiKeyId = "key-1",
                 },
             ]));
 
@@ -142,6 +143,53 @@ public sealed class ChannelRegistrationToolTests
         var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
         actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
             .Returns(Task.FromResult<IActor?>(actor));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var verifier = new RecordingOwnershipVerifier();
+
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(queryPort)
+            .AddSingleton(actorRuntime)
+            .AddSingleton((IActorDispatchPort)actorRuntime)
+            .AddSingleton<INyxRelayApiKeyOwnershipVerifier>(verifier)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken();
+        var json = await tool.ExecuteAsync("""{"action":"rebuild_projection","reason":"manual-debug","registration_id":"reg-1"}""");
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        doc.RootElement.GetProperty("observed_registrations_before_rebuild").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(1);
+        capturedEnvelopes.Should().HaveCount(2);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
+        capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+        verifier.Calls.Should().ContainSingle()
+            .Which.Should().Be(("test-token", "scope-1", "key-1"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RebuildProjection_DoesNotBackfillEmptyScopeRegistrationWithoutSelector()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-1",
+                    Platform = "lark",
+                },
+            ]));
+
+        List<EventEnvelope> capturedEnvelopes = [];
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
         ((IActorDispatchPort)actorRuntime).DispatchAsync(
                 ChannelBotRegistrationGAgent.WellKnownId,
                 Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
@@ -161,10 +209,64 @@ public sealed class ChannelRegistrationToolTests
 
         doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
         doc.RootElement.GetProperty("observed_registrations_before_rebuild").GetInt32().Should().Be(1);
-        doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(1);
-        capturedEnvelopes.Should().HaveCount(2);
-        capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
-        capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+        doc.RootElement.GetProperty("empty_scope_registrations_observed").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(0);
+        doc.RootElement.GetProperty("note").GetString().Should().Contain("pass registration_id");
+        capturedEnvelopes.Should().HaveCount(1);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RebuildProjection_DoesNotBackfillEmptyScopeRegistrationsWhenForceHasNoSelector()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-1",
+                    Platform = "lark",
+                    NyxAgentApiKeyId = "key-1",
+                },
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-2",
+                    Platform = "lark",
+                    NyxAgentApiKeyId = "key-2",
+                },
+            ]));
+
+        List<EventEnvelope> capturedEnvelopes = [];
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var verifier = new RecordingOwnershipVerifier();
+
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(queryPort)
+            .AddSingleton(actorRuntime)
+            .AddSingleton((IActorDispatchPort)actorRuntime)
+            .AddSingleton<INyxRelayApiKeyOwnershipVerifier>(verifier)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken();
+        var json = await tool.ExecuteAsync("""{"action":"rebuild_projection","reason":"manual-debug","force":true}""");
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        doc.RootElement.GetProperty("empty_scope_registrations_observed").GetInt32().Should().Be(2);
+        doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(0);
+        doc.RootElement.GetProperty("note").GetString().Should().Contain("force=true only applies");
+        capturedEnvelopes.Should().HaveCount(1);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+        verifier.Calls.Should().BeEmpty();
     }
 
     [Fact]
@@ -536,6 +638,21 @@ public sealed class ChannelRegistrationToolTests
         AgentToolRequestContext.CurrentMetadata = next;
 
         return new ResetMetadataScope(previous);
+    }
+
+    private sealed class RecordingOwnershipVerifier : INyxRelayApiKeyOwnershipVerifier
+    {
+        public List<(string AccessToken, string ExpectedScopeId, string NyxAgentApiKeyId)> Calls { get; } = [];
+
+        public Task<NyxRelayApiKeyOwnershipVerification> VerifyAsync(
+            string accessToken,
+            string expectedScopeId,
+            string nyxAgentApiKeyId,
+            CancellationToken ct)
+        {
+            Calls.Add((accessToken, expectedScopeId, nyxAgentApiKeyId));
+            return Task.FromResult(new NyxRelayApiKeyOwnershipVerification(true, "verified"));
+        }
     }
 
     private sealed class ResetMetadataScope(IReadOnlyDictionary<string, string>? previous) : IDisposable

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxLarkProvisioningServiceTests.cs
@@ -76,15 +76,17 @@ public class NyxLarkProvisioningServiceTests
     }
 
     [Theory]
-    [InlineData("", "cli_a1b2c3", "secret-xyz", "https://aevatar.example.com", "missing_access_token")]
-    [InlineData("user-token", "", "secret-xyz", "https://aevatar.example.com", "missing_app_id")]
-    [InlineData("user-token", "cli_a1b2c3", "", "https://aevatar.example.com", "missing_app_secret")]
-    [InlineData("user-token", "cli_a1b2c3", "secret-xyz", "", "missing_webhook_base_url")]
+    [InlineData("", "cli_a1b2c3", "secret-xyz", "https://aevatar.example.com", "scope-1", "missing_access_token")]
+    [InlineData("user-token", "", "secret-xyz", "https://aevatar.example.com", "scope-1", "missing_app_id")]
+    [InlineData("user-token", "cli_a1b2c3", "", "https://aevatar.example.com", "scope-1", "missing_app_secret")]
+    [InlineData("user-token", "cli_a1b2c3", "secret-xyz", "", "scope-1", "missing_webhook_base_url")]
+    [InlineData("user-token", "cli_a1b2c3", "secret-xyz", "https://aevatar.example.com", "", "missing_scope_id")]
     public async Task ProvisionAsync_ShouldRejectInvalidRequests_BeforeCallingNyx(
         string accessToken,
         string appId,
         string appSecret,
         string webhookBaseUrl,
+        string scopeId,
         string expectedError)
     {
         var handler = new RecordingHandler();
@@ -97,7 +99,7 @@ public class NyxLarkProvisioningServiceTests
                 AppSecret: appSecret,
                 VerificationToken: string.Empty,
                 WebhookBaseUrl: webhookBaseUrl,
-                ScopeId: "scope-1",
+                ScopeId: scopeId,
                 Label: "Ops Bot",
                 NyxProviderSlug: "api-lark-bot"),
             CancellationToken.None);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayApiKeyOwnershipVerifierTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayApiKeyOwnershipVerifierTests.cs
@@ -25,6 +25,34 @@ public sealed class NyxRelayApiKeyOwnershipVerifierTests
     }
 
     [Fact]
+    public async Task VerifyAsync_RejectsPersonalApiKeyWhenReturnedUserIdDiffers()
+    {
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys/key-1", """{"id":"key-1","user_id":"scope-other","credential_source":{"type":"personal"}}""");
+        handler.Enqueue("/api/v1/users/me", """{"id":"scope-1"}""");
+        var verifier = CreateVerifier(handler);
+
+        var result = await verifier.VerifyAsync("token-1", "scope-1", "key-1", CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("api_key_owner_scope_mismatch key_user_id_mismatch");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_RejectsOrgApiKeyWhenCallerIsNotAdmin()
+    {
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys/key-1", """{"id":"key-1","credential_source":{"type":"org","org_id":"scope-org","role":"member"}}""");
+        var verifier = CreateVerifier(handler);
+
+        var result = await verifier.VerifyAsync("token-1", "scope-org", "key-1", CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("api_key_owner_scope_unresolved org_role=member");
+        handler.Requests.Select(request => request.Path).Should().Equal("/api/v1/api-keys/key-1");
+    }
+
+    [Fact]
     public async Task VerifyAsync_RejectsOrgApiKeyWhenOwnerScopeDiffers()
     {
         var handler = new RecordingHandler();
@@ -35,6 +63,20 @@ public sealed class NyxRelayApiKeyOwnershipVerifierTests
 
         result.Succeeded.Should().BeFalse();
         result.Detail.Should().Be("api_key_owner_scope_mismatch");
+        handler.Requests.Select(request => request.Path).Should().Equal("/api/v1/api-keys/key-1");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_RejectsNyxIdErrorEnvelope()
+    {
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys/key-1", """{"error":true,"status":404,"body":"not found"}""");
+        var verifier = CreateVerifier(handler);
+
+        var result = await verifier.VerifyAsync("token-1", "scope-1", "key-1", CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Contain("api_key_lookup_failed nyx_status=404");
         handler.Requests.Select(request => request.Path).Should().Equal("/api/v1/api-keys/key-1");
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayApiKeyOwnershipVerifierTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayApiKeyOwnershipVerifierTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Text;
+using Aevatar.AI.ToolProviders.NyxId;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class NyxRelayApiKeyOwnershipVerifierTests
+{
+    [Fact]
+    public async Task VerifyAsync_AcceptsPersonalApiKeyWhenCurrentUserMatchesScope()
+    {
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys/key-1", """{"id":"key-1","credential_source":{"type":"personal"}}""");
+        handler.Enqueue("/api/v1/users/me", """{"id":"scope-1"}""");
+        var verifier = CreateVerifier(handler);
+
+        var result = await verifier.VerifyAsync("token-1", "scope-1", "key-1", CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        handler.Requests.Select(request => request.Path).Should().Equal(
+            "/api/v1/api-keys/key-1",
+            "/api/v1/users/me");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_RejectsOrgApiKeyWhenOwnerScopeDiffers()
+    {
+        var handler = new RecordingHandler();
+        handler.Enqueue("/api/v1/api-keys/key-1", """{"id":"key-1","credential_source":{"type":"org","org_id":"scope-org","role":"admin"}}""");
+        var verifier = CreateVerifier(handler);
+
+        var result = await verifier.VerifyAsync("token-1", "scope-other", "key-1", CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Detail.Should().Be("api_key_owner_scope_mismatch");
+        handler.Requests.Select(request => request.Path).Should().Equal("/api/v1/api-keys/key-1");
+    }
+
+    private static NyxRelayApiKeyOwnershipVerifier CreateVerifier(HttpMessageHandler handler) =>
+        new(new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler)));
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Queue<(string Path, string Body)> _responses = new();
+
+        public List<(HttpMethod Method, string Path, string? Authorization)> Requests { get; } = [];
+
+        public void Enqueue(string path, string body) => _responses.Enqueue((path, body));
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_responses.Count == 0)
+                throw new InvalidOperationException("No more queued responses.");
+
+            var (expectedPath, responseBody) = _responses.Dequeue();
+            request.RequestUri.Should().NotBeNull();
+            request.RequestUri!.AbsolutePath.Should().Be(expectedPath);
+            Requests.Add((request.Method, expectedPath, request.Headers.Authorization?.ToString()));
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Existing Lark relay registrations can have an empty `scope_id`, which prevents relay callbacks from resolving the bot owner's Aevatar scope and applying the owner UserConfig.

## Solution
- Reject new Lark channel bot registrations that do not carry a canonical `scope_id`.
- Resolve `scope_id` from the current NyxID request context for `channel_registrations` tool calls, so nyxid-chat should not ask the user for it.
- Add rebuild/backfill logic that re-registers empty-scope Lark mirror entries with the resolved scope before dispatching projection rebuild.
- Allow targeted repair by `registration_id` or `nyx_agent_api_key_id`, with `force` for deliberate bulk repair.

## Verification
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --filter "FullyQualifiedName~ChannelBotRegistrationGAgentTests|FullyQualifiedName~ChannelCallbackEndpointsTests|FullyQualifiedName~ChannelRegistrationToolTests|FullyQualifiedName~NyxLarkProvisioningServiceTests" --no-restore --nologo`
- `bash tools/ci/test_stability_guards.sh`