### PR TITLE
feat(console-web): close out member-first Studio Invoke flow

### DIFF
--- a/apps/aevatar-console-web/jest.config.ts
+++ b/apps/aevatar-console-web/jest.config.ts
@@ -94,6 +94,7 @@ const nodeTestFiles = [
   '<rootDir>/src/shared/datetime/dateTime.test.ts',
   '<rootDir>/src/shared/playground/stepSummary.test.ts',
   '<rootDir>/src/shared/studio/document.test.ts',
+  '<rootDir>/src/shared/studio/invokeHistoryStore.test.ts',
   '<rootDir>/src/shared/studio/navigation.test.ts',
   '<rootDir>/src/shared/ui/aevatarWorkbench.test.ts',
   '<rootDir>/src/shared/workflows/catalogVisibility.test.ts',

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -1,8 +1,17 @@
 import { AGUIEventType } from '@aevatar-react-sdk/types';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import React from 'react';
 import { parseBackendSSEStream } from '@/shared/agui/sseFrameNormalizer';
 import { runtimeRunsApi } from '@/shared/api/runtimeRunsApi';
+import { history } from '@/shared/navigation/history';
+import type { ScopeConsoleServiceOption } from '@/shared/runs/scopeConsole';
+import { buildStudioInvokeHistoryStorageKey } from '@/shared/studio/invokeHistoryStore';
 import StudioMemberInvokePanel from './StudioMemberInvokePanel';
 
 jest.mock('@/shared/api/runtimeRunsApi', () => ({
@@ -22,16 +31,23 @@ jest.mock('@/shared/studio/api', () => ({
   },
 }));
 
+jest.mock('@/shared/navigation/history', () => ({
+  history: { push: jest.fn() },
+}));
+
 describe('StudioMemberInvokePanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    window.sessionStorage.clear();
     (runtimeRunsApi.invokeEndpoint as jest.Mock).mockResolvedValue({
       accepted: true,
       commandId: 'cmd-1',
       requestId: 'run-1',
       targetActorId: 'actor-1',
     });
-    (parseBackendSSEStream as jest.Mock).mockImplementation(async function* () {});
+    (parseBackendSSEStream as jest.Mock).mockImplementation(
+      async function* () {},
+    );
   });
 
   it('renders the invoke workbench skeleton with a compact contract and a persistent console', async () => {
@@ -88,7 +104,9 @@ describe('StudioMemberInvokePanel', () => {
       }),
     );
 
-    expect(await screen.findByTestId('studio-member-invoke-panel')).toBeTruthy();
+    expect(
+      await screen.findByTestId('studio-member-invoke-panel'),
+    ).toBeTruthy();
     expect(screen.getByText('调用契约')).toBeTruthy();
     expect(screen.getByText('调试台')).toBeTruthy();
     expect(screen.getByText('当前结果')).toBeTruthy();
@@ -102,7 +120,9 @@ describe('StudioMemberInvokePanel', () => {
     expect(screen.getByText('原始')).toBeTruthy();
     expect(screen.getByTestId('studio-invoke-playground-actions')).toBeTruthy();
     expect(
-      screen.getByText('还没有开始调用。先在上方输入提示词或载荷，再发起一次调用。'),
+      screen.getByText(
+        '还没有开始调用。先在上方输入提示词或载荷，再发起一次调用。',
+      ),
     ).toBeTruthy();
     expect(screen.queryByText('Runs（0）')).toBeNull();
     expect(screen.queryByText('运行详情')).toBeNull();
@@ -145,7 +165,9 @@ describe('StudioMemberInvokePanel', () => {
     expect(screen.queryByText('缺少提示词')).toBeNull();
     expect(screen.getByText('当前结果')).toBeTruthy();
     expect(
-      screen.getByText('还没有开始调用。先在上方输入提示词或载荷，再发起一次调用。'),
+      screen.getByText(
+        '还没有开始调用。先在上方输入提示词或载荷，再发起一次调用。',
+      ),
     ).toBeTruthy();
     expect(screen.queryByText(/Runs（/)).toBeNull();
     expect(screen.queryByText('这次调用失败了。')).toBeNull();
@@ -248,13 +270,18 @@ describe('StudioMemberInvokePanel', () => {
         value: 'Route this escalation to billing review.',
       },
     });
-    fireEvent.change(screen.getByPlaceholderText('type.googleapis.com/example.Command'), {
-      target: {
-        value: 'type.googleapis.com/example.Submit',
-      },
-    });
     fireEvent.change(
-      screen.getByPlaceholderText('如需类型化调用，请粘贴预编码的 protobuf payload。'),
+      screen.getByPlaceholderText('type.googleapis.com/example.Command'),
+      {
+        target: {
+          value: 'type.googleapis.com/example.Submit',
+        },
+      },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        '如需类型化调用，请粘贴预编码的 protobuf payload。',
+      ),
       {
         target: {
           value: 'ZXhhbXBsZS1wYXlsb2Fk',
@@ -281,12 +308,16 @@ describe('StudioMemberInvokePanel', () => {
 
     expect(await screen.findByText('Runs（1）')).toBeTruthy();
     expect(
-      screen.getByText('这次结构化调用已经返回结果。切到“原始”可以查看完整返回体。'),
+      screen.getByText(
+        '这次结构化调用已经返回结果。切到“原始”可以查看完整返回体。',
+      ),
     ).toBeTruthy();
     expect(screen.queryByText('运行详情')).toBeNull();
     expect(screen.queryByText('最新输出')).toBeNull();
 
-    const inlineDetail = await screen.findByTestId('studio-invoke-inline-detail');
+    const inlineDetail = await screen.findByTestId(
+      'studio-invoke-inline-detail',
+    );
     const inlineScope = within(inlineDetail);
     expect(inlineScope.getByText('Command ID')).toBeTruthy();
     expect(inlineScope.getByText('cmd-1')).toBeTruthy();
@@ -300,7 +331,202 @@ describe('StudioMemberInvokePanel', () => {
       },
     });
 
-    expect(screen.getByLabelText('调用请求输入')).toHaveValue('Overwrite prompt');
+    expect(screen.getByLabelText('调用请求输入')).toHaveValue(
+      'Overwrite prompt',
+    );
+  });
+
+  it('persists invoke history per scope+member so transcripts survive panel remounts', async () => {
+    const services: ScopeConsoleServiceOption[] = [
+      {
+        deploymentStatus: 'Active',
+        displayName: 'workspace-demo',
+        endpoints: [
+          {
+            description: 'Send a structured request into the member.',
+            displayName: 'Submit',
+            endpointId: 'submit',
+            kind: 'invoke',
+            requestTypeUrl: 'type.googleapis.com/example.Submit',
+            responseTypeUrl: 'type.googleapis.com/example.SubmitResult',
+          },
+        ],
+        kind: 'service',
+        namespace: 'default',
+        primaryActorId: 'actor-default',
+        serviceId: 'default',
+      },
+    ];
+
+    const props = {
+      memberKey: 'workflow:workflow-1',
+      scopeId: 'scope-1',
+      services,
+    };
+
+    const { unmount } = render(
+      React.createElement(StudioMemberInvokePanel, props),
+    );
+
+    fireEvent.change(await screen.findByLabelText('调用请求输入'), {
+      target: { value: 'Persisted prompt about billing' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('type.googleapis.com/example.Command'),
+      {
+        target: { value: 'type.googleapis.com/example.Submit' },
+      },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        '如需类型化调用，请粘贴预编码的 protobuf payload。',
+      ),
+      { target: { value: 'cGVyc2lzdGVkLXBheWxvYWQ=' } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: '执行调用' }));
+
+    expect(await screen.findByText('Runs（1）')).toBeTruthy();
+
+    const storageKey = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'workflow:workflow-1',
+    });
+    expect(window.sessionStorage.getItem(storageKey)).not.toBeNull();
+
+    unmount();
+
+    render(React.createElement(StudioMemberInvokePanel, props));
+
+    expect(await screen.findByText('Runs（1）')).toBeTruthy();
+  });
+
+  it('keeps invoke history scoped per member so switching members does not bleed transcripts', async () => {
+    const baseService: ScopeConsoleServiceOption = {
+      deploymentStatus: 'Active',
+      displayName: 'workspace-demo',
+      endpoints: [
+        {
+          description: 'Send a structured request into the member.',
+          displayName: 'Submit',
+          endpointId: 'submit',
+          kind: 'invoke',
+          requestTypeUrl: 'type.googleapis.com/example.Submit',
+          responseTypeUrl: 'type.googleapis.com/example.SubmitResult',
+        },
+      ],
+      kind: 'service',
+      namespace: 'default',
+      primaryActorId: 'actor-default',
+      serviceId: 'default',
+    };
+
+    const { rerender } = render(
+      React.createElement(StudioMemberInvokePanel, {
+        memberKey: 'workflow:workflow-1',
+        scopeId: 'scope-1',
+        services: [baseService],
+      }),
+    );
+
+    fireEvent.change(await screen.findByLabelText('调用请求输入'), {
+      target: { value: 'workflow-1 prompt' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('type.googleapis.com/example.Command'),
+      {
+        target: { value: 'type.googleapis.com/example.Submit' },
+      },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        '如需类型化调用，请粘贴预编码的 protobuf payload。',
+      ),
+      { target: { value: 'd29ya2Zsb3ctcGF5bG9hZA==' } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: '执行调用' }));
+
+    expect(await screen.findByText('Runs（1）')).toBeTruthy();
+
+    rerender(
+      React.createElement(StudioMemberInvokePanel, {
+        memberKey: 'workflow:workflow-2',
+        scopeId: 'scope-1',
+        services: [baseService],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Runs（/)).toBeNull();
+    });
+  });
+
+  it('routes the in-Studio Observe handoff back into Studio with the current member key preserved', async () => {
+    render(
+      React.createElement(StudioMemberInvokePanel, {
+        memberKey: 'workflow:workflow-1',
+        scopeId: 'scope-1',
+        services: [
+          {
+            deploymentStatus: 'Active',
+            displayName: 'workspace-demo',
+            endpoints: [
+              {
+                description: 'Chat with the member.',
+                displayName: 'Chat',
+                endpointId: 'chat',
+                kind: 'invoke',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+              },
+            ],
+            kind: 'service',
+            namespace: 'default',
+            primaryActorId: 'actor-default',
+            serviceId: 'default',
+          },
+        ],
+      }),
+    );
+
+    fireEvent.click(await screen.findByTestId('studio-invoke-observe-button'));
+
+    expect(history.push).toHaveBeenCalledWith(
+      '/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=observe&tab=executions',
+    );
+  });
+
+  it('falls back to the selected service id for Observe handoff when no member key is provided', async () => {
+    render(
+      React.createElement(StudioMemberInvokePanel, {
+        scopeId: 'scope-1',
+        services: [
+          {
+            deploymentStatus: 'Active',
+            displayName: 'workspace-demo',
+            endpoints: [
+              {
+                description: 'Chat with the member.',
+                displayName: 'Chat',
+                endpointId: 'chat',
+                kind: 'invoke',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+              },
+            ],
+            kind: 'service',
+            namespace: 'default',
+            primaryActorId: 'actor-fallback',
+            serviceId: 'service-fallback',
+          },
+        ],
+      }),
+    );
+
+    fireEvent.click(await screen.findByTestId('studio-invoke-observe-button'));
+
+    expect(history.push).toHaveBeenCalledWith(
+      '/studio?scopeId=scope-1&member=member%3Aservice-fallback&step=observe&tab=executions',
+    );
   });
 
   it('renders a clear empty state when no selected member is available for invoke', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
@@ -28,14 +28,22 @@ import {
 } from '@/shared/runs/scopeConsole';
 import { studioApi } from '@/shared/studio/api';
 import {
+  buildStudioInvokeHistoryStorageKey,
+  loadStudioInvokeHistory,
+  saveStudioInvokeHistory,
+  STUDIO_INVOKE_HISTORY_LIMIT,
+} from '@/shared/studio/invokeHistoryStore';
+import {
   describeStudioScopeBindingRevisionContext,
   type StudioScopeBindingRevision,
 } from '@/shared/studio/models';
+import { buildStudioObserveWorkspaceRoute } from '@/shared/studio/navigation';
 import { AevatarPanel, AevatarStatusTag } from '@/shared/ui/aevatarPageShells';
 import { AEVATAR_PRESSABLE_CARD_CLASS } from '@/shared/ui/interactionStandards';
 
 type StudioMemberInvokePanelProps = {
   readonly scopeId: string;
+  readonly memberKey?: string;
   readonly memberRevision?: StudioScopeBindingRevision | null;
   readonly services: readonly ScopeConsoleServiceOption[];
   readonly selectedMemberLabel?: string;
@@ -518,6 +526,7 @@ const CompactCopyableValue: React.FC<{
 
 const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   scopeId,
+  memberKey,
   memberRevision,
   services,
   selectedMemberLabel,
@@ -549,7 +558,17 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
     null,
   );
   const [chatMessages, setChatMessages] = useState<StudioInvokeChatMessage[]>([]);
-  const [requestHistory, setRequestHistory] = useState<InvokeHistoryEntry[]>([]);
+  const invokeHistoryStorageKey = useMemo(
+    () =>
+      buildStudioInvokeHistoryStorageKey({
+        scopeId,
+        memberKey,
+      }),
+    [memberKey, scopeId],
+  );
+  const [requestHistory, setRequestHistory] = useState<InvokeHistoryEntry[]>(
+    () => loadStudioInvokeHistory<InvokeHistoryEntry>(invokeHistoryStorageKey),
+  );
   const [expandedHistoryId, setExpandedHistoryId] = useState('');
   const [consoleTab, setConsoleTab] = useState<'result' | 'trace' | 'raw'>(
     'result',
@@ -774,6 +793,17 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   );
 
   useEffect(() => {
+    setRequestHistory(
+      loadStudioInvokeHistory<InvokeHistoryEntry>(invokeHistoryStorageKey),
+    );
+    setExpandedHistoryId('');
+  }, [invokeHistoryStorageKey]);
+
+  useEffect(() => {
+    saveStudioInvokeHistory(invokeHistoryStorageKey, requestHistory);
+  }, [invokeHistoryStorageKey, requestHistory]);
+
+  useEffect(() => {
     transcriptAnchorRef.current?.scrollIntoView?.({
       behavior: chatMessages.length > 1 ? 'smooth' : 'auto',
       block: 'end',
@@ -816,7 +846,9 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
         id: createClientId('request'),
       };
       setExpandedHistoryId(nextEntry.id);
-      setRequestHistory((current) => [nextEntry, ...current].slice(0, 8));
+      setRequestHistory((current) =>
+        [nextEntry, ...current].slice(0, STUDIO_INVOKE_HISTORY_LIMIT),
+      );
     },
     [],
   );
@@ -1269,6 +1301,25 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
     selectedService?.serviceId,
   ]);
 
+  const handleOpenStudioObserve = useCallback(() => {
+    if (!scopeId) {
+      return;
+    }
+
+    const observeMemberKey =
+      trimOptional(memberKey) ||
+      (selectedService?.serviceId
+        ? `member:${trimOptional(selectedService.serviceId)}`
+        : '');
+
+    history.push(
+      buildStudioObserveWorkspaceRoute({
+        scopeId,
+        memberKey: observeMemberKey || undefined,
+      }),
+    );
+  }, [memberKey, scopeId, selectedService?.serviceId]);
+
   const handleClear = useCallback(() => {
     setChatMessages([]);
     setConsoleTab('result');
@@ -1656,6 +1707,14 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
                   onClick={handleAbort}
                 >
                   中止
+                </Button>
+                <Button
+                  data-testid="studio-invoke-observe-button"
+                  disabled={!scopeId}
+                  icon={<LinkOutlined />}
+                  onClick={handleOpenStudioObserve}
+                >
+                  在 Studio 中查看 Observe
                 </Button>
                 <Button
                   disabled={!scopeId || !selectedEndpoint}

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -5878,6 +5878,10 @@ const StudioPage: React.FC = () => {
     ) : isInvokeSurface ? (
       <StudioMemberInvokePanel
         emptyState={invokeEmptyState}
+        memberKey={
+          trimOptional(routeState.memberKey) ||
+          (invokeTargetServiceId ? `member:${invokeTargetServiceId}` : undefined)
+        }
         memberRevision={invokeTargetServiceId
           ? currentServiceRevisionByServiceId.get(invokeTargetServiceId) ?? null
           : null}

--- a/apps/aevatar-console-web/src/shared/studio/invokeHistoryStore.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/invokeHistoryStore.test.ts
@@ -1,0 +1,146 @@
+import {
+  buildStudioInvokeHistoryStorageKey,
+  loadStudioInvokeHistory,
+  STUDIO_INVOKE_HISTORY_LIMIT,
+  saveStudioInvokeHistory,
+} from './invokeHistoryStore';
+
+function installSessionStorageMock(): void {
+  const state = new Map<string, string>();
+  const sessionStorageMock: Storage = {
+    get length() {
+      return state.size;
+    },
+    clear: () => {
+      state.clear();
+    },
+    getItem: (key: string) =>
+      state.has(String(key)) ? (state.get(String(key)) as string) : null,
+    key: (index: number) => Array.from(state.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      state.delete(String(key));
+    },
+    setItem: (key: string, value: string) => {
+      state.set(String(key), String(value));
+    },
+  };
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { sessionStorage: sessionStorageMock },
+  });
+}
+
+describe('studio invoke history store', () => {
+  beforeEach(() => {
+    installSessionStorageMock();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(
+      globalThis as unknown as Record<string, unknown>,
+      'window',
+    );
+  });
+
+  it('builds storage keys scoped by scopeId and member key', () => {
+    expect(
+      buildStudioInvokeHistoryStorageKey({
+        scopeId: 'scope-1',
+        memberKey: 'workflow:workflow-1',
+      }),
+    ).toBe('aevatar-studio-invoke-history:scope-1::workflow:workflow-1');
+  });
+
+  it('returns an empty key when scope or member is missing', () => {
+    expect(
+      buildStudioInvokeHistoryStorageKey({
+        scopeId: '',
+        memberKey: 'workflow:workflow-1',
+      }),
+    ).toBe('');
+    expect(
+      buildStudioInvokeHistoryStorageKey({
+        scopeId: 'scope-1',
+        memberKey: '',
+      }),
+    ).toBe('');
+  });
+
+  it('round-trips invoke history entries through sessionStorage', () => {
+    const key = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'workflow:workflow-1',
+    });
+    const entries = [
+      { id: 'a', prompt: 'hello' },
+      { id: 'b', prompt: 'world' },
+    ];
+
+    saveStudioInvokeHistory(key, entries);
+
+    expect(
+      loadStudioInvokeHistory<{ id: string; prompt: string }>(key),
+    ).toEqual(entries);
+  });
+
+  it('caps persisted history at the documented limit so transcripts stay scrollable', () => {
+    const key = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'workflow:workflow-1',
+    });
+    const overflow = Array.from({
+      length: STUDIO_INVOKE_HISTORY_LIMIT + 4,
+    }).map((_unused, index) => ({ id: `entry-${index}` }));
+
+    saveStudioInvokeHistory(key, overflow);
+
+    expect(loadStudioInvokeHistory(key)).toHaveLength(
+      STUDIO_INVOKE_HISTORY_LIMIT,
+    );
+  });
+
+  it('keeps history isolated between members so switching members does not bleed transcripts', () => {
+    const workflowKey = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'workflow:workflow-1',
+    });
+    const scriptKey = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'script:script-1',
+    });
+
+    saveStudioInvokeHistory(workflowKey, [{ id: 'workflow-only' }]);
+
+    expect(loadStudioInvokeHistory(workflowKey)).toEqual([
+      { id: 'workflow-only' },
+    ]);
+    expect(loadStudioInvokeHistory(scriptKey)).toEqual([]);
+  });
+
+  it('returns an empty list when stored data is invalid', () => {
+    const key = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'workflow:workflow-1',
+    });
+    (globalThis as { window: Window }).window.sessionStorage.setItem(
+      key,
+      'not-json',
+    );
+
+    expect(loadStudioInvokeHistory(key)).toEqual([]);
+  });
+
+  it('clears the stored entry when an empty history is saved', () => {
+    const key = buildStudioInvokeHistoryStorageKey({
+      scopeId: 'scope-1',
+      memberKey: 'workflow:workflow-1',
+    });
+    saveStudioInvokeHistory(key, [{ id: 'a' }]);
+    saveStudioInvokeHistory(key, []);
+
+    expect(
+      (globalThis as { window: Window }).window.sessionStorage.getItem(key),
+    ).toBeNull();
+  });
+});

--- a/apps/aevatar-console-web/src/shared/studio/invokeHistoryStore.ts
+++ b/apps/aevatar-console-web/src/shared/studio/invokeHistoryStore.ts
@@ -1,0 +1,71 @@
+const STORAGE_PREFIX = 'aevatar-studio-invoke-history:';
+const MAX_HISTORY_ENTRIES = 8;
+
+export type StudioInvokeHistoryStorageKey = string;
+
+function trimText(value: string | null | undefined): string {
+  return value?.trim() ?? '';
+}
+
+export function buildStudioInvokeHistoryStorageKey(options: {
+  scopeId?: string | null;
+  memberKey?: string | null;
+}): StudioInvokeHistoryStorageKey {
+  const scopeId = trimText(options.scopeId);
+  const memberKey = trimText(options.memberKey);
+  if (!scopeId || !memberKey) {
+    return '';
+  }
+
+  return `${STORAGE_PREFIX}${scopeId}::${memberKey}`;
+}
+
+export function loadStudioInvokeHistory<T>(
+  storageKey: StudioInvokeHistoryStorageKey,
+): T[] {
+  if (!storageKey || typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.sessionStorage.getItem(storageKey);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.slice(0, MAX_HISTORY_ENTRIES) as T[];
+  } catch {
+    return [];
+  }
+}
+
+export function saveStudioInvokeHistory<T>(
+  storageKey: StudioInvokeHistoryStorageKey,
+  entries: readonly T[],
+): void {
+  if (!storageKey || typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    if (entries.length === 0) {
+      window.sessionStorage.removeItem(storageKey);
+      return;
+    }
+
+    window.sessionStorage.setItem(
+      storageKey,
+      JSON.stringify(entries.slice(0, MAX_HISTORY_ENTRIES)),
+    );
+  } catch {
+    // sessionStorage can throw on quota or privacy modes; history is
+    // best-effort transcript closeout, not a source of truth.
+  }
+}
+
+export const STUDIO_INVOKE_HISTORY_LIMIT = MAX_HISTORY_ENTRIES;

--- a/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
@@ -1,8 +1,10 @@
 import {
-  buildStudioWorkflowMemberKey,
+  buildStudioInvokeWorkspaceRoute,
+  buildStudioObserveWorkspaceRoute,
   buildStudioRoute,
   buildStudioScriptsWorkspaceRoute,
   buildStudioWorkflowEditorRoute,
+  buildStudioWorkflowMemberKey,
   buildStudioWorkflowWorkspaceRoute,
 } from './navigation';
 
@@ -109,7 +111,9 @@ describe('buildStudioRoute', () => {
         memberKey: 'workflow:workflow-1',
         step: 'bind',
       }),
-    ).toBe('/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=bind&tab=bindings');
+    ).toBe(
+      '/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=bind&tab=bindings',
+    );
   });
 
   it('builds dedicated workflow and script workspace routes', () => {
@@ -188,6 +192,54 @@ describe('buildStudioRoute', () => {
       }),
     ).toBe(
       '/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=executions&execution=execution-1',
+    );
+  });
+
+  it('keeps Build -> Bind -> Invoke -> Observe deep links pinned to the same member', () => {
+    const memberKey = 'workflow:workflow-1';
+    expect(
+      buildStudioWorkflowEditorRoute({
+        scopeId: 'scope-1',
+        memberKey,
+        workflowId: 'workflow-1',
+      }),
+    ).toBe('/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&tab=studio');
+    expect(
+      buildStudioRoute({
+        scopeId: 'scope-1',
+        memberKey,
+        step: 'bind',
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=bind&tab=bindings',
+    );
+    expect(
+      buildStudioInvokeWorkspaceRoute({
+        scopeId: 'scope-1',
+        memberKey,
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=invoke&tab=invoke',
+    );
+    expect(
+      buildStudioObserveWorkspaceRoute({
+        scopeId: 'scope-1',
+        memberKey,
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=observe&tab=executions',
+    );
+  });
+
+  it('carries an execution focus into the Observe deep link without dropping member context', () => {
+    expect(
+      buildStudioObserveWorkspaceRoute({
+        scopeId: 'scope-1',
+        memberKey: 'workflow:workflow-1',
+        executionId: 'execution-9',
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-1&member=workflow%3Aworkflow-1&step=observe&tab=executions&execution=execution-9',
     );
   });
 

--- a/apps/aevatar-console-web/src/shared/studio/navigation.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.ts
@@ -233,6 +233,19 @@ export function buildStudioInvokeWorkspaceRoute(options?: {
   });
 }
 
+export function buildStudioObserveWorkspaceRoute(options?: {
+  scopeId?: string;
+  memberId?: string;
+  memberKey?: StudioMemberKey | string;
+  executionId?: string;
+} & Record<string, unknown>): string {
+  return buildStudioRoute({
+    ...options,
+    step: 'observe',
+    tab: 'executions',
+  });
+}
+
 export function buildStudioScriptsWorkspaceRoute(options?: {
   scopeId?: string;
   memberId?: string;


### PR DESCRIPTION
Part of #340 / #322 — closes out the member-first Studio Invoke flow so the
`Build -> Bind -> Invoke -> Observe` main chain stops bouncing users out of
Studio.

## Summary
- Added `buildStudioObserveWorkspaceRoute` so `Observe` shares the same
  `scopeId + memberKey + step + focus + execution` deep-link contract as
  the rest of the Studio main chain.
- Added a `Studio` invoke history store backed by `sessionStorage`, keyed by
  `scopeId + memberKey`, capped at the documented Runs-panel limit. Wired the
  store into `StudioMemberInvokePanel` so the transcript persists across
  panel remounts and step switches but stays isolated per member.
- Added an in-Studio Observe handoff button on `StudioMemberInvokePanel`
  that routes through `buildStudioObserveWorkspaceRoute` while preserving the
  current `memberKey` (or falling back to the selected `serviceId`), so
  users stop being kicked into `runtime/runs` to look at recent runs.
- Plumbed the active `memberKey` from `studio/index.tsx` into the panel so
  the storage key and the Observe handoff stay aligned with the route.

## Out of scope (follow-up issues)
- Backend member-first roster API (`#340` Phase B work).
- Team detail entry directly into Bind/Invoke step.
- Workflow-side member-first polish that does not touch the Invoke flow.

## Test plan
- [x] `pnpm jest src/shared/studio/navigation.test.ts` — covers the new
      `Build -> Bind -> Invoke -> Observe` deep-link consistency assertions
      and the `Observe` execution focus carry-through.
- [x] `pnpm jest src/shared/studio/invokeHistoryStore.test.ts` — covers
      key derivation, cap, isolation between members, invalid storage, and
      the empty-list cleanup case.
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm biome check` on changed files — no new lint issues.
- [ ] `StudioMemberInvokePanel.test.tsx` cases (history persistence,
      cross-member isolation, Observe handoff) — added but not executed
      locally; the worktree's `@testing-library/react` + React 19 setup
      raises `React.act is not a function` for every existing jsdom test
      in this file, so those failures are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)