### PR TITLE
chore(agent-builder): diagnostic logs for /daily 403 root-cause hunt

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -233,16 +233,31 @@ public sealed class AgentBuilderTool : IAgentTool
             ? SkillRunnerDefaults.GenerateActorId()
             : args.Str("agent_id")!.Trim();
 
-        var createKeyResponse = await nyxClient.CreateApiKeyAsync(
-            token,
-            BuildCreateApiKeyPayload(agentId, requiredServiceIds.value!),
-            ct);
+        // Diagnostic (#417 follow-up, PR for production 403 root-cause hunt): log the resolved
+        // service-id list and the exact payload we're about to send to NyxID `POST /api-keys`.
+        // The api-key request body is otherwise opaque in production; without this we can't tell
+        // whether the deployed binary actually carries the `allow_all_services=false` field, or
+        // whether `requiredServiceIds` resolved to per-user `UserService.id`s vs catalog ids.
+        var apiKeyPayload = BuildCreateApiKeyPayload(agentId, requiredServiceIds.value!);
+        _logger?.LogInformation(
+            "Diagnostic[#417]: minting agent api-key. agentId={AgentId} requiredSlugs={Slugs} resolvedServiceIds={Ids} payload={Payload}",
+            agentId,
+            string.Join(",", templateSpec!.RequiredServiceSlugs),
+            string.Join(",", requiredServiceIds.value!),
+            apiKeyPayload);
+
+        var createKeyResponse = await nyxClient.CreateApiKeyAsync(token, apiKeyPayload, ct);
 
         if (IsErrorPayload(createKeyResponse))
             return createKeyResponse;
 
         if (!TryParseApiKeyCreateResponse(createKeyResponse, out var apiKeyId, out var apiKeyValue, out var apiKeyError))
             return JsonSerializer.Serialize(new { error = apiKeyError });
+
+        _logger?.LogInformation(
+            "Diagnostic[#417]: agent api-key created. agentId={AgentId} apiKeyId={ApiKeyId}",
+            agentId,
+            apiKeyId);
 
         // Issue aevatarAI/aevatar#411 / #417 follow-up: catch in-flight GitHub OAuth revocation.
         // The earlier `BuildGitHubAuthorizationResponseAsync` check covers the "no provider token
@@ -258,6 +273,11 @@ public sealed class AgentBuilderTool : IAgentTool
         var preflight = await PreflightGitHubProxyAsync(nyxClient, apiKeyValue!, providerSlug, ct);
         if (preflight is not null)
         {
+            _logger?.LogWarning(
+                "Diagnostic[#417]: preflight failed; revoking new api-key. agentId={AgentId} apiKeyId={ApiKeyId} preflightResponse={Response}",
+                agentId,
+                apiKeyId,
+                preflight);
             await BestEffortRevokeApiKeyAsync(nyxClient, token, apiKeyId!, "github_preflight_failed", ct);
             return preflight;
         }
@@ -1757,6 +1777,18 @@ public sealed class AgentBuilderTool : IAgentTool
             body: null,
             extraHeaders: null,
             ct);
+
+        // Diagnostic (#417 follow-up): log the *raw* probe response. The parsed JSON envelope
+        // we return as `proxy_body` only carries the inner Lark/GitHub `body` string when
+        // SendAsync wraps non-2xx; the unparsed `probe` is the only place we see what NyxID
+        // actually returned. Distinguishes:
+        //   - `{"error":true,"status":403,"error_code":9000,"message":"API key does not have access..."}` → NyxID `ApiKeyScopeForbidden` (our payload still wrong)
+        //   - `{"error":true,"status":403,"body":"{\"message\":\"Bad credentials\",...}"}` → GitHub upstream 403 (OAuth grant revoked)
+        //   - other shapes → unclassified
+        _logger?.LogInformation(
+            "Diagnostic[#417]: GitHub preflight probe response. providerSlug={ProviderSlug} probe={Probe}",
+            nyxProviderSlug,
+            string.IsNullOrWhiteSpace(probe) ? "<empty>" : probe);
 
         if (string.IsNullOrWhiteSpace(probe))
             return null;


### PR DESCRIPTION
## Summary

After #418 merged, production `/daily` still fails with `github_proxy_access_denied`. Independent manual reproduction (session-token-minted child key, both narrow and broad scopes) succeeds end-to-end against the same NyxID account, GitHub UserService, and proxy slug. The production-only failure has to live in either the deployed `POST /api-keys` payload or the preflight response shape, neither of which is visible in current logs.

This PR adds **diagnostic-only** log lines on the daily-report create path so the next failed `/daily` captures ground truth, then revert.

## What's logged

- **Before `CreateApiKeyAsync`**: resolved per-user `UserService.id`s and the literal payload JSON. Tells us whether the deployed binary actually carries `allow_all_services=false` and whether `ResolveProxyServiceIdsAsync` returned per-user ids vs catalog ids.
- **After successful create**: the new api-key id, for correlating to NyxID-side `proxy_request_denied` audit records.
- **Inside `PreflightGitHubProxyAsync`** (Information level): the *raw* probe response. The parsed `proxy_body` we return only carries the inner Lark/GitHub body string when SendAsync wraps non-2xx; the unparsed probe is the only place we see exactly what NyxID returned. Distinguishes:
  - NyxID `ApiKeyScopeForbidden` (`error_code:9000`, our payload is still wrong somehow)
  - GitHub upstream 403 (`Bad credentials`, OAuth grant revoked)
  - Other shapes
- **On preflight failure** (Warning level): the structured envelope we hand back to the user, so the failure is one self-contained log line.

## Why this PR exists separately

These logs are temporary debugging — once the production log captures the real failure shape, this PR (or just the four log lines) gets reverted. Splitting it off keeps the revert clean and avoids re-opening the #418 conversation.

## Test plan

- [x] `dotnet build agents/Aevatar.GAgents.ChannelRuntime/Aevatar.GAgents.ChannelRuntime.csproj` — clean (40 pre-existing warnings, 0 errors).
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --filter AgentBuilderToolTests` — 30/30 passing.
- [ ] Deploy + trigger `/daily alice` from Lark, capture log lines tagged `Diagnostic[#417]`. Revert this PR after.

## Follow-up after capture

Depending on what `Diagnostic[#417]: GitHub preflight probe response` shows:
- If NyxID `error_code:9000` → resolver still returns wrong ids despite the apparent fix; need to revisit `ResolveProxyServiceIdsAsync` or how the relay-token auth path lists user-services
- If GitHub `Bad credentials` → OAuth grant on the bot owner's GitHub binding is unhealthy on the relay-token path even though it's healthy on session-token reads; need to look at how NyxID picks the credential to inject for relay-scoped api-keys
- If something else → analyze case-by-case