### PR TITLE
fix(nyxid-proxy): inject default User-Agent so GitHub doesn't 403

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -1833,7 +1833,7 @@ public sealed class AgentBuilderTool : IAgentTool
                 detail = string.IsNullOrWhiteSpace(detail) ? "GitHub proxy returned 401/403 for the new agent API key." : detail,
                 http_status = status,
                 proxy_body = string.IsNullOrWhiteSpace(body) ? null : body,
-                hint = "GitHub returned 401/403 to NyxID's stored OAuth token. The token was likely revoked at GitHub or had its scopes downgraded after the provider was connected. Re-authorize the GitHub provider at NyxID, then run /daily again.",
+                hint = "GitHub returned 401/403 through the NyxID proxy. Common causes: (a) the OAuth grant for GitHub was revoked at github.com/settings/applications or its scopes were downgraded — re-authorize the GitHub provider at NyxID; (b) the request reached GitHub without a User-Agent header (NyxIdApiClient now sends a default; if you see this, check that the deployed binary includes that fix). The agent will not produce a useful daily report until proxy access succeeds.",
                 nyx_provider_slug = nyxProviderSlug,
             });
         }

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -233,20 +233,10 @@ public sealed class AgentBuilderTool : IAgentTool
             ? SkillRunnerDefaults.GenerateActorId()
             : args.Str("agent_id")!.Trim();
 
-        // Diagnostic (#417 follow-up, PR for production 403 root-cause hunt): log the resolved
-        // service-id list and the exact payload we're about to send to NyxID `POST /api-keys`.
-        // The api-key request body is otherwise opaque in production; without this we can't tell
-        // whether the deployed binary actually carries the `allow_all_services=false` field, or
-        // whether `requiredServiceIds` resolved to per-user `UserService.id`s vs catalog ids.
-        var apiKeyPayload = BuildCreateApiKeyPayload(agentId, requiredServiceIds.value!);
-        _logger?.LogInformation(
-            "Diagnostic[#417]: minting agent api-key. agentId={AgentId} requiredSlugs={Slugs} resolvedServiceIds={Ids} payload={Payload}",
-            agentId,
-            string.Join(",", templateSpec!.RequiredServiceSlugs),
-            string.Join(",", requiredServiceIds.value!),
-            apiKeyPayload);
-
-        var createKeyResponse = await nyxClient.CreateApiKeyAsync(token, apiKeyPayload, ct);
+        var createKeyResponse = await nyxClient.CreateApiKeyAsync(
+            token,
+            BuildCreateApiKeyPayload(agentId, requiredServiceIds.value!),
+            ct);
 
         if (IsErrorPayload(createKeyResponse))
             return createKeyResponse;
@@ -254,30 +244,19 @@ public sealed class AgentBuilderTool : IAgentTool
         if (!TryParseApiKeyCreateResponse(createKeyResponse, out var apiKeyId, out var apiKeyValue, out var apiKeyError))
             return JsonSerializer.Serialize(new { error = apiKeyError });
 
-        _logger?.LogInformation(
-            "Diagnostic[#417]: agent api-key created. agentId={AgentId} apiKeyId={ApiKeyId}",
-            agentId,
-            apiKeyId);
-
-        // Issue aevatarAI/aevatar#411 / #417 follow-up: catch in-flight GitHub OAuth revocation.
-        // The earlier `BuildGitHubAuthorizationResponseAsync` check covers the "no provider token
-        // at all" case; this preflight only earns its keep when the OAuth grant was revoked or
-        // had its scopes downgraded between connect-time and create-time.
+        // Issue aevatarAI/aevatar#411 / #417 follow-up: catch in-flight GitHub-side issues.
+        // The earlier `BuildGitHubAuthorizationResponseAsync` check covers the "no provider
+        // token at all" case; this preflight catches misconfigurations that only surface at
+        // request time (the original case under #421 was a missing `User-Agent` header that
+        // GitHub rejects with 403; OAuth grant revocation is the other one).
         //
-        // Codex review (PR #418 r3141846175): even though the api-key itself is correctly
-        // configured under #417, we still revoke it on preflight failure. Reason: each retry of
-        // `/daily` mints a *new* api-key before the preflight runs, so without revoke the user's
-        // NyxID account accumulates one orphan proxy-scoped key per failed retry until they
-        // re-authorize GitHub. The revoke is a best-effort cleanup, not a safety claim about the
-        // key's correctness.
+        // PR #418 review r3141846175: revoke the freshly-minted key on preflight failure so
+        // each `/daily` retry doesn't leave another orphan proxy-scoped key behind in the
+        // user's NyxID account. The revoke is best-effort cleanup, not a safety claim about
+        // the key's correctness.
         var preflight = await PreflightGitHubProxyAsync(nyxClient, apiKeyValue!, providerSlug, ct);
         if (preflight is not null)
         {
-            _logger?.LogWarning(
-                "Diagnostic[#417]: preflight failed; revoking new api-key. agentId={AgentId} apiKeyId={ApiKeyId} preflightResponse={Response}",
-                agentId,
-                apiKeyId,
-                preflight);
             await BestEffortRevokeApiKeyAsync(nyxClient, token, apiKeyId!, "github_preflight_failed", ct);
             return preflight;
         }
@@ -1777,18 +1756,6 @@ public sealed class AgentBuilderTool : IAgentTool
             body: null,
             extraHeaders: null,
             ct);
-
-        // Diagnostic (#417 follow-up): log the *raw* probe response. The parsed JSON envelope
-        // we return as `proxy_body` only carries the inner Lark/GitHub `body` string when
-        // SendAsync wraps non-2xx; the unparsed `probe` is the only place we see what NyxID
-        // actually returned. Distinguishes:
-        //   - `{"error":true,"status":403,"error_code":9000,"message":"API key does not have access..."}` → NyxID `ApiKeyScopeForbidden` (our payload still wrong)
-        //   - `{"error":true,"status":403,"body":"{\"message\":\"Bad credentials\",...}"}` → GitHub upstream 403 (OAuth grant revoked)
-        //   - other shapes → unclassified
-        _logger?.LogInformation(
-            "Diagnostic[#417]: GitHub preflight probe response. providerSlug={ProviderSlug} probe={Probe}",
-            nyxProviderSlug,
-            string.IsNullOrWhiteSpace(probe) ? "<empty>" : probe);
 
         if (string.IsNullOrWhiteSpace(probe))
             return null;

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs
@@ -23,6 +23,19 @@ public sealed record NyxIdChannelRelayReplyResult(
 /// <summary>HTTP client for calling NyxID REST API endpoints.</summary>
 public sealed class NyxIdApiClient
 {
+    /// <summary>
+    /// Default <c>User-Agent</c> injected on every call to <see cref="ProxyRequestAsync"/>
+    /// when the caller does not specify one in <c>extraHeaders</c>. GitHub's REST API rejects
+    /// requests without a <c>User-Agent</c> with HTTP 403 ("Request forbidden by administrative
+    /// rules") — see https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required.
+    /// .NET's <c>HttpClient</c> does not set one by default; NyxID proxies the client's headers
+    /// through to GitHub, so the absence at the .NET layer manifests as a GitHub 403 in
+    /// production. CLI tools written against <c>reqwest</c> (e.g. <c>nyxid proxy request</c>)
+    /// happen to send <c>reqwest/x.y</c> as their default and so never hit this.
+    /// </summary>
+    public const string DefaultProxyUserAgent = "aevatar-agent-builder";
+    private const string UserAgentHeaderName = "User-Agent";
+
     private readonly HttpClient _http;
     private readonly NyxIdToolOptions _options;
     private readonly ILogger _logger;
@@ -131,11 +144,25 @@ public sealed class NyxIdApiClient
         using var request = new HttpRequestMessage(httpMethod, url);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
+        var callerSpecifiedUserAgent = false;
         if (extraHeaders != null)
         {
             foreach (var (key, value) in extraHeaders)
+            {
                 request.Headers.TryAddWithoutValidation(key, value);
+                if (string.Equals(key, UserAgentHeaderName, StringComparison.OrdinalIgnoreCase))
+                    callerSpecifiedUserAgent = true;
+            }
         }
+
+        // GitHub-required User-Agent (#417 follow-up). NyxID proxies whatever the .NET client
+        // sends, and HttpClient sends none by default, so without this every GitHub call lands
+        // as 403 "Request forbidden by administrative rules". Inject a default for *all* proxy
+        // targets — non-GitHub services don't care about UA either way, and pinning it at the
+        // proxy boundary means SkillRunner / agent-builder / preflight all benefit without
+        // every call site remembering to pass it.
+        if (!callerSpecifiedUserAgent)
+            request.Headers.TryAddWithoutValidation(UserAgentHeaderName, DefaultProxyUserAgent);
 
         if (!string.IsNullOrEmpty(body) && httpMethod != HttpMethod.Get && httpMethod != HttpMethod.Head)
         {

--- a/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs
@@ -176,6 +176,66 @@ public sealed class NyxIdApiClientCoverageTests
     }
 
     [Fact]
+    public async Task ProxyRequestAsync_ShouldInjectDefaultUserAgent_WhenCallerOmitsIt()
+    {
+        // #417 follow-up: GitHub's REST API rejects requests without a `User-Agent` header
+        // with a 403 "Request forbidden by administrative rules". .NET's `HttpClient` doesn't
+        // send one by default, and NyxID proxies whatever the .NET client sends — so without
+        // this default, every agent-builder GitHub call lands as a spurious 403 (root cause of
+        // production /daily failures captured under PR #420 diagnostic logs).
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        });
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler),
+            NullLogger<NyxIdApiClient>.Instance);
+
+        await client.ProxyRequestAsync(
+            "token",
+            "api-github",
+            "/rate_limit",
+            "GET",
+            body: null,
+            extraHeaders: null,
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        var ua = handler.LastRequest!.Headers.UserAgent.ToString();
+        ua.Should().Be(NyxIdApiClient.DefaultProxyUserAgent);
+    }
+
+    [Fact]
+    public async Task ProxyRequestAsync_ShouldHonorCallerSuppliedUserAgent()
+    {
+        // The default is only injected when the caller doesn't specify one — agent code that
+        // wants to identify as a different UA (e.g. SkillRunner with a per-template label)
+        // should win over the boundary default.
+        var handler = new CaptureHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        });
+        var client = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler),
+            NullLogger<NyxIdApiClient>.Instance);
+
+        await client.ProxyRequestAsync(
+            "token",
+            "api-github",
+            "/rate_limit",
+            "GET",
+            body: null,
+            extraHeaders: new Dictionary<string, string> { ["User-Agent"] = "custom-skill-runner/1.2.3" },
+            CancellationToken.None);
+
+        handler.LastRequest.Should().NotBeNull();
+        var ua = handler.LastRequest!.Headers.UserAgent.ToString();
+        ua.Should().Be("custom-skill-runner/1.2.3");
+    }
+
+    [Fact]
     public void TryParseErrorEnvelope_ShouldHandleEmptyInvalidAndStructuredResponses()
     {
         InvokeTryParseErrorEnvelope(string.Empty).Should().Be((true, "empty_response"));

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -434,7 +434,10 @@ public sealed class AgentBuilderToolTests
             doc.RootElement.GetProperty("http_status").GetInt32().Should().Be(403);
             // The hint should point users at re-authorizing the GitHub provider at NyxID, not
             // at api-key bindings (which used to be the misdiagnosis under #411 — see #417).
-            doc.RootElement.GetProperty("hint").GetString().Should().Contain("Re-authorize");
+            // Match case-insensitively so future hint copy edits (capitalization, punctuation)
+            // don't require flipping this assertion in lockstep — the *intent* of the assertion
+            // is "hint mentions re-authorization", not "hint matches one specific prefix".
+            doc.RootElement.GetProperty("hint").GetString()!.ToLowerInvariant().Should().Contain("re-authorize");
 
             // The actor must NOT receive InitializeSkillRunnerCommand — preflight aborts
             // BEFORE the actor is invoked so we don't leave a broken agent in the catalog.


### PR DESCRIPTION
Closes #411.

## Summary

Fixes the production `/daily` 403 — both at agent-create time (preflight) and at SkillRunner runtime (every `nyxid_proxy` GitHub call).

The smoking gun came from the diagnostic logs added in #420. GitHub returned **403 with body**:

> Request forbidden by administrative rules. Please make sure your request has a User-Agent header (https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required).

Not OAuth. Not `ApiKeyScopeForbidden`. **GitHub rejects any REST request without a `User-Agent` header.**

## Why this only manifested in production

| Caller | UA sent | GitHub response |
|---|---|---|
| `nyxid proxy request ...` (Rust `reqwest`) | `reqwest/0.x.y` (auto) | ✅ 200 |
| `curl` | `curl/8.x` (auto) | ✅ 200 |
| **Production backend (.NET `HttpClient`)** | **none — `HttpClient` doesn't send one by default** | ❌ 403 |

Every CLI reproduction I did against the same NyxID account, same UserService, same api-key scope returned 200, because `reqwest` auto-injects a UA. The .NET `HttpClient` does not. NyxID's proxy transparently forwards whatever the client sends, so the missing-at-the-.NET-layer header surfaces as `403 Request forbidden by administrative rules` from GitHub at the bottom of the stack.

This is also why all of #418's fixes were correct — `allow_all_services=false`, per-user `UserService.id`s, eligible-row picker, `BestEffortRevoke` — none of those had any effect on the GitHub-side rejection.

## Why this fix closes #411

#411 describes the runtime symptom directly: `daily_report` agent gets created, then at SkillRunner execution time **every** GitHub call through `nyxid_proxy` returns 403. The runtime path is `SkillRunnerGAgent` → LLM tool calls `nyxid_proxy` → `NyxIdProxyTool.ExecuteAsync` (`src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdProxyTool.cs:111`) → `NyxIdApiClient.ProxyRequestAsync` → NyxID → GitHub. By injecting the default UA at the `ProxyRequestAsync` boundary, every call on that runtime path now carries a UA and stops being rejected.

Mapping #411's suggested fixes to what landed:

| #411 suggestion | Status |
|---|---|
| 1. Preflight GitHub access at agent-create time | ✅ Landed in #418 (`PreflightGitHubProxyAsync` in `AgentBuilderTool.cs`) |
| 2. Surface "all GitHub calls failed at runtime" as SkillRunner failure with `LastError` | Not addressed here — root cause removed makes this a secondary concern. Can open a follow-up if anyone wants the bookkeeping anyway |
| 3. Sanitized diagnostic logging for proxy 4xx bodies | Partial — `github_proxy_access_denied` envelope now includes the upstream `proxy_body` (carries the real GitHub error), and the temporary `Diagnostic[#417]` logs from #420 captured the production root cause that drove this PR (logs removed here, the diagnostic envelope stays) |
| 4. Typed GitHub activity tool | Not addressed; orthogonal to the 403 root cause |

## Changes

- `src/Aevatar.AI.ToolProviders.NyxId/NyxIdApiClient.cs`:
  - Add `DefaultProxyUserAgent` constant (`aevatar-agent-builder`).
  - `ProxyRequestAsync` now injects this UA on every call when the caller hasn't supplied one. Caller-supplied `User-Agent` in `extraHeaders` (case-insensitive) wins.
  - Pinned at the proxy boundary so agent-builder preflight, SkillRunner runtime `nyxid_proxy` calls, and any future agent that reaches GitHub via NyxID proxy all benefit without each call site remembering to send UA.
- `agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs`:
  - Rewrite `github_proxy_access_denied` hint. The previous wording ("OAuth grant was revoked, re-authorize") was based on the #418 misdiagnosis; the actual production failure was missing UA, not revoked OAuth. New hint covers both causes.
  - Remove the four `Diagnostic[#417]` log lines added in #420. They served their purpose and don't have a long-term place on the hot path (full payload JSON including api-key prefixes).
  - Tighten the comment block at the preflight call site to reflect the broader rationale (UA, OAuth revocation, etc.).
- `test/Aevatar.AI.Tests/NyxIdApiClientCoverageTests.cs`:
  - `_ShouldInjectDefaultUserAgent_WhenCallerOmitsIt` — pins the regression
  - `_ShouldHonorCallerSuppliedUserAgent` — pins that caller override still works
- `test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs`:
  - Soften the hint substring assertion to a case-insensitive match (per review at 4175638754) so future hint copy edits don't require synchronized assertion flips.

## Verification

- [x] `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj` — 12/12 passing
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/...` — 421/421 passing (verified at 160c4748 after the review-driven assertion fix)
- [ ] Production smoke after merge: `/daily alice` from a Lark DM should now succeed end-to-end and the resulting agent's scheduled runs should produce a real GitHub-backed report.

## Follow-up

Filed at the proxy layer too: ChronoAIProject/NyxID#514 proposes NyxID default-inject `User-Agent` for proxy targets whose upstream requires it. The contract "every NyxID proxy caller must remember to send UA" is fragile (Python `urllib`, Java `HttpURLConnection`, .NET `HttpClient` all default to no UA); the proxy is a better place to enforce GitHub's hard requirement than every SDK.

## Related

- #411 — the runtime-failure issue this closes (root cause was layered: catalog-id-vs-UserService-id → allow_all_services default → User-Agent)
- #418 — `allow_all_services=false` + per-user `UserService.id` fix (correct, but masked by the UA issue underneath)
- #420 — diagnostic logs that surfaced this; logs removed in this PR
- #416 / #419 — `/agents` 502 from malformed Lark v2 card payload (separate issue, fixed in #419)
- ChronoAIProject/NyxID#514 — upstream proposal to default-inject UA at the proxy layer