### PR TITLE
Grain-level retry for transient inbound turn failures (#399)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -355,17 +355,15 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var pending = FindPendingInboundTurn(evt.ActivityId);
         if (pending is null || pending.Activity is null)
         {
+            // Pending entry already reaped — either by ApplyTurnCompleted (success), the
+            // terminal NotRetryable ApplyContinueFailed (exhaustion), or ApplyLlmReplyRequested
+            // (redelivery accepted into the LLM reply pipeline before this retry could fire).
             Logger.LogDebug(
                 "Ignoring deferred inbound turn retry without pending entry: activity={ActivityId}",
                 evt.ActivityId);
             return;
         }
 
-        // If the turn already completed via another path between scheduling and firing, the
-        // dedup guard in HandleInboundActivityCoreAsync will drop the redelivery without
-        // running the turn runner. That's still desired behaviour — we just log and let the
-        // core handler's existing check handle the cleanup.
-        //
         // The in-memory _nyxRelayReplyTokens dict is the authoritative source for the relay
         // reply credential. If the activation is still alive, BuildNyxRelayRuntimeContext
         // will re-hydrate it from activity.outbound_delivery.correlation_id; if the pod was
@@ -1167,6 +1165,11 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         if (!string.IsNullOrWhiteSpace(activityId))
         {
             AppendBounded(next.ProcessedMessageIds, activityId, ProcessedIdsCap);
+            // Acceptance into the LLM reply pipeline supersedes any pending inbound retry
+            // entry for the same activity. Without this reap, a redelivery that takes the
+            // LLM path would leave the stale pending entry in state, where it would be
+            // re-scheduled on every activation and silently no-op against the dedup guard.
+            RemovePendingInboundTurn(next.PendingInboundTurns, activityId);
         }
 
         if (evt.Activity?.Conversation != null && next.Conversation == null)

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -38,6 +38,15 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     // and the user access token (~15 min TTL) used for the LLM call is definitely gone.
     // Drop them rather than burn an LLM round and reply hours late.
     private static readonly TimeSpan PendingLlmReplyRequestMaxAge = TimeSpan.FromMinutes(5);
+
+    // Mirror of DeferredLlmDispatchRetryDelay for the inbound-turn retry pipeline.
+    // The same reminder-granularity floor applies: any requested retry shorter than this
+    // would be silently rounded up by Orleans and appear lost.
+    private static readonly TimeSpan DeferredInboundTurnRetryDelay = TimeSpan.FromSeconds(60);
+    // Bounded retry count for transient inbound-turn failures. On exhaustion the actor
+    // persists a terminal ConversationContinueFailedEvent (NotRetryable) so the pending
+    // set does not grow unboundedly.
+    public const int MaxInboundTurnRetryCount = 5;
     private readonly Dictionary<string, NyxRelayReplyTokenContext> _nyxRelayReplyTokens = new(StringComparer.Ordinal);
     private readonly Dictionary<string, NyxRelayStreamingState> _nyxRelayStreamingStates = new(StringComparer.Ordinal);
 
@@ -86,6 +95,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     {
         await base.OnActivateAsync(ct);
         await SchedulePendingLlmReplyDispatchesAsync(ct);
+        await SchedulePendingInboundTurnRetriesAsync(ct);
     }
 
     /// <inheritdoc />
@@ -96,6 +106,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             .On<NeedsLlmReplyEvent>(ApplyLlmReplyRequested)
             .On<ConversationContinueRejectedEvent>(ApplyContinueRejected)
             .On<ConversationContinueFailedEvent>(ApplyContinueFailed)
+            .On<InboundTurnRetryScheduledEvent>(ApplyInboundTurnRetryScheduled)
             .OrCurrent();
 
     /// <summary>
@@ -183,6 +194,12 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             return;
         }
 
+        if (result.FailureKind == FailureKind.TransientAdapterError)
+        {
+            await HandleInboundTurnTransientFailureAsync(activity, runtimeContext, result, nowMs);
+            return;
+        }
+
         var failed = new ConversationContinueFailedEvent
         {
             CommandId = string.Empty,
@@ -199,6 +216,80 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         Logger.LogWarning(
             "Inbound turn failed: activity={ActivityId} code={Code} kind={Kind}",
             activity.Id, result.ErrorCode, result.FailureKind);
+    }
+
+    /// <summary>
+    /// Mirrors the deferred LLM reply retry pattern for the inbound-turn path: bounds the retry
+    /// count, schedules a durable reminder for the next attempt, or emits a terminal
+    /// <see cref="ConversationContinueFailedEvent"/> on exhaustion so the pending entry is
+    /// reaped by the state matcher.
+    /// </summary>
+    private async Task HandleInboundTurnTransientFailureAsync(
+        ChatActivity activity,
+        ConversationTurnRuntimeContext runtimeContext,
+        ConversationTurnResult result,
+        long nowMs)
+    {
+        var existingPending = FindPendingInboundTurn(activity.Id);
+        var nextRetryCount = (existingPending?.RetryCount ?? 0) + 1;
+
+        if (nextRetryCount > MaxInboundTurnRetryCount)
+        {
+            var failed = new ConversationContinueFailedEvent
+            {
+                CommandId = string.Empty,
+                CorrelationId = activity.Id,
+                CausationId = string.Empty,
+                Kind = FailureKind.TransientAdapterError,
+                ErrorCode = string.IsNullOrWhiteSpace(result.ErrorCode)
+                    ? "inbound_turn_retries_exhausted"
+                    : result.ErrorCode,
+                ErrorSummary = string.IsNullOrWhiteSpace(result.ErrorSummary)
+                    ? "Inbound turn retries exhausted."
+                    : result.ErrorSummary,
+                NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
+                FailedAtUnixMs = nowMs,
+            };
+            await PersistDomainEventAsync(failed);
+            RemoveNyxRelayReplyToken(runtimeContext.NyxRelayReplyToken?.CorrelationId, activity);
+            Logger.LogWarning(
+                "Inbound turn retries exhausted: activity={ActivityId} retryCount={RetryCount} code={Code}",
+                activity.Id,
+                nextRetryCount - 1,
+                result.ErrorCode);
+            return;
+        }
+
+        var requested = result.RetryAfter ?? DeferredInboundTurnRetryDelay;
+        // Floor to reminder granularity so the durable scheduler does not silently round the
+        // request up past the retry window and drop the dispatch (same trap the LLM reply
+        // retry path has to guard against).
+        var retryAfter = requested < DeferredInboundTurnRetryDelay
+            ? DeferredInboundTurnRetryDelay
+            : requested;
+        var firstFailedUnixMs = existingPending is { FirstFailedUnixMs: > 0 }
+            ? existingPending.FirstFailedUnixMs
+            : nowMs;
+        var nextRetryUnixMs = DateTimeOffset.UtcNow.Add(retryAfter).ToUnixTimeMilliseconds();
+
+        var scheduled = new InboundTurnRetryScheduledEvent
+        {
+            ActivityId = activity.Id,
+            Activity = activity.Clone(),
+            RetryCount = nextRetryCount,
+            FirstFailedUnixMs = firstFailedUnixMs,
+            NextRetryUnixMs = nextRetryUnixMs,
+            ScheduledAtUnixMs = nowMs,
+        };
+        await PersistDomainEventAsync(scheduled);
+        await ScheduleDeferredInboundTurnRetryAsync(activity.Id, retryAfter, CancellationToken.None);
+
+        Logger.LogInformation(
+            "Scheduled inbound turn retry: activity={ActivityId} retryCount={RetryCount} retryAfter={RetryAfter} code={Code}",
+            activity.Id,
+            nextRetryCount,
+            retryAfter,
+            result.ErrorCode);
     }
 
     [EventHandler]
@@ -254,6 +345,37 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             "Retired pending LLM reply after inbox drop: correlation={CorrelationId} reason={Reason}",
             evt.CorrelationId,
             reason);
+    }
+
+    [EventHandler]
+    public async Task HandleDeferredInboundTurnRetryRequestedAsync(DeferredInboundTurnRetryRequestedEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        var pending = FindPendingInboundTurn(evt.ActivityId);
+        if (pending is null || pending.Activity is null)
+        {
+            Logger.LogDebug(
+                "Ignoring deferred inbound turn retry without pending entry: activity={ActivityId}",
+                evt.ActivityId);
+            return;
+        }
+
+        // If the turn already completed via another path between scheduling and firing, the
+        // dedup guard in HandleInboundActivityCoreAsync will drop the redelivery without
+        // running the turn runner. That's still desired behaviour — we just log and let the
+        // core handler's existing check handle the cleanup.
+        //
+        // The in-memory _nyxRelayReplyTokens dict is the authoritative source for the relay
+        // reply credential. If the activation is still alive, BuildNyxRelayRuntimeContext
+        // will re-hydrate it from activity.outbound_delivery.correlation_id; if the pod was
+        // restarted between attempts the dict is empty and the retry runs with Empty
+        // context. In both cases the runner is invoked identically to the first turn.
+        var runtimeContext = BuildNyxRelayRuntimeContext(
+            pending.Activity.OutboundDelivery?.CorrelationId,
+            pending.Activity);
+
+        await HandleInboundActivityCoreAsync(pending.Activity.Clone(), runtimeContext);
     }
 
     private async Task DispatchPendingLlmReplyAsync(NeedsLlmReplyEvent request, CancellationToken ct)
@@ -734,6 +856,9 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     private static string BuildNyxRelayReplyTokenCleanupCallbackId(string? correlationId) =>
         $"nyx-relay-reply-token-cleanup:{correlationId?.Trim() ?? string.Empty}";
 
+    private static string BuildDeferredInboundTurnRetryCallbackId(string? activityId) =>
+        $"conversation-inbound-turn-retry:{activityId?.Trim() ?? string.Empty}";
+
     private async Task ScheduleDeferredLlmReplyDispatchAsync(
         NeedsLlmReplyEvent request,
         TimeSpan dueTime,
@@ -748,6 +873,51 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             },
             ct: ct);
+    }
+
+    private async Task ScheduleDeferredInboundTurnRetryAsync(
+        string activityId,
+        TimeSpan dueTime,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(activityId);
+        await ScheduleSelfDurableTimeoutAsync(
+            BuildDeferredInboundTurnRetryCallbackId(activityId),
+            dueTime <= TimeSpan.Zero ? DeferredInboundTurnRetryDelay : dueTime,
+            new DeferredInboundTurnRetryRequestedEvent
+            {
+                ActivityId = activityId,
+                RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            },
+            ct: ct);
+    }
+
+    private async Task SchedulePendingInboundTurnRetriesAsync(CancellationToken ct)
+    {
+        // Snapshot to avoid enumerating the live repeated field while downstream scheduling
+        // may trigger state mutations (the same invariant SchedulePendingLlmReplyDispatchesAsync
+        // already relies on).
+        var pending = State.PendingInboundTurns.ToArray();
+        if (pending.Length == 0)
+            return;
+
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        foreach (var entry in pending)
+        {
+            if (string.IsNullOrWhiteSpace(entry.ActivityId))
+                continue;
+
+            var remainingMs = entry.NextRetryUnixMs > 0
+                ? entry.NextRetryUnixMs - nowMs
+                : 0;
+            var delay = remainingMs > 0
+                ? TimeSpan.FromMilliseconds(remainingMs)
+                : DeferredInboundTurnRetryDelay;
+            if (delay < DeferredInboundTurnRetryDelay)
+                delay = DeferredInboundTurnRetryDelay;
+
+            await ScheduleDeferredInboundTurnRetryAsync(entry.ActivityId, delay, ct);
+        }
     }
 
     private Task ScheduleNyxRelayReplyTokenCleanupAsync(NyxRelayReplyTokenContext tokenContext, CancellationToken ct)
@@ -951,6 +1121,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         if (!string.IsNullOrEmpty(evt.ProcessedActivityId))
         {
             AppendBounded(next.ProcessedMessageIds, evt.ProcessedActivityId, ProcessedIdsCap);
+            // Successful inbound completion supersedes any pending retry entry.
+            RemovePendingInboundTurn(next.PendingInboundTurns, evt.ProcessedActivityId);
         }
         if (!string.IsNullOrEmpty(evt.CausationCommandId))
         {
@@ -962,6 +1134,27 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             next.Conversation = evt.Conversation.Clone();
         }
         next.LastUpdatedUnixMs = evt.CompletedAtUnixMs;
+        return next;
+    }
+
+    private static ConversationGAgentState ApplyInboundTurnRetryScheduled(
+        ConversationGAgentState current,
+        InboundTurnRetryScheduledEvent evt)
+    {
+        var next = current.Clone();
+        if (string.IsNullOrEmpty(evt.ActivityId))
+            return next;
+
+        var pending = new PendingInboundTurn
+        {
+            ActivityId = evt.ActivityId,
+            Activity = evt.Activity?.Clone(),
+            RetryCount = evt.RetryCount,
+            FirstFailedUnixMs = evt.FirstFailedUnixMs,
+            NextRetryUnixMs = evt.NextRetryUnixMs,
+        };
+        UpsertPendingInboundTurn(next.PendingInboundTurns, pending);
+        next.LastUpdatedUnixMs = evt.ScheduledAtUnixMs > 0 ? evt.ScheduledAtUnixMs : evt.NextRetryUnixMs;
         return next;
     }
 
@@ -1018,6 +1211,15 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             AppendBounded(next.ProcessedCommandIds, evt.CommandId, ProcessedIdsCap);
             RemovePendingLlmReplyRequest(next.PendingLlmReplyRequests, ExtractLlmReplyCorrelationId(evt.CommandId));
         }
+        // Inbound terminal failures (e.g. retries exhausted) carry an empty CommandId and set
+        // CorrelationId to the activity id; reap the matching pending retry entry so the set
+        // does not leak.
+        if (string.IsNullOrEmpty(evt.CommandId)
+            && !string.IsNullOrEmpty(evt.CorrelationId)
+            && evt.RetryPolicyCase == ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable)
+        {
+            RemovePendingInboundTurn(next.PendingInboundTurns, evt.CorrelationId);
+        }
         next.LastUpdatedUnixMs = evt.FailedAtUnixMs;
         return next;
     }
@@ -1051,6 +1253,39 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         for (var i = field.Count - 1; i >= 0; i--)
         {
             if (string.Equals(field[i].CorrelationId, normalizedCorrelationId, StringComparison.Ordinal))
+                field.RemoveAt(i);
+        }
+    }
+
+    private PendingInboundTurn? FindPendingInboundTurn(string? activityId)
+    {
+        var normalized = NormalizeOptional(activityId);
+        if (normalized is null)
+            return null;
+
+        return State.PendingInboundTurns.FirstOrDefault(entry =>
+            string.Equals(entry.ActivityId, normalized, StringComparison.Ordinal));
+    }
+
+    private static void UpsertPendingInboundTurn(
+        Google.Protobuf.Collections.RepeatedField<PendingInboundTurn> field,
+        PendingInboundTurn entry)
+    {
+        RemovePendingInboundTurn(field, entry.ActivityId);
+        field.Add(entry.Clone());
+    }
+
+    private static void RemovePendingInboundTurn(
+        Google.Protobuf.Collections.RepeatedField<PendingInboundTurn> field,
+        string? activityId)
+    {
+        var normalized = NormalizeOptional(activityId);
+        if (normalized is null)
+            return;
+
+        for (var i = field.Count - 1; i >= 0; i--)
+        {
+            if (string.Equals(field[i].ActivityId, normalized, StringComparison.Ordinal))
                 field.RemoveAt(i);
         }
     }

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -104,6 +104,27 @@ message DeferredLlmReplyDispatchRequestedEvent {
   int64 requested_at_unix_ms = 2;
 }
 
+// Actor self-message fired by the durable scheduler when an inbound turn retry
+// is due. The handler looks up `activity_id` in
+// ConversationGAgentState.pending_inbound_turns, rebuilds the runtime context
+// from the in-memory reply-token dict, and re-invokes the turn runner.
+message DeferredInboundTurnRetryRequestedEvent {
+  string activity_id = 1;
+  int64 requested_at_unix_ms = 2;
+}
+
+// Persisted alongside each retry scheduling so that (a) pending_inbound_turns is
+// driven through the standard state matcher pipeline and (b) actor rehydration
+// after deactivation can walk the pending set and re-register durable timeouts.
+message InboundTurnRetryScheduledEvent {
+  string activity_id = 1;
+  aevatar.gagents.channel.abstractions.ChatActivity activity = 2;
+  int32 retry_count = 3;
+  int64 first_failed_unix_ms = 4;
+  int64 next_retry_unix_ms = 5;
+  int64 scheduled_at_unix_ms = 6;
+}
+
 message NyxRelayReplyTokenCleanupRequestedEvent {
   string correlation_id = 1;
   int64 requested_at_unix_ms = 2;

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
@@ -14,10 +14,23 @@ message ConversationGAgentState {
   repeated PendingSession pending_sessions = 4;
   int64 last_updated_unix_ms = 5;
   repeated NeedsLlmReplyEvent pending_llm_reply_requests = 6;
+  repeated PendingInboundTurn pending_inbound_turns = 7;
 }
 
 message PendingSession {
   string session_id = 1;
   string correlation_id = 2;
   int64 started_at_unix_ms = 3;
+}
+
+// Tracks an inbound activity that hit a transient adapter failure and is waiting
+// for a grain-owned durable retry. The reply credential (if any) is intentionally
+// NOT persisted here; on retry firing the actor rebuilds the runtime context from
+// its in-memory _nyxRelayReplyTokens dict using activity.outbound_delivery.correlation_id.
+message PendingInboundTurn {
+  string activity_id = 1;
+  aevatar.gagents.channel.abstractions.ChatActivity activity = 2;
+  int32 retry_count = 3;
+  int64 first_failed_unix_ms = 4;
+  int64 next_retry_unix_ms = 5;
 }

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -225,6 +225,63 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task ApplyLlmReplyRequested_AfterTransientFailureRetryPending_ReapsPendingInboundTurn()
+    {
+        // Codex review on #399 retry: a transient-failed activity that later succeeds via
+        // redelivery on the LLM reply path must reap the pending retry entry. Without this,
+        // the deferred retry would find the stale pending entry, hit the dedup guard, and
+        // silently no-op — but the entry would survive to be re-registered on every
+        // activation, growing PendingInboundTurns unboundedly.
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return ConversationTurnResult.TransientFailure("rate_limited", "retry later");
+                return ConversationTurnResult.LlmReplyRequested(
+                    new NeedsLlmReplyEvent
+                    {
+                        CorrelationId = activity.Id,
+                        TargetActorId = "conversation:actor",
+                        RegistrationId = "reg-1",
+                        Activity = activity.Clone(),
+                        RequestedAtUnixMs = 7,
+                    });
+            },
+        };
+        var (agent, store) = CreateAgent(runner, "conv-llm-supersedes-retry");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-llm-supersedes", "conv:slack:C1"));
+        agent.State.PendingInboundTurns.ShouldContain(entry => entry.ActivityId == "act-llm-supersedes");
+
+        // Redelivery hits the LLM reply branch; ApplyLlmReplyRequested must reap the pending
+        // entry alongside adding the activity id to ProcessedMessageIds.
+        await agent.HandleInboundActivityAsync(CreateActivity("act-llm-supersedes", "conv:slack:C1"));
+
+        runner.InboundCount.ShouldBe(2);
+        agent.State.ProcessedMessageIds.ShouldContain("act-llm-supersedes");
+        agent.State.PendingInboundTurns.ShouldNotContain(entry => entry.ActivityId == "act-llm-supersedes");
+
+        var eventsAfterRedelivery = await store.GetEventsAsync(agent.Id);
+
+        // The deferred retry that was scheduled on the first delivery now fires. With the
+        // pending entry already reaped, the handler is a true no-op: no runner invocation,
+        // no further events persisted, and PendingInboundTurns stays empty.
+        await agent.HandleDeferredInboundTurnRetryRequestedAsync(new DeferredInboundTurnRetryRequestedEvent
+        {
+            ActivityId = "act-llm-supersedes",
+            RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        runner.InboundCount.ShouldBe(2);
+        agent.State.PendingInboundTurns.ShouldNotContain(entry => entry.ActivityId == "act-llm-supersedes");
+        var eventsAfterRetryFire = await store.GetEventsAsync(agent.Id);
+        eventsAfterRetryFire.Count.ShouldBe(eventsAfterRedelivery.Count);
+    }
+
+    [Fact]
     public async Task HandleInboundActivityAsync_WhenRunnerReportsPermanentFailure_EmitsTerminalWithoutScheduling()
     {
         // Issue #399 non-regression: permanent-adapter failures must skip the retry pipeline and

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -107,8 +107,12 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleInboundActivityAsync_WhenRunnerReportsFailure_EmitsFailedEvent()
+    public async Task HandleInboundActivityAsync_WhenRunnerReportsTransientFailure_SchedulesGrainOwnedRetry()
     {
+        // Grain-level retry pattern (issue #399): a transient inbound-turn failure must land as
+        // an InboundTurnRetryScheduledEvent with a bounded retry count rather than a leaf
+        // ConversationContinueFailedEvent, because the webhook adapter no longer surfaces a
+        // retryable 503 back to NyxID and the end-user reply would otherwise be dropped.
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = _ => ConversationTurnResult.TransientFailure("rate_limited", "retry later", TimeSpan.FromMilliseconds(250)),
@@ -118,12 +122,128 @@ public sealed class ConversationGAgentDedupTests
         await agent.HandleInboundActivityAsync(CreateActivity("act-fail", "conv:slack:C1"));
 
         agent.State.ProcessedMessageIds.ShouldBeEmpty();
+        agent.State.PendingInboundTurns.ShouldContain(entry => entry.ActivityId == "act-fail");
+        var pending = agent.State.PendingInboundTurns.Single(entry => entry.ActivityId == "act-fail");
+        pending.RetryCount.ShouldBe(1);
+        pending.FirstFailedUnixMs.ShouldBeGreaterThan(0);
+        pending.NextRetryUnixMs.ShouldBeGreaterThan(pending.FirstFailedUnixMs);
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(1);
+        events[0].EventType.ShouldContain(nameof(InboundTurnRetryScheduledEvent));
+        var parsed = InboundTurnRetryScheduledEvent.Parser.ParseFrom(events[0].EventData.Value);
+        parsed.ActivityId.ShouldBe("act-fail");
+        parsed.RetryCount.ShouldBe(1);
+        parsed.Activity.Id.ShouldBe("act-fail");
+    }
+
+    [Fact]
+    public async Task HandleDeferredInboundTurnRetryRequestedAsync_AfterTransientFailure_RerunsTurnAndClearsPendingOnSuccess()
+    {
+        // Issue #399 success path: once the adapter recovers, the durable reminder fires the
+        // retry, the runner returns a proper ConversationTurnResult.Sent, and the pending entry
+        // is reaped by ApplyTurnCompleted via ProcessedActivityId.
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = _ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return ConversationTurnResult.TransientFailure("rate_limited", "retry later");
+                return ConversationTurnResult.Sent(
+                    "sent:act-retry-success",
+                    new MessageContent { Text = "ok" },
+                    "bot");
+            },
+        };
+        var (agent, store) = CreateAgent(runner, "conv-retry-success");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-retry-success", "conv:slack:C1"));
+        agent.State.PendingInboundTurns.ShouldContain(entry => entry.ActivityId == "act-retry-success");
+
+        await agent.HandleDeferredInboundTurnRetryRequestedAsync(new DeferredInboundTurnRetryRequestedEvent
+        {
+            ActivityId = "act-retry-success",
+            RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        runner.InboundCount.ShouldBe(2);
+        agent.State.ProcessedMessageIds.ShouldContain("act-retry-success");
+        agent.State.PendingInboundTurns.ShouldNotContain(entry => entry.ActivityId == "act-retry-success");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Count.ShouldBe(2);
+        events[0].EventType.ShouldContain(nameof(InboundTurnRetryScheduledEvent));
+        events[1].EventType.ShouldContain(nameof(ConversationTurnCompletedEvent));
+    }
+
+    [Fact]
+    public async Task HandleDeferredInboundTurnRetryRequestedAsync_WhenRetriesExhausted_EmitsNotRetryableTerminalFailure()
+    {
+        // Issue #399 exhaustion path: after MaxInboundTurnRetryCount successive transient
+        // failures, the actor persists a terminal NotRetryable ConversationContinueFailedEvent
+        // so the pending set does not leak and downstream observers see a final state.
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = _ => ConversationTurnResult.TransientFailure("stuck", "persistent transient error"),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-retry-exhaust");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-exhaust", "conv:slack:C1"));
+        agent.State.PendingInboundTurns.Single(e => e.ActivityId == "act-exhaust").RetryCount.ShouldBe(1);
+
+        // Fire MaxInboundTurnRetryCount - 1 retries, each bumps the retry count but stays pending.
+        for (var i = 0; i < ConversationGAgent.MaxInboundTurnRetryCount - 1; i++)
+        {
+            await agent.HandleDeferredInboundTurnRetryRequestedAsync(new DeferredInboundTurnRetryRequestedEvent
+            {
+                ActivityId = "act-exhaust",
+                RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            });
+        }
+        agent.State.PendingInboundTurns.Single(e => e.ActivityId == "act-exhaust").RetryCount
+            .ShouldBe(ConversationGAgent.MaxInboundTurnRetryCount);
+
+        // One more retry pushes retry_count past the cap; the actor emits a terminal failure
+        // and reaps the pending entry.
+        await agent.HandleDeferredInboundTurnRetryRequestedAsync(new DeferredInboundTurnRetryRequestedEvent
+        {
+            ActivityId = "act-exhaust",
+            RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        runner.InboundCount.ShouldBe(ConversationGAgent.MaxInboundTurnRetryCount + 1);
+        agent.State.PendingInboundTurns.ShouldNotContain(entry => entry.ActivityId == "act-exhaust");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Last().EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
+        var terminal = ConversationContinueFailedEvent.Parser.ParseFrom(events.Last().EventData.Value);
+        terminal.CorrelationId.ShouldBe("act-exhaust");
+        terminal.Kind.ShouldBe(FailureKind.TransientAdapterError);
+        terminal.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable);
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_WhenRunnerReportsPermanentFailure_EmitsTerminalWithoutScheduling()
+    {
+        // Issue #399 non-regression: permanent-adapter failures must skip the retry pipeline and
+        // land as terminal ConversationContinueFailedEvent with NotRetryable semantics, as before.
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = _ => ConversationTurnResult.PermanentFailure("bad_input", "rejected"),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-permanent-inbound");
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-permanent", "conv:slack:C1"));
+
+        agent.State.PendingInboundTurns.ShouldBeEmpty();
         var events = await store.GetEventsAsync(agent.Id);
         events.Count.ShouldBe(1);
         events[0].EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
         var parsed = ConversationContinueFailedEvent.Parser.ParseFrom(events[0].EventData.Value);
-        parsed.Kind.ShouldBe(FailureKind.TransientAdapterError);
-        parsed.RetryAfterMs.ShouldBe(250);
+        parsed.Kind.ShouldBe(FailureKind.PermanentAdapterError);
+        parsed.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Mirror the deferred LLM reply retry pattern for `ConversationGAgent.HandleInboundActivityCoreAsync`, so transient adapter failures (`workflow_resume_dispatch_failed`, AgentBuilder adapter 500s, Lark API transient errors, …) get retried by the grain instead of being silently dropped as leaf `ConversationContinueFailedEvent` records.
- PR #397 unified the `/api/webhooks/nyxid-relay` webhook into a thin adapter, so the old retryable 503 back to NyxID relay is gone. Without grain-owned retry the end-user reply to card clicks disappeared on any single transient dispatch failure.

## Scope
- Extend `ConversationGAgentState` with `repeated PendingInboundTurn pending_inbound_turns = 7`; new `DeferredInboundTurnRetryRequestedEvent` + `InboundTurnRetryScheduledEvent` so scheduling flows through the standard state matcher.
- Transient inbound failures now persist `InboundTurnRetryScheduledEvent`, enqueue a durable self-message floored to reminder granularity (60s, same as LLM reply retry), and bump `retry_count`. On firing, the actor rebuilds `ConversationTurnRuntimeContext` from the in-memory reply-token dict via `activity.outbound_delivery.correlation_id` and re-invokes `HandleInboundActivityCoreAsync`.
- Retries exhaust at `MaxInboundTurnRetryCount = 5` with a terminal `NotRetryable` `ConversationContinueFailedEvent`, keeping `PendingInboundTurns` bounded. `ApplyTurnCompleted` reaps the pending entry when the turn eventually succeeds.
- Rehydration: `OnActivateAsync` walks `PendingInboundTurns` and re-registers the durable timeouts, so the retry survives activation drops (same invariant already used for `PendingLlmReplyRequests`).

## Non-goals
- No change to the webhook-layer: it still returns `202 accepted`. Cross-grain end-to-end ack semantics are unchanged.
- Permanent adapter failures continue to short-circuit to a terminal `ConversationContinueFailedEvent` without scheduling a retry.

## Test plan
- [x] New unit tests in `ConversationGAgentDedupTests`:
  - transient failure → `InboundTurnRetryScheduledEvent` persisted, `retry_count=1`
  - retry handler → runner re-invoked → success → pending cleared, `ConversationTurnCompletedEvent` persisted
  - retries exhausted → terminal `NotRetryable` `ConversationContinueFailedEvent`, pending reaped
  - permanent adapter failure → terminal without scheduling
- [x] `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/` (33 passed)
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/` (344 passed)
- [x] `dotnet test test/Aevatar.Workflow.Core.Tests/` (236 passed)
- [x] `dotnet test test/Aevatar.Foundation.Core.Tests/` (159 passed)
- [x] `bash tools/ci/architecture_guards.sh` + `test_stability_guards.sh` + `workflow_binding_boundary_guard.sh` + `query_projection_priming_guard.sh` + `projection_state_version_guard.sh` + `projection_state_mirror_current_state_guard.sh` + `projection_route_mapping_guard.sh`

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)