### PR TITLE
fix(channel-runtime): resolve Lark DM receive_id_type and quiet best-effort reaction noise

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -236,6 +236,10 @@ public sealed class AgentBuilderTool : IAgentTool
                     ?? await actorRuntime.CreateAsync<SkillRunnerGAgent>(agentId, ct);
 
         var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+        var deliveryTarget = LarkConversationTargets.BuildFromInbound(
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType),
+            conversationId,
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId));
         var initialize = new InitializeSkillRunnerCommand
         {
             SkillName = templateSpec.SkillName,
@@ -256,6 +260,8 @@ public sealed class AgentBuilderTool : IAgentTool
                 NyxApiKey = apiKeyValue!,
                 OwnerNyxUserId = ownerNyxUserId!,
                 ApiKeyId = apiKeyId!,
+                LarkReceiveId = deliveryTarget.ReceiveId,
+                LarkReceiveIdType = deliveryTarget.ReceiveIdType,
             },
         };
 
@@ -377,6 +383,10 @@ public sealed class AgentBuilderTool : IAgentTool
                     ?? await actorRuntime.CreateAsync<WorkflowAgentGAgent>(agentId, ct);
 
         var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+        var deliveryTarget = LarkConversationTargets.BuildFromInbound(
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType),
+            conversationId,
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId));
         var initialize = new InitializeWorkflowAgentCommand
         {
             WorkflowId = workflowUpsert.Workflow.WorkflowId,
@@ -392,6 +402,8 @@ public sealed class AgentBuilderTool : IAgentTool
             ApiKeyId = apiKeyId!,
             Enabled = true,
             ScopeId = scopeId.Trim(),
+            LarkReceiveId = deliveryTarget.ReceiveId,
+            LarkReceiveIdType = deliveryTarget.ReceiveIdType,
         };
 
         await actor.HandleEventAsync(BuildDirectEnvelope(actor.Id, initialize), ct);

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -930,7 +930,13 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
 
             if (TryGetProxyError(response, out var detail))
             {
-                _logger.LogWarning(
+                // Best-effort acknowledgment. The most common cause is the bot
+                // missing reaction permission on Lark (code 231002), which is a
+                // tenant-level config issue that recurs on every inbound message
+                // until ops fixes the app scope. Log at Debug so it stays
+                // discoverable when the channel is opted into verbose logging
+                // without spamming Warnings on every turn.
+                _logger.LogDebug(
                     "Immediate Lark acknowledgment reaction failed: provider={ProviderSlug}, message={MessageId}, detail={Detail}",
                     providerSlug,
                     platformMessageId,

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
@@ -928,19 +927,34 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
                 null,
                 ct);
 
-            if (TryGetProxyError(response, out var detail))
+            if (LarkProxyResponse.TryGetError(response, out var larkCode, out var detail))
             {
-                // Best-effort acknowledgment. The most common cause is the bot
-                // missing reaction permission on Lark (code 231002), which is a
-                // tenant-level config issue that recurs on every inbound message
-                // until ops fixes the app scope. Log at Debug so it stays
-                // discoverable when the channel is opted into verbose logging
-                // without spamming Warnings on every turn.
-                _logger.LogDebug(
-                    "Immediate Lark acknowledgment reaction failed: provider={ProviderSlug}, message={MessageId}, detail={Detail}",
-                    providerSlug,
-                    platformMessageId,
-                    detail);
+                if (larkCode == LarkBotErrorCodes.NoPermissionToReact)
+                {
+                    // The bot is missing reaction permission on Lark — a
+                    // tenant-level config issue that recurs on every inbound
+                    // message until ops fixes the app scope. Log at Debug so
+                    // it stays discoverable when the channel is opted into
+                    // verbose logging without spamming Warnings on every turn.
+                    _logger.LogDebug(
+                        "Immediate Lark acknowledgment reaction skipped (missing reaction scope): provider={ProviderSlug}, message={MessageId}, detail={Detail}",
+                        providerSlug,
+                        platformMessageId,
+                        detail);
+                }
+                else
+                {
+                    // Anything else — a Nyx envelope error, an unexpected Lark
+                    // business code (rate limit, archived message, bot kicked,
+                    // etc.) — is a real signal that should stay at Warning so
+                    // we notice when Lark behavior changes.
+                    _logger.LogWarning(
+                        "Immediate Lark acknowledgment reaction failed: provider={ProviderSlug}, message={MessageId}, larkCode={LarkCode}, detail={Detail}",
+                        providerSlug,
+                        platformMessageId,
+                        larkCode,
+                        detail);
+                }
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -988,67 +1002,6 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
                !string.IsNullOrWhiteSpace(providerSlug) &&
                !string.IsNullOrWhiteSpace(platformMessageId) &&
                platformMessageId.StartsWith("om_", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static bool TryGetProxyError(string? response, out string detail)
-    {
-        detail = string.Empty;
-        if (string.IsNullOrWhiteSpace(response))
-            return false;
-
-        try
-        {
-            using var document = JsonDocument.Parse(response);
-            var root = document.RootElement;
-
-            if (root.TryGetProperty("error", out var errorProperty))
-            {
-                if (errorProperty.ValueKind == JsonValueKind.True)
-                {
-                    detail = TryReadJsonString(root, "message") ??
-                             TryReadJsonString(root, "body") ??
-                             "proxy_error";
-                    return true;
-                }
-
-                if (errorProperty.ValueKind == JsonValueKind.String)
-                {
-                    var error = errorProperty.GetString()?.Trim();
-                    if (!string.IsNullOrWhiteSpace(error))
-                    {
-                        detail = error;
-                        return true;
-                    }
-                }
-            }
-
-            if (root.TryGetProperty("code", out var codeProperty) &&
-                codeProperty.ValueKind == JsonValueKind.Number &&
-                codeProperty.TryGetInt32(out var code) &&
-                code != 0)
-            {
-                detail = TryReadJsonString(root, "msg") ?? $"code={code}";
-                return true;
-            }
-        }
-        catch (JsonException)
-        {
-            // Ignore invalid bodies for best-effort acknowledgment.
-        }
-
-        return false;
-    }
-
-    private static string? TryReadJsonString(JsonElement element, string propertyName)
-    {
-        if (!element.TryGetProperty(propertyName, out var property) ||
-            property.ValueKind != JsonValueKind.String)
-        {
-            return null;
-        }
-
-        var value = property.GetString()?.Trim();
-        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     private static ConversationTurnResult ToRelayFailure(EmitResult emit)

--- a/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
@@ -323,10 +323,24 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         string failurePrefix,
         CancellationToken cancellationToken)
     {
-        var receiveIdType = LarkConversationTargets.ResolveReceiveIdType(target.ConversationId);
+        var deliveryTarget = LarkConversationTargets.Resolve(
+            target.LarkReceiveId,
+            target.LarkReceiveIdType,
+            target.ConversationId);
+        if (deliveryTarget.FellBackToPrefixInference)
+        {
+            // Catalog entry predates the typed lark_receive_id fields; fall back to the prefix
+            // heuristic on conversation_id and emit a breadcrumb so format drift is observable.
+            _logger.LogDebug(
+                "Feishu human interaction port resolved Lark receive target by prefix inference (legacy entry): agent={AgentId}, conversationId={ConversationId}, receiveIdType={ReceiveIdType}",
+                target.AgentId,
+                target.ConversationId,
+                deliveryTarget.ReceiveIdType);
+        }
+
         var body = JsonSerializer.Serialize(new
         {
-            receive_id = target.ConversationId,
+            receive_id = deliveryTarget.ReceiveId,
             msg_type = messageType,
             content = contentJson,
         });
@@ -334,7 +348,7 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         var result = await _nyxIdApiClient.ProxyRequestAsync(
             target.NyxApiKey,
             target.NyxProviderSlug,
-            $"open-apis/im/v1/messages?receive_id_type={receiveIdType}",
+            $"open-apis/im/v1/messages?receive_id_type={deliveryTarget.ReceiveIdType}",
             "POST",
             body,
             extraHeaders: null,
@@ -343,8 +357,13 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         if (string.IsNullOrWhiteSpace(result))
             throw new InvalidOperationException(emptyResponseMessage);
 
-        if (result.Contains("\"error\"", StringComparison.OrdinalIgnoreCase))
-            throw new InvalidOperationException($"{failurePrefix}: {result}");
+        if (LarkProxyResponse.TryGetError(result, out var larkCode, out var detail))
+        {
+            throw new InvalidOperationException(
+                larkCode is { } code
+                    ? $"{failurePrefix} (code={code}): {detail}"
+                    : $"{failurePrefix}: {detail}");
+        }
     }
 
     private static bool SupportsApproveReject(HumanInteractionRequest request) =>

--- a/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
@@ -323,6 +323,7 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         string failurePrefix,
         CancellationToken cancellationToken)
     {
+        var receiveIdType = LarkConversationTargets.ResolveReceiveIdType(target.ConversationId);
         var body = JsonSerializer.Serialize(new
         {
             receive_id = target.ConversationId,
@@ -333,7 +334,7 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
         var result = await _nyxIdApiClient.ProxyRequestAsync(
             target.NyxApiKey,
             target.NyxProviderSlug,
-            "open-apis/im/v1/messages?receive_id_type=chat_id",
+            $"open-apis/im/v1/messages?receive_id_type={receiveIdType}",
             "POST",
             body,
             extraHeaders: null,

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkBotErrorCodes.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkBotErrorCodes.cs
@@ -1,0 +1,15 @@
+namespace Aevatar.GAgents.ChannelRuntime;
+
+/// <summary>
+/// Documented Lark Open Platform error codes that the runtime branches on. Add new entries only
+/// when behavior depends on the specific code (e.g. log gating, retry decisions); generic error
+/// surfacing should keep using the textual <c>msg</c> from the response body.
+/// </summary>
+internal static class LarkBotErrorCodes
+{
+    /// <summary>
+    /// "The operator has no permission to react on the specific message" — recurring tenant
+    /// config gap when the bot's app scope is missing the reaction permission.
+    /// </summary>
+    public const int NoPermissionToReact = 231002;
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
@@ -3,7 +3,45 @@ namespace Aevatar.GAgents.ChannelRuntime;
 internal static class LarkConversationTargets
 {
     private const string DefaultReceiveIdType = "chat_id";
+    private const string OpenIdReceiveIdType = "open_id";
+    private const string UnionIdReceiveIdType = "union_id";
 
+    /// <summary>
+    /// Resolves the Lark <c>receive_id</c> + <c>receive_id_type</c> pair to use for an outbound
+    /// proxy call. When the typed fields captured at delivery-target creation are both populated,
+    /// they are returned verbatim. Otherwise — only for legacy state persisted before the typed
+    /// fields existed — the helper falls back to inferring the type from the prefix of
+    /// <paramref name="legacyConversationId"/>. The <c>FellBackToPrefixInference</c> flag lets
+    /// call sites emit a breadcrumb so format drift is observable instead of silently rejected
+    /// by Lark.
+    /// </summary>
+    public static LarkReceiveTarget Resolve(
+        string? typedReceiveId,
+        string? typedReceiveIdType,
+        string? legacyConversationId)
+    {
+        var trimmedTypedId = (typedReceiveId ?? string.Empty).Trim();
+        var trimmedTypedType = (typedReceiveIdType ?? string.Empty).Trim();
+        if (!string.IsNullOrEmpty(trimmedTypedId) && !string.IsNullOrEmpty(trimmedTypedType))
+        {
+            return new LarkReceiveTarget(
+                trimmedTypedId,
+                trimmedTypedType,
+                FellBackToPrefixInference: false);
+        }
+
+        var trimmedLegacy = (legacyConversationId ?? string.Empty).Trim();
+        return new LarkReceiveTarget(
+            trimmedLegacy,
+            ResolveReceiveIdType(trimmedLegacy),
+            FellBackToPrefixInference: true);
+    }
+
+    /// <summary>
+    /// Picks a Lark <c>receive_id_type</c> by prefix. Public only so tests and callers that have
+    /// already committed to the legacy <c>conversation_id</c> field can use it; new code paths
+    /// should prefer <see cref="Resolve"/> with the typed fields.
+    /// </summary>
     public static string ResolveReceiveIdType(string? conversationId)
     {
         var trimmed = conversationId?.Trim();
@@ -11,10 +49,46 @@ internal static class LarkConversationTargets
             return DefaultReceiveIdType;
 
         if (trimmed.StartsWith("ou_", StringComparison.Ordinal))
-            return "open_id";
+            return OpenIdReceiveIdType;
         if (trimmed.StartsWith("on_", StringComparison.Ordinal))
-            return "union_id";
+            return UnionIdReceiveIdType;
 
         return DefaultReceiveIdType;
     }
+
+    /// <summary>
+    /// Builds the typed receive-target for a Lark inbound captured at agent creation. For p2p we
+    /// store the user's open_id (always <c>ou_*</c>) so outbound DMs do not depend on the relay
+    /// also propagating an underlying chat_id; for everything else we send to the originating
+    /// chat via its <c>oc_*</c> chat_id, which Lark accepts uniformly for groups, threads, and
+    /// channels.
+    /// </summary>
+    public static LarkReceiveTarget BuildFromInbound(string? chatType, string? conversationId, string? senderId)
+    {
+        var trimmedSender = (senderId ?? string.Empty).Trim();
+        if (IsDirectMessage(chatType) && !string.IsNullOrEmpty(trimmedSender))
+        {
+            return new LarkReceiveTarget(trimmedSender, OpenIdReceiveIdType, FellBackToPrefixInference: false);
+        }
+
+        var trimmedConversation = (conversationId ?? string.Empty).Trim();
+        return new LarkReceiveTarget(trimmedConversation, DefaultReceiveIdType, FellBackToPrefixInference: false);
+    }
+
+    private static bool IsDirectMessage(string? chatType)
+    {
+        if (string.IsNullOrWhiteSpace(chatType))
+            return false;
+
+        var normalized = chatType.Trim();
+        return string.Equals(normalized, "p2p", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalized, "direct_message", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalized, "directmessage", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalized, "dm", StringComparison.OrdinalIgnoreCase);
+    }
 }
+
+internal readonly record struct LarkReceiveTarget(
+    string ReceiveId,
+    string ReceiveIdType,
+    bool FellBackToPrefixInference);

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
@@ -62,30 +62,33 @@ internal static class LarkConversationTargets
     /// also propagating an underlying chat_id; for everything else we send to the originating
     /// chat via its <c>oc_*</c> chat_id, which Lark accepts uniformly for groups, threads, and
     /// channels.
+    ///
+    /// If the inbound is p2p but the relay omitted <c>SenderId</c>, returning a typed pair would
+    /// silently re-create the original /daily 400 (typing the user open_id as <c>chat_id</c>).
+    /// Instead, return an empty typed pair with <c>FellBackToPrefixInference=true</c> so
+    /// <see cref="Resolve"/> falls back to the legacy prefix path and call sites emit a Debug
+    /// breadcrumb. The relay always emits <c>Sender.PlatformId</c> in production, so this path
+    /// is defensive.
     /// </summary>
     public static LarkReceiveTarget BuildFromInbound(string? chatType, string? conversationId, string? senderId)
     {
         var trimmedSender = (senderId ?? string.Empty).Trim();
-        if (IsDirectMessage(chatType) && !string.IsNullOrEmpty(trimmedSender))
+        if (IsDirectMessage(chatType))
         {
-            return new LarkReceiveTarget(trimmedSender, OpenIdReceiveIdType, FellBackToPrefixInference: false);
+            return string.IsNullOrEmpty(trimmedSender)
+                ? new LarkReceiveTarget(string.Empty, string.Empty, FellBackToPrefixInference: true)
+                : new LarkReceiveTarget(trimmedSender, OpenIdReceiveIdType, FellBackToPrefixInference: false);
         }
 
         var trimmedConversation = (conversationId ?? string.Empty).Trim();
         return new LarkReceiveTarget(trimmedConversation, DefaultReceiveIdType, FellBackToPrefixInference: false);
     }
 
-    private static bool IsDirectMessage(string? chatType)
-    {
-        if (string.IsNullOrWhiteSpace(chatType))
-            return false;
-
-        var normalized = chatType.Trim();
-        return string.Equals(normalized, "p2p", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(normalized, "direct_message", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(normalized, "directmessage", StringComparison.OrdinalIgnoreCase) ||
-               string.Equals(normalized, "dm", StringComparison.OrdinalIgnoreCase);
-    }
+    // Only "p2p" is emitted by ChannelConversationTurnRunner.ResolveConversationChatType today,
+    // which is the single source for ChannelMetadataKeys.ChatType in this repo. Keep the check
+    // narrow until a second emitter (e.g. a Telegram bridge) actually lands.
+    private static bool IsDirectMessage(string? chatType) =>
+        string.Equals(chatType?.Trim(), "p2p", StringComparison.Ordinal);
 }
 
 internal readonly record struct LarkReceiveTarget(

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
@@ -1,0 +1,20 @@
+namespace Aevatar.GAgents.ChannelRuntime;
+
+internal static class LarkConversationTargets
+{
+    private const string DefaultReceiveIdType = "chat_id";
+
+    public static string ResolveReceiveIdType(string? conversationId)
+    {
+        var trimmed = conversationId?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return DefaultReceiveIdType;
+
+        if (trimmed.StartsWith("ou_", StringComparison.Ordinal))
+            return "open_id";
+        if (trimmed.StartsWith("on_", StringComparison.Ordinal))
+            return "union_id";
+
+        return DefaultReceiveIdType;
+    }
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkProxyResponse.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkProxyResponse.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace Aevatar.GAgents.ChannelRuntime;
+
+/// <summary>
+/// Inspects response bodies returned by NyxIdApiClient.ProxyRequestAsync for downstream
+/// Lark API calls. The proxy is two-layered: HTTP non-2xx from NyxID gets packaged into a
+/// Nyx error envelope (<c>{"error": true, "message": "..."}</c> or <c>{"error": "..."}</c>),
+/// and HTTP 200 from NyxID may still carry a Lark business error
+/// (<c>{"code": &lt;non-zero&gt;, "msg": "..."}</c>). Callers that ignore the result silently
+/// drop both classes of failure, which is what motivates this helper.
+/// </summary>
+internal static class LarkProxyResponse
+{
+    /// <summary>
+    /// Returns true when the response body indicates a downstream failure. <paramref name="larkCode"/>
+    /// is set only for the Lark business-error path so callers can selectively gate logging on
+    /// known recurring config gaps (e.g. 231002 = no permission to react). <paramref name="detail"/>
+    /// is a short human-readable summary suitable for log lines or exception messages.
+    /// </summary>
+    public static bool TryGetError(string? response, out int? larkCode, out string detail)
+    {
+        larkCode = null;
+        detail = string.Empty;
+        if (string.IsNullOrWhiteSpace(response))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(response);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+                return false;
+
+            if (root.TryGetProperty("error", out var errorProperty))
+            {
+                if (errorProperty.ValueKind == JsonValueKind.True)
+                {
+                    detail = TryReadString(root, "message")
+                             ?? TryReadString(root, "body")
+                             ?? "proxy_error";
+                    return true;
+                }
+
+                if (errorProperty.ValueKind == JsonValueKind.String)
+                {
+                    var error = errorProperty.GetString()?.Trim();
+                    if (!string.IsNullOrWhiteSpace(error))
+                    {
+                        detail = error;
+                        return true;
+                    }
+                }
+            }
+
+            if (root.TryGetProperty("code", out var codeProperty) &&
+                codeProperty.ValueKind == JsonValueKind.Number &&
+                codeProperty.TryGetInt32(out var code) &&
+                code != 0)
+            {
+                larkCode = code;
+                detail = TryReadString(root, "msg") ?? $"code={code}";
+                return true;
+            }
+        }
+        catch (JsonException)
+        {
+            // Best-effort detection: bodies that are not valid JSON are treated as a non-error
+            // (the caller decides what to do with them).
+        }
+
+        return false;
+    }
+
+    private static string? TryReadString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var value = property.GetString()?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+}

--- a/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
@@ -261,6 +261,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             return;
         }
 
+        var receiveIdType = LarkConversationTargets.ResolveReceiveIdType(State.OutboundConfig.ConversationId);
         var body = JsonSerializer.Serialize(new
         {
             receive_id = State.OutboundConfig.ConversationId,
@@ -271,7 +272,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         await client.ProxyRequestAsync(
             State.OutboundConfig.NyxApiKey,
             State.OutboundConfig.NyxProviderSlug,
-            "open-apis/im/v1/messages?receive_id_type=chat_id",
+            $"open-apis/im/v1/messages?receive_id_type={receiveIdType}",
             "POST", body, null, ct);
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
@@ -268,19 +268,44 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             return;
         }
 
-        var receiveIdType = LarkConversationTargets.ResolveReceiveIdType(State.OutboundConfig.ConversationId);
+        var deliveryTarget = LarkConversationTargets.Resolve(
+            State.OutboundConfig.LarkReceiveId,
+            State.OutboundConfig.LarkReceiveIdType,
+            State.OutboundConfig.ConversationId);
+        if (deliveryTarget.FellBackToPrefixInference)
+        {
+            // No typed receive_id captured at create time; only legacy state predating the
+            // typed fields hits this path. Keep the breadcrumb so format drift is observable
+            // when the prefix heuristic stops matching.
+            Logger.LogDebug(
+                "Skill runner {ActorId} resolved Lark receive target by prefix inference (legacy state): conversationId={ConversationId}, receiveIdType={ReceiveIdType}",
+                Id,
+                State.OutboundConfig.ConversationId,
+                deliveryTarget.ReceiveIdType);
+        }
+
         var body = JsonSerializer.Serialize(new
         {
-            receive_id = State.OutboundConfig.ConversationId,
+            receive_id = deliveryTarget.ReceiveId,
             msg_type = "text",
             content = JsonSerializer.Serialize(new { text = output }),
         });
 
-        await client.ProxyRequestAsync(
+        var response = await client.ProxyRequestAsync(
             State.OutboundConfig.NyxApiKey,
             State.OutboundConfig.NyxProviderSlug,
-            $"open-apis/im/v1/messages?receive_id_type={receiveIdType}",
+            $"open-apis/im/v1/messages?receive_id_type={deliveryTarget.ReceiveIdType}",
             "POST", body, null, ct);
+
+        if (LarkProxyResponse.TryGetError(response, out var larkCode, out var detail))
+        {
+            // Surface downstream rejection so HandleTriggerAsync sees a real failure instead of
+            // persisting SkillRunnerExecutionCompletedEvent on a silently-dropped Lark response.
+            throw new InvalidOperationException(
+                larkCode is { } code
+                    ? $"Lark message delivery rejected (code={code}): {detail}"
+                    : $"Lark message delivery rejected: {detail}");
+        }
     }
 
     private async Task TrySendFailureAsync(string error, CancellationToken ct)
@@ -335,6 +360,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ScheduleCron = State.ScheduleCron ?? string.Empty,
             ScheduleTimezone = State.ScheduleTimezone ?? string.Empty,
             Status = status,
+            LarkReceiveId = State.OutboundConfig?.LarkReceiveId ?? string.Empty,
+            LarkReceiveIdType = State.OutboundConfig?.LarkReceiveIdType ?? string.Empty,
         };
 
         await actor.HandleEventAsync(BuildDirectEnvelope(actor.Id, command), ct);

--- a/agents/Aevatar.GAgents.ChannelRuntime/UserAgentCatalogGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/UserAgentCatalogGAgent.cs
@@ -53,6 +53,8 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
             NextRunAt = existing?.NextRunAt,
             ErrorCount = existing?.ErrorCount ?? 0,
             LastError = existing?.LastError ?? string.Empty,
+            LarkReceiveId = MergeNonEmpty(command.LarkReceiveId, existing?.LarkReceiveId),
+            LarkReceiveIdType = MergeNonEmpty(command.LarkReceiveIdType, existing?.LarkReceiveIdType),
         };
 
         await PersistDomainEventAsync(new UserAgentCatalogUpsertedEvent

--- a/agents/Aevatar.GAgents.ChannelRuntime/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/UserAgentCatalogProjector.cs
@@ -56,5 +56,7 @@ public sealed class UserAgentCatalogProjector
             ActorId = context.RootActorId,
             UpdatedAt = updatedAt,
             CreatedAt = entry.CreatedAt != null ? entry.CreatedAt.ToDateTimeOffset() : updatedAt,
+            LarkReceiveId = entry.LarkReceiveId ?? string.Empty,
+            LarkReceiveIdType = entry.LarkReceiveIdType ?? string.Empty,
         };
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/UserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/UserAgentCatalogQueryPort.cs
@@ -61,5 +61,7 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             CreatedAt = document.CreatedAtUtc,
             UpdatedAt = document.UpdatedAtUtc,
             Tombstoned = document.Tombstoned,
+            LarkReceiveId = document.LarkReceiveId ?? string.Empty,
+            LarkReceiveIdType = document.LarkReceiveIdType ?? string.Empty,
         };
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/WorkflowAgentGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/WorkflowAgentGAgent.cs
@@ -72,6 +72,8 @@ public sealed class WorkflowAgentGAgent : GAgentBase<WorkflowAgentState>
             Enabled = command.Enabled,
             ScopeId = command.ScopeId?.Trim() ?? string.Empty,
             Platform = command.Platform?.Trim() ?? string.Empty,
+            LarkReceiveId = command.LarkReceiveId?.Trim() ?? string.Empty,
+            LarkReceiveIdType = command.LarkReceiveIdType?.Trim() ?? string.Empty,
         });
 
         await Scheduler.ScheduleNextRunAsync(DateTimeOffset.UtcNow, CancellationToken.None);
@@ -229,6 +231,8 @@ public sealed class WorkflowAgentGAgent : GAgentBase<WorkflowAgentState>
             ScheduleCron = State.ScheduleCron ?? string.Empty,
             ScheduleTimezone = State.ScheduleTimezone ?? string.Empty,
             Status = status,
+            LarkReceiveId = State.LarkReceiveId ?? string.Empty,
+            LarkReceiveIdType = State.LarkReceiveIdType ?? string.Empty,
         };
 
         await actor.HandleEventAsync(BuildDirectEnvelope(actor.Id, command), ct);
@@ -279,6 +283,8 @@ public sealed class WorkflowAgentGAgent : GAgentBase<WorkflowAgentState>
         next.Enabled = evt.Enabled;
         next.ScopeId = evt.ScopeId ?? string.Empty;
         next.Platform = evt.Platform ?? string.Empty;
+        next.LarkReceiveId = evt.LarkReceiveId ?? string.Empty;
+        next.LarkReceiveIdType = evt.LarkReceiveIdType ?? string.Empty;
         return next;
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto
+++ b/agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto
@@ -282,6 +282,11 @@ message UserAgentCatalogDocument {
   google.protobuf.Timestamp next_run_at_utc = 21;
   int32 error_count = 22;
   string last_error = 23;
+  // Mirrors UserAgentCatalogEntry.lark_receive_id*. Required so catalog-backed
+  // outbound senders (FeishuCardHumanInteractionPort) read the typed target
+  // through the projection rather than re-deriving from conversation_id.
+  string lark_receive_id = 24;
+  string lark_receive_id_type = 25;
 }
 
 // Runtime-only Nyx credential read model for delivery-target execution paths.

--- a/agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto
+++ b/agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto
@@ -185,6 +185,12 @@ message UserAgentCatalogEntry {
   int32 error_count = 19;
   string last_error = 20;
   int64 tombstone_state_version = 21;
+  // Authoritative Lark outbound delivery target captured at create time. When
+  // both fields are present, outbound senders use them verbatim instead of
+  // inferring receive_id_type from the conversation_id prefix. For p2p the
+  // creator stores the user open_id (`ou_*`) here, not the DM thread chat_id.
+  string lark_receive_id = 22;
+  string lark_receive_id_type = 23;
 }
 
 message UserAgentCatalogState {
@@ -205,6 +211,10 @@ message UserAgentCatalogUpsertCommand {
   string schedule_cron = 11;
   string schedule_timezone = 12;
   string status = 13;
+  // See UserAgentCatalogEntry.lark_receive_id for semantics. Empty values
+  // preserve any existing entry value via the merge-non-empty upsert policy.
+  string lark_receive_id = 14;
+  string lark_receive_id_type = 15;
 }
 
 message UserAgentCatalogTombstoneCommand {
@@ -295,6 +305,11 @@ message SkillRunnerOutboundConfig {
   // Channel platform identifier (e.g. "lark", "telegram"). Empty = unspecified;
   // UserAgentCatalog upsert defaults to "lark" for backward compatibility.
   string platform = 6;
+  // Authoritative Lark outbound delivery target captured at create time. When
+  // both fields are present, SkillRunnerGAgent.SendOutputAsync uses them
+  // verbatim; conversation_id stays for LLM metadata propagation only.
+  string lark_receive_id = 7;
+  string lark_receive_id_type = 8;
 }
 
 message SkillRunnerState {
@@ -417,6 +432,11 @@ message WorkflowAgentState {
   // Channel platform identifier (e.g. "lark", "telegram"). Empty = unspecified;
   // UserAgentCatalog upsert defaults to "lark" for backward compatibility.
   string platform = 18;
+  // See UserAgentCatalogEntry.lark_receive_id for semantics; copied verbatim
+  // into the catalog entry on UpsertRegistryAsync so downstream Lark senders
+  // (e.g. FeishuCardHumanInteractionPort) read the typed target.
+  string lark_receive_id = 19;
+  string lark_receive_id_type = 20;
 }
 
 message InitializeWorkflowAgentCommand {
@@ -435,6 +455,8 @@ message InitializeWorkflowAgentCommand {
   string scope_id = 13;
   // Channel platform identifier; empty → default "lark" at upsert time.
   string platform = 14;
+  string lark_receive_id = 15;
+  string lark_receive_id_type = 16;
 }
 
 message WorkflowAgentInitializedEvent {
@@ -453,6 +475,8 @@ message WorkflowAgentInitializedEvent {
   string scope_id = 13;
   // Channel platform identifier; empty → default "lark" at upsert time.
   string platform = 14;
+  string lark_receive_id = 15;
+  string lark_receive_id_type = 16;
 }
 
 message TriggerWorkflowAgentExecutionCommand {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -909,6 +909,7 @@ public sealed class AgentBuilderToolTests
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
             [ChannelMetadataKeys.ChatType] = "p2p",
             [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
             ["scope_id"] = "scope-1",
         };
         try
@@ -950,7 +951,12 @@ public sealed class AgentBuilderToolTests
                     e.Payload.Unpack<InitializeWorkflowAgentCommand>().WorkflowActorId == "workflow-actor-1" &&
                     e.Payload.Unpack<InitializeWorkflowAgentCommand>().ConversationId == "oc_chat_1" &&
                     e.Payload.Unpack<InitializeWorkflowAgentCommand>().NyxApiKey == "full-key-2" &&
-                    e.Payload.Unpack<InitializeWorkflowAgentCommand>().ApiKeyId == "key-2"),
+                    e.Payload.Unpack<InitializeWorkflowAgentCommand>().ApiKeyId == "key-2" &&
+                    // Mirror of the daily_report p2p assertion: BuildFromInbound must pin the
+                    // sender open_id at delivery-target creation time so FeishuCardHumanInteraction
+                    // Port reads it through the catalog projection without re-deriving the type.
+                    e.Payload.Unpack<InitializeWorkflowAgentCommand>().LarkReceiveId == "ou_user_1" &&
+                    e.Payload.Unpack<InitializeWorkflowAgentCommand>().LarkReceiveIdType == "open_id"),
                 Arg.Any<CancellationToken>());
 
             await workflowAgentActor.Received(1).HandleEventAsync(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -161,6 +161,7 @@ public sealed class AgentBuilderToolTests
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
             [ChannelMetadataKeys.ChatType] = "p2p",
             [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
             ["scope_id"] = "scope-1",
         };
         try
@@ -196,7 +197,12 @@ public sealed class AgentBuilderToolTests
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.NyxProviderSlug == "api-lark-bot" &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.NyxApiKey == "full-key-1" &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.ApiKeyId == "key-1" &&
-                    e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.OwnerNyxUserId == "user-1"),
+                    e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.OwnerNyxUserId == "user-1" &&
+                    // For p2p the typed delivery target pins the user open_id from SenderId so
+                    // outbound DMs go through Lark's open_id receive type even when the relay's
+                    // ConversationId is the underlying oc_* chat or a route id.
+                    e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveId == "ou_user_1" &&
+                    e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveIdType == "open_id"),
                 Arg.Any<CancellationToken>());
 
             await skillRunnerActor.Received(1).HandleEventAsync(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
@@ -10,7 +10,7 @@ public sealed class LarkConversationTargetsTests
     [InlineData("ou_short", "open_id")]
     [InlineData("on_union_user_token", "union_id")]
     [InlineData("oc_group_chat_1", "chat_id")]
-    [InlineData("oc_dm_thread", "chat_id")]
+    [InlineData("oc_group_chat_2", "chat_id")]
     public void ResolveReceiveIdType_ShouldMapKnownPrefixes(string conversationId, string expected)
     {
         LarkConversationTargets.ResolveReceiveIdType(conversationId).Should().Be(expected);
@@ -42,5 +42,108 @@ public sealed class LarkConversationTargetsTests
         // case mismatch as unknown rather than guessing a mapping.
         LarkConversationTargets.ResolveReceiveIdType("OU_user_1").Should().Be("chat_id");
         LarkConversationTargets.ResolveReceiveIdType("ON_user_1").Should().Be("chat_id");
+    }
+
+    [Fact]
+    public void Resolve_ShouldUseTypedFieldsVerbatim_WhenBothPopulated()
+    {
+        var resolved = LarkConversationTargets.Resolve(
+            typedReceiveId: "ou_user_1",
+            typedReceiveIdType: "open_id",
+            legacyConversationId: "oc_chat_1");
+
+        resolved.ReceiveId.Should().Be("ou_user_1");
+        resolved.ReceiveIdType.Should().Be("open_id");
+        resolved.FellBackToPrefixInference.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("", "open_id")]
+    [InlineData("ou_user_1", "")]
+    [InlineData(null, "open_id")]
+    [InlineData("ou_user_1", null)]
+    public void Resolve_ShouldFallBackToLegacyInference_WhenEitherTypedFieldIsBlank(
+        string? typedReceiveId,
+        string? typedReceiveIdType)
+    {
+        var resolved = LarkConversationTargets.Resolve(
+            typedReceiveId,
+            typedReceiveIdType,
+            legacyConversationId: "ou_legacy_user");
+
+        resolved.ReceiveId.Should().Be("ou_legacy_user");
+        resolved.ReceiveIdType.Should().Be("open_id");
+        resolved.FellBackToPrefixInference.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Resolve_ShouldFallBackToChatIdDefault_WhenLegacyConversationIdIsUnrecognized()
+    {
+        var resolved = LarkConversationTargets.Resolve(
+            typedReceiveId: null,
+            typedReceiveIdType: null,
+            legacyConversationId: "om_legacy_message_id");
+
+        resolved.ReceiveId.Should().Be("om_legacy_message_id");
+        resolved.ReceiveIdType.Should().Be("chat_id");
+        resolved.FellBackToPrefixInference.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("p2p")]
+    [InlineData("P2P")]
+    [InlineData("direct_message")]
+    [InlineData("DirectMessage")]
+    [InlineData("dm")]
+    public void BuildFromInbound_ShouldUseSenderOpenId_ForDirectMessages(string chatType)
+    {
+        // The relay puts the Lark sender open_id (`ou_*`) into ChannelInboundEvent.SenderId,
+        // while ConversationId may be the route id or the DM's underlying `oc_*` chat_id —
+        // neither of which Lark's outbound API will accept with receive_id_type=chat_id when
+        // the bot is only authorised to DM the user, not the synthetic DM thread. Pin sender
+        // open_id at delivery-target creation time.
+        var target = LarkConversationTargets.BuildFromInbound(
+            chatType,
+            conversationId: "oc_dm_underlying_chat",
+            senderId: "ou_user_1");
+
+        target.ReceiveId.Should().Be("ou_user_1");
+        target.ReceiveIdType.Should().Be("open_id");
+        target.FellBackToPrefixInference.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("group")]
+    [InlineData("channel")]
+    [InlineData("thread")]
+    [InlineData("conversation")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildFromInbound_ShouldUseConversationChatId_ForNonDirectMessages(string? chatType)
+    {
+        var target = LarkConversationTargets.BuildFromInbound(
+            chatType,
+            conversationId: "oc_group_chat_1",
+            senderId: "ou_user_1");
+
+        target.ReceiveId.Should().Be("oc_group_chat_1");
+        target.ReceiveIdType.Should().Be("chat_id");
+        target.FellBackToPrefixInference.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildFromInbound_ShouldFallBackToConversationChatId_WhenSenderIsMissingForDm()
+    {
+        // Defensive: if the relay payload omits the sender open_id for a DM, we cannot
+        // reliably target the user. Returning the conversation_id (typed as chat_id) lets the
+        // outbound proxy fail loudly with the actual Lark error rather than silently sending
+        // to a wrong target.
+        var target = LarkConversationTargets.BuildFromInbound(
+            chatType: "p2p",
+            conversationId: "oc_chat_1",
+            senderId: "");
+
+        target.ReceiveId.Should().Be("oc_chat_1");
+        target.ReceiveIdType.Should().Be("chat_id");
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class LarkConversationTargetsTests
+{
+    [Theory]
+    [InlineData("ou_937adb03f3538c5e041bb3034c4e348e", "open_id")]
+    [InlineData("ou_short", "open_id")]
+    [InlineData("on_union_user_token", "union_id")]
+    [InlineData("oc_group_chat_1", "chat_id")]
+    [InlineData("oc_dm_thread", "chat_id")]
+    public void ResolveReceiveIdType_ShouldMapKnownPrefixes(string conversationId, string expected)
+    {
+        LarkConversationTargets.ResolveReceiveIdType(conversationId).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("om_message_id")]
+    [InlineData("user@example.com")]
+    [InlineData("12345678")]
+    public void ResolveReceiveIdType_ShouldFallBackToChatId_ForUnknownOrEmptyInput(string? conversationId)
+    {
+        LarkConversationTargets.ResolveReceiveIdType(conversationId).Should().Be("chat_id");
+    }
+
+    [Fact]
+    public void ResolveReceiveIdType_ShouldTrimWhitespaceBeforeMatching()
+    {
+        LarkConversationTargets.ResolveReceiveIdType("  ou_user_1  ").Should().Be("open_id");
+        LarkConversationTargets.ResolveReceiveIdType("\toc_chat_1\n").Should().Be("chat_id");
+    }
+
+    [Fact]
+    public void ResolveReceiveIdType_ShouldBeCaseSensitive()
+    {
+        // Lark IDs are produced by Lark and are always lower-case. Treat any
+        // case mismatch as unknown rather than guessing a mapping.
+        LarkConversationTargets.ResolveReceiveIdType("OU_user_1").Should().Be("chat_id");
+        LarkConversationTargets.ResolveReceiveIdType("ON_user_1").Should().Be("chat_id");
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
@@ -89,13 +89,8 @@ public sealed class LarkConversationTargetsTests
         resolved.FellBackToPrefixInference.Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData("p2p")]
-    [InlineData("P2P")]
-    [InlineData("direct_message")]
-    [InlineData("DirectMessage")]
-    [InlineData("dm")]
-    public void BuildFromInbound_ShouldUseSenderOpenId_ForDirectMessages(string chatType)
+    [Fact]
+    public void BuildFromInbound_ShouldUseSenderOpenId_ForP2pDirectMessages()
     {
         // The relay puts the Lark sender open_id (`ou_*`) into ChannelInboundEvent.SenderId,
         // while ConversationId may be the route id or the DM's underlying `oc_*` chat_id —
@@ -103,7 +98,7 @@ public sealed class LarkConversationTargetsTests
         // the bot is only authorised to DM the user, not the synthetic DM thread. Pin sender
         // open_id at delivery-target creation time.
         var target = LarkConversationTargets.BuildFromInbound(
-            chatType,
+            chatType: "p2p",
             conversationId: "oc_dm_underlying_chat",
             senderId: "ou_user_1");
 
@@ -119,8 +114,16 @@ public sealed class LarkConversationTargetsTests
     [InlineData("conversation")]
     [InlineData(null)]
     [InlineData("")]
-    public void BuildFromInbound_ShouldUseConversationChatId_ForNonDirectMessages(string? chatType)
+    [InlineData("P2P")]
+    [InlineData("direct_message")]
+    [InlineData("dm")]
+    public void BuildFromInbound_ShouldUseConversationChatId_ForNonP2pChatTypes(string? chatType)
     {
+        // ChannelConversationTurnRunner.ResolveConversationChatType is the only emitter of
+        // ChannelMetadataKeys.ChatType in this repo and produces exactly "p2p" for direct
+        // messages. Anything else — group/channel/thread/blank, or even other casings of "p2p" —
+        // is treated as a non-DM target and routed through `oc_*/chat_id`. Keep this guard
+        // narrow until a second emitter actually lands.
         var target = LarkConversationTargets.BuildFromInbound(
             chatType,
             conversationId: "oc_group_chat_1",
@@ -132,18 +135,40 @@ public sealed class LarkConversationTargetsTests
     }
 
     [Fact]
-    public void BuildFromInbound_ShouldFallBackToConversationChatId_WhenSenderIsMissingForDm()
+    public void BuildFromInbound_ShouldReturnEmptyTypedPairWithFellBack_WhenP2pAndSenderIsMissing()
     {
-        // Defensive: if the relay payload omits the sender open_id for a DM, we cannot
-        // reliably target the user. Returning the conversation_id (typed as chat_id) lets the
-        // outbound proxy fail loudly with the actual Lark error rather than silently sending
-        // to a wrong target.
+        // Defensive: a confused inbound (chat_type=p2p but no sender open_id) cannot be pinned
+        // to a typed receive target without re-creating the original /daily outage shape (open_id
+        // typed as chat_id). Return an empty typed pair with FellBack=true so the outbound
+        // resolver runs the legacy prefix path and call sites emit the Debug breadcrumb.
         var target = LarkConversationTargets.BuildFromInbound(
             chatType: "p2p",
-            conversationId: "oc_chat_1",
+            conversationId: "ou_user_1",
             senderId: "");
 
-        target.ReceiveId.Should().Be("oc_chat_1");
-        target.ReceiveIdType.Should().Be("chat_id");
+        target.ReceiveId.Should().BeEmpty();
+        target.ReceiveIdType.Should().BeEmpty();
+        target.FellBackToPrefixInference.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Resolve_ShouldRecoverOpenIdForP2pConfusedInbound_ViaPrefixInference()
+    {
+        // Pairs with BuildFromInbound's defensive p2p+empty-sender path: the empty typed pair
+        // makes Resolve fall back to the prefix heuristic on the legacy ConversationId, which
+        // recovers `open_id` for an `ou_*` value. Net effect: confused inbound is observable
+        // (FellBack=true) and still produces the right receive_id_type.
+        var typed = LarkConversationTargets.BuildFromInbound(
+            chatType: "p2p",
+            conversationId: "ou_user_1",
+            senderId: "");
+        var resolved = LarkConversationTargets.Resolve(
+            typed.ReceiveId,
+            typed.ReceiveIdType,
+            legacyConversationId: "ou_user_1");
+
+        resolved.ReceiveId.Should().Be("ou_user_1");
+        resolved.ReceiveIdType.Should().Be("open_id");
+        resolved.FellBackToPrefixInference.Should().BeTrue();
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -1,4 +1,8 @@
+using System.Net;
 using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Core;
@@ -89,6 +93,153 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         _agent.State.HasMaxTokens.Should().BeTrue();
         _agent.State.MaxTokens.Should().Be(0);
         _agent.EffectiveConfig.MaxTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SendOutputAsync_ShouldUseTypedReceiveTarget_WhenLarkReceiveIdIsPopulated()
+    {
+        // Initialize with typed fields set (the shape AgentBuilderTool now writes for p2p flows).
+        // Even though the legacy ConversationId is an `oc_*` chat id (which Lark would also accept
+        // with chat_id), the typed open_id target should be sent verbatim — this is what fixes the
+        // production 400 where the relay's ConversationId fell through to ou_*.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_chat_legacy",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_1"}}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        await InvokeSendOutputAsync(_agent, "scheduled report body");
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages?receive_id_type=open_id");
+        using var body = JsonDocument.Parse(handler.LastBody!);
+        body.RootElement.GetProperty("receive_id").GetString().Should().Be("ou_user_1");
+        body.RootElement.GetProperty("msg_type").GetString().Should().Be("text");
+    }
+
+    [Fact]
+    public async Task SendOutputAsync_ShouldFallBackToConversationIdPrefixInference_ForLegacyState()
+    {
+        // Backward compatibility: state persisted before the typed lark_receive_id fields existed
+        // still resolves through the prefix heuristic on ConversationId. The send still succeeds
+        // (no exception); the sender emits a Debug breadcrumb that is not visible to xUnit.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "ou_legacy_user",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"code":0,"msg":"success"}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        await InvokeSendOutputAsync(_agent, "legacy report body");
+
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot/open-apis/im/v1/messages?receive_id_type=open_id");
+        using var body = JsonDocument.Parse(handler.LastBody!);
+        body.RootElement.GetProperty("receive_id").GetString().Should().Be("ou_legacy_user");
+    }
+
+    [Fact]
+    public async Task SendOutputAsync_ShouldThrow_WhenLarkBusinessCodeIsNonZero()
+    {
+        // Lark reports business errors as HTTP 200 with `code != 0`. Ignoring the response would
+        // let HandleTriggerAsync persist SkillRunnerExecutionCompletedEvent on a silent failure.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"code":230002,"msg":"invalid receive_id"}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        Func<Task> act = () => InvokeSendOutputAsync(_agent, "report");
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.WithMessage("*code=230002*");
+        assertion.WithMessage("*invalid receive_id*");
+    }
+
+    [Fact]
+    public async Task SendOutputAsync_ShouldThrow_WhenNyxProxyEnvelopeReportsError()
+    {
+        // HTTP non-2xx from NyxID gets packaged into a Nyx envelope that ProxyRequestAsync returns
+        // verbatim. Ignoring it would mask transport / auth failures.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"error":true,"message":"upstream timeout"}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        Func<Task> act = () => InvokeSendOutputAsync(_agent, "report");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*upstream timeout*");
+    }
+
+    private static void AttachNyxIdApiClient(SkillRunnerGAgent agent, HttpMessageHandler handler)
+    {
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+        var field = typeof(SkillRunnerGAgent).GetField(
+            "_nyxIdApiClient",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        field.Should().NotBeNull();
+        field!.SetValue(agent, client);
+    }
+
+    private static Task InvokeSendOutputAsync(SkillRunnerGAgent agent, string output)
+    {
+        var method = typeof(SkillRunnerGAgent).GetMethod(
+            "SendOutputAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+        return (Task)method!.Invoke(agent, [output, CancellationToken.None])!;
+    }
+
+    private sealed class RecordingHandler(string responseBody) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            LastBody = request.Content == null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json"),
+            };
+        }
     }
 
     private SkillRunnerGAgent CreateAgent(string actorId)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
@@ -54,6 +54,8 @@ public sealed class UserAgentCatalogProjectorTests
                     ErrorCount = 1,
                     LastError = "last-error",
                     CreatedAt = createdAt,
+                    LarkReceiveId = "ou_user_1",
+                    LarkReceiveIdType = "open_id",
                 },
             },
         };
@@ -83,6 +85,32 @@ public sealed class UserAgentCatalogProjectorTests
         document.ActorId.Should().Be("agent-registry-store");
         document.CreatedAt.Should().Be(createdAt.ToDateTimeOffset());
         document.UpdatedAt.Should().Be(_clock.UtcNow);
+        // Typed Lark target round-trips through the projection so catalog-backed senders
+        // (FeishuCardHumanInteractionPort) read it via UserAgentCatalogQueryPort.ToEntry
+        // instead of falling back to conversation_id prefix inference.
+        document.LarkReceiveId.Should().Be("ou_user_1");
+        document.LarkReceiveIdType.Should().Be("open_id");
+    }
+
+    [Fact]
+    public void ToEntry_ShouldRoundTripTypedLarkReceiveTarget_FromDocumentToEntry()
+    {
+        // FeishuCardHumanInteractionPort consumes UserAgentCatalogEntry via this conversion;
+        // dropping the typed fields would silently regress workflow / social_media DM delivery
+        // back to the prefix-inference path even after the projection captured them.
+        var document = new UserAgentCatalogDocument
+        {
+            Id = "agent-1",
+            Platform = "lark",
+            ConversationId = "oc_chat_1",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+        };
+
+        var entry = UserAgentCatalogQueryPort.ToEntry(document, nyxApiKey: "");
+
+        entry.LarkReceiveId.Should().Be("ou_user_1");
+        entry.LarkReceiveIdType.Should().Be("open_id");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem & Approach

Two independent issues surfaced in the same `/daily` failure trace (see https://github.com/aevatarAI/aevatar/pull/402#issuecomment-4317512015 for the original log triage). Both are scoped to Lark channel runtime and unrelated to the GPT-5 temperature fix in #402.

### 1. SkillRunner / human-interaction outbound DM rejected

`SkillRunnerGAgent.SendOutputAsync` and `FeishuCardHumanInteractionPort.SendMessageAsync` both hard-coded `receive_id_type=chat_id` when posting to `open-apis/im/v1/messages`. In DM flows, the `OutboundConfig.ConversationId` is the user `open_id` (`ou_*`), not a `chat_id` (`oc_*`), so every outbound message returned HTTP 400 from Lark.

**Fix**: Introduce `LarkConversationTargets.ResolveReceiveIdType` to derive `receive_id_type` from the conversation_id prefix:
- `ou_*` → `open_id`
- `on_*` → `union_id`
- `oc_*` and anything else → `chat_id` (default)

Reuse from both call sites.

### 2. Reaction acknowledgment spams Warnings

`ChannelConversationTurnRunner.TrySendImmediateLarkReactionAsync` is a best-effort UX sugar that adds an "OK" emoji to the user's message as a delivery acknowledgment. When the Lark app lacks reaction permission (most common cause: Lark error code 231002 `The operator has no permission to react on the specific message`), it fails on **every** inbound message until ops fixes the app scope. The current `LogWarning` floods the run log with the same line.

**Fix**: Demote the proxy-error path to `LogDebug` so the signal stays discoverable when the channel is opted into verbose logging without spamming Warnings on every turn. The exception path stays at `LogWarning` because thrown exceptions indicate genuine network or code-level issues, not a recurring config gap.

## Affected Paths

- `agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs` (new helper)
- `agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs` (`SendOutputAsync`)
- `agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs` (`SendMessageAsync`)
- `agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs` (reaction failure log level)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs` (new helper unit tests)

## Verification

```
dotnet build agents/Aevatar.GAgents.ChannelRuntime/Aevatar.GAgents.ChannelRuntime.csproj --nologo
dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo
bash tools/ci/test_stability_guards.sh
```

Results:
- Build: 0 errors (existing CA warnings only).
- Helper tests: 13 passed (`LarkConversationTargetsTests`).
- Full ChannelRuntime suite: 357 passed, 0 failed.
- Stability guard: passed.

## Out of Scope

- The Lark app's missing reaction scope itself is a tenant-level config issue tracked separately by ops; this PR only stops the log spam.
- GPT-5 `temperature` rejection is being fixed in #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)