### PR TITLE
fix(channel-runtime): Lark /delete-agent tombstone-not-reflected race

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -775,22 +775,23 @@ public sealed class AgentBuilderTool : IAgentTool
         string expectedStatus,
         CancellationToken ct)
     {
-        // Capture the readmodel version before waiting so we can distinguish "the
-        // expected status hasn't materialized yet" from "the read model is stale".
-        var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
-
         // Mirrors create_agent: ensure the projection scope is alive so the
         // actor's committed status event has a subscribed materializer.
         await EnsureUserAgentCatalogProjectionAsync(ct);
 
+        // Status-driven polling (no version anchor): caller dispatches the
+        // lifecycle command and we wait for the read model to reflect the
+        // expected status. A version-gated optimization here was wrong because
+        // `versionBefore` would be captured *after* dispatch, so a fast
+        // projection that already advanced the version made `versionAfter ==
+        // versionBefore` and burned the entire budget. The Status field itself
+        // is the authoritative signal — `expectedStatus` is enum-like and only
+        // moves when the lifecycle event materializes, so reading it on every
+        // attempt is both correct and cheap.
         for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
                 await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
-
-            var versionAfter = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
-            if (versionAfter <= versionBefore)
-                continue;
 
             var entry = await queryPort.GetAsync(agentId, ct);
             if (entry != null && string.Equals(entry.Status, expectedStatus, StringComparison.Ordinal))

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -666,8 +666,15 @@ public sealed class AgentBuilderTool : IAgentTool
         if (dispatch.error != null)
             return dispatch.error;
 
-        var after = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, versionBefore, SkillRunnerDefaults.StatusDisabled, ct) ?? entry.value;
-        return SerializeAgentStatus(after, "Agent disabled. Scheduling paused.");
+        var observation = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, versionBefore, SkillRunnerDefaults.StatusDisabled, ct);
+        if (observation.Confirmed)
+            return SerializeAgentStatus(observation.Entry!, "Agent disabled. Scheduling paused.");
+
+        // Dual gate never passed — the disable was dispatched but the read
+        // model has not confirmed the lifecycle change within the wait
+        // budget. Surface the pre-dispatch entry with an honest propagating
+        // note so the caller (LLM/user) does not assume the agent is paused.
+        return SerializeAgentStatus(entry.value, "Disable submitted. Run /agent-status in a few seconds to confirm the agent is paused.");
     }
 
     private async Task<string> EnableAgentAsync(
@@ -697,8 +704,12 @@ public sealed class AgentBuilderTool : IAgentTool
         if (dispatch.error != null)
             return dispatch.error;
 
-        var after = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, versionBefore, SkillRunnerDefaults.StatusRunning, ct) ?? entry.value;
-        return SerializeAgentStatus(after, "Agent enabled. Scheduling resumed.");
+        var observation = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, versionBefore, SkillRunnerDefaults.StatusRunning, ct);
+        if (observation.Confirmed)
+            return SerializeAgentStatus(observation.Entry!, "Agent enabled. Scheduling resumed.");
+
+        // See DisableAgentAsync for the rationale on the un-confirmed branch.
+        return SerializeAgentStatus(entry.value, "Enable submitted. Run /agent-status in a few seconds to confirm the agent is running.");
     }
 
     private static EventEnvelope BuildDirectEnvelope(string targetActorId, IMessage payload)
@@ -830,7 +841,7 @@ public sealed class AgentBuilderTool : IAgentTool
         await projectionPort.EnsureProjectionForActorAsync(UserAgentCatalogGAgent.WellKnownId, ct);
     }
 
-    private async Task<UserAgentCatalogEntry?> WaitForAgentStatusAsync(
+    private async Task<(bool Confirmed, UserAgentCatalogEntry? Entry)> WaitForAgentStatusAsync(
         IUserAgentCatalogQueryPort queryPort,
         string agentId,
         long versionBefore,
@@ -864,10 +875,15 @@ public sealed class AgentBuilderTool : IAgentTool
 
             var entry = await queryPort.GetAsync(agentId, ct);
             if (entry != null && string.Equals(entry.Status, expectedStatus, StringComparison.Ordinal))
-                return entry;
+                return (Confirmed: true, Entry: entry);
         }
 
-        return await queryPort.GetAsync(agentId, ct);
+        // Budget exhausted: the dual gate never passed. Do NOT fall back to an
+        // un-gated GetAsync read — that would surface a stale-but-expected-
+        // looking entry and let callers report success despite the contract
+        // not being satisfied. Callers must surface honest "submitted /
+        // propagating" copy when Confirmed is false.
+        return (Confirmed: false, Entry: null);
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -248,6 +248,12 @@ public sealed class AgentBuilderTool : IAgentTool
                     ?? await actorRuntime.CreateAsync<SkillRunnerGAgent>(agentId, ct);
 
         var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+
+        // Prime the projection scope BEFORE dispatch — see DeleteAgentAsync for
+        // the rationale. A late prime can't recover an event the projector
+        // already missed.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
+
         var deliveryTarget = ResolveDeliveryTarget(conversationId, agentId);
         var initialize = new InitializeSkillRunnerCommand
         {
@@ -282,7 +288,6 @@ public sealed class AgentBuilderTool : IAgentTool
                 BuildDirectEnvelope(actor.Id, new TriggerSkillRunnerExecutionCommand { Reason = "create_agent" }),
                 ct);
 
-        await EnsureUserAgentCatalogProjectionAsync(ct);
         var confirmed = await WaitForCreatedAgentAsync(
             queryPort,
             agentId,
@@ -392,6 +397,12 @@ public sealed class AgentBuilderTool : IAgentTool
                     ?? await actorRuntime.CreateAsync<WorkflowAgentGAgent>(agentId, ct);
 
         var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+
+        // Prime the projection scope BEFORE dispatch — see DeleteAgentAsync for
+        // the rationale. A late prime can't recover an event the projector
+        // already missed.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
+
         var deliveryTarget = ResolveDeliveryTarget(conversationId, agentId);
         var initialize = new InitializeWorkflowAgentCommand
         {
@@ -414,7 +425,6 @@ public sealed class AgentBuilderTool : IAgentTool
 
         await actor.HandleEventAsync(BuildDirectEnvelope(actor.Id, initialize), ct);
 
-        await EnsureUserAgentCatalogProjectionAsync(ct);
         var confirmed = await WaitForCreatedAgentAsync(
             queryPort,
             agentId,
@@ -620,6 +630,13 @@ public sealed class AgentBuilderTool : IAgentTool
             string.Equals(entry.value.Status, WorkflowAgentDefaults.StatusDisabled, StringComparison.Ordinal))
             return SerializeAgentStatus(entry.value, "Agent is already disabled.");
 
+        // Capture baseline version BEFORE dispatch so the wait can distinguish
+        // "projection has materialized this disable" from "stale read replica
+        // happens to surface a historical disabled status". Capture must
+        // precede dispatch — capturing inside the wait helper would race
+        // against a fast projection that already advanced the version.
+        var versionBefore = await queryPort.GetStateVersionAsync(entry.value.AgentId, ct) ?? -1;
+
         // Prime the projection scope BEFORE dispatch — see DeleteAgentAsync for
         // the rationale. A late prime can't recover an event the projector
         // already missed.
@@ -629,7 +646,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (dispatch.error != null)
             return dispatch.error;
 
-        var after = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, SkillRunnerDefaults.StatusDisabled, ct) ?? entry.value;
+        var after = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, versionBefore, SkillRunnerDefaults.StatusDisabled, ct) ?? entry.value;
         return SerializeAgentStatus(after, "Agent disabled. Scheduling paused.");
     }
 
@@ -647,6 +664,10 @@ public sealed class AgentBuilderTool : IAgentTool
             string.Equals(entry.value.Status, WorkflowAgentDefaults.StatusRunning, StringComparison.Ordinal))
             return SerializeAgentStatus(entry.value, "Agent is already enabled.");
 
+        // See DisableAgentAsync for why versionBefore is captured here (before
+        // any dispatch) and not inside WaitForAgentStatusAsync.
+        var versionBefore = await queryPort.GetStateVersionAsync(entry.value.AgentId, ct) ?? -1;
+
         // Prime the projection scope BEFORE dispatch — see DeleteAgentAsync for
         // the rationale. A late prime can't recover an event the projector
         // already missed.
@@ -656,7 +677,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (dispatch.error != null)
             return dispatch.error;
 
-        var after = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, SkillRunnerDefaults.StatusRunning, ct) ?? entry.value;
+        var after = await WaitForAgentStatusAsync(queryPort, entry.value.AgentId, versionBefore, SkillRunnerDefaults.StatusRunning, ct) ?? entry.value;
         return SerializeAgentStatus(after, "Agent enabled. Scheduling resumed.");
     }
 
@@ -792,25 +813,34 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<UserAgentCatalogEntry?> WaitForAgentStatusAsync(
         IUserAgentCatalogQueryPort queryPort,
         string agentId,
+        long versionBefore,
         string expectedStatus,
         CancellationToken ct)
     {
-        // Status-driven polling (no version anchor): caller dispatches the
-        // lifecycle command and we wait for the read model to reflect the
-        // expected status. A version-gated optimization here was wrong because
-        // `versionBefore` would be captured *after* dispatch, so a fast
-        // projection that already advanced the version made `versionAfter ==
-        // versionBefore` and burned the entire budget. The Status field itself
-        // is the authoritative signal — `expectedStatus` is enum-like and only
-        // moves when the lifecycle event materializes, so reading it on every
-        // attempt is both correct and cheap. Projection scope priming happens
-        // in the caller before the dispatch (see DisableAgentAsync /
+        // Status + version dual-condition (mirrors WaitForCreatedAgentAsync):
+        // wait until the read model both advances past the caller-captured
+        // baseline AND surfaces the expected status. Status alone is not
+        // enough — a stale replica can hold an expected-looking historical
+        // status (e.g., a previous disable→enable→disable cycle) and pass a
+        // status-only check while the actor has not yet processed *this*
+        // dispatch. Conversely, version alone is not enough either — an
+        // unrelated state event could advance the version without changing
+        // status. Both conditions together pin "this specific lifecycle
+        // event has materialized in the read model". Caller must capture
+        // versionBefore *before* dispatch, otherwise a fast projection that
+        // already advanced the version would make versionAfter == versionBefore
+        // and burn the entire budget. Projection scope priming also happens
+        // in the caller before dispatch (see DisableAgentAsync /
         // EnableAgentAsync) — a late prime here cannot recover an event the
         // projector already missed.
         for (var attempt = 0; attempt < _projectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
                 await Task.Delay(_projectionWaitDelayMilliseconds, ct);
+
+            var versionAfter = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+            if (versionAfter <= versionBefore)
+                continue;
 
             var entry = await queryPort.GetAsync(agentId, ct);
             if (entry != null && string.Equals(entry.Status, expectedStatus, StringComparison.Ordinal))

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -17,23 +17,25 @@ namespace Aevatar.GAgents.ChannelRuntime;
 
 public sealed class AgentBuilderTool : IAgentTool
 {
-    // Read-model wait budget for actor -> projector -> document store propagation.
-    // 30 attempts × 500 ms = 15 s. The previous 5 s budget routinely lost the race
-    // to projection lag in production, so /delete-agent and /disable-agent
-    // returned "accepted" while the document was still visible.
-    //
-    // Internal (not const) so tests can shrink the budget when they need to exercise
-    // the "did not reflect within budget" branch without burning the full 15 s.
-    internal static int ProjectionWaitAttempts = 30;
-    internal static int ProjectionWaitDelayMilliseconds = 500;
-
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<AgentBuilderTool>? _logger;
+    // Per-instance polling budget for actor -> projector -> document store
+    // propagation. Defaults to ProjectionWaitDefaults (15 s); tests inject
+    // shrunk values via the constructor instead of mutating a process-global,
+    // which would race other tests if the test surface ever parallelizes.
+    private readonly int _projectionWaitAttempts;
+    private readonly int _projectionWaitDelayMilliseconds;
 
-    public AgentBuilderTool(IServiceProvider serviceProvider, ILogger<AgentBuilderTool>? logger = null)
+    public AgentBuilderTool(
+        IServiceProvider serviceProvider,
+        ILogger<AgentBuilderTool>? logger = null,
+        int projectionWaitAttempts = ProjectionWaitDefaults.Attempts,
+        int projectionWaitDelayMilliseconds = ProjectionWaitDefaults.DelayMilliseconds)
     {
         _serviceProvider = serviceProvider;
         _logger = logger;
+        _projectionWaitAttempts = projectionWaitAttempts;
+        _projectionWaitDelayMilliseconds = projectionWaitDelayMilliseconds;
     }
 
     public string Name => "agent_builder";
@@ -508,6 +510,14 @@ public sealed class AgentBuilderTool : IAgentTool
         // distinguish "projection caught up" from "projector did not run yet".
         var versionBefore = await queryPort.GetStateVersionAsync(entry.AgentId, ct) ?? -1;
 
+        // Prime the projection scope BEFORE any dispatch. If we primed after
+        // HandleEventAsync, an idle-deactivated projection grain would have
+        // already missed the published event and a late activation could not
+        // recover it (the activation contract is "be alive when the event
+        // arrives", not "replay missed events"). Activating up front costs at
+        // most one extra warm-grain round trip.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
+
         var disableResult = await DispatchAgentLifecycleAsync(entry, actorRuntime, "delete_agent", LifecycleAction.Disable, null, ct);
         if (disableResult.error != null)
             return disableResult.error;
@@ -521,13 +531,13 @@ public sealed class AgentBuilderTool : IAgentTool
             BuildDirectEnvelope(registryActor.Id, new UserAgentCatalogTombstoneCommand { AgentId = entry.AgentId }),
             ct);
 
-        // Mirrors create_agent: ensure the projection scope is active so the actor's
-        // committed tombstone event has a subscribed materializer to translate into a
-        // document delete. Without this priming, an Orleans grain that idle-deactivated
-        // may queue the tombstone with no consumer.
-        await EnsureUserAgentCatalogProjectionAsync(ct);
-
-        var deleted = await WaitForTombstoneReflectedAsync(queryPort, entry.AgentId, versionBefore, ct);
+        var deleted = await WaitForTombstoneReflectedAsync(
+            queryPort,
+            entry.AgentId,
+            versionBefore,
+            ct,
+            _projectionWaitAttempts,
+            _projectionWaitDelayMilliseconds);
 
         var ownerFilter = !string.IsNullOrWhiteSpace(entry.OwnerNyxUserId)
             ? entry.OwnerNyxUserId
@@ -610,6 +620,11 @@ public sealed class AgentBuilderTool : IAgentTool
             string.Equals(entry.value.Status, WorkflowAgentDefaults.StatusDisabled, StringComparison.Ordinal))
             return SerializeAgentStatus(entry.value, "Agent is already disabled.");
 
+        // Prime the projection scope BEFORE dispatch — see DeleteAgentAsync for
+        // the rationale. A late prime can't recover an event the projector
+        // already missed.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
+
         var dispatch = await DispatchAgentLifecycleAsync(entry.value, actorRuntime, "disable_agent", LifecycleAction.Disable, null, ct);
         if (dispatch.error != null)
             return dispatch.error;
@@ -631,6 +646,11 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.Equals(entry.value!.Status, SkillRunnerDefaults.StatusRunning, StringComparison.Ordinal) ||
             string.Equals(entry.value.Status, WorkflowAgentDefaults.StatusRunning, StringComparison.Ordinal))
             return SerializeAgentStatus(entry.value, "Agent is already enabled.");
+
+        // Prime the projection scope BEFORE dispatch — see DeleteAgentAsync for
+        // the rationale. A late prime can't recover an event the projector
+        // already missed.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
 
         var dispatch = await DispatchAgentLifecycleAsync(entry.value, actorRuntime, "enable_agent", LifecycleAction.Enable, null, ct);
         if (dispatch.error != null)
@@ -775,10 +795,6 @@ public sealed class AgentBuilderTool : IAgentTool
         string expectedStatus,
         CancellationToken ct)
     {
-        // Mirrors create_agent: ensure the projection scope is alive so the
-        // actor's committed status event has a subscribed materializer.
-        await EnsureUserAgentCatalogProjectionAsync(ct);
-
         // Status-driven polling (no version anchor): caller dispatches the
         // lifecycle command and we wait for the read model to reflect the
         // expected status. A version-gated optimization here was wrong because
@@ -787,11 +803,14 @@ public sealed class AgentBuilderTool : IAgentTool
         // versionBefore` and burned the entire budget. The Status field itself
         // is the authoritative signal — `expectedStatus` is enum-like and only
         // moves when the lifecycle event materializes, so reading it on every
-        // attempt is both correct and cheap.
-        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
+        // attempt is both correct and cheap. Projection scope priming happens
+        // in the caller before the dispatch (see DisableAgentAsync /
+        // EnableAgentAsync) — a late prime here cannot recover an event the
+        // projector already missed.
+        for (var attempt = 0; attempt < _projectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+                await Task.Delay(_projectionWaitDelayMilliseconds, ct);
 
             var entry = await queryPort.GetAsync(agentId, ct);
             if (entry != null && string.Equals(entry.Status, expectedStatus, StringComparison.Ordinal))
@@ -811,12 +830,14 @@ public sealed class AgentBuilderTool : IAgentTool
         IUserAgentCatalogQueryPort queryPort,
         string agentId,
         long versionBefore,
-        CancellationToken ct)
+        CancellationToken ct,
+        int maxAttempts = ProjectionWaitDefaults.Attempts,
+        int delayMilliseconds = ProjectionWaitDefaults.DelayMilliseconds)
     {
-        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+                await Task.Delay(delayMilliseconds, ct);
 
             // GetStateVersionAsync reads the same document; if it is null the
             // document has been deleted by the projector.

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -17,6 +17,16 @@ namespace Aevatar.GAgents.ChannelRuntime;
 
 public sealed class AgentBuilderTool : IAgentTool
 {
+    // Read-model wait budget for actor -> projector -> document store propagation.
+    // 30 attempts × 500 ms = 15 s. The previous 5 s budget routinely lost the race
+    // to projection lag in production, so /delete-agent and /disable-agent
+    // returned "accepted" while the document was still visible.
+    //
+    // Internal (not const) so tests can shrink the budget when they need to exercise
+    // the "did not reflect within budget" branch without burning the full 15 s.
+    internal static int ProjectionWaitAttempts = 30;
+    internal static int ProjectionWaitDelayMilliseconds = 500;
+
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<AgentBuilderTool>? _logger;
 
@@ -494,6 +504,10 @@ public sealed class AgentBuilderTool : IAgentTool
             });
         }
 
+        // Capture the read-model version before issuing tombstone so the wait can
+        // distinguish "projection caught up" from "projector did not run yet".
+        var versionBefore = await queryPort.GetStateVersionAsync(entry.AgentId, ct) ?? -1;
+
         var disableResult = await DispatchAgentLifecycleAsync(entry, actorRuntime, "delete_agent", LifecycleAction.Disable, null, ct);
         if (disableResult.error != null)
             return disableResult.error;
@@ -507,42 +521,41 @@ public sealed class AgentBuilderTool : IAgentTool
             BuildDirectEnvelope(registryActor.Id, new UserAgentCatalogTombstoneCommand { AgentId = entry.AgentId }),
             ct);
 
-        for (var attempt = 0; attempt < 10; attempt++)
-        {
-            if (attempt > 0)
-                await Task.Delay(500, ct);
+        // Mirrors create_agent: ensure the projection scope is active so the actor's
+        // committed tombstone event has a subscribed materializer to translate into a
+        // document delete. Without this priming, an Orleans grain that idle-deactivated
+        // may queue the tombstone with no consumer.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
 
-            if (await queryPort.GetAsync(entry.AgentId, ct) == null)
-            {
-                var ownerFilter = !string.IsNullOrWhiteSpace(entry.OwnerNyxUserId)
-                    ? entry.OwnerNyxUserId
-                    : await ResolveCurrentUserIdAsync(nyxClient, token, ct);
-                var agents = await QueryAgentsForOwnerAsync(queryPort, ownerFilter, ct);
-                return JsonSerializer.Serialize(new
-                {
-                    status = "deleted",
-                    agent_id = entry.AgentId,
-                    revoked_api_key_id = entry.ApiKeyId,
-                    delete_notice = $"Deleted agent `{entry.AgentId}`. Revoked API key: `{entry.ApiKeyId ?? "n/a"}`.",
-                    agents,
-                    total = agents.Length,
-                });
-            }
-        }
+        var deleted = await WaitForTombstoneReflectedAsync(queryPort, entry.AgentId, versionBefore, ct);
 
-        var acceptedOwnerFilter = !string.IsNullOrWhiteSpace(entry.OwnerNyxUserId)
+        var ownerFilter = !string.IsNullOrWhiteSpace(entry.OwnerNyxUserId)
             ? entry.OwnerNyxUserId
             : await ResolveCurrentUserIdAsync(nyxClient, token, ct);
-        var acceptedAgents = await QueryAgentsForOwnerAsync(queryPort, acceptedOwnerFilter, ct);
+        var agents = await QueryAgentsForOwnerAsync(queryPort, ownerFilter, ct);
+
+        if (deleted)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                status = "deleted",
+                agent_id = entry.AgentId,
+                revoked_api_key_id = entry.ApiKeyId,
+                delete_notice = $"Deleted agent `{entry.AgentId}`. Revoked API key: `{entry.ApiKeyId ?? "n/a"}`.",
+                agents,
+                total = agents.Length,
+            });
+        }
+
         return JsonSerializer.Serialize(new
         {
             status = "accepted",
             agent_id = entry.AgentId,
             revoked_api_key_id = entry.ApiKeyId,
             delete_notice = $"Delete submitted for `{entry.AgentId}`. Revoked API key: `{entry.ApiKeyId ?? "n/a"}`.",
-            agents = acceptedAgents,
-            total = acceptedAgents.Length,
-            note = "Delete was submitted but registry tombstone is not yet reflected.",
+            agents,
+            total = agents.Length,
+            note = "Tombstone is propagating. Run /agents in a few seconds to confirm the agent is gone.",
         });
     }
 
@@ -762,10 +775,22 @@ public sealed class AgentBuilderTool : IAgentTool
         string expectedStatus,
         CancellationToken ct)
     {
-        for (var attempt = 0; attempt < 10; attempt++)
+        // Capture the readmodel version before waiting so we can distinguish "the
+        // expected status hasn't materialized yet" from "the read model is stale".
+        var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+
+        // Mirrors create_agent: ensure the projection scope is alive so the
+        // actor's committed status event has a subscribed materializer.
+        await EnsureUserAgentCatalogProjectionAsync(ct);
+
+        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(500, ct);
+                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+
+            var versionAfter = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+            if (versionAfter <= versionBefore)
+                continue;
 
             var entry = await queryPort.GetAsync(agentId, ct);
             if (entry != null && string.Equals(entry.Status, expectedStatus, StringComparison.Ordinal))
@@ -773,6 +798,43 @@ public sealed class AgentBuilderTool : IAgentTool
         }
 
         return await queryPort.GetAsync(agentId, ct);
+    }
+
+    /// <summary>
+    /// Polls the read model until the agent's tombstoned state is reflected as a
+    /// document deletion. The read-model contract guarantees that a tombstoned
+    /// entry causes <see cref="UserAgentCatalogProjector"/> to dispatch
+    /// <c>DeleteAsync</c>; document absence is therefore the authoritative signal.
+    /// </summary>
+    private static async Task<bool> WaitForTombstoneReflectedAsync(
+        IUserAgentCatalogQueryPort queryPort,
+        string agentId,
+        long versionBefore,
+        CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
+        {
+            if (attempt > 0)
+                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+
+            // GetStateVersionAsync reads the same document; if it is null the
+            // document has been deleted by the projector.
+            var versionAfter = await queryPort.GetStateVersionAsync(agentId, ct);
+            if (versionAfter == null)
+                return true;
+
+            if (versionAfter.Value <= versionBefore)
+                continue;
+
+            // Version advanced (a fresh state event reached the projector) but the
+            // document still exists; if it is the tombstoned entry the projector
+            // would have deleted it on the same advance, so a non-null entry means
+            // either an interleaving upsert or a stale read replica - keep waiting.
+            if (await queryPort.GetAsync(agentId, ct) == null)
+                return true;
+        }
+
+        return false;
     }
 
     private async Task<(bool success, string? error)> DispatchAgentLifecycleAsync(

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentDeliveryTargetTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentDeliveryTargetTool.cs
@@ -13,18 +13,21 @@ namespace Aevatar.GAgents.ChannelRuntime;
 /// </summary>
 public sealed class AgentDeliveryTargetTool : IAgentTool
 {
-    // Read-model wait budget for actor -> projector -> document store propagation.
-    // 30 attempts × 500 ms = 15 s. The previous 5 s budget routinely lost the race
-    // to projection lag in production, so deletes returned "accepted" while the
-    // tombstoned document was still visible.
-    private const int ProjectionWaitAttempts = 30;
-    private const int ProjectionWaitDelayMilliseconds = 500;
-
     private readonly IServiceProvider _serviceProvider;
+    // Per-instance polling budget (see ProjectionWaitDefaults). Tests inject
+    // shrunk values via the constructor to exercise the budget-exhausted
+    // branch without burning the production 15 s.
+    private readonly int _projectionWaitAttempts;
+    private readonly int _projectionWaitDelayMilliseconds;
 
-    public AgentDeliveryTargetTool(IServiceProvider serviceProvider)
+    public AgentDeliveryTargetTool(
+        IServiceProvider serviceProvider,
+        int projectionWaitAttempts = ProjectionWaitDefaults.Attempts,
+        int projectionWaitDelayMilliseconds = ProjectionWaitDefaults.DelayMilliseconds)
     {
         _serviceProvider = serviceProvider;
+        _projectionWaitAttempts = projectionWaitAttempts;
+        _projectionWaitDelayMilliseconds = projectionWaitDelayMilliseconds;
     }
 
     public string Name => "agent_delivery_targets";
@@ -223,10 +226,10 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         await actor.HandleEventAsync(envelope);
 
         var confirmed = false;
-        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
+        for (var attempt = 0; attempt < _projectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+                await Task.Delay(_projectionWaitDelayMilliseconds, ct);
 
             var versionAfter = await queryPort.GetStateVersionAsync(agentId.value!, ct) ?? -1;
             if (versionAfter <= versionBefore)
@@ -330,10 +333,10 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         // delete — the prior absence-only check returned false negatives whenever the
         // 5 s budget lost the race to projection lag.
         var confirmed = false;
-        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
+        for (var attempt = 0; attempt < _projectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+                await Task.Delay(_projectionWaitDelayMilliseconds, ct);
 
             var versionAfter = await queryPort.GetStateVersionAsync(agentId, ct);
             if (versionAfter == null)

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentDeliveryTargetTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentDeliveryTargetTool.cs
@@ -13,6 +13,13 @@ namespace Aevatar.GAgents.ChannelRuntime;
 /// </summary>
 public sealed class AgentDeliveryTargetTool : IAgentTool
 {
+    // Read-model wait budget for actor -> projector -> document store propagation.
+    // 30 attempts × 500 ms = 15 s. The previous 5 s budget routinely lost the race
+    // to projection lag in production, so deletes returned "accepted" while the
+    // tombstoned document was still visible.
+    private const int ProjectionWaitAttempts = 30;
+    private const int ProjectionWaitDelayMilliseconds = 500;
+
     private readonly IServiceProvider _serviceProvider;
 
     public AgentDeliveryTargetTool(IServiceProvider serviceProvider)
@@ -216,10 +223,10 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         await actor.HandleEventAsync(envelope);
 
         var confirmed = false;
-        for (var attempt = 0; attempt < 10; attempt++)
+        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(500, ct);
+                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
 
             var versionAfter = await queryPort.GetStateVersionAsync(agentId.value!, ct) ?? -1;
             if (versionAfter <= versionBefore)
@@ -289,6 +296,15 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             });
         }
 
+        // Capture version + ensure projection scope is alive (matches the Upsert path
+        // above). Without priming, an idle-deactivated projection grain leaves the
+        // tombstone enqueued with no consumer and the document persists indefinitely.
+        var versionBefore = await queryPort.GetStateVersionAsync(agentId, ct) ?? -1;
+
+        var projectionPort = _serviceProvider.GetService<UserAgentCatalogProjectionPort>();
+        if (projectionPort != null)
+            await projectionPort.EnsureProjectionForActorAsync(UserAgentCatalogGAgent.WellKnownId, ct);
+
         var actor = await actorRuntime.GetAsync(UserAgentCatalogGAgent.WellKnownId)
                     ?? await actorRuntime.CreateAsync<UserAgentCatalogGAgent>(UserAgentCatalogGAgent.WellKnownId);
 
@@ -310,12 +326,24 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
 
         // Tombstone triggers IProjectionWriteDispatcher.DeleteAsync (Channel RFC §7.1.1),
         // which also removes the document's projected StateVersion. Gate confirmation
-        // purely on document absence — versionAfter would be null after the delete lands.
+        // on either document absence or a state-version advance that materializes the
+        // delete — the prior absence-only check returned false negatives whenever the
+        // 5 s budget lost the race to projection lag.
         var confirmed = false;
-        for (var attempt = 0; attempt < 10; attempt++)
+        for (var attempt = 0; attempt < ProjectionWaitAttempts; attempt++)
         {
             if (attempt > 0)
-                await Task.Delay(500, ct);
+                await Task.Delay(ProjectionWaitDelayMilliseconds, ct);
+
+            var versionAfter = await queryPort.GetStateVersionAsync(agentId, ct);
+            if (versionAfter == null)
+            {
+                confirmed = true;
+                break;
+            }
+
+            if (versionAfter.Value <= versionBefore)
+                continue;
 
             if (await queryPort.GetAsync(agentId, ct) == null)
             {
@@ -329,7 +357,7 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             status = confirmed ? "deleted" : "accepted",
             agent_id = agentId,
             delivery_target_id = agentId,
-            note = confirmed ? "" : "Delete submitted but projection not yet confirmed. Try 'list' after a few seconds.",
+            note = confirmed ? "" : "Tombstone is propagating. Try 'list' in a few seconds to confirm the delivery target is gone.",
         });
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ProjectionWaitDefaults.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ProjectionWaitDefaults.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.GAgents.ChannelRuntime;
+
+/// <summary>
+/// Shared default polling budget for tools that wait on the read model after
+/// dispatching a write to the user agent catalog actor. 30 attempts × 500 ms
+/// = 15 s — covers the production projection lag the prior 5 s budget lost to.
+/// </summary>
+internal static class ProjectionWaitDefaults
+{
+    public const int Attempts = 30;
+    public const int DelayMilliseconds = 500;
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1665,17 +1665,27 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_DisableAgent_ReturnsStatusFast_WhenProjectionUpdatedBeforeBaselineRead()
+    public async Task ExecuteAsync_DisableAgent_ReturnsStatusFast_WhenProjectionAdvancesOnFirstPoll()
     {
-        // Regression guard for PR #413 codex review (P2): an earlier iteration
-        // gated `GetAsync` on `GetStateVersionAsync` strictly advancing past
-        // a captured baseline. Because `WaitForAgentStatusAsync` runs *after*
-        // dispatch, a fast Local actor + projection could land the new
-        // status before the baseline read, so `versionAfter == versionBefore`
-        // and the loop burned the entire 15 s budget despite the read model
-        // already being correct. This pins the version-anchor-free behavior:
-        // if the read model surfaces the expected status on the first poll,
-        // we return immediately regardless of whether the version moved.
+        // Pins the new version+status dual-gate fast-exit contract: when the
+        // caller-captured baseline is X and the read model advances to X+1
+        // with status==expected on the very first post-dispatch poll, the
+        // wait helper must exit immediately (<1 s) instead of running the
+        // full 15 s budget. This guards against two regressions:
+        //
+        //  1. Re-introducing a status-only check (codex P3 in this PR's
+        //     thread): would accept a stale replica that already happens to
+        //     hold the expected historical status, returning before the
+        //     dispatch is actually materialized.
+        //
+        //  2. Re-introducing the *helper-side* baseline capture (codex P2 in
+        //     PR #413's first review pass): would capture versionBefore
+        //     after dispatch, so a fast projection that already advanced
+        //     the version would make versionAfter == versionBefore on every
+        //     poll and burn the full budget.
+        //
+        // Both regressions make this test fail (case 1 by accepting before
+        // the dispatch, case 2 by deadlocking past the 1 s ceiling).
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
         queryPort.GetAsync("skill-runner-fast", Arg.Any<CancellationToken>())
             .Returns(
@@ -1687,9 +1697,7 @@ public sealed class AgentBuilderToolTests
                     TemplateName = "daily_report",
                     Status = SkillRunnerDefaults.StatusRunning,
                 }),
-                // Wait helper's first poll already sees the disabled status because the
-                // projection raced ahead of the baseline read. With the version gate this
-                // test would burn the full 15 s; the gate-free wait must finish in <100 ms.
+                // Wait helper's first poll sees the materialized disable.
                 Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
                 {
                     AgentId = "skill-runner-fast",
@@ -1697,11 +1705,13 @@ public sealed class AgentBuilderToolTests
                     TemplateName = "daily_report",
                     Status = SkillRunnerDefaults.StatusDisabled,
                 }));
-        // Pin the codex scenario: state version stays flat across polls. If we
-        // ever re-introduce a version gate the test would deadlock and fail
-        // the suite timeout.
+        // Caller's pre-dispatch baseline read returns 42; helper's post-
+        // dispatch poll sees 43 (the projection materialized the disable on
+        // the very next state event). Both checks pass on the first iteration.
         queryPort.GetStateVersionAsync("skill-runner-fast", Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<long?>(42L));
+            .Returns(
+                Task.FromResult<long?>(42L),
+                Task.FromResult<long?>(43L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-fast");
@@ -1736,10 +1746,100 @@ public sealed class AgentBuilderToolTests
 
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusDisabled);
-            // 1 s ceiling: a regression that re-introduces the version gate
-            // would make the wait loop burn the full ProjectionWaitAttempts ×
+            // 1 s ceiling: any regression that prevents a dual-gate first-poll
+            // exit would burn the full ProjectionWaitAttempts ×
             // ProjectionWaitDelayMilliseconds budget (15 s by default).
             stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DisableAgent_KeepsWaitingWhenStatusMatchesButVersionStale()
+    {
+        // Stale-replica defense: a read replica can surface a historically
+        // expected status (e.g., a previous disable→enable→disable cycle
+        // left the entry's last-projected status as Disabled in some replica)
+        // while the current actor has not yet processed *this* dispatch.
+        // Status-only polling would accept this replica and return prematurely
+        // before the dispatch materializes. The dual gate keeps waiting
+        // until version advances.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetAsync("skill-runner-stale", Arg.Any<CancellationToken>())
+            .Returns(
+                // RequireManagedAgentAsync sees the canonical Running state
+                // because that is what the caller observed when issuing the
+                // disable. (A different replica surfaces stale Disabled below.)
+                Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+                {
+                    AgentId = "skill-runner-stale",
+                    AgentType = SkillRunnerDefaults.AgentType,
+                    TemplateName = "daily_report",
+                    Status = SkillRunnerDefaults.StatusRunning,
+                }),
+                // Helper's terminal fallback (after budget exhausts) returns
+                // a stale-but-expected-looking Disabled. With status-only
+                // polling the wait would have returned this entry on the
+                // first iteration. With the dual gate the version stays at
+                // baseline, so the version check short-circuits before the
+                // status check is even reached.
+                Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+                {
+                    AgentId = "skill-runner-stale",
+                    AgentType = SkillRunnerDefaults.AgentType,
+                    TemplateName = "daily_report",
+                    Status = SkillRunnerDefaults.StatusDisabled,
+                }));
+        // Caller baseline = 7; replica's view never advances past 7. Helper
+        // must keep iterating; we shrink the budget so the test finishes fast.
+        queryPort.GetStateVersionAsync("skill-runner-stale", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(7L));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-stale");
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-stale").Returns(Task.FromResult<IActor?>(skillRunnerActor));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(new RoutingJsonHandler())
+            {
+                BaseAddress = new Uri("https://nyx.example.com"),
+            }));
+        // Shrunk budget so the version-stale path finishes in <100 ms.
+        var tool = new AgentBuilderTool(
+            services.BuildServiceProvider(),
+            projectionWaitAttempts: 3,
+            projectionWaitDelayMilliseconds: 1);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "disable_agent",
+                  "agent_id": "skill-runner-stale"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            // The crucial assertion is that the helper exhausted the
+            // injected 3-attempt budget instead of returning on the first
+            // status match: 1 caller baseline + 3 helper iterations =
+            // 4 calls. With status-only polling the helper would have
+            // returned on iteration 0 without ever calling
+            // GetStateVersionAsync, so total would be 1. Tightly coupled to
+            // the injected budget by design — that is what pins the contract.
+            await queryPort.Received(4).GetStateVersionAsync("skill-runner-stale", Arg.Any<CancellationToken>());
         }
         finally
         {
@@ -1771,6 +1871,12 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
+        // Caller's pre-dispatch baseline read returns 5; helper's post-dispatch
+        // poll sees 6, satisfying the new version+status dual gate.
+        queryPort.GetStateVersionAsync("skill-runner-1", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<long?>(5L),
+                Task.FromResult<long?>(6L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-1");
@@ -1843,6 +1949,12 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
+        // Caller's pre-dispatch baseline read returns 5; helper's post-dispatch
+        // poll sees 6, satisfying the new version+status dual gate.
+        queryPort.GetStateVersionAsync("skill-runner-1", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<long?>(5L),
+                Task.FromResult<long?>(6L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-1");
@@ -1915,6 +2027,12 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
+        // Caller's pre-dispatch baseline read returns 5; helper's post-dispatch
+        // poll sees 6, satisfying the new version+status dual gate.
+        queryPort.GetStateVersionAsync("workflow-agent-1", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<long?>(5L),
+                Task.FromResult<long?>(6L));
 
         var workflowAgentActor = Substitute.For<IActor>();
         workflowAgentActor.Id.Returns("workflow-agent-1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1395,6 +1395,103 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_DeleteAgent_ReturnsAcceptedWithPropagatingHint_WhenTombstoneDoesNotReflectWithinBudget()
+    {
+        // Production bug class: with the old 5 s polling budget, /delete-agent
+        // routinely returned "accepted" + "tombstone is not yet reflected" while
+        // the document was still visible to /agents minutes later. This guard
+        // proves that when the read model legitimately stays behind, the user-
+        // facing payload now nudges the user to retry rather than implying the
+        // delete might not have landed at all.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetAsync("skill-runner-stuck", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-stuck",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                ApiKeyId = "key-stuck",
+                OwnerNyxUserId = "user-1",
+            }));
+        // Read-model lags forever in this test: GetStateVersionAsync keeps
+        // returning the same version (the projector never advances past it),
+        // and GetAsync keeps surfacing the entry.
+        queryPort.GetStateVersionAsync("skill-runner-stuck", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(7L));
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogEntry>>(
+                [new UserAgentCatalogEntry { AgentId = "skill-runner-stuck", OwnerNyxUserId = "user-1" }]));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-stuck");
+        var registryActor = Substitute.For<IActor>();
+        registryActor.Id.Returns(UserAgentCatalogGAgent.WellKnownId);
+
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-stuck").Returns(Task.FromResult<IActor?>(skillRunnerActor));
+        actorRuntime.GetAsync(UserAgentCatalogGAgent.WellKnownId).Returns(Task.FromResult<IActor?>(registryActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Delete, "/api/v1/api-keys/key-stuck", """{"ok":true}""");
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        // Shrink the polling budget so the not-reflected branch fires in <100 ms
+        // instead of the production 15 s. Reset in finally so other tests in the
+        // class still see the production constants.
+        var originalAttempts = AgentBuilderTool.ProjectionWaitAttempts;
+        var originalDelay = AgentBuilderTool.ProjectionWaitDelayMilliseconds;
+        AgentBuilderTool.ProjectionWaitAttempts = 3;
+        AgentBuilderTool.ProjectionWaitDelayMilliseconds = 1;
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "delete_agent",
+                  "agent_id": "skill-runner-stuck",
+                  "confirm": true
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            doc.RootElement.GetProperty("revoked_api_key_id").GetString().Should().Be("key-stuck");
+            doc.RootElement.GetProperty("delete_notice").GetString()
+                .Should().Contain("Delete submitted for");
+            // The new copy must point users at /agents to verify rather than
+            // implying the tombstone did not land.
+            doc.RootElement.GetProperty("note").GetString()
+                .Should().Contain("propagating")
+                .And.Contain("/agents");
+
+            await registryActor.Received(1).HandleEventAsync(
+                Arg.Is<EventEnvelope>(e =>
+                    e.Payload != null &&
+                    e.Payload.Is(UserAgentCatalogTombstoneCommand.Descriptor) &&
+                    e.Payload.Unpack<UserAgentCatalogTombstoneCommand>().AgentId == "skill-runner-stuck"),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentBuilderTool.ProjectionWaitAttempts = originalAttempts;
+            AgentBuilderTool.ProjectionWaitDelayMilliseconds = originalDelay;
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RunAgent_DispatchesManualTrigger()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
@@ -1592,6 +1689,14 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
+        // The status wait now skips polls until the read-model state version
+        // advances past versionBefore. Returning a fresh version on the second
+        // call keeps the test exercising the success path without burning the
+        // full 15 s polling budget.
+        queryPort.GetStateVersionAsync("skill-runner-1", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<long?>(7L),
+                Task.FromResult<long?>(8L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-1");
@@ -1664,6 +1769,12 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
+        // See DisableAgent test — advance the version on the second poll so
+        // the wait helper escapes the loop quickly instead of timing out.
+        queryPort.GetStateVersionAsync("skill-runner-1", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<long?>(7L),
+                Task.FromResult<long?>(8L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-1");
@@ -1736,6 +1847,13 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
+        // Advance the version on the second poll so the wait helper exits
+        // immediately on the disabled status — keeps the test under the
+        // production polling budget.
+        queryPort.GetStateVersionAsync("workflow-agent-1", Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<long?>(7L),
+                Task.FromResult<long?>(8L));
 
         var workflowAgentActor = Substitute.For<IActor>();
         workflowAgentActor.Id.Returns("workflow-agent-1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1666,6 +1666,89 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_DisableAgent_ReturnsStatusFast_WhenProjectionUpdatedBeforeBaselineRead()
+    {
+        // Regression guard for PR #413 codex review (P2): an earlier iteration
+        // gated `GetAsync` on `GetStateVersionAsync` strictly advancing past
+        // a captured baseline. Because `WaitForAgentStatusAsync` runs *after*
+        // dispatch, a fast Local actor + projection could land the new
+        // status before the baseline read, so `versionAfter == versionBefore`
+        // and the loop burned the entire 15 s budget despite the read model
+        // already being correct. This pins the version-anchor-free behavior:
+        // if the read model surfaces the expected status on the first poll,
+        // we return immediately regardless of whether the version moved.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetAsync("skill-runner-fast", Arg.Any<CancellationToken>())
+            .Returns(
+                // RequireManagedAgentAsync's existence check sees the pre-disable status.
+                Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+                {
+                    AgentId = "skill-runner-fast",
+                    AgentType = SkillRunnerDefaults.AgentType,
+                    TemplateName = "daily_report",
+                    Status = SkillRunnerDefaults.StatusRunning,
+                }),
+                // Wait helper's first poll already sees the disabled status because the
+                // projection raced ahead of the baseline read. With the version gate this
+                // test would burn the full 15 s; the gate-free wait must finish in <100 ms.
+                Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+                {
+                    AgentId = "skill-runner-fast",
+                    AgentType = SkillRunnerDefaults.AgentType,
+                    TemplateName = "daily_report",
+                    Status = SkillRunnerDefaults.StatusDisabled,
+                }));
+        // Pin the codex scenario: state version stays flat across polls. If we
+        // ever re-introduce a version gate the test would deadlock and fail
+        // the suite timeout.
+        queryPort.GetStateVersionAsync("skill-runner-fast", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(42L));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-fast");
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-fast").Returns(Task.FromResult<IActor?>(skillRunnerActor));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(new RoutingJsonHandler())
+            {
+                BaseAddress = new Uri("https://nyx.example.com"),
+            }));
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "disable_agent",
+                  "agent_id": "skill-runner-fast"
+                }
+                """);
+            stopwatch.Stop();
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusDisabled);
+            // 1 s ceiling: a regression that re-introduces the version gate
+            // would make the wait loop burn the full ProjectionWaitAttempts ×
+            // ProjectionWaitDelayMilliseconds budget (15 s by default).
+            stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_DisableAgent_DispatchesDisableAndReturnsStatus()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
@@ -1689,14 +1772,6 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
-        // The status wait now skips polls until the read-model state version
-        // advances past versionBefore. Returning a fresh version on the second
-        // call keeps the test exercising the success path without burning the
-        // full 15 s polling budget.
-        queryPort.GetStateVersionAsync("skill-runner-1", Arg.Any<CancellationToken>())
-            .Returns(
-                Task.FromResult<long?>(7L),
-                Task.FromResult<long?>(8L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-1");
@@ -1769,12 +1844,6 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
-        // See DisableAgent test — advance the version on the second poll so
-        // the wait helper escapes the loop quickly instead of timing out.
-        queryPort.GetStateVersionAsync("skill-runner-1", Arg.Any<CancellationToken>())
-            .Returns(
-                Task.FromResult<long?>(7L),
-                Task.FromResult<long?>(8L));
 
         var skillRunnerActor = Substitute.For<IActor>();
         skillRunnerActor.Id.Returns("skill-runner-1");
@@ -1847,13 +1916,6 @@ public sealed class AgentBuilderToolTests
                     ScheduleCron = "0 9 * * *",
                     ScheduleTimezone = "UTC",
                 }));
-        // Advance the version on the second poll so the wait helper exits
-        // immediately on the disabled status — keeps the test under the
-        // production polling budget.
-        queryPort.GetStateVersionAsync("workflow-agent-1", Arg.Any<CancellationToken>())
-            .Returns(
-                Task.FromResult<long?>(7L),
-                Task.FromResult<long?>(8L));
 
         var workflowAgentActor = Substitute.For<IActor>();
         workflowAgentActor.Id.Returns("workflow-agent-1");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1946,14 +1946,30 @@ public sealed class AgentBuilderToolTests
                 """);
 
             using var doc = JsonDocument.Parse(result);
-            // The crucial assertion is that the helper exhausted the
-            // injected 3-attempt budget instead of returning on the first
-            // status match: 1 caller baseline + 3 helper iterations =
-            // 4 calls. With status-only polling the helper would have
-            // returned on iteration 0 without ever calling
-            // GetStateVersionAsync, so total would be 1. Tightly coupled to
-            // the injected budget by design — that is what pins the contract.
+
+            // Path-level assertion: the helper exhausted the injected
+            // 3-attempt budget instead of returning on the first status
+            // match: 1 caller baseline + 3 helper iterations = 4 calls.
+            // With status-only polling the helper would have returned on
+            // iteration 0 without ever calling GetStateVersionAsync, so
+            // total would be 1. Tightly coupled to the injected budget by
+            // design — that is what pins the contract.
             await queryPort.Received(4).GetStateVersionAsync("skill-runner-stale", Arg.Any<CancellationToken>());
+
+            // Outcome-level assertion: when the dual gate never passes, the
+            // user-facing payload must NOT claim success. The wait helper
+            // returns Confirmed=false (no un-gated GetAsync fallback), and
+            // DisableAgentAsync surfaces the pre-dispatch entry plus an
+            // honest "submitted / propagating" note. A regression that
+            // re-introduces the un-gated final read OR drops the
+            // confirmed/unconfirmed branching makes this test fail by
+            // surfacing "Scheduling paused" + status=Disabled despite the
+            // dual gate having been violated.
+            doc.RootElement.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusRunning);
+            var note = doc.RootElement.GetProperty("note").GetString();
+            note.Should().Contain("Disable submitted")
+                .And.Contain("/agent-status")
+                .And.NotContain("Scheduling paused");
         }
         finally
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1441,15 +1441,16 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(actorRuntime);
         services.AddSingleton(nyxClient);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
-
-        // Shrink the polling budget so the not-reflected branch fires in <100 ms
-        // instead of the production 15 s. Reset in finally so other tests in the
-        // class still see the production constants.
-        var originalAttempts = AgentBuilderTool.ProjectionWaitAttempts;
-        var originalDelay = AgentBuilderTool.ProjectionWaitDelayMilliseconds;
-        AgentBuilderTool.ProjectionWaitAttempts = 3;
-        AgentBuilderTool.ProjectionWaitDelayMilliseconds = 1;
+        // Inject a shrunk wait budget per-instance (3 attempts × 1 ms) so the
+        // not-reflected branch fires in <100 ms instead of the production
+        // 15 s. Per-instance state replaces the earlier mutable-static
+        // approach (codex review r3141706856) so concurrent test classes
+        // that exercise other AgentBuilderTool paths cannot be poisoned by
+        // shrunk values leaking through process-global state.
+        var tool = new AgentBuilderTool(
+            services.BuildServiceProvider(),
+            projectionWaitAttempts: 3,
+            projectionWaitDelayMilliseconds: 1);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -1485,8 +1486,6 @@ public sealed class AgentBuilderToolTests
         }
         finally
         {
-            AgentBuilderTool.ProjectionWaitAttempts = originalAttempts;
-            AgentBuilderTool.ProjectionWaitDelayMilliseconds = originalDelay;
             AgentToolRequestContext.CurrentMetadata = null;
         }
     }


### PR DESCRIPTION
## Summary
- Lark `/delete-agent <id> confirm` was returning "Delete submitted but registry tombstone is not yet reflected" and leaving the agent visible in `/agents`. Three compounding causes, all fixed.
- Same fix lifts `/disable-agent`, `/enable-agent`, and `AgentDeliveryTargetTool` upsert/delete onto a 15 s, projection-primed wait.

## Root cause

| # | Cause | Effect |
|---|---|---|
| 1 | Polling budget = 10 × 500 ms = 5 s | Below the 95th percentile of production projection lag; tool fell through to "accepted" while the document was still materializing. |
| 2 | Projection scope grain not guaranteed alive at dispatch time | If the Orleans projection scope grain idle-deactivated, the actor's `CommittedStateEventPublished` for the tombstone landed in the stream with **no subscribed materializer** — `DeleteAsync` was never called and the document persisted indefinitely. The activation contract is "be alive when the event arrives", not "replay missed events", so a *late* prime cannot recover an event the projector already missed. `delete_agent` did no priming at all; existing `create_agent` primed *after* dispatch (same race, narrower window). |
| 3 | Polling was absence-only, no version anchor | Any stale-replica read counted as "still present" and consumed a poll attempt without progress. |

`OrleansActor.HandleEventAsync` is fire-and-forget (`return _streams.GetStream(Id).ProduceAsync(envelope, ct)`) — `await` only signals "envelope queued", not "handler ran". So the post-dispatch wait must be defensive.

## Fix

- `agents/Aevatar.GAgents.ChannelRuntime/ProjectionWaitDefaults.cs` (new)
  - Shared `internal static class` with `Attempts = 30` / `DelayMilliseconds = 500` (15 s budget). Used as default values for constructor parameters in both tools below; tests inject shrunk values per-instance via the constructor instead of mutating process-global state.
- `agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs`
  - Per-instance `_projectionWaitAttempts` / `_projectionWaitDelayMilliseconds` readonly fields populated from constructor parameters (defaulted to `ProjectionWaitDefaults`).
  - `DeleteAgentAsync` now: capture `versionBefore` → `EnsureUserAgentCatalogProjectionAsync` → dispatch disable to skill-runner → revoke API key → dispatch tombstone to registry → `WaitForTombstoneReflectedAsync` (version-aware, exits early on document deletion). **Priming runs before every dispatch** so the projection scope is alive when the actor publishes; a late prime cannot recover a missed event.
  - `DisableAgentAsync` / `EnableAgentAsync` now also prime *before* dispatch (previously relied on `WaitForAgentStatusAsync`'s late prime, which was a no-op for the missed-event case).
  - `WaitForAgentStatusAsync` is now version+status dual-gated (mirrors `WaitForCreatedAgentAsync`) and returns `(bool Confirmed, UserAgentCatalogEntry? Entry)`: the caller captures `versionBefore` *before* dispatch and the helper waits for `StateVersion > versionBefore && Status == expected`. When the budget exhausts the helper returns `(Confirmed: false, Entry: null)` — **no un-gated terminal `GetAsync` fallback** that would surface a stale-but-expected-looking entry and let callers report success despite the contract not being satisfied. Both halves of the gate matter: status alone admits stale replicas that surface a historically expected status (e.g., from a prior disable→enable→disable cycle) before this dispatch materializes; version alone admits unrelated state events that advance the version without changing status. An earlier iteration captured `versionBefore` *inside* the helper after dispatch, which let a fast projection make `versionAfter == versionBefore` and burned the budget — that's why capture must happen before dispatch.
  - `DisableAgentAsync` / `EnableAgentAsync` branch on `observation.Confirmed`: confirmed → success copy (`"Agent disabled. Scheduling paused."` / `"Agent enabled. Scheduling resumed."`) with the projector-observed entry; unconfirmed → surface the *pre-dispatch* entry (preserving the original status field) plus an honest propagating note (`"Disable submitted. Run /agent-status in a few seconds to confirm the agent is paused."`), symmetric with `DeleteAgentAsync`'s `deleted` vs `accepted` / `"Tombstone is propagating"` pattern.
  - Fallback copy when budget exhausts: `"Tombstone is propagating. Run /agents in a few seconds to confirm the agent is gone."` (no longer suggests the dispatch may not have landed).
- `agents/Aevatar.GAgents.ChannelRuntime/AgentDeliveryTargetTool.cs`
  - Same per-instance constructor-injected budget (replaces the previous `private const`, which prevented tests from exercising the budget-exhausted branch).
  - `DeleteAsync` mirrors the `AgentBuilderTool` pattern (prime-before-dispatch + version-aware tombstone wait + 15 s). `UpsertAsync` picks up the longer budget through the same fields.

## Other slash commands reviewed

| Command | Status |
|---|---|
| `/agents`, `/agent-status`, `/templates` | Pure reads, no actor dispatch — unaffected. |
| `/run-agent` | Fire-and-forget by design (user follows up with `/agent-status`); no polling, no race. |
| `/disable-agent`, `/enable-agent` | Same root cause — fixed via prime-before-dispatch + dual-gated (`StateVersion > versionBefore && Status == expected`) `WaitForAgentStatusAsync`. |
| `/daily`, `/social-media` (→ create_agent) | Now also primes *before* dispatch (was post-dispatch — same race-class as the original delete bug). Wait helper continues to use the existing 5 s budget; if create surfaces the budget-exhausted symptom in the future, switching the helper defaults to `ProjectionWaitDefaults` is a one-liner. |
| `agent_delivery_targets` upsert / delete | Fixed (constructor-injected budget + prime-before-dispatch on both upsert and delete). List is read-only. |

## Test plan

- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — 417 / 417 pass in ~6 s
- [x] `bash tools/ci/test_stability_guards.sh` — passed
- [x] `bash tools/ci/query_projection_priming_guard.sh` — passed
- [x] `bash tools/ci/projection_route_mapping_guard.sh` — passed
- [x] `bash tools/ci/projection_state_version_guard.sh` — passed
- [x] `bash tools/ci/projection_state_mirror_current_state_guard.sh` — passed
- [x] `ExecuteAsync_DeleteAgent_ReturnsAcceptedWithPropagatingHint_WhenTombstoneDoesNotReflectWithinBudget` covers the fallback branch by injecting a shrunk wait budget through the constructor (`projectionWaitAttempts: 3, projectionWaitDelayMilliseconds: 1`) and asserts the new copy is shown — no process-global mutation, no try/finally reset.
- [x] `ExecuteAsync_DisableAgent_ReturnsStatusFast_WhenProjectionAdvancesOnFirstPoll` pins the dual-gate first-poll exit (`versionBefore=42`, helper poll sees `versionAfter=43 && Status==Disabled` → return immediately, < 1 s). A regression that re-introduces status-only polling or moves the version capture back inside the helper makes this test fail.
- [x] `ExecuteAsync_DisableAgent_KeepsWaitingWhenStatusMatchesButVersionStale`: stale-replica defense with both path-level and outcome-level assertions. Path: `GetStateVersionAsync` is called exactly 4 times (1 caller baseline + 3 helper polls). Outcome: when the dual gate never passes, the user-facing payload must surface `status=Running` (the pre-dispatch value) and a propagating note (`"Disable submitted"` + `"/agent-status"`) — never `"Scheduling paused"`. A regression that re-introduces the un-gated terminal `GetAsync` OR drops the `Confirmed/Entry` branching makes this test fail.
- [x] Existing disable / enable / workflow-disable tests now mock `GetStateVersionAsync` to return the caller-side baseline `5L` then advance to `6L` on the helper poll — exercising the dual-gate fast-exit (suite recovers from ~50 s → ~6 s).
- [ ] After merge: regression-verify on aevatar.eanzhao.com by recreating + deleting a skill-runner via Lark and confirming `/agents` reflects the delete within ~15 s.

## Review-driven changes

- `948cba58` — drop the *helper-side* version gate from `WaitForAgentStatusAsync` (codex P2: `versionBefore` captured after dispatch let a fast projection burn the full budget). Replaced again in `062f4728` with a *caller-side* version gate that does not have this race.
- `5183b0c5` — move priming *before* every dispatch (delete / disable / enable); switch shared budget from mutable static to constructor-injected per-instance readonly fields; extract `ProjectionWaitDefaults`.
- `062f4728` — prime *before* `create_agent` dispatches as well (daily report + social media — same race-class as the originally fixed delete path); add caller-side `versionBefore` capture for `disable_agent` / `enable_agent` and dual-gate `WaitForAgentStatusAsync` on `StateVersion > versionBefore && Status == expected` (defends against stale read replicas surfacing a historically expected status).
- `be4292d0` — **(this commit)** close the dual-gate bypass: `WaitForAgentStatusAsync`'s terminal fallback used to do an un-gated `GetAsync` and callers used `?? entry.value` + unconditional success copy, so stale replicas could still produce `"Scheduling paused"` despite the dual gate having been violated. Helper now returns `(Confirmed, Entry)`; callers branch on `Confirmed` and surface honest "submitted / propagating" copy when the gate never passes. The new test for stale-replica defense gained an outcome-level assertion that was missing in `062f4728`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


