### PR TITLE
fix(channel-runtime): cross-app safe Lark outbound via tenant-stable union_id + card UX

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -287,6 +287,16 @@ message TransportExtras {
   string nyx_user_access_token = 5;
   // The platform-native message id of the originating user message when Nyx relay can recover it.
   string nyx_platform_message_id = 6;
+  // The Lark `union_id` (`on_*`) of the inbound sender. Tenant-stable and cross-app safe, so
+  // outbound delivery can target the user via `receive_id_type=union_id` even when the inbound
+  // event was relayed through a different Lark app than the outbound sender. Empty when the
+  // platform is not Lark or the relay payload could not surface a `union_id`.
+  string nyx_lark_union_id = 7;
+  // The Lark `chat_id` (`oc_*`) of the inbound conversation as observed by the relay-side Lark
+  // app. Cross-app safe within the tenant for groups/threads/channels (any app added to the
+  // chat can address it via `receive_id_type=chat_id`). For p2p DMs the chat_id is bot-specific
+  // and not cross-app safe; downstream senders prefer `nyx_lark_union_id` for p2p targets.
+  string nyx_lark_chat_id = 8;
 }
 
 // Represents one normalized activity flowing through the channel pipeline.

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -181,6 +181,13 @@ internal static class AgentBuilderCardFlow
                 decision = AgentBuilderFlowDecision.ToolCall(ListAgentsAction, """{"action":"list_agents"}""");
                 return true;
 
+            case ListTemplatesAction:
+                // The /agents card surfaces a `Templates` button (also reachable via the
+                // text-flow `/templates` slash command). Without this branch, clicking the
+                // button leaves the user with an unhandled card action and no feedback.
+                decision = AgentBuilderFlowDecision.ToolCall(ListTemplatesAction, """{"action":"list_templates"}""");
+                return true;
+
             case AgentStatusAction:
                 if (!TryBuildAgentActionArguments(evt, "agent_status", out argumentsJson, out validationError))
                 {

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -236,12 +236,7 @@ public sealed class AgentBuilderTool : IAgentTool
                     ?? await actorRuntime.CreateAsync<SkillRunnerGAgent>(agentId, ct);
 
         var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
-        var deliveryTarget = LarkConversationTargets.BuildFromInbound(
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType),
-            conversationId,
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId),
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkUnionId),
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkChatId));
+        var deliveryTarget = ResolveDeliveryTarget(conversationId, agentId);
         var initialize = new InitializeSkillRunnerCommand
         {
             SkillName = templateSpec.SkillName,
@@ -385,12 +380,7 @@ public sealed class AgentBuilderTool : IAgentTool
                     ?? await actorRuntime.CreateAsync<WorkflowAgentGAgent>(agentId, ct);
 
         var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
-        var deliveryTarget = LarkConversationTargets.BuildFromInbound(
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType),
-            conversationId,
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId),
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkUnionId),
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkChatId));
+        var deliveryTarget = ResolveDeliveryTarget(conversationId, agentId);
         var initialize = new InitializeWorkflowAgentCommand
         {
             WorkflowId = workflowUpsert.Workflow.WorkflowId,
@@ -1419,6 +1409,46 @@ public sealed class AgentBuilderTool : IAgentTool
     {
         var normalized = (value ?? string.Empty).Trim();
         return normalized.Length == 0 ? null : normalized;
+    }
+
+    /// <summary>
+    /// Builds the typed Lark delivery target from the current AgentToolRequestContext and emits
+    /// a LogDebug breadcrumb when <see cref="LarkConversationTargets.BuildFromInbound"/> falls
+    /// back from the cross-app safe pair (union_id / chat_id) to the legacy open_id /
+    /// conversation_id path. The fallback flag is intentionally NOT persisted on
+    /// <c>SkillRunnerOutboundConfig</c> / <c>InitializeWorkflowAgentCommand</c> because the
+    /// downstream <see cref="LarkConversationTargets.Resolve"/> path treats any populated typed
+    /// pair as authoritative — so this is the only place the cross-app risk surfaces. Operators
+    /// correlating Lark <c>code:99992361 open_id cross app</c> rejections need this log line to
+    /// confirm whether the relay surfaced <c>union_id</c> at agent-create time.
+    /// </summary>
+    private LarkReceiveTarget ResolveDeliveryTarget(string conversationId, string agentId)
+    {
+        var chatType = AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType);
+        var senderId = AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId);
+        var unionId = AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkUnionId);
+        var chatId = AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkChatId);
+
+        var target = LarkConversationTargets.BuildFromInbound(
+            chatType,
+            conversationId,
+            senderId,
+            unionId,
+            chatId);
+
+        if (target.FellBackToPrefixInference)
+        {
+            _logger?.LogDebug(
+                "Agent builder fell back to legacy delivery target inference for {AgentId}: chatType={ChatType}, hasUnionId={HasUnionId}, hasLarkChatId={HasLarkChatId}, hasSenderId={HasSenderId}, resolvedReceiveIdType={ReceiveIdType}. Cross-app outbound (e.g. customer api-lark-bot) may surface Lark `99992361 open_id cross app` until the relay propagates union_id.",
+                agentId,
+                chatType ?? string.Empty,
+                !string.IsNullOrWhiteSpace(unionId),
+                !string.IsNullOrWhiteSpace(chatId),
+                !string.IsNullOrWhiteSpace(senderId),
+                target.ReceiveIdType);
+        }
+
+        return target;
     }
 
     private sealed class BuilderArgs

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -239,7 +239,9 @@ public sealed class AgentBuilderTool : IAgentTool
         var deliveryTarget = LarkConversationTargets.BuildFromInbound(
             AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType),
             conversationId,
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId));
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId),
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkUnionId),
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkChatId));
         var initialize = new InitializeSkillRunnerCommand
         {
             SkillName = templateSpec.SkillName,
@@ -386,7 +388,9 @@ public sealed class AgentBuilderTool : IAgentTool
         var deliveryTarget = LarkConversationTargets.BuildFromInbound(
             AgentToolRequestContext.TryGet(ChannelMetadataKeys.ChatType),
             conversationId,
-            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId));
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.SenderId),
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkUnionId),
+            AgentToolRequestContext.TryGet(ChannelMetadataKeys.LarkChatId));
         var initialize = new InitializeWorkflowAgentCommand
         {
             WorkflowId = workflowUpsert.Workflow.WorkflowId,

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
@@ -681,6 +681,18 @@ internal sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (!string.IsNullOrWhiteSpace(platformMessageId))
             metadata[ChannelMetadataKeys.PlatformMessageId] = platformMessageId;
 
+        // Lark cross-app outbound delivery: agent-builder consumers prefer the tenant-stable
+        // union_id / chat_id captured at ingress over the relay-app-scoped open_id, so a
+        // mismatch between the relay-side Lark app and the customer's outbound Lark app does
+        // not surface as `code:99992361 open_id cross app` rejections at send time.
+        var larkUnionId = NormalizeOptional(activity?.TransportExtras?.NyxLarkUnionId);
+        if (!string.IsNullOrWhiteSpace(larkUnionId))
+            metadata[ChannelMetadataKeys.LarkUnionId] = larkUnionId;
+
+        var larkChatId = NormalizeOptional(activity?.TransportExtras?.NyxLarkChatId);
+        if (!string.IsNullOrWhiteSpace(larkChatId))
+            metadata[ChannelMetadataKeys.LarkChatId] = larkChatId;
+
         return metadata;
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelMetadataKeys.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelMetadataKeys.cs
@@ -13,4 +13,19 @@ public static class ChannelMetadataKeys
     public const string MessageId = "channel.message_id";
     public const string PlatformMessageId = "channel.platform_message_id";
     public const string ChatType = "channel.chat_type";
+    /// <summary>
+    /// Lark <c>union_id</c> (<c>on_*</c>) of the inbound sender. Tenant-stable and cross-app safe;
+    /// downstream Lark senders prefer this over <see cref="SenderId"/> (<c>open_id</c>) for p2p
+    /// outbound delivery so a relay-app vs outbound-app mismatch does not produce
+    /// <c>open_id cross app</c> rejections from Lark. Empty when the platform is not Lark or the
+    /// relay did not surface a <c>union_id</c>.
+    /// </summary>
+    public const string LarkUnionId = "channel.lark.union_id";
+    /// <summary>
+    /// Lark <c>chat_id</c> (<c>oc_*</c>) as observed by the relay-side Lark app. Cross-app safe
+    /// within the tenant for groups/threads/channels. Downstream Lark senders prefer this for
+    /// non-p2p outbound delivery instead of inferring a chat_id from the routing
+    /// <see cref="ConversationId"/> (which may be a NyxID-internal route id).
+    /// </summary>
+    public const string LarkChatId = "channel.lark.chat_id";
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/FeishuCardHumanInteractionPort.cs
@@ -359,11 +359,28 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
 
         if (LarkProxyResponse.TryGetError(result, out var larkCode, out var detail))
         {
-            throw new InvalidOperationException(
-                larkCode is { } code
-                    ? $"{failurePrefix} (code={code}): {detail}"
-                    : $"{failurePrefix}: {detail}");
+            throw new InvalidOperationException(BuildLarkRejectionMessage(failurePrefix, larkCode, detail));
         }
+    }
+
+    private static string BuildLarkRejectionMessage(string failurePrefix, int? larkCode, string detail)
+    {
+        if (larkCode == LarkBotErrorCodes.OpenIdCrossApp)
+        {
+            // Mirrors the SkillRunnerGAgent recovery hint: the workflow agent's catalog target
+            // was captured before union_id ingress existed and the persisted typed pair is
+            // permanently relay-app-scoped. Surface the recreate-the-agent instruction inside
+            // the exception message so it ends up in `/agent-status`'s `last_error` field
+            // instead of the cryptic Lark `99992361 open_id cross app`.
+            return
+                $"{failurePrefix} (code={larkCode}): {detail}. " +
+                "This workflow agent was created before cross-app union_id ingress existed; " +
+                "delete and recreate it (`/agents` → Delete → `/social-media`) to pick up the cross-app safe target.";
+        }
+
+        return larkCode is { } code
+            ? $"{failurePrefix} (code={code}): {detail}"
+            : $"{failurePrefix}: {detail}";
     }
 
     private static bool SupportsApproveReject(HumanInteractionRequest request) =>

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkBotErrorCodes.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkBotErrorCodes.cs
@@ -12,4 +12,15 @@ internal static class LarkBotErrorCodes
     /// config gap when the bot's app scope is missing the reaction permission.
     /// </summary>
     public const int NoPermissionToReact = 231002;
+
+    /// <summary>
+    /// "open_id cross app" — Lark <c>open_id</c> is app-scoped (each Lark app issues its own
+    /// <c>ou_*</c> for the same user). When relay-side ingress (e.g. NyxID's Lark app) and
+    /// outbound (e.g. customer's <c>api-lark-bot</c>) are different apps, sending to a
+    /// <c>receive_id_type=open_id</c> with the relay-app-scoped <c>ou_*</c> is rejected. Surfaces
+    /// on legacy SkillRunner / human-interaction state captured before <c>union_id</c> ingress
+    /// existed; rebuild the agent (e.g. <c>/agents</c> → Delete → <c>/daily</c>) to pin the new
+    /// cross-app safe pair.
+    /// </summary>
+    public const int OpenIdCrossApp = 99992361;
 }

--- a/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
@@ -57,29 +57,68 @@ internal static class LarkConversationTargets
     }
 
     /// <summary>
-    /// Builds the typed receive-target for a Lark inbound captured at agent creation. For p2p we
-    /// store the user's open_id (always <c>ou_*</c>) so outbound DMs do not depend on the relay
-    /// also propagating an underlying chat_id; for everything else we send to the originating
-    /// chat via its <c>oc_*</c> chat_id, which Lark accepts uniformly for groups, threads, and
-    /// channels.
+    /// Builds the typed receive-target for a Lark inbound captured at agent creation.
     ///
-    /// If the inbound is p2p but the relay omitted <c>SenderId</c>, returning a typed pair would
-    /// silently re-create the original /daily 400 (typing the user open_id as <c>chat_id</c>).
-    /// Instead, return an empty typed pair with <c>FellBackToPrefixInference=true</c> so
-    /// <see cref="Resolve"/> falls back to the legacy prefix path and call sites emit a Debug
-    /// breadcrumb. The relay always emits <c>Sender.PlatformId</c> in production, so this path
-    /// is defensive.
+    /// <para>
+    /// <b>p2p (DM):</b> prefer the tenant-stable <c>union_id</c> (<c>on_*</c>) when the relay
+    /// surfaces it. <c>union_id</c> is cross-app safe within the tenant — Lark accepts it as a
+    /// <c>receive_id_type=union_id</c> target regardless of whether the relay-side ingress app
+    /// matches the customer's outbound app. Without union_id we fall back to the sender
+    /// <c>open_id</c> (<c>ou_*</c>), which is app-scoped and produces
+    /// <c>code:99992361 open_id cross app</c> when the two apps differ; the fallback flips
+    /// <c>FellBackToPrefixInference=true</c> so the call site emits a Debug breadcrumb and
+    /// operators can correlate Lark rejections with missing-union_id ingress.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>group / channel / thread:</b> prefer the inbound Lark <c>chat_id</c> (<c>oc_*</c>) which
+    /// is tenant-scoped — any app added to the chat can address it via
+    /// <c>receive_id_type=chat_id</c>. Without an explicit Lark chat_id the helper falls back to
+    /// the routing <paramref name="conversationId"/>, which works only when the routing id is
+    /// itself a Lark <c>oc_*</c>; otherwise the outbound proxy will surface a Lark validation
+    /// failure that the call site logs and retries.
+    /// </para>
+    ///
+    /// <para>
+    /// If the inbound is p2p but the relay omitted both <c>union_id</c> and <c>senderId</c>,
+    /// returning a typed pair would silently re-create the original /daily 400 (typing the user
+    /// open_id as <c>chat_id</c>). Instead, return an empty typed pair with
+    /// <c>FellBackToPrefixInference=true</c> so <see cref="Resolve"/> falls back to the legacy
+    /// prefix path and call sites emit a Debug breadcrumb.
+    /// </para>
     /// </summary>
-    public static LarkReceiveTarget BuildFromInbound(string? chatType, string? conversationId, string? senderId)
+    public static LarkReceiveTarget BuildFromInbound(
+        string? chatType,
+        string? conversationId,
+        string? senderId,
+        string? larkUnionId = null,
+        string? larkChatId = null)
     {
-        var trimmedSender = (senderId ?? string.Empty).Trim();
         if (IsDirectMessage(chatType))
         {
-            return string.IsNullOrEmpty(trimmedSender)
-                ? new LarkReceiveTarget(string.Empty, string.Empty, FellBackToPrefixInference: true)
-                : new LarkReceiveTarget(trimmedSender, OpenIdReceiveIdType, FellBackToPrefixInference: false);
+            // Cross-app safe: tenant-stable user identifier, accepted by any Lark app.
+            var trimmedUnion = (larkUnionId ?? string.Empty).Trim();
+            if (!string.IsNullOrEmpty(trimmedUnion))
+                return new LarkReceiveTarget(trimmedUnion, UnionIdReceiveIdType, FellBackToPrefixInference: false);
+
+            // Fallback: app-scoped open_id. Will surface `code:99992361 open_id cross app` from
+            // Lark when the relay-side ingress app does not match the customer's outbound app.
+            // Flag the fallback so call sites can LogDebug for incident correlation.
+            var trimmedSender = (senderId ?? string.Empty).Trim();
+            if (!string.IsNullOrEmpty(trimmedSender))
+                return new LarkReceiveTarget(trimmedSender, OpenIdReceiveIdType, FellBackToPrefixInference: true);
+
+            return new LarkReceiveTarget(string.Empty, string.Empty, FellBackToPrefixInference: true);
         }
 
+        // group / channel / thread: prefer the inbound Lark chat_id (cross-app within tenant).
+        var trimmedChat = (larkChatId ?? string.Empty).Trim();
+        if (!string.IsNullOrEmpty(trimmedChat))
+            return new LarkReceiveTarget(trimmedChat, DefaultReceiveIdType, FellBackToPrefixInference: false);
+
+        // Fallback: assume the routing conversation_id is a Lark `oc_*` (legacy behavior pre
+        // ingress-side chat_id capture). If it is not, the proxy will reject and the call site
+        // logs the surfaced Lark error.
         var trimmedConversation = (conversationId ?? string.Empty).Trim();
         return new LarkReceiveTarget(trimmedConversation, DefaultReceiveIdType, FellBackToPrefixInference: false);
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs
@@ -64,8 +64,8 @@ internal static class NyxRelayAgentBuilderFlow
                 "create_daily_report" => FormatCreateDailyReportResult(doc.RootElement),
                 "create_social_media" => TextContent(FormatCreateSocialMediaResult(doc.RootElement)),
                 "list_templates" => TextContent(FormatListTemplatesResult(doc.RootElement)),
-                "list_agents" => TextContent(FormatListAgentsResult(doc.RootElement)),
-                "agent_status" => TextContent(FormatAgentStatusResult(doc.RootElement)),
+                "list_agents" => FormatListAgentsCard(doc.RootElement),
+                "agent_status" => FormatAgentStatusCard(doc.RootElement),
                 "run_agent" => TextContent(FormatRunAgentResult(doc.RootElement)),
                 "disable_agent" => TextContent(FormatLifecycleStatusResult("Agent disabled.", doc.RootElement)),
                 "enable_agent" => TextContent(FormatLifecycleStatusResult("Agent enabled.", doc.RootElement)),
@@ -366,6 +366,80 @@ internal static class NyxRelayAgentBuilderFlow
         return string.Join('\n', lines);
     }
 
+    /// <summary>
+    /// Renders <c>/agents</c> as an interactive Lark card. Each agent gets a section block with
+    /// status fields and a "Status" button that triggers <c>agent_builder_action=agent_status</c>
+    /// (handled by <see cref="AgentBuilderCardFlow"/>); a footer button cluster offers shortcuts
+    /// to create another agent or browse templates. Empty result keeps the existing helper-text
+    /// reply since there are no per-agent buttons to render.
+    /// </summary>
+    private static MessageContent FormatListAgentsCard(JsonElement root)
+    {
+        if (TryReadError(root, out var error))
+            return TextContent($"List agents failed: {error}");
+
+        var content = new MessageContent();
+
+        if (!root.TryGetProperty("agents", out var agentsElement) ||
+            agentsElement.ValueKind != JsonValueKind.Array ||
+            agentsElement.GetArrayLength() == 0)
+        {
+            content.Cards.Add(new CardBlock
+            {
+                Kind = CardBlockKind.Section,
+                BlockId = "agents_empty",
+                Title = "No agents yet",
+                Text = "Create one with `/daily` for a daily GitHub report or `/social-media` for a social-media drafter.",
+            });
+            content.Actions.Add(BuildButton("Create Daily Report", "open_daily_report_form", isPrimary: true));
+            content.Actions.Add(BuildButton("Create Social Media", "open_social_media_form", isPrimary: false));
+            return content;
+        }
+
+        var summary = new CardBlock
+        {
+            Kind = CardBlockKind.Section,
+            BlockId = "agents_summary",
+            Title = "Your agents",
+            Text = "Tap **Status** under any agent to drill in. Action buttons there run, disable/enable, or delete the agent.",
+        };
+        content.Cards.Add(summary);
+
+        foreach (var item in agentsElement.EnumerateArray())
+        {
+            var agentId = ReadString(item, "agent_id") ?? "unknown-agent";
+            var template = ReadString(item, "template") ?? "unknown-template";
+            var status = ReadString(item, "status") ?? "unknown";
+            var nextRun = ReadString(item, "next_scheduled_run") ?? "pending";
+            var lastRun = NormalizeOptional(ReadString(item, "last_run_at"));
+
+            var card = new CardBlock
+            {
+                Kind = CardBlockKind.Section,
+                BlockId = $"agent_row:{agentId}",
+                Title = $"`{agentId}`",
+                Text = $"Template: `{template}` · Status: `{status}`\nNext run: `{nextRun}`{(lastRun is null ? string.Empty : $" · Last run: `{lastRun}`")}",
+            };
+            content.Cards.Add(card);
+
+            // Per-agent "Status" button: triggers `agent_status` action which AgentBuilderCardFlow
+            // already handles and re-renders as a status card with the run / lifecycle actions.
+            content.Actions.Add(BuildAgentScopedButton(
+                label: $"Status: {ShortenAgentId(agentId)}",
+                agentBuilderAction: "agent_status",
+                agentId: agentId,
+                isPrimary: false));
+        }
+
+        // Footer shortcut row mirrors what AgentBuilderCardFlow renders on the dedicated card
+        // path so users have one consistent UX whether they typed `/agents` or arrived via card.
+        content.Actions.Add(BuildButton("Create Daily Report", "open_daily_report_form", isPrimary: false));
+        content.Actions.Add(BuildButton("Create Social Media", "open_social_media_form", isPrimary: false));
+        content.Actions.Add(BuildButton("Templates", "list_templates", isPrimary: false));
+
+        return content;
+    }
+
     private static string FormatAgentStatusResult(JsonElement root)
     {
         if (TryReadError(root, out var error))
@@ -383,6 +457,102 @@ internal static class NyxRelayAgentBuilderFlow
             NormalizeOptional(ReadString(root, "last_error")) is { } lastError ? $"Last error: {lastError}" : null,
             NormalizeOptional(ReadString(root, "note")),
             $"Next commands: /run-agent {agentId}, /disable-agent {agentId}, /enable-agent {agentId}, /delete-agent {agentId} confirm");
+    }
+
+    /// <summary>
+    /// Renders <c>/agent-status &lt;agent_id&gt;</c> as an interactive card with action buttons
+    /// (Run, Disable, Enable, Delete). Each button submits the corresponding
+    /// <c>agent_builder_action</c> with the agent_id as an argument so
+    /// <see cref="AgentBuilderCardFlow"/> can route the click to the existing tool action without
+    /// the user having to retype the id. Mirrors the card produced by the card-flow path so the
+    /// text-command and card-flow surfaces stay visually consistent.
+    /// </summary>
+    private static MessageContent FormatAgentStatusCard(JsonElement root)
+    {
+        if (TryReadError(root, out var error))
+            return TextContent($"Agent status failed: {error}");
+
+        var agentId = ReadString(root, "agent_id") ?? "unknown-agent";
+        var template = ReadString(root, "template") ?? "unknown-template";
+        var status = ReadString(root, "status") ?? "unknown";
+        var schedule = $"{ReadString(root, "schedule_cron") ?? "n/a"} ({ReadString(root, "schedule_timezone") ?? "n/a"})";
+        var lastRun = ReadString(root, "last_run_at") ?? "n/a";
+        var nextRun = ReadString(root, "next_scheduled_run") ?? "n/a";
+        var lastError = NormalizeOptional(ReadString(root, "last_error"));
+        var note = NormalizeOptional(ReadString(root, "note"));
+
+        var bodyLines = new List<string>
+        {
+            $"Agent ID: `{agentId}`",
+            $"Template: `{template}`",
+            $"Status: `{status}`",
+            $"Schedule: `{schedule}`",
+            $"Last run: `{lastRun}`",
+            $"Next run: `{nextRun}`",
+        };
+        if (lastError is not null)
+            bodyLines.Add($"Last error: {lastError}");
+        if (note is not null)
+            bodyLines.Add(note);
+
+        var content = new MessageContent();
+        content.Cards.Add(new CardBlock
+        {
+            Kind = CardBlockKind.Section,
+            BlockId = $"agent_status:{agentId}",
+            Title = "Agent Status",
+            Text = string.Join("\n", bodyLines),
+        });
+
+        // Lifecycle buttons mirror the legacy text "Next commands: ..." line. Disable and Enable
+        // are both shown so the user can flip status either direction without typing; the click
+        // handler enforces the invariants. Delete is marked danger so Lark renders it red and the
+        // user has a final visual confirm before submitting.
+        var isRunning = string.Equals(status, SkillRunnerDefaults.StatusRunning, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(status, SkillRunnerDefaults.StatusError, StringComparison.OrdinalIgnoreCase);
+        content.Actions.Add(BuildAgentScopedButton("Run Now", "run_agent", agentId, isPrimary: isRunning));
+        content.Actions.Add(BuildAgentScopedButton("Disable", "disable_agent", agentId, isPrimary: false));
+        content.Actions.Add(BuildAgentScopedButton("Enable", "enable_agent", agentId, isPrimary: false));
+        var deleteButton = BuildAgentScopedButton("Delete", "delete_agent", agentId, isPrimary: false);
+        deleteButton.IsDanger = true;
+        deleteButton.Arguments["confirm"] = "true";
+        content.Actions.Add(deleteButton);
+        content.Actions.Add(BuildButton("Back to Agents", "list_agents", isPrimary: false));
+
+        return content;
+    }
+
+    private static ActionElement BuildButton(string label, string agentBuilderAction, bool isPrimary)
+    {
+        var button = new ActionElement
+        {
+            Kind = ActionElementKind.Button,
+            ActionId = agentBuilderAction,
+            Label = label,
+            IsPrimary = isPrimary,
+        };
+        button.Arguments["agent_builder_action"] = agentBuilderAction;
+        return button;
+    }
+
+    private static ActionElement BuildAgentScopedButton(string label, string agentBuilderAction, string agentId, bool isPrimary)
+    {
+        var button = BuildButton(label, agentBuilderAction, isPrimary);
+        button.Arguments["agent_id"] = agentId;
+        return button;
+    }
+
+    /// <summary>
+    /// Compresses long agent ids (e.g. <c>skill-runner-94d754dfdfbb416aa5a676cecd0d7a71</c>) into
+    /// a 10-char suffix so per-agent button labels stay readable in narrow Lark cards. The full
+    /// id is still carried in the button's <c>arguments</c> so the click handler routes correctly.
+    /// </summary>
+    private static string ShortenAgentId(string agentId)
+    {
+        if (string.IsNullOrEmpty(agentId) || agentId.Length <= 14)
+            return agentId;
+
+        return $"…{agentId[^10..]}";
     }
 
     private static string FormatRunAgentResult(JsonElement root)

--- a/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/SkillRunnerGAgent.cs
@@ -301,11 +301,32 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         {
             // Surface downstream rejection so HandleTriggerAsync sees a real failure instead of
             // persisting SkillRunnerExecutionCompletedEvent on a silently-dropped Lark response.
-            throw new InvalidOperationException(
-                larkCode is { } code
-                    ? $"Lark message delivery rejected (code={code}): {detail}"
-                    : $"Lark message delivery rejected: {detail}");
+            // The Error field on SkillRunnerExecutionFailedEvent ends up in `/agent-status`'s
+            // `last_error`, so for known recurring stale-state codes we expand the bare Lark
+            // message into actionable recovery guidance — otherwise the user sees a cryptic
+            // `99992361 open_id cross app` and has no way to know they need to rebuild the
+            // agent.
+            throw new InvalidOperationException(BuildLarkRejectionMessage(larkCode, detail));
         }
+    }
+
+    private static string BuildLarkRejectionMessage(int? larkCode, string detail)
+    {
+        if (larkCode == LarkBotErrorCodes.OpenIdCrossApp)
+        {
+            // The agent's persisted OutboundConfig was captured before union_id ingress existed
+            // (PR #409 added that), so `LarkReceiveIdType=open_id` is permanently scoped to a
+            // different Lark app than the customer outbound. Self-heal is not possible without
+            // a fresh ingress event carrying union_id; the user must rebuild the agent.
+            return
+                $"Lark message delivery rejected (code={larkCode}): {detail}. " +
+                "This agent was created before cross-app union_id ingress existed; " +
+                "delete and recreate it (`/agents` → Delete → `/daily`) to pick up the cross-app safe target.";
+        }
+
+        return larkCode is { } code
+            ? $"Lark message delivery rejected (code={code}): {detail}"
+            : $"Lark message delivery rejected: {detail}";
     }
 
     private async Task TrySendFailureAsync(string error, CancellationToken ct)

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -127,6 +127,8 @@ public sealed class NyxIdRelayTransport
                 NyxPlatform = platform,
                 NyxConversationId = payload.Conversation?.Id?.Trim() ?? conversationIdentity,
                 NyxPlatformMessageId = platformMessageId,
+                NyxLarkUnionId = ExtractLarkUnionId(platform, payload, isCardAction),
+                NyxLarkChatId = ExtractLarkChatId(platform, payload, isCardAction),
             },
         };
 
@@ -306,6 +308,84 @@ public sealed class NyxIdRelayTransport
             return senderId;
 
         return $"{platform}-conversation";
+    }
+
+    /// <summary>
+    /// Extracts the Lark <c>union_id</c> (<c>on_*</c>) of the inbound sender from the relay's
+    /// <c>raw_platform_data</c>. <c>union_id</c> is tenant-stable and cross-app safe — outbound
+    /// senders running under a different Lark app than the relay-side ingress app must use this
+    /// to avoid <c>open_id cross app</c> rejections from Lark. Returns empty when the platform
+    /// is not Lark or the original event did not surface a <c>union_id</c> at the well-known
+    /// path. The empty case is normal for non-Lark traffic and for misconfigured Lark apps that
+    /// have not enabled <c>union_id</c> emission.
+    /// </summary>
+    private static string ExtractLarkUnionId(string platform, NyxIdRelayCallbackPayload payload, bool isCardAction)
+    {
+        if (!IsLark(platform) || payload.RawPlatformData is not { } raw || raw.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        if (!raw.TryGetProperty("event", out var evt) || evt.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        // Lark `im.message.receive_v1` puts sender ids under `event.sender.sender_id`. Card
+        // submissions (`card.action.trigger`) put the operator's union_id directly under
+        // `event.operator`, since there is no `sender_id` envelope on that event shape.
+        if (isCardAction)
+        {
+            if (evt.TryGetProperty("operator", out var op) && op.ValueKind == JsonValueKind.Object)
+                return ReadStringProperty(op, "union_id");
+            return string.Empty;
+        }
+
+        if (!evt.TryGetProperty("sender", out var sender) || sender.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+        if (!sender.TryGetProperty("sender_id", out var senderId) || senderId.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        return ReadStringProperty(senderId, "union_id");
+    }
+
+    /// <summary>
+    /// Extracts the Lark <c>chat_id</c> (<c>oc_*</c>) of the inbound conversation from the
+    /// relay's <c>raw_platform_data</c>. Cross-app safe within the tenant for groups/threads/
+    /// channels — any app added to the chat can address it via <c>receive_id_type=chat_id</c>.
+    /// For p2p DMs the chat_id is bot-specific (each Lark app has its own DM thread with the
+    /// user) and not cross-app safe; downstream senders must prefer <see cref="ExtractLarkUnionId"/>
+    /// for p2p targets. Returns empty when the platform is not Lark or the event did not carry
+    /// a <c>chat_id</c> at the well-known path.
+    /// </summary>
+    private static string ExtractLarkChatId(string platform, NyxIdRelayCallbackPayload payload, bool isCardAction)
+    {
+        if (!IsLark(platform) || payload.RawPlatformData is not { } raw || raw.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        if (!raw.TryGetProperty("event", out var evt) || evt.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        if (isCardAction)
+        {
+            if (evt.TryGetProperty("context", out var ctx) && ctx.ValueKind == JsonValueKind.Object)
+                return ReadStringProperty(ctx, "open_chat_id");
+            return string.Empty;
+        }
+
+        if (!evt.TryGetProperty("message", out var message) || message.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+
+        return ReadStringProperty(message, "chat_id");
+    }
+
+    private static bool IsLark(string platform) =>
+        string.Equals(platform, "lark", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(platform, "feishu", StringComparison.OrdinalIgnoreCase);
+
+    private static string ReadStringProperty(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+            return string.Empty;
+
+        var value = property.GetString();
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
     }
 
     private static string BuildCanonicalKey(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
@@ -39,6 +39,30 @@ public sealed class AgentBuilderCardFlowTests
     }
 
     [Fact]
+    public async Task TryResolveAsync_TemplatesCardButton_DispatchesListTemplatesTool()
+    {
+        // The /agents card surfaces a `Templates` button; PR #409 added it. Without an explicit
+        // case in the card_action switch the button click would no-op and confuse users who
+        // navigate by tapping rather than typing /templates. Pin the contract so a refactor can
+        // not silently drop the routing.
+        var inbound = new ChannelInboundEvent
+        {
+            ChatType = "card_action",
+            RegistrationScopeId = "scope-1",
+        };
+        inbound.Extra["agent_builder_action"] = "list_templates";
+
+        var decision = await AgentBuilderCardFlow.TryResolveAsync(inbound, userConfigQueryPort: null);
+
+        decision.Should().NotBeNull();
+        decision!.RequiresToolExecution.Should().BeTrue();
+        decision.ToolAction.Should().Be("list_templates");
+
+        using var body = JsonDocument.Parse(decision.ToolArgumentsJson!);
+        body.RootElement.GetProperty("action").GetString().Should().Be("list_templates");
+    }
+
+    [Fact]
     public async Task TryResolveAsync_DailyReportSubmit_AllowsMissingGithubUsername_ForUserConfigFallback()
     {
         var inbound = new ChannelInboundEvent

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -198,9 +198,10 @@ public sealed class AgentBuilderToolTests
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.NyxApiKey == "full-key-1" &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.ApiKeyId == "key-1" &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.OwnerNyxUserId == "user-1" &&
-                    // For p2p the typed delivery target pins the user open_id from SenderId so
-                    // outbound DMs go through Lark's open_id receive type even when the relay's
-                    // ConversationId is the underlying oc_* chat or a route id.
+                    // p2p inbound without LarkUnionId in the request context falls back to the
+                    // sender open_id. Lark accepts this only when the relay-side and outbound
+                    // apps match; cross-app deployments must populate LarkUnionId at ingress
+                    // (see test below) to avoid `code:99992361 open_id cross app` rejections.
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveId == "ou_user_1" &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveIdType == "open_id"),
                 Arg.Any<CancellationToken>());
@@ -221,6 +222,116 @@ public sealed class AgentBuilderToolTests
                 .Should()
                 .BeEquivalentTo(["svc-github", "svc-lark"]);
             apiKeyDoc.RootElement.TryGetProperty("allow_all_services", out _).Should().BeFalse();
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_PinsLarkUnionId_When_RelayPropagatesIt()
+    {
+        // Cross-app outbound delivery (`code:99992361 open_id cross app`) requires the
+        // tenant-stable `union_id`. When the relay surfaces it via
+        // ChannelMetadataKeys.LarkUnionId the typed delivery target on
+        // InitializeSkillRunnerCommand must pin (union_id, "union_id") instead of falling back
+        // to the relay-app-scoped open_id. Integration counterpart of
+        // LarkConversationTargetsTests.BuildFromInbound_ShouldPreferLarkUnionId_*.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionAsync("skill-runner-union-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync("skill-runner-union-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-union-1",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-union-1");
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-union-1").Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<SkillRunnerGAgent>("skill-runner-union-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(skillRunnerActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {
+                  "provider_id":"provider-github",
+                  "provider_name":"GitHub",
+                  "provider_slug":"github",
+                  "provider_type":"oauth2",
+                  "status":"active",
+                  "connected_at":"2026-04-15T00:00:00Z"
+                }
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+            {
+              "services": [
+                {"id":"svc-github","slug":"api-github"}
+              ],
+              "custom_services": [
+                {"id":"svc-lark","slug":"api-lark-bot"}
+              ],
+              "total": 2,
+              "page": 1,
+              "per_page": 100
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-union-1","full_key":"full-key-union-1"}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_dm_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            [ChannelMetadataKeys.LarkUnionId] = "on_user_1",
+            [ChannelMetadataKeys.LarkChatId] = "oc_dm_chat_1",
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-union-1",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            await skillRunnerActor.Received(1).HandleEventAsync(
+                Arg.Is<EventEnvelope>(e =>
+                    e.Payload != null &&
+                    e.Payload.Is(InitializeSkillRunnerCommand.Descriptor) &&
+                    e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveId == "on_user_1" &&
+                    e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveIdType == "union_id"),
+                Arg.Any<CancellationToken>());
         }
         finally
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -11,6 +11,7 @@ using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 using StudioUserConfig = Aevatar.Studio.Application.Studio.Abstractions.UserConfig;
@@ -332,6 +333,216 @@ public sealed class AgentBuilderToolTests
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveId == "on_user_1" &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().OutboundConfig.LarkReceiveIdType == "union_id"),
                 Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_LogsFallbackBreadcrumb_When_LarkUnionIdMissing()
+    {
+        // Reviewer (PR #409 r3141562097): when the relay does not surface LarkUnionId at agent
+        // creation, BuildFromInbound returns (ou_*, open_id, FellBack=true). The flag itself is
+        // not persisted on OutboundConfig (typed receive id/type only), so a downstream
+        // LarkConversationTargets.Resolve() at SkillRunner send time sees populated typed fields
+        // and reports FellBack=false — meaning the cross-app risk is invisible to operators
+        // unless the agent-create site logs it once. Pin the LogDebug breadcrumb so the
+        // observability promised in the PR description actually fires in production.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionAsync("skill-runner-fallback-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync("skill-runner-fallback-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-fallback-1",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-fallback-1");
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-fallback-1").Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<SkillRunnerGAgent>("skill-runner-fallback-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(skillRunnerActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {
+                  "provider_id":"provider-github",
+                  "provider_name":"GitHub",
+                  "provider_slug":"github",
+                  "provider_type":"oauth2",
+                  "status":"active",
+                  "connected_at":"2026-04-15T00:00:00Z"
+                }
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+            {
+              "services": [{"id":"svc-github","slug":"api-github"}],
+              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
+              "total": 2,
+              "page": 1,
+              "per_page": 100
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-fallback-1","full_key":"full-key-fallback-1"}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+
+        var logger = new ListLogger<AgentBuilderTool>();
+        var tool = new AgentBuilderTool(services.BuildServiceProvider(), logger);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            // Deliberately NO LarkUnionId / LarkChatId — this is the cross-app risky path.
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-fallback-1",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            // The breadcrumb must capture enough context to correlate with downstream Lark
+            // `99992361` rejections: agent_id, the missing typed fields, and the chosen receive
+            // type. Otherwise operators get no signal and the silent-default bug class re-opens.
+            var fallback = logger.Entries.Should().ContainSingle(entry =>
+                entry.Level == LogLevel.Debug &&
+                entry.Message.Contains("Agent builder fell back to legacy delivery target inference") &&
+                entry.Message.Contains("skill-runner-fallback-1") &&
+                entry.Message.Contains("hasUnionId=False") &&
+                entry.Message.Contains("hasLarkChatId=False") &&
+                entry.Message.Contains("hasSenderId=True") &&
+                entry.Message.Contains("resolvedReceiveIdType=open_id")).Subject;
+            fallback.Message.Should().Contain("99992361");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_DoesNotLogFallback_When_LarkUnionIdPresent()
+    {
+        // Counterpart to the breadcrumb test: when the relay surfaces union_id, the typed
+        // delivery target is cross-app safe and we must NOT spam Debug logs on every successful
+        // ingress (otherwise the breadcrumb signal becomes useless noise once /agents traffic
+        // ramps up).
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionAsync("skill-runner-no-fallback-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync("skill-runner-no-fallback-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-no-fallback-1",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-no-fallback-1");
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-no-fallback-1").Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<SkillRunnerGAgent>("skill-runner-no-fallback-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(skillRunnerActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {
+                  "provider_id":"provider-github",
+                  "provider_slug":"github",
+                  "provider_type":"oauth2",
+                  "status":"active",
+                  "connected_at":"2026-04-15T00:00:00Z"
+                }
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+            {
+              "services": [{"id":"svc-github","slug":"api-github"}],
+              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
+              "total": 2,
+              "page": 1,
+              "per_page": 100
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-no-fallback-1","full_key":"full-key-no-fallback-1"}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+
+        var logger = new ListLogger<AgentBuilderTool>();
+        var tool = new AgentBuilderTool(services.BuildServiceProvider(), logger);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            [ChannelMetadataKeys.LarkUnionId] = "on_user_1",
+            [ChannelMetadataKeys.LarkChatId] = "oc_chat_1",
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-no-fallback-1",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            logger.Entries.Should().NotContain(entry =>
+                entry.Message.Contains("fell back to legacy delivery target inference"));
         }
         finally
         {
@@ -1656,6 +1867,40 @@ public sealed class AgentBuilderToolTests
             SavedScopeId = scopeId;
             SavedGithubUsername = githubUsername;
             return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Minimal in-memory <see cref="ILogger{T}"/> that records each log call so tests can assert
+    /// on level + formatted message. Avoids a full Microsoft.Extensions.Logging.Testing dependency
+    /// for a single observability assertion.
+    /// </summary>
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+
+        public sealed record LogEntry(LogLevel Level, string Message);
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose() { }
         }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
@@ -90,13 +90,33 @@ public sealed class LarkConversationTargetsTests
     }
 
     [Fact]
-    public void BuildFromInbound_ShouldUseSenderOpenId_ForP2pDirectMessages()
+    public void BuildFromInbound_ShouldPreferLarkUnionId_ForP2pDirectMessages()
     {
-        // The relay puts the Lark sender open_id (`ou_*`) into ChannelInboundEvent.SenderId,
-        // while ConversationId may be the route id or the DM's underlying `oc_*` chat_id —
-        // neither of which Lark's outbound API will accept with receive_id_type=chat_id when
-        // the bot is only authorised to DM the user, not the synthetic DM thread. Pin sender
-        // open_id at delivery-target creation time.
+        // union_id is tenant-stable and cross-app safe, so a relay-side ingress app and an
+        // outbound-side customer app see the SAME `on_*` for the user. This eliminates the
+        // `code:99992361 open_id cross app` rejection that was breaking SkillRunner DMs when
+        // only the open_id was available.
+        var target = LarkConversationTargets.BuildFromInbound(
+            chatType: "p2p",
+            conversationId: "oc_dm_underlying_chat",
+            senderId: "ou_user_1",
+            larkUnionId: "on_user_1",
+            larkChatId: "oc_dm_underlying_chat");
+
+        target.ReceiveId.Should().Be("on_user_1");
+        target.ReceiveIdType.Should().Be("union_id");
+        target.FellBackToPrefixInference.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildFromInbound_ShouldFallBackToSenderOpenId_ForP2pWithoutUnionId()
+    {
+        // When the relay does not surface a union_id (older relay revisions, misconfigured
+        // Lark app, non-Lark traffic mistyped as p2p), the only DM identifier we have is the
+        // sender open_id. Lark accepts it inside the originating app and rejects it
+        // (`code:99992361 open_id cross app`) when sent from a different app — flip
+        // FellBackToPrefixInference=true so call sites LogDebug and operators can correlate
+        // a missing-union_id ingress with downstream Lark rejections.
         var target = LarkConversationTargets.BuildFromInbound(
             chatType: "p2p",
             conversationId: "oc_dm_underlying_chat",
@@ -104,6 +124,25 @@ public sealed class LarkConversationTargetsTests
 
         target.ReceiveId.Should().Be("ou_user_1");
         target.ReceiveIdType.Should().Be("open_id");
+        target.FellBackToPrefixInference.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildFromInbound_ShouldPreferLarkChatId_ForGroupChats()
+    {
+        // For groups/channels/threads, the inbound Lark `oc_*` chat_id is tenant-scoped and
+        // cross-app safe (any app added to the chat can post via receive_id_type=chat_id).
+        // Prefer it over the routing conversation_id, which may be a NyxID-internal route id
+        // that Lark cannot resolve.
+        var target = LarkConversationTargets.BuildFromInbound(
+            chatType: "group",
+            conversationId: "ddd-1234-route-id",
+            senderId: "ou_user_1",
+            larkUnionId: "on_user_1",
+            larkChatId: "oc_group_chat_1");
+
+        target.ReceiveId.Should().Be("oc_group_chat_1");
+        target.ReceiveIdType.Should().Be("chat_id");
         target.FellBackToPrefixInference.Should().BeFalse();
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -358,4 +358,146 @@ public sealed class NyxIdRelayTransportTests
         parsed.Ignored.Should().BeTrue();
         parsed.ErrorCode.Should().Be("invalid_card_action_payload");
     }
+
+    [Fact]
+    public void Parse_ShouldExposeLarkUnionIdAndChatId_FromMessageReceiveRawPlatformData()
+    {
+        // Cross-app outbound delivery (issue: `code:99992361 open_id cross app`) needs the
+        // tenant-stable `union_id` and the inbound `chat_id` to be visible at the agent-builder
+        // layer. Both live inside the original Lark `im.message.receive_v1` event payload that
+        // NyxID forwards verbatim under `raw_platform_data`.
+        var body = """
+            {
+              "message_id": "msg-lark-1",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_chat_1", "type": "private" },
+              "sender": { "platform_id": "ou_user_1", "display_name": "User One" },
+              "content": { "type": "text", "text": "/daily" },
+              "raw_platform_data": {
+                "schema": "2.0",
+                "header": { "event_type": "im.message.receive_v1" },
+                "event": {
+                  "sender": {
+                    "sender_id": {
+                      "open_id": "ou_user_1",
+                      "union_id": "on_user_1",
+                      "user_id": "u123"
+                    }
+                  },
+                  "message": {
+                    "message_id": "om_lark_1",
+                    "chat_id": "oc_dm_chat_1",
+                    "chat_type": "p2p"
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.TransportExtras.NyxLarkUnionId.Should().Be("on_user_1");
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().Be("oc_dm_chat_1");
+    }
+
+    [Fact]
+    public void Parse_ShouldExposeLarkUnionIdAndChatId_FromCardActionRawPlatformData()
+    {
+        // Lark card submissions arrive as `card.action.trigger`, which carries the operator's
+        // identifiers under `event.operator` (no `sender_id` envelope) and the chat under
+        // `event.context.open_chat_id`. Verify both are surfaced on TransportExtras so the
+        // post-submit agent-builder branch can consume the cross-app safe pair.
+        var body = """
+            {
+              "message_id": "msg-card-1",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-2", "platform_id": "oc_chat_2", "type": "private" },
+              "sender": { "platform_id": "ou_user_2", "display_name": "User Two" },
+              "content": {
+                "content_type": "card_action",
+                "text": "{\"value\":{\"agent_builder_action\":\"create_daily_report\"}}"
+              },
+              "raw_platform_data": {
+                "schema": "2.0",
+                "header": { "event_type": "card.action.trigger" },
+                "event": {
+                  "operator": {
+                    "open_id": "ou_user_2",
+                    "union_id": "on_user_2",
+                    "user_id": "u456"
+                  },
+                  "context": {
+                    "open_chat_id": "oc_dm_chat_2",
+                    "open_message_id": "om_card_2"
+                  },
+                  "action": {
+                    "tag": "button",
+                    "value": { "agent_builder_action": "create_daily_report" }
+                  }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.TransportExtras.NyxLarkUnionId.Should().Be("on_user_2");
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().Be("oc_dm_chat_2");
+    }
+
+    [Fact]
+    public void Parse_ShouldLeaveLarkExtrasEmpty_ForNonLarkPlatform()
+    {
+        // The lark_* TransportExtras fields are intentionally Lark-specific: other platforms
+        // populate their own platform-native equivalents. Pin the empty contract for non-Lark
+        // traffic so a future refactor that broadens the parser cannot accidentally write
+        // Lark IDs onto Telegram / Discord activities.
+        var body = """
+            {
+              "message_id": "msg-tg-1",
+              "platform": "telegram",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-tg-1", "platform_id": "12345", "type": "private" },
+              "sender": { "platform_id": "tg-user-1", "display_name": "User TG" },
+              "content": { "type": "text", "text": "hi" },
+              "raw_platform_data": {
+                "event": {
+                  "sender": { "sender_id": { "union_id": "should_not_propagate" } },
+                  "message": { "chat_id": "should_not_propagate" }
+                }
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.TransportExtras.NyxLarkUnionId.Should().BeEmpty();
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_ShouldLeaveLarkExtrasEmpty_WhenRawPlatformDataMissing()
+    {
+        var body = """
+            {
+              "message_id": "msg-lark-2",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-3", "platform_id": "oc_chat_3", "type": "private" },
+              "sender": { "platform_id": "ou_user_3", "display_name": "User Three" },
+              "content": { "type": "text", "text": "/daily" }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        parsed.Activity!.TransportExtras.NyxLarkUnionId.Should().BeEmpty();
+        parsed.Activity.TransportExtras.NyxLarkChatId.Should().BeEmpty();
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
@@ -152,8 +152,12 @@ public sealed class NyxRelayAgentBuilderFlowTests
     }
 
     [Fact]
-    public void FormatToolResult_ShouldRenderPlainTextListAgentsResponse()
+    public void FormatToolResult_ShouldRenderListAgentsAsInteractiveCard()
     {
+        // /agents now returns an interactive card so users can drill into per-agent status
+        // without retyping the long agent_id. Per-row "Status" buttons carry the full agent_id
+        // in their arguments so AgentBuilderCardFlow's existing card_action handler routes them
+        // back to the agent_status tool path.
         var decision = AgentBuilderFlowDecision.ToolCall("list_agents", """{"action":"list_agents"}""");
         var result = NyxRelayAgentBuilderFlow.FormatToolResult(
             decision,
@@ -161,20 +165,93 @@ public sealed class NyxRelayAgentBuilderFlowTests
             {
               "agents": [
                 {
-                  "agent_id": "agent-1",
+                  "agent_id": "skill-runner-94d754dfdfbb416aa5a676cecd0d7a71",
                   "template": "daily_report",
                   "status": "running",
-                  "next_scheduled_run": "2026-04-23T09:00:00Z"
+                  "next_scheduled_run": "2026-04-23T09:00:00Z",
+                  "last_run_at": "2026-04-22T09:00:00Z"
                 }
               ]
             }
             """);
 
-        result.Actions.Should().BeEmpty();
+        result.Cards.Should().NotBeEmpty();
+        // First card is the summary; subsequent cards are per-agent rows.
+        result.Cards[0].Title.Should().Be("Your agents");
+        result.Cards.Skip(1).Should().ContainSingle(card =>
+            card.BlockId == "agent_row:skill-runner-94d754dfdfbb416aa5a676cecd0d7a71");
+
+        var statusButton = result.Actions.Should().Contain(a => a.ActionId == "agent_status").Subject;
+        statusButton.Arguments.Should().Contain(new KeyValuePair<string, string>(
+            "agent_builder_action", "agent_status"));
+        statusButton.Arguments.Should().Contain(new KeyValuePair<string, string>(
+            "agent_id", "skill-runner-94d754dfdfbb416aa5a676cecd0d7a71"));
+
+        result.Actions.Should().Contain(a => a.ActionId == "open_daily_report_form");
+        result.Actions.Should().Contain(a => a.ActionId == "open_social_media_form");
+    }
+
+    [Fact]
+    public void FormatToolResult_ShouldRenderEmptyListAgentsAsCallToActionCard()
+    {
+        var decision = AgentBuilderFlowDecision.ToolCall("list_agents", """{"action":"list_agents"}""");
+        var result = NyxRelayAgentBuilderFlow.FormatToolResult(decision, """{"agents":[]}""");
+
+        result.Cards.Should().ContainSingle(card => card.BlockId == "agents_empty");
+        result.Actions.Should().Contain(a => a.ActionId == "open_daily_report_form");
+        result.Actions.Should().Contain(a => a.ActionId == "open_social_media_form");
+    }
+
+    [Fact]
+    public void FormatToolResult_ShouldRenderAgentStatusAsInteractiveCard_WithLifecycleButtons()
+    {
+        // /agent-status now ships as an interactive card with one button per lifecycle action
+        // (Run, Disable, Enable, Delete) so the user does not have to retype the agent_id for
+        // each follow-up command. Each button carries the agent_id in its arguments and the
+        // delete button additionally carries `confirm=true` so AgentBuilderCardFlow's existing
+        // confirm-required handler skips the second-step prompt.
+        var decision = AgentBuilderFlowDecision.ToolCall("agent_status", """{"action":"agent_status"}""");
+        var result = NyxRelayAgentBuilderFlow.FormatToolResult(
+            decision,
+            """
+            {
+              "agent_id": "skill-runner-1",
+              "template": "daily_report",
+              "status": "error",
+              "schedule_cron": "0 9 * * *",
+              "schedule_timezone": "UTC",
+              "last_run_at": "2026-04-25T05:30:00Z",
+              "next_scheduled_run": "2026-04-26T09:00:00Z",
+              "last_error": "Lark message delivery rejected"
+            }
+            """);
+
+        result.Cards.Should().ContainSingle(card => card.BlockId == "agent_status:skill-runner-1");
+        result.Cards[0].Text.Should().Contain("Status: `error`");
+        result.Cards[0].Text.Should().Contain("Last error:");
+
+        result.Actions.Should().Contain(a => a.ActionId == "run_agent");
+        result.Actions.Should().Contain(a => a.ActionId == "disable_agent");
+        result.Actions.Should().Contain(a => a.ActionId == "enable_agent");
+        result.Actions.Should().Contain(a => a.ActionId == "list_agents");
+
+        var deleteButton = result.Actions.Should().Contain(a => a.ActionId == "delete_agent").Subject;
+        deleteButton.IsDanger.Should().BeTrue();
+        deleteButton.Arguments.Should().Contain(new KeyValuePair<string, string>("confirm", "true"));
+        deleteButton.Arguments.Should().Contain(new KeyValuePair<string, string>("agent_id", "skill-runner-1"));
+    }
+
+    [Fact]
+    public void FormatToolResult_ShouldRenderAgentStatusError_WhenToolReturnsError()
+    {
+        var decision = AgentBuilderFlowDecision.ToolCall("agent_status", """{"action":"agent_status"}""");
+        var result = NyxRelayAgentBuilderFlow.FormatToolResult(
+            decision,
+            """{"error":"Agent not found"}""");
+
         result.Cards.Should().BeEmpty();
-        result.Text.Should().Contain("Current agents:");
-        result.Text.Should().Contain("agent-1: template=daily_report, status=running");
-        result.Text.Should().Contain("/agent-status <agent_id>");
+        result.Actions.Should().BeEmpty();
+        result.Text.Should().Contain("Agent status failed: Agent not found");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -203,6 +203,42 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
             .WithMessage("*upstream timeout*");
     }
 
+    [Fact]
+    public async Task SendOutputAsync_ShouldIncludeRecreateHint_When_LarkRejectsAsCrossAppOpenId()
+    {
+        // PR #409 review (pulls/409#review-4175198266): after this fix new agents capture
+        // union_id, but agents created before the fix still have `LarkReceiveIdType=open_id`
+        // pinned to a relay-app-scoped `ou_*`. Their next scheduled run hits Lark
+        // `99992361 open_id cross app` and the user sees the bare error in `/agent-status`'s
+        // `last_error` with no clue what to do. Surface explicit "delete and recreate" guidance
+        // so the failure becomes self-documenting.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_relay_app_user_1",
+            LarkReceiveIdType = "open_id",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler(
+            """{"code":99992361,"msg":"open_id cross app","error":{"message":"Refer to the documentation"}}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        Func<Task> act = () => InvokeSendOutputAsync(_agent, "report");
+
+        var assertion = await act.Should().ThrowAsync<InvalidOperationException>();
+        assertion.WithMessage("*code=99992361*");
+        assertion.WithMessage("*open_id cross app*");
+        // The hint must be actionable enough that the user can recover without reading source.
+        assertion.WithMessage("*before cross-app union_id ingress existed*");
+        assertion.WithMessage("*/agents*");
+        assertion.WithMessage("*Delete*");
+        assertion.WithMessage("*/daily*");
+    }
+
     private static void AttachNyxIdApiClient(SkillRunnerGAgent agent, HttpMessageHandler handler)
     {
         var client = new NyxIdApiClient(


### PR DESCRIPTION
## Symptom

After [PR #403](https://github.com/aevatarAI/aevatar/pull/403) shipped, every SkillRunner outbound DM was rejected by Lark with `code:99992361 open_id cross app` (production log [`aevatar-console-backend-75fd899df8-s6mp7`](file)). The user now sees the Daily Report agent created successfully and the immediate ack, but every scheduled run fails on send. PR #403 fixed the typed `receive_id_type` plumbing — this PR fixes the actual identifier that gets sent.

```
NyxID API request failed: POST .../proxy/s/api-lark-bot/.../messages?receive_id_type=open_id -> 400
Skill runner skill-runner-94d754dfdfbb416aa5a676cecd0d7a71 execution failed
System.InvalidOperationException: Lark message delivery rejected:
  {"code":99992361,"msg":"open_id cross app", ... "How to Obtain OpenID"}
```

## Root cause

Lark `open_id` is **app-scoped**: each Lark app issues its own `ou_*` for the same user, and an open_id minted by app A is invalid as a `receive_id` on app B. In our deployment:

- **Inbound side**: Lark Open Platform delivers events to NyxID's relay-side Lark app. The `ou_*` in the event payload is scoped to that app.
- **Outbound side**: SkillRunner sends through `s/api-lark-bot` proxy — the customer's Lark app, a different app from the relay-side ingress.

PR #403's `BuildFromInbound("p2p", ...)` pinned `(senderId, "open_id")` on the typed delivery target. Lark rejects the cross-app open_id every time; the retry loop runs out of attempts and the agent flips to `error`.

The right cross-app identifier is Lark `union_id` (`on_*`): tenant-stable, shared across apps in the same tenant, accepted by Lark as `receive_id_type=union_id` from any app. Lark events always carry it under `event.sender.sender_id.union_id` (and `event.operator.union_id` for card actions). NyxID forwards the original event verbatim under `raw_platform_data` ([NyxID `build_callback_payload`](https://github.com/aevatarAI/NyxID/blob/main/backend/src/services/channel_relay_service.rs#L514)), so aevatar can recover it without a NyxID change.

## Fix scope

### 1. Surface `union_id` and `chat_id` at ingress

- `TransportExtras` proto: add `nyx_lark_union_id` (cross-app stable user identifier) and `nyx_lark_chat_id` (tenant-scoped group/channel id). Lark-only.
- `NyxIdRelayTransport.ParseInboundAsync`: parse `raw_platform_data` for Lark traffic.
  - `im.message.receive_v1`: read `event.sender.sender_id.union_id` and `event.message.chat_id`.
  - `card.action.trigger`: read `event.operator.union_id` and `event.context.open_chat_id`.
- `ChannelMetadataKeys` + `ChannelConversationTurnRunner.BuildReplyMetadata`: add `LarkUnionId` / `LarkChatId` keys and propagate from `TransportExtras`.
- `AgentBuilderTool.CreateDailyReportAgentAsync` + `CreateSocialMediaAgentAsync`: pass `LarkUnionId` and `LarkChatId` to `BuildFromInbound`.

### 2. Prefer cross-app safe targets in `BuildFromInbound`

```
p2p:
  if union_id present  → (union_id, "union_id", FellBack=false)   [cross-app safe]
  else if sender present → (sender, "open_id", FellBack=true)     [legacy fallback, breadcrumb]
  else                   → (empty, empty, FellBack=true)          [confused inbound]

group / channel / thread:
  if lark_chat_id present → (lark_chat_id, "chat_id", FellBack=false)  [cross-app safe]
  else                    → (conversation_id, "chat_id", FellBack=false) [legacy]
```

The legacy open_id path keeps the relay-app self-send case working in dev / single-app deployments; the FellBack flag makes the cross-app fallback observable so operators can correlate Lark `99992361` rejections with missing-union_id ingress.

### 3. /agents and /agent-status as interactive cards (顺手)

User asked to lift the bot's text replies to Lark cards with action buttons:

- **`/agents`**: summary card + one section per agent + a **Status** button per agent (carries the full `agent_id` so users do not have to retype the long skill-runner id) + footer shortcuts (Create Daily / Create Social Media / Templates).
- **`/agent-status <id>`**: status card + lifecycle action buttons (Run / Disable / Enable / Delete-with-confirm-pre-set / Back to Agents). Delete is marked danger; Lark renders it red.

Buttons reuse the existing `agent_builder_action` arguments handled by [`AgentBuilderCardFlow`](agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs)'s card event branch — click routing is unchanged.

## Files

```
agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
agents/Aevatar.GAgents.ChannelRuntime/ChannelMetadataKeys.cs
agents/Aevatar.GAgents.ChannelRuntime/ChannelConversationTurnRunner.cs
agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
agents/Aevatar.GAgents.ChannelRuntime/LarkConversationTargets.cs
agents/Aevatar.GAgents.ChannelRuntime/NyxRelayAgentBuilderFlow.cs   (cards)

test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
test/Aevatar.GAgents.ChannelRuntime.Tests/LarkConversationTargetsTests.cs
test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayAgentBuilderFlowTests.cs
```

### 4. Migration: existing broken agents won't self-heal — give them a recreate hint

This fix captures `union_id` at agent-CREATE time, so SkillRunner / WorkflowAgent state persisted before this PR is permanently pinned to `LarkReceiveIdType=open_id` against a relay-app-scoped `ou_*`. Their next scheduled run will keep firing `99992361 open_id cross app`. There is no automatic self-heal — scheduled runs do not have a fresh ingress event to mine `union_id` from.

To make the failure self-documenting, `SkillRunnerGAgent.SendOutputAsync` and `FeishuCardHumanInteractionPort.SendMessageAsync` now detect Lark `code=99992361` (`LarkBotErrorCodes.OpenIdCrossApp`) and expand the thrown exception into:

> Lark message delivery rejected (code=99992361): open_id cross app. This agent was created before cross-app union_id ingress existed; delete and recreate it (`/agents` → Delete → `/daily`) to pick up the cross-app safe target.

The `Error` field on `SkillRunnerExecutionFailedEvent` carries this verbatim, so `/agent-status`'s `last_error` is now actionable. Combined with the new `/agents` / `/agent-status` card UI in this PR, the recovery flow is two clicks (Delete row + new `/daily`) — no operator-side migration tool needed.

**Other migration options considered and rejected:**
- ❌ State-side `union_id` backfill: SkillRunner has no fresh ingress at scheduled-run time; would need a separate inbound-event hook to repair.
- ❌ Catalog-wide repair: same problem, plus requires a customer-app `users:read` scope or `batch_get_id` translation we don't have.
- ❌ Auto-disable agents on first `99992361`: would mask transient errors and surprise users who already recreated.

## Verification

```
dotnet build agents/Aevatar.GAgents.ChannelRuntime/Aevatar.GAgents.ChannelRuntime.csproj --nologo
dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo
bash tools/ci/test_stability_guards.sh
```

- Build: 0 errors.
- Tests: 402/402 passed (covers ingress parser, BuildFromInbound union_id-preferred / open_id fallback, AgentBuilderTool integration, fallback breadcrumb LogDebug, card output structure, Lark `99992361` recreate hint).
- Stability guard: passed.

`tools/ci/architecture_guards.sh` reports `Playground asset drift detected for app.js / app.css` — verified pre-existing on `origin/dev` (PR #407), unrelated to this change.

## Out of scope

- The cross-app diagnosis applies to other Lark outbound paths too. `FeishuCardHumanInteractionPort` and the immediate-ack reaction in `ChannelConversationTurnRunner` should ALSO prefer union_id; left for a follow-up PR since the SkillRunner DM path is the production blocker today.
- The `/run-agent`, `/disable-agent`, `/enable-agent`, `/delete-agent` text-command replies still return plain text (their card-flow counterparts in `AgentBuilderCardFlow` already render cards). Symmetric card output for those is a follow-up.
- `lark_*` fields living on platform-agnostic protos (`SkillRunnerOutboundConfig`, `UserAgentCatalogEntry`, `WorkflowAgentState`, `TransportExtras`) is tracked under [#408](https://github.com/aevatarAI/aevatar/issues/408) — refactor to typed `OutboundTarget` oneof when a second platform's delivery code lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
