### PR TITLE
Fix scoped relay LLM replies

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -594,8 +594,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         SweepExpiredNyxRelayReplyTokens();
 
         var outboundDelivery = activity.OutboundDelivery;
-        var correlationId = NormalizeOptional(relayActivity.CorrelationId) ??
-                            NormalizeOptional(outboundDelivery?.CorrelationId);
+        var correlationId = NormalizeOptional(outboundDelivery?.CorrelationId) ??
+                            NormalizeOptional(relayActivity.CorrelationId);
         var replyToken = NormalizeOptional(relayActivity.ReplyToken);
         var replyMessageId = NormalizeOptional(outboundDelivery?.ReplyMessageId);
         if (correlationId is null || replyToken is null || replyMessageId is null)
@@ -690,8 +690,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private void RemoveNyxRelayReplyToken(string? correlationId, ChatActivity? activity)
     {
-        var normalizedCorrelationId = NormalizeOptional(correlationId) ??
-                                      NormalizeOptional(activity?.OutboundDelivery?.CorrelationId);
+        var normalizedCorrelationId = NormalizeOptional(activity?.OutboundDelivery?.CorrelationId) ??
+                                      NormalizeOptional(correlationId);
         if (normalizedCorrelationId is not null)
             _nyxRelayReplyTokens.Remove(normalizedCorrelationId);
     }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -112,7 +112,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             // The transient inbox copy keeps reply_token + expiry so the LLM worker can
             // echo them back inside LlmReplyReadyEvent; the persisted state copy must
             // not carry the credential into the event store / projection / read model.
-            var inboxCopy = result.LlmReplyRequest;
+            var inboxCopy = result.LlmReplyRequest.Clone();
+            inboxCopy.TargetActorId = Id;
             var persistedCopy = inboxCopy.Clone();
             persistedCopy.ReplyToken = string.Empty;
             persistedCopy.ReplyTokenExpiresAtUnixMs = 0;
@@ -262,8 +263,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         if (!string.IsNullOrWhiteSpace(request.ReplyToken))
             return request;
 
-        var correlationId = NormalizeOptional(request.CorrelationId) ??
-                            NormalizeOptional(request.Activity?.OutboundDelivery?.CorrelationId);
+        var correlationId = NormalizeOptional(request.Activity?.OutboundDelivery?.CorrelationId) ??
+                            NormalizeOptional(request.CorrelationId);
         if (correlationId is null)
             return request;
 
@@ -618,8 +619,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     {
         SweepExpiredNyxRelayReplyTokens();
 
-        var normalizedCorrelationId = NormalizeOptional(correlationId) ??
-                                      NormalizeOptional(activity?.OutboundDelivery?.CorrelationId);
+        var normalizedCorrelationId = NormalizeOptional(activity?.OutboundDelivery?.CorrelationId) ??
+                                      NormalizeOptional(correlationId);
         if (normalizedCorrelationId is null)
             return ConversationTurnRuntimeContext.Empty;
 
@@ -653,8 +654,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 : DateTimeOffset.UtcNow.AddMinutes(30);
             if (expiresAt > DateTimeOffset.UtcNow)
             {
-                var correlationId = NormalizeOptional(evt.CorrelationId) ??
-                                    NormalizeOptional(activity?.OutboundDelivery?.CorrelationId) ??
+                var correlationId = NormalizeOptional(activity?.OutboundDelivery?.CorrelationId) ??
+                                    NormalizeOptional(evt.CorrelationId) ??
                                     string.Empty;
                 var replyMessageId = NormalizeOptional(activity?.OutboundDelivery?.ReplyMessageId) ?? string.Empty;
                 return new ConversationTurnRuntimeContext(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
@@ -41,9 +41,10 @@ For Lark, follow this guidance:
 2. Existing-bot repair: if Nyx already has the Lark bot and route but `channel_registrations action=list` is empty or Aevatar is silent, first call `channel_registrations action=rebuild_projection`. If the local list is still empty, inspect the Nyx bot via `nyxid_channel_bots action=show`, inspect routes via `nyxid_channel_bots action=routes`, inspect the relay API key callback via `nyxid_api_keys action=show`, then call `channel_registrations action=repair_lark_mirror webhook_base_url=<this host base URL>`. Aevatar no longer preserves relay signing credential references for this path; relay callbacks must use NyxID callback JWT.
 
 3. Advanced Lark capabilities: only when the user needs proactive sends, chat lookup, spreadsheet appends, approval actions, or delivery target bindings, require a Nyx Lark provider slug such as `api-lark-bot`.
-   In those cases, prefer typed Lark tools such as `lark_messages_send`, `lark_messages_reply`, `lark_messages_search`, `lark_messages_batch_get`, `lark_messages_react`, `lark_messages_reactions_list`, `lark_messages_reactions_delete`, `lark_chats_lookup`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act` over generic `nyxid_proxy_execute`.
+   In those cases, prefer typed Lark tools such as `lark_messages_send`, `lark_messages_search`, `lark_messages_batch_get`, `lark_messages_reactions_list`, `lark_messages_reactions_delete`, `lark_chats_lookup`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act` over generic `nyxid_proxy_execute`.
+   Only call `lark_messages_reply` or `lark_messages_react` when the user explicitly asks you to reply to or react to a specific Lark message outside the current relay turn.
 
-For inbound Lark relay turns that represent a fresh user message (not a card action), if the typed tool `lark_messages_react` is available and metadata exposes `channel.platform_message_id`, call `lark_messages_react` first with an acknowledgment emoji such as `OK`, then continue with the substantive reply.
+For inbound Lark relay turns that represent a fresh user message, do not call `lark_messages_reply`, `lark_messages_react`, or `nyxid_proxy_execute` to deliver the answer. Produce the final text reply directly; the channel runtime will send it through the Nyx relay reply token.
 """;
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -176,12 +176,10 @@ Ensure NyxID has a usable Lark outbound provider slug, typically `api-lark-bot`:
 `nyxid_services action=list` → check if the service exists
 If not: `nyxid_catalog action=list` → find the slug → guide user to add it
 
-For advanced Lark API operations, prefer typed tools such as:
+For advanced Lark API operations that are not the current inbound relay reply, prefer typed tools such as:
 - `lark_messages_send`
-- `lark_messages_reply`
 - `lark_messages_search`
 - `lark_messages_batch_get`
-- `lark_messages_react`
 - `lark_messages_reactions_list`
 - `lark_messages_reactions_delete`
 - `lark_chats_lookup`
@@ -189,9 +187,11 @@ For advanced Lark API operations, prefer typed tools such as:
 - `lark_approvals_list`
 - `lark_approvals_act`
 
+Only call `lark_messages_reply` or `lark_messages_react` when the user explicitly asks you to reply to or react to a specific Lark message outside the current relay turn.
+
 Use generic `nyxid_proxy_execute` only when typed tools do not cover the operation.
 
-For inbound Lark relay turns that represent a fresh user message (not a card action), if `lark_messages_react` is available and metadata exposes `channel.platform_message_id`, call `lark_messages_react` first with an acknowledgment emoji such as `OK`, then continue with the real reply.
+For inbound Lark relay turns that represent a fresh user message, do not call `lark_messages_reply`, `lark_messages_react`, or `nyxid_proxy_execute` to deliver the answer. Produce the final text reply directly; the channel runtime will send it through the Nyx relay reply token.
 
 When binding workflow delivery or proactive agent delivery, use a Lark outbound provider slug such as `api-lark-bot`.
 

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -186,6 +186,9 @@ public class NyxIdChatGAgentTests
         var systemPrompt = llmProviderFactory.StreamRequests[0].Messages.First(message => message.Role == "system").Content;
         systemPrompt.Should().Contain("https://dev.aevatar.local/api/webhooks/nyxid-relay");
         systemPrompt.Should().NotContain("https://aevatar-console-backend-api.aevatar.ai/api/webhooks/nyxid-relay");
+        systemPrompt.Should().Contain("do not call `lark_messages_reply`, `lark_messages_react`, or `nyxid_proxy_execute` to deliver the answer");
+        systemPrompt.Should().Contain("the channel runtime will send it through the Nyx relay reply token");
+        systemPrompt.Should().NotContain("call `lark_messages_react` first");
     }
 
     private static ServiceProvider BuildServiceProvider()

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -406,7 +406,7 @@ public sealed class ConversationGAgentDedupTests
             Activity = inboundActivity,
             ReplyToken = sentinelReplyToken,
             ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
-            CorrelationId = "callback-jti-1",
+            CorrelationId = "legacy-callback-jti-1",
         });
 
         inbox.Enqueued.Count.ShouldBe(1);
@@ -424,6 +424,55 @@ public sealed class ConversationGAgentDedupTests
         inbox.Enqueued[0].CorrelationId.ShouldBe("nyx-msg-1");
         inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
         inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_RemovesRelayTokenUsingOutboundDeliveryCorrelation()
+    {
+        const string sentinelReplyToken = "sentinel-cleanup-token-6d41";
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.Id,
+                    TargetActorId = "stale-unscoped-actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                }),
+        };
+        var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner");
+
+        var inboundActivity = CreateActivity("nyx-msg-cleanup", "conv:slack:C1");
+        inboundActivity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "nyx-msg-cleanup",
+            CorrelationId = "callback-jti-cleanup",
+        };
+
+        await agent.HandleNyxRelayInboundActivityAsync(new NyxRelayInboundActivity
+        {
+            Activity = inboundActivity,
+            ReplyToken = sentinelReplyToken,
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
+            CorrelationId = "legacy-callback-jti-cleanup",
+        });
+
+        GetNyxRelayReplyTokenCount(agent).ShouldBe(1);
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "nyx-msg-cleanup",
+            RegistrationId = "reg-1",
+            SourceActorId = "llm-worker-1",
+            Activity = inboundActivity.Clone(),
+            Outbound = new MessageContent { Text = "reply-from-llm" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        GetNyxRelayReplyTokenCount(agent).ShouldBe(0);
     }
 
     [Fact]
@@ -722,6 +771,17 @@ public sealed class ConversationGAgentDedupTests
         }
 
         throw new InvalidOperationException("Unable to set agent id via reflection.");
+    }
+
+    private static int GetNyxRelayReplyTokenCount(ConversationGAgent agent)
+    {
+        var field = typeof(ConversationGAgent).GetField(
+            "_nyxRelayReplyTokens",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        field.ShouldNotBeNull();
+        var value = field.GetValue(agent);
+        value.ShouldNotBeNull();
+        return (int)value.GetType().GetProperty("Count")!.GetValue(value)!;
     }
 
     private static ChatActivity CreateActivity(string id, string canonicalKey) => new()

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -281,6 +281,7 @@ public sealed class ConversationGAgentDedupTests
 
         inbox.Enqueued.Count.ShouldBe(1);
         inbox.Enqueued[0].CorrelationId.ShouldBe("act-direct");
+        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
     }
 
     [Fact]
@@ -369,6 +370,60 @@ public sealed class ConversationGAgentDedupTests
                 return true;
         }
         return false;
+    }
+
+    [Fact]
+    public async Task HandleDeferredLlmReplyDispatchRequestedAsync_RehydratesRelayTokenUsingOutboundDeliveryCorrelation()
+    {
+        // NyxID's message_id and callback correlation_id are distinct. Pending LLM
+        // requests are tracked by message_id, while reply tokens are keyed by the
+        // callback correlation_id carried in OutboundDelivery.
+        const string sentinelReplyToken = "sentinel-retry-token-7c10";
+        var inbox = new RecordingInbox();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.Id,
+                    TargetActorId = "stale-unscoped-actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                }),
+        };
+        var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner", inbox);
+
+        var inboundActivity = CreateActivity("nyx-msg-1", "conv:slack:C1");
+        inboundActivity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "nyx-msg-1",
+            CorrelationId = "callback-jti-1",
+        };
+
+        await agent.HandleNyxRelayInboundActivityAsync(new NyxRelayInboundActivity
+        {
+            Activity = inboundActivity,
+            ReplyToken = sentinelReplyToken,
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
+            CorrelationId = "callback-jti-1",
+        });
+
+        inbox.Enqueued.Count.ShouldBe(1);
+        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
+        inbox.Enqueued.Clear();
+
+        await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
+        {
+            CorrelationId = "nyx-msg-1",
+            RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        inbox.Enqueued.Count.ShouldBe(1);
+        inbox.Enqueued[0].CorrelationId.ShouldBe("nyx-msg-1");
+        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
     }
 
     [Fact]
@@ -507,7 +562,7 @@ public sealed class ConversationGAgentDedupTests
 
         await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
         {
-            CorrelationId = "corr-inbox-echo",
+            CorrelationId = "nyx-msg-inbox-echo",
             RegistrationId = "reg-1",
             SourceActorId = "llm-worker-1",
             Activity = activity.Clone(),


### PR DESCRIPTION
## Summary

Fixes the Lark/Nyx relay reply path by addressing both runtime routing and prompt guidance issues:

- Route deferred LLM reply ready events back to the actual current conversation actor, including scoped actor IDs.
- Rehydrate Nyx relay reply tokens using `OutboundDelivery.CorrelationId`, because NyxID callback correlation/JWT `jti` is distinct from the inbound `message_id` used as the LLM request correlation.
- Update NyxID chat relay prompt guidance so inbound relay replies are produced as final assistant text and sent by the channel runtime via the relay reply token, instead of nudging the model to call `lark_messages_reply` or `lark_messages_react` through the `api-lark-bot` proxy.

## Why

The logs showed the callback scope resolution working and the LLM reply generation completing, but delivery still failed with `reply_token_missing_or_expired` / Lark proxy 400s. Looking at the NyxID code, relay reply tokens are bound to the stored message ID while callback correlation is the callback JWT `jti`; the Aevatar runtime was mixing those identities in retry/ready paths. Separately, the system prompt could cause the model to proactively call Lark proxy reply/react tools, which bypasses the correct `channel-relay/reply` path.

## Validation

- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter ActivateAsync_ShouldUseConfiguredRelayCallbackUrlInSystemPrompt`
- `bash tools/ci/test_stability_guards.sh`