### PR TITLE
[codex] Fix Lark v2 card schema

### DIFF
--- a/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
@@ -133,7 +133,10 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
                 },
                 template,
             },
-            elements,
+            body = new
+            {
+                elements,
+            },
         });
 
         return new LarkOutboundMessage(

--- a/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
+++ b/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
@@ -68,6 +68,51 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
     }
 
     [Fact]
+    public void Compose_WhenRenderingInteractiveCard_UsesLarkV2BodyElements()
+    {
+        var intent = new MessageContent
+        {
+            Text = "Choose an agent",
+        };
+        intent.Cards.Add(new CardBlock
+        {
+            Title = "Agents",
+            Text = "skill-runner",
+        });
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.Button,
+            ActionId = "status",
+            Label = "Status",
+        });
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        payload.MessageType.ShouldBe("interactive");
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        document.RootElement.GetProperty("schema").GetString().ShouldBe("2.0");
+        document.RootElement.TryGetProperty("elements", out _).ShouldBeFalse();
+        var bodyElements = document.RootElement.GetProperty("body").GetProperty("elements");
+        bodyElements.GetArrayLength().ShouldBe(3);
+        bodyElements[0].GetProperty("content").GetString().ShouldBe("Choose an agent");
+        var cardMarkdown = bodyElements[1].GetProperty("content").GetString();
+        cardMarkdown.ShouldNotBeNull();
+        cardMarkdown.ShouldContain("skill-runner");
+        bodyElements[2].GetProperty("tag").GetString().ShouldBe("action");
+    }
+
+    [Fact]
     public void Compose_WhenFormInputCarriesValue_RendersLarkDefaultValue()
     {
         var intent = new MessageContent();


### PR DESCRIPTION
## Problem and solution

Fixes #416.

Lark schema 2.0 interactive cards require renderable card blocks under `body.elements`. The standard `LarkMessageComposer` interactive-card path still emitted `elements` at the root, producing a hybrid v1/v2 payload that NyxID forwards to Lark and can fail with a 502 for `/agents` and other card-only replies.

This PR changes the standard interactive-card branch to emit `body.elements`, matching the existing form-mode branch and Lark v2 shape.

## Impact paths

- `agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs`
- `test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs`

## NyxID cross-check

Checked the local NyxID repository at `~/Code/NyxID`:

- `backend/src/services/channel_adapters/lark.rs` passes `reply.metadata.card` through as the interactive Lark `content` string.
- The send path posts that `content` to `/open-apis/im/v1/messages` with `msg_type = "interactive"`.
- Existing NyxID card body tests still cover the older root-level `elements` shape, so this repository needs to produce the valid Lark v2 `body.elements` payload before handing it to NyxID.

No NyxID code change is included in this PR; the issue's timeout/schema-validation hardening remains a separate defense-in-depth follow-up.

## Validation

- `dotnet test test/Aevatar.GAgents.Platform.Lark.Tests/Aevatar.GAgents.Platform.Lark.Tests.csproj --nologo` - passed, 13 tests
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo` - passed, 421 tests
- `bash tools/ci/test_stability_guards.sh` - passed
- `git diff --check` - passed

## Docs

No architecture or user-facing documentation changes were needed.
