### PR TITLE
fix(mainnet): deny local file secrets store, source from env vars (#386)

### DIFF
--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -376,12 +376,12 @@ public static class ServiceCollectionExtensions
         if (!options.EnableMEAIProviders)
             return;
 
-        var secretsStoreAccessor = CreateSecretsStoreAccessor(options);
         if (options.EnableReloadableProviderFactory)
         {
             var versionProvider = BuildProviderConfigVersionProvider(options);
             services.TryAddSingleton<ILLMProviderFactory>(sp =>
             {
+                var secretsStoreAccessor = CreateSecretsStoreAccessor(options, sp);
                 var logger = sp.GetService<ILogger<ReloadableLLMProviderFactory>>();
                 return new ReloadableLLMProviderFactory(
                     () => BuildLlmProviderFactory(configuration, options, secretsStoreAccessor),
@@ -391,8 +391,11 @@ public static class ServiceCollectionExtensions
             return;
         }
 
-        var factory = BuildLlmProviderFactory(configuration, options, secretsStoreAccessor);
-        services.TryAddSingleton<ILLMProviderFactory>(factory);
+        services.TryAddSingleton<ILLMProviderFactory>(sp =>
+        {
+            var secretsStoreAccessor = CreateSecretsStoreAccessor(options, sp);
+            return BuildLlmProviderFactory(configuration, options, secretsStoreAccessor);
+        });
     }
 
     private static ILLMProviderFactory BuildLlmProviderFactory(
@@ -586,10 +589,20 @@ public static class ServiceCollectionExtensions
         return new ConfiguredProvider("nyxid", "nyxid", model, gatewayEndpoint, string.Empty);
     }
 
-    private static Func<IAevatarSecretsStore> CreateSecretsStoreAccessor(AevatarAIFeatureOptions options)
+    private static Func<IAevatarSecretsStore> CreateSecretsStoreAccessor(
+        AevatarAIFeatureOptions options,
+        IServiceProvider services)
     {
         if (options.SecretsStore != null)
             return () => options.SecretsStore;
+
+        // Prefer the DI-registered store so hosts that opted into the
+        // read-only EnvironmentSecretsStore (e.g. mainnet) are honored
+        // here too. Falling back to a fresh AevatarSecretsStore() would
+        // re-open the local secrets.json on disk.
+        var registered = services.GetService<IAevatarSecretsStore>();
+        if (registered != null)
+            return () => registered;
 
         return static () => new AevatarSecretsStore();
     }

--- a/src/Aevatar.Bootstrap/Hosting/WebApplicationBuilderExtensions.cs
+++ b/src/Aevatar.Bootstrap/Hosting/WebApplicationBuilderExtensions.cs
@@ -33,6 +33,26 @@ public sealed class AevatarDefaultHostOptions
     public bool EnableOpenApiDocument { get; set; } = true;
 
     public string OpenApiDocumentRoute { get; set; } = "/api/openapi.json";
+
+    /// <summary>
+    /// Whether the host may use the local file secrets store
+    /// (<c>~/.aevatar/secrets.json</c>) and register
+    /// <c>AevatarSecretsStore</c>.
+    /// <para>
+    /// <c>true</c> (default): legacy behavior — secrets.json is loaded into
+    /// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/> and a
+    /// read/write store is registered. Suitable for local dev, CLI tools,
+    /// localnet, and demos.
+    /// </para>
+    /// <para>
+    /// <c>false</c>: production / mainnet hosts. The host must not load or
+    /// persist secrets to disk. <c>secrets.json</c> is skipped and the
+    /// read-only <c>EnvironmentSecretsStore</c> is registered; secrets must
+    /// come from configuration / <c>AEVATAR_</c>-prefixed environment
+    /// variables. Mutation methods on the store throw on call.
+    /// </para>
+    /// </summary>
+    public bool AllowLocalFileSecretsStore { get; set; } = true;
 }
 
 public static class WebApplicationBuilderExtensions
@@ -47,8 +67,10 @@ public static class WebApplicationBuilderExtensions
         configureHost?.Invoke(hostOptions);
 
         AddApplicationBaseConfiguration(builder);
-        builder.Configuration.AddAevatarConfig();
-        builder.Services.AddAevatarBootstrap(builder.Configuration);
+        builder.Configuration.AddAevatarConfig(allowLocalFileStore: hostOptions.AllowLocalFileSecretsStore);
+        builder.Services.AddAevatarBootstrap(
+            builder.Configuration,
+            allowLocalFileSecretsStore: hostOptions.AllowLocalFileSecretsStore);
         builder.Services.AddSingleton(hostOptions);
         builder.Services.AddSingleton(new AevatarHostMetadata
         {

--- a/src/Aevatar.Bootstrap/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap/ServiceCollectionExtensions.cs
@@ -11,9 +11,10 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddAevatarBootstrap(
         this IServiceCollection services,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        bool allowLocalFileSecretsStore = true)
     {
-        services.AddAevatarConfig();
+        services.AddAevatarConfig(allowLocalFileSecretsStore);
         services.AddHttpClient();
         services.AddAevatarActorRuntime(configuration);
         RegisterConnectorBuilders(services);

--- a/src/Aevatar.Bootstrap/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap/ServiceCollectionExtensions.cs
@@ -14,6 +14,12 @@ public static class ServiceCollectionExtensions
         IConfiguration configuration,
         bool allowLocalFileSecretsStore = true)
     {
+        // EnvironmentSecretsStore (registered by AddAevatarConfig when
+        // allowLocalFileSecretsStore=false) ctor-injects IConfiguration. The
+        // overload here already receives the instance, so register it into DI
+        // up front instead of forcing every caller to add it themselves.
+        // TryAdd preserves any existing registration from a host builder.
+        services.TryAddSingleton(configuration);
         services.AddAevatarConfig(allowLocalFileSecretsStore);
         services.AddHttpClient();
         services.AddAevatarActorRuntime(configuration);

--- a/src/Aevatar.Configuration/AevatarConfigLoader.cs
+++ b/src/Aevatar.Configuration/AevatarConfigLoader.cs
@@ -30,8 +30,10 @@ public static class AevatarConfigLoader
         this IConfigurationBuilder builder,
         bool allowLocalFileStore = true)
     {
-        // 确保目录存在
-        AevatarPaths.EnsureDirectories();
+        // 仅在使用本地文件 store 时创建 ~/.aevatar/ 目录树；
+        // 生产入口（allowLocalFileStore=false）保持零本地文件足迹。
+        if (allowLocalFileStore)
+            AevatarPaths.EnsureDirectories();
 
         // config.json — 非敏感配置（低优先级）
         builder.AddJsonFile(AevatarPaths.ConfigJson, optional: true, reloadOnChange: true);

--- a/src/Aevatar.Configuration/AevatarConfigLoader.cs
+++ b/src/Aevatar.Configuration/AevatarConfigLoader.cs
@@ -19,8 +19,16 @@ public static class AevatarConfigLoader
     /// 将 ~/.aevatar/ 下的配置文件添加到 IConfigurationBuilder。
     /// </summary>
     /// <param name="builder">配置构建器。</param>
+    /// <param name="allowLocalFileStore">
+    /// 是否允许加载 <c>~/.aevatar/secrets.json</c>。生产/mainnet 入口必须传
+    /// <c>false</c>，确保 secrets 仅来自部署平台注入的环境变量。其他 host 可
+    /// 保留默认值。<c>config.json</c>、<c>mcp.json</c>、<c>connectors.json</c>
+    /// 等非敏感文件不受此开关影响。
+    /// </param>
     /// <returns>构建器（链式调用）。</returns>
-    public static IConfigurationBuilder AddAevatarConfig(this IConfigurationBuilder builder)
+    public static IConfigurationBuilder AddAevatarConfig(
+        this IConfigurationBuilder builder,
+        bool allowLocalFileStore = true)
     {
         // 确保目录存在
         AevatarPaths.EnsureDirectories();
@@ -29,7 +37,9 @@ public static class AevatarConfigLoader
         builder.AddJsonFile(AevatarPaths.ConfigJson, optional: true, reloadOnChange: true);
 
         // secrets.json — 敏感配置（高优先级，覆盖 config.json 的同名 key）
-        builder.AddJsonFile(AevatarPaths.SecretsJson, optional: true, reloadOnChange: false);
+        // 生产入口（mainnet）必须显式禁用：禁止把 secrets 落地到本地文件。
+        if (allowLocalFileStore)
+            builder.AddJsonFile(AevatarPaths.SecretsJson, optional: true, reloadOnChange: false);
 
         // mcp.json — MCP 服务器配置（Cursor 兼容格式）
         builder.AddJsonFile(AevatarPaths.MCPJson, optional: true, reloadOnChange: true);

--- a/src/Aevatar.Configuration/EnvironmentSecretsStore.cs
+++ b/src/Aevatar.Configuration/EnvironmentSecretsStore.cs
@@ -1,0 +1,82 @@
+// ─────────────────────────────────────────────────────────────
+// EnvironmentSecretsStore — read-only IAevatarSecretsStore backed by
+// IConfiguration (env vars + non-secret config files).
+//
+// Used by hosts that must not persist secrets to local files
+// (e.g. Aevatar.Mainnet.Host.Api). Secrets are expected to come from
+// the deploy platform via AEVATAR_-prefixed environment variables.
+// Set / Remove deliberately throw so a misconfigured caller fails
+// fast at the call site rather than silently falling back to disk.
+// ─────────────────────────────────────────────────────────────
+
+using Microsoft.Extensions.Configuration;
+
+namespace Aevatar.Configuration;
+
+/// <summary>
+/// Read-only secrets store that resolves keys from <see cref="IConfiguration"/>.
+/// Mutation methods throw <see cref="InvalidOperationException"/> by design:
+/// hosts opting into this store have explicitly disabled local file persistence.
+/// </summary>
+public sealed class EnvironmentSecretsStore : IAevatarSecretsStore
+{
+    private readonly IConfiguration _configuration;
+
+    public EnvironmentSecretsStore(IConfiguration configuration)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public string? Get(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return null;
+        var value = _configuration[key];
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    public string? GetApiKey(string providerName)
+    {
+        if (string.IsNullOrWhiteSpace(providerName)) return null;
+
+        var byProvidersSection = _configuration[$"LLMProviders:Providers:{providerName}:ApiKey"];
+        if (!string.IsNullOrWhiteSpace(byProvidersSection))
+            return byProvidersSection;
+
+        var byProviderSection = _configuration[$"LLMProviders:{providerName}:ApiKey"];
+        if (!string.IsNullOrWhiteSpace(byProviderSection))
+            return byProviderSection;
+
+        var byEnvConvention = _configuration[$"{providerName}_API_KEY"];
+        if (!string.IsNullOrWhiteSpace(byEnvConvention))
+            return byEnvConvention;
+
+        return null;
+    }
+
+    public string? GetDefaultProvider()
+    {
+        var value = _configuration["LLMProviders:Default"];
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    public IReadOnlyDictionary<string, string> GetAll()
+    {
+        var snapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in _configuration.AsEnumerable())
+        {
+            if (!string.IsNullOrEmpty(kv.Value))
+                snapshot[kv.Key] = kv.Value;
+        }
+        return snapshot;
+    }
+
+    public void Set(string key, string value) =>
+        throw new InvalidOperationException(
+            "EnvironmentSecretsStore is read-only: this host disables local file secrets persistence. " +
+            "Inject secrets via AEVATAR_-prefixed environment variables or platform-managed configuration.");
+
+    public void Remove(string key) =>
+        throw new InvalidOperationException(
+            "EnvironmentSecretsStore is read-only: this host disables local file secrets persistence. " +
+            "Manage secret removal via AEVATAR_-prefixed environment variables or platform-managed configuration.");
+}

--- a/src/Aevatar.Configuration/EnvironmentSecretsStore.cs
+++ b/src/Aevatar.Configuration/EnvironmentSecretsStore.cs
@@ -59,16 +59,33 @@ public sealed class EnvironmentSecretsStore : IAevatarSecretsStore
         return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
+    /// <summary>
+    /// Returns a snapshot of secret-shaped configuration entries. Only keys
+    /// that match the conventions <see cref="GetApiKey"/> understands are
+    /// included: anything under <c>LLMProviders:</c> (provider definitions,
+    /// API keys, default name) and any <c>{NAME}_API_KEY</c>-style keys.
+    /// <para>
+    /// This is intentionally narrower than dumping the entire
+    /// <see cref="IConfiguration"/> view: in env-driven hosts, the config root
+    /// also contains binding URLs, feature flags and connection strings, none
+    /// of which belong on the secrets API surface.
+    /// </para>
+    /// </summary>
     public IReadOnlyDictionary<string, string> GetAll()
     {
         var snapshot = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var kv in _configuration.AsEnumerable())
         {
-            if (!string.IsNullOrEmpty(kv.Value))
-                snapshot[kv.Key] = kv.Value;
+            if (string.IsNullOrEmpty(kv.Value)) continue;
+            if (!IsSecretShapedKey(kv.Key)) continue;
+            snapshot[kv.Key] = kv.Value;
         }
         return snapshot;
     }
+
+    private static bool IsSecretShapedKey(string key) =>
+        key.StartsWith("LLMProviders:", StringComparison.OrdinalIgnoreCase) ||
+        key.EndsWith("_API_KEY", StringComparison.OrdinalIgnoreCase);
 
     public void Set(string key, string value) =>
         throw new InvalidOperationException(

--- a/src/Aevatar.Configuration/README.md
+++ b/src/Aevatar.Configuration/README.md
@@ -13,11 +13,21 @@
 ## 核心类型
 
 - `AevatarConfigLoader`：把本地配置合并到 `IConfigurationBuilder`
-- `AevatarSecretsStore`：按 key 读取/写入敏感配置
+- `AevatarSecretsStore`：按 key 读写本地文件 secrets store（`~/.aevatar/secrets.json`），开发/CLI/localnet 默认实现
+- `EnvironmentSecretsStore`：只读 secrets store，仅从 `IConfiguration`（含 `AEVATAR_` 环境变量）读取，`Set`/`Remove` 直接抛 `InvalidOperationException`；mainnet 等生产宿主必须使用此实现，禁止把 secrets 落地到本地文件
 - `AevatarMCPConfig`：读取 MCP 服务器配置
 - `AevatarConnectorConfig`：读取命名 connector 配置（含 allowlist/timeout/retry）
 - `AevatarAgentYamlLoader`：扫描并读取 Agent/Workflow YAML
 - `AevatarPaths`：统一路径定义与目录初始化；另提供 `RepoRoot` / `RepoRootWorkflows`，宿主（如 Api）会从仓库根目录的 `workflows/` 加载 YAML（若存在），用户无需拷贝到 `~/.aevatar`。
+
+### 选择 secrets store
+
+`AddAevatarConfig` 的 `bool allowLocalFileStore = true` 参数控制注册哪个 store：
+
+- `true`（默认）：注册 `AevatarSecretsStore`，并把 `~/.aevatar/secrets.json` 加入 `IConfiguration`。
+- `false`：注册 `EnvironmentSecretsStore`，跳过 `secrets.json` 加载。供 mainnet/生产宿主使用。
+
+宿主层通过 `AevatarDefaultHostOptions.AllowLocalFileSecretsStore` 暴露此开关，由 `AddAevatarDefaultHost` 透传到 `AddAevatarBootstrap` 与 `AddAevatarConfig`。`Aevatar.Mainnet.Host.Api` 在 bootstrap 链路中显式设置为 `false`。
 
 ## Connector 作用与配置
 

--- a/src/Aevatar.Configuration/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Configuration/ServiceCollectionExtensions.cs
@@ -2,9 +2,10 @@
 // ServiceCollectionExtensions — Aevatar Config DI 注册
 // ─────────────────────────────────────────────────────────────
 
+using Aevatar.Foundation.Abstractions.Credentials;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Aevatar.Foundation.Abstractions.Credentials;
 
 namespace Aevatar.Configuration;
 
@@ -14,11 +15,35 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// 注册 Aevatar 配置服务。自动创建 ~/.aevatar/ 目录结构。
     /// </summary>
-    public static IServiceCollection AddAevatarConfig(this IServiceCollection services)
+    /// <param name="services">DI 容器。</param>
+    /// <param name="allowLocalFileStore">
+    /// 是否允许使用本地文件 secrets store（<see cref="AevatarSecretsStore"/>，
+    /// 读写 <c>~/.aevatar/secrets.json</c>）。
+    /// <para>
+    /// <c>true</c>（默认）：注册 <see cref="AevatarSecretsStore"/>，沿用历史行为。
+    /// </para>
+    /// <para>
+    /// <c>false</c>：注册只读的 <see cref="EnvironmentSecretsStore"/>，
+    /// 仅从 <see cref="IConfiguration"/>（含 <c>AEVATAR_</c> 环境变量）读取，
+    /// <c>Set</c>/<c>Remove</c> 直接抛 <see cref="InvalidOperationException"/>。
+    /// 生产/mainnet 入口必须传 <c>false</c>。
+    /// </para>
+    /// </param>
+    public static IServiceCollection AddAevatarConfig(
+        this IServiceCollection services,
+        bool allowLocalFileStore = true)
     {
         AevatarPaths.EnsureDirectories();
-        services.TryAddSingleton<IAevatarSecretsStore, AevatarSecretsStore>();
-        services.TryAddSingleton<AevatarSecretsStore>();
+        if (allowLocalFileStore)
+        {
+            services.TryAddSingleton<IAevatarSecretsStore, AevatarSecretsStore>();
+            services.TryAddSingleton<AevatarSecretsStore>();
+        }
+        else
+        {
+            services.TryAddSingleton<IAevatarSecretsStore, EnvironmentSecretsStore>();
+            services.TryAddSingleton<EnvironmentSecretsStore>();
+        }
         services.TryAddSingleton<ICredentialProvider, SecretsStoreCredentialProvider>();
         services.TryAddSingleton<SecretsStoreCredentialProvider>();
         return services;

--- a/src/Aevatar.Configuration/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Configuration/ServiceCollectionExtensions.cs
@@ -13,29 +13,39 @@ namespace Aevatar.Configuration;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// 注册 Aevatar 配置服务。自动创建 ~/.aevatar/ 目录结构。
+    /// 注册 Aevatar 配置服务。
     /// </summary>
     /// <param name="services">DI 容器。</param>
     /// <param name="allowLocalFileStore">
     /// 是否允许使用本地文件 secrets store（<see cref="AevatarSecretsStore"/>，
     /// 读写 <c>~/.aevatar/secrets.json</c>）。
     /// <para>
-    /// <c>true</c>（默认）：注册 <see cref="AevatarSecretsStore"/>，沿用历史行为。
+    /// <c>true</c>（默认）：注册 <see cref="AevatarSecretsStore"/> 并自动创建
+    /// <c>~/.aevatar/</c> 目录结构，沿用历史行为。
     /// </para>
     /// <para>
     /// <c>false</c>：注册只读的 <see cref="EnvironmentSecretsStore"/>，
     /// 仅从 <see cref="IConfiguration"/>（含 <c>AEVATAR_</c> 环境变量）读取，
     /// <c>Set</c>/<c>Remove</c> 直接抛 <see cref="InvalidOperationException"/>。
-    /// 生产/mainnet 入口必须传 <c>false</c>。
+    /// 不创建本地目录。生产/mainnet 入口必须传 <c>false</c>。
+    /// </para>
+    /// <para>
+    /// <b>前置条件（仅 <c>false</c> 路径）</b>：DI 容器中必须已注册
+    /// <see cref="IConfiguration"/>，<see cref="EnvironmentSecretsStore"/>
+    /// 通过构造函数注入它。<see cref="AddAevatarConfig"/>
+    /// 自身不注册 <see cref="IConfiguration"/>；通过
+    /// <c>WebApplicationBuilder</c> 或 <c>HostBuilder</c> 调用本扩展时框架已经
+    /// 注册好。裸 <see cref="IServiceCollection"/> 调用方需自行
+    /// <c>services.AddSingleton&lt;IConfiguration&gt;(...)</c>。
     /// </para>
     /// </param>
     public static IServiceCollection AddAevatarConfig(
         this IServiceCollection services,
         bool allowLocalFileStore = true)
     {
-        AevatarPaths.EnsureDirectories();
         if (allowLocalFileStore)
         {
+            AevatarPaths.EnsureDirectories();
             services.TryAddSingleton<IAevatarSecretsStore, AevatarSecretsStore>();
             services.TryAddSingleton<AevatarSecretsStore>();
         }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -41,12 +41,12 @@ public static class MainnetHostBuilderExtensions
         {
             options.ServiceName = "Aevatar.Mainnet.Host.Api";
             options.EnableWebSockets = true;
-            // Mainnet must never persist secrets to ~/.aevatar/secrets.json.
-            // Secrets are injected via AEVATAR_-prefixed environment variables
-            // managed by the deploy platform; Set/Remove on the secrets store
-            // will throw at the call site instead of silently writing to disk.
-            options.AllowLocalFileSecretsStore = false;
             configureHost?.Invoke(options);
+            // Mainnet invariant — enforced after the caller's configureHost so
+            // user callbacks cannot re-enable the local file secrets store.
+            // Secrets must come from AEVATAR_-prefixed environment variables;
+            // Set/Remove on the secrets store will throw at the call site.
+            options.AllowLocalFileSecretsStore = false;
         });
         builder.AddMainnetDistributedOrleansHost();
         builder.AddAevatarPlatform(options =>

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -41,6 +41,11 @@ public static class MainnetHostBuilderExtensions
         {
             options.ServiceName = "Aevatar.Mainnet.Host.Api";
             options.EnableWebSockets = true;
+            // Mainnet must never persist secrets to ~/.aevatar/secrets.json.
+            // Secrets are injected via AEVATAR_-prefixed environment variables
+            // managed by the deploy platform; Set/Remove on the secrets store
+            // will throw at the call site instead of silently writing to disk.
+            options.AllowLocalFileSecretsStore = false;
             configureHost?.Invoke(options);
         });
         builder.AddMainnetDistributedOrleansHost();

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapCoverageTests.cs
@@ -392,6 +392,37 @@ public class AIFeatureBootstrapCoverageTests
     }
 
     [Fact]
+    public void AddAevatarAIFeatures_WhenSecretsStoreOptionAbsent_ShouldUseDIRegisteredStore()
+    {
+        // Mainnet path: a host registers IAevatarSecretsStore (e.g. the
+        // read-only EnvironmentSecretsStore) into DI but does not pass
+        // options.SecretsStore. Before the fix, AddAevatarAIFeatures fell
+        // back to `new AevatarSecretsStore()` which re-opens secrets.json
+        // from disk. This asserts that the DI-registered store is honored.
+        var diRegistered = new InMemorySecretsStore(new Dictionary<string, string>
+        {
+            ["LLMProviders:Providers:deepseek:ApiKey"] = "from-di-registered-store",
+            ["LLMProviders:Providers:deepseek:ProviderType"] = "deepseek",
+            ["LLMProviders:Default"] = "deepseek",
+        });
+        var services = new ServiceCollection();
+        services.AddSingleton<IAevatarSecretsStore>(diRegistered);
+        var config = new ConfigurationBuilder().Build();
+
+        services.AddAevatarAIFeatures(config, options =>
+        {
+            options.EnableMEAIProviders = true;
+            options.EnableMEAIToTornadoFailover = false;
+            // intentionally leave options.SecretsStore = null
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var llmFactory = provider.GetRequiredService<ILLMProviderFactory>();
+        llmFactory.GetAvailableProviders().Should().ContainSingle().Which.Should().Be("deepseek");
+        llmFactory.GetDefault().Name.Should().Be("deepseek");
+    }
+
+    [Fact]
     public async Task AddAevatarAIFeatures_WhenMCPEnabledAndConfigured_ShouldRegisterMCPToolSourceAndConnectorBuilder()
     {
         var tempHome = Path.Combine(Path.GetTempPath(), $"ai-feature-mcp-{Guid.NewGuid():N}");

--- a/test/Aevatar.Bootstrap.Tests/BootstrapServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/BootstrapServiceCollectionExtensionsTests.cs
@@ -28,12 +28,64 @@ public class BootstrapServiceCollectionExtensionsTests
         using var provider = services.BuildServiceProvider();
 
         provider.GetService<IActorRuntime>().Should().NotBeNull();
-        provider.GetService<IAevatarSecretsStore>().Should().NotBeNull();
+        provider.GetService<IAevatarSecretsStore>().Should().BeOfType<AevatarSecretsStore>();
 
         var connectorBuilders = provider.GetServices<IConnectorBuilder>().ToList();
         connectorBuilders.Should().ContainSingle(x => x.GetType() == typeof(HttpConnectorBuilder));
         connectorBuilders.Should().ContainSingle(x => x.GetType() == typeof(CliConnectorBuilder));
         connectorBuilders.Should().ContainSingle(x => x.GetType() == typeof(TelegramUserConnectorBuilder));
+    }
+
+    [Fact]
+    public void AddAevatarBootstrap_WhenLocalFileSecretsStoreDisabled_ShouldRegisterEnvironmentSecretsStore()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["LLMProviders:Default"] = "deepseek",
+        });
+        services.AddSingleton(configuration);
+
+        services.AddAevatarBootstrap(configuration, allowLocalFileSecretsStore: false);
+        using var provider = services.BuildServiceProvider();
+
+        var store = provider.GetRequiredService<IAevatarSecretsStore>();
+        store.Should().BeOfType<EnvironmentSecretsStore>();
+        store.GetDefaultProvider().Should().Be("deepseek");
+        store.Invoking(s => s.Set("k", "v")).Should().Throw<InvalidOperationException>();
+        store.Invoking(s => s.Remove("k")).Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void AddAevatarDefaultHost_WhenLocalFileSecretsStoreDisabled_ShouldSkipSecretsJsonAndUseEnvironmentStore()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        File.WriteAllText(
+            Path.Combine(home.Root, "secrets.json"),
+            """{"FromSecretsJson":"should-not-load"}""");
+        Environment.SetEnvironmentVariable("AEVATAR_LLMProviders__Default", "deepseek");
+        try
+        {
+            var builder = CreateBuilder();
+
+            builder.AddAevatarDefaultHost(options =>
+            {
+                options.AllowLocalFileSecretsStore = false;
+                options.EnableConnectorBootstrap = false;
+                options.EnableCors = false;
+            });
+
+            using var provider = builder.Services.BuildServiceProvider();
+            var store = provider.GetRequiredService<IAevatarSecretsStore>();
+            store.Should().BeOfType<EnvironmentSecretsStore>();
+            builder.Configuration["FromSecretsJson"].Should().BeNull();
+            builder.Configuration["LLMProviders:Default"].Should().Be("deepseek");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AEVATAR_LLMProviders__Default", null);
+        }
     }
 
     [Fact]
@@ -195,8 +247,11 @@ public class BootstrapServiceCollectionExtensionsTests
         {
             _previous = Environment.GetEnvironmentVariable(AevatarPaths.HomeEnv);
             _path = Path.Combine(Path.GetTempPath(), $"aevatar-bootstrap-tests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_path);
             Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, _path);
         }
+
+        public string Root => _path;
 
         public void Dispose()
         {

--- a/test/Aevatar.Bootstrap.Tests/BootstrapServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/BootstrapServiceCollectionExtensionsTests.cs
@@ -45,8 +45,10 @@ public class BootstrapServiceCollectionExtensionsTests
         {
             ["LLMProviders:Default"] = "deepseek",
         });
-        services.AddSingleton(configuration);
 
+        // No services.AddSingleton(configuration) — AddAevatarBootstrap
+        // must register the IConfiguration it received so the env-only
+        // EnvironmentSecretsStore can resolve without caller workaround.
         services.AddAevatarBootstrap(configuration, allowLocalFileSecretsStore: false);
         using var provider = services.BuildServiceProvider();
 

--- a/test/Aevatar.Foundation.Abstractions.Tests/EnvironmentSecretsStoreTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/EnvironmentSecretsStoreTests.cs
@@ -1,0 +1,94 @@
+using Aevatar.Configuration;
+using Microsoft.Extensions.Configuration;
+using Shouldly;
+
+namespace Aevatar.Foundation.Abstractions.Tests;
+
+public sealed class EnvironmentSecretsStoreTests
+{
+    [Fact]
+    public void Get_ShouldReturnConfigurationValue_OrNullWhenMissing()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Custom:Value"] = "v",
+            ["Empty"] = "",
+        });
+        var store = new EnvironmentSecretsStore(configuration);
+
+        store.Get("Custom:Value").ShouldBe("v");
+        store.Get("Missing").ShouldBeNull();
+        store.Get("Empty").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetApiKey_ShouldResolveByProviderConventions_InOrder()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["LLMProviders:Providers:deepseek:ApiKey"] = "k1",
+            ["LLMProviders:openai:ApiKey"] = "k2",
+            ["GROQ_API_KEY"] = "k3",
+            ["LLMProviders:Default"] = "deepseek",
+        });
+        var store = new EnvironmentSecretsStore(configuration);
+
+        // Convention 1: LLMProviders:Providers:{name}:ApiKey
+        store.GetApiKey("deepseek").ShouldBe("k1");
+        // Convention 2: LLMProviders:{name}:ApiKey
+        store.GetApiKey("openai").ShouldBe("k2");
+        // Convention 3: {PROVIDER}_API_KEY
+        store.GetApiKey("GROQ").ShouldBe("k3");
+        store.GetApiKey("missing").ShouldBeNull();
+        store.GetDefaultProvider().ShouldBe("deepseek");
+    }
+
+    [Fact]
+    public void GetAll_ShouldFlattenConfigurationEntries_AndDropEmptyValues()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["A:B"] = "1",
+            ["C"] = "",
+            ["D"] = "2",
+        });
+        var store = new EnvironmentSecretsStore(configuration);
+
+        var snapshot = store.GetAll();
+
+        snapshot.ContainsKey("A:B").ShouldBeTrue();
+        snapshot["A:B"].ShouldBe("1");
+        snapshot["D"].ShouldBe("2");
+        snapshot.ContainsKey("C").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Set_ShouldThrow_BecauseStoreIsReadOnly()
+    {
+        var store = new EnvironmentSecretsStore(BuildConfiguration());
+
+        Should.Throw<InvalidOperationException>(() => store.Set("k", "v"));
+    }
+
+    [Fact]
+    public void Remove_ShouldThrow_BecauseStoreIsReadOnly()
+    {
+        var store = new EnvironmentSecretsStore(BuildConfiguration());
+
+        Should.Throw<InvalidOperationException>(() => store.Remove("k"));
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNullConfiguration()
+    {
+        Should.Throw<ArgumentNullException>(() => new EnvironmentSecretsStore(null!));
+    }
+
+    private static IConfiguration BuildConfiguration(Dictionary<string, string?>? values = null)
+    {
+        var builder = new ConfigurationBuilder();
+        if (values != null)
+            builder.AddInMemoryCollection(values);
+        return builder.Build();
+    }
+}

--- a/test/Aevatar.Foundation.Abstractions.Tests/EnvironmentSecretsStoreTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/EnvironmentSecretsStoreTests.cs
@@ -44,22 +44,31 @@ public sealed class EnvironmentSecretsStoreTests
     }
 
     [Fact]
-    public void GetAll_ShouldFlattenConfigurationEntries_AndDropEmptyValues()
+    public void GetAll_ShouldOnlyReturnSecretShapedKeys_NotArbitraryConfiguration()
     {
         var configuration = BuildConfiguration(new()
         {
-            ["A:B"] = "1",
-            ["C"] = "",
-            ["D"] = "2",
+            // Secret-shaped: included
+            ["LLMProviders:Providers:deepseek:ApiKey"] = "k1",
+            ["LLMProviders:Default"] = "deepseek",
+            ["GROQ_API_KEY"] = "k2",
+            // Non-secret config: must NOT leak through GetAll
+            ["ConnectionStrings:Db"] = "Server=...;Pwd=should-not-leak",
+            ["Cors:AllowedOrigins:0"] = "https://app.example.com",
+            ["FeatureFlags:Foo"] = "true",
+            ["Empty"] = "",
         });
         var store = new EnvironmentSecretsStore(configuration);
 
         var snapshot = store.GetAll();
 
-        snapshot.ContainsKey("A:B").ShouldBeTrue();
-        snapshot["A:B"].ShouldBe("1");
-        snapshot["D"].ShouldBe("2");
-        snapshot.ContainsKey("C").ShouldBeFalse();
+        snapshot.ContainsKey("LLMProviders:Providers:deepseek:ApiKey").ShouldBeTrue();
+        snapshot.ContainsKey("LLMProviders:Default").ShouldBeTrue();
+        snapshot.ContainsKey("GROQ_API_KEY").ShouldBeTrue();
+        snapshot.ContainsKey("ConnectionStrings:Db").ShouldBeFalse();
+        snapshot.ContainsKey("Cors:AllowedOrigins:0").ShouldBeFalse();
+        snapshot.ContainsKey("FeatureFlags:Foo").ShouldBeFalse();
+        snapshot.ContainsKey("Empty").ShouldBeFalse();
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.Abstractions.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/ServiceCollectionExtensionsTests.cs
@@ -61,6 +61,18 @@ public sealed class ServiceCollectionExtensionsTests
             .ShouldBeFalse();
     }
 
+    [Fact]
+    public void AddAevatarConfig_WhenLocalFileStoreDisabled_ShouldNotCreateLocalDirectoryTree()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"aevatar-config-tests-{Guid.NewGuid():N}");
+        using var scope = new EnvironmentVariableScope(AevatarPaths.HomeEnv, tempRoot);
+        var services = new ServiceCollection();
+
+        services.AddAevatarConfig(allowLocalFileStore: false);
+
+        Directory.Exists(tempRoot).ShouldBeFalse();
+    }
+
     private sealed class EnvironmentVariableScope : IDisposable
     {
         private readonly string _name;

--- a/test/Aevatar.Foundation.Abstractions.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Foundation.Abstractions.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.Configuration;
 using Aevatar.Foundation.Abstractions.Credentials;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 
@@ -24,6 +25,40 @@ public sealed class ServiceCollectionExtensionsTests
             .ShouldBeTrue();
         Directory.Exists(Path.Combine(tempRoot, "agents")).ShouldBeTrue();
         Directory.Exists(Path.Combine(tempRoot, "skills")).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void AddAevatarConfig_ByDefault_ShouldRegisterFileBackedSecretsStore()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"aevatar-config-tests-{Guid.NewGuid():N}");
+        using var scope = new EnvironmentVariableScope(AevatarPaths.HomeEnv, tempRoot);
+        var services = new ServiceCollection();
+
+        services.AddAevatarConfig();
+
+        services.Any(d =>
+                d.ServiceType == typeof(IAevatarSecretsStore) &&
+                d.ImplementationType == typeof(AevatarSecretsStore))
+            .ShouldBeTrue();
+        services.Any(d => d.ImplementationType == typeof(EnvironmentSecretsStore))
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AddAevatarConfig_WhenLocalFileStoreDisabled_ShouldRegisterEnvironmentSecretsStore()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"aevatar-config-tests-{Guid.NewGuid():N}");
+        using var scope = new EnvironmentVariableScope(AevatarPaths.HomeEnv, tempRoot);
+        var services = new ServiceCollection();
+
+        services.AddAevatarConfig(allowLocalFileStore: false);
+
+        services.Any(d =>
+                d.ServiceType == typeof(IAevatarSecretsStore) &&
+                d.ImplementationType == typeof(EnvironmentSecretsStore))
+            .ShouldBeTrue();
+        services.Any(d => d.ImplementationType == typeof(AevatarSecretsStore))
+            .ShouldBeFalse();
     }
 
     private sealed class EnvironmentVariableScope : IDisposable

--- a/test/Aevatar.Hosting.Tests/MainnetSecretsStoreInvariantTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetSecretsStoreInvariantTests.cs
@@ -1,0 +1,86 @@
+using Aevatar.Bootstrap.Hosting;
+using Aevatar.Configuration;
+using Aevatar.Mainnet.Host.Api.Hosting;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Aevatar.Hosting.Tests;
+
+public sealed class MainnetSecretsStoreInvariantTests
+{
+    [Fact]
+    public void AddAevatarMainnetHost_ShouldRegisterEnvironmentSecretsStore_RegardlessOfCallerOverride()
+    {
+        using var home = new TemporaryAevatarHomeScope();
+        using var runtimeProvider = new EnvironmentVariableScope(
+            "AEVATAR_ActorRuntime__Provider", "InMemory");
+
+        var builder = CreateBuilder();
+
+        // Caller deliberately tries to flip the flag back on. The mainnet
+        // bootstrap must enforce false AFTER configureHost runs so this is
+        // ignored — otherwise mainnet would silently re-enable the file store.
+        builder.AddAevatarMainnetHost(options =>
+        {
+            options.AllowLocalFileSecretsStore = true;
+            options.EnableConnectorBootstrap = false;
+            options.EnableCors = false;
+        });
+
+        var hostOptions = builder.Services
+            .BuildServiceProvider()
+            .GetRequiredService<AevatarDefaultHostOptions>();
+        hostOptions.AllowLocalFileSecretsStore.Should().BeFalse();
+
+        // The DI registration must reflect the enforced invariant.
+        var descriptor = builder.Services.Single(d => d.ServiceType == typeof(IAevatarSecretsStore));
+        descriptor.ImplementationType.Should().Be(typeof(EnvironmentSecretsStore));
+    }
+
+    private static WebApplicationBuilder CreateBuilder() =>
+        WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+
+    private sealed class TemporaryAevatarHomeScope : IDisposable
+    {
+        private readonly string? _previous;
+        private readonly string _path;
+
+        public TemporaryAevatarHomeScope()
+        {
+            _previous = Environment.GetEnvironmentVariable(AevatarPaths.HomeEnv);
+            _path = Path.Combine(Path.GetTempPath(), $"aevatar-mainnet-invariant-{Guid.NewGuid():N}");
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, _path);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, _previous);
+            if (Directory.Exists(_path))
+                Directory.Delete(_path, recursive: true);
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _previous;
+
+        public EnvironmentVariableScope(string name, string value)
+        {
+            _name = name;
+            _previous = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _previous);
+        }
+    }
+}


### PR DESCRIPTION
Closes #386.

## 问题

`AevatarSecretsStore` 在所有宿主中默认注册（经 `AddAevatarConfig()`），把 secrets 落地到 `~/.aevatar/secrets.json`。Mainnet 项目继承这一行为，生产环境因此存在把 API key 等敏感信息写到本地文件的风险。

## 方案

不依赖运行时配置：只要入口是 mainnet，就在框架层切断本地文件 secrets store 的注册路径。其余宿主（localnet、CLI、demos、tests）保持默认行为，无破坏性变化。

### 改动概览

- `Aevatar.Configuration/EnvironmentSecretsStore.cs`（新）：只读 `IAevatarSecretsStore` 实现，仅从 `IConfiguration`（含 `AEVATAR_` 前缀环境变量）读取；`Set`/`Remove` 直接抛 `InvalidOperationException`，misconfig 在调用点炸出而非静默落盘。
- `AevatarConfigLoader.AddAevatarConfig(IConfigurationBuilder, bool allowLocalFileStore = true)`：当 `false` 时跳过 `secrets.json` 加载（`config.json`/`mcp.json`/`connectors.json`/env 不变）。
- `Aevatar.Configuration.ServiceCollectionExtensions.AddAevatarConfig(IServiceCollection, bool allowLocalFileStore = true)`：当 `false` 时注册 `EnvironmentSecretsStore` 替代 `AevatarSecretsStore`。
- `AevatarDefaultHostOptions.AllowLocalFileSecretsStore`（新）：宿主层开关，`AddAevatarDefaultHost` 透传到 `AddAevatarBootstrap` 与 `AddAevatarConfig`。`AddAevatarBootstrap` 也增加同名 overload。
- `Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs`：在 `AddAevatarMainnetHost` 中显式置为 `false`。
- `src/Aevatar.Configuration/README.md`：补充新类型与 store 选择规则。

接口 `IAevatarSecretsStore` 未改动；现有架构守卫 `secret_store_di_hits`（禁止宿主直接 `AddSingleton<IAevatarSecretsStore>`）继续生效。

## 影响路径

- mainnet：通过 `AEVATAR_LLMProviders__Providers__deepseek__ApiKey` 等环境变量注入；任何 `Set`/`Remove` 调用立即抛错。
- 其他宿主（localnet、tools、demos、test）：默认 `true`，行为与 dev 完全一致。

## 验证

- `dotnet build src/Aevatar.Configuration/...`、`src/Aevatar.Bootstrap/...`、`src/Aevatar.Mainnet.Host.Api/...` — 0 errors。
- `dotnet test test/Aevatar.Foundation.Abstractions.Tests/Aevatar.Foundation.Abstractions.Tests.csproj` — 50/50 通过（含 6 个新增 `EnvironmentSecretsStore` 用例 + 2 个 `AddAevatarConfig` 注册门禁用例）。
- `dotnet test test/Aevatar.Bootstrap.Tests/...` — 51 通过（含 2 个新增端到端用例：`AddAevatarBootstrap` 与 `AddAevatarDefaultHost` 的 disable 路径）。
- `dotnet test test/Aevatar.Integration.Tests/... --filter SecretsStore|ConfigurationCoverage` — 18/18 通过。
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/...` — 465/465 通过。
- 架构守卫 `secret_store_di_hits` 扫描宿主与 agent 扩展：no hits（pre-existing playground asset drift 与 `MainnetHostCompositionTests` 已确认在 dev 上同样失败，与本 PR 无关）。

## Test plan

- [ ] CI 通过 architecture/build/test 矩阵。
- [ ] `Aevatar.Mainnet.Host.Api` 启动时若调用方误用 `_secretsStore.Set(...)`，应抛 `InvalidOperationException`。
- [ ] 通过 `AEVATAR_*` 环境变量在 mainnet 中读取 `LLMProviders:Providers:{name}:ApiKey` / `LLMProviders:Default` 等仍然生效。
- [ ] `~/.aevatar/secrets.json` 存在时 mainnet 不再加载（验证 `IConfiguration` 中无对应 key）。