### PR TITLE
fix(lark): emit card v2 callback buttons

### DIFF
--- a/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
@@ -53,11 +53,13 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             if (leading is not null)
                 formElements.Add(leading);
 
+            var actionElements = intent.Actions.SelectMany(BuildFormChildElements).ToArray();
             formElements.Add(new
             {
                 tag = "form",
                 name = DefaultFormName,
-                elements = intent.Actions.Select(BuildFormChildAction).ToArray(),
+                direction = "vertical",
+                elements = actionElements,
             });
 
             var formCardJson = JsonSerializer.Serialize(new
@@ -78,6 +80,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
                 },
                 body = new
                 {
+                    direction = "vertical",
                     elements = formElements,
                 },
             });
@@ -110,11 +113,9 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
 
         if (intent.Actions.Count > 0)
         {
-            elements.Add(new
-            {
-                tag = "action",
-                actions = intent.Actions.Select(BuildAction).ToArray(),
-            });
+            elements.AddRange(intent.Actions
+                .Where(action => action.Kind != ActionElementKind.TextInput)
+                .Select(BuildAction));
         }
 
         var cardJson = JsonSerializer.Serialize(new
@@ -135,6 +136,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             },
             body = new
             {
+                direction = "vertical",
                 elements,
             },
         });
@@ -212,10 +214,26 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         };
     }
 
-    private static object BuildFormChildAction(ActionElement action) =>
-        action.Kind == ActionElementKind.TextInput
-            ? BuildFormInput(action)
-            : BuildFormButton(action);
+    private static IEnumerable<object> BuildFormChildElements(ActionElement action)
+    {
+        if (action.Kind != ActionElementKind.TextInput)
+        {
+            yield return BuildFormButton(action);
+            yield break;
+        }
+
+        var label = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label;
+        if (!string.IsNullOrWhiteSpace(label))
+        {
+            yield return new
+            {
+                tag = "markdown",
+                content = $"**{label}**",
+            };
+        }
+
+        yield return BuildFormInput(action);
+    }
 
     private static object BuildFormInput(ActionElement action)
     {
@@ -226,11 +244,8 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         {
             ["tag"] = "input",
             ["name"] = action.ActionId,
-            ["label"] = new
-            {
-                tag = "plain_text",
-                content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
-            },
+            ["input_type"] = "text",
+            ["width"] = "fill",
             ["placeholder"] = new
             {
                 tag = "plain_text",
@@ -245,7 +260,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
     private static object BuildFormButton(ActionElement action) => new
     {
         tag = "button",
-        type = action.IsPrimary ? "primary" : "default",
+        type = ResolveButtonType(action),
         name = action.ActionId,
         form_action_type = "submit",
         text = new
@@ -253,7 +268,7 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             tag = "plain_text",
             content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
         },
-        value = BuildActionValueObject(action),
+        behaviors = BuildButtonBehaviors(action),
     };
 
     private static object BuildAction(ActionElement action) => new
@@ -264,9 +279,40 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             tag = "plain_text",
             content = string.IsNullOrWhiteSpace(action.Label) ? action.ActionId : action.Label,
         },
-        type = action.IsPrimary ? "primary" : "default",
-        value = BuildActionValueObject(action),
+        type = ResolveButtonType(action),
+        behaviors = BuildButtonBehaviors(action),
     };
+
+    private static string ResolveButtonType(ActionElement action)
+    {
+        if (action.IsDanger)
+            return "danger";
+        return action.IsPrimary ? "primary" : "default";
+    }
+
+    private static object[] BuildButtonBehaviors(ActionElement action)
+    {
+        if (action.Kind == ActionElementKind.Link && !string.IsNullOrWhiteSpace(action.Value))
+        {
+            return new object[]
+            {
+                new
+                {
+                    type = "open_url",
+                    default_url = action.Value,
+                },
+            };
+        }
+
+        return new object[]
+        {
+            new
+            {
+                type = "callback",
+                value = BuildActionValueObject(action),
+            },
+        };
+    }
 
     private static IDictionary<string, object?> BuildActionValueObject(ActionElement action)
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortRoundTripTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortRoundTripTests.cs
@@ -8,8 +8,8 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
 /// <summary>
 /// The outbound approval card is parsed back on the inbound side by
-/// <c>NyxIdRelayTransport</c>, which normalizes <c>content.text.value</c> into the strongly typed
-/// <c>CardActionSubmission.Arguments</c> map and <c>content.text.form_value</c> into
+/// <c>NyxIdRelayTransport</c>, which normalizes the Lark callback <c>action.value</c> into the
+/// strongly typed <c>CardActionSubmission.Arguments</c> map and <c>action.form_value</c> into
 /// <c>CardActionSubmission.FormFields</c>. These tests pin that the composer output still carries
 /// the correlation keys in the exact locations the transport reads, so <c>ChannelCardActionRouting</c>
 /// can rebuild the workflow resume command end-to-end.
@@ -17,7 +17,7 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public sealed class FeishuCardHumanInteractionPortRoundTripTests
 {
     [Fact]
-    public void Approval_card_buttons_carry_correlation_keys_in_value()
+    public void Approval_card_buttons_carry_correlation_keys_in_callback_value()
     {
         var card = FeishuCardHumanInteractionPort.BuildCardJson(new HumanInteractionRequest
         {
@@ -36,19 +36,26 @@ public sealed class FeishuCardHumanInteractionPortRoundTripTests
             .GetProperty("elements")[1]
             .GetProperty("elements");
 
-        var approveButton = formElements[2];
+        var approveButton = formElements
+            .EnumerateArray()
+            .First(e => e.GetProperty("tag").GetString() == "button" &&
+                        e.GetProperty("text").GetProperty("content").GetString() == "Approve");
         approveButton.GetProperty("text").GetProperty("content").GetString().Should().Be("Approve");
-        var approveValue = approveButton.GetProperty("value");
+        var approveValue = approveButton.GetProperty("behaviors")[0].GetProperty("value");
         approveValue.GetProperty("actor_id").GetString().Should().Be("actor-A");
         approveValue.GetProperty("run_id").GetString().Should().Be("run-A");
         approveValue.GetProperty("step_id").GetString().Should().Be("step-A");
         approveValue.GetProperty("approved").GetBoolean().Should().BeTrue();
         approveButton.GetProperty("name").GetString().Should().Be("approve");
         approveButton.GetProperty("form_action_type").GetString().Should().Be("submit");
+        approveButton.TryGetProperty("value", out _).Should().BeFalse();
 
-        var rejectButton = formElements[3];
+        var rejectButton = formElements
+            .EnumerateArray()
+            .First(e => e.GetProperty("tag").GetString() == "button" &&
+                        e.GetProperty("text").GetProperty("content").GetString() == "Reject");
         rejectButton.GetProperty("text").GetProperty("content").GetString().Should().Be("Reject");
-        var rejectValue = rejectButton.GetProperty("value");
+        var rejectValue = rejectButton.GetProperty("behaviors")[0].GetProperty("value");
         rejectValue.GetProperty("actor_id").GetString().Should().Be("actor-A");
         rejectValue.GetProperty("approved").GetBoolean().Should().BeFalse();
     }
@@ -72,10 +79,15 @@ public sealed class FeishuCardHumanInteractionPortRoundTripTests
             .GetProperty("elements")[1]
             .GetProperty("elements");
 
-        formElements[0].GetProperty("tag").GetString().Should().Be("input");
-        formElements[0].GetProperty("name").GetString().Should().Be("edited_content");
-        formElements[1].GetProperty("tag").GetString().Should().Be("input");
-        formElements[1].GetProperty("name").GetString().Should().Be("user_input");
+        var inputs = formElements
+            .EnumerateArray()
+            .Where(e => e.GetProperty("tag").GetString() == "input")
+            .ToArray();
+        inputs.Should().HaveCount(2);
+        inputs[0].GetProperty("name").GetString().Should().Be("edited_content");
+        inputs[0].TryGetProperty("label", out _).Should().BeFalse();
+        inputs[1].GetProperty("name").GetString().Should().Be("user_input");
+        inputs[1].TryGetProperty("label", out _).Should().BeFalse();
     }
 
     [Fact]
@@ -105,12 +117,16 @@ public sealed class FeishuCardHumanInteractionPortRoundTripTests
             .GetProperty("elements")[1]
             .GetProperty("elements");
 
-        formElements.GetArrayLength().Should().Be(2);
-        formElements[0].GetProperty("tag").GetString().Should().Be("input");
-        formElements[0].GetProperty("name").GetString().Should().Be("user_input");
-        formElements[1].GetProperty("tag").GetString().Should().Be("button");
-        formElements[1].GetProperty("name").GetString().Should().Be("submit");
-        var submitValue = formElements[1].GetProperty("value");
+        var input = formElements
+            .EnumerateArray()
+            .Single(e => e.GetProperty("tag").GetString() == "input");
+        input.GetProperty("name").GetString().Should().Be("user_input");
+        input.TryGetProperty("label", out _).Should().BeFalse();
+        var submitButton = formElements
+            .EnumerateArray()
+            .Single(e => e.GetProperty("tag").GetString() == "button");
+        submitButton.GetProperty("name").GetString().Should().Be("submit");
+        var submitValue = submitButton.GetProperty("behaviors")[0].GetProperty("value");
         submitValue.GetProperty("actor_id").GetString().Should().Be("actor-B");
         submitValue.GetProperty("run_id").GetString().Should().Be("run-B");
         submitValue.GetProperty("step_id").GetString().Should().Be("input-B");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortTests.cs
@@ -53,9 +53,18 @@ public sealed class FeishuCardHumanInteractionPortTests
         bodyElements.GetArrayLength().Should().BeGreaterThan(1);
         bodyElements[1].GetProperty("tag").GetString().Should().Be("form");
         var formElements = bodyElements[1].GetProperty("elements");
-        formElements[2].GetProperty("text").GetProperty("content").GetString().Should().Be("Approve");
-        formElements[3].GetProperty("text").GetProperty("content").GetString().Should().Be("Reject");
-        formElements[2].GetProperty("value").GetProperty("actor_id").GetString().Should().Be("workflow-actor-1");
+        var approveButton = formElements
+            .EnumerateArray()
+            .First(e => e.GetProperty("tag").GetString() == "button" &&
+                        e.GetProperty("text").GetProperty("content").GetString() == "Approve");
+        var rejectButton = formElements
+            .EnumerateArray()
+            .First(e => e.GetProperty("tag").GetString() == "button" &&
+                        e.GetProperty("text").GetProperty("content").GetString() == "Reject");
+        approveButton.GetProperty("text").GetProperty("content").GetString().Should().Be("Approve");
+        rejectButton.GetProperty("text").GetProperty("content").GetString().Should().Be("Reject");
+        approveButton.GetProperty("behaviors")[0].GetProperty("value").GetProperty("actor_id").GetString()
+            .Should().Be("workflow-actor-1");
     }
 
     [Fact]
@@ -298,9 +307,17 @@ public sealed class FeishuCardHumanInteractionPortTests
         var formElements = form.GetProperty("elements");
         document.RootElement.GetProperty("body").GetProperty("elements")[0].GetProperty("content").GetString()
             .Should().Contain("/submit actor_id=workflow-actor-2 run_id=run-2 step_id=input-1");
-        formElements[0].GetProperty("name").GetString().Should().Be("user_input");
-        formElements[1].GetProperty("text").GetProperty("content").GetString().Should().Be("Submit");
-        formElements[1].GetProperty("value").GetProperty("run_id").GetString().Should().Be("run-2");
+        var input = formElements
+            .EnumerateArray()
+            .Single(e => e.GetProperty("tag").GetString() == "input");
+        input.GetProperty("name").GetString().Should().Be("user_input");
+        input.TryGetProperty("label", out _).Should().BeFalse();
+        var submitButton = formElements
+            .EnumerateArray()
+            .Single(e => e.GetProperty("tag").GetString() == "button");
+        submitButton.GetProperty("text").GetProperty("content").GetString().Should().Be("Submit");
+        submitButton.GetProperty("behaviors")[0].GetProperty("value").GetProperty("run_id").GetString()
+            .Should().Be("run-2");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
+++ b/test/Aevatar.GAgents.Platform.Lark.Tests/LarkMessageComposerTests.cs
@@ -109,7 +109,12 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
         var cardMarkdown = bodyElements[1].GetProperty("content").GetString();
         cardMarkdown.ShouldNotBeNull();
         cardMarkdown.ShouldContain("skill-runner");
-        bodyElements[2].GetProperty("tag").GetString().ShouldBe("action");
+        var button = bodyElements[2];
+        button.GetProperty("tag").GetString().ShouldBe("button");
+        button.TryGetProperty("value", out _).ShouldBeFalse();
+        var behavior = button.GetProperty("behaviors")[0];
+        behavior.GetProperty("type").GetString().ShouldBe("callback");
+        behavior.GetProperty("value").GetProperty("action_id").GetString().ShouldBe("status");
     }
 
     [Fact]
@@ -156,6 +161,7 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
             .GetProperty("elements")
             .EnumerateArray()
             .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "input");
+        inputElement.TryGetProperty("label", out _).ShouldBeFalse();
         inputElement.GetProperty("default_value").GetString().ShouldBe("eanzhao");
     }
 
@@ -202,5 +208,60 @@ public sealed class LarkMessageComposerTests : MessageComposerUnitTests<LarkMess
             .EnumerateArray()
             .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "input");
         inputElement.TryGetProperty("default_value", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Compose_WhenRenderingFormSubmit_UsesLarkV2CallbackBehavior()
+    {
+        var intent = new MessageContent();
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.TextInput,
+            ActionId = "github_username",
+            Label = "GitHub Username",
+            Placeholder = "octocat",
+        });
+        var submit = new ActionElement
+        {
+            Kind = ActionElementKind.FormSubmit,
+            ActionId = "submit_daily_report",
+            Label = "Create",
+            IsPrimary = true,
+        };
+        submit.Arguments["agent_builder_action"] = "create_daily_report";
+        intent.Actions.Add(submit);
+
+        var payload = CreateComposer().Compose(
+            intent,
+            new ComposeContext
+            {
+                Conversation = ConversationReference.Create(
+                    ChannelId.From("lark"),
+                    BotInstanceId.From("bot-1"),
+                    ConversationScope.DirectMessage,
+                    partition: null,
+                    "user-1"),
+                Capabilities = LarkMessageComposer.DefaultCapabilities.Clone(),
+            });
+
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var formElement = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "form");
+        var submitButton = formElement
+            .GetProperty("elements")
+            .EnumerateArray()
+            .First(e => e.TryGetProperty("tag", out var tag) && tag.GetString() == "button");
+
+        submitButton.GetProperty("name").GetString().ShouldBe("submit_daily_report");
+        submitButton.GetProperty("form_action_type").GetString().ShouldBe("submit");
+        submitButton.TryGetProperty("value", out _).ShouldBeFalse();
+        var behavior = submitButton.GetProperty("behaviors")[0];
+        behavior.GetProperty("type").GetString().ShouldBe("callback");
+        var value = behavior.GetProperty("value");
+        value.GetProperty("action_id").GetString().ShouldBe("submit_daily_report");
+        value.GetProperty("agent_builder_action").GetString().ShouldBe("create_daily_report");
     }
 }


### PR DESCRIPTION
## Summary
- Render Lark/Feishu Card JSON 2.0 buttons directly in `body.elements` instead of the legacy `action.actions` wrapper.
- Move button callback payloads from top-level `value` to `behaviors[0].value`, matching Card JSON 2.0 while preserving the existing NyxID `card.action.trigger` parsing contract.
- Update form card rendering and tests so form inputs/buttons use the same v2 shape.

## Root Cause
`/agents` still produced a hybrid card after PR #419: the card body was moved under `body.elements`, but buttons kept the older container/value shape. Lark rejected the interactive reply through NyxID with `channel-relay/reply -> 502`, and the single-use relay token prevented text fallback.

## Validation
- `dotnet test test/Aevatar.GAgents.Platform.Lark.Tests/Aevatar.GAgents.Platform.Lark.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`