### PR TITLE
Fix /daily card rendering and immediate-run acknowledgment

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardContent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardContent.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using Aevatar.GAgents.Channel.Abstractions;
+
+namespace Aevatar.GAgents.ChannelRuntime;
+
+/// <summary>
+/// Builds channel-neutral <see cref="MessageContent"/> payloads for the Day One agent builder flow.
+/// Actions and CardBlocks let the platform composer render native interactive cards instead of
+/// bouncing a pre-serialized JSON blob through a plain-text fallback.
+/// </summary>
+internal static class AgentBuilderCardContent
+{
+    private const string DailyReportAction = "create_daily_report";
+    private const string SocialMediaAction = "create_social_media";
+    private const string DefaultScheduleTime = "09:00";
+
+    public static MessageContent BuildDailyReportForm(string? preferredGithubUsername)
+    {
+        var savedNote = string.IsNullOrWhiteSpace(preferredGithubUsername)
+            ? string.Empty
+            : $"\n\nSaved GitHub username: `{preferredGithubUsername}`. Leave the field blank to reuse it.";
+
+        var content = new MessageContent();
+        content.Cards.Add(new CardBlock
+        {
+            Kind = CardBlockKind.Section,
+            BlockId = "daily_report_intro",
+            Title = "Create Daily Report Agent",
+            Text =
+                "**Day One template:** Daily GitHub report\n" +
+                "Fill in the fields below. The agent will run once now and then repeat every day at your chosen local time." +
+                savedNote,
+        });
+
+        content.Actions.Add(BuildTextInput(
+            "github_username",
+            "GitHub Username",
+            preferredGithubUsername ?? "alice"));
+        content.Actions.Add(BuildTextInput(
+            "repositories",
+            "Repositories (Optional)",
+            "owner/repo, owner/repo"));
+        content.Actions.Add(BuildTextInput(
+            "schedule_time",
+            "Daily Time (HH:mm)",
+            DefaultScheduleTime));
+        content.Actions.Add(BuildTextInput(
+            "schedule_timezone",
+            "Time Zone",
+            SkillRunnerDefaults.DefaultTimezone));
+
+        var submit = BuildFormSubmit(
+            "submit_daily_report",
+            "Create Agent",
+            isPrimary: true);
+        submit.Arguments["agent_builder_action"] = DailyReportAction;
+        submit.Arguments["run_immediately"] = "true";
+        content.Actions.Add(submit);
+
+        return content;
+    }
+
+    public static MessageContent BuildSocialMediaForm()
+    {
+        var content = new MessageContent();
+        content.Cards.Add(new CardBlock
+        {
+            Kind = CardBlockKind.Section,
+            BlockId = "social_media_intro",
+            Title = "Create Social Media Agent",
+            Text =
+                "**Workflow-backed template:** Social media draft + approval\n" +
+                "Fill in the fields below. Each scheduled run will generate one draft and send approval instructions into this Feishu private chat.",
+        });
+
+        content.Actions.Add(BuildTextInput(
+            "topic",
+            "Topic",
+            "Launch update for the new workflow feature"));
+        content.Actions.Add(BuildTextInput(
+            "audience",
+            "Audience (Optional)",
+            "Developers and technical founders"));
+        content.Actions.Add(BuildTextInput(
+            "style",
+            "Style (Optional)",
+            "Confident, concise, product-focused"));
+        content.Actions.Add(BuildTextInput(
+            "schedule_time",
+            "Daily Time (HH:mm)",
+            DefaultScheduleTime));
+        content.Actions.Add(BuildTextInput(
+            "schedule_timezone",
+            "Time Zone",
+            SkillRunnerDefaults.DefaultTimezone));
+
+        var submit = BuildFormSubmit(
+            "submit_social_media",
+            "Create Agent",
+            isPrimary: true);
+        submit.Arguments["agent_builder_action"] = SocialMediaAction;
+        submit.Arguments["run_immediately"] = "true";
+        content.Actions.Add(submit);
+
+        return content;
+    }
+
+    /// <summary>
+    /// Builds the post-tool acknowledgment for the Day One daily report creation flow.
+    /// The tool response returns GitHub username, preference-save status, and run_immediately trigger
+    /// status, which this method folds into a short text reply that leads with "running now" when
+    /// the schedule fired the first report, so the user knows a report is on the way.
+    /// </summary>
+    public static MessageContent FormatDailyReportToolReply(JsonElement root)
+    {
+        if (TryReadError(root, out var error))
+            return TextContent($"Create daily report agent failed: {error}");
+
+        var status = TryReadString(root, "status") ?? "accepted";
+        if (string.Equals(status, "credentials_required", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(status, "oauth_required", StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildDailyReportCredentialsCard(root, status);
+        }
+
+        var agentId = TryReadString(root, "agent_id") ?? "unknown-agent";
+        var githubUsername = TryReadString(root, "github_username");
+        var savedPreference = TryReadBool(root, "github_username_preference_saved");
+        var runImmediatelyTriggered = TryReadBool(root, "run_immediately_triggered");
+        var nextRun = TryReadString(root, "next_scheduled_run") ?? "pending";
+
+        var headline = runImmediatelyTriggered
+            ? (string.IsNullOrWhiteSpace(githubUsername)
+                ? "Daily report scheduled. Running first report now — I'll reply with the results shortly."
+                : $"Daily report scheduled for `{githubUsername}`. Running first report now — I'll reply with the results shortly.")
+            : (string.IsNullOrWhiteSpace(githubUsername)
+                ? "Daily report scheduled."
+                : $"Daily report scheduled for `{githubUsername}`.");
+
+        var lines = new List<string> { headline };
+        if (savedPreference && !string.IsNullOrWhiteSpace(githubUsername))
+            lines.Add($"Saved `{githubUsername}` as your default GitHub username.");
+
+        lines.Add($"Next scheduled run: {nextRun}");
+        lines.Add($"Agent ID: {agentId}");
+
+        var note = TryReadOptional(root, "note");
+        if (note is not null)
+            lines.Add(note);
+
+        lines.Add($"Next commands: /agents, /agent-status {agentId}, /run-agent {agentId}");
+
+        return TextContent(string.Join('\n', lines));
+    }
+
+    private static MessageContent BuildDailyReportCredentialsCard(JsonElement root, string status)
+    {
+        var providerId = TryReadString(root, "provider_id") ?? "unknown-provider";
+        var url = TryReadString(root, "authorization_url")
+                  ?? TryReadString(root, "auth_url")
+                  ?? TryReadString(root, "url")
+                  ?? TryReadString(root, "documentation_url");
+        var note = TryReadString(root, "note")
+                   ?? "Enter your GitHub username below — I'll save it as your default and run the report immediately.";
+        var heading = string.Equals(status, "oauth_required", StringComparison.OrdinalIgnoreCase)
+            ? "GitHub authorization required."
+            : "GitHub credentials required.";
+
+        var content = BuildDailyReportForm(preferredGithubUsername: null);
+        // Replace the intro card with a context-specific description so the user knows why the form
+        // popped up and where to authorize GitHub when the provider returned an auth URL.
+        content.Cards.Clear();
+
+        var descriptionLines = new List<string>
+        {
+            $"**{heading}**",
+            note,
+            $"Provider ID: `{providerId}`",
+        };
+        if (!string.IsNullOrWhiteSpace(url))
+            descriptionLines.Add($"Open: {url}");
+        descriptionLines.Add("Or just reply with `/daily <github_username>` — I'll save it and run the report now.");
+
+        content.Cards.Add(new CardBlock
+        {
+            Kind = CardBlockKind.Section,
+            BlockId = "daily_report_credentials",
+            Title = "Create Daily Report Agent",
+            Text = string.Join('\n', descriptionLines),
+        });
+
+        // Plain-text fallback for channels that cannot render the card.
+        var fallbackLines = new List<string>
+        {
+            heading,
+            note,
+            $"Provider ID: {providerId}",
+        };
+        if (!string.IsNullOrWhiteSpace(url))
+            fallbackLines.Add($"Open: {url}");
+        fallbackLines.Add("Reply with `/daily <github_username>` — I'll save it and run the report immediately.");
+
+        content.Text = string.Join('\n', fallbackLines);
+        return content;
+    }
+
+    private static ActionElement BuildTextInput(string actionId, string label, string placeholder) =>
+        new()
+        {
+            Kind = ActionElementKind.TextInput,
+            ActionId = actionId,
+            Label = label,
+            Placeholder = placeholder,
+        };
+
+    private static ActionElement BuildFormSubmit(string actionId, string label, bool isPrimary) =>
+        new()
+        {
+            Kind = ActionElementKind.FormSubmit,
+            ActionId = actionId,
+            Label = label,
+            IsPrimary = isPrimary,
+        };
+
+    private static MessageContent TextContent(string text) => new() { Text = text };
+
+    private static bool TryReadError(JsonElement root, out string error)
+    {
+        error = TryReadString(root, "error") ?? string.Empty;
+        return error.Length > 0;
+    }
+
+    private static string? TryReadString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            return null;
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.String => property.GetString(),
+            JsonValueKind.Number => property.GetRawText(),
+            JsonValueKind.True => bool.TrueString,
+            JsonValueKind.False => bool.FalseString,
+            _ => null,
+        };
+    }
+
+    private static bool TryReadBool(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property))
+            return false;
+
+        return property.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.String => bool.TryParse(property.GetString(), out var parsed) && parsed,
+            _ => false,
+        };
+    }
+
+    private static string? TryReadOptional(JsonElement element, string propertyName)
+    {
+        var raw = TryReadString(element, propertyName);
+        return string.IsNullOrWhiteSpace(raw) ? null : raw.Trim();
+    }
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardContent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardContent.cs
@@ -14,28 +14,37 @@ internal static class AgentBuilderCardContent
     private const string SocialMediaAction = "create_social_media";
     private const string DefaultScheduleTime = "09:00";
 
-    public static MessageContent BuildDailyReportForm(string? preferredGithubUsername)
+    public static MessageContent BuildDailyReportForm(string? preferredGithubUsername) =>
+        BuildDailyReportForm(preferredGithubUsername, introCard: null);
+
+    /// <summary>
+    /// Builds the Daily Report creation form card. When <paramref name="introCard"/> is null the
+    /// default Day One description card is rendered; callers that need a different header (for
+    /// example, the credentials-required re-prompt) pass their own <see cref="CardBlock"/> and this
+    /// method uses it verbatim instead.
+    /// </summary>
+    public static MessageContent BuildDailyReportForm(
+        string? preferredGithubUsername,
+        CardBlock? introCard)
     {
-        var savedNote = string.IsNullOrWhiteSpace(preferredGithubUsername)
-            ? string.Empty
-            : $"\n\nSaved GitHub username: `{preferredGithubUsername}`. Leave the field blank to reuse it.";
+        var normalizedSaved = string.IsNullOrWhiteSpace(preferredGithubUsername)
+            ? null
+            : preferredGithubUsername!.Trim();
 
         var content = new MessageContent();
-        content.Cards.Add(new CardBlock
-        {
-            Kind = CardBlockKind.Section,
-            BlockId = "daily_report_intro",
-            Title = "Create Daily Report Agent",
-            Text =
-                "**Day One template:** Daily GitHub report\n" +
-                "Fill in the fields below. The agent will run once now and then repeat every day at your chosen local time." +
-                savedNote,
-        });
+        content.Cards.Add(introCard ?? BuildDefaultDailyReportIntroCard(normalizedSaved));
 
-        content.Actions.Add(BuildTextInput(
+        // Pre-fill the saved GitHub username into the input's default_value so users see it inline
+        // and can keep it with one submit click. Placeholder stays as a generic hint so the field
+        // does not disappear when the user clicks to edit.
+        var githubInput = BuildTextInput(
             "github_username",
             "GitHub Username",
-            preferredGithubUsername ?? "alice"));
+            placeholder: "octocat");
+        if (normalizedSaved is not null)
+            githubInput.Value = normalizedSaved;
+        content.Actions.Add(githubInput);
+
         content.Actions.Add(BuildTextInput(
             "repositories",
             "Repositories (Optional)",
@@ -58,6 +67,24 @@ internal static class AgentBuilderCardContent
         content.Actions.Add(submit);
 
         return content;
+    }
+
+    private static CardBlock BuildDefaultDailyReportIntroCard(string? savedGithubUsername)
+    {
+        var savedNote = savedGithubUsername is null
+            ? string.Empty
+            : $"\n\nSaved GitHub username: `{savedGithubUsername}` — it is already filled in, just press **Create Agent** to reuse it.";
+
+        return new CardBlock
+        {
+            Kind = CardBlockKind.Section,
+            BlockId = "daily_report_intro",
+            Title = "Create Daily Report Agent",
+            Text =
+                "**Day One template:** Daily GitHub report\n" +
+                "Fill in the fields below. The agent will run once now and then repeat every day at your chosen local time." +
+                savedNote,
+        };
     }
 
     public static MessageContent BuildSocialMediaForm()
@@ -126,10 +153,14 @@ internal static class AgentBuilderCardContent
         var agentId = TryReadString(root, "agent_id") ?? "unknown-agent";
         var githubUsername = TryReadString(root, "github_username");
         var savedPreference = TryReadBool(root, "github_username_preference_saved");
-        var runImmediatelyTriggered = TryReadBool(root, "run_immediately_triggered");
+        // The tool reports whether it asked the skill-runner actor to run now, not whether the
+        // runner actually finished — hence "requested", not "triggered". The ack text still says
+        // "Running first report now" because we sent the command; if it fails downstream, the
+        // ground-truth status surfaces through /agent-status, not through this immediate reply.
+        var runImmediatelyRequested = TryReadBool(root, "run_immediately_requested");
         var nextRun = TryReadString(root, "next_scheduled_run") ?? "pending";
 
-        var headline = runImmediatelyTriggered
+        var headline = runImmediatelyRequested
             ? (string.IsNullOrWhiteSpace(githubUsername)
                 ? "Daily report scheduled. Running first report now — I'll reply with the results shortly."
                 : $"Daily report scheduled for `{githubUsername}`. Running first report now — I'll reply with the results shortly.")
@@ -166,11 +197,6 @@ internal static class AgentBuilderCardContent
             ? "GitHub authorization required."
             : "GitHub credentials required.";
 
-        var content = BuildDailyReportForm(preferredGithubUsername: null);
-        // Replace the intro card with a context-specific description so the user knows why the form
-        // popped up and where to authorize GitHub when the provider returned an auth URL.
-        content.Cards.Clear();
-
         var descriptionLines = new List<string>
         {
             $"**{heading}**",
@@ -181,13 +207,15 @@ internal static class AgentBuilderCardContent
             descriptionLines.Add($"Open: {url}");
         descriptionLines.Add("Or just reply with `/daily <github_username>` — I'll save it and run the report now.");
 
-        content.Cards.Add(new CardBlock
+        var introCard = new CardBlock
         {
             Kind = CardBlockKind.Section,
             BlockId = "daily_report_credentials",
             Title = "Create Daily Report Agent",
             Text = string.Join('\n', descriptionLines),
-        });
+        };
+
+        var content = BuildDailyReportForm(preferredGithubUsername: null, introCard: introCard);
 
         // Plain-text fallback for channels that cannot render the card.
         var fallbackLines = new List<string>

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.Studio.Application.Studio.Abstractions;
 
 namespace Aevatar.GAgents.ChannelRuntime;
@@ -241,7 +242,7 @@ internal static class AgentBuilderCardFlow
         }
     }
 
-    public static string FormatToolResult(AgentBuilderFlowDecision decision, string toolResultJson)
+    public static MessageContent FormatToolResult(AgentBuilderFlowDecision decision, string toolResultJson)
     {
         ArgumentNullException.ThrowIfNull(decision);
 
@@ -250,23 +251,28 @@ internal static class AgentBuilderCardFlow
             using var doc = JsonDocument.Parse(toolResultJson);
             return decision.ToolAction switch
             {
-                DailyReportAction => FormatCreateDailyReportResult(doc.RootElement),
-                SocialMediaAction => FormatCreateSocialMediaResult(doc.RootElement),
-                ListTemplatesAction => FormatListTemplatesResult(doc.RootElement),
-                ListAgentsAction => FormatListAgentsResult(doc.RootElement),
-                AgentStatusAction => FormatAgentStatusResult(doc.RootElement),
-                RunAgentAction => FormatRunAgentResult(doc.RootElement),
-                DisableAgentAction => FormatDisableAgentResult(doc.RootElement),
-                EnableAgentAction => FormatEnableAgentResult(doc.RootElement),
-                DeleteAgentAction => FormatDeleteAgentResult(doc.RootElement),
-                _ => toolResultJson,
+                // Daily report creation uses the shared formatter so Nyx-relay slash commands and
+                // Feishu card-action submits render the same "running now, I'll reply when done"
+                // acknowledgment instead of one path dumping the legacy JSON card as text.
+                DailyReportAction => AgentBuilderCardContent.FormatDailyReportToolReply(doc.RootElement),
+                SocialMediaAction => ToTextContent(FormatCreateSocialMediaResult(doc.RootElement)),
+                ListTemplatesAction => ToTextContent(FormatListTemplatesResult(doc.RootElement)),
+                ListAgentsAction => ToTextContent(FormatListAgentsResult(doc.RootElement)),
+                AgentStatusAction => ToTextContent(FormatAgentStatusResult(doc.RootElement)),
+                RunAgentAction => ToTextContent(FormatRunAgentResult(doc.RootElement)),
+                DisableAgentAction => ToTextContent(FormatDisableAgentResult(doc.RootElement)),
+                EnableAgentAction => ToTextContent(FormatEnableAgentResult(doc.RootElement)),
+                DeleteAgentAction => ToTextContent(FormatDeleteAgentResult(doc.RootElement)),
+                _ => ToTextContent(toolResultJson),
             };
         }
         catch (JsonException)
         {
-            return toolResultJson;
+            return ToTextContent(toolResultJson);
         }
     }
+
+    private static MessageContent ToTextContent(string text) => new() { Text = text };
 
     public static string ResolveToolChatType(ChannelInboundEvent evt)
     {
@@ -1506,10 +1512,22 @@ internal sealed record AgentBuilderFlowDecision(
     bool RequiresToolExecution,
     string ReplyPayload,
     string? ToolArgumentsJson,
-    string? ToolAction)
+    string? ToolAction,
+    MessageContent? ReplyContent = null)
 {
     public static AgentBuilderFlowDecision DirectReply(string replyPayload) =>
         new(false, replyPayload, null, null);
+
+    public static AgentBuilderFlowDecision DirectReply(MessageContent content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return new AgentBuilderFlowDecision(
+            RequiresToolExecution: false,
+            ReplyPayload: string.IsNullOrWhiteSpace(content.Text) ? string.Empty : content.Text,
+            ToolArgumentsJson: null,
+            ToolAction: null,
+            ReplyContent: content);
+    }
 
     public static AgentBuilderFlowDecision ToolCall(string toolAction, string argumentsJson) =>
         new(true, string.Empty, argumentsJson, toolAction);

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -107,13 +107,18 @@ internal static class AgentBuilderCardFlow
             var normalized = NormalizeText(evt.Text);
             if (LaunchIntents.Contains(normalized))
             {
-                decision = AgentBuilderFlowDecision.DirectReply(BuildDailyReportCard(preferredGithubUsername));
+                // Direct webhook deployments hit this path (no Nyx relay in front); the pre-serialized
+                // Lark JSON card from BuildDailyReportCard used to land in MessageContent.Text and
+                // render as raw JSON. Route through the channel-neutral form builder so the composer
+                // emits a real interactive card.
+                decision = AgentBuilderFlowDecision.DirectReply(
+                    AgentBuilderCardContent.BuildDailyReportForm(preferredGithubUsername));
                 return true;
             }
 
             if (SocialMediaIntents.Contains(normalized))
             {
-                decision = AgentBuilderFlowDecision.DirectReply(BuildSocialMediaCard());
+                decision = AgentBuilderFlowDecision.DirectReply(AgentBuilderCardContent.BuildSocialMediaForm());
                 return true;
             }
 
@@ -144,11 +149,12 @@ internal static class AgentBuilderCardFlow
         switch ((action ?? string.Empty).Trim())
         {
             case OpenDailyReportFormAction:
-                decision = AgentBuilderFlowDecision.DirectReply(BuildDailyReportCard(preferredGithubUsername));
+                decision = AgentBuilderFlowDecision.DirectReply(
+                    AgentBuilderCardContent.BuildDailyReportForm(preferredGithubUsername));
                 return true;
 
             case OpenSocialMediaFormAction:
-                decision = AgentBuilderFlowDecision.DirectReply(BuildSocialMediaCard());
+                decision = AgentBuilderFlowDecision.DirectReply(AgentBuilderCardContent.BuildSocialMediaForm());
                 return true;
 
             case DailyReportAction:
@@ -584,263 +590,6 @@ internal static class AgentBuilderCardFlow
 
     private static string NormalizeScopeId(string? scopeId) =>
         string.IsNullOrWhiteSpace(scopeId) ? "default" : scopeId.Trim();
-
-    private static string BuildDailyReportCard(string? preferredGithubUsername)
-    {
-        var normalizedGithubUsername = NormalizeOptional(preferredGithubUsername);
-        var savedPreferenceNote = normalizedGithubUsername is null
-            ? string.Empty
-            : $"\nSaved GitHub username: `{EscapeMarkdown(normalizedGithubUsername)}`. Leave the field blank to reuse it.";
-
-        return JsonSerializer.Serialize(new
-        {
-            schema = "2.0",
-            config = new
-            {
-                wide_screen_mode = true,
-            },
-            header = new
-            {
-                title = new
-                {
-                    tag = "plain_text",
-                    content = "Create Daily Report Agent",
-                },
-                template = "blue",
-            },
-            body = new
-            {
-                elements = new object[]
-                {
-                    new
-                    {
-                        tag = "markdown",
-                        content =
-                            "**Day One template:** Daily GitHub report\nFill in the fields below. The agent will run once now and then repeat every day at your chosen local time." +
-                            savedPreferenceNote,
-                    },
-                    BuildForm(
-                        "daily_report_form",
-                        BuildInput("github_username", "GitHub Username", normalizedGithubUsername ?? "alice"),
-                        BuildInput("repositories", "Repositories (Optional)", "owner/repo, owner/repo"),
-                        BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
-                        BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
-                        BuildSubmitButton("Create Agent", "primary", "submit_daily_report", new
-                        {
-                            agent_builder_action = DailyReportAction,
-                            run_immediately = true,
-                        })),
-                    new
-                    {
-                        tag = "action",
-                        actions = new object[]
-                        {
-                            BuildButton("List Agents", "default", new
-                            {
-                                agent_builder_action = ListAgentsAction,
-                            }),
-                        },
-                    }
-                }
-            },
-        });
-    }
-
-    private static string BuildSocialMediaCard()
-    {
-        return JsonSerializer.Serialize(new
-        {
-            schema = "2.0",
-            config = new
-            {
-                wide_screen_mode = true,
-            },
-            header = new
-            {
-                title = new
-                {
-                    tag = "plain_text",
-                    content = "Create Social Media Agent",
-                },
-                template = "orange",
-            },
-            body = new
-            {
-                elements = new object[]
-                {
-                    new
-                    {
-                        tag = "markdown",
-                        content =
-                            "**Workflow-backed template:** Social media draft + approval\nFill in the fields below. Each scheduled run will generate one draft and send approval instructions into this Feishu private chat.",
-                    },
-                    BuildForm(
-                        "social_media_form",
-                        BuildInput("topic", "Topic", "Launch update for the new workflow feature"),
-                        BuildInput("audience", "Audience (Optional)", "Developers and technical founders"),
-                        BuildInput("style", "Style (Optional)", "Confident, concise, product-focused"),
-                        BuildInput("schedule_time", "Daily Time (HH:mm)", DefaultScheduleTime),
-                        BuildInput("schedule_timezone", "Time Zone", SkillRunnerDefaults.DefaultTimezone),
-                        BuildSubmitButton("Create Agent", "primary", "submit_social_media", new
-                        {
-                            agent_builder_action = SocialMediaAction,
-                            run_immediately = true,
-                        })),
-                    new
-                    {
-                        tag = "action",
-                        actions = new object[]
-                        {
-                            BuildButton("List Agents", "default", new
-                            {
-                                agent_builder_action = ListAgentsAction,
-                            }),
-                        },
-                    }
-                }
-            },
-        });
-    }
-
-    private static object BuildForm(string name, params object[] elements) =>
-        new
-        {
-            tag = "form",
-            name,
-            elements,
-        };
-
-    private static object BuildInput(string name, string label, string placeholder)
-    {
-        return new
-        {
-            tag = "input",
-            name,
-            label = new
-            {
-                tag = "plain_text",
-                content = label,
-            },
-            placeholder = new
-            {
-                tag = "plain_text",
-                content = placeholder,
-            },
-        };
-    }
-
-    private static object BuildSubmitButton(string label, string style, string name, object value) =>
-        new
-        {
-            tag = "button",
-            type = style,
-            name,
-            form_action_type = "submit",
-            text = new
-            {
-                tag = "plain_text",
-                content = label,
-            },
-            value,
-        };
-
-    private static string FormatCreateDailyReportResult(JsonElement root)
-    {
-        if (TryReadError(root, out var error))
-            return $"Create daily report agent failed: {error}";
-
-        var status = ReadString(root, "status") ?? "accepted";
-        if (string.Equals(status, "credentials_required", StringComparison.OrdinalIgnoreCase))
-        {
-            var providerId = ReadString(root, "provider_id") ?? "unknown-provider";
-            var documentationUrl = ReadString(root, "documentation_url");
-            var credentialsNote = ReadString(root, "note") ??
-                                  "Set your GitHub OAuth app credentials in NyxID first, then submit the daily report form again.";
-
-            var credentialsLines = new List<string>
-            {
-                credentialsNote,
-                $"Provider ID: `{providerId}`",
-            };
-
-            var actions = new List<object>();
-            if (!string.IsNullOrWhiteSpace(documentationUrl))
-                actions.Add(BuildLinkButton("OAuth Docs", "default", documentationUrl!));
-
-            actions.Add(BuildButton("Back to Form", "primary", new
-            {
-                agent_builder_action = OpenDailyReportFormAction,
-            }));
-
-            return BuildInfoCard(
-                "GitHub Credentials Required",
-                string.Join("\n", credentialsLines),
-                "orange",
-                actions.ToArray());
-        }
-
-        if (string.Equals(status, "oauth_required", StringComparison.OrdinalIgnoreCase))
-        {
-            var providerId = ReadString(root, "provider_id") ?? "unknown-provider";
-            var authorizationUrl = ReadString(root, "authorization_url")
-                                   ?? ReadString(root, "auth_url")
-                                   ?? ReadString(root, "url");
-            var oauthNote = ReadString(root, "note") ??
-                            "Connect GitHub in NyxID, then return here and submit the daily report form again.";
-
-            var oauthLines = new List<string>
-            {
-                oauthNote,
-                $"Provider ID: `{providerId}`",
-            };
-
-            var actions = new List<object>();
-            if (!string.IsNullOrWhiteSpace(authorizationUrl))
-                actions.Add(BuildLinkButton("Connect GitHub", "primary", authorizationUrl!));
-
-            actions.Add(BuildButton("Back to Form", "default", new
-            {
-                agent_builder_action = OpenDailyReportFormAction,
-            }));
-
-            return BuildInfoCard(
-                "GitHub Authorization Required",
-                string.Join("\n", oauthLines),
-                "orange",
-                actions.ToArray());
-        }
-
-        var agentId = ReadString(root, "agent_id") ?? "unknown-agent";
-        var nextRun = ReadString(root, "next_scheduled_run") ?? "pending";
-        var note = ReadString(root, "note");
-
-        var lines = new List<string>
-        {
-            string.Equals(status, "created", StringComparison.OrdinalIgnoreCase)
-                ? $"Daily report agent created: {agentId}"
-                : $"Daily report agent accepted: {agentId}",
-            $"Next scheduled run: {nextRun}",
-        };
-
-        if (!string.IsNullOrWhiteSpace(note))
-            lines.Add(note!);
-
-        return BuildInfoCard(
-            "Daily Report Agent",
-            string.Join("\n", lines),
-            "green",
-            new object[]
-            {
-                BuildButton("View Agents", "primary", new
-                {
-                    agent_builder_action = ListAgentsAction,
-                }),
-                BuildButton("Create Another", "default", new
-                {
-                    agent_builder_action = OpenDailyReportFormAction,
-                }),
-            });
-    }
 
     private static string FormatCreateSocialMediaResult(JsonElement root)
     {

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -261,7 +261,8 @@ public sealed class AgentBuilderTool : IAgentTool
 
         await actor.HandleEventAsync(BuildDirectEnvelope(actor.Id, initialize), ct);
 
-        if (args.Bool("run_immediately") == true)
+        var runImmediatelyRequested = args.Bool("run_immediately") == true;
+        if (runImmediatelyRequested)
             await actor.HandleEventAsync(
                 BuildDirectEnvelope(actor.Id, new TriggerSkillRunnerExecutionCommand { Reason = "create_agent" }),
                 ct);
@@ -274,12 +275,13 @@ public sealed class AgentBuilderTool : IAgentTool
             entry => string.Equals(entry.AgentType, SkillRunnerDefaults.AgentType, StringComparison.Ordinal) &&
                      string.Equals(entry.TemplateName, templateSpec.TemplateName, StringComparison.Ordinal),
             ct,
-            maxAttempts: args.Bool("run_immediately") == true ? 20 : 10);
+            maxAttempts: runImmediatelyRequested ? 20 : 10);
 
-        await SaveGithubUsernamePreferenceIfRequestedAsync(
+        var savePreferenceRequested = args.Bool("save_github_username_preference") == true;
+        var preferenceSaved = await SaveGithubUsernamePreferenceIfRequestedAsync(
             configScopeId,
             githubUsernameResolution.GithubUsername ?? string.Empty,
-            args.Bool("save_github_username_preference") == true,
+            savePreferenceRequested,
             ct);
 
         return JsonSerializer.Serialize(new
@@ -288,6 +290,9 @@ public sealed class AgentBuilderTool : IAgentTool
             agent_id = agentId,
             agent_type = SkillRunnerDefaults.AgentType,
             template = templateSpec.TemplateName,
+            github_username = githubUsernameResolution.GithubUsername,
+            github_username_preference_saved = preferenceSaved,
+            run_immediately_triggered = runImmediatelyRequested,
             next_scheduled_run = nextRunAtUtc,
             conversation_id = conversationId,
             api_key_id = apiKeyId,
@@ -1251,22 +1256,23 @@ public sealed class AgentBuilderTool : IAgentTool
         }
     }
 
-    private async Task SaveGithubUsernamePreferenceIfRequestedAsync(
+    private async Task<bool> SaveGithubUsernamePreferenceIfRequestedAsync(
         string scopeId,
         string githubUsername,
         bool shouldSave,
         CancellationToken ct)
     {
         if (!shouldSave || string.IsNullOrWhiteSpace(githubUsername))
-            return;
+            return false;
 
         var commandService = _serviceProvider.GetService<IUserConfigCommandService>();
         if (commandService is null)
-            return;
+            return false;
 
         try
         {
             await commandService.SaveGithubUsernameAsync(scopeId, githubUsername, ct);
+            return true;
         }
         catch (OperationCanceledException)
         {
@@ -1274,6 +1280,7 @@ public sealed class AgentBuilderTool : IAgentTool
         }
         catch
         {
+            return false;
         }
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -292,7 +292,7 @@ public sealed class AgentBuilderTool : IAgentTool
             template = templateSpec.TemplateName,
             github_username = githubUsernameResolution.GithubUsername,
             github_username_preference_saved = preferenceSaved,
-            run_immediately_triggered = runImmediatelyRequested,
+            run_immediately_requested = runImmediatelyRequested,
             next_scheduled_run = nextRunAtUtc,
             conversation_id = conversationId,
             api_key_id = apiKeyId,

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -197,7 +197,7 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (decision is null)
             return null;
 
-        var replyPayload = decision.ReplyPayload;
+        var replyContent = decision.ReplyContent ?? new MessageContent { Text = decision.ReplyPayload };
         if (decision.RequiresToolExecution)
         {
             var previousMetadata = AgentToolRequestContext.CurrentMetadata;
@@ -209,7 +209,7 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
                     ResolveUserAccessToken(activity));
                 var tool = ActivatorUtilities.CreateInstance<AgentBuilderTool>(_services);
                 var toolResult = await tool.ExecuteAsync(decision.ToolArgumentsJson!, ct);
-                replyPayload = relayDecisionMatched
+                replyContent = relayDecisionMatched
                     ? NyxRelayAgentBuilderFlow.FormatToolResult(decision, toolResult)
                     : AgentBuilderCardFlow.FormatToolResult(decision, toolResult);
             }
@@ -219,11 +219,18 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             }
         }
 
-        var result = await SendReplyAsync(replyPayload, activity, ToInboundMessage(activity), registration, runtimeContext, ct);
+        var result = await SendReplyAsync(
+            replyContent,
+            activity.Id,
+            activity.Conversation,
+            ToInboundMessage(activity),
+            registration,
+            runtimeContext,
+            ct);
         return result.Success
             ? ConversationTurnResult.Sent(
                 sentActivityId: $"direct-reply:{activity.Id}",
-                outbound: new MessageContent { Text = replyPayload },
+                outbound: replyContent.Clone(),
                 authPrincipal: "bot",
                 outboundDelivery: result.OutboundDelivery?.Clone())
             : result;

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
+using Aevatar.GAgents.Channel.Abstractions;
 
 namespace Aevatar.GAgents.ChannelRuntime;
 
@@ -51,7 +52,7 @@ internal static class NyxRelayAgentBuilderFlow
         return TryResolveKnownCommand(command, tokens, evt.ConversationId, out decision);
     }
 
-    public static string FormatToolResult(AgentBuilderFlowDecision decision, string toolResultJson)
+    public static MessageContent FormatToolResult(AgentBuilderFlowDecision decision, string toolResultJson)
     {
         ArgumentNullException.ThrowIfNull(decision);
 
@@ -61,22 +62,24 @@ internal static class NyxRelayAgentBuilderFlow
             return decision.ToolAction switch
             {
                 "create_daily_report" => FormatCreateDailyReportResult(doc.RootElement),
-                "create_social_media" => FormatCreateSocialMediaResult(doc.RootElement),
-                "list_templates" => FormatListTemplatesResult(doc.RootElement),
-                "list_agents" => FormatListAgentsResult(doc.RootElement),
-                "agent_status" => FormatAgentStatusResult(doc.RootElement),
-                "run_agent" => FormatRunAgentResult(doc.RootElement),
-                "disable_agent" => FormatLifecycleStatusResult("Agent disabled.", doc.RootElement),
-                "enable_agent" => FormatLifecycleStatusResult("Agent enabled.", doc.RootElement),
-                "delete_agent" => FormatDeleteAgentResult(doc.RootElement),
-                _ => toolResultJson,
+                "create_social_media" => TextContent(FormatCreateSocialMediaResult(doc.RootElement)),
+                "list_templates" => TextContent(FormatListTemplatesResult(doc.RootElement)),
+                "list_agents" => TextContent(FormatListAgentsResult(doc.RootElement)),
+                "agent_status" => TextContent(FormatAgentStatusResult(doc.RootElement)),
+                "run_agent" => TextContent(FormatRunAgentResult(doc.RootElement)),
+                "disable_agent" => TextContent(FormatLifecycleStatusResult("Agent disabled.", doc.RootElement)),
+                "enable_agent" => TextContent(FormatLifecycleStatusResult("Agent enabled.", doc.RootElement)),
+                "delete_agent" => TextContent(FormatDeleteAgentResult(doc.RootElement)),
+                _ => TextContent(toolResultJson),
             };
         }
         catch (JsonException)
         {
-            return toolResultJson;
+            return TextContent(toolResultJson);
         }
     }
+
+    private static MessageContent TextContent(string text) => new() { Text = text };
 
     private static bool IsKnownCommand(string command) =>
         command is DailyCommand
@@ -143,8 +146,8 @@ internal static class NyxRelayAgentBuilderFlow
     {
         decision = null;
         var args = ChannelTextCommandParser.ParseNamedArguments(tokens);
-        var githubUsername = GetOptional(args, "github_username")
-                             ?? FirstPositionalArgument(tokens);
+        var githubUsername = NormalizeOptional(
+            GetOptional(args, "github_username") ?? FirstPositionalArgument(tokens));
 
         if (!TryResolveSchedule(args, out var scheduleCron, out var scheduleTimezone, out var error))
         {
@@ -154,13 +157,17 @@ internal static class NyxRelayAgentBuilderFlow
 
         var repositories = GetOptional(args, "repositories");
         var runImmediately = ResolveRunImmediately(args);
+        // When the user typed a positional username we persist it as their default so the next /daily
+        // call auto-resolves via the saved preference fallback inside AgentBuilderTool.
+        var savePreference = githubUsername is not null;
         decision = AgentBuilderFlowDecision.ToolCall(
             "create_daily_report",
             JsonSerializer.Serialize(new
             {
                 action = "create_agent",
                 template = "daily_report",
-                github_username = NormalizeOptional(githubUsername),
+                github_username = githubUsername,
+                save_github_username_preference = savePreference,
                 repositories,
                 schedule_cron = scheduleCron,
                 schedule_timezone = scheduleTimezone,
@@ -283,39 +290,8 @@ internal static class NyxRelayAgentBuilderFlow
         return true;
     }
 
-    private static string FormatCreateDailyReportResult(JsonElement root)
-    {
-        if (TryReadError(root, out var error))
-            return $"Create daily report agent failed: {error}";
-
-        var status = ReadString(root, "status") ?? "accepted";
-        if (string.Equals(status, "credentials_required", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(status, "oauth_required", StringComparison.OrdinalIgnoreCase))
-        {
-            var providerId = ReadString(root, "provider_id") ?? "unknown-provider";
-            var url = ReadString(root, "authorization_url")
-                      ?? ReadString(root, "auth_url")
-                      ?? ReadString(root, "url")
-                      ?? ReadString(root, "documentation_url");
-            var note = ReadString(root, "note") ?? "Finish the GitHub authorization step, then run /daily again.";
-
-            return BuildTextBlock(
-                string.Equals(status, "oauth_required", StringComparison.OrdinalIgnoreCase)
-                    ? "GitHub authorization required."
-                    : "GitHub credentials required.",
-                note,
-                $"Provider ID: {providerId}",
-                string.IsNullOrWhiteSpace(url) ? null : $"Open: {url}",
-                BuildDailyReportHelpText());
-        }
-
-        return BuildTextBlock(
-            "Daily report agent registered.",
-            $"Agent ID: {ReadString(root, "agent_id") ?? "unknown-agent"}",
-            $"Next scheduled run: {ReadString(root, "next_scheduled_run") ?? "pending"}",
-            NormalizeOptional(ReadString(root, "note")),
-            "Next commands: /agents, /agent-status <agent_id>, /run-agent <agent_id>");
-    }
+    private static MessageContent FormatCreateDailyReportResult(JsonElement root) =>
+        AgentBuilderCardContent.FormatDailyReportToolReply(root);
 
     private static string FormatCreateSocialMediaResult(JsonElement root)
     {

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -73,7 +73,7 @@ Use `nyxid_proxy` with a Telegram/Discord bot's slug to send messages. For Teleg
 ### Channel Bots & Events
 - **channel_registrations** — List, provision, rebuild, repair, and delete Aevatar's local Lark relay registrations. Use this for Aevatar-managed Lark setup, for rebuilding the local read model from the authoritative actor state, and for restoring the local mirror when Nyx relay resources already exist
 - **agent_delivery_targets** — Manage agent delivery target mappings used by workflow human approval/input cards and other outbound channel delivery
-- **agent_builder** — Create and manage Day One persistent automation agents in Feishu private chat (`list_templates`, `create_agent`, `list_agents`, `agent_status`, `run_agent`, `disable_agent`, `enable_agent`, `delete_agent`) across `daily_report` and `social_media`
+- **agent_builder** — Create and manage Day One persistent automation agents in Feishu private chat. Internal tool actions: `list_templates`, `create_agent`, `list_agents`, `agent_status`, `run_agent`, `disable_agent`, `enable_agent`, `delete_agent`. Internal template names (used only inside `create_agent` arguments): `daily_report`, `social_media`. **When talking to the user, always use the slash-command names — never surface the internal template names `daily_report` / `social_media`.** User-facing slash commands: `/daily [github_username]`, `/social-media <topic>`, `/agents`, `/agent-status <agent_id>`, `/run-agent <agent_id>`, `/disable-agent <agent_id>`, `/enable-agent <agent_id>`, `/delete-agent <agent_id> confirm`.
 - **nyxid_channel_bots** — NyxID-native channel bot management: inspect/register/verify/delete bots and manage conversation routes directly via NyxID API. Use this to inspect existing Nyx Lark bot/route state or register Nyx-native fields such as `verification_token`
 - **nyxid_channel_events** — Push device/analyzer events through the NyxID HTTP Event Gateway to agent conversations
 
@@ -225,17 +225,34 @@ Notes:
 
 Use `agent_builder` when the user wants a persistent Day One automation agent in Feishu private chat.
 
-- Day One currently supports `template=daily_report` and `template=social_media`
-- Creation is private-chat only; if the current chat is not `p2p`, tell the user to DM the bot
-- `create_agent` will create a persistent agent plus a non-expiring NyxID API key for outbound delivery
-- `daily_report` is a `SkillRunnerGAgent` that sends plain-text GitHub summaries back into the current private chat
-- `social_media` is a workflow-backed scheduled agent that generates one draft and routes approval through the current supported human-interaction surface
-- The Nyx relay path supports text commands such as `/daily ...`, `/social-media ...`, `/agents`, `/agent-status <agent_id>` and interactive Lark cards for card-aware flows
-- `list_agents` and `agent_status` read the registry-backed current state
-- `run_agent` only works when the agent is enabled
-- `disable_agent` pauses scheduled execution without deleting the agent or revoking its API key
-- `enable_agent` resumes scheduled execution for a previously disabled agent
-- `delete_agent` disables the agent, revokes the NyxID API key, and tombstones the registry entry
+### User-facing vocabulary (critical)
+
+When you describe Day One to the user — capability summaries, suggested replies, example commands, help text — use the slash commands below, **not** the internal template names. `daily_report` and `social_media` are tool-argument identifiers; they are not commands the user types. If the user says something like "帮我建一个 daily_report" or "create a daily_report", treat that as intent for `/daily` and present your reply using `/daily`.
+
+| Intent | Slash command users type | Internal `template` (only for tool calls) |
+|---|---|---|
+| Daily GitHub summary | `/daily [github_username]` | `daily_report` |
+| Social media draft + approval | `/social-media <topic>` | `social_media` |
+| List agents | `/agents` | — |
+| Inspect one agent | `/agent-status <agent_id>` | — |
+| Manual run | `/run-agent <agent_id>` | — |
+| Pause schedule | `/disable-agent <agent_id>` | — |
+| Resume schedule | `/enable-agent <agent_id>` | — |
+| Delete (two-step) | `/delete-agent <agent_id> confirm` | — |
+
+`/daily` with no arguments pops an interactive card (GitHub username + schedule fields). `/daily <github_username>` saves the username as the user's default and runs the first report immediately — the ack message should say the first run is on its way, not just "scheduled for tomorrow".
+
+### Tool semantics
+
+- Creation is private-chat only; if the current chat is not `p2p`, tell the user to DM the bot.
+- `create_agent` with `template=daily_report` provisions a `SkillRunnerGAgent` that sends plain-text GitHub summaries back into the current private chat, plus a non-expiring NyxID API key for outbound delivery.
+- `create_agent` with `template=social_media` provisions a workflow-backed scheduled agent that generates one draft and routes approval through the current supported human-interaction surface.
+- `list_agents` and `agent_status` read the registry-backed current state.
+- `run_agent` only works when the agent is enabled.
+- `disable_agent` pauses scheduled execution without deleting the agent or revoking its API key.
+- `enable_agent` resumes scheduled execution for a previously disabled agent.
+- `delete_agent` disables the agent, revokes the NyxID API key, and tombstones the registry entry.
+- The Nyx relay path handles the slash commands above directly (and renders the `/daily` and `/social-media` cards) without an LLM round-trip. You typically only see these flows when the user asks for them in natural language instead of typing the slash command.
 
 ## Notifications & Approvals
 

--- a/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
@@ -214,21 +214,30 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             ? BuildFormInput(action)
             : BuildFormButton(action);
 
-    private static object BuildFormInput(ActionElement action) => new
+    private static object BuildFormInput(ActionElement action)
     {
-        tag = "input",
-        name = action.ActionId,
-        label = new
+        // Lark schema 2.0 input honors `default_value` as the pre-filled textbox content; if we emit
+        // it unconditionally even as empty string, the rendered input still shows placeholder ghost
+        // text, which defeats the point. So only add it when the caller put something in Value.
+        var input = new Dictionary<string, object?>(StringComparer.Ordinal)
         {
-            tag = "plain_text",
-            content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
-        },
-        placeholder = new
-        {
-            tag = "plain_text",
-            content = action.Placeholder ?? string.Empty,
-        },
-    };
+            ["tag"] = "input",
+            ["name"] = action.ActionId,
+            ["label"] = new
+            {
+                tag = "plain_text",
+                content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
+            },
+            ["placeholder"] = new
+            {
+                tag = "plain_text",
+                content = action.Placeholder ?? string.Empty,
+            },
+        };
+        if (!string.IsNullOrEmpty(action.Value))
+            input["default_value"] = action.Value;
+        return input;
+    }
 
     private static object BuildFormButton(ActionElement action) => new
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardContentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardContentTests.cs
@@ -1,0 +1,67 @@
+using System.Linq;
+using Aevatar.GAgents.Channel.Abstractions;
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class AgentBuilderCardContentTests
+{
+    [Fact]
+    public void BuildDailyReportForm_EmitsTextInputsAndSubmitButton()
+    {
+        var content = AgentBuilderCardContent.BuildDailyReportForm(preferredGithubUsername: null);
+
+        content.Actions.Should().HaveCount(5);
+        content.Actions.Where(a => a.Kind == ActionElementKind.TextInput)
+            .Select(a => a.ActionId)
+            .Should().BeEquivalentTo(new[]
+            {
+                "github_username",
+                "repositories",
+                "schedule_time",
+                "schedule_timezone",
+            });
+
+        var submit = content.Actions.Single(a => a.Kind == ActionElementKind.FormSubmit);
+        submit.ActionId.Should().Be("submit_daily_report");
+        submit.IsPrimary.Should().BeTrue();
+        submit.Arguments["agent_builder_action"].Should().Be("create_daily_report");
+        submit.Arguments["run_immediately"].Should().Be("true");
+
+        content.Cards.Should().HaveCount(1);
+        content.Cards[0].Title.Should().Be("Create Daily Report Agent");
+    }
+
+    [Fact]
+    public void BuildDailyReportForm_PrefillsGithubUsernamePlaceholder_WhenProvided()
+    {
+        var content = AgentBuilderCardContent.BuildDailyReportForm("eanzhao");
+
+        var githubField = content.Actions.Single(a =>
+            a.Kind == ActionElementKind.TextInput && a.ActionId == "github_username");
+        githubField.Placeholder.Should().Be("eanzhao");
+
+        content.Cards.Single().Text.Should().Contain("Saved GitHub username: `eanzhao`");
+    }
+
+    [Fact]
+    public void BuildSocialMediaForm_EmitsFormInputsAndSubmitButton()
+    {
+        var content = AgentBuilderCardContent.BuildSocialMediaForm();
+
+        content.Actions.Where(a => a.Kind == ActionElementKind.TextInput)
+            .Select(a => a.ActionId)
+            .Should().BeEquivalentTo(new[]
+            {
+                "topic",
+                "audience",
+                "style",
+                "schedule_time",
+                "schedule_timezone",
+            });
+
+        var submit = content.Actions.Single(a => a.Kind == ActionElementKind.FormSubmit);
+        submit.Arguments["agent_builder_action"].Should().Be("create_social_media");
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardContentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardContentTests.cs
@@ -34,15 +34,31 @@ public sealed class AgentBuilderCardContentTests
     }
 
     [Fact]
-    public void BuildDailyReportForm_PrefillsGithubUsernamePlaceholder_WhenProvided()
+    public void BuildDailyReportForm_PrefillsSavedGithubUsernameIntoValue_WhenProvided()
     {
         var content = AgentBuilderCardContent.BuildDailyReportForm("eanzhao");
 
         var githubField = content.Actions.Single(a =>
             a.Kind == ActionElementKind.TextInput && a.ActionId == "github_username");
-        githubField.Placeholder.Should().Be("eanzhao");
+        // Saved usernames must live in Value so LarkMessageComposer emits default_value and the
+        // user sees the name as real input text they can edit, not as ghost placeholder that
+        // disappears on click.
+        githubField.Value.Should().Be("eanzhao");
+        githubField.Placeholder.Should().Be("octocat");
 
         content.Cards.Single().Text.Should().Contain("Saved GitHub username: `eanzhao`");
+        content.Cards.Single().Text.Should().Contain("already filled in");
+    }
+
+    [Fact]
+    public void BuildDailyReportForm_LeavesValueEmpty_WhenNoSavedUsername()
+    {
+        var content = AgentBuilderCardContent.BuildDailyReportForm(preferredGithubUsername: null);
+
+        var githubField = content.Actions.Single(a =>
+            a.Kind == ActionElementKind.TextInput && a.ActionId == "github_username");
+        githubField.Value.Should().BeEmpty();
+        githubField.Placeholder.Should().Be("octocat");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Text.Json;
+using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Xunit;
@@ -24,8 +26,16 @@ public sealed class AgentBuilderCardFlowTests
 
         decision.Should().NotBeNull();
         decision!.RequiresToolExecution.Should().BeFalse();
-        decision.ReplyPayload.Should().Contain("saved-user");
-        decision.ReplyPayload.Should().Contain("Leave the field blank to reuse it.");
+        decision.ReplyContent.Should().NotBeNull();
+
+        var githubInput = decision.ReplyContent!.Actions.Single(a =>
+            a.Kind == ActionElementKind.TextInput && a.ActionId == "github_username");
+        // Saved usernames belong in Value (rendered as default_value) so the user sees editable text
+        // rather than placeholder ghost text that disappears on click.
+        githubInput.Value.Should().Be("saved-user");
+
+        decision.ReplyContent.Cards.Single().Text.Should().Contain("saved-user");
+        decision.ReplyContent.Cards.Single().Text.Should().Contain("already filled in");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -182,6 +182,9 @@ public sealed class AgentBuilderToolTests
             doc.RootElement.GetProperty("status").GetString().Should().Be("created");
             doc.RootElement.GetProperty("agent_id").GetString().Should().Be("skill-runner-1");
             doc.RootElement.GetProperty("api_key_id").GetString().Should().Be("key-1");
+            doc.RootElement.GetProperty("github_username").GetString().Should().Be("alice");
+            doc.RootElement.GetProperty("run_immediately_triggered").GetBoolean().Should().BeTrue();
+            doc.RootElement.GetProperty("github_username_preference_saved").GetBoolean().Should().BeFalse();
 
             await skillRunnerActor.Received(1).HandleEventAsync(
                 Arg.Is<EventEnvelope>(e =>
@@ -584,6 +587,9 @@ public sealed class AgentBuilderToolTests
 
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+            doc.RootElement.GetProperty("github_username").GetString().Should().Be("alice");
+            doc.RootElement.GetProperty("github_username_preference_saved").GetBoolean().Should().BeTrue();
+            doc.RootElement.GetProperty("run_immediately_triggered").GetBoolean().Should().BeFalse();
 
             await userConfigCommandService.Received(1)
                 .SaveGithubUsernameAsync("scope-1", "alice", Arg.Any<CancellationToken>());

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -183,7 +183,7 @@ public sealed class AgentBuilderToolTests
             doc.RootElement.GetProperty("agent_id").GetString().Should().Be("skill-runner-1");
             doc.RootElement.GetProperty("api_key_id").GetString().Should().Be("key-1");
             doc.RootElement.GetProperty("github_username").GetString().Should().Be("alice");
-            doc.RootElement.GetProperty("run_immediately_triggered").GetBoolean().Should().BeTrue();
+            doc.RootElement.GetProperty("run_immediately_requested").GetBoolean().Should().BeTrue();
             doc.RootElement.GetProperty("github_username_preference_saved").GetBoolean().Should().BeFalse();
 
             await skillRunnerActor.Received(1).HandleEventAsync(
@@ -589,7 +589,7 @@ public sealed class AgentBuilderToolTests
             doc.RootElement.GetProperty("status").GetString().Should().Be("created");
             doc.RootElement.GetProperty("github_username").GetString().Should().Be("alice");
             doc.RootElement.GetProperty("github_username_preference_saved").GetBoolean().Should().BeTrue();
-            doc.RootElement.GetProperty("run_immediately_triggered").GetBoolean().Should().BeFalse();
+            doc.RootElement.GetProperty("run_immediately_requested").GetBoolean().Should().BeFalse();
 
             await userConfigCommandService.Received(1)
                 .SaveGithubUsernameAsync("scope-1", "alice", Arg.Any<CancellationToken>());

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
@@ -304,7 +304,7 @@ public sealed class NyxRelayAgentBuilderFlowTests
             template = "daily_report",
             github_username = "eanzhao",
             github_username_preference_saved = true,
-            run_immediately_triggered = true,
+            run_immediately_requested = true,
             next_scheduled_run = "2026-04-25T09:00:00+00:00",
             conversation_id = "oc_default_daily",
         });
@@ -332,7 +332,7 @@ public sealed class NyxRelayAgentBuilderFlowTests
             template = "daily_report",
             github_username = "eanzhao",
             github_username_preference_saved = false,
-            run_immediately_triggered = true,
+            run_immediately_requested = true,
             next_scheduled_run = "2026-04-25T09:00:00+00:00",
         });
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Text.Json;
+using Aevatar.GAgents.Channel.Abstractions;
 using FluentAssertions;
 using Xunit;
 
@@ -52,7 +54,30 @@ public sealed class NyxRelayAgentBuilderFlowTests
         body.RootElement.GetProperty("action").GetString().Should().Be("create_agent");
         body.RootElement.GetProperty("template").GetString().Should().Be("daily_report");
         body.RootElement.GetProperty("github_username").GetString().Should().Be("eanzhao");
+        body.RootElement.GetProperty("save_github_username_preference").GetBoolean().Should().BeTrue();
+        body.RootElement.GetProperty("run_immediately").GetBoolean().Should().BeTrue();
         body.RootElement.GetProperty("conversation_id").GetString().Should().Be("oc_8a70aeefbdb4340e1fa5f575b4c794eb");
+    }
+
+    [Fact]
+    public void TryResolve_ShouldNotRequestPreferenceSave_WhenDailyHasNoUsername()
+    {
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            ConversationId = "oc_default_daily",
+            Text = "/daily",
+        };
+
+        var matched = NyxRelayAgentBuilderFlow.TryResolve(inbound, out var decision);
+
+        matched.Should().BeTrue();
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeTrue();
+
+        using var body = JsonDocument.Parse(decision.ToolArgumentsJson!);
+        body.RootElement.GetProperty("github_username").ValueKind.Should().Be(JsonValueKind.Null);
+        body.RootElement.GetProperty("save_github_username_preference").GetBoolean().Should().BeFalse();
     }
 
     [Theory]
@@ -145,9 +170,11 @@ public sealed class NyxRelayAgentBuilderFlowTests
             }
             """);
 
-        result.Should().Contain("Current agents:");
-        result.Should().Contain("agent-1: template=daily_report, status=running");
-        result.Should().Contain("/agent-status <agent_id>");
+        result.Actions.Should().BeEmpty();
+        result.Cards.Should().BeEmpty();
+        result.Text.Should().Contain("Current agents:");
+        result.Text.Should().Contain("agent-1: template=daily_report, status=running");
+        result.Text.Should().Contain("/agent-status <agent_id>");
     }
 
     [Fact]
@@ -236,5 +263,83 @@ public sealed class NyxRelayAgentBuilderFlowTests
 
         matched.Should().BeFalse();
         decision.Should().BeNull();
+    }
+
+    [Fact]
+    public void FormatToolResult_ShouldReturnCardForm_WhenCredentialsRequired()
+    {
+        var decision = AgentBuilderFlowDecision.ToolCall("create_daily_report", "{}");
+        var toolResultJson = JsonSerializer.Serialize(new
+        {
+            status = "credentials_required",
+            template = "daily_report",
+            provider_id = "p-github",
+            note = "Could not resolve github_username. Provide github_username explicitly, save a default preference, or reconnect GitHub in NyxID.",
+        });
+
+        var result = NyxRelayAgentBuilderFlow.FormatToolResult(decision, toolResultJson);
+
+        result.Actions.Should().NotBeEmpty();
+        result.Actions.Any(action => action.Kind == ActionElementKind.TextInput && action.ActionId == "github_username")
+            .Should().BeTrue();
+        result.Actions.Any(action => action.Kind == ActionElementKind.FormSubmit && action.ActionId == "submit_daily_report")
+            .Should().BeTrue();
+        result.Cards.Should().HaveCount(1);
+        result.Cards[0].Title.Should().Be("Create Daily Report Agent");
+        result.Cards[0].Text.Should().Contain("GitHub credentials required");
+        result.Cards[0].Text.Should().Contain("p-github");
+        result.Text.Should().NotBeEmpty();
+        result.Text.Should().Contain("GitHub credentials required");
+    }
+
+    [Fact]
+    public void FormatToolResult_ShouldAckImmediateRun_WithSavedPreference()
+    {
+        var decision = AgentBuilderFlowDecision.ToolCall("create_daily_report", "{}");
+        var toolResultJson = JsonSerializer.Serialize(new
+        {
+            status = "created",
+            agent_id = "skill-runner-1ba2e9f3",
+            agent_type = "skill_runner",
+            template = "daily_report",
+            github_username = "eanzhao",
+            github_username_preference_saved = true,
+            run_immediately_triggered = true,
+            next_scheduled_run = "2026-04-25T09:00:00+00:00",
+            conversation_id = "oc_default_daily",
+        });
+
+        var result = NyxRelayAgentBuilderFlow.FormatToolResult(decision, toolResultJson);
+
+        result.Actions.Should().BeEmpty();
+        result.Cards.Should().BeEmpty();
+        result.Text.Should().Contain("Daily report scheduled for `eanzhao`");
+        result.Text.Should().Contain("Running first report now");
+        result.Text.Should().Contain("I'll reply with the results shortly");
+        result.Text.Should().Contain("Saved `eanzhao` as your default GitHub username");
+        result.Text.Should().Contain("Next scheduled run: 2026-04-25T09:00:00+00:00");
+        result.Text.Should().Contain("skill-runner-1ba2e9f3");
+    }
+
+    [Fact]
+    public void FormatToolResult_ShouldNotMentionSavedPreference_WhenSaveNotRequested()
+    {
+        var decision = AgentBuilderFlowDecision.ToolCall("create_daily_report", "{}");
+        var toolResultJson = JsonSerializer.Serialize(new
+        {
+            status = "created",
+            agent_id = "skill-runner-1",
+            template = "daily_report",
+            github_username = "eanzhao",
+            github_username_preference_saved = false,
+            run_immediately_triggered = true,
+            next_scheduled_run = "2026-04-25T09:00:00+00:00",
+        });
+
+        var result = NyxRelayAgentBuilderFlow.FormatToolResult(decision, toolResultJson);
+
+        result.Text.Should().Contain("Daily report scheduled for `eanzhao`");
+        result.Text.Should().Contain("Running first report now");
+        result.Text.Should().NotContain("as your default GitHub username");
     }
 }

--- a/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
+++ b/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
@@ -66,4 +66,96 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
 
         payload.PlainText.ShouldBe("A🙂");
     }
+
+    [Fact]
+    public void Compose_WhenFormInputCarriesValue_RendersLarkDefaultValue()
+    {
+        var intent = new MessageContent();
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.TextInput,
+            ActionId = "github_username",
+            Label = "GitHub Username",
+            Placeholder = "octocat",
+            Value = "eanzhao",
+        });
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.FormSubmit,
+            ActionId = "submit",
+            Label = "Submit",
+            IsPrimary = true,
+        });
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        payload.MessageType.ShouldBe("interactive");
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var formElement = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "form");
+        var inputElement = formElement
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "input");
+        inputElement.GetProperty("default_value").GetString().ShouldBe("eanzhao");
+    }
+
+    [Fact]
+    public void Compose_WhenFormInputHasNoValue_OmitsLarkDefaultValue()
+    {
+        var intent = new MessageContent();
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.TextInput,
+            ActionId = "github_username",
+            Label = "GitHub Username",
+            Placeholder = "octocat",
+        });
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.FormSubmit,
+            ActionId = "submit",
+            Label = "Submit",
+            IsPrimary = true,
+        });
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var formElement = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "form");
+        var inputElement = formElement
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "input");
+        inputElement.TryGetProperty("default_value", out _).ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

Two user-facing fixes for the Day One agent builder flow that land together because they share the same wiring.

### 1. `/daily` (no args) now shows a real Lark interactive card

The Lark bot already had a card schema for `/daily` in `AgentBuilderCardFlow.BuildDailyReportCard`, but it never reached the user as a card. Two problems:

- `NyxRelayAgentBuilderFlow.TryResolve` matched `/daily` first and short-circuited the card-flow path entirely; its `FormatCreateDailyReportResult` returned plain text via `BuildTextBlock(...)` — clear, but no interactive form, just a paragraph telling the user to fix something.
- `AgentBuilderCardFlow`'s own daily-report builder returned a pre-serialized Lark schema-2.0 JSON **string**, which `ChannelConversationTurnRunner` stuffed into `MessageContent.Text`. `HasInteractiveContent` only triggers the interactive relay dispatcher when `Actions/Cards` are populated, so on non-relay webhook deployments (where this path is reachable) the user saw the raw JSON.

The fix routes the card through the platform-neutral abstraction:

- New `AgentBuilderCardContent.BuildDailyReportForm` emits `ActionElement` TextInputs + a FormSubmit button and a `CardBlock` header. `LarkMessageComposer.RequiresFormWrapping` already knows how to render that as a schema-2.0 form card via `metadata.card`.
- `AgentBuilderFlowDecision` gained a `MessageContent? ReplyContent` slot so decisions can carry interactive intents in addition to text.
- `FormatToolResult` on both `NyxRelayAgentBuilderFlow` and `AgentBuilderCardFlow` now returns `MessageContent`. Simple text-based formatters wrap into `MessageContent { Text = ... }`; the daily-report formatter returns a true card when the tool reports `credentials_required` / `oauth_required`.
- `AgentBuilderCardFlow.TryResolveAsync` direct `/daily` / `/social-media` text paths and the `OpenDailyReportFormAction` / `OpenSocialMediaFormAction` card-action branches all now emit `MessageContent` instead of the legacy JSON strings. The old string builders (`BuildDailyReportCard`, `BuildSocialMediaCard`, `BuildForm`, `BuildInput`, `BuildSubmitButton`, and the unused `FormatCreateDailyReportResult`) are deleted.

### 2. Saved GitHub username is prefilled as editable text, not ghost placeholder

`LarkMessageComposer.BuildFormInput` now renders `default_value` from `ActionElement.Value` when set. `BuildDailyReportForm` puts the saved username in `Value` and keeps `"octocat"` as the placeholder, so the user sees their saved name as editable text they can submit with one click instead of a placeholder hint that vanishes when they focus the input.

### 3. `/daily <github_username>` saves the binding and leads with "running now"

The old UX said "Daily report agent registered. Next scheduled run: 2026-04-25T09:00:00+00:00", burying the fact that we already kicked off the first run and ignoring the chance to persist the username as the user's default.

- `NyxRelayAgentBuilderFlow.TryResolveDailyReport` now sets `save_github_username_preference = true` whenever the user supplied a positional username, so the next `/daily` call auto-resolves without re-asking.
- `AgentBuilderTool.CreateDailyReportAgentAsync` now returns `github_username`, `github_username_preference_saved`, and `run_immediately_requested` in its response. The shared formatter in `AgentBuilderCardContent.FormatDailyReportToolReply` uses those flags to produce:

    ```
    Daily report scheduled for `eanzhao`. Running first report now — I'll reply with the results shortly.
    Saved `eanzhao` as your default GitHub username.
    Next scheduled run: 2026-04-25T09:00:00+00:00
    Agent ID: skill-runner-…
    Next commands: /agents, /agent-status …, /run-agent …
    ```

The field is named `run_immediately_requested` (not `triggered`) because it records that we dispatched `TriggerSkillRunnerExecutionCommand`, not that the skill-runner actor actually completed its first run. The authoritative status surfaces via `/agent-status`, not via this immediate ack.

Both the Nyx-relay slash-command path and the Feishu card-action submit path share that formatter, so card-form submits do not fall back to JSON-as-text.

## Test plan

- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` (317 pass)
- [x] `dotnet test test/Aevatar.GAgents.Platform.Lark.Tests/Aevatar.GAgents.Platform.Lark.Tests.csproj` (12 pass)
- [x] `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj` (110 pass)
- [x] `bash tools/ci/architecture_guards.sh`
- [x] `bash tools/ci/channel_card_literal_guard.sh` (further reduced literals; two `tag = "button"` remain for non-form buttons in list/status/templates/delete paths still on the allowlist TODO)
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `bash tools/ci/channel_mega_interface_guard.sh`
- [x] `bash tools/ci/channel_relay_nyx_chat_direct_create_guard.sh`
- [x] `bash tools/ci/channel_inbox_gagent_guard.sh`
- [x] `bash tools/ci/committed_state_projection_guard.sh`
- [x] `bash tools/ci/cqrs_eventsourcing_boundary_guard.sh`
- [x] `bash tools/ci/workflow_binding_boundary_guard.sh`
- [x] `bash tools/ci/projection_route_mapping_guard.sh`

New tests:

- `LarkMessageComposerTests.Compose_WhenFormInputCarriesValue_RendersLarkDefaultValue`
- `LarkMessageComposerTests.Compose_WhenFormInputHasNoValue_OmitsLarkDefaultValue`
- `AgentBuilderCardContentTests.BuildDailyReportForm_PrefillsSavedGithubUsernameIntoValue_WhenProvided`
- `AgentBuilderCardContentTests.BuildDailyReportForm_LeavesValueEmpty_WhenNoSavedUsername`
- `AgentBuilderCardContentTests.BuildSocialMediaForm_EmitsFormInputsAndSubmitButton`
- `NyxRelayAgentBuilderFlowTests.FormatToolResult_ShouldReturnCardForm_WhenCredentialsRequired`
- `NyxRelayAgentBuilderFlowTests.FormatToolResult_ShouldAckImmediateRun_WithSavedPreference`
- `NyxRelayAgentBuilderFlowTests.FormatToolResult_ShouldNotMentionSavedPreference_WhenSaveNotRequested`
- `NyxRelayAgentBuilderFlowTests.TryResolve_ShouldNotRequestPreferenceSave_WhenDailyHasNoUsername`

## Follow-ups not in this PR

- `AgentBuilderCardFlow` still builds Lark schema-2.0 JSON literals for the non-daily formatters (list/status/templates/delete). Two `tag = "button"` hits remain flagged by `channel_card_literal_guard`'s allowlist. Migrating those to `MessageContent` primitives is a natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)