### PR TITLE
Add member-first Studio APIs

### DIFF
--- a/docs/2026-04-27-member-first-studio-apis.md
+++ b/docs/2026-04-27-member-first-studio-apis.md
@@ -1,0 +1,40 @@
+# Member-First Studio APIs
+
+## Scope
+
+This slice closes the minimum backend contract gap for Studio member-first Bind / Invoke / Observe flows.
+
+The current authoritative resolver maps each normalized `memberId` to a stable published service with the same id:
+
+| Field | Meaning |
+|---|---|
+| `scopeId` | Team scope that owns the member and published service. |
+| `memberId` | Studio member address used by frontend routes. |
+| `publishedServiceId` | Stable service id used by backend service runtime for that member. |
+| `publishedServiceKey` | Internal service identity key for diagnostics and contract inspection. |
+
+The resolver is exposed through `IMemberPublishedServiceResolver`, so a later actor-owned member catalog can replace the deterministic mapping without changing HTTP routes. Until that catalog is authoritative, member binding writes are restricted to scope administrators; member reads and invokes require either the matching authenticated member claim or a scope administrator role.
+
+## Routes
+
+| Route | Purpose |
+|---|---|
+| `GET /api/scopes/{scopeId}/members/{memberId}/published-service` | Resolve the member-owned published service id. |
+| `GET /api/scopes/{scopeId}/members/{memberId}/binding` | Read current binding status for the member-owned published service. |
+| `PUT /api/scopes/{scopeId}/members/{memberId}/binding` | Publish workflow/script/GAgent implementation to the member-owned published service. |
+| `POST /api/scopes/{scopeId}/members/{memberId}/invoke/{endpointId}` | Invoke a typed endpoint by member id. |
+| `POST /api/scopes/{scopeId}/members/{memberId}/invoke/{endpointId}:stream` | Invoke an SSE endpoint by member id. |
+| `GET /api/scopes/{scopeId}/members/{memberId}/runs` | List read-model-backed runs for the member-owned published service. |
+| `GET /api/scopes/{scopeId}/members/{memberId}/runs/{runId}` | Read a run summary for the member-owned published service. |
+| `GET /api/scopes/{scopeId}/members/{memberId}/runs/{runId}/audit` | Read a run audit report for the member-owned published service. |
+| `POST /api/scopes/{scopeId}/members/{memberId}/runs/{runId}:resume` | Resume a member-owned published service run. |
+| `POST /api/scopes/{scopeId}/members/{memberId}/runs/{runId}:signal` | Signal a member-owned published service run. |
+| `POST /api/scopes/{scopeId}/members/{memberId}/runs/{runId}:stop` | Stop a member-owned published service run. |
+
+## Semantics
+
+- Member routes for Bind / Invoke / Observe-read / run lifecycle control do not require frontend callers to know or pass `serviceId`.
+- Binding and invoke still use the existing service command/runtime path after the resolver has produced `publishedServiceId`.
+- Runs and run detail still read workflow run read models; they do not query actor state or replay events.
+- Responses use `publishedServiceId` instead of overloading `serviceId` in member-centric DTOs.
+- The member-first public contract does not accept an `appId` override or expose the fixed service namespace.

--- a/src/Aevatar.Hosting/AevatarMemberAccessGuard.cs
+++ b/src/Aevatar.Hosting/AevatarMemberAccessGuard.cs
@@ -1,0 +1,159 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace Aevatar.Hosting;
+
+public static class AevatarMemberAccessGuard
+{
+    private const string MemberIdClaimType = "member_id";
+    private const string UserIdClaimType = "user_id";
+    private const string ScopeRoleClaimType = "scope_role";
+    private const string DottedScopeRoleClaimType = "scope.role";
+    private const string PlainRoleClaimType = "role";
+
+    private static readonly string[] MemberClaimTypes =
+    [
+        MemberIdClaimType,
+        UserIdClaimType,
+        "uid",
+        "sub",
+        ClaimTypes.NameIdentifier,
+    ];
+
+    private static readonly string[] RoleClaimTypes =
+    [
+        ScopeRoleClaimType,
+        DottedScopeRoleClaimType,
+        PlainRoleClaimType,
+        ClaimTypes.Role,
+    ];
+
+    private static readonly HashSet<string> ScopeAdminRoleValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "admin",
+        "owner",
+        "scope-admin",
+        "scope_admin",
+    };
+
+    public static bool TryCreateMemberAccessDeniedResult(
+        HttpContext http,
+        string memberId,
+        out IResult denied)
+    {
+        if (!TryGetAuthenticatedMemberGuardFailure(http, memberId, requireScopeAdmin: false, out var code, out var message))
+        {
+            denied = Results.Empty;
+            return false;
+        }
+
+        denied = Results.Json(
+            new
+            {
+                code,
+                message,
+            },
+            statusCode: StatusCodes.Status403Forbidden);
+        return true;
+    }
+
+    public static bool TryCreateScopeAdminRequiredResult(
+        HttpContext http,
+        string memberId,
+        out IResult denied)
+    {
+        if (!TryGetAuthenticatedMemberGuardFailure(http, memberId, requireScopeAdmin: true, out var code, out var message))
+        {
+            denied = Results.Empty;
+            return false;
+        }
+
+        denied = Results.Json(
+            new
+            {
+                code,
+                message,
+            },
+            statusCode: StatusCodes.Status403Forbidden);
+        return true;
+    }
+
+    public static async Task<bool> TryWriteMemberAccessDeniedAsync(
+        HttpContext http,
+        string memberId,
+        CancellationToken ct)
+    {
+        if (!TryGetAuthenticatedMemberGuardFailure(http, memberId, requireScopeAdmin: false, out var code, out var message))
+            return false;
+
+        http.Response.StatusCode = StatusCodes.Status403Forbidden;
+        http.Response.ContentType = "application/json";
+        await http.Response.WriteAsJsonAsync(
+            new
+            {
+                code,
+                message,
+            },
+            cancellationToken: ct);
+        return true;
+    }
+
+    private static bool TryGetAuthenticatedMemberGuardFailure(
+        HttpContext http,
+        string requestedMemberId,
+        bool requireScopeAdmin,
+        out string code,
+        out string message)
+    {
+        ArgumentNullException.ThrowIfNull(http);
+
+        code = string.Empty;
+        message = string.Empty;
+        if (!AevatarScopeAccessGuard.IsAuthenticationEnabled(http.RequestServices))
+            return false;
+
+        if (http.User?.Identity?.IsAuthenticated != true)
+        {
+            code = "MEMBER_ACCESS_DENIED";
+            message = "Authentication is required.";
+            return true;
+        }
+
+        var normalizedRequestedMemberId = NormalizeRequired(requestedMemberId, nameof(requestedMemberId));
+        if (HasScopeAdminRole(http.User))
+            return false;
+
+        if (requireScopeAdmin)
+        {
+            code = "SCOPE_ADMIN_REQUIRED";
+            message = "Scope administrator access is required for member binding until the member catalog is authoritative.";
+            return true;
+        }
+
+        if (HasMatchingMemberClaim(http.User, normalizedRequestedMemberId))
+            return false;
+
+        code = "MEMBER_ACCESS_DENIED";
+        message = "Authenticated member does not match requested member.";
+        return true;
+    }
+
+    private static bool HasScopeAdminRole(ClaimsPrincipal user) =>
+        user.Claims.Any(static claim =>
+            RoleClaimTypes.Contains(claim.Type, StringComparer.OrdinalIgnoreCase)
+            && ScopeAdminRoleValues.Contains(claim.Value?.Trim() ?? string.Empty));
+
+    private static bool HasMatchingMemberClaim(ClaimsPrincipal user, string requestedMemberId) =>
+        user.Claims.Any(claim =>
+            MemberClaimTypes.Contains(claim.Type, StringComparer.OrdinalIgnoreCase)
+            && string.Equals(claim.Value?.Trim(), requestedMemberId, StringComparison.Ordinal));
+
+    private static string NormalizeRequired(string? value, string paramName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new InvalidOperationException($"{paramName} is required.");
+
+        return normalized;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IMemberPublishedServiceResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IMemberPublishedServiceResolver.cs
@@ -1,0 +1,17 @@
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public sealed record MemberPublishedServiceResolveRequest(
+    string ScopeId,
+    string MemberId);
+
+public sealed record MemberPublishedServiceResolution(
+    string ScopeId,
+    string MemberId,
+    string PublishedServiceId);
+
+public interface IMemberPublishedServiceResolver
+{
+    Task<MemberPublishedServiceResolution> ResolveAsync(
+        MemberPublishedServiceResolveRequest request,
+        CancellationToken ct = default);
+}

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/DefaultMemberPublishedServiceResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/DefaultMemberPublishedServiceResolver.cs
@@ -1,0 +1,34 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Application.Workflows;
+
+namespace Aevatar.GAgentService.Application.Bindings;
+
+public sealed class DefaultMemberPublishedServiceResolver : IMemberPublishedServiceResolver
+{
+    public Task<MemberPublishedServiceResolution> ResolveAsync(
+        MemberPublishedServiceResolveRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+
+        var scopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(request.ScopeId, nameof(request.ScopeId));
+        var memberId = NormalizeMemberId(request.MemberId);
+
+        // TODO: replace this deterministic development resolver with an actor-owned member
+        // catalog that defines authoritative membership, ownership, and cleanup semantics.
+        return Task.FromResult(new MemberPublishedServiceResolution(
+            scopeId,
+            memberId,
+            memberId));
+    }
+
+    private static string NormalizeMemberId(string memberId)
+    {
+        var normalized = ScopeWorkflowCapabilityOptions.NormalizeRequired(memberId, nameof(MemberPublishedServiceResolveRequest.MemberId));
+        if (normalized.IndexOfAny([':', '/', '\\', '?', '#']) >= 0)
+            throw new InvalidOperationException("memberId must not contain ':', '/', '\\', '?' or '#'.");
+
+        return normalized;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IScopeWorkflowQueryPort>(sp => sp.GetRequiredService<ScopeWorkflowQueryApplicationService>());
         services.TryAddSingleton<IScopeWorkflowCommandPort, ScopeWorkflowCommandApplicationService>();
         services.TryAddSingleton<IScopeBindingCommandPort, ScopeBindingCommandApplicationService>();
+        services.TryAddSingleton<IMemberPublishedServiceResolver, DefaultMemberPublishedServiceResolver>();
         services.AddOptions<ScopeScriptCapabilityOptions>()
             .Bind(configuration.GetSection(ScopeScriptCapabilityOptions.SectionName));
         services.TryAddSingleton<ScopeScriptQueryApplicationService>();

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -53,14 +53,25 @@ public static class ScopeServiceEndpoints
         group.MapPost("/{scopeId}/workflow/draft-run", HandleDraftRunAsync);
         group.MapPut("/{scopeId}/binding", HandleUpsertBindingAsync);
         group.MapGet("/{scopeId}/binding", HandleGetBindingAsync);
+        group.MapGet("/{scopeId}/members/{memberId}/published-service", HandleGetMemberPublishedServiceAsync);
+        group.MapPut("/{scopeId}/members/{memberId}/binding", HandleUpsertMemberBindingAsync);
+        group.MapGet("/{scopeId}/members/{memberId}/binding", HandleGetMemberBindingAsync);
         group.MapPost("/{scopeId}/binding/revisions/{revisionId}:activate", HandleActivateBindingRevisionAsync);
         group.MapGet("/{scopeId}/revisions", HandleGetDefaultServiceRevisionsAsync);
         group.MapGet("/{scopeId}/revisions/{revisionId}", HandleGetDefaultServiceRevisionAsync);
         group.MapPost("/{scopeId}/binding/revisions/{revisionId}:retire", HandleRetireBindingRevisionAsync);
         group.MapPost("/{scopeId}/invoke/chat:stream", HandleInvokeDefaultChatStreamAsync);
         group.MapPost("/{scopeId}/invoke/{endpointId}", HandleInvokeDefaultAsync);
+        group.MapPost("/{scopeId}/members/{memberId}/invoke/{endpointId}:stream", HandleInvokeMemberStreamAsync);
+        group.MapPost("/{scopeId}/members/{memberId}/invoke/{endpointId}", HandleInvokeMemberAsync);
         group.MapGet("/{scopeId}/runs", HandleListDefaultRunsAsync);
         group.MapGet("/{scopeId}/runs/{runId}", HandleGetDefaultRunAsync);
+        group.MapGet("/{scopeId}/members/{memberId}/runs", HandleListMemberRunsAsync);
+        group.MapGet("/{scopeId}/members/{memberId}/runs/{runId}", HandleGetMemberRunAsync);
+        group.MapGet("/{scopeId}/members/{memberId}/runs/{runId}/audit", HandleGetMemberRunAuditAsync);
+        group.MapPost("/{scopeId}/members/{memberId}/runs/{runId}:resume", HandleResumeMemberRunAsync);
+        group.MapPost("/{scopeId}/members/{memberId}/runs/{runId}:signal", HandleSignalMemberRunAsync);
+        group.MapPost("/{scopeId}/members/{memberId}/runs/{runId}:stop", HandleStopMemberRunAsync);
         group.MapGet("/{scopeId}/runs/{runId}/audit", HandleGetDefaultRunAuditAsync);
         group.MapPost("/{scopeId}/runs/{runId}:resume", HandleResumeDefaultRunAsync);
         group.MapPost("/{scopeId}/runs/{runId}:signal", HandleSignalDefaultRunAsync);
@@ -247,6 +258,147 @@ public static class ScopeServiceEndpoints
         var revisions = await lifecycleQueryPort.GetServiceRevisionsAsync(identity, ct);
         var servingSet = await servingQueryPort.GetServiceServingSetAsync(identity, ct);
         return Results.Ok(BuildScopeBindingStatusResponse(normalizedScopeId, service, revisions, servingSet));
+    }
+
+    private static async Task<IResult> HandleGetMemberPublishedServiceAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            var identity = BuildScopeServiceIdentity(
+                options.Value,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId);
+            return Results.Ok(BuildMemberPublishedServiceResponse(memberResolution, identity));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_PUBLISHED_SERVICE_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleUpsertMemberBindingAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        UpsertMemberScopeBindingHttpRequest request,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IScopeBindingCommandPort commandPort,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateScopeAdminRequiredResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            var result = await commandPort.UpsertAsync(
+                new ScopeBindingUpsertRequest(
+                    memberResolution.ScopeId,
+                    ParseScopeBindingImplementationKind(request.ImplementationKind),
+                    ToWorkflowSpec(request),
+                    request.Script == null
+                        ? null
+                        : new ScopeBindingScriptSpec(
+                            request.Script.ScriptId,
+                            request.Script.ScriptRevision),
+                    request.GAgent == null
+                        ? null
+                        : new ScopeBindingGAgentSpec(
+                            request.GAgent.ActorTypeName,
+                            (request.GAgent.Endpoints ?? [])
+                            .Select(endpoint => new ScopeBindingGAgentEndpoint(
+                                endpoint.EndpointId,
+                                endpoint.DisplayName,
+                                ParseEndpointKind(endpoint.Kind),
+                                endpoint.RequestTypeUrl,
+                                endpoint.ResponseTypeUrl,
+                                endpoint.Description))
+                            .ToArray()),
+                    request.DisplayName,
+                    request.RevisionId,
+                    null,
+                    memberResolution.PublishedServiceId),
+                ct);
+
+            return Results.Ok(BuildMemberBindingUpsertResponse(memberResolution, result));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_BINDING_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleGetMemberBindingAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IServiceServingQueryPort servingQueryPort,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            var identity = BuildScopeServiceIdentity(
+                options.Value,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId);
+            var service = await lifecycleQueryPort.GetServiceAsync(identity, ct);
+            if (service == null)
+            {
+                return Results.Ok(BuildUnavailableMemberBindingStatusResponse(memberResolution, identity));
+            }
+
+            var revisions = await lifecycleQueryPort.GetServiceRevisionsAsync(identity, ct);
+            var servingSet = await servingQueryPort.GetServiceServingSetAsync(identity, ct);
+            return Results.Ok(BuildMemberBindingStatusResponse(memberResolution, service, revisions, servingSet));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_BINDING_REQUEST",
+                message = ex.Message,
+            });
+        }
     }
 
     private static async Task<IResult> HandleActivateBindingRevisionAsync(
@@ -608,6 +760,104 @@ public static class ScopeServiceEndpoints
             options,
             ct);
 
+    private static async Task HandleInvokeMemberStreamAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string endpointId,
+        StreamScopeServiceHttpRequest request,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] ServiceInvocationResolutionService resolutionService,
+        [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
+        [FromServices] ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
+        [FromServices] ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> gagentDraftRunService,
+        [FromServices] IScriptRuntimeCommandPort scriptRuntimeCommandPort,
+        [FromServices] IScriptExecutionProjectionPort scriptExecutionProjectionPort,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
+            if (await AevatarMemberAccessGuard.TryWriteMemberAccessDeniedAsync(http, memberId, ct))
+                return;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            await HandleInvokeStreamAsync(
+                http,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                endpointId,
+                request,
+                null,
+                resolutionService,
+                admissionAuthorizer,
+                chatRunService,
+                gagentDraftRunService,
+                scriptRuntimeCommandPort,
+                scriptExecutionProjectionPort,
+                options,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                StatusCodes.Status400BadRequest,
+                "INVALID_MEMBER_SERVICE_STREAM_REQUEST",
+                ex.Message,
+                ct);
+        }
+    }
+
+    private static async Task<IResult> HandleInvokeMemberAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string endpointId,
+        InvokeScopeServiceHttpRequest request,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceInvocationPort invocationPort,
+        [FromServices] IServiceCatalogQueryReader catalogReader,
+        [FromServices] IServiceRevisionArtifactStore artifactStore,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            return await HandleInvokeAsyncCore(
+                http,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                endpointId,
+                request,
+                null,
+                BuildMemberApiPath(memberResolution.ScopeId, memberResolution.MemberId),
+                invocationPort,
+                catalogReader,
+                artifactStore,
+                options,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return CreateScopeInvokeFailureResult(ex);
+        }
+    }
+
     private static Task<IResult> HandleListDefaultRunsAsync(
         HttpContext http,
         string scopeId,
@@ -737,6 +987,346 @@ public static class ScopeServiceEndpoints
             stopService,
             options,
             ct);
+
+    private static async Task<IResult> HandleListMemberRunsAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        int take,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
+        [FromServices] IWorkflowExecutionQueryApplicationService workflowExecutionQueryService,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            var resolution = await ResolveScopeServiceAsync(
+                http,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                lifecycleQueryPort,
+                options.Value,
+                ct,
+                appId: null);
+            if (resolution.Failure != null)
+                return resolution.Failure;
+
+            var bindings = await ListScopeServiceRunsAsync(
+                memberResolution.ScopeId,
+                resolution.Service!,
+                resolution.Deployments,
+                workflowRunBindingReader,
+                take,
+                ct);
+
+            var summaries = new List<MemberScopeServiceRunSummaryHttpResponse>(bindings.Count);
+            foreach (var binding in bindings)
+            {
+                var serviceSummary = await BuildScopeRunSummaryAsync(
+                    memberResolution.ScopeId,
+                    memberResolution.PublishedServiceId,
+                    binding,
+                    resolution.Service!,
+                    resolution.Deployments,
+                    workflowExecutionQueryService,
+                    ct);
+                summaries.Add(BuildMemberRunSummaryResponse(memberResolution, serviceSummary));
+            }
+
+            return Results.Ok(new MemberScopeServiceRunCatalogHttpResponse(
+                memberResolution.ScopeId,
+                memberResolution.MemberId,
+                memberResolution.PublishedServiceId,
+                resolution.Service!.ServiceKey,
+                resolution.Service.DisplayName,
+                summaries));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_RUNS_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleGetMemberRunAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string runId,
+        string? actorId,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
+        [FromServices] IWorkflowExecutionQueryApplicationService workflowExecutionQueryService,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            var resolution = await ResolveScopeServiceRunAsync(
+                http,
+                options.Value,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                runId,
+                actorId,
+                lifecycleQueryPort,
+                workflowRunBindingReader,
+                ct,
+                appId: null);
+            if (resolution.Failure != null)
+                return resolution.Failure;
+
+            var serviceSummary = await BuildScopeRunSummaryAsync(
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                resolution.Binding!,
+                resolution.Service!,
+                resolution.Deployments,
+                workflowExecutionQueryService,
+                ct);
+            return Results.Ok(BuildMemberRunSummaryResponse(memberResolution, serviceSummary));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_RUN_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleGetMemberRunAuditAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string runId,
+        string? actorId,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
+        [FromServices] IWorkflowExecutionQueryApplicationService workflowExecutionQueryService,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            var resolution = await ResolveScopeServiceRunAsync(
+                http,
+                options.Value,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                runId,
+                actorId,
+                lifecycleQueryPort,
+                workflowRunBindingReader,
+                ct,
+                appId: null);
+            if (resolution.Failure != null)
+                return resolution.Failure;
+
+            var serviceSummary = await BuildScopeRunSummaryAsync(
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                resolution.Binding!,
+                resolution.Service!,
+                resolution.Deployments,
+                workflowExecutionQueryService,
+                ct);
+            var report = await workflowExecutionQueryService.GetActorReportAsync(resolution.Binding!.ActorId, ct);
+            if (report == null)
+            {
+                return Results.NotFound(new
+                {
+                    code = "MEMBER_SERVICE_RUN_AUDIT_NOT_FOUND",
+                    message = $"Audit report for run '{resolution.Binding.RunId}' was not found for member '{memberResolution.MemberId}' in scope '{memberResolution.ScopeId}'.",
+                });
+            }
+
+            return Results.Ok(new MemberScopeServiceRunAuditHttpResponse(
+                BuildMemberRunSummaryResponse(memberResolution, serviceSummary),
+                report));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_RUN_AUDIT_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleResumeMemberRunAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string runId,
+        ResumeScopeServiceRunHttpRequest request,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
+        [FromServices] ICommandDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> resumeService,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            return await HandleResumeRunAsync(
+                http,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                runId,
+                request,
+                lifecycleQueryPort,
+                workflowRunBindingReader,
+                resumeService,
+                options,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_RUN_RESUME_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleSignalMemberRunAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string runId,
+        SignalScopeServiceRunHttpRequest request,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
+        [FromServices] ICommandDispatchService<WorkflowSignalCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> signalService,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            return await HandleSignalRunAsync(
+                http,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                runId,
+                request,
+                lifecycleQueryPort,
+                workflowRunBindingReader,
+                signalService,
+                options,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_RUN_SIGNAL_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
+
+    private static async Task<IResult> HandleStopMemberRunAsync(
+        HttpContext http,
+        string scopeId,
+        string memberId,
+        string runId,
+        StopScopeServiceRunHttpRequest request,
+        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IWorkflowRunBindingReader workflowRunBindingReader,
+        [FromServices] ICommandDispatchService<WorkflowStopCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError> stopService,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            if (AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, memberId, out var memberDenied))
+                return memberDenied;
+
+            var memberResolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(scopeId, memberId),
+                ct);
+            return await HandleStopRunAsync(
+                http,
+                memberResolution.ScopeId,
+                memberResolution.PublishedServiceId,
+                runId,
+                request,
+                lifecycleQueryPort,
+                workflowRunBindingReader,
+                stopService,
+                options,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Results.BadRequest(new
+            {
+                code = "INVALID_MEMBER_RUN_STOP_REQUEST",
+                message = ex.Message,
+            });
+        }
+    }
 
     private static async Task<IResult> HandleListRunsAsync(
         HttpContext http,
@@ -1244,6 +1834,33 @@ public static class ScopeServiceEndpoints
         [FromServices] IServiceCatalogQueryReader catalogReader,
         [FromServices] IServiceRevisionArtifactStore artifactStore,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct) =>
+        await HandleInvokeAsyncCore(
+            http,
+            scopeId,
+            serviceId,
+            endpointId,
+            request,
+            appId,
+            acceptedResourcePath: null,
+            invocationPort,
+            catalogReader,
+            artifactStore,
+            options,
+            ct);
+
+    private static async Task<IResult> HandleInvokeAsyncCore(
+        HttpContext http,
+        string scopeId,
+        string serviceId,
+        string endpointId,
+        InvokeScopeServiceHttpRequest request,
+        string? appId,
+        string? acceptedResourcePath,
+        IServiceInvocationPort invocationPort,
+        IServiceCatalogQueryReader catalogReader,
+        IServiceRevisionArtifactStore artifactStore,
+        IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
         try
@@ -1278,7 +1895,10 @@ public static class ScopeServiceEndpoints
                     AppId = string.Empty,
                 },
             }, ct);
-            return Results.Accepted($"/api/scopes/{Uri.EscapeDataString(scopeId)}/services/{Uri.EscapeDataString(serviceId)}", receipt);
+            var locationPath = string.IsNullOrWhiteSpace(acceptedResourcePath)
+                ? $"/api/scopes/{Uri.EscapeDataString(scopeId)}/services/{Uri.EscapeDataString(serviceId)}"
+                : acceptedResourcePath;
+            return Results.Accepted(locationPath, receipt);
         }
         catch (Exception ex) when (ex is FormatException or InvalidOperationException)
         {
@@ -1606,10 +2226,11 @@ public static class ScopeServiceEndpoints
         string? requestedActorId,
         IServiceLifecycleQueryPort lifecycleQueryPort,
         IWorkflowRunBindingReader workflowRunBindingReader,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? appId = null)
     {
         var normalizedRunId = ScopeWorkflowCapabilityOptions.NormalizeRequired(runId, nameof(runId));
-        var scopeService = await ResolveScopeServiceAsync(http, scopeId, serviceId, lifecycleQueryPort, options, ct);
+        var scopeService = await ResolveScopeServiceAsync(http, scopeId, serviceId, lifecycleQueryPort, options, ct, appId);
         if (scopeService.Failure != null)
             return new ScopeServiceRunResolution(scopeService.Identity, scopeService.Service, scopeService.Deployments, null, scopeService.Failure);
 
@@ -1680,6 +2301,83 @@ public static class ScopeServiceEndpoints
             revisionSnapshots,
             revisions?.StateVersion ?? 0,
             revisions?.LastEventId ?? string.Empty);
+    }
+
+    private static MemberPublishedServiceHttpResponse BuildMemberPublishedServiceResponse(
+        MemberPublishedServiceResolution memberResolution,
+        ServiceIdentity identity)
+    {
+        return new MemberPublishedServiceHttpResponse(
+            memberResolution.ScopeId,
+            memberResolution.MemberId,
+            memberResolution.PublishedServiceId,
+            ServiceKeys.Build(identity));
+    }
+
+    private static MemberScopeBindingStatusHttpResponse BuildUnavailableMemberBindingStatusResponse(
+        MemberPublishedServiceResolution memberResolution,
+        ServiceIdentity identity)
+    {
+        return new MemberScopeBindingStatusHttpResponse(
+            false,
+            memberResolution.ScopeId,
+            memberResolution.MemberId,
+            memberResolution.PublishedServiceId,
+            string.Empty,
+            ServiceKeys.Build(identity),
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            string.Empty,
+            null,
+            [],
+            0,
+            string.Empty);
+    }
+
+    private static MemberScopeBindingStatusHttpResponse BuildMemberBindingStatusResponse(
+        MemberPublishedServiceResolution memberResolution,
+        ServiceCatalogSnapshot service,
+        ServiceRevisionCatalogSnapshot? revisions,
+        ServiceServingSetSnapshot? servingSet)
+    {
+        var status = BuildScopeBindingStatusResponse(memberResolution.ScopeId, service, revisions, servingSet);
+        return new MemberScopeBindingStatusHttpResponse(
+            status.Available,
+            status.ScopeId,
+            memberResolution.MemberId,
+            memberResolution.PublishedServiceId,
+            status.DisplayName,
+            status.ServiceKey,
+            status.DefaultServingRevisionId,
+            status.ActiveServingRevisionId,
+            status.DeploymentId,
+            status.DeploymentStatus,
+            status.PrimaryActorId,
+            status.UpdatedAt,
+            status.Revisions,
+            status.CatalogStateVersion,
+            status.CatalogLastEventId);
+    }
+
+    private static MemberScopeBindingUpsertHttpResponse BuildMemberBindingUpsertResponse(
+        MemberPublishedServiceResolution memberResolution,
+        ScopeBindingUpsertResult result)
+    {
+        return new MemberScopeBindingUpsertHttpResponse(
+            memberResolution.ScopeId,
+            memberResolution.MemberId,
+            memberResolution.PublishedServiceId,
+            result.DisplayName,
+            result.RevisionId,
+            result.ImplementationKind,
+            result.ExpectedActorId,
+            result.WorkflowName,
+            result.DefinitionActorIdPrefix,
+            result.Workflow,
+            result.Script,
+            result.GAgent);
     }
 
     private static ScopeServiceRevisionCatalogHttpResponse BuildScopeServiceRevisionCatalogResponse(
@@ -1837,6 +2535,9 @@ public static class ScopeServiceEndpoints
 
     private static string BuildScopeServiceStreamInvokePath(string scopeId, string serviceId, string endpointId) =>
         $"{BuildScopeServiceInvokePath(scopeId, serviceId, endpointId)}:stream";
+
+    private static string BuildMemberApiPath(string scopeId, string memberId) =>
+        $"/api/scopes/{Uri.EscapeDataString(scopeId)}/members/{Uri.EscapeDataString(memberId)}";
 
     private static string? BuildTypedInvokeRequestExampleBody(string? requestTypeUrl, bool prettyPrinted)
     {
@@ -2026,6 +2727,34 @@ const response = await fetch("{{invokePath}}", {
             snapshot?.RoleReplyCount ?? 0,
             snapshot?.LastOutput ?? string.Empty,
             snapshot?.LastError ?? string.Empty);
+    }
+
+    private static MemberScopeServiceRunSummaryHttpResponse BuildMemberRunSummaryResponse(
+        MemberPublishedServiceResolution memberResolution,
+        ScopeServiceRunSummaryHttpResponse summary)
+    {
+        return new MemberScopeServiceRunSummaryHttpResponse(
+            summary.ScopeId,
+            memberResolution.MemberId,
+            memberResolution.PublishedServiceId,
+            summary.RunId,
+            summary.ActorId,
+            summary.DefinitionActorId,
+            summary.RevisionId,
+            summary.DeploymentId,
+            summary.WorkflowName,
+            summary.CompletionStatus,
+            summary.StateVersion,
+            summary.LastEventId,
+            summary.LastUpdatedAt,
+            summary.BoundAt,
+            summary.BindingUpdatedAt,
+            summary.LastSuccess,
+            summary.TotalSteps,
+            summary.CompletedSteps,
+            summary.RoleReplyCount,
+            summary.LastOutput,
+            summary.LastError);
     }
 
     private static ServiceDeploymentSnapshot? ResolveRunDeployment(
@@ -2451,6 +3180,12 @@ const response = await fetch("{{invokePath}}", {
         return workflowYamls == null ? null : new ScopeBindingWorkflowSpec(workflowYamls);
     }
 
+    private static ScopeBindingWorkflowSpec? ToWorkflowSpec(UpsertMemberScopeBindingHttpRequest request)
+    {
+        var workflowYamls = request.Workflow?.WorkflowYamls ?? request.WorkflowYamls;
+        return workflowYamls == null ? null : new ScopeBindingWorkflowSpec(workflowYamls);
+    }
+
     private static string? NormalizeOptional(string? value)
     {
         var normalized = (value ?? string.Empty).Trim();
@@ -2500,6 +3235,15 @@ const response = await fetch("{{invokePath}}", {
         string? RevisionId = null,
         string? AppId = null,
         string? ServiceId = null);
+
+    public sealed record UpsertMemberScopeBindingHttpRequest(
+        string ImplementationKind,
+        IReadOnlyList<string>? WorkflowYamls = null,
+        ScopeBindingWorkflowHttpRequest? Workflow = null,
+        ScopeBindingScriptHttpRequest? Script = null,
+        ScopeBindingGAgentHttpRequest? GAgent = null,
+        string? DisplayName = null,
+        string? RevisionId = null);
 
     public sealed record ScopeBindingWorkflowHttpRequest(
         IReadOnlyList<string>? WorkflowYamls);
@@ -2597,6 +3341,43 @@ const response = await fetch("{{invokePath}}", {
         long CatalogStateVersion = 0,
         string CatalogLastEventId = "");
 
+    public sealed record MemberPublishedServiceHttpResponse(
+        string ScopeId,
+        string MemberId,
+        string PublishedServiceId,
+        string PublishedServiceKey);
+
+    public sealed record MemberScopeBindingStatusHttpResponse(
+        bool Available,
+        string ScopeId,
+        string MemberId,
+        string PublishedServiceId,
+        string DisplayName,
+        string PublishedServiceKey,
+        string DefaultServingRevisionId,
+        string ActiveServingRevisionId,
+        string DeploymentId,
+        string DeploymentStatus,
+        string PrimaryActorId,
+        DateTimeOffset? UpdatedAt,
+        IReadOnlyList<ScopeBindingRevisionHttpResponse> Revisions,
+        long CatalogStateVersion = 0,
+        string CatalogLastEventId = "");
+
+    public sealed record MemberScopeBindingUpsertHttpResponse(
+        string ScopeId,
+        string MemberId,
+        string PublishedServiceId,
+        string DisplayName,
+        string RevisionId,
+        ScopeBindingImplementationKind ImplementationKind,
+        string ExpectedActorId,
+        string WorkflowName = "",
+        string DefinitionActorIdPrefix = "",
+        ScopeBindingWorkflowResult? Workflow = null,
+        ScopeBindingScriptResult? Script = null,
+        ScopeBindingGAgentResult? GAgent = null);
+
     public sealed record ScopeBindingRevisionHttpResponse(
         string RevisionId,
         string ImplementationKind,
@@ -2680,6 +3461,14 @@ const response = await fetch("{{invokePath}}", {
         string DisplayName,
         IReadOnlyList<ScopeServiceRunSummaryHttpResponse> Runs);
 
+    public sealed record MemberScopeServiceRunCatalogHttpResponse(
+        string ScopeId,
+        string MemberId,
+        string PublishedServiceId,
+        string PublishedServiceKey,
+        string DisplayName,
+        IReadOnlyList<MemberScopeServiceRunSummaryHttpResponse> Runs);
+
     public sealed record ScopeServiceRunSummaryHttpResponse(
         string ScopeId,
         string ServiceId,
@@ -2702,7 +3491,34 @@ const response = await fetch("{{invokePath}}", {
         string LastOutput,
         string LastError);
 
+    public sealed record MemberScopeServiceRunSummaryHttpResponse(
+        string ScopeId,
+        string MemberId,
+        string PublishedServiceId,
+        string RunId,
+        string ActorId,
+        string DefinitionActorId,
+        string RevisionId,
+        string DeploymentId,
+        string WorkflowName,
+        WorkflowRunCompletionStatus CompletionStatus,
+        long StateVersion,
+        string LastEventId,
+        DateTimeOffset? LastUpdatedAt,
+        DateTimeOffset? BoundAt,
+        DateTimeOffset? BindingUpdatedAt,
+        bool? LastSuccess,
+        int TotalSteps,
+        int CompletedSteps,
+        int RoleReplyCount,
+        string LastOutput,
+        string LastError);
+
     public sealed record ScopeServiceRunAuditHttpResponse(
         ScopeServiceRunSummaryHttpResponse Summary,
+        WorkflowRunReport Audit);
+
+    public sealed record MemberScopeServiceRunAuditHttpResponse(
+        MemberScopeServiceRunSummaryHttpResponse Summary,
         WorkflowRunReport Audit);
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -14,6 +14,7 @@ using Aevatar.GAgentService.Abstractions.Commands;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Application.Bindings;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Application.Workflows;
 using Aevatar.Foundation.Abstractions.Streaming;
@@ -362,6 +363,136 @@ public sealed class ScopeServiceEndpointsTests
         response.ScopeId.Should().Be("scope-a");
         response.ServiceId.Should().Be("default");
         response.Revisions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMemberPublishedServiceEndpoint_ShouldReturnStableMemberMapping()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberPublishedServiceHttpResponse>(
+            "/api/scopes/scope-a/members/member-a/published-service");
+
+        response.Should().NotBeNull();
+        response!.ScopeId.Should().Be("scope-a");
+        response.MemberId.Should().Be("member-a");
+        response.PublishedServiceId.Should().Be("member-a");
+        response.PublishedServiceKey.Should().Be("scope-a:default:default:member-a");
+    }
+
+    [Fact]
+    public async Task GetMemberPublishedServiceEndpoint_ShouldRejectDifferentAuthenticatedMember()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/members/member-a/published-service");
+        request.Headers.Add("X-Test-Member-Id", "member-b");
+
+        var response = await host.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task MemberBindingEndpoint_ShouldBindToMemberPublishedService()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/api/scopes/scope-a/members/member-a/binding")
+        {
+            Content = JsonContent.Create(new
+            {
+                implementationKind = "workflow",
+                displayName = "Member A",
+                workflowYamls = new[]
+                {
+                    "name: main\nsteps:\n  - run: echo hello",
+                },
+            }),
+        };
+        request.Headers.Add("X-Test-Role", "scope-admin");
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadFromJsonAsync<ScopeServiceEndpoints.MemberScopeBindingUpsertHttpResponse>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!.MemberId.Should().Be("member-a");
+        body.PublishedServiceId.Should().Be("member-a");
+        host.ScopeBindingPort.LastRequest.Should().NotBeNull();
+        host.ScopeBindingPort.LastRequest!.ScopeId.Should().Be("scope-a");
+        host.ScopeBindingPort.LastRequest.ServiceId.Should().Be("member-a");
+        host.ScopeBindingPort.LastRequest.AppId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MemberBindingEndpoint_ShouldRequireScopeAdminUntilMemberCatalogIsAuthoritative()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PutAsJsonAsync("/api/scopes/scope-a/members/member-a/binding", new
+        {
+            implementationKind = "workflow",
+            displayName = "Member A",
+            workflowYamls = new[]
+            {
+                "name: main\nsteps:\n  - run: echo hello",
+            },
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        host.ScopeBindingPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetMemberBindingEndpoint_ShouldReturnMemberBindingSummary()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-a");
+        host.LifecycleQueryPort.Revisions = new ServiceRevisionCatalogSnapshot(
+            "scope-a:default:default:member-a",
+            [
+                new ServiceRevisionSnapshot(
+                    "rev-1",
+                    "workflow",
+                    "Published",
+                    "hash-1",
+                    string.Empty,
+                    [],
+                    DateTimeOffset.UtcNow.AddHours(-1),
+                    DateTimeOffset.UtcNow.AddHours(-1),
+                    DateTimeOffset.UtcNow.AddHours(-1),
+                    null),
+            ],
+            DateTimeOffset.UtcNow,
+            5,
+            "evt-5");
+        host.ServingQueryPort.ServingSet = new ServiceServingSetSnapshot(
+            "scope-a:default:default:member-a",
+            5,
+            string.Empty,
+            [
+                new ServiceServingTargetSnapshot(
+                    "dep-member-a",
+                    "rev-1",
+                    "def-member-a",
+                    100,
+                    ServiceServingState.Active.ToString(),
+                    []),
+            ],
+            DateTimeOffset.UtcNow);
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeBindingStatusHttpResponse>(
+            "/api/scopes/scope-a/members/member-a/binding");
+
+        response.Should().NotBeNull();
+        response!.Available.Should().BeTrue();
+        response.ScopeId.Should().Be("scope-a");
+        response.MemberId.Should().Be("member-a");
+        response.PublishedServiceId.Should().Be("member-a");
+        response.PublishedServiceKey.Should().Be("scope-a:default:default:member-a");
+        response.Revisions.Should().ContainSingle();
+        response.Revisions[0].DeploymentId.Should().Be("dep-member-a");
+        response.CatalogStateVersion.Should().Be(5);
+        response.CatalogLastEventId.Should().Be("evt-5");
     }
 
     [Fact]
@@ -1838,6 +1969,89 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task MemberInvokeStreamEndpoint_ShouldResolveMemberPublishedServiceAndDelegateToWorkflowPipeline()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        var service = BuildService("scope-a", "member-a", "definition-actor-member-a");
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            "dep-member-a-1",
+                            "rev-member-a-1",
+                            "definition-actor-member-a",
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.ArtifactStore.SaveAsync(
+            service.ServiceKey,
+            "rev-member-a-1",
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = "member-a",
+                },
+                RevisionId = "rev-member-a-1",
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    WorkflowPlan = new WorkflowServiceDeploymentPlan
+                    {
+                        WorkflowName = "member-a",
+                        WorkflowYaml = "name: member_a\nsteps:\n  - run: echo member",
+                        DefinitionActorId = "definition-actor-member-a",
+                    },
+                },
+            },
+            CancellationToken.None);
+        host.InteractionService.ResultFactory = async (request, emitAsync, onAcceptedAsync, ct) =>
+        {
+            var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-member-a", "member-a", "cmd-member-a", "corr-member-a");
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+            return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+        };
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/invoke/chat:stream", new
+        {
+            prompt = "hello member",
+            headers = new Dictionary<string, string> { ["channel"] = "member-tests" },
+        });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        body.Should().Contain("aevatar.run.context");
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-member-a");
+        host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("member-tests");
+    }
+
+    [Fact]
     public async Task InvokeStreamEndpoint_WhenAuthenticationIsDisabled_ShouldExecuteExplicitServiceFlowWithoutClaims()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync(authenticationEnabled: false);
@@ -2201,6 +2415,31 @@ public sealed class ScopeServiceEndpointsTests
             ServiceId = "default",
         });
         host.InvocationPort.LastRequest.EndpointId.Should().Be("run");
+    }
+
+    [Fact]
+    public async Task MemberInvokeEndpoint_ShouldMapMemberToPublishedServiceIdentity()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/invoke/chat", new
+        {
+            payloadTypeUrl = "type.googleapis.com/google.protobuf.Empty",
+            payloadBase64 = "",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/members/member-a");
+        host.InvocationPort.LastRequest.Should().NotBeNull();
+        host.InvocationPort.LastRequest!.Identity.Should().BeEquivalentTo(new ServiceIdentity
+        {
+            TenantId = "scope-a",
+            AppId = "default",
+            Namespace = "default",
+            ServiceId = "member-a",
+        });
+        host.InvocationPort.LastRequest.EndpointId.Should().Be("chat");
     }
 
     [Fact]
@@ -2628,6 +2867,283 @@ public sealed class ScopeServiceEndpointsTests
         response.WorkflowName.Should().Be("approval");
         response.StateVersion.Should().Be(4);
         response.LastEventId.Should().Be("evt-4");
+    }
+
+    [Fact]
+    public async Task ListMemberRunsEndpoint_ShouldReturnMemberScopedRunHistory()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        var createdAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var updatedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-active");
+        host.LifecycleQueryPort.Deployments = new ServiceDeploymentCatalogSnapshot(
+            "scope-a:default:default:member-a",
+            [
+                new ServiceDeploymentSnapshot("dep-member-active", "rev-2", "def-member-active", "Active", createdAt, updatedAt),
+                new ServiceDeploymentSnapshot("dep-member-old", "rev-1", "def-member-old", "Inactive", createdAt.AddMinutes(-10), updatedAt.AddMinutes(-10)),
+            ],
+            updatedAt);
+        host.RunBindingReader.BindingsByRunId["run-member-list-1"] =
+        [
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "run-actor-member-list-1",
+                "def-member-old",
+                "run-member-list-1",
+                "member-flow",
+                "yaml",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-a",
+                CreatedAt: createdAt,
+                UpdatedAt: updatedAt),
+        ];
+        host.WorkflowQueryService.SnapshotsByActorId["run-actor-member-list-1"] = new WorkflowActorSnapshot
+        {
+            ActorId = "run-actor-member-list-1",
+            WorkflowName = "member-flow",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+            StateVersion = 13,
+            LastEventId = "evt-13",
+            LastUpdatedAt = updatedAt,
+            LastSuccess = true,
+            TotalSteps = 2,
+            CompletedSteps = 2,
+            RoleReplyCount = 1,
+            LastOutput = "done",
+        };
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunCatalogHttpResponse>(
+            "/api/scopes/scope-a/members/member-a/runs?take=5");
+
+        response.Should().NotBeNull();
+        response!.ScopeId.Should().Be("scope-a");
+        response.MemberId.Should().Be("member-a");
+        response.PublishedServiceId.Should().Be("member-a");
+        response.PublishedServiceKey.Should().Be("scope-a:default:default:member-a");
+        response.Runs.Should().ContainSingle();
+        response.Runs[0].RunId.Should().Be("run-member-list-1");
+        response.Runs[0].MemberId.Should().Be("member-a");
+        response.Runs[0].PublishedServiceId.Should().Be("member-a");
+        response.Runs[0].RevisionId.Should().Be("rev-1");
+        response.Runs[0].DeploymentId.Should().Be("dep-member-old");
+        response.Runs[0].StateVersion.Should().Be(13);
+        host.RunBindingReader.Queries.Should().ContainSingle();
+        host.RunBindingReader.Queries[0].DefinitionActorIds.Should().BeEquivalentTo(["def-member-active", "def-member-old"]);
+    }
+
+    [Fact]
+    public async Task GetMemberRunEndpoint_ShouldReturnMemberScopedRunSummary()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        var createdAt = DateTimeOffset.UtcNow.AddMinutes(-7);
+        var updatedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-1");
+        host.LifecycleQueryPort.Deployments = BuildDeployments("scope-a:default:default:member-a", "dep-member-1", "rev-1", "def-member-1");
+        host.RunBindingReader.BindingsByRunId["run-member-detail-1"] =
+        [
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "run-actor-member-detail-1",
+                "def-member-1",
+                "run-member-detail-1",
+                "member-flow",
+                "yaml",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-a",
+                CreatedAt: createdAt,
+                UpdatedAt: updatedAt),
+        ];
+        host.WorkflowQueryService.SnapshotsByActorId["run-actor-member-detail-1"] = new WorkflowActorSnapshot
+        {
+            ActorId = "run-actor-member-detail-1",
+            WorkflowName = "member-flow",
+            CompletionStatus = WorkflowRunCompletionStatus.Running,
+            StateVersion = 14,
+            LastEventId = "evt-14",
+            LastUpdatedAt = updatedAt,
+            LastSuccess = null,
+            TotalSteps = 3,
+            CompletedSteps = 1,
+            RoleReplyCount = 1,
+            LastOutput = "working",
+        };
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunSummaryHttpResponse>(
+            "/api/scopes/scope-a/members/member-a/runs/run-member-detail-1");
+
+        response.Should().NotBeNull();
+        response!.ScopeId.Should().Be("scope-a");
+        response.MemberId.Should().Be("member-a");
+        response.PublishedServiceId.Should().Be("member-a");
+        response.RunId.Should().Be("run-member-detail-1");
+        response.ActorId.Should().Be("run-actor-member-detail-1");
+        response.RevisionId.Should().Be("rev-1");
+        response.WorkflowName.Should().Be("member-flow");
+        response.StateVersion.Should().Be(14);
+        response.LastEventId.Should().Be("evt-14");
+    }
+
+    [Fact]
+    public async Task GetMemberRunAuditEndpoint_ShouldReturnMemberScopedRunAuditReport()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        var createdAt = DateTimeOffset.UtcNow.AddMinutes(-7);
+        var updatedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-audit");
+        host.LifecycleQueryPort.Deployments = BuildDeployments("scope-a:default:default:member-a", "dep-member-audit", "rev-1", "def-member-audit");
+        host.RunBindingReader.BindingsByRunId["run-member-audit-1"] =
+        [
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "run-actor-member-audit-1",
+                "def-member-audit",
+                "run-member-audit-1",
+                "member-flow",
+                "yaml",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-a",
+                CreatedAt: createdAt,
+                UpdatedAt: updatedAt),
+        ];
+        host.WorkflowQueryService.SnapshotsByActorId["run-actor-member-audit-1"] = new WorkflowActorSnapshot
+        {
+            ActorId = "run-actor-member-audit-1",
+            WorkflowName = "member-flow",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+            StateVersion = 15,
+            LastEventId = "evt-15",
+            LastUpdatedAt = updatedAt,
+            LastSuccess = true,
+            TotalSteps = 3,
+            CompletedSteps = 3,
+            RoleReplyCount = 1,
+            LastOutput = "done",
+        };
+        host.WorkflowQueryService.ReportsByActorId["run-actor-member-audit-1"] = new WorkflowRunReport
+        {
+            WorkflowName = "member-flow",
+            RootActorId = "run-actor-member-audit-1",
+            StateVersion = 15,
+            LastEventId = "evt-15",
+            CompletionStatus = WorkflowRunCompletionStatus.Completed,
+            ProjectionScope = WorkflowRunProjectionScope.RunIsolated,
+            TopologySource = WorkflowRunTopologySource.RuntimeSnapshot,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            Success = true,
+            FinalOutput = "done",
+            Summary = new WorkflowRunStatistics
+            {
+                TotalSteps = 3,
+                CompletedSteps = 3,
+                RoleReplyCount = 1,
+            },
+        };
+
+        var response = await host.Client.GetFromJsonAsync<ScopeServiceEndpoints.MemberScopeServiceRunAuditHttpResponse>(
+            "/api/scopes/scope-a/members/member-a/runs/run-member-audit-1/audit");
+
+        response.Should().NotBeNull();
+        response!.Summary.MemberId.Should().Be("member-a");
+        response.Summary.PublishedServiceId.Should().Be("member-a");
+        response.Summary.RunId.Should().Be("run-member-audit-1");
+        response.Audit.RootActorId.Should().Be("run-actor-member-audit-1");
+        host.WorkflowQueryService.ReportCalls.Should().ContainSingle("run-actor-member-audit-1");
+    }
+
+    [Fact]
+    public async Task ResumeMemberRunEndpoint_ShouldResolveMemberPublishedServiceAndDispatch()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-resume");
+        host.LifecycleQueryPort.Deployments = BuildDeployments("scope-a:default:default:member-a", "dep-member-resume", "rev-1", "def-member-resume");
+        host.RunBindingReader.BindingsByRunId["run-member-resume-1"] =
+        [
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "run-actor-member-resume-1",
+                "def-member-resume",
+                "run-member-resume-1",
+                "member-flow",
+                "yaml",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-a"),
+        ];
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/runs/run-member-resume-1:resume", new
+        {
+            stepId = "approval-1",
+            approved = true,
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.ResumeDispatchService.LastCommand.Should().NotBeNull();
+        host.ResumeDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-resume-1");
+        host.ResumeDispatchService.LastCommand.RunId.Should().Be("run-member-resume-1");
+        host.ResumeDispatchService.LastCommand.StepId.Should().Be("approval-1");
+    }
+
+    [Fact]
+    public async Task SignalMemberRunEndpoint_ShouldResolveMemberPublishedServiceAndDispatch()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-signal");
+        host.LifecycleQueryPort.Deployments = BuildDeployments("scope-a:default:default:member-a", "dep-member-signal", "rev-1", "def-member-signal");
+        host.RunBindingReader.BindingsByRunId["run-member-signal-1"] =
+        [
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "run-actor-member-signal-1",
+                "def-member-signal",
+                "run-member-signal-1",
+                "member-flow",
+                "yaml",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-a"),
+        ];
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/runs/run-member-signal-1:signal", new
+        {
+            signalName = "ops_window_open",
+            stepId = "wait-1",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.SignalDispatchService.LastCommand.Should().NotBeNull();
+        host.SignalDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-signal-1");
+        host.SignalDispatchService.LastCommand.RunId.Should().Be("run-member-signal-1");
+        host.SignalDispatchService.LastCommand.SignalName.Should().Be("ops_window_open");
+    }
+
+    [Fact]
+    public async Task StopMemberRunEndpoint_ShouldResolveMemberPublishedServiceAndDispatch()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Service = BuildService("scope-a", "member-a", "def-member-stop");
+        host.LifecycleQueryPort.Deployments = BuildDeployments("scope-a:default:default:member-a", "dep-member-stop", "rev-1", "def-member-stop");
+        host.RunBindingReader.BindingsByRunId["run-member-stop-1"] =
+        [
+            new WorkflowActorBinding(
+                WorkflowActorKind.Run,
+                "run-actor-member-stop-1",
+                "def-member-stop",
+                "run-member-stop-1",
+                "member-flow",
+                "yaml",
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                "scope-a"),
+        ];
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/members/member-a/runs/run-member-stop-1:stop", new
+        {
+            reason = "manual",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.StopDispatchService.LastCommand.Should().NotBeNull();
+        host.StopDispatchService.LastCommand!.ActorId.Should().Be("run-actor-member-stop-1");
+        host.StopDispatchService.LastCommand.RunId.Should().Be("run-member-stop-1");
+        host.StopDispatchService.LastCommand.Reason.Should().Be("manual");
     }
 
     [Fact]
@@ -3729,6 +4245,7 @@ public sealed class ScopeServiceEndpointsTests
             builder.Services.AddSingleton<IServiceInvocationPort>(invocationPort);
             builder.Services.AddSingleton<IServiceLifecycleQueryPort>(lifecycleQueryPort);
             builder.Services.AddSingleton<IServiceServingQueryPort>(servingQueryPort);
+            builder.Services.AddSingleton<IMemberPublishedServiceResolver, DefaultMemberPublishedServiceResolver>();
             builder.Services.AddSingleton<IServiceCatalogQueryReader>(serviceCatalogReader);
             builder.Services.AddSingleton<IServiceTrafficViewQueryReader>(trafficViewReader);
             builder.Services.AddSingleton<IServiceRevisionArtifactStore>(artifactStore);
@@ -3787,6 +4304,33 @@ public sealed class ScopeServiceEndpointsTests
                             claims.Add(new Claim(WorkflowRunCommandMetadataKeys.ScopeId, requestedScopeId));
                         }
 
+                        if (http.Request.Headers.TryGetValue("X-Test-Member-Id", out var claimedMemberValues))
+                        {
+                            var claimedMemberIds = claimedMemberValues
+                                .ToString()
+                                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                            foreach (var claimedMemberId in claimedMemberIds)
+                            {
+                                claims.Add(new Claim("member_id", claimedMemberId));
+                            }
+                        }
+                        else if (!hasExplicitAuthenticationHeader &&
+                            TryGetRequestedMemberId(http.Request.Path.Value, out var requestedMemberId))
+                        {
+                            claims.Add(new Claim("member_id", requestedMemberId));
+                        }
+
+                        if (http.Request.Headers.TryGetValue("X-Test-Role", out var claimedRoleValues))
+                        {
+                            var claimedRoles = claimedRoleValues
+                                .ToString()
+                                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                            foreach (var claimedRole in claimedRoles)
+                            {
+                                claims.Add(new Claim("role", claimedRole));
+                            }
+                        }
+
                         http.User = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
                     }
 
@@ -3842,6 +4386,24 @@ public sealed class ScopeServiceEndpointsTests
             }
 
             scopeId = string.Empty;
+            return false;
+        }
+
+        private static bool TryGetRequestedMemberId(string? path, out string memberId)
+        {
+            var segments = path?
+                .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments is { Length: >= 5 } &&
+                string.Equals(segments[0], "api", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(segments[1], "scopes", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(segments[3], "members", StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(segments[4]))
+            {
+                memberId = segments[4];
+                return true;
+            }
+
+            memberId = string.Empty;
             return false;
         }
 

--- a/test/Aevatar.GAgentService.Tests/Application/DefaultMemberPublishedServiceResolverTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/DefaultMemberPublishedServiceResolverTests.cs
@@ -1,0 +1,44 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Application.Bindings;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class DefaultMemberPublishedServiceResolverTests
+{
+    [Fact]
+    public async Task ResolveAsync_ShouldMapMemberToStablePublishedServiceId()
+    {
+        var resolver = new DefaultMemberPublishedServiceResolver();
+
+        var result = await resolver.ResolveAsync(new MemberPublishedServiceResolveRequest(
+            " scope-a ",
+            " member-a "));
+
+        result.ScopeId.Should().Be("scope-a");
+        result.MemberId.Should().Be("member-a");
+        result.PublishedServiceId.Should().Be("member-a");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectBlankMemberId()
+    {
+        var resolver = new DefaultMemberPublishedServiceResolver();
+
+        var act = () => resolver.ResolveAsync(new MemberPublishedServiceResolveRequest("scope-a", " "));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*MemberId is required*");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectMemberIdThatBreaksServiceKeySegments()
+    {
+        var resolver = new DefaultMemberPublishedServiceResolver();
+
+        var act = () => resolver.ResolveAsync(new MemberPublishedServiceResolveRequest("scope-a", "foo:bar"));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*memberId must not contain*");
+    }
+}

--- a/test/Aevatar.Studio.Tests/ScopeEndpointAccessTests.cs
+++ b/test/Aevatar.Studio.Tests/ScopeEndpointAccessTests.cs
@@ -92,6 +92,38 @@ public sealed class ScopeEndpointAccessTests
     }
 
     [Fact]
+    public void TryCreateMemberAccessDeniedResult_ShouldAllow_WhenMemberClaimMatches()
+    {
+        var http = CreateContext(true, new Claim("member_id", "member-1"));
+        AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, "member-1", out _)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryCreateMemberAccessDeniedResult_ShouldDeny_WhenMemberClaimDiffers()
+    {
+        var http = CreateContext(true, new Claim("member_id", "member-1"));
+        AevatarMemberAccessGuard.TryCreateMemberAccessDeniedResult(http, "member-2", out _)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryCreateScopeAdminRequiredResult_ShouldAllow_WhenScopeAdminRoleIsPresent()
+    {
+        var http = CreateContext(true, new Claim("role", "scope-admin"));
+        AevatarMemberAccessGuard.TryCreateScopeAdminRequiredResult(http, "member-1", out _)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryCreateScopeAdminRequiredResult_ShouldDeny_WhenOnlyMemberClaimMatches()
+    {
+        var http = CreateContext(true, new Claim("member_id", "member-1"));
+        AevatarMemberAccessGuard.TryCreateScopeAdminRequiredResult(http, "member-1", out _)
+            .Should().BeTrue();
+    }
+
+    [Fact]
     public void TryCreateScopeAccessDeniedResult_ShouldMatchTrimmed()
     {
         var http = CreateContext(true, new Claim("scope_id", "  scope-1  "));


### PR DESCRIPTION
## Problem
Studio Bind / Invoke / Observe needs member-first backend routes so the frontend can address a member and let the backend resolve the published service id.

Closes #364

## Solution
- Add `IMemberPublishedServiceResolver` and a deterministic default resolver that maps normalized `memberId` to the member-owned `publishedServiceId` while rejecting service-key-unsafe member ids.
- Add member-first scope routes for published service resolution, binding upsert/status, invoke/stream invoke, run list/detail, audit, resume, signal, and stop.
- Gate member binding writes to scope-admin until an actor-owned member catalog defines authoritative membership, ownership, and cleanup semantics.
- Require member routes to pass both scope access and member access, allowing either the matching authenticated member or a scope-admin.
- Remove public member API `appId` overrides and app/namespace exposure from member resolver/response contracts.
- Keep observe/run reads on existing read-model-backed services and document the contract in `docs/2026-04-27-member-first-studio-apis.md`.

## Impact Paths
- `src/Aevatar.Hosting`
- `src/platform/Aevatar.GAgentService.Abstractions`
- `src/platform/Aevatar.GAgentService.Application`
- `src/platform/Aevatar.GAgentService.Hosting`
- `test/Aevatar.GAgentService.Tests`
- `test/Aevatar.GAgentService.Integration.Tests`
- `test/Aevatar.Studio.Tests`
- `docs/`

## Validation
- PASS: `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter DefaultMemberPublishedServiceResolverTests`
- PASS: `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo --filter ScopeEndpointAccessTests`
- PASS: `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter ScopeServiceEndpointsTests`
- PASS: `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo`
- PASS: `dotnet build aevatar.slnx --nologo`
- PASS: `bash tools/ci/test_stability_guards.sh`
- PASS: `bash tools/ci/query_projection_priming_guard.sh`
- PASS: `git diff --check`
- PARTIAL: `bash tools/ci/architecture_guards.sh` passes through proto/channel/projection/workflow guards, then fails in `playground_asset_drift_guard.sh` because existing CLI playground build output differs from `demos/Aevatar.Demos.Workflow.Web/wwwroot` assets. This PR does not modify those frontend assets.
