### PR TITLE
Harden NyxID scoped chat access

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
+++ b/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\src\Aevatar.AI.LLMProviders.NyxId\Aevatar.AI.LLMProviders.NyxId.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Hosting\Aevatar.Hosting.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Presentation.AGUI\Aevatar.Presentation.AGUI.csproj" />
     <ProjectReference Include="..\..\src\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Studio.Application\Aevatar.Studio.Application.csproj" />

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
@@ -4,6 +4,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.Hosting;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -32,6 +33,9 @@ public static partial class NyxIdChatEndpoints
 
         try
         {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
             accessToken = ExtractBearerToken(http);
             if (string.IsNullOrWhiteSpace(accessToken))
             {
@@ -215,6 +219,9 @@ public static partial class NyxIdChatEndpoints
 
         try
         {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
             var accessToken = ExtractBearerToken(http);
             if (string.IsNullOrWhiteSpace(accessToken))
             {

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -5,6 +5,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -86,6 +87,9 @@ public static partial class NyxIdChatEndpoints
         [FromServices] IActorRuntime actorRuntime,
         CancellationToken ct)
     {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
         // Conversation creation is fail-fast on registry persistence.
         // NyxId chat depends on the registry being available; there is no
         // degraded mode where a conversation can run without being registered.
@@ -165,6 +169,9 @@ public static partial class NyxIdChatEndpoints
         [FromServices] IGAgentActorRegistryQueryPort registryQueryPort,
         CancellationToken ct)
     {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
         var snapshot = await registryQueryPort.ListActorsAsync(scopeId, ct);
         var actorIds = snapshot.Groups
             .FirstOrDefault(g => string.Equals(g.GAgentType, NyxIdChatServiceDefaults.GAgentTypeName, StringComparison.Ordinal))
@@ -189,6 +196,9 @@ public static partial class NyxIdChatEndpoints
         [FromServices] IChatHistoryStore chatHistoryStore,
         CancellationToken ct)
     {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
         var admissionError = await AuthorizeConversationAsync(
             admissionPort,
             scopeId,

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -162,6 +162,26 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleCreateConversationAsync_ShouldRejectScopeMismatch_BeforeCreatingActor()
+    {
+        var actorStore = new StubGAgentActorStore();
+        var runtime = new StubActorRuntime();
+        var result = await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            CreateScopeGuardedContext("scope-other"),
+            "scope-a",
+            actorStore,
+            runtime,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        response.Body.Should().Contain("SCOPE_ACCESS_DENIED");
+        actorStore.AddedActors.Should().BeEmpty();
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleCreateConversationAsync_ShouldBubbleFailure_WhenActorRegistrationFails()
     {
         var actorStore = new StubGAgentActorStore
@@ -296,6 +316,24 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleListConversationsAsync_ShouldRejectScopeMismatch_BeforeRegistryRead()
+    {
+        var actorStore = new StubGAgentActorStore();
+
+        var result = await InvokeResultAsync(
+            "HandleListConversationsAsync",
+            CreateScopeGuardedContext("scope-other"),
+            "scope-a",
+            actorStore,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        response.Body.Should().Contain("SCOPE_ACCESS_DENIED");
+        actorStore.LastRequestedScopeId.Should().BeNull();
+    }
+
+    [Fact]
     public async Task HandleListConversationsAsync_ShouldBubbleRegistryReadFailure()
     {
         var actorStore = new StubGAgentActorStore
@@ -338,6 +376,67 @@ public class NyxIdChatEndpointsCoverageTests
         historyStore.DeletedConversations.Should().ContainSingle(entry =>
             entry.ScopeId == "scope-a" &&
             entry.ConversationId == "actor-1");
+        actorStore.AdmissionTargets.Should().ContainSingle(target =>
+            target.ScopeId == "scope-a" &&
+            target.ResourceKind == ScopeResourceKind.GAgentActor &&
+            target.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
+            target.ActorId == "actor-1" &&
+            target.Operation == ScopeResourceOperation.Delete);
+    }
+
+    [Fact]
+    public async Task HandleDeleteConversationAsync_ShouldRejectScopeMismatch_BeforeAdmission()
+    {
+        var actorStore = new StubGAgentActorStore();
+        var historyStore = new StubChatHistoryStore();
+
+        var result = await InvokeResultAsync(
+            "HandleDeleteConversationAsync",
+            CreateScopeGuardedContext("scope-other"),
+            "scope-a",
+            "actor-1",
+            actorStore,
+            actorStore,
+            historyStore,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        response.Body.Should().Contain("SCOPE_ACCESS_DENIED");
+        actorStore.AdmissionTargets.Should().BeEmpty();
+        actorStore.RemovedActors.Should().BeEmpty();
+        historyStore.DeletedConversations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleDeleteConversationAsync_ShouldReturnNotFound_WhenConversationIsUnregistered()
+    {
+        var actorStore = new StubGAgentActorStore
+        {
+            AdmissionResult = ScopeResourceAdmissionResult.NotFound(),
+        };
+        var historyStore = new StubChatHistoryStore();
+
+        var result = await InvokeResultAsync(
+            "HandleDeleteConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            "actor-missing",
+            actorStore,
+            actorStore,
+            historyStore,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        actorStore.AdmissionTargets.Should().ContainSingle(target =>
+            target.ScopeId == "scope-a" &&
+            target.ResourceKind == ScopeResourceKind.GAgentActor &&
+            target.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
+            target.ActorId == "actor-missing" &&
+            target.Operation == ScopeResourceOperation.Delete);
+        actorStore.RemovedActors.Should().BeEmpty();
+        historyStore.DeletedConversations.Should().BeEmpty();
     }
 
     [Fact]
@@ -439,6 +538,61 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleStreamMessageAsync_ShouldRejectScopeMismatch_BeforeAdmission()
+    {
+        var context = CreateScopeGuardedContext("scope-other");
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        context.Response.Body = new MemoryStream();
+        var actorStore = new StubGAgentActorStore();
+
+        await InvokeTaskAsync(
+            "HandleStreamMessageAsync",
+            context,
+            "scope-a",
+            "actor-1",
+            new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
+            new StubActorRuntime(),
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        actorStore.AdmissionTargets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleStreamMessageAsync_ShouldReturnNotFound_WhenConversationIsUnregistered()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        var actorStore = new StubGAgentActorStore
+        {
+            AdmissionResult = ScopeResourceAdmissionResult.NotFound(),
+        };
+
+        await InvokeTaskAsync(
+            "HandleStreamMessageAsync",
+            context,
+            "scope-a",
+            "actor-missing",
+            new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
+            new StubActorRuntime(),
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        actorStore.AdmissionTargets.Should().ContainSingle(target =>
+            target.ScopeId == "scope-a" &&
+            target.ResourceKind == ScopeResourceKind.GAgentActor &&
+            target.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
+            target.ActorId == "actor-missing" &&
+            target.Operation == ScopeResourceOperation.Stream);
+    }
+
+    [Fact]
     public async Task HandleApproveAsync_ShouldRejectWithoutAuthorization()
     {
         var context = new DefaultHttpContext();
@@ -478,6 +632,61 @@ public class NyxIdChatEndpointsCoverageTests
             NullLoggerFactory.Instance,
             CancellationToken.None);
         context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task HandleApproveAsync_ShouldRejectScopeMismatch_BeforeAdmission()
+    {
+        var context = CreateScopeGuardedContext("scope-other");
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        context.Response.Body = new MemoryStream();
+        var actorStore = new StubGAgentActorStore();
+
+        await InvokeTaskAsync(
+            "HandleApproveAsync",
+            context,
+            "scope-a",
+            "actor-1",
+            new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
+            new StubActorRuntime(),
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        actorStore.AdmissionTargets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleApproveAsync_ShouldReturnNotFound_WhenConversationIsUnregistered()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Authorization = "Bearer valid-token";
+        var actorStore = new StubGAgentActorStore
+        {
+            AdmissionResult = ScopeResourceAdmissionResult.NotFound(),
+        };
+
+        await InvokeTaskAsync(
+            "HandleApproveAsync",
+            context,
+            "scope-a",
+            "actor-missing",
+            new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
+            new StubActorRuntime(),
+            actorStore,
+            new StubSubscriptionProvider(),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        actorStore.AdmissionTargets.Should().ContainSingle(target =>
+            target.ScopeId == "scope-a" &&
+            target.ResourceKind == ScopeResourceKind.GAgentActor &&
+            target.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
+            target.ActorId == "actor-missing" &&
+            target.Operation == ScopeResourceOperation.Approve);
     }
 
     [Fact]
@@ -1782,6 +1991,7 @@ public class NyxIdChatEndpointsCoverageTests
 
     private static async Task<IResult> InvokeResultAsync(string methodName, params object[] args)
     {
+        EnsureEndpointContextServices(args);
         var method = EndpointsType.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!;
         var result = method.Invoke(null, args);
         return result switch
@@ -1794,6 +2004,7 @@ public class NyxIdChatEndpointsCoverageTests
 
     private static async Task InvokeTaskAsync(string methodName, params object[] args)
     {
+        EnsureEndpointContextServices(args);
         var method = EndpointsType.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!;
         var result = method.Invoke(null, args)!;
         switch (result)
@@ -1818,6 +2029,62 @@ public class NyxIdChatEndpointsCoverageTests
             Task<T> task => await task,
             _ => throw new InvalidOperationException($"Unexpected return type: {result.GetType().FullName}"),
         };
+    }
+
+    private static void EnsureEndpointContextServices(IEnumerable<object> args)
+    {
+        foreach (var context in args.OfType<DefaultHttpContext>())
+        {
+            var currentServices = context.RequestServices;
+            if (currentServices?.GetService<IHostEnvironment>() is not null)
+                continue;
+
+            context.RequestServices = new FallbackServiceProvider(
+                currentServices ?? EmptyServiceProvider.Instance,
+                CreateScopeGuardServices(authenticationEnabled: false));
+        }
+    }
+
+    private static DefaultHttpContext CreateScopeGuardedContext(string claimedScopeId)
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = CreateScopeGuardServices(authenticationEnabled: true),
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim("scope_id", claimedScopeId)],
+                authenticationType: "test")),
+        };
+        return context;
+    }
+
+    private static ServiceProvider CreateScopeGuardServices(bool authenticationEnabled) =>
+        new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Aevatar:Authentication:Enabled"] = authenticationEnabled ? "true" : "false",
+                })
+                .Build())
+            .AddSingleton<IHostEnvironment>(new TestHostEnvironment
+            {
+                EnvironmentName = authenticationEnabled ? Environments.Production : Environments.Development,
+            })
+            .BuildServiceProvider();
+
+    private sealed class FallbackServiceProvider(
+        IServiceProvider primary,
+        IServiceProvider fallback) : IServiceProvider
+    {
+        public object? GetService(Type serviceType) =>
+            primary.GetService(serviceType) ?? fallback.GetService(serviceType);
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public static EmptyServiceProvider Instance { get; } = new();
+
+        public object? GetService(Type serviceType) => null;
     }
 
     private static string BuildScopedRelayConversationActorId(string scopeId, string canonicalKey)
@@ -2112,8 +2379,11 @@ public class NyxIdChatEndpointsCoverageTests
         public Exception? RemoveActorException { get; init; }
         public GAgentActorRegistryCommandStage RegisterStage { get; init; } =
             GAgentActorRegistryCommandStage.AdmissionVisible;
+        public ScopeResourceAdmissionResult AdmissionResult { get; init; } =
+            ScopeResourceAdmissionResult.Allowed();
         public List<(string ScopeId, string GAgentType, string ActorId)> AddedActors { get; } = [];
         public List<(string ScopeId, string GAgentType, string ActorId)> RemovedActors { get; } = [];
+        public List<ScopeResourceTarget> AdmissionTargets { get; } = [];
         public string? LastRequestedScopeId { get; private set; }
 
         public Task<GAgentActorRegistrySnapshot> ListActorsAsync(
@@ -2162,7 +2432,19 @@ public class NyxIdChatEndpointsCoverageTests
         public Task<ScopeResourceAdmissionResult> AuthorizeTargetAsync(
             ScopeResourceTarget target,
             CancellationToken cancellationToken = default)
-            => Task.FromResult(ScopeResourceAdmissionResult.Allowed());
+        {
+            AdmissionTargets.Add(target);
+            return Task.FromResult(AdmissionResult);
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "Aevatar.AI.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
     }
 
     private sealed class StubChatHistoryStore : IChatHistoryStore


### PR DESCRIPTION
## Summary
- Apply `AevatarScopeAccessGuard` to scoped NyxID chat create, list, delete, stream, and approve endpoints before scoped side effects or target admission.
- Keep target conversation ownership validation on stream, approve, and delete via `IScopeResourceAdmissionPort` with the NyxID chat GAgent target tuple.
- Add targeted regression coverage for authenticated scope mismatches and unregistered conversation admission paths.

## Issue
Fixes #372.

## Validation
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter "FullyQualifiedName~NyxIdChatEndpointsCoverageTests" --nologo` — 57 passed
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo` — 483 passed
- `bash tools/ci/test_stability_guards.sh` — passed
- `git diff --check` — passed

## Notes
- `../NyxID` was not present locally, so this follows the contracts available in this repository.