### PR TITLE
feat(channel): structured backfill outcome + audit + scope repair (#391)

### DIFF
--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs
@@ -24,6 +24,8 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
             .Match(current, evt)
             .On<ChannelBotRegisteredEvent>(ApplyRegistered)
             .On<ChannelBotProjectionRebuildRequestedEvent>(static (state, _) => state)
+            .On<ChannelBotRegistrationRejectedEvent>(static (state, _) => state)
+            .On<ChannelBotScopeIdRepairedEvent>(ApplyScopeIdRepaired)
             .On<ChannelBotUnregisteredEvent>(ApplyUnregistered)
             .On<ChannelBotTombstonesCompactedEvent>(ApplyTombstonesCompacted)
             .OrCurrent();
@@ -57,11 +59,22 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
 
         if (string.IsNullOrWhiteSpace(cmd.ScopeId))
         {
-            Logger.LogWarning(
-                "Ignoring channel bot registration without scope id: platform={Platform}, requestedId={RequestedId}, apiKeyId={ApiKeyId}",
+            // Elevated to LogError so log-based metrics surface upstream
+            // contract breaks; persisted as a domain event so the audit trail
+            // captures the rejection without polluting the registration set.
+            Logger.LogError(
+                "Rejecting channel bot registration without scope id: platform={Platform}, requestedId={RequestedId}, apiKeyId={ApiKeyId}",
                 cmd.Platform,
                 cmd.RequestedId,
                 cmd.NyxAgentApiKeyId);
+            await PersistDomainEventAsync(new ChannelBotRegistrationRejectedEvent
+            {
+                Reason = "missing_scope_id",
+                Platform = cmd.Platform ?? string.Empty,
+                RequestedId = cmd.RequestedId ?? string.Empty,
+                NyxAgentApiKeyId = cmd.NyxAgentApiKeyId ?? string.Empty,
+                RejectedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            });
             return;
         }
 
@@ -99,6 +112,53 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
             TombstoneStateVersion = NextCommittedVersion(),
         });
         Logger.LogInformation("Unregistered channel bot: id={Id}", cmd.RegistrationId);
+    }
+
+    [EventHandler]
+    public async Task HandleRepairScopeId(ChannelBotRepairScopeIdCommand cmd)
+    {
+        var registrationId = cmd.RegistrationId?.Trim();
+        if (string.IsNullOrWhiteSpace(registrationId))
+        {
+            Logger.LogWarning("Cannot repair scope id: registration id is required.");
+            return;
+        }
+
+        var scopeId = cmd.ScopeId?.Trim();
+        if (string.IsNullOrWhiteSpace(scopeId))
+        {
+            Logger.LogWarning(
+                "Cannot repair scope id: scope id is required for registrationId={RegistrationId}",
+                registrationId);
+            return;
+        }
+
+        var entry = State.Registrations.FirstOrDefault(r => r.Id == registrationId);
+        if (entry is null || entry.Tombstoned)
+        {
+            Logger.LogWarning(
+                "Cannot repair scope id: registration not found or tombstoned: {RegistrationId}",
+                registrationId);
+            return;
+        }
+
+        // Idempotent: re-applying the same scope id is a no-op so the audit log
+        // is not littered with redundant repair events.
+        if (string.Equals(entry.ScopeId, scopeId, StringComparison.Ordinal))
+            return;
+
+        await PersistDomainEventAsync(new ChannelBotScopeIdRepairedEvent
+        {
+            RegistrationId = registrationId,
+            PreviousScopeId = entry.ScopeId ?? string.Empty,
+            ScopeId = scopeId,
+            RepairedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        Logger.LogInformation(
+            "Repaired channel bot registration scope id: registrationId={RegistrationId}, previousScopeId={PreviousScopeId}, scopeId={ScopeId}",
+            registrationId,
+            entry.ScopeId ?? string.Empty,
+            scopeId);
     }
 
     [EventHandler]
@@ -151,6 +211,22 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
         entry.Tombstoned = false;
         entry.TombstoneStateVersion = 0;
         next.Registrations.Add(entry);
+        return next;
+    }
+
+    // Repair-only transition: rewrites the scope id of an existing entry while
+    // preserving created_at and the rest of the registration shape.
+    private static ChannelBotRegistrationStoreState ApplyScopeIdRepaired(
+        ChannelBotRegistrationStoreState current,
+        ChannelBotScopeIdRepairedEvent evt)
+    {
+        var entry = current.Registrations.FirstOrDefault(r => r.Id == evt.RegistrationId);
+        if (entry is null || entry.Tombstoned)
+            return current;
+
+        var next = current.Clone();
+        var target = next.Registrations.First(r => r.Id == evt.RegistrationId);
+        target.ScopeId = evt.ScopeId ?? string.Empty;
         return next;
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs
@@ -220,12 +220,11 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
         ChannelBotRegistrationStoreState current,
         ChannelBotScopeIdRepairedEvent evt)
     {
-        var entry = current.Registrations.FirstOrDefault(r => r.Id == evt.RegistrationId);
-        if (entry is null || entry.Tombstoned)
+        var next = current.Clone();
+        var target = next.Registrations.FirstOrDefault(r => r.Id == evt.RegistrationId);
+        if (target is null || target.Tombstoned)
             return current;
 
-        var next = current.Clone();
-        var target = next.Registrations.First(r => r.Id == evt.RegistrationId);
         target.ScopeId = evt.ScopeId ?? string.Empty;
         return next;
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
@@ -11,11 +11,26 @@ internal sealed record ChannelBotRegistrationScopeBackfillAuthorization(
     string? AccessToken = null,
     INyxRelayApiKeyOwnershipVerifier? OwnershipVerifier = null);
 
+/// <summary>
+/// Stable machine-readable status for the rebuild backfill outcome. Surfaced
+/// to CLI/UI callers so a 202 rebuild dispatch is not misread as a successful
+/// backfill — see issue #391.
+/// </summary>
+internal static class ChannelBotRegistrationScopeBackfillStatus
+{
+    public const string NotRequired = "not_required";
+    public const string Skipped = "skipped";
+    public const string Verified = "verified";
+    public const string Rejected = "rejected";
+}
+
 internal sealed record ChannelBotRegistrationScopeBackfillResult(
+    string Status,
     int EmptyScopeRegistrationsObserved,
     int CandidateRegistrations,
     int BackfilledRegistrations,
-    string Note);
+    string Note,
+    IReadOnlyList<string> Warnings);
 
 internal static class ChannelBotRegistrationScopeBackfill
 {
@@ -44,20 +59,25 @@ internal static class ChannelBotRegistrationScopeBackfill
         if (emptyScopeRegistrations.Length == 0)
         {
             return new ChannelBotRegistrationScopeBackfillResult(
+                ChannelBotRegistrationScopeBackfillStatus.NotRequired,
                 0,
                 0,
                 0,
-                "No empty-scope channel bot registrations were observed.");
+                "No empty-scope channel bot registrations were observed.",
+                Array.Empty<string>());
         }
 
         var normalizedScopeId = NormalizeOptional(scopeId);
         if (normalizedScopeId is null)
         {
+            const string warning = "Empty-scope registrations were observed, but no canonical scope_id was available for repair.";
             return new ChannelBotRegistrationScopeBackfillResult(
+                ChannelBotRegistrationScopeBackfillStatus.Skipped,
                 emptyScopeRegistrations.Length,
                 0,
                 0,
-                "Empty-scope registrations were observed, but no canonical scope_id was available for repair.");
+                warning,
+                new[] { warning });
         }
 
         var registrationId = NormalizeOptional(selection.RegistrationId);
@@ -70,39 +90,51 @@ internal static class ChannelBotRegistrationScopeBackfill
         var hasExplicitSelector = registrationId is not null || apiKeyId is not null;
         if (!hasExplicitSelector)
         {
+            const string warning = "Empty-scope registrations were observed; pass registration_id or nyx_agent_api_key_id to repair one safely. force=true only applies after a selector matches multiple registrations.";
             return new ChannelBotRegistrationScopeBackfillResult(
+                ChannelBotRegistrationScopeBackfillStatus.Skipped,
                 emptyScopeRegistrations.Length,
                 candidates.Length,
                 0,
-                "Empty-scope registrations were observed; pass registration_id or nyx_agent_api_key_id to repair one safely. force=true only applies after a selector matches multiple registrations.");
+                warning,
+                new[] { warning });
         }
 
         if (candidates.Length == 0)
         {
+            const string warning = "No empty-scope registration matched the requested repair selector.";
             return new ChannelBotRegistrationScopeBackfillResult(
+                ChannelBotRegistrationScopeBackfillStatus.Skipped,
                 emptyScopeRegistrations.Length,
                 0,
                 0,
-                "No empty-scope registration matched the requested repair selector.");
+                warning,
+                new[] { warning });
         }
 
         if (!selection.Force && candidates.Length != 1)
         {
+            const string warning = "Multiple empty-scope registrations matched the repair selector; pass force=true to repair all matched registrations.";
             return new ChannelBotRegistrationScopeBackfillResult(
+                ChannelBotRegistrationScopeBackfillStatus.Skipped,
                 emptyScopeRegistrations.Length,
                 candidates.Length,
                 0,
-                "Multiple empty-scope registrations matched the repair selector; pass force=true to repair all matched registrations.");
+                warning,
+                new[] { warning });
         }
 
         var accessToken = NormalizeOptional(authorization.AccessToken);
         if (accessToken is null || authorization.OwnershipVerifier is null)
         {
+            const string warning = "Empty-scope registration repair requires NyxID api-key ownership verification.";
             return new ChannelBotRegistrationScopeBackfillResult(
+                ChannelBotRegistrationScopeBackfillStatus.Rejected,
                 emptyScopeRegistrations.Length,
                 candidates.Length,
                 0,
-                "Empty-scope registration repair requires NyxID api-key ownership verification.");
+                warning,
+                new[] { warning });
         }
 
         foreach (var entry in candidates)
@@ -110,11 +142,14 @@ internal static class ChannelBotRegistrationScopeBackfill
             var candidateApiKeyId = NormalizeOptional(entry.NyxAgentApiKeyId);
             if (candidateApiKeyId is null)
             {
+                var warning = $"Empty-scope registration '{entry.Id}' is missing nyx_agent_api_key_id; cannot verify ownership.";
                 return new ChannelBotRegistrationScopeBackfillResult(
+                    ChannelBotRegistrationScopeBackfillStatus.Rejected,
                     emptyScopeRegistrations.Length,
                     candidates.Length,
                     0,
-                    $"Empty-scope registration '{entry.Id}' is missing nyx_agent_api_key_id; cannot verify ownership.");
+                    warning,
+                    new[] { warning });
             }
 
             var ownership = await authorization.OwnershipVerifier.VerifyAsync(
@@ -124,38 +159,36 @@ internal static class ChannelBotRegistrationScopeBackfill
                 ct);
             if (!ownership.Succeeded)
             {
+                var warning = $"Empty-scope registration '{entry.Id}' failed NyxID api-key ownership verification: {ownership.Detail}";
                 return new ChannelBotRegistrationScopeBackfillResult(
+                    ChannelBotRegistrationScopeBackfillStatus.Rejected,
                     emptyScopeRegistrations.Length,
                     candidates.Length,
                     0,
-                    $"Empty-scope registration '{entry.Id}' failed NyxID api-key ownership verification: {ownership.Detail}");
+                    warning,
+                    new[] { warning });
             }
         }
 
+        // Repair-only path: rewrites scope_id while preserving created_at and the
+        // rest of the registration shape (issue #391 follow-up 3).
         foreach (var entry in candidates)
         {
-            await ChannelBotRegistrationStoreCommands.DispatchRegisterAsync(
+            await ChannelBotRegistrationStoreCommands.DispatchRepairScopeIdAsync(
                 actorRuntime,
                 dispatchPort,
-                new ChannelBotRegisterCommand
-                {
-                    RequestedId = entry.Id,
-                    Platform = entry.Platform,
-                    NyxProviderSlug = entry.NyxProviderSlug,
-                    ScopeId = normalizedScopeId,
-                    WebhookUrl = entry.WebhookUrl,
-                    NyxChannelBotId = entry.NyxChannelBotId,
-                    NyxAgentApiKeyId = entry.NyxAgentApiKeyId,
-                    NyxConversationRouteId = entry.NyxConversationRouteId,
-                },
+                entry.Id,
+                normalizedScopeId,
                 ct);
         }
 
         return new ChannelBotRegistrationScopeBackfillResult(
+            ChannelBotRegistrationScopeBackfillStatus.Verified,
             emptyScopeRegistrations.Length,
             candidates.Length,
             candidates.Length,
-            "Empty-scope channel bot registrations were backfilled before projection rebuild; backfill re-registers entries and refreshes created_at.");
+            "Empty-scope channel bot registrations were repaired in place; created_at preserved.",
+            Array.Empty<string>());
     }
 
     private static string? NormalizeOptional(string? value)

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs
@@ -16,24 +16,61 @@ internal sealed record ChannelBotRegistrationScopeBackfillAuthorization(
 /// to CLI/UI callers so a 202 rebuild dispatch is not misread as a successful
 /// backfill — see issue #391.
 /// </summary>
-internal static class ChannelBotRegistrationScopeBackfillStatus
+internal enum ChannelBotRegistrationScopeBackfillStatus
 {
-    public const string NotRequired = "not_required";
-    public const string Skipped = "skipped";
-    public const string Verified = "verified";
-    public const string Rejected = "rejected";
+    NotRequired,
+    Skipped,
+    Rejected,
+    // Ownership verified and repair commands dispatched. Application is
+    // eventually consistent — repair commands may no-op if the actor's
+    // authoritative state diverges from the projection snapshot used to pick
+    // candidates, so callers should re-query to confirm completion.
+    Dispatched,
+    // The query/backfill path threw before a status could be decided. Surfaced
+    // so callers always receive a known enum value rather than null.
+    Unavailable,
+}
+
+internal static class ChannelBotRegistrationScopeBackfillStatusExtensions
+{
+    // Wire format is snake_case to match the surrounding JSON conventions.
+    // Kept explicit so renaming the enum members never silently changes the
+    // wire contract that CLI/UI callers branch on.
+    public static string ToWireString(this ChannelBotRegistrationScopeBackfillStatus status) => status switch
+    {
+        ChannelBotRegistrationScopeBackfillStatus.NotRequired => "not_required",
+        ChannelBotRegistrationScopeBackfillStatus.Skipped => "skipped",
+        ChannelBotRegistrationScopeBackfillStatus.Rejected => "rejected",
+        ChannelBotRegistrationScopeBackfillStatus.Dispatched => "dispatched",
+        ChannelBotRegistrationScopeBackfillStatus.Unavailable => "unavailable",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Unknown backfill status."),
+    };
 }
 
 internal sealed record ChannelBotRegistrationScopeBackfillResult(
-    string Status,
+    ChannelBotRegistrationScopeBackfillStatus Status,
     int EmptyScopeRegistrationsObserved,
     int CandidateRegistrations,
-    int BackfilledRegistrations,
+    int RepairCommandsDispatched,
     string Note,
     IReadOnlyList<string> Warnings);
 
 internal static class ChannelBotRegistrationScopeBackfill
 {
+    public static ChannelBotRegistrationScopeBackfillResult Unavailable(string detail)
+    {
+        var warning = string.IsNullOrWhiteSpace(detail)
+            ? "Channel registration query/backfill path was unavailable; backfill outcome could not be decided."
+            : $"Channel registration query/backfill path was unavailable; backfill outcome could not be decided: {detail}";
+        return new ChannelBotRegistrationScopeBackfillResult(
+            ChannelBotRegistrationScopeBackfillStatus.Unavailable,
+            EmptyScopeRegistrationsObserved: 0,
+            CandidateRegistrations: 0,
+            RepairCommandsDispatched: 0,
+            Note: warning,
+            Warnings: new[] { warning });
+    }
+
     public static async Task<ChannelBotRegistrationScopeBackfillResult> BackfillAsync(
         IReadOnlyList<ChannelBotRegistrationEntry> registrations,
         string? scopeId,
@@ -171,7 +208,10 @@ internal static class ChannelBotRegistrationScopeBackfill
         }
 
         // Repair-only path: rewrites scope_id while preserving created_at and the
-        // rest of the registration shape (issue #391 follow-up 3).
+        // rest of the registration shape (issue #391 follow-up 3). The dispatch is
+        // fire-and-forget — the authoritative actor may no-op if the candidate has
+        // since been tombstoned or already has a matching scope_id, so we surface
+        // `dispatched` (not `verified`) to honestly signal eventual consistency.
         foreach (var entry in candidates)
         {
             await ChannelBotRegistrationStoreCommands.DispatchRepairScopeIdAsync(
@@ -183,11 +223,11 @@ internal static class ChannelBotRegistrationScopeBackfill
         }
 
         return new ChannelBotRegistrationScopeBackfillResult(
-            ChannelBotRegistrationScopeBackfillStatus.Verified,
+            ChannelBotRegistrationScopeBackfillStatus.Dispatched,
             emptyScopeRegistrations.Length,
             candidates.Length,
             candidates.Length,
-            "Empty-scope channel bot registrations were repaired in place; created_at preserved.",
+            "Empty-scope channel bot registration repair commands dispatched (created_at preserved); re-query the registrations endpoint to confirm completion.",
             Array.Empty<string>());
     }
 

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationStoreCommands.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationStoreCommands.cs
@@ -47,6 +47,22 @@ internal static class ChannelBotRegistrationStoreCommands
             },
             ct);
 
+    public static Task DispatchRepairScopeIdAsync(
+        IActorRuntime actorRuntime,
+        IActorDispatchPort dispatchPort,
+        string registrationId,
+        string scopeId,
+        CancellationToken ct = default) =>
+        DispatchAsync(
+            actorRuntime,
+            dispatchPort,
+            new ChannelBotRepairScopeIdCommand
+            {
+                RegistrationId = registrationId ?? string.Empty,
+                ScopeId = scopeId ?? string.Empty,
+            },
+            ct);
+
     private static async Task DispatchAsync<TCommand>(
         IActorRuntime actorRuntime,
         IActorDispatchPort dispatchPort,

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
@@ -258,6 +258,10 @@ public static class ChannelCallbackEndpoints
             observed_registrations_before_rebuild = observedRegistrationsBeforeRebuild,
             empty_scope_registrations_observed = backfill?.EmptyScopeRegistrationsObserved,
             empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
+            // Machine-readable backfill outcome so CLI/UI callers do not misread
+            // a 202 rebuild dispatch as a successful backfill (issue #391).
+            backfill_status = backfill?.Status,
+            warnings = backfill?.Warnings ?? Array.Empty<string>(),
             note,
         });
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs
@@ -240,7 +240,11 @@ public static class ChannelCallbackEndpoints
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Channel registration query failed before dispatching a manual rebuild");
-            note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side observation is currently unavailable; registrations may still refresh asynchronously.";
+            // Surface a known `unavailable` enum value (issue #391 review): callers
+            // must always be able to branch on backfill_status, especially when
+            // the read side is degraded.
+            backfill = ChannelBotRegistrationScopeBackfill.Unavailable(ex.Message);
+            note = $"Projection rebuild dispatched from authoritative channel-bot-registration-store state. {backfill.Note}";
         }
 
         await ChannelBotRegistrationStoreCommands.DispatchRebuildProjectionAsync(
@@ -257,10 +261,12 @@ public static class ChannelCallbackEndpoints
             actor_id = ChannelBotRegistrationGAgent.WellKnownId,
             observed_registrations_before_rebuild = observedRegistrationsBeforeRebuild,
             empty_scope_registrations_observed = backfill?.EmptyScopeRegistrationsObserved,
-            empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
+            empty_scope_registrations_backfilled = backfill?.RepairCommandsDispatched,
             // Machine-readable backfill outcome so CLI/UI callers do not misread
-            // a 202 rebuild dispatch as a successful backfill (issue #391).
-            backfill_status = backfill?.Status,
+            // a 202 rebuild dispatch as a successful backfill (issue #391). The
+            // catch path above guarantees a non-null value even when the read
+            // side throws.
+            backfill_status = backfill?.Status.ToWireString(),
             warnings = backfill?.Warnings ?? Array.Empty<string>(),
             note,
         });

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
@@ -405,9 +405,12 @@ public sealed class ChannelRegistrationTool : IAgentTool
             if (backfill.EmptyScopeRegistrationsObserved > 0)
                 note = $"{note} {backfill.Note}";
         }
-        catch
+        catch (Exception ex)
         {
-            note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side observation is currently unavailable; registrations may still refresh asynchronously.";
+            // Mirror the HTTP endpoint catch path so tool callers always receive
+            // a non-null backfill_status enum value (issue #391 review).
+            backfill = ChannelBotRegistrationScopeBackfill.Unavailable(ex.Message);
+            note = $"Projection rebuild dispatched from authoritative channel-bot-registration-store state. {backfill.Note}";
         }
 
         await ChannelBotRegistrationStoreCommands.DispatchRebuildProjectionAsync(
@@ -422,11 +425,12 @@ public sealed class ChannelRegistrationTool : IAgentTool
             actor_id = ChannelBotRegistrationGAgent.WellKnownId,
             observed_registrations_before_rebuild = observedRegistrationsBeforeRebuild,
             empty_scope_registrations_observed = backfill?.EmptyScopeRegistrationsObserved,
-            empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
+            empty_scope_registrations_backfilled = backfill?.RepairCommandsDispatched,
             // Machine-readable backfill outcome + warnings (issue #391); CLI/UI
-            // callers should branch on backfill_status, not infer success from the
-            // 202 rebuild dispatch alone.
-            backfill_status = backfill?.Status,
+            // callers should branch on backfill_status, not infer success from
+            // the 202 rebuild dispatch alone. The catch path guarantees a
+            // non-null value even when the read side throws.
+            backfill_status = backfill?.Status.ToWireString(),
             warnings = backfill?.Warnings ?? Array.Empty<string>(),
             note,
         });

--- a/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
+++ b/agents/Aevatar.GAgents.ChannelRuntime/ChannelRegistrationTool.cs
@@ -423,6 +423,11 @@ public sealed class ChannelRegistrationTool : IAgentTool
             observed_registrations_before_rebuild = observedRegistrationsBeforeRebuild,
             empty_scope_registrations_observed = backfill?.EmptyScopeRegistrationsObserved,
             empty_scope_registrations_backfilled = backfill?.BackfilledRegistrations,
+            // Machine-readable backfill outcome + warnings (issue #391); CLI/UI
+            // callers should branch on backfill_status, not infer success from the
+            // 202 rebuild dispatch alone.
+            backfill_status = backfill?.Status,
+            warnings = backfill?.Warnings ?? Array.Empty<string>(),
             note,
         });
     }

--- a/agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto
+++ b/agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto
@@ -133,6 +133,14 @@ message ChannelBotCompactTombstonesCommand {
   int64 safe_state_version = 1;
 }
 
+// Repairs the canonical scope_id of an existing registration without rewriting
+// the rest of the entry. Emitted by the rebuild backfill path so empty-scope
+// entries can be patched in place — preserves created_at and webhook target.
+message ChannelBotRepairScopeIdCommand {
+  string registration_id = 1;
+  string scope_id = 2;
+}
+
 message ChannelBotProjectionRebuildRequestedEvent {
   string reason = 1;
   google.protobuf.Timestamp requested_at = 2;
@@ -141,6 +149,28 @@ message ChannelBotProjectionRebuildRequestedEvent {
 message ChannelBotTombstonesCompactedEvent {
   repeated string registration_ids = 1;
   int64 safe_state_version = 2;
+}
+
+// Persisted when the registration store rejects an inbound register command
+// (e.g. missing scope_id). Carries no state transition; lives in the actor
+// event log as a durable diagnostic so upstream contract breaks remain
+// auditable without polluting the registration set.
+message ChannelBotRegistrationRejectedEvent {
+  string reason = 1;
+  string platform = 2;
+  string requested_id = 3;
+  string nyx_agent_api_key_id = 4;
+  google.protobuf.Timestamp rejected_at = 5;
+}
+
+// Emitted when a previously empty-scope entry is repaired in place. Captures
+// the prior scope_id so the audit trail records the rewrite without losing
+// historical context, and the projector picks the new scope_id off state.
+message ChannelBotScopeIdRepairedEvent {
+  string registration_id = 1;
+  string previous_scope_id = 2;
+  string scope_id = 3;
+  google.protobuf.Timestamp repaired_at = 4;
 }
 
 // Projection read model for channel bot registrations

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
@@ -124,6 +124,24 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleRegister_PersistsRejectionEvent_WhenScopeIdMissing()
+    {
+        var beforeVersion = _agent.EventSourcing!.CurrentVersion;
+
+        await _agent.HandleRegister(new ChannelBotRegisterCommand
+        {
+            Platform = "lark",
+            NyxProviderSlug = "api-lark-bot",
+            RequestedId = "reg-1",
+            NyxAgentApiKeyId = "key-1",
+        });
+
+        // Audit event recorded; state unchanged.
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion + 1);
+        _agent.State.Registrations.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleUnregister_TombstonesEntry()
     {
         await _agent.HandleRegister(new ChannelBotRegisterCommand
@@ -167,6 +185,99 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
         });
 
         _agent.State.Registrations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleRepairScopeId_PreservesCreatedAt_WhenRewritingScope()
+    {
+        await _agent.HandleRegister(new ChannelBotRegisterCommand
+        {
+            Platform = "lark",
+            NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-original",
+            RequestedId = "reg-1",
+            NyxAgentApiKeyId = "key-1",
+        });
+
+        var originalCreatedAt = _agent.State.Registrations[0].CreatedAt;
+        originalCreatedAt.Should().NotBeNull();
+        var beforeVersion = _agent.EventSourcing!.CurrentVersion;
+
+        await _agent.HandleRepairScopeId(new ChannelBotRepairScopeIdCommand
+        {
+            RegistrationId = "reg-1",
+            ScopeId = "scope-repaired",
+        });
+
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion + 1);
+        var entry = _agent.State.Registrations.Should().ContainSingle().Subject;
+        entry.ScopeId.Should().Be("scope-repaired");
+        entry.CreatedAt.Should().Be(originalCreatedAt);
+        entry.Tombstoned.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleRepairScopeId_IsIdempotent_WhenScopeUnchanged()
+    {
+        await _agent.HandleRegister(new ChannelBotRegisterCommand
+        {
+            Platform = "lark",
+            NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-1",
+            RequestedId = "reg-1",
+        });
+
+        var beforeVersion = _agent.EventSourcing!.CurrentVersion;
+
+        await _agent.HandleRepairScopeId(new ChannelBotRepairScopeIdCommand
+        {
+            RegistrationId = "reg-1",
+            ScopeId = "scope-1",
+        });
+
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion);
+    }
+
+    [Fact]
+    public async Task HandleRepairScopeId_IgnoresTombstonedRegistration()
+    {
+        await _agent.HandleRegister(new ChannelBotRegisterCommand
+        {
+            Platform = "lark",
+            NyxProviderSlug = "api-lark-bot",
+            ScopeId = "scope-1",
+            RequestedId = "reg-1",
+        });
+        await _agent.HandleUnregister(new ChannelBotUnregisterCommand
+        {
+            RegistrationId = "reg-1",
+        });
+
+        var beforeVersion = _agent.EventSourcing!.CurrentVersion;
+
+        await _agent.HandleRepairScopeId(new ChannelBotRepairScopeIdCommand
+        {
+            RegistrationId = "reg-1",
+            ScopeId = "scope-2",
+        });
+
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion);
+        _agent.State.Registrations[0].ScopeId.Should().Be("scope-1");
+        _agent.State.Registrations[0].Tombstoned.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleRepairScopeId_IgnoresMissingRegistration()
+    {
+        var beforeVersion = _agent.EventSourcing!.CurrentVersion;
+
+        await _agent.HandleRepairScopeId(new ChannelBotRepairScopeIdCommand
+        {
+            RegistrationId = "reg-missing",
+            ScopeId = "scope-1",
+        });
+
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
@@ -110,21 +110,7 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleRegister_RejectsLarkRegistrationWithoutScopeId()
-    {
-        await _agent.HandleRegister(new ChannelBotRegisterCommand
-        {
-            Platform = "lark",
-            NyxProviderSlug = "api-lark-bot",
-            RequestedId = "reg-1",
-            NyxAgentApiKeyId = "key-1",
-        });
-
-        _agent.State.Registrations.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task HandleRegister_PersistsRejectionEvent_WhenScopeIdMissing()
+    public async Task HandleRegister_RejectsLarkRegistrationWithoutScopeId_AndPersistsRejectionEvent()
     {
         var beforeVersion = _agent.EventSourcing!.CurrentVersion;
 
@@ -136,7 +122,9 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
             NyxAgentApiKeyId = "key-1",
         });
 
-        // Audit event recorded; state unchanged.
+        // Audit event recorded for the contract break (issue #391); the
+        // registration set stays empty because the rejection is a no-op
+        // transition.
         _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion + 1);
         _agent.State.Registrations.Should().BeEmpty();
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -211,7 +211,7 @@ public sealed class ChannelCallbackEndpointsTests
     }
 
     [Fact]
-    public async Task HandleRebuildRegistrationsAsync_RepairsScopeIdInPlaceForVerifiedBackfill()
+    public async Task HandleRebuildRegistrationsAsync_RepairsScopeIdInPlaceAndDispatches()
     {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
         queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
@@ -254,7 +254,7 @@ public sealed class ChannelCallbackEndpointsTests
         response.Body.Should().Contain("\"status\":\"accepted\"");
         response.Body.Should().Contain("\"observed_registrations_before_rebuild\":1");
         response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":1");
-        response.Body.Should().Contain("\"backfill_status\":\"verified\"");
+        response.Body.Should().Contain("\"backfill_status\":\"dispatched\"");
         response.Body.Should().Contain("\"warnings\":[]");
         capturedEnvelopes.Should().HaveCount(2);
         var repair = capturedEnvelopes[0].Payload.Unpack<ChannelBotRepairScopeIdCommand>();
@@ -492,7 +492,8 @@ public sealed class ChannelCallbackEndpointsTests
         response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         response.Body.Should().Contain("\"status\":\"accepted\"");
         response.Body.Should().Contain("\"observed_registrations_before_rebuild\":null");
-        response.Body.Should().Contain("Query-side observation is currently unavailable");
+        response.Body.Should().Contain("\"backfill_status\":\"unavailable\"");
+        response.Body.Should().Contain("projection reader unavailable");
         capturedEnvelope.Should().NotBeNull();
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -211,7 +211,7 @@ public sealed class ChannelCallbackEndpointsTests
     }
 
     [Fact]
-    public async Task HandleRebuildRegistrationsAsync_DispatchesRefreshCommand()
+    public async Task HandleRebuildRegistrationsAsync_RepairsScopeIdInPlaceForVerifiedBackfill()
     {
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
         queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
@@ -254,8 +254,12 @@ public sealed class ChannelCallbackEndpointsTests
         response.Body.Should().Contain("\"status\":\"accepted\"");
         response.Body.Should().Contain("\"observed_registrations_before_rebuild\":1");
         response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":1");
+        response.Body.Should().Contain("\"backfill_status\":\"verified\"");
+        response.Body.Should().Contain("\"warnings\":[]");
         capturedEnvelopes.Should().HaveCount(2);
-        capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
+        var repair = capturedEnvelopes[0].Payload.Unpack<ChannelBotRepairScopeIdCommand>();
+        repair.RegistrationId.Should().Be("reg-1");
+        repair.ScopeId.Should().Be("scope-1");
         capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
         verifier.Calls.Should().ContainSingle()
             .Which.Should().Be(("test-token", "scope-1", "key-1"));
@@ -305,6 +309,7 @@ public sealed class ChannelCallbackEndpointsTests
 
         response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":0");
+        response.Body.Should().Contain("\"backfill_status\":\"rejected\"");
         response.Body.Should().Contain("ownership_denied");
         capturedEnvelopes.Should().ContainSingle();
         capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
@@ -350,8 +355,54 @@ public sealed class ChannelCallbackEndpointsTests
         response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
         response.Body.Should().Contain("\"empty_scope_registrations_observed\":1");
         response.Body.Should().Contain("\"empty_scope_registrations_backfilled\":0");
+        response.Body.Should().Contain("\"backfill_status\":\"skipped\"");
         response.Body.Should().Contain("pass registration_id");
         capturedEnvelopes.Should().HaveCount(1);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
+    }
+
+    [Fact]
+    public async Task HandleRebuildRegistrationsAsync_ReportsNotRequired_WhenNoEmptyScopeRegistrations()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-1",
+                    Platform = "lark",
+                    ScopeId = "scope-1",
+                    NyxAgentApiKeyId = "key-1",
+                },
+            ]));
+
+        List<EventEnvelope> capturedEnvelopes = [];
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var result = await InvokeAsync(
+            "HandleRebuildRegistrationsAsync",
+            CreateHttpContext("scope-1"),
+            actorRuntime,
+            (IActorDispatchPort)actorRuntime,
+            queryPort,
+            (INyxRelayApiKeyOwnershipVerifier?)null,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        response.Body.Should().Contain("\"backfill_status\":\"not_required\"");
+        response.Body.Should().Contain("\"warnings\":[]");
+        response.Body.Should().Contain("\"empty_scope_registrations_observed\":0");
+        capturedEnvelopes.Should().ContainSingle();
         capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("http_api_manual_rebuild");
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -165,8 +165,12 @@ public sealed class ChannelRegistrationToolTests
         doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
         doc.RootElement.GetProperty("observed_registrations_before_rebuild").GetInt32().Should().Be(1);
         doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(1);
+        doc.RootElement.GetProperty("backfill_status").GetString().Should().Be("verified");
+        doc.RootElement.GetProperty("warnings").GetArrayLength().Should().Be(0);
         capturedEnvelopes.Should().HaveCount(2);
-        capturedEnvelopes[0].Payload.Unpack<ChannelBotRegisterCommand>().ScopeId.Should().Be("scope-1");
+        var repair = capturedEnvelopes[0].Payload.Unpack<ChannelBotRepairScopeIdCommand>();
+        repair.RegistrationId.Should().Be("reg-1");
+        repair.ScopeId.Should().Be("scope-1");
         capturedEnvelopes[1].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
         verifier.Calls.Should().ContainSingle()
             .Which.Should().Be(("test-token", "scope-1", "key-1"));
@@ -211,6 +215,12 @@ public sealed class ChannelRegistrationToolTests
         doc.RootElement.GetProperty("observed_registrations_before_rebuild").GetInt32().Should().Be(1);
         doc.RootElement.GetProperty("empty_scope_registrations_observed").GetInt32().Should().Be(1);
         doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(0);
+        doc.RootElement.GetProperty("backfill_status").GetString().Should().Be("skipped");
+        doc.RootElement.GetProperty("warnings")
+            .EnumerateArray()
+            .Select(static value => value.GetString())
+            .Should()
+            .ContainSingle(message => message != null && message.Contains("pass registration_id", StringComparison.Ordinal));
         doc.RootElement.GetProperty("note").GetString().Should().Contain("pass registration_id");
         capturedEnvelopes.Should().HaveCount(1);
         capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -165,7 +165,7 @@ public sealed class ChannelRegistrationToolTests
         doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
         doc.RootElement.GetProperty("observed_registrations_before_rebuild").GetInt32().Should().Be(1);
         doc.RootElement.GetProperty("empty_scope_registrations_backfilled").GetInt32().Should().Be(1);
-        doc.RootElement.GetProperty("backfill_status").GetString().Should().Be("verified");
+        doc.RootElement.GetProperty("backfill_status").GetString().Should().Be("dispatched");
         doc.RootElement.GetProperty("warnings").GetArrayLength().Should().Be(0);
         capturedEnvelopes.Should().HaveCount(2);
         var repair = capturedEnvelopes[0].Payload.Unpack<ChannelBotRepairScopeIdCommand>();
@@ -223,6 +223,46 @@ public sealed class ChannelRegistrationToolTests
             .ContainSingle(message => message != null && message.Contains("pass registration_id", StringComparison.Ordinal));
         doc.RootElement.GetProperty("note").GetString().Should().Contain("pass registration_id");
         capturedEnvelopes.Should().HaveCount(1);
+        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RebuildProjection_ReportsUnavailable_WhenQuerySideThrows()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<ChannelBotRegistrationEntry>>(
+                new InvalidOperationException("projection reader unavailable")));
+
+        List<EventEnvelope> capturedEnvelopes = [];
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
+        ((IActorDispatchPort)actorRuntime).DispatchAsync(
+                ChannelBotRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(queryPort)
+            .AddSingleton(actorRuntime)
+            .AddSingleton((IActorDispatchPort)actorRuntime)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken();
+        var json = await tool.ExecuteAsync("""{"action":"rebuild_projection","reason":"manual-debug"}""");
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+        doc.RootElement.GetProperty("backfill_status").GetString().Should().Be("unavailable");
+        doc.RootElement.GetProperty("warnings")
+            .EnumerateArray()
+            .Select(static value => value.GetString())
+            .Should()
+            .ContainSingle(message => message != null && message.Contains("projection reader unavailable", StringComparison.Ordinal));
+        capturedEnvelopes.Should().ContainSingle();
         capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
     }
 
@@ -309,7 +349,8 @@ public sealed class ChannelRegistrationToolTests
 
         doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
         doc.RootElement.GetProperty("observed_registrations_before_rebuild").ValueKind.Should().Be(JsonValueKind.Null);
-        doc.RootElement.GetProperty("note").GetString().Should().Contain("observation is currently unavailable");
+        doc.RootElement.GetProperty("backfill_status").GetString().Should().Be("unavailable");
+        doc.RootElement.GetProperty("note").GetString().Should().Contain("backfill outcome could not be decided");
         capturedEnvelope.Should().NotBeNull();
     }
 


### PR DESCRIPTION
## Summary

Closes the three Lark relay registration backfill follow-ups tracked by #391:

- **Structured backfill outcome** — `backfill_status` (`not_required|skipped|verified|rejected`) plus a `warnings[]` array now ride alongside the existing `empty_scope_*` counters in rebuild responses (HTTP endpoint + `channel_registrations` tool). CLI/UI callers can branch on the status enum instead of inferring success from a 202 rebuild dispatch.
- **Empty-scope register diagnostics** — `ChannelBotRegistrationGAgent.HandleRegister` now emits `LogError` (was `LogWarning`) and persists a new no-op `ChannelBotRegistrationRejectedEvent`, so upstream contract breaks (e.g. registrations missing `scope_id`) are visible in both log-based metrics and the actor's audit trail.
- **Scope repair preserves `CreatedAt`** — added `ChannelBotRepairScopeIdCommand` / `ChannelBotScopeIdRepairedEvent`. The rebuild backfill now dispatches the repair command for each candidate, so empty-scope entries get their `scope_id` rewritten in place while `created_at` and the rest of the registration shape stay intact (no more re-register churn).

## Affected paths

- `agents/Aevatar.GAgents.ChannelRuntime/channel_runtime_messages.proto` — new `ChannelBotRepairScopeIdCommand`, `ChannelBotRegistrationRejectedEvent`, `ChannelBotScopeIdRepairedEvent`
- `agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationGAgent.cs` — `LogError` + rejection event, new `HandleRepairScopeId`, `ApplyScopeIdRepaired` matcher
- `agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationScopeBackfill.cs` — emits `Status` + `Warnings`; dispatches repair instead of re-register
- `agents/Aevatar.GAgents.ChannelRuntime/ChannelBotRegistrationStoreCommands.cs` — `DispatchRepairScopeIdAsync`
- `agents/Aevatar.GAgents.ChannelRuntime/ChannelCallbackEndpoints.cs` & `ChannelRegistrationTool.cs` — surface `backfill_status` / `warnings`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/*` — updated rebuild assertions, new repair-scope and rejection-event tests

## Test plan

- [x] `dotnet build agents/Aevatar.GAgents.ChannelRuntime/Aevatar.GAgents.ChannelRuntime.csproj`
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — 479/479 pass
- [x] `bash tools/ci/test_stability_guards.sh`
- [x] `bash tools/ci/projection_state_version_guard.sh`
- [x] `bash tools/ci/projection_route_mapping_guard.sh`
- [x] `bash tools/ci/architecture_guards.sh` — passes through `playground_asset_drift_guard` (pre-existing pnpm issue on dev, unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)