### PR TITLE
fix(daily): scope GitHub username binding per Lark user (#436)

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderCardFlow.cs
@@ -77,7 +77,7 @@ internal static class AgentBuilderCardFlow
             try
             {
                 preferredGithubUsername = (await userConfigQueryPort.GetAsync(
-                    NormalizeScopeId(evt.RegistrationScopeId),
+                    ChannelUserConfigScope.FromInboundEvent(evt),
                     ct)).GithubUsername;
             }
             catch (OperationCanceledException)
@@ -594,9 +594,6 @@ internal static class AgentBuilderCardFlow
         var normalized = (value ?? string.Empty).Trim();
         return normalized.Length == 0 ? null : normalized;
     }
-
-    private static string NormalizeScopeId(string? scopeId) =>
-        string.IsNullOrWhiteSpace(scopeId) ? "default" : scopeId.Trim();
 
     private static string FormatCreateSocialMediaResult(JsonElement root)
     {

--- a/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/AgentBuilderTool.cs
@@ -185,11 +185,17 @@ public sealed class AgentBuilderTool : IAgentTool
     {
         var rawScopeId = NormalizeOptional(AgentToolRequestContext.TryGet("scope_id"));
         var configScopeId = NormalizeScopeId(rawScopeId);
+        // Bot's RegistrationScopeId is per-NyxID-account (one bot = one scope), so multiple
+        // Lark users sharing one bot would otherwise share a single UserConfigGAgent and
+        // overwrite each other's saved github_username (issue #436). Compose a per-end-user
+        // scope from the channel sender for personal-preference reads/writes only;
+        // SkillRunner.ScopeId stays bot-scoped for downstream NyxID-tenant tools.
+        var userConfigScopeId = ChannelUserConfigScope.FromMetadata(AgentToolRequestContext.CurrentMetadata);
         var githubUsernameResolution = await ResolveDailyReportGithubUsernameAsync(
             args,
             nyxClient,
             token,
-            configScopeId,
+            userConfigScopeId,
             ct);
         if (githubUsernameResolution.ErrorResponse is not null)
             return githubUsernameResolution.ErrorResponse;
@@ -318,7 +324,7 @@ public sealed class AgentBuilderTool : IAgentTool
 
         var savePreferenceRequested = args.Bool("save_github_username_preference") == true;
         var preferenceSaved = await SaveGithubUsernamePreferenceIfRequestedAsync(
-            configScopeId,
+            userConfigScopeId,
             githubUsernameResolution.GithubUsername ?? string.Empty,
             savePreferenceRequested,
             ct);

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserConfigScope.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelUserConfigScope.cs
@@ -1,0 +1,49 @@
+namespace Aevatar.GAgents.ChannelRuntime;
+
+/// <summary>
+/// Composes the per-end-user scope id used by <c>UserConfigGAgent</c> for
+/// channel-bound preferences such as the saved <c>github_username</c>.
+///
+/// The bot's <c>RegistrationScopeId</c> alone is per-NyxID-account (one bot =
+/// one scope), so multiple Lark users sharing the same bot would otherwise
+/// share a single user-config record and overwrite each other's preferences
+/// (issue #436). The composite <c>{registrationScopeId}:{platform}:{senderId}</c>
+/// gives every channel sender their own actor while leaving the bot scope
+/// intact for downstream tools that legitimately need NyxID tenant scope
+/// (binding store, service invocation, etc.).
+/// </summary>
+internal static class ChannelUserConfigScope
+{
+    private const string DefaultScope = "default";
+    private const string DefaultPlatform = "channel";
+
+    public static string FromInboundEvent(ChannelInboundEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        return Compose(evt.RegistrationScopeId, evt.Platform, evt.SenderId);
+    }
+
+    public static string FromMetadata(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata is null)
+            return DefaultScope;
+
+        metadata.TryGetValue("scope_id", out var scope);
+        metadata.TryGetValue(ChannelMetadataKeys.Platform, out var platform);
+        metadata.TryGetValue(ChannelMetadataKeys.SenderId, out var senderId);
+        return Compose(scope, platform, senderId);
+    }
+
+    private static string Compose(string? scopeId, string? platform, string? senderId)
+    {
+        var normalizedScope = string.IsNullOrWhiteSpace(scopeId) ? DefaultScope : scopeId.Trim();
+        var normalizedSender = senderId?.Trim();
+        if (string.IsNullOrEmpty(normalizedSender))
+            return normalizedScope;
+
+        var normalizedPlatform = string.IsNullOrWhiteSpace(platform)
+            ? DefaultPlatform
+            : platform.Trim().ToLowerInvariant();
+        return $"{normalizedScope}:{normalizedPlatform}:{normalizedSender}";
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderCardFlowTests.cs
@@ -13,16 +13,21 @@ public sealed class AgentBuilderCardFlowTests
     [Fact]
     public async Task TryResolveAsync_DailyReportLaunch_PrefillsSavedGithubUsername()
     {
+        // Inbound carries Platform + SenderId so the prefill query must hit the per-user
+        // scope (`scope-1:lark:ou_alice`), not the bot-level `scope-1` — otherwise multiple
+        // Lark users sharing a bot would see each other's saved usernames (issue #436).
         var inbound = new ChannelInboundEvent
         {
             ChatType = "p2p",
             RegistrationScopeId = "scope-1",
+            Platform = "lark",
+            SenderId = "ou_alice",
             Text = "/daily",
         };
+        var queryPort = new MapStubUserConfigQueryPort();
+        queryPort.SetGithubUsername("scope-1:lark:ou_alice", "saved-user");
 
-        var decision = await AgentBuilderCardFlow.TryResolveAsync(
-            inbound,
-            new StubUserConfigQueryPort(new StudioUserConfig(DefaultModel: string.Empty, GithubUsername: "saved-user")));
+        var decision = await AgentBuilderCardFlow.TryResolveAsync(inbound, queryPort);
 
         decision.Should().NotBeNull();
         decision!.RequiresToolExecution.Should().BeFalse();
@@ -36,6 +41,51 @@ public sealed class AgentBuilderCardFlowTests
 
         decision.ReplyContent.Cards.Single().Text.Should().Contain("saved-user");
         decision.ReplyContent.Cards.Single().Text.Should().Contain("already filled in");
+    }
+
+    [Fact]
+    public async Task TryResolveAsync_DailyReportLaunch_TwoLarkUsersInSameBot_SeeIndependentSavedUsernames()
+    {
+        // Issue #436: when colleagues share one Lark bot, the prefill must read each
+        // sender's own saved github_username — not the most recent writer's value.
+        // Pin that the per-user scope (`{bot}:{platform}:{sender}`) is what reaches the
+        // query port, so the read isn't accidentally collapsed back to the bot scope.
+        var queryPort = new MapStubUserConfigQueryPort();
+        queryPort.SetGithubUsername("scope-1:lark:ou_alice", "alice");
+        queryPort.SetGithubUsername("scope-1:lark:ou_bob", "bob");
+
+        var aliceInbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            RegistrationScopeId = "scope-1",
+            Platform = "lark",
+            SenderId = "ou_alice",
+            Text = "/daily",
+        };
+        var bobInbound = new ChannelInboundEvent
+        {
+            ChatType = "p2p",
+            RegistrationScopeId = "scope-1",
+            Platform = "lark",
+            SenderId = "ou_bob",
+            Text = "/daily",
+        };
+
+        var aliceDecision = await AgentBuilderCardFlow.TryResolveAsync(aliceInbound, queryPort);
+        var bobDecision = await AgentBuilderCardFlow.TryResolveAsync(bobInbound, queryPort);
+
+        aliceDecision!.ReplyContent!.Actions
+            .Single(a => a.Kind == ActionElementKind.TextInput && a.ActionId == "github_username")
+            .Value.Should().Be("alice");
+        bobDecision!.ReplyContent!.Actions
+            .Single(a => a.Kind == ActionElementKind.TextInput && a.ActionId == "github_username")
+            .Value.Should().Be("bob");
+
+        queryPort.QueriedScopes.Should().BeEquivalentTo(new[]
+        {
+            "scope-1:lark:ou_alice",
+            "scope-1:lark:ou_bob",
+        });
     }
 
     [Fact]
@@ -85,17 +135,27 @@ public sealed class AgentBuilderCardFlowTests
         body.RootElement.GetProperty("github_username").ValueKind.Should().Be(JsonValueKind.Null);
     }
 
-    private sealed class StubUserConfigQueryPort : IUserConfigQueryPort
+    private sealed class MapStubUserConfigQueryPort : IUserConfigQueryPort
     {
-        private readonly StudioUserConfig _config;
+        private readonly Dictionary<string, StudioUserConfig> _byScope = new(StringComparer.Ordinal);
+        private readonly List<string> _queriedScopes = new();
 
-        public StubUserConfigQueryPort(StudioUserConfig config)
+        public IReadOnlyList<string> QueriedScopes => _queriedScopes;
+
+        public void SetGithubUsername(string scopeId, string githubUsername)
         {
-            _config = config;
+            _byScope[scopeId] = new StudioUserConfig(DefaultModel: string.Empty, GithubUsername: githubUsername);
         }
 
-        public Task<StudioUserConfig> GetAsync(CancellationToken ct = default) => Task.FromResult(_config);
+        public Task<StudioUserConfig> GetAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException("Channel paths must call GetAsync(scopeId).");
 
-        public Task<StudioUserConfig> GetAsync(string scopeId, CancellationToken ct = default) => Task.FromResult(_config);
+        public Task<StudioUserConfig> GetAsync(string scopeId, CancellationToken ct = default)
+        {
+            _queriedScopes.Add(scopeId);
+            return Task.FromResult(_byScope.TryGetValue(scopeId, out var config)
+                ? config
+                : new StudioUserConfig(DefaultModel: string.Empty, GithubUsername: null));
+        }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1012,6 +1012,8 @@ public sealed class AgentBuilderToolTests
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
             [ChannelMetadataKeys.ChatType] = "p2p",
             [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.Platform] = "lark",
+            [ChannelMetadataKeys.SenderId] = "ou_alice",
             ["scope_id"] = "scope-1",
         };
         try
@@ -1034,8 +1036,12 @@ public sealed class AgentBuilderToolTests
             doc.RootElement.GetProperty("github_username_preference_saved").GetBoolean().Should().BeTrue();
             doc.RootElement.GetProperty("run_immediately_requested").GetBoolean().Should().BeFalse();
 
+            // Issue #436: the bot's RegistrationScopeId is shared across all Lark users using
+            // one bot, so the saved github_username must land in a per-end-user actor
+            // (`{bot}:{platform}:{sender}`), not the bot scope alone. SkillRunner.ScopeId
+            // (asserted elsewhere) keeps the bot scope for downstream NyxID-tenant tools.
             await userConfigCommandService.Received(1)
-                .SaveGithubUsernameAsync("scope-1", "alice", Arg.Any<CancellationToken>());
+                .SaveGithubUsernameAsync("scope-1:lark:ou_alice", "alice", Arg.Any<CancellationToken>());
         }
         finally
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -691,9 +691,19 @@ public sealed class AgentBuilderToolTests
         actorRuntime.CreateAsync<SkillRunnerGAgent>("skill-runner-pref-1", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IActor>(skillRunnerActor));
 
+        // Issue #436 PR #438 review: pin that the no-username `/daily` relay path reads the
+        // saved github_username from the per-end-user composite scope, not the bot's
+        // RegistrationScopeId. Without sender_id + platform set in the metadata this test
+        // would silently keep passing if the read accidentally drifted back to `configScopeId`.
         var userConfigQueryPort = Substitute.For<IUserConfigQueryPort>();
-        userConfigQueryPort.GetAsync("scope-1", Arg.Any<CancellationToken>())
+        userConfigQueryPort.GetAsync("scope-1:lark:ou_alice", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(new StudioUserConfig(string.Empty, GithubUsername: "saved-user")));
+        // Bot scope alone must NOT resolve a saved username: if the read regressed back to
+        // `configScopeId`, the prompt assertion below would still pass because both stubs
+        // would return "saved-user". Stub the bot-scope key with a sentinel so the assertion
+        // fails loudly on regression.
+        userConfigQueryPort.GetAsync("scope-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new StudioUserConfig(string.Empty, GithubUsername: "WRONG-bot-scope-leak")));
 
         var handler = new RoutingJsonHandler();
         handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
@@ -736,6 +746,8 @@ public sealed class AgentBuilderToolTests
             [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
             [ChannelMetadataKeys.ChatType] = "p2p",
             [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.Platform] = "lark",
+            [ChannelMetadataKeys.SenderId] = "ou_alice",
             ["scope_id"] = "scope-1",
         };
         try
@@ -760,6 +772,12 @@ public sealed class AgentBuilderToolTests
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().SkillContent.Contains("Primary GitHub username: saved-user", StringComparison.Ordinal) &&
                     e.Payload.Unpack<InitializeSkillRunnerCommand>().ExecutionPrompt.Contains("saved-user", StringComparison.Ordinal)),
                 Arg.Any<CancellationToken>());
+
+            // Direct evidence the per-end-user scope is what reaches the query port.
+            await userConfigQueryPort.Received(1)
+                .GetAsync("scope-1:lark:ou_alice", Arg.Any<CancellationToken>());
+            await userConfigQueryPort.DidNotReceive()
+                .GetAsync("scope-1", Arg.Any<CancellationToken>());
 
             handler.Requests.Should().NotContain(x => x.Path == "/api/v1/proxy/s/api-github/user");
         }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserConfigScopeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelUserConfigScopeTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class ChannelUserConfigScopeTests
+{
+    [Fact]
+    public void FromInboundEvent_WithSenderId_ComposesPerUserScope()
+    {
+        // Two Lark users sharing one bot must produce different user-config scopes,
+        // otherwise their saved github_username preferences overwrite each other
+        // (issue #436).
+        var alice = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            Platform = "lark",
+            SenderId = "ou_alice",
+        };
+        var bob = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            Platform = "lark",
+            SenderId = "ou_bob",
+        };
+
+        var aliceScope = ChannelUserConfigScope.FromInboundEvent(alice);
+        var bobScope = ChannelUserConfigScope.FromInboundEvent(bob);
+
+        aliceScope.Should().Be("bot-scope-1:lark:ou_alice");
+        bobScope.Should().Be("bot-scope-1:lark:ou_bob");
+        aliceScope.Should().NotBe(bobScope);
+    }
+
+    [Fact]
+    public void FromInboundEvent_NoSenderId_FallsBackToRegistrationScope()
+    {
+        // Programmatic / system inbound paths without an end-user identity keep the
+        // existing bot-scoped behavior.
+        var evt = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            Platform = "lark",
+        };
+
+        ChannelUserConfigScope.FromInboundEvent(evt).Should().Be("bot-scope-1");
+    }
+
+    [Fact]
+    public void FromInboundEvent_EmptyRegistrationScope_DefaultsToDefault()
+    {
+        var evt = new ChannelInboundEvent
+        {
+            Platform = "lark",
+            SenderId = "ou_alice",
+        };
+
+        ChannelUserConfigScope.FromInboundEvent(evt).Should().Be("default:lark:ou_alice");
+    }
+
+    [Fact]
+    public void FromInboundEvent_EmptyPlatform_UsesChannelLiteral()
+    {
+        // Channel-neutral fallback when the inbound platform tag is missing — keeps
+        // the composite key well-formed even on synthetic test fixtures.
+        var evt = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            SenderId = "ou_alice",
+        };
+
+        ChannelUserConfigScope.FromInboundEvent(evt).Should().Be("bot-scope-1:channel:ou_alice");
+    }
+
+    [Fact]
+    public void FromInboundEvent_PlatformIsLowerCased_SoCasingDifferencesShareOneActor()
+    {
+        // Same human + same bot reaching us via two casings of the platform tag must
+        // collapse to the same scope; otherwise they'd see different saved preferences
+        // depending on adapter capitalization.
+        var lower = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            Platform = "lark",
+            SenderId = "ou_alice",
+        };
+        var upper = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            Platform = "Lark",
+            SenderId = "ou_alice",
+        };
+
+        ChannelUserConfigScope.FromInboundEvent(lower)
+            .Should().Be(ChannelUserConfigScope.FromInboundEvent(upper));
+    }
+
+    [Fact]
+    public void FromMetadata_BuildsSameScopeAsInboundEvent()
+    {
+        // The tool path receives the same fields via AgentToolRequestContext.CurrentMetadata
+        // rather than a ChannelInboundEvent. Both code paths must agree on the scope key
+        // — otherwise the form prefill would read one actor and the preference save
+        // would write to another.
+        var evt = new ChannelInboundEvent
+        {
+            RegistrationScopeId = "bot-scope-1",
+            Platform = "lark",
+            SenderId = "ou_alice",
+        };
+        var metadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "bot-scope-1",
+            [ChannelMetadataKeys.Platform] = "lark",
+            [ChannelMetadataKeys.SenderId] = "ou_alice",
+        };
+
+        ChannelUserConfigScope.FromMetadata(metadata)
+            .Should().Be(ChannelUserConfigScope.FromInboundEvent(evt));
+    }
+
+    [Fact]
+    public void FromMetadata_NullMetadata_ReturnsDefault()
+    {
+        ChannelUserConfigScope.FromMetadata(null).Should().Be("default");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #436. The bot's `RegistrationScopeId` is per-NyxID-account (one bot = one scope), so multiple Lark users sharing one bot all hit the same `UserConfigGAgent` actor (`user-config-{registrationScopeId}`) and each `/daily` save overwrites everyone else's saved `github_username`. Last writer wins — colleague binds their username, bot owner's daily report starts targeting colleague's GitHub account.

This patch composes `{registrationScopeId}:{platform}:{senderId}` for the user-config read (form prefill in `AgentBuilderCardFlow.TryResolveAsync`) and write (preference save in `AgentBuilderTool.CreateDailyReportAgentAsync`). Each Lark user now gets their own `UserConfigGAgent`.

`SkillRunnerGAgent.ScopeId` stays **bot-scoped** on purpose — downstream tools that read `scope_id` as a NyxID tenant key (binding store, service invocation, etc.) need the bot's scope, not a per-end-user composite. The CLI / Tools UI goes through `IAppScopeResolver` and is unaffected.

## What changed

- `agents/Aevatar.GAgents.ChannelRuntime/ChannelUserConfigScope.cs` (new) — composes the per-end-user scope from `ChannelInboundEvent` or from `AgentToolRequestContext.CurrentMetadata`. Falls back to bare `registrationScopeId` when no sender is present (programmatic / system paths).
- `AgentBuilderCardFlow.TryResolveAsync` — reads via `ChannelUserConfigScope.FromInboundEvent(evt)` instead of `NormalizeScopeId(evt.RegistrationScopeId)`.
- `AgentBuilderTool.CreateDailyReportAgentAsync` — separates `configScopeId` (bot scope, still used for `InitializeSkillRunnerCommand.ScopeId`) from `userConfigScopeId` (per-end-user composite, used for both `ResolveDailyReportGithubUsernameAsync` read and `SaveGithubUsernamePreferenceIfRequestedAsync` write).

## Test plan

- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests` — 473 passed, 0 failed.
- [x] `dotnet test test/Aevatar.Tools.Cli.Tests --filter UserConfig` — 26 passed, 0 failed (CLI / projection paths unaffected).
- [x] `bash tools/ci/architecture_guards.sh` — exit 0.
- [x] New `ChannelUserConfigScopeTests` — 7 tests pinning the composition rules: per-user differentiation, fallback when SenderId missing, default scope when RegistrationScopeId missing, channel-literal fallback when Platform missing, casing collapse, FromInboundEvent ↔ FromMetadata parity.
- [x] Updated `AgentBuilderCardFlowTests.TryResolveAsync_DailyReportLaunch_PrefillsSavedGithubUsername` — pins prefill reads from per-user scope.
- [x] New `AgentBuilderCardFlowTests.TryResolveAsync_DailyReportLaunch_TwoLarkUsersInSameBot_SeeIndependentSavedUsernames` — pins the bug-fix scenario directly.
- [x] Updated `AgentBuilderToolTests.ExecuteAsync_CreateAgent_DailyReport_SavesGithubUsernamePreference_WhenRequested` — asserts `SaveGithubUsernameAsync("scope-1:lark:ou_alice", ...)`, not `("scope-1", ...)`.

## Migration note

Existing user-config records keyed at the bot's `RegistrationScopeId` are now ambiguous (no per-user provenance). Each Lark user will simply re-bind on first `/daily` after this lands — the form already prompts when no username is prefilled. The orphan shared record can be cleaned up out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)