### PR TITLE
Fix skill runner GPT-5 temperature handling

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
@@ -381,6 +381,9 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.ScopeId = evt.ScopeId ?? string.Empty;
         next.ProviderName = NormalizeProviderName(evt.ProviderName);
         next.Model = evt.Model ?? string.Empty;
+
+        // Missing sampling fields intentionally use upstream model defaults;
+        // missing runner limits fall back to SkillRunner defaults.
         if (evt.HasTemperature)
             next.Temperature = evt.Temperature;
         else
@@ -389,6 +392,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             next.MaxTokens = evt.MaxTokens;
         else
             next.ClearMaxTokens();
+
         next.MaxToolRounds = evt.HasMaxToolRounds ? evt.MaxToolRounds : SkillRunnerDefaults.DefaultMaxToolRounds;
         next.MaxHistoryMessages = evt.HasMaxHistoryMessages ? evt.MaxHistoryMessages : SkillRunnerDefaults.DefaultMaxHistoryMessages;
         return next;

--- a/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
@@ -96,7 +96,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             return;
         }
 
-        await PersistDomainEventAsync(new SkillRunnerInitializedEvent
+        var initialized = new SkillRunnerInitializedEvent
         {
             SkillName = command.SkillName?.Trim() ?? string.Empty,
             TemplateName = command.TemplateName?.Trim() ?? string.Empty,
@@ -109,11 +109,18 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ScopeId = command.ScopeId?.Trim() ?? string.Empty,
             ProviderName = NormalizeProviderName(command.ProviderName),
             Model = command.Model?.Trim() ?? string.Empty,
-            Temperature = command.Temperature,
-            MaxTokens = command.MaxTokens,
-            MaxToolRounds = command.MaxToolRounds,
-            MaxHistoryMessages = command.MaxHistoryMessages,
-        });
+        };
+
+        if (command.HasTemperature)
+            initialized.Temperature = command.Temperature;
+        if (command.HasMaxTokens)
+            initialized.MaxTokens = command.MaxTokens;
+        if (command.HasMaxToolRounds)
+            initialized.MaxToolRounds = command.MaxToolRounds;
+        if (command.HasMaxHistoryMessages)
+            initialized.MaxHistoryMessages = command.MaxHistoryMessages;
+
+        await PersistDomainEventAsync(initialized);
 
         await Scheduler.ScheduleNextRunAsync(DateTimeOffset.UtcNow, CancellationToken.None);
         await UpsertRegistryAsync(State.Enabled ? SkillRunnerDefaults.StatusRunning : SkillRunnerDefaults.StatusDisabled, CancellationToken.None);
@@ -374,8 +381,14 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.ScopeId = evt.ScopeId ?? string.Empty;
         next.ProviderName = NormalizeProviderName(evt.ProviderName);
         next.Model = evt.Model ?? string.Empty;
-        next.Temperature = evt.Temperature;
-        next.MaxTokens = evt.MaxTokens;
+        if (evt.HasTemperature)
+            next.Temperature = evt.Temperature;
+        else
+            next.ClearTemperature();
+        if (evt.HasMaxTokens)
+            next.MaxTokens = evt.MaxTokens;
+        else
+            next.ClearMaxTokens();
         next.MaxToolRounds = evt.HasMaxToolRounds ? evt.MaxToolRounds : SkillRunnerDefaults.DefaultMaxToolRounds;
         next.MaxHistoryMessages = evt.HasMaxHistoryMessages ? evt.MaxHistoryMessages : SkillRunnerDefaults.DefaultMaxHistoryMessages;
         return next;

--- a/src/Aevatar.AI.LLMProviders.NyxId/NyxIdLLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.NyxId/NyxIdLLMProvider.cs
@@ -292,6 +292,7 @@ public sealed class NyxIdLLMProvider : ILLMProvider
     private LLMRequest NormalizeRequest(LLMRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
+        var model = ResolveModel(request);
 
         return new LLMRequest
         {
@@ -299,11 +300,33 @@ public sealed class NyxIdLLMProvider : ILLMProvider
             RequestId = request.RequestId,
             Metadata = request.Metadata,
             Tools = request.Tools,
-            Model = ResolveModel(request),
-            Temperature = request.Temperature,
+            Model = model,
+            Temperature = NormalizeTemperatureForModel(model, request.Temperature),
             MaxTokens = request.MaxTokens,
             ResponseFormat = request.ResponseFormat,
         };
+    }
+
+    internal static double? NormalizeTemperatureForModel(string? model, double? temperature)
+    {
+        if (!temperature.HasValue)
+            return null;
+
+        // NyxID's current OpenAI-compatible GPT-5 routes reject the temperature parameter.
+        return IsGpt5Model(model) ? null : temperature;
+    }
+
+    private static bool IsGpt5Model(string? model)
+    {
+        var normalized = model?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            return false;
+
+        var slashIndex = normalized.LastIndexOf('/');
+        if (slashIndex >= 0 && slashIndex < normalized.Length - 1)
+            normalized = normalized[(slashIndex + 1)..];
+
+        return normalized.StartsWith("gpt-5", StringComparison.OrdinalIgnoreCase);
     }
 
     private string ResolveModel(LLMRequest request)

--- a/src/Aevatar.AI.LLMProviders.NyxId/NyxIdLLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.NyxId/NyxIdLLMProvider.cs
@@ -312,11 +312,11 @@ public sealed class NyxIdLLMProvider : ILLMProvider
         if (!temperature.HasValue)
             return null;
 
-        // NyxID's current OpenAI-compatible GPT-5 routes reject the temperature parameter.
-        return IsGpt5Model(model) ? null : temperature;
+        // NyxID's current OpenAI-compatible reasoning routes reject the temperature parameter.
+        return IsReasoningModel(model) ? null : temperature;
     }
 
-    private static bool IsGpt5Model(string? model)
+    private static bool IsReasoningModel(string? model)
     {
         var normalized = model?.Trim();
         if (string.IsNullOrWhiteSpace(normalized))
@@ -326,7 +326,19 @@ public sealed class NyxIdLLMProvider : ILLMProvider
         if (slashIndex >= 0 && slashIndex < normalized.Length - 1)
             normalized = normalized[(slashIndex + 1)..];
 
-        return normalized.StartsWith("gpt-5", StringComparison.OrdinalIgnoreCase);
+        if (normalized.StartsWith("gpt-5-chat", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return normalized.StartsWith("gpt-5", StringComparison.OrdinalIgnoreCase)
+            || IsOpenAIReasoningFamily(normalized, "o1")
+            || IsOpenAIReasoningFamily(normalized, "o3")
+            || IsOpenAIReasoningFamily(normalized, "o4");
+    }
+
+    private static bool IsOpenAIReasoningFamily(string model, string family)
+    {
+        return model.Equals(family, StringComparison.OrdinalIgnoreCase)
+            || model.StartsWith(family + "-", StringComparison.OrdinalIgnoreCase);
     }
 
     private string ResolveModel(LLMRequest request)

--- a/test/Aevatar.AI.Tests/NyxIdLLMProviderRoutingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdLLMProviderRoutingTests.cs
@@ -134,7 +134,11 @@ public sealed class NyxIdLLMProviderRoutingTests
     [InlineData("gpt-5")]
     [InlineData("gpt-5.4")]
     [InlineData("openai/gpt-5.4")]
-    public async Task ResolveRouteAsync_ShouldOmitTemperature_ForGpt5Models(string model)
+    [InlineData("o1")]
+    [InlineData("o1-mini")]
+    [InlineData("openai/o3-mini")]
+    [InlineData("o4-mini")]
+    public async Task ResolveRouteAsync_ShouldOmitTemperature_ForReasoningModels(string model)
     {
         var provider = CreateProvider();
         var request = new LLMRequest
@@ -153,14 +157,17 @@ public sealed class NyxIdLLMProviderRoutingTests
         route.Request.Temperature.Should().BeNull();
     }
 
-    [Fact]
-    public async Task ResolveRouteAsync_ShouldKeepTemperature_ForNonGpt5Models()
+    [Theory]
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-5-chat-latest")]
+    [InlineData("openai/gpt-5-chat-latest")]
+    public async Task ResolveRouteAsync_ShouldKeepTemperature_ForNonReasoningModels(string model)
     {
         var provider = CreateProvider();
         var request = new LLMRequest
         {
             Messages = [ChatMessage.User("hi")],
-            Model = "gpt-4o",
+            Model = model,
             Temperature = 0.2,
             Metadata = new Dictionary<string, string>
             {

--- a/test/Aevatar.AI.Tests/NyxIdLLMProviderRoutingTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdLLMProviderRoutingTests.cs
@@ -130,6 +130,49 @@ public sealed class NyxIdLLMProviderRoutingTests
         route.Request.Model.Should().Be("gpt-4-turbo");
     }
 
+    [Theory]
+    [InlineData("gpt-5")]
+    [InlineData("gpt-5.4")]
+    [InlineData("openai/gpt-5.4")]
+    public async Task ResolveRouteAsync_ShouldOmitTemperature_ForGpt5Models(string model)
+    {
+        var provider = CreateProvider();
+        var request = new LLMRequest
+        {
+            Messages = [ChatMessage.User("hi")],
+            Model = model,
+            Temperature = 0,
+            Metadata = new Dictionary<string, string>
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "test-token",
+            },
+        };
+
+        var route = await provider.ResolveRouteAsync(request);
+
+        route.Request.Temperature.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolveRouteAsync_ShouldKeepTemperature_ForNonGpt5Models()
+    {
+        var provider = CreateProvider();
+        var request = new LLMRequest
+        {
+            Messages = [ChatMessage.User("hi")],
+            Model = "gpt-4o",
+            Temperature = 0.2,
+            Metadata = new Dictionary<string, string>
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "test-token",
+            },
+        };
+
+        var route = await provider.ResolveRouteAsync(request);
+
+        route.Request.Temperature.Should().Be(0.2);
+    }
+
     [Fact]
     public async Task ResolveRouteAsync_ShouldIgnoreAbsoluteUriInRoutePreference()
     {

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunActorQueryIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunActorQueryIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using Aevatar.Bootstrap.Hosting;
 using Aevatar.GAgentService.Hosting.Endpoints;
+using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Extensions.Hosting;
@@ -143,6 +144,7 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
                 options.EnableScriptingCapability = false;
             });
             builder.AddGAgentServiceCapabilityBundle();
+            builder.Services.AddSingleton<IGAgentActorStore, InMemoryGAgentActorStore>();
             builder.Services.AddAuthentication("Test")
                 .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
             builder.Services.AddAuthorization();
@@ -200,6 +202,65 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
 
             throw new InvalidOperationException("Unable to locate repository root from test base directory.");
         }
+    }
+
+    private sealed class InMemoryGAgentActorStore : IGAgentActorStore
+    {
+        private readonly List<ActorRegistration> _registrations = [];
+
+        public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(BuildGroups(_registrations));
+
+        public Task<IReadOnlyList<GAgentActorGroup>> GetAsync(
+            string scopeId,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(BuildGroups(_registrations.Where(registration =>
+                string.Equals(registration.ScopeId, scopeId, StringComparison.Ordinal))));
+
+        public Task AddActorAsync(
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default) =>
+            AddActorAsync(string.Empty, gagentType, actorId, cancellationToken);
+
+        public Task AddActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            _registrations.Add(new ActorRegistration(scopeId, gagentType, actorId));
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveActorAsync(
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default) =>
+            RemoveActorAsync(string.Empty, gagentType, actorId, cancellationToken);
+
+        public Task RemoveActorAsync(
+            string scopeId,
+            string gagentType,
+            string actorId,
+            CancellationToken cancellationToken = default)
+        {
+            _registrations.RemoveAll(registration =>
+                string.Equals(registration.ScopeId, scopeId, StringComparison.Ordinal) &&
+                string.Equals(registration.GAgentType, gagentType, StringComparison.Ordinal) &&
+                string.Equals(registration.ActorId, actorId, StringComparison.Ordinal));
+            return Task.CompletedTask;
+        }
+
+        private static IReadOnlyList<GAgentActorGroup> BuildGroups(IEnumerable<ActorRegistration> registrations) =>
+            registrations
+                .GroupBy(static registration => registration.GAgentType, StringComparer.Ordinal)
+                .Select(static group => new GAgentActorGroup(
+                    group.Key,
+                    group.Select(static registration => registration.ActorId).ToArray()))
+                .ToArray();
+
+        private sealed record ActorRegistration(string ScopeId, string GAgentType, string ActorId);
     }
 
     private sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeWorkflowEndpointsTests.cs
@@ -14,7 +14,9 @@ using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
 
@@ -652,10 +654,7 @@ public sealed class ScopeWorkflowEndpointsTests
     {
         var http = new DefaultHttpContext
         {
-            RequestServices = new ServiceCollection()
-                .AddLogging()
-                .AddOptions()
-                .BuildServiceProvider(),
+            RequestServices = BuildRequestServices(),
         };
         http.Response.Body = new MemoryStream();
         http.User = new ClaimsPrincipal(
@@ -671,13 +670,26 @@ public sealed class ScopeWorkflowEndpointsTests
     {
         var http = new DefaultHttpContext
         {
-            RequestServices = new ServiceCollection()
-                .AddLogging()
-                .AddOptions()
-                .BuildServiceProvider(),
+            RequestServices = BuildRequestServices(),
         };
         http.Response.Body = new MemoryStream();
         return http;
+    }
+
+    private static ServiceProvider BuildRequestServices() =>
+        new ServiceCollection()
+            .AddLogging()
+            .AddOptions()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder().Build())
+            .AddSingleton<IHostEnvironment>(new TestHostEnvironment())
+            .BuildServiceProvider();
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "Aevatar.GAgentService.Integration.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 
     private static async Task<string> ReadBodyAsync(HttpResponse response)

--- a/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointHelperTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ServiceEndpointHelperTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Governance.Abstractions;
 using Aevatar.GAgentService.Governance.Hosting.DependencyInjection;
 using Aevatar.GAgentService.Hosting.Endpoints;
@@ -108,13 +109,14 @@ public sealed class ServiceEndpointHelperTests
             null,
             Activator.CreateInstance(boundSecretType, "secret-a"),
             null)!;
+        var ownerContext = new ServiceIdentityContext("tenant", "app", "ns", "test");
 
         var serviceKind = (ServiceBindingKind)parseBindingKind.Invoke(null, ["service"])!;
         var connectorKind = (ServiceBindingKind)parseBindingKind.Invoke(null, [" connector "])!;
         var secretKind = (ServiceBindingKind)parseBindingKind.Invoke(null, ["SECRET"])!;
-        var serviceSpec = (ServiceBindingSpec)toSpec.Invoke(null, ["checkout", serviceRequest, "binding-service"])!;
-        var connectorSpec = (ServiceBindingSpec)toSpec.Invoke(null, ["checkout", connectorRequest, "binding-connector"])!;
-        var secretSpec = (ServiceBindingSpec)toSpec.Invoke(null, ["checkout", secretRequest, "binding-secret"])!;
+        var serviceSpec = InvokeToSpec(toSpec, serviceRequest, "binding-service", serviceKind, ownerContext);
+        var connectorSpec = InvokeToSpec(toSpec, connectorRequest, "binding-connector", connectorKind, ownerContext);
+        var secretSpec = InvokeToSpec(toSpec, secretRequest, "binding-secret", secretKind, ownerContext);
         Action invalidBindingKind = () => parseBindingKind.Invoke(null, ["unsupported"]);
 
         serviceKind.Should().Be(ServiceBindingKind.Service);
@@ -147,6 +149,14 @@ public sealed class ServiceEndpointHelperTests
             .WithInnerException<InvalidOperationException>()
             .WithMessage("*Unsupported binding kind*");
     }
+
+    private static ServiceBindingSpec InvokeToSpec(
+        MethodInfo toSpec,
+        object request,
+        string bindingId,
+        ServiceBindingKind bindingKind,
+        ServiceIdentityContext ownerContext) =>
+        (ServiceBindingSpec)toSpec.Invoke(null, ["checkout", request, bindingId, bindingKind, ownerContext, null])!;
 
     [Fact]
     public void ServiceServingEndpoints_ShouldParseServingState_AndMapTargetsAndStages()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using FluentAssertions;
+using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class SkillRunnerGAgentTests : IAsyncLifetime
+{
+    private InMemoryEventStore _store = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private SkillRunnerGAgent _agent = null!;
+
+    public async Task InitializeAsync()
+    {
+        _store = new InMemoryEventStore();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IEventStore>(_store);
+        services.AddSingleton<EventSourcingRuntimeOptions>();
+        services.AddTransient(
+            typeof(IEventSourcingBehaviorFactory<>),
+            typeof(DefaultEventSourcingBehaviorFactory<>));
+
+        _serviceProvider = services.BuildServiceProvider();
+        _agent = CreateAgent("skill-runner-test");
+        await _agent.ActivateAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _serviceProvider.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WhenSamplingFieldsAreOmitted_ShouldKeepThemUnset()
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommand());
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var initialized = persisted.Should().ContainSingle().Subject.EventData.Unpack<SkillRunnerInitializedEvent>();
+        initialized.HasTemperature.Should().BeFalse();
+        initialized.HasMaxTokens.Should().BeFalse();
+
+        _agent.State.HasTemperature.Should().BeFalse();
+        _agent.State.HasMaxTokens.Should().BeFalse();
+        _agent.State.MaxToolRounds.Should().Be(SkillRunnerDefaults.DefaultMaxToolRounds);
+        _agent.State.MaxHistoryMessages.Should().Be(SkillRunnerDefaults.DefaultMaxHistoryMessages);
+        _agent.EffectiveConfig.Temperature.Should().BeNull();
+        _agent.EffectiveConfig.MaxTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_WhenTemperatureIsExplicitZero_ShouldPreserveIt()
+    {
+        var command = CreateInitializeCommand();
+        command.Temperature = 0;
+
+        await _agent.HandleInitializeAsync(command);
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var initialized = persisted.Should().ContainSingle().Subject.EventData.Unpack<SkillRunnerInitializedEvent>();
+        initialized.HasTemperature.Should().BeTrue();
+        initialized.Temperature.Should().Be(0);
+
+        _agent.State.HasTemperature.Should().BeTrue();
+        _agent.State.Temperature.Should().Be(0);
+        _agent.EffectiveConfig.Temperature.Should().Be(0);
+    }
+
+    private SkillRunnerGAgent CreateAgent(string actorId)
+    {
+        var agent = new SkillRunnerGAgent
+        {
+            Services = _serviceProvider,
+            EventSourcingBehaviorFactory =
+                _serviceProvider.GetRequiredService<IEventSourcingBehaviorFactory<SkillRunnerState>>(),
+        };
+        AssignActorId(agent, actorId);
+        return agent;
+    }
+
+    private static InitializeSkillRunnerCommand CreateInitializeCommand() => new()
+    {
+        SkillName = "daily_report",
+        TemplateName = "daily_report",
+        SkillContent = "You are a daily report runner.",
+        ExecutionPrompt = "Run the report.",
+        ScheduleCron = string.Empty,
+        ScheduleTimezone = SkillRunnerDefaults.DefaultTimezone,
+        Enabled = true,
+        ScopeId = "scope-1",
+        ProviderName = SkillRunnerDefaults.DefaultProviderName,
+        OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+        },
+    };
+
+    private static void AssignActorId(GAgentBase agent, string actorId)
+    {
+        var setIdMethod = typeof(GAgentBase).GetMethod(
+            "SetId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        setIdMethod.Should().NotBeNull();
+        setIdMethod!.Invoke(agent, [actorId]);
+    }
+
+    private sealed class InMemoryEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+            {
+                stream = [];
+                _events[agentId] = stream;
+            }
+
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            if (currentVersion != expectedVersion)
+                throw new InvalidOperationException(
+                    $"Optimistic concurrency conflict: expected {expectedVersion}, actual {currentVersion}");
+
+            var appended = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(appended);
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream[^1].Version,
+                CommittedEvents = { appended.Select(x => x.Clone()) },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult<IReadOnlyList<StateEvent>>([]);
+
+            IReadOnlyList<StateEvent> result = fromVersion.HasValue
+                ? stream.Where(x => x.Version > fromVersion.Value).Select(x => x.Clone()).ToList()
+                : stream.Select(x => x.Clone()).ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream) || stream.Count == 0)
+                return Task.FromResult(0L);
+            return Task.FromResult(stream[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (toVersion <= 0 || !_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var before = stream.Count;
+            stream.RemoveAll(x => x.Version <= toVersion);
+            return Task.FromResult((long)(before - stream.Count));
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -73,6 +73,24 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         _agent.EffectiveConfig.Temperature.Should().Be(0);
     }
 
+    [Fact]
+    public async Task HandleInitializeAsync_WhenMaxTokensIsExplicitZero_ShouldPreserveStateAndSuppressEffectiveConfig()
+    {
+        var command = CreateInitializeCommand();
+        command.MaxTokens = 0;
+
+        await _agent.HandleInitializeAsync(command);
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var initialized = persisted.Should().ContainSingle().Subject.EventData.Unpack<SkillRunnerInitializedEvent>();
+        initialized.HasMaxTokens.Should().BeTrue();
+        initialized.MaxTokens.Should().Be(0);
+
+        _agent.State.HasMaxTokens.Should().BeTrue();
+        _agent.State.MaxTokens.Should().Be(0);
+        _agent.EffectiveConfig.MaxTokens.Should().BeNull();
+    }
+
     private SkillRunnerGAgent CreateAgent(string actorId)
     {
         var agent = new SkillRunnerGAgent


### PR DESCRIPTION
## Summary
- Preserve protobuf optional presence when initializing SkillRunner sampling fields so omitted temperature/max tokens remain unset.
- Drop `temperature` for NyxID reasoning-model routes before forwarding to the OpenAI-compatible upstream while leaving chat-style GPT-5 routes untouched.
- Add regression coverage for SkillRunner initialization, NyxID route normalization, and the coverage-quality integration test fixtures.

## Upgrade Note
- Existing SkillRunner actors created during the bad initialization window may already have a persisted `Temperature=0` initialization event. Those actors will not be rewritten by this fix; recreate the affected `/daily` or `/social_media` runner so it initializes without an explicit temperature.

## Verification
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --no-restore --filter "SkillRunnerGAgentTests" --nologo`
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --no-restore --filter "NyxIdLLMProviderRoutingTests" --nologo`
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --no-restore --filter "ServiceEndpointHelperTests|ScopeWorkflowEndpointsTests|ScopeDraftRunActorQueryIntegrationTests" --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/restore_and_build.sh`
- `bash tools/ci/coverage_quality_guard.sh` (line 87.6%, branch 72.4%)