### PR TITLE
fix(agent-builder): use UserService.id for api-key allowed_service_ids (#417)

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -226,8 +226,8 @@ public sealed class AgentBuilderTool : IAgentTool
 
         var providerSlug = (args.Str("nyx_provider_slug") ?? "api-lark-bot").Trim();
         var requiredServiceIds = await ResolveProxyServiceIdsAsync(nyxClient, token, templateSpec!.RequiredServiceSlugs, ct);
-        if (requiredServiceIds.error != null)
-            return JsonSerializer.Serialize(new { error = requiredServiceIds.error });
+        if (requiredServiceIds.errorJson != null)
+            return requiredServiceIds.errorJson;
 
         var agentId = string.IsNullOrWhiteSpace(args.Str("agent_id"))
             ? SkillRunnerDefaults.GenerateActorId()
@@ -244,21 +244,16 @@ public sealed class AgentBuilderTool : IAgentTool
         if (!TryParseApiKeyCreateResponse(createKeyResponse, out var apiKeyId, out var apiKeyValue, out var apiKeyError))
             return JsonSerializer.Serialize(new { error = apiKeyError });
 
-        // Issue #411: the new agent API key is allowed_service_ids=api-github but might lack a
-        // bound GitHub credential, in which case every scheduled run hits 401/403 from
-        // proxy/s/api-github and the user sees no useful daily report. Preflight a safe
-        // GitHub endpoint with the freshly minted key and fail the create with an actionable
-        // error rather than persisting an agent that will never produce a usable report.
-        //
-        // Reviewer (PR #412 r3141699756): on the fail-fast path the freshly created NyxID API
-        // key would be left behind — repeated `/daily` attempts that hit GitHub preflight
-        // accumulate orphan proxy keys. Best-effort revoke before returning.
+        // Issue aevatarAI/aevatar#411 / #417 follow-up: catch in-flight GitHub OAuth revocation.
+        // The earlier `BuildGitHubAuthorizationResponseAsync` check covers the "no provider token
+        // at all" case; this preflight only earns its keep when the OAuth grant was revoked or
+        // had its scopes downgraded between connect-time and create-time. The api-key itself is
+        // healthy at this point (`#417` fixed `allowed_service_ids` to carry per-user
+        // `UserService.id`s), so we do NOT revoke it on preflight failure — the failure mode is
+        // upstream GitHub denying the stored credential, not a malformed proxy scope.
         var preflight = await PreflightGitHubProxyAsync(nyxClient, apiKeyValue!, providerSlug, ct);
         if (preflight is not null)
-        {
-            await BestEffortRevokeApiKeyAsync(nyxClient, token, apiKeyId!, "github_preflight_failed", ct);
             return preflight;
-        }
 
         var actor = await actorRuntime.GetAsync(agentId)
                     ?? await actorRuntime.CreateAsync<SkillRunnerGAgent>(agentId, ct);
@@ -373,8 +368,8 @@ public sealed class AgentBuilderTool : IAgentTool
 
         var providerSlug = (args.Str("nyx_provider_slug") ?? "api-lark-bot").Trim();
         var requiredServiceIds = await ResolveProxyServiceIdsAsync(nyxClient, token, [providerSlug], ct);
-        if (requiredServiceIds.error != null)
-            return JsonSerializer.Serialize(new { error = requiredServiceIds.error });
+        if (requiredServiceIds.errorJson != null)
+            return requiredServiceIds.errorJson;
 
         var agentId = string.IsNullOrWhiteSpace(args.Str("agent_id"))
             ? WorkflowAgentDefaults.GenerateActorId()
@@ -998,55 +993,151 @@ public sealed class AgentBuilderTool : IAgentTool
         }
     }
 
-    private async Task<(IReadOnlyList<string>? value, string? error)> ResolveProxyServiceIdsAsync(
+    /// <summary>
+    /// Resolves the per-user <c>UserService.id</c> values that the new agent's API key needs in
+    /// <c>allowed_service_ids</c> to reach each required catalog slug through the NyxID proxy.
+    /// </summary>
+    /// <remarks>
+    /// <para>Issue aevatarAI/aevatar#417. The previous implementation called
+    /// <c>GET /api/v1/proxy/services</c> (the <em>catalog</em> list) and pulled out each row's
+    /// <c>id</c>, which is a <c>DownstreamService.id</c> — a global catalog UUID shared across
+    /// all users. NyxID's proxy enforcement (<c>backend/src/handlers/proxy.rs:1030</c>) checks the
+    /// API key's <c>allowed_service_ids</c> against the per-user <c>UserService.id</c>, not the
+    /// catalog id. The mismatch silently passed at <c>POST /api-keys</c> creation time, then
+    /// surfaced as <c>403 ApiKeyScopeForbidden</c> on every proxy call.</para>
+    /// <para>Why the old code looked correct in development: <c>allow_all_services=true</c>
+    /// short-circuits the enforcement check. Session-token-minted API keys default to
+    /// <c>allow_all_services=true</c>, so a developer reproducing the create-key + proxy-call
+    /// dance from a CLI never tripped the bug. The agent path mints child keys via the
+    /// channel-relay delegation token; NyxID forces those children to inherit
+    /// <c>allow_all_services=false</c> from the parent, which is when enforcement kicks in.</para>
+    /// <para>The fix: use <c>GET /api/v1/user-services</c>, which lists this user's
+    /// <c>UserService</c> instances. For each instance the response carries the per-user
+    /// <c>id</c> (what enforcement actually checks) plus <c>slug</c>, <c>is_active</c>, and a
+    /// <c>credential_source</c> envelope. We filter to active rows whose slug matches a required
+    /// slug, and skip org-shared rows the caller cannot use as a proxy target — those would later
+    /// surface as a less-actionable <c>org_role_insufficient</c> error.</para>
+    /// </remarks>
+    private async Task<(IReadOnlyList<string>? value, string? errorJson)> ResolveProxyServiceIdsAsync(
         NyxIdApiClient client,
         string token,
         IReadOnlyList<string> requiredSlugs,
         CancellationToken ct)
     {
         if (requiredSlugs.Count == 0)
-            return (null, "At least one required Nyx proxy service slug must be provided.");
+        {
+            return (null, JsonSerializer.Serialize(new
+            {
+                error = "no_required_slugs",
+                hint = "At least one required Nyx proxy service slug must be provided.",
+            }));
+        }
 
-        var response = await client.DiscoverProxyServicesAsync(token, ct);
+        var response = await client.ListUserServicesAsync(token, ct);
         if (IsErrorPayload(response))
-            return (null, "Could not discover required Nyx proxy services.");
+        {
+            return (null, JsonSerializer.Serialize(new
+            {
+                error = "user_services_unavailable",
+                hint = "Could not list connected Nyx user-services. Try again or check NyxID availability.",
+            }));
+        }
 
         try
         {
             using var doc = JsonDocument.Parse(response);
-            var serviceIdsBySlug = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            // List response shape: { "services": [ {id, slug, is_active, credential_source: {...}}, ... ] }
+            // The catalog response also nests under "services" (and additionally "custom_services"),
+            // so reusing EnumerateProxyServiceItems is safe — but we accept *only* rows that look
+            // like UserService instances by checking presence of `slug`.
+            var resolutionsBySlug = new Dictionary<string, ServiceResolution>(StringComparer.OrdinalIgnoreCase);
             foreach (var svc in EnumerateProxyServiceItems(doc.RootElement))
             {
                 var slug = ReadString(svc, "slug");
                 if (string.IsNullOrWhiteSpace(slug))
                     continue;
 
-                var id = ReadString(svc, "id", "service_id");
-                if (!string.IsNullOrWhiteSpace(id))
-                    serviceIdsBySlug[slug] = id;
+                var id = ReadString(svc, "id");
+                if (string.IsNullOrWhiteSpace(id))
+                    continue;
+
+                var isActive = TryReadBool(svc, "is_active") ?? true;
+                var credentialSource = svc.TryGetProperty("credential_source", out var cs) ? cs : default;
+                var sourceType = credentialSource.ValueKind == JsonValueKind.Object
+                    ? ReadString(credentialSource, "type")
+                    : null;
+                var orgAllowed = credentialSource.ValueKind == JsonValueKind.Object
+                    ? TryReadBool(credentialSource, "allowed")
+                    : null;
+
+                // Surface the *first* match per slug. If the user happens to have multiple
+                // UserService rows for the same slug (legacy migration leftovers), order is
+                // server-determined; we don't try to pick "the best" one because the caller
+                // doesn't have a preference signal here.
+                if (resolutionsBySlug.ContainsKey(slug))
+                    continue;
+
+                resolutionsBySlug[slug] = new ServiceResolution(
+                    Id: id!,
+                    IsActive: isActive,
+                    CredentialSourceType: sourceType,
+                    OrgAllowed: orgAllowed);
             }
 
-            var missingSlugs = requiredSlugs
-                .Where(slug => !serviceIdsBySlug.ContainsKey(slug))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-            if (missingSlugs.Length > 0)
+            var ids = new List<string>(requiredSlugs.Count);
+            foreach (var slug in requiredSlugs.Distinct(StringComparer.OrdinalIgnoreCase))
             {
-                return (null,
-                    $"Missing required Nyx proxy services: {string.Join(", ", missingSlugs)}. API key creation was rejected to avoid broad proxy access.");
+                if (!resolutionsBySlug.TryGetValue(slug, out var resolution))
+                {
+                    return (null, JsonSerializer.Serialize(new
+                    {
+                        error = "service_not_connected",
+                        slug,
+                        hint = $"NyxID has no connected user-service for slug `{slug}`. Connect the provider at NyxID before creating this agent.",
+                    }));
+                }
+
+                if (!resolution.IsActive)
+                {
+                    return (null, JsonSerializer.Serialize(new
+                    {
+                        error = "service_inactive",
+                        slug,
+                        hint = $"NyxID user-service for slug `{slug}` is inactive. Re-activate it at NyxID before creating this agent.",
+                    }));
+                }
+
+                if (string.Equals(resolution.CredentialSourceType, "org", StringComparison.OrdinalIgnoreCase) &&
+                    resolution.OrgAllowed != true)
+                {
+                    return (null, JsonSerializer.Serialize(new
+                    {
+                        error = "service_org_viewer_only",
+                        slug,
+                        hint = $"NyxID user-service for slug `{slug}` is shared by your org but your role does not permit using it as a proxy target. Ask an admin to widen the org role scope, or connect a personal credential.",
+                    }));
+                }
+
+                ids.Add(resolution.Id);
             }
 
-            var ids = requiredSlugs
-                .Select(slug => serviceIdsBySlug[slug])
-                .Distinct(StringComparer.Ordinal)
-                .ToArray();
-            return (ids, null);
+            return (ids.Distinct(StringComparer.Ordinal).ToArray(), null);
         }
         catch (JsonException)
         {
-            return (null, "Could not parse Nyx proxy service discovery response.");
+            return (null, JsonSerializer.Serialize(new
+            {
+                error = "user_services_parse_failed",
+                hint = "NyxID user-services response was not valid JSON.",
+            }));
         }
     }
+
+    private readonly record struct ServiceResolution(
+        string Id,
+        bool IsActive,
+        string? CredentialSourceType,
+        bool? OrgAllowed);
 
     private async Task<string?> BuildGitHubAuthorizationResponseAsync(
         NyxIdApiClient client,
@@ -1574,13 +1665,23 @@ public sealed class AgentBuilderTool : IAgentTool
     /// relay surfaced <c>union_id</c> at agent-create time.
     /// </summary>
     /// <summary>
-    /// Preflights GitHub proxy access using the newly created agent API key against
-    /// <c>/rate_limit</c> — an unauthenticated-friendly read endpoint that returns 401/403 when
-    /// the key lacks a bound GitHub credential. Returns a structured error JSON suitable for
-    /// returning verbatim from the tool when access is denied; returns <c>null</c> when access
-    /// works (or when the daily-report's required service list does not include GitHub, in
-    /// which case there's nothing to preflight). Issue aevatarAI/aevatar#411.
+    /// Preflights GitHub proxy access using the newly created agent API key against GitHub's
+    /// <c>/rate_limit</c> — a cheap read-only endpoint that returns 401/403 when NyxID's stored
+    /// OAuth token was revoked or had its scopes downgraded at GitHub between connect-time and
+    /// agent-create-time. Returns a structured error JSON suitable for returning verbatim from
+    /// the tool when access is denied; returns <c>null</c> on success or on probe shapes we
+    /// don't classify as "fundamentally broken" (rate limits, 5xx).
     /// </summary>
+    /// <remarks>
+    /// Issue aevatarAI/aevatar#411 added this preflight to fail fast on a misdiagnosed root
+    /// cause (we thought the api-key was missing a GitHub binding). Issue #417 fixed that real
+    /// cause — the api-key now carries the right per-user <c>UserService.id</c>s. The probe is
+    /// retained because the OAuth grant can still be revoked outside our control (user clicks
+    /// "Revoke access" in GitHub Settings → Applications, GitHub temp-bans the account, etc.),
+    /// and surfacing that at create-time avoids persisting a daily-report agent that would
+    /// produce empty output on every run. The api-key is NOT revoked on preflight failure: it
+    /// is healthy, only its downstream credential is.
+    /// </remarks>
     private async Task<string?> PreflightGitHubProxyAsync(
         NyxIdApiClient nyxClient,
         string apiKey,
@@ -1641,7 +1742,7 @@ public sealed class AgentBuilderTool : IAgentTool
                 detail = string.IsNullOrWhiteSpace(detail) ? "GitHub proxy returned 401/403 for the new agent API key." : detail,
                 http_status = status,
                 proxy_body = string.IsNullOrWhiteSpace(body) ? null : body,
-                hint = "The new agent API key was created with `allowed_service_ids=api-github` but cannot reach GitHub via NyxID. Verify the GitHub OAuth provider is connected at NyxID and that the key picks up the binding (NyxID `api-keys/{id}/bindings`). Until this is resolved the daily report will return empty/degraded output every run.",
+                hint = "GitHub returned 401/403 to NyxID's stored OAuth token. The token was likely revoked at GitHub or had its scopes downgraded after the provider was connected. Re-authorize the GitHub provider at NyxID, then run /daily again.",
                 nyx_provider_slug = nyxProviderSlug,
             });
         }
@@ -1664,43 +1765,20 @@ public sealed class AgentBuilderTool : IAgentTool
         return value;
     }
 
-    /// <summary>
-    /// Best-effort revoke of an API key minted earlier in the create flow. Used when a
-    /// preflight (e.g. GitHub proxy access) detects that the agent will be DOA at runtime, so
-    /// we don't leave orphan proxy-scoped keys behind on every retry. Failures here are
-    /// logged at Warning but do NOT propagate — the structured create-time error is the
-    /// user-facing signal; an orphan key is an ops cleanup concern, not a hard failure.
-    /// </summary>
-    private async Task BestEffortRevokeApiKeyAsync(
-        NyxIdApiClient nyxClient,
-        string sessionToken,
-        string apiKeyId,
-        string reason,
-        CancellationToken ct)
+    private static bool? TryReadBool(JsonElement element, string propertyName)
     {
-        if (string.IsNullOrWhiteSpace(apiKeyId))
-            return;
+        if (element.ValueKind != JsonValueKind.Object ||
+            !element.TryGetProperty(propertyName, out var property))
+        {
+            return null;
+        }
 
-        try
+        return property.ValueKind switch
         {
-            var response = await nyxClient.DeleteApiKeyAsync(sessionToken, apiKeyId, ct);
-            if (LarkProxyResponse.TryGetError(response, out _, out var detail))
-            {
-                _logger?.LogWarning(
-                    "Failed to revoke orphan agent API key {ApiKeyId} after {Reason}: {Detail}",
-                    apiKeyId,
-                    reason,
-                    detail);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(
-                ex,
-                "Exception revoking orphan agent API key {ApiKeyId} after {Reason}",
-                apiKeyId,
-                reason);
-        }
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        };
     }
 
     private LarkReceiveTargetWithFallback ResolveDeliveryTarget(string conversationId, string agentId)

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -728,6 +728,33 @@ public sealed class AgentBuilderTool : IAgentTool
         };
     }
 
+    /// <summary>
+    /// Builds the JSON body for <c>POST /api/v1/api-keys</c> when the agent-builder mints a
+    /// scoped child key for a new agent. Pins <c>allow_all_services = false</c> alongside the
+    /// resolved <c>allowed_service_ids</c> so the agent's proxy reach is bounded to exactly the
+    /// catalog slugs the template requires.
+    /// </summary>
+    /// <remarks>
+    /// PR #418 review (4175529548): NyxID's <c>CreateApiKeyRequest.allow_all_services</c>
+    /// (<c>backend/src/handlers/api_keys.rs:105</c>) is <c>#[serde(default = "default_true")]</c>,
+    /// and proxy enforcement (<c>backend/src/handlers/proxy.rs:1030</c>) only checks
+    /// <c>allowed_service_ids</c> when <c>!auth_user.allow_all_services</c>. Omitting the field
+    /// means NyxID stores <c>true</c>, the resolved <c>UserService.id</c> list is persisted but
+    /// never consulted, and the key has broad proxy reach across every service the parent token
+    /// can see. Setting <c>false</c> explicitly:
+    /// <list type="bullet">
+    ///   <item>activates the enforcement path #417 was written to satisfy,</item>
+    ///   <item>makes the narrow-scope intent first-class instead of relying on the parent
+    ///   delegation token's setting (which is what surfaced the bug in production), and</item>
+    ///   <item>triggers <c>validate_service_ids</c> at create-time
+    ///   (<c>backend/src/services/key_service.rs:183</c>), so a malformed
+    ///   <c>UserService.id</c> fails fast at <c>POST /api-keys</c> instead of silently passing
+    ///   through and 403'ing on every later proxy call.</item>
+    /// </list>
+    /// <c>allow_all_nodes</c> stays at the NyxID default — this flow does not restrict node
+    /// routing, and pinning it would surface a separate boundary that has nothing to do with
+    /// the agent's service reach.
+    /// </remarks>
     private static string BuildCreateApiKeyPayload(string agentId, IReadOnlyList<string> requiredServiceIds)
     {
         if (requiredServiceIds.Count == 0)
@@ -739,6 +766,7 @@ public sealed class AgentBuilderTool : IAgentTool
             ["scopes"] = "proxy",
             ["platform"] = "generic",
             ["allowed_service_ids"] = requiredServiceIds,
+            ["allow_all_services"] = false,
         };
 
         return JsonSerializer.Serialize(payload);
@@ -1013,11 +1041,14 @@ public sealed class AgentBuilderTool : IAgentTool
     /// catalog id. The mismatch silently passed at <c>POST /api-keys</c> creation time, then
     /// surfaced as <c>403 ApiKeyScopeForbidden</c> on every proxy call.</para>
     /// <para>Why the old code looked correct in development: <c>allow_all_services=true</c>
-    /// short-circuits the enforcement check. Session-token-minted API keys default to
-    /// <c>allow_all_services=true</c>, so a developer reproducing the create-key + proxy-call
+    /// short-circuits the enforcement check (NyxID <c>proxy.rs:1030</c>). Session-token-minted
+    /// API keys default to <c>true</c>, so a developer reproducing the create-key + proxy-call
     /// dance from a CLI never tripped the bug. The agent path mints child keys via the
     /// channel-relay delegation token; NyxID forces those children to inherit
-    /// <c>allow_all_services=false</c> from the parent, which is when enforcement kicks in.</para>
+    /// <c>allow_all_services=false</c> from the parent, which is when enforcement kicks in.
+    /// The <c>BuildCreateApiKeyPayload</c> change in PR #418 (review 4175529548) makes the
+    /// narrow-scope intent first-class by setting <c>allow_all_services=false</c> explicitly,
+    /// so this resolver's output is consulted regardless of the parent's setting.</para>
     /// <para>The fix: use <c>GET /api/v1/user-services</c>, which lists this user's
     /// <c>UserService</c> instances. For each instance the response carries the per-user
     /// <c>id</c> (what enforcement actually checks) plus <c>slug</c>, <c>is_active</c>, and a

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -247,13 +247,20 @@ public sealed class AgentBuilderTool : IAgentTool
         // Issue aevatarAI/aevatar#411 / #417 follow-up: catch in-flight GitHub OAuth revocation.
         // The earlier `BuildGitHubAuthorizationResponseAsync` check covers the "no provider token
         // at all" case; this preflight only earns its keep when the OAuth grant was revoked or
-        // had its scopes downgraded between connect-time and create-time. The api-key itself is
-        // healthy at this point (`#417` fixed `allowed_service_ids` to carry per-user
-        // `UserService.id`s), so we do NOT revoke it on preflight failure — the failure mode is
-        // upstream GitHub denying the stored credential, not a malformed proxy scope.
+        // had its scopes downgraded between connect-time and create-time.
+        //
+        // Codex review (PR #418 r3141846175): even though the api-key itself is correctly
+        // configured under #417, we still revoke it on preflight failure. Reason: each retry of
+        // `/daily` mints a *new* api-key before the preflight runs, so without revoke the user's
+        // NyxID account accumulates one orphan proxy-scoped key per failed retry until they
+        // re-authorize GitHub. The revoke is a best-effort cleanup, not a safety claim about the
+        // key's correctness.
         var preflight = await PreflightGitHubProxyAsync(nyxClient, apiKeyValue!, providerSlug, ct);
         if (preflight is not null)
+        {
+            await BestEffortRevokeApiKeyAsync(nyxClient, token, apiKeyId!, "github_preflight_failed", ct);
             return preflight;
+        }
 
         var actor = await actorRuntime.GetAsync(agentId)
                     ?? await actorRuntime.CreateAsync<SkillRunnerGAgent>(agentId, ct);
@@ -1050,7 +1057,15 @@ public sealed class AgentBuilderTool : IAgentTool
             // The catalog response also nests under "services" (and additionally "custom_services"),
             // so reusing EnumerateProxyServiceItems is safe — but we accept *only* rows that look
             // like UserService instances by checking presence of `slug`.
-            var resolutionsBySlug = new Dictionary<string, ServiceResolution>(StringComparer.OrdinalIgnoreCase);
+            //
+            // Codex review (PR #418 r3141846173): users with mixed bindings can have multiple
+            // rows for the same slug (e.g. an org-shared `allowed:false` row alongside a personal
+            // active row). NyxID does not guarantee any ordering, so the resolver must keep the
+            // *most eligible* row per slug rather than the first one seen. We track the first
+            // ineligible row anyway so that when no eligible row exists we can still emit a
+            // specific error (`service_inactive` / `service_org_viewer_only`) instead of a
+            // generic miss.
+            var bestBySlug = new Dictionary<string, ServiceResolution>(StringComparer.OrdinalIgnoreCase);
             foreach (var svc in EnumerateProxyServiceItems(doc.RootElement))
             {
                 var slug = ReadString(svc, "slug");
@@ -1070,24 +1085,30 @@ public sealed class AgentBuilderTool : IAgentTool
                     ? TryReadBool(credentialSource, "allowed")
                     : null;
 
-                // Surface the *first* match per slug. If the user happens to have multiple
-                // UserService rows for the same slug (legacy migration leftovers), order is
-                // server-determined; we don't try to pick "the best" one because the caller
-                // doesn't have a preference signal here.
-                if (resolutionsBySlug.ContainsKey(slug))
-                    continue;
-
-                resolutionsBySlug[slug] = new ServiceResolution(
+                var candidate = new ServiceResolution(
                     Id: id!,
                     IsActive: isActive,
                     CredentialSourceType: sourceType,
                     OrgAllowed: orgAllowed);
+
+                if (bestBySlug.TryGetValue(slug, out var existing))
+                {
+                    // Already have an eligible row → never downgrade.
+                    if (existing.IsEligible)
+                        continue;
+                    // Existing is ineligible; only replace with another ineligible row if we
+                    // would otherwise lose information. Replace iff candidate is eligible.
+                    if (!candidate.IsEligible)
+                        continue;
+                }
+
+                bestBySlug[slug] = candidate;
             }
 
             var ids = new List<string>(requiredSlugs.Count);
             foreach (var slug in requiredSlugs.Distinct(StringComparer.OrdinalIgnoreCase))
             {
-                if (!resolutionsBySlug.TryGetValue(slug, out var resolution))
+                if (!bestBySlug.TryGetValue(slug, out var resolution))
                 {
                     return (null, JsonSerializer.Serialize(new
                     {
@@ -1097,14 +1118,10 @@ public sealed class AgentBuilderTool : IAgentTool
                     }));
                 }
 
-                if (!resolution.IsActive)
+                if (resolution.IsEligible)
                 {
-                    return (null, JsonSerializer.Serialize(new
-                    {
-                        error = "service_inactive",
-                        slug,
-                        hint = $"NyxID user-service for slug `{slug}` is inactive. Re-activate it at NyxID before creating this agent.",
-                    }));
+                    ids.Add(resolution.Id);
+                    continue;
                 }
 
                 if (string.Equals(resolution.CredentialSourceType, "org", StringComparison.OrdinalIgnoreCase) &&
@@ -1118,7 +1135,13 @@ public sealed class AgentBuilderTool : IAgentTool
                     }));
                 }
 
-                ids.Add(resolution.Id);
+                // Remaining ineligible reason: !is_active.
+                return (null, JsonSerializer.Serialize(new
+                {
+                    error = "service_inactive",
+                    slug,
+                    hint = $"NyxID user-service for slug `{slug}` is inactive. Re-activate it at NyxID before creating this agent.",
+                }));
             }
 
             return (ids.Distinct(StringComparer.Ordinal).ToArray(), null);
@@ -1137,7 +1160,12 @@ public sealed class AgentBuilderTool : IAgentTool
         string Id,
         bool IsActive,
         string? CredentialSourceType,
-        bool? OrgAllowed);
+        bool? OrgAllowed)
+    {
+        public bool IsEligible =>
+            IsActive &&
+            !(string.Equals(CredentialSourceType, "org", StringComparison.OrdinalIgnoreCase) && OrgAllowed != true);
+    }
 
     private async Task<string?> BuildGitHubAuthorizationResponseAsync(
         NyxIdApiClient client,
@@ -1679,8 +1707,8 @@ public sealed class AgentBuilderTool : IAgentTool
     /// retained because the OAuth grant can still be revoked outside our control (user clicks
     /// "Revoke access" in GitHub Settings → Applications, GitHub temp-bans the account, etc.),
     /// and surfacing that at create-time avoids persisting a daily-report agent that would
-    /// produce empty output on every run. The api-key is NOT revoked on preflight failure: it
-    /// is healthy, only its downstream credential is.
+    /// produce empty output on every run. The freshly minted api-key is best-effort revoked at
+    /// the call site so retries don't accumulate orphan proxy-scoped keys.
     /// </remarks>
     private async Task<string?> PreflightGitHubProxyAsync(
         NyxIdApiClient nyxClient,
@@ -1779,6 +1807,45 @@ public sealed class AgentBuilderTool : IAgentTool
             JsonValueKind.False => false,
             _ => null,
         };
+    }
+
+    /// <summary>
+    /// Best-effort revoke of an API key minted earlier in the create flow. Used when GitHub
+    /// preflight fails so retries of <c>/daily</c> don't accumulate orphan proxy-scoped keys
+    /// in the user's NyxID account (codex review #418 r3141846175). Failures here are logged
+    /// at Warning but do NOT propagate — the structured create-time error is the user-facing
+    /// signal; an orphan key is an ops cleanup concern, not a hard failure.
+    /// </summary>
+    private async Task BestEffortRevokeApiKeyAsync(
+        NyxIdApiClient nyxClient,
+        string sessionToken,
+        string apiKeyId,
+        string reason,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(apiKeyId))
+            return;
+
+        try
+        {
+            var response = await nyxClient.DeleteApiKeyAsync(sessionToken, apiKeyId, ct);
+            if (LarkProxyResponse.TryGetError(response, out _, out var detail))
+            {
+                _logger?.LogWarning(
+                    "Failed to revoke orphan agent API key {ApiKeyId} after {Reason}: {Detail}",
+                    apiKeyId,
+                    reason,
+                    detail);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(
+                ex,
+                "Exception revoking orphan agent API key {ApiKeyId} after {Reason}",
+                apiKeyId,
+                reason);
+        }
     }
 
     private LarkReceiveTargetWithFallback ResolveDeliveryTarget(string conversationId, string agentId)

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
@@ -209,6 +209,9 @@ public sealed class NyxIdApiClient
 
     // ─── User Services (for route command) ───
 
+    public Task<string> ListUserServicesAsync(string token, CancellationToken ct) =>
+        GetAsync(token, "/api/v1/user-services", ct);
+
     public Task<string> UpdateUserServiceAsync(string token, string id, string body, CancellationToken ct) =>
         PutAsync(token, $"/api/v1/user-services/{Uri.EscapeDataString(id)}", body, ct);
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -343,8 +343,8 @@ public sealed class AgentBuilderToolTests
         // would produce empty output on every scheduled run.
         //
         // Pinned in this test: the structured `github_proxy_access_denied` error is returned
-        // (no actor invocation), AND the api-key is NOT revoked (it is healthy; only the
-        // downstream GitHub credential is broken).
+        // (no actor invocation), AND the freshly minted api-key IS revoked so retries don't
+        // accumulate orphan proxy-scoped keys (codex review PR #418 r3141846175).
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
         queryPort.GetStateVersionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<long?>(null));
@@ -388,6 +388,11 @@ public sealed class AgentBuilderToolTests
         // exercised against what runtime delivers, not a synthetic shape.
         handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
             """{"error": true, "status": 403, "body": "{\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}"}""");
+        // Codex review (PR #418 r3141846175): retries of `/daily` mint a new api-key on every
+        // run. Without best-effort revoke on preflight failure, the user's NyxID account would
+        // accumulate one orphan proxy-scoped key per failed retry. Stub the DELETE so the test
+        // can verify the revoke fires.
+        handler.Add(HttpMethod.Delete, "/api/v1/api-keys/key-403", """{"deleted":true}""");
 
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
@@ -433,12 +438,12 @@ public sealed class AgentBuilderToolTests
                 Arg.Any<EventEnvelope>(),
                 Arg.Any<CancellationToken>());
 
-            // Issue #417 follow-up: the api-key itself is healthy when preflight surfaces a
-            // GitHub-side 401/403 (in-flight OAuth revocation). We must NOT revoke it — that
-            // was the old behavior under the #411 misdiagnosis where we thought the api-key
-            // was the broken party. Pin "no DELETE on the freshly minted key" so the
-            // regression from re-introducing the orphan-cleanup dance gets caught.
-            handler.Requests.Should().NotContain(r =>
+            // Codex review (PR #418 r3141846175): even though the api-key carries the right
+            // `allowed_service_ids` under #417, the create flow mints a *new* key per run.
+            // Without best-effort revoke on preflight failure, every failed `/daily` retry
+            // would orphan one proxy-scoped key in the user's NyxID account. Pin that the
+            // DELETE fires so we don't regress on this cleanup.
+            handler.Requests.Should().Contain(r =>
                 r.Method == HttpMethod.Delete &&
                 r.Path == "/api/v1/api-keys/key-403");
         }
@@ -1335,6 +1340,109 @@ public sealed class AgentBuilderToolTests
                 .ToArray();
             allowed.Should().BeEquivalentTo(["user-svc-github-instance", "user-svc-lark-instance"]);
             allowed.Should().NotContain("catalog-github").And.NotContain("catalog-lark");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_PicksEligibleRow_When_DuplicateSlugRowsExist()
+    {
+        // Codex review (PR #418 r3141846173): a user with mixed bindings can have multiple
+        // UserService rows for the same slug — e.g. an org-shared `allowed:false` row and a
+        // personal active row. NyxID does not guarantee any ordering, so the resolver must
+        // pick the *eligible* row regardless of position. Pin the case where the ineligible
+        // row arrives first; the resolver must still produce the personal id and succeed.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionAsync("skill-runner-dup", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync("skill-runner-dup", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-dup",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-dup");
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-dup").Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<SkillRunnerGAgent>("skill-runner-dup", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(skillRunnerActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        // Two rows for `api-github` (ineligible org-viewer first, eligible personal second) and
+        // two rows for `api-lark-bot` (inactive first, active second). The resolver must pick
+        // the eligible rows in both cases, not the first-seen ones.
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"svc-github-org","slug":"api-github","is_active":true,"credential_source":{"type":"org","org_id":"org-1","role":"viewer","allowed":false}},
+                {"id":"svc-github-personal","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark-stale","slug":"api-lark-bot","is_active":false,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark-active","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-dup","full_key":"full-key-dup"}""");
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
+            """{"resources":{"core":{"limit":5000,"remaining":4999}}}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-dup",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            var apiKeyRequest = handler.Requests.Should()
+                .ContainSingle(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys")
+                .Subject;
+            using var apiKeyDoc = JsonDocument.Parse(apiKeyRequest.Body!);
+            var allowed = apiKeyDoc.RootElement.GetProperty("allowed_service_ids").EnumerateArray()
+                .Select(static item => item.GetString())
+                .ToArray();
+            allowed.Should().BeEquivalentTo(["svc-github-personal", "svc-lark-active"]);
+            allowed.Should().NotContain("svc-github-org").And.NotContain("svc-lark-stale");
         }
         finally
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -132,17 +132,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
               "services": [
-                {"id":"svc-github","slug":"api-github"}
-              ],
-              "custom_services": [
-                {"id":"svc-lark","slug":"api-lark-bot"}
-              ],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-1","full_key":"full-key-1"}""");
@@ -275,17 +270,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
               "services": [
-                {"id":"svc-github","slug":"api-github"}
-              ],
-              "custom_services": [
-                {"id":"svc-lark","slug":"api-lark-bot"}
-              ],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-union-1","full_key":"full-key-union-1"}""");
@@ -343,12 +333,18 @@ public sealed class AgentBuilderToolTests
     [Fact]
     public async Task ExecuteAsync_CreateAgent_DailyReport_FailsClosed_When_GithubProxyDeniedForNewKey()
     {
-        // Issue aevatarAI/aevatar#411: a daily_report agent is created with the new agent API
-        // key flagged `allowed_service_ids=api-github`, but if NyxID's binding for the user's
-        // GitHub OAuth credential is missing/expired, every scheduled run hits 401/403 from
-        // the proxy and the user only sees an empty / degraded report. Preflight
-        // `proxy/s/api-github/rate_limit` with the freshly minted key and fail-fast with an
-        // actionable error so the agent is not persisted in a "always-fails-at-runtime" state.
+        // Issue aevatarAI/aevatar#411 + #417: the create flow preflights GitHub proxy access
+        // with the freshly minted agent API key. Originally (#411) the failure mode this caught
+        // was misdiagnosed as a missing api-key→GitHub binding; #417 fixed that root cause by
+        // populating `allowed_service_ids` with per-user `UserService.id`s instead of catalog
+        // ids. The probe is retained because GitHub OAuth grants can still be revoked outside
+        // our control (user clicks "Revoke access" at GitHub, scopes downgraded, account
+        // temp-banned). Surfacing the 401/403 at create-time avoids persisting an agent that
+        // would produce empty output on every scheduled run.
+        //
+        // Pinned in this test: the structured `github_proxy_access_denied` error is returned
+        // (no actor invocation), AND the api-key is NOT revoked (it is healthy; only the
+        // downstream GitHub credential is broken).
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
         queryPort.GetStateVersionAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<long?>(null));
@@ -376,13 +372,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
-              "services": [{"id":"svc-github","slug":"api-github"}],
-              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-403","full_key":"full-key-403"}""");
@@ -393,10 +388,6 @@ public sealed class AgentBuilderToolTests
         // exercised against what runtime delivers, not a synthetic shape.
         handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
             """{"error": true, "status": 403, "body": "{\"message\":\"Bad credentials\",\"documentation_url\":\"https://docs.github.com/rest\"}"}""");
-        // Reviewer (PR #412 r3141699756): on the fail-fast path we must also revoke the
-        // freshly-created agent API key, otherwise repeated `/daily` attempts accumulate
-        // orphan proxy-scoped keys. Wire a DELETE handler so the test can verify it ran.
-        handler.Add(HttpMethod.Delete, "/api/v1/api-keys/key-403", """{"deleted":true}""");
 
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
@@ -432,7 +423,9 @@ public sealed class AgentBuilderToolTests
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("error").GetString().Should().Be("github_proxy_access_denied");
             doc.RootElement.GetProperty("http_status").GetInt32().Should().Be(403);
-            doc.RootElement.GetProperty("hint").GetString().Should().Contain("api-keys");
+            // The hint should point users at re-authorizing the GitHub provider at NyxID, not
+            // at api-key bindings (which used to be the misdiagnosis under #411 — see #417).
+            doc.RootElement.GetProperty("hint").GetString().Should().Contain("Re-authorize");
 
             // The actor must NOT receive InitializeSkillRunnerCommand — preflight aborts
             // BEFORE the actor is invoked so we don't leave a broken agent in the catalog.
@@ -440,11 +433,12 @@ public sealed class AgentBuilderToolTests
                 Arg.Any<EventEnvelope>(),
                 Arg.Any<CancellationToken>());
 
-            // Best-effort revoke of the freshly-minted API key so repeated `/daily` attempts
-            // that hit GitHub preflight don't accumulate orphan proxy-scoped keys (reviewer
-            // r3141699756). The DELETE call is the only proof from this layer that the orphan
-            // is being cleaned up.
-            handler.Requests.Should().Contain(r =>
+            // Issue #417 follow-up: the api-key itself is healthy when preflight surfaces a
+            // GitHub-side 401/403 (in-flight OAuth revocation). We must NOT revoke it — that
+            // was the old behavior under the #411 misdiagnosis where we thought the api-key
+            // was the broken party. Pin "no DELETE on the freshly minted key" so the
+            // regression from re-introducing the orphan-cleanup dance gets caught.
+            handler.Requests.Should().NotContain(r =>
                 r.Method == HttpMethod.Delete &&
                 r.Path == "/api/v1/api-keys/key-403");
         }
@@ -500,13 +494,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
-              "services": [{"id":"svc-github","slug":"api-github"}],
-              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-fallback-1","full_key":"full-key-fallback-1"}""");
@@ -609,13 +602,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
-              "services": [{"id":"svc-github","slug":"api-github"}],
-              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-no-fallback-1","full_key":"full-key-no-fallback-1"}""");
@@ -706,13 +698,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
-              "services": [{"id":"svc-github","slug":"api-github"}],
-              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-pref-1","full_key":"full-key-pref-1"}""");
@@ -809,13 +800,12 @@ public sealed class AgentBuilderToolTests
             }
             """);
         handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/user", """{"login":"derived-user"}""");
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
-              "services": [{"id":"svc-github","slug":"api-github"}],
-              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-derived-1","full_key":"full-key-derived-1"}""");
@@ -984,13 +974,12 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
-              "services": [{"id":"svc-github","slug":"api-github"}],
-              "custom_services": [{"id":"svc-lark","slug":"api-lark-bot"}],
-              "total": 2,
-              "page": 1,
-              "per_page": 100
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-save-1","full_key":"full-key-save-1"}""");
@@ -1064,15 +1053,11 @@ public sealed class AgentBuilderToolTests
               ]
             }
             """);
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
               "services": [
-                {"id":"svc-lark","slug":"api-lark-bot"}
-              ],
-              "custom_services": [],
-              "total": 1,
-              "page": 1,
-              "per_page": 100
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
 
@@ -1105,9 +1090,251 @@ public sealed class AgentBuilderToolTests
                 }
                 """);
 
-            result.Should().Contain("Missing required Nyx proxy services");
+            // #417: when a required slug has no UserService row, surface a structured
+            // `service_not_connected` error naming the slug (was: free-text "Missing required
+            // Nyx proxy services" wrapped in `{error: "..."}`). The actor must NOT be created
+            // and no api-key request should fire.
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("error").GetString().Should().Be("service_not_connected");
+            doc.RootElement.GetProperty("slug").GetString().Should().Be("api-github");
+            doc.RootElement.GetProperty("hint").GetString().Should().Contain("api-github");
             handler.Requests.Should().NotContain(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys");
             await actorRuntime.DidNotReceive().CreateAsync<SkillRunnerGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_FailsClosed_When_RequiredSlug_IsInactive()
+    {
+        // #417: when the user has a UserService row for the required slug but it's marked
+        // `is_active: false`, surface `service_inactive` rather than persisting an api-key
+        // that NyxID's enforcement will reject at proxy time.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":false,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("error").GetString().Should().Be("service_inactive");
+            doc.RootElement.GetProperty("slug").GetString().Should().Be("api-github");
+            handler.Requests.Should().NotContain(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_FailsClosed_When_OrgSharedSlug_IsViewerOnly()
+    {
+        // #417: when the only matching UserService row is org-shared with `allowed: false`
+        // (org viewer role), don't bind it as a proxy target — NyxID would reject the proxy
+        // call later as `org_role_insufficient`. Surface `service_org_viewer_only` so the
+        // user knows to ask an admin or connect a personal credential.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"org","org_id":"org-1","role":"viewer","allowed":false}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("error").GetString().Should().Be("service_org_viewer_only");
+            doc.RootElement.GetProperty("slug").GetString().Should().Be("api-github");
+            handler.Requests.Should().NotContain(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_AllowedServiceIds_AreUserServiceIds_NotCatalogIds()
+    {
+        // #417 regression pin. The bug: backend used `GET /proxy/services` (catalog list) and
+        // populated the new api-key's `allowed_service_ids` with `DownstreamService.id` (catalog
+        // UUIDs). NyxID's proxy enforcement (proxy.rs:1030) compares against `UserService.id`
+        // (per-user instance UUIDs). The mismatch was silently accepted on api-key create and
+        // 403'd on every proxy call. The fix routes through `/user-services`, returning per-user
+        // ids. Stub a response where the per-user `id` is *distinct from* `catalog_service_id`
+        // and pin that the api-key payload carries the per-user `id` value.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionAsync("skill-runner-id-pin", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetAsync("skill-runner-id-pin", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-id-pin",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerActor = Substitute.For<IActor>();
+        skillRunnerActor.Id.Returns("skill-runner-id-pin");
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        actorRuntime.GetAsync("skill-runner-id-pin").Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<SkillRunnerGAgent>("skill-runner-id-pin", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(skillRunnerActor));
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"user-svc-github-instance","slug":"api-github","catalog_service_id":"catalog-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"user-svc-lark-instance","slug":"api-lark-bot","catalog_service_id":"catalog-lark","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-id-pin","full_key":"full-key-id-pin"}""");
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
+            """{"resources":{"core":{"limit":5000,"remaining":4999}}}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(actorRuntime);
+        services.AddSingleton(nyxClient);
+        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            ["scope_id"] = "scope-1",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-id-pin",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            var apiKeyRequest = handler.Requests.Should()
+                .ContainSingle(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys")
+                .Subject;
+            using var apiKeyDoc = JsonDocument.Parse(apiKeyRequest.Body!);
+            var allowed = apiKeyDoc.RootElement.GetProperty("allowed_service_ids").EnumerateArray()
+                .Select(static item => item.GetString())
+                .ToArray();
+            allowed.Should().BeEquivalentTo(["user-svc-github-instance", "user-svc-lark-instance"]);
+            allowed.Should().NotContain("catalog-github").And.NotContain("catalog-lark");
         }
         finally
         {
@@ -1315,15 +1542,11 @@ public sealed class AgentBuilderToolTests
 
         var handler = new RoutingJsonHandler();
         handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
-        handler.Add(HttpMethod.Get, "/api/v1/proxy/services?per_page=100", """
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
             {
               "services": [
-                {"id":"svc-lark","slug":"api-lark-bot"}
-              ],
-              "custom_services": [],
-              "total": 1,
-              "page": 1,
-              "per_page": 100
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
             }
             """);
         handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-2","full_key":"full-key-2"}""");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -217,7 +217,11 @@ public sealed class AgentBuilderToolTests
                 .Select(static item => item.GetString())
                 .Should()
                 .BeEquivalentTo(["svc-github", "svc-lark"]);
-            apiKeyDoc.RootElement.TryGetProperty("allow_all_services", out _).Should().BeFalse();
+            // PR #418 review (4175529548): NyxID's `allow_all_services` defaults to `true`
+            // (api_keys.rs:105) and proxy enforcement only fires when `!allow_all_services`
+            // (proxy.rs:1030). Pin that the field is *present* and `false` so the resolved
+            // `allowed_service_ids` actually constrains the key's reach.
+            apiKeyDoc.RootElement.GetProperty("allow_all_services").GetBoolean().Should().BeFalse();
         }
         finally
         {
@@ -1747,7 +1751,11 @@ public sealed class AgentBuilderToolTests
                 .Select(static item => item.GetString())
                 .Should()
                 .BeEquivalentTo(["svc-lark"]);
-            apiKeyDoc.RootElement.TryGetProperty("allow_all_services", out _).Should().BeFalse();
+            // PR #418 review (4175529548): NyxID's `allow_all_services` defaults to `true`
+            // (api_keys.rs:105) and proxy enforcement only fires when `!allow_all_services`
+            // (proxy.rs:1030). Pin that the field is *present* and `false` so the resolved
+            // `allowed_service_ids` actually constrains the key's reach.
+            apiKeyDoc.RootElement.GetProperty("allow_all_services").GetBoolean().Should().BeFalse();
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Fixes #417: `/daily` (and any `agent_builder` flow that mints a child NyxID API key) consistently fails with `github_proxy_access_denied` even when the user's GitHub OAuth is healthy. Root cause is that we populate the new key's `allowed_service_ids` with catalog `DownstreamService.id` values, but NyxID's proxy enforcement (`proxy.rs:1030`) compares against per-user `UserService.id`. The mismatch is silently accepted at create-time and surfaces as 403 `ApiKeyScopeForbidden` on every proxy call.
- Routes service resolution through `GET /api/v1/user-services` and populates `allowed_service_ids` with each per-user `UserService.id`. When the same slug has multiple rows (mixed personal + org bindings, stale rows, etc.), prefers the most eligible one — only emits `service_inactive` / `service_org_viewer_only` errors when no eligible row exists.
- Pins `allow_all_services = false` in the api-key payload so NyxID's enforcement actually consults `allowed_service_ids` (the field defaults to `true`, which short-circuits enforcement and silently grants broad scope; see "Why this was invisible" below).
- Retains `BestEffortRevokeApiKeyAsync`: the GitHub preflight failure path still revokes the freshly minted key so retries don't accumulate orphans. Hint reworded to point at re-authorizing the GitHub provider, not at api-key bindings (the previous hint was based on the misdiagnosis that #411 fixed).

## Why this was invisible until production

Session-token-minted API keys default to `allow_all_services=true`, which short-circuits the enforcement check (NyxID `proxy.rs:1030`). A developer reproducing `POST /api-keys` + `/proxy/s/api-github/rate_limit` from a CLI never tripped the bug. The agent path mints child keys via the channel-relay delegation token; NyxID forces those children to inherit `allow_all_services=false` from the parent, which is what activates the enforcement check and makes the ID mismatch fatal. See #417 review comment for the full repro matrix.

This PR also makes the narrow scope first-class — `BuildCreateApiKeyPayload` sends `allow_all_services = false` explicitly, so the resolver's output is enforced regardless of what the parent's setting happens to be. As a side benefit this also turns on NyxID's `validate_service_ids` at create-time (`key_service.rs:183`), so a malformed `UserService.id` fails fast at `POST /api-keys` instead of silently passing through and 403'ing every later proxy call.

## Changes

- `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs` — add `ListUserServicesAsync` (`GET /api/v1/user-services`).
- `agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs`:
  - Rewrite `ResolveProxyServiceIdsAsync` to use `/user-services` and return per-user `UserService.id`. When the same slug has duplicate rows, prefer the most eligible (`is_active && !(org && allowed != true)`) instead of freezing the first row seen. Specific `service_inactive` / `service_org_viewer_only` errors are only emitted when no eligible row exists for a slug.
  - Failure contract is now pre-formed JSON envelopes with stable `error` keys (`service_not_connected`, `service_inactive`, `service_org_viewer_only`, `user_services_unavailable`, `user_services_parse_failed`, `no_required_slugs`). Both call sites return the envelope verbatim instead of double-wrapping.
  - `BuildCreateApiKeyPayload` adds `allow_all_services = false` (per review #4175529548). `allow_all_nodes` left at the NyxID default — this flow does not restrict node routing.
  - `PreflightGitHubProxyAsync` doc comment + user-facing `hint` rewritten to point at re-authorizing the GitHub provider at NyxID, not at api-key bindings. `BestEffortRevokeApiKeyAsync` retained for the preflight failure path so retries don't accumulate orphan keys.
- `test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs`:
  - Update all 10 stub sites from `/proxy/services?per_page=100` to `/user-services` with the new row shape (`id`, `slug`, `is_active`, `credential_source`).
  - Update `_FailsClosed_When_RequiredProxyServices_AreMissing` to assert the structured `service_not_connected` envelope instead of free-text.
  - Update `_FailsClosed_When_GithubProxyDeniedForNewKey` to pin the new hint wording AND that the api-key IS revoked (DELETE on `/api/v1/api-keys/key-403`).
  - Existing `allow_all_services` assertions flipped from `TryGetProperty(...).Should().BeFalse()` (field absent) to `GetProperty(...).GetBoolean().Should().BeFalse()` (field present and `false`).
  - Add four new tests:
    - `_FailsClosed_When_RequiredSlug_IsInactive` — `is_active: false` row → `service_inactive`.
    - `_FailsClosed_When_OrgSharedSlug_IsViewerOnly` — org-shared `allowed: false` → `service_org_viewer_only`.
    - `_AllowedServiceIds_AreUserServiceIds_NotCatalogIds` — regression pin: stub `id` distinct from `catalog_service_id`, assert the api-key payload carries the per-user `id`.
    - `_PicksEligibleRow_When_DuplicateSlugRowsExist` — duplicate slug rows with the ineligible one first; assert the resolver still picks the eligible one.

## Test plan

- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — 421/421 passing.
- [x] `bash tools/ci/architecture_guards.sh` — clean (only flag is missing `buf` for proto lint, unrelated).
- [ ] Production smoke after merge: `/daily alice` from a Lark DM should now succeed end-to-end with a healthy GitHub OAuth connection. With a revoked GitHub token the response should be the `github_proxy_access_denied` error pointing at re-authorization (not at api-key bindings).

## Follow-ups

- Optional: open a NyxID issue to make `allowed_service_ids` accept catalog `DownstreamService.id` or `slug` as aliases. Would prevent future SDK consumers from repeating this footgun. Not required if this fix lands.
- The malformed Lark v2 card schema causing `/agents` 502 is tracked separately at #416.