### PR TITLE
enhance(daily): failure-notification slug fallback + chunked delivery (#423 §C)

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -266,9 +266,22 @@ public sealed class AgentBuilderTool : IAgentTool
             return gitHubAuthorizationResponse;
 
         var providerSlug = (args.Str("nyx_provider_slug") ?? "api-lark-bot").Trim();
-        var requiredServiceIds = await ResolveProxyServiceIdsAsync(nyxClient, token, templateSpec!.RequiredServiceSlugs, ct);
-        if (requiredServiceIds.errorJson != null)
-            return requiredServiceIds.errorJson;
+        var serviceResolution = await ResolveProxyServiceIdsAsync(nyxClient, token, templateSpec!.RequiredServiceSlugs, ct);
+        if (serviceResolution.ErrorJson != null)
+            return serviceResolution.ErrorJson;
+
+        // Issue #423 §C — capture the inbound channel-bot slug as a failure-notification
+        // fallback. By definition the user can be reached through the bot they just
+        // messaged, so when a primary outbound delivery is rejected (e.g. cross-tenant
+        // Lark `99992364`) the failure-notification message can still land if the agent's
+        // API key is allowed to route through the inbound bot. Optional: if the inbound
+        // slug is not registered as a per-user UserService row (or equals the primary,
+        // in which case the fallback would just hit the same proxy), we leave the field
+        // empty and TrySendFailureAsync degrades to the current single-attempt behavior.
+        var failureNotificationContext = ResolveFailureNotificationContext(
+            providerSlug,
+            serviceResolution.RequiredIds!,
+            serviceResolution.EligibleIdBySlug);
 
         var agentId = string.IsNullOrWhiteSpace(args.Str("agent_id"))
             ? SkillRunnerDefaults.GenerateActorId()
@@ -276,7 +289,7 @@ public sealed class AgentBuilderTool : IAgentTool
 
         var createKeyResponse = await nyxClient.CreateApiKeyAsync(
             token,
-            BuildCreateApiKeyPayload(agentId, requiredServiceIds.value!),
+            BuildCreateApiKeyPayload(agentId, failureNotificationContext.AllowedServiceIds),
             ct);
 
         if (IsErrorPayload(createKeyResponse))
@@ -322,6 +335,7 @@ public sealed class AgentBuilderTool : IAgentTool
             LarkReceiveIdFallback = deliveryTarget.Fallback?.ReceiveId ?? string.Empty,
             LarkReceiveIdTypeFallback = deliveryTarget.Fallback?.ReceiveIdType ?? string.Empty,
             OwnerScope = caller.Clone(),
+            FailureNotificationProviderSlug = failureNotificationContext.FailureSlug ?? string.Empty,
         };
 #pragma warning restore CS0612
 
@@ -439,17 +453,17 @@ public sealed class AgentBuilderTool : IAgentTool
         // hardcoded `[providerSlug, publishProviderSlug]` was fine for two slugs but would
         // drift if a third slug were ever added; route through the spec so the source of
         // truth lives next to the workflow YAML.
-        var requiredServiceIds = await ResolveProxyServiceIdsAsync(
+        var serviceResolution = await ResolveProxyServiceIdsAsync(
             nyxClient,
             token,
             templateSpec!.RequiredServiceSlugs,
             ct);
-        if (requiredServiceIds.errorJson != null)
-            return requiredServiceIds.errorJson;
+        if (serviceResolution.ErrorJson != null)
+            return serviceResolution.ErrorJson;
 
         var createKeyResponse = await nyxClient.CreateApiKeyAsync(
             token,
-            BuildCreateApiKeyPayload(agentId, requiredServiceIds.value!),
+            BuildCreateApiKeyPayload(agentId, serviceResolution.RequiredIds!),
             ct);
 
         if (IsErrorPayload(createKeyResponse))
@@ -1040,29 +1054,45 @@ public sealed class AgentBuilderTool : IAgentTool
     /// slug, and skip org-shared rows the caller cannot use as a proxy target — those would later
     /// surface as a less-actionable <c>org_role_insufficient</c> error.</para>
     /// </remarks>
-    private async Task<(IReadOnlyList<string>? value, string? errorJson)> ResolveProxyServiceIdsAsync(
+    /// <summary>
+    /// Result of <see cref="ResolveProxyServiceIdsAsync"/>. <see cref="RequiredIds"/> /
+    /// <see cref="ErrorJson"/> are mutually exclusive (success vs. blocking error). Even on
+    /// success, callers can use <see cref="EligibleIdBySlug"/> to look up <em>optional</em>
+    /// slugs that were not in <c>requiredSlugs</c> — e.g. the inbound channel-bot slug for
+    /// SkillRunner's failure-notification fallback (issue #423 §C). Optional lookups must
+    /// not block agent creation, so they go through this map instead of being added to
+    /// <c>requiredSlugs</c> (which would cause <see cref="ResolveProxyServiceIdsAsync"/> to
+    /// return a <c>service_not_connected</c> error if the slug is missing).
+    /// </summary>
+    private readonly record struct ProxyServiceResolutionResult(
+        IReadOnlyList<string>? RequiredIds,
+        string? ErrorJson,
+        IReadOnlyDictionary<string, string> EligibleIdBySlug);
+
+    private async Task<ProxyServiceResolutionResult> ResolveProxyServiceIdsAsync(
         NyxIdApiClient client,
         string token,
         IReadOnlyList<string> requiredSlugs,
         CancellationToken ct)
     {
+        var emptyEligible = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         if (requiredSlugs.Count == 0)
         {
-            return (null, JsonSerializer.Serialize(new
+            return new ProxyServiceResolutionResult(null, JsonSerializer.Serialize(new
             {
                 error = "no_required_slugs",
                 hint = "At least one required Nyx proxy service slug must be provided.",
-            }));
+            }), emptyEligible);
         }
 
         var response = await client.ListUserServicesAsync(token, ct);
         if (IsErrorPayload(response))
         {
-            return (null, JsonSerializer.Serialize(new
+            return new ProxyServiceResolutionResult(null, JsonSerializer.Serialize(new
             {
                 error = "user_services_unavailable",
                 hint = "Could not list connected Nyx user-services. Try again or check NyxID availability.",
-            }));
+            }), emptyEligible);
         }
 
         try
@@ -1120,17 +1150,29 @@ public sealed class AgentBuilderTool : IAgentTool
                 bestBySlug[slug] = candidate;
             }
 
+            // Snapshot the eligible (slug → id) map before the per-required-slug check so
+            // callers can look up optional slugs (e.g. inbound channel-bot for failure-
+            // notification fallback) without re-listing user-services. Ineligible rows are
+            // intentionally excluded — including them would let optional lookups silently
+            // pick up an inactive or org-viewer-only service the API key cannot route through.
+            var eligibleBySlug = bestBySlug
+                .Where(static pair => pair.Value.IsEligible)
+                .ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value.Id,
+                    StringComparer.OrdinalIgnoreCase);
+
             var ids = new List<string>(requiredSlugs.Count);
             foreach (var slug in requiredSlugs.Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 if (!bestBySlug.TryGetValue(slug, out var resolution))
                 {
-                    return (null, JsonSerializer.Serialize(new
+                    return new ProxyServiceResolutionResult(null, JsonSerializer.Serialize(new
                     {
                         error = "service_not_connected",
                         slug,
                         hint = $"NyxID has no connected user-service for slug `{slug}`. Connect the provider at NyxID before creating this agent.",
-                    }));
+                    }), emptyEligible);
                 }
 
                 if (resolution.IsEligible)
@@ -1142,32 +1184,35 @@ public sealed class AgentBuilderTool : IAgentTool
                 if (string.Equals(resolution.CredentialSourceType, "org", StringComparison.OrdinalIgnoreCase) &&
                     resolution.OrgAllowed != true)
                 {
-                    return (null, JsonSerializer.Serialize(new
+                    return new ProxyServiceResolutionResult(null, JsonSerializer.Serialize(new
                     {
                         error = "service_org_viewer_only",
                         slug,
                         hint = $"NyxID user-service for slug `{slug}` is shared by your org but your role does not permit using it as a proxy target. Ask an admin to widen the org role scope, or connect a personal credential.",
-                    }));
+                    }), emptyEligible);
                 }
 
                 // Remaining ineligible reason: !is_active.
-                return (null, JsonSerializer.Serialize(new
+                return new ProxyServiceResolutionResult(null, JsonSerializer.Serialize(new
                 {
                     error = "service_inactive",
                     slug,
                     hint = $"NyxID user-service for slug `{slug}` is inactive. Re-activate it at NyxID before creating this agent.",
-                }));
+                }), emptyEligible);
             }
 
-            return (ids.Distinct(StringComparer.Ordinal).ToArray(), null);
+            return new ProxyServiceResolutionResult(
+                ids.Distinct(StringComparer.Ordinal).ToArray(),
+                null,
+                eligibleBySlug);
         }
         catch (JsonException)
         {
-            return (null, JsonSerializer.Serialize(new
+            return new ProxyServiceResolutionResult(null, JsonSerializer.Serialize(new
             {
                 error = "user_services_parse_failed",
                 hint = "NyxID user-services response was not valid JSON.",
-            }));
+            }), emptyEligible);
         }
     }
 
@@ -1180,6 +1225,51 @@ public sealed class AgentBuilderTool : IAgentTool
         public bool IsEligible =>
             IsActive &&
             !(string.Equals(CredentialSourceType, "org", StringComparison.OrdinalIgnoreCase) && OrgAllowed != true);
+    }
+
+    /// <summary>
+    /// Result of resolving the inbound channel-bot fallback used by SkillRunner's
+    /// failure-notification path (issue #423 §C). When the inbound slug is reachable
+    /// (registered + eligible + distinct from the primary), <see cref="FailureSlug"/>
+    /// is set and its corresponding <c>UserService.id</c> is appended to
+    /// <see cref="AllowedServiceIds"/> so the agent's API key can route through it
+    /// at runtime. Otherwise <see cref="FailureSlug"/> is null and the agent
+    /// degrades to the existing single-attempt failure notification.
+    /// </summary>
+    private readonly record struct FailureNotificationContext(
+        string? FailureSlug,
+        IReadOnlyList<string> AllowedServiceIds);
+
+    private FailureNotificationContext ResolveFailureNotificationContext(
+        string primarySlug,
+        IReadOnlyList<string> requiredIds,
+        IReadOnlyDictionary<string, string> eligibleIdBySlug)
+    {
+        var inboundSlug = AgentToolRequestContext.TryGet(ChannelMetadataKeys.InboundChannelBotProxySlug)?.Trim();
+        if (string.IsNullOrWhiteSpace(inboundSlug))
+            return new FailureNotificationContext(null, requiredIds);
+
+        // Same-proxy fallback gives no recovery benefit — a primary rejection at
+        // `slug=X` would also fail at `slug=X`. Skip the capture so TrySendFailureAsync
+        // doesn't pay the wasted POST and doesn't double-log the same rejection.
+        if (string.Equals(inboundSlug, primarySlug, StringComparison.Ordinal))
+            return new FailureNotificationContext(null, requiredIds);
+
+        // Optional slug must be a connected, eligible user-service for the API key to
+        // route through it. If it's not, leaving the failure-notification field empty
+        // keeps the runtime on the existing single-attempt path — better than persisting
+        // a slug whose every send would 403 at proxy enforcement time.
+        if (!eligibleIdBySlug.TryGetValue(inboundSlug, out var inboundId))
+            return new FailureNotificationContext(null, requiredIds);
+
+        // Dedupe — if the inbound slug's UserService.id is already in requiredIds the
+        // expanded list is identical, but we still surface the slug on OutboundConfig so
+        // the runtime knows to use it for failure notifications.
+        var allowed = requiredIds.Contains(inboundId, StringComparer.Ordinal)
+            ? requiredIds
+            : requiredIds.Append(inboundId).ToArray();
+
+        return new FailureNotificationContext(inboundSlug, allowed);
     }
 
     private async Task<string?> BuildGitHubAuthorizationResponseAsync(

--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelMetadataKeys.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelMetadataKeys.cs
@@ -55,4 +55,21 @@ public static class ChannelMetadataKeys
     /// <c>outbound_proxy_slug</c> form makes the routing-side semantics explicit.
     /// </summary>
     public const string LarkOutboundProxySlug = "channel.lark.outbound_proxy_slug";
+
+    /// <summary>
+    /// NyxID provider slug of the inbound channel-bot that received this turn's webhook
+    /// event. Equivalent to <c>ChannelInboundEvent.NyxProviderSlug</c>, surfaced as request
+    /// metadata so the agent-builder tool can capture it on the new agent's
+    /// <c>SkillRunnerOutboundConfig.FailureNotificationProviderSlug</c> at create time.
+    /// </summary>
+    /// <remarks>
+    /// The inbound channel-bot is the bot the user just successfully messaged. When the
+    /// agent's primary outbound proxy fails with a structural rejection (e.g. Lark
+    /// <c>99992364 user id cross tenant</c> from a cross-tenant relay/outbound mismatch),
+    /// the inbound bot's slug is the only known proxy that can still deliver to the user.
+    /// SkillRunner uses this for failure notifications only — primary outbound stays on the
+    /// caller-provided <c>nyx_provider_slug</c> argument so existing deployments are not
+    /// rerouted unexpectedly. See issue #423 §C.
+    /// </remarks>
+    public const string InboundChannelBotProxySlug = "channel.inbound.channel_bot_provider_slug";
 }

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -694,6 +694,13 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             [ChannelMetadataKeys.ChatType] = inboundEvent.ChatType,
         };
 
+        // Inbound channel-bot's NyxID provider slug. SkillRunner agent-builder captures this on
+        // SkillRunnerOutboundConfig.FailureNotificationProviderSlug so a failed outbound delivery
+        // (e.g. cross-tenant Lark 99992364) can still notify the user via the bot they just
+        // successfully messaged. See issue #423 §C and ChannelMetadataKeys.InboundChannelBotProxySlug.
+        if (!string.IsNullOrWhiteSpace(inboundEvent.NyxProviderSlug))
+            metadata[ChannelMetadataKeys.InboundChannelBotProxySlug] = inboundEvent.NyxProviderSlug;
+
         var platformMessageId = NormalizeOptional(activity?.TransportExtras?.NyxPlatformMessageId);
         if (!string.IsNullOrWhiteSpace(platformMessageId))
             metadata[ChannelMetadataKeys.PlatformMessageId] = platformMessageId;

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -271,14 +271,14 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             if (string.IsNullOrWhiteSpace(output))
                 output = "No update generated.";
 
-            if (sink is not null)
-                await sink.FinalizeAsync(output, ct);
-            else
-                // No streaming sink (no NyxID client, missing outbound config, or
-                // tests injecting a null client). Fall back to a one-shot send so the
-                // user still receives the report and tests that don't construct a sink
-                // keep working.
-                await SendOutputAsync(output, ct);
+            // Issue #423 §C — chunked delivery for outputs that exceed the Lark body cap.
+            // For ≤30 KB outputs the chunker returns a single-element list and the dispatch
+            // loop below collapses to the existing single-message path. Larger outputs split
+            // at `\n\n` boundaries (or hard-split for no-paragraph inputs) so the full report
+            // lands as a sequence of "[part k/N]" messages instead of being silently truncated
+            // at the cap.
+            var chunks = SkillRunnerOutputChunker.Split(output);
+            await DispatchOutputChunksAsync(sink, chunks, ct);
 
             return output;
         }
@@ -286,6 +286,41 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         {
             sink?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Sends the chunk sequence produced by <see cref="SkillRunnerOutputChunker.Split"/>:
+    /// chunk[0] flows through the streaming-edit sink (so the in-flight message the user has
+    /// been watching grow lands cleanly as "part 1"); chunks 1..N go as fresh one-shot POSTs
+    /// through the primary <see cref="SendOutputAsync(string, CancellationToken)"/> path
+    /// since edit-in-place only applies to the message captured at sink-creation time.
+    /// </summary>
+    /// <remarks>
+    /// Failure semantics match the pre-chunking single-message path: any send rejection
+    /// throws and propagates to <c>HandleTriggerAsync</c>'s retry/persist contract. A failure
+    /// on chunk N &gt; 0 means chunks 0..N-1 already landed in chat — that's intentional
+    /// partial visibility. Atomic multi-message delivery would require either a Lark-side
+    /// transactional API (none exists) or buffering until all chunks succeed (loses the
+    /// streaming-edit UX), neither of which is worth the complexity here.
+    /// </remarks>
+    private async Task DispatchOutputChunksAsync(
+        SkillRunnerStreamingReplySink? sink,
+        IReadOnlyList<string> chunks,
+        CancellationToken ct)
+    {
+        if (chunks.Count == 0)
+            return;
+
+        if (sink is not null)
+            await sink.FinalizeAsync(chunks[0], ct);
+        else
+            // No streaming sink (no NyxID client, missing outbound config, or tests injecting
+            // a null client). Fall back to a one-shot send so the user still receives the
+            // report and tests that don't construct a sink keep working.
+            await SendOutputAsync(chunks[0], ct);
+
+        for (var i = 1; i < chunks.Count; i++)
+            await SendOutputAsync(chunks[i], ct);
     }
 
     /// <summary>
@@ -346,7 +381,18 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             Logger);
     }
 
-    private async Task SendOutputAsync(string output, CancellationToken ct)
+    private Task SendOutputAsync(string output, CancellationToken ct) =>
+        SendOutputAsync(output, providerSlugOverride: null, ct);
+
+    /// <summary>
+    /// Posts <paramref name="output"/> as a Lark text message. <paramref name="providerSlugOverride"/>
+    /// is non-null only on the failure-notification fallback path (#423 §C); when set, the proxy
+    /// routing slug temporarily replaces the agent's primary <c>NyxProviderSlug</c> so a message
+    /// can still reach the user via the inbound channel-bot after the primary outbound has been
+    /// rejected (e.g. cross-tenant <c>99992364</c>). All other call sites — main report send,
+    /// chunked overflow continuations — pass <c>null</c> and stay on the primary slug.
+    /// </summary>
+    private async Task SendOutputAsync(string output, string? providerSlugOverride, CancellationToken ct)
     {
         var client = _nyxIdApiClient ?? Services.GetService<NyxIdApiClient>();
         if (client is null)
@@ -362,6 +408,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             Logger.LogWarning("Skill runner {ActorId} has incomplete outbound config; skipping outbound delivery", Id);
             return;
         }
+
+        var slug = string.IsNullOrWhiteSpace(providerSlugOverride)
+            ? State.OutboundConfig.NyxProviderSlug
+            : providerSlugOverride!;
 
         var deliveryTarget = LarkConversationTargets.Resolve(
             State.OutboundConfig.LarkReceiveId,
@@ -379,7 +429,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
                 deliveryTarget.ReceiveIdType);
         }
 
-        var outcome = await TrySendWithFallbackAsync(client, output, deliveryTarget, ct);
+        var outcome = await TrySendWithFallbackAsync(client, output, slug, deliveryTarget, ct);
 
         if (!outcome.Succeeded)
         {
@@ -412,10 +462,11 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     private async Task<SendOutcome> TrySendWithFallbackAsync(
         NyxIdApiClient client,
         string output,
+        string slug,
         LarkReceiveTarget primary,
         CancellationToken ct)
     {
-        var primaryResponse = await SendOutboundAsync(client, output, primary, ct);
+        var primaryResponse = await SendOutboundAsync(client, output, slug, primary, ct);
         if (!LarkProxyResponse.TryGetError(primaryResponse, out var larkCode, out var detail))
             return SendOutcome.Success();
 
@@ -436,7 +487,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             fallbackType);
 
         var fallbackTarget = new LarkReceiveTarget(fallbackId, fallbackType, FellBackToPrefixInference: false);
-        var fallbackResponse = await SendOutboundAsync(client, output, fallbackTarget, ct);
+        var fallbackResponse = await SendOutboundAsync(client, output, slug, fallbackTarget, ct);
         if (!LarkProxyResponse.TryGetError(fallbackResponse, out var fallbackCode, out var fallbackDetail))
             return SendOutcome.Success();
 
@@ -446,6 +497,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     private async Task<string> SendOutboundAsync(
         NyxIdApiClient client,
         string output,
+        string slug,
         LarkReceiveTarget target,
         CancellationToken ct)
     {
@@ -458,7 +510,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
         return await client.ProxyRequestAsync(
             State.OutboundConfig.NyxApiKey,
-            State.OutboundConfig.NyxProviderSlug,
+            slug,
             $"open-apis/im/v1/messages?receive_id_type={target.ReceiveIdType}",
             "POST", body, null, ct);
     }
@@ -497,9 +549,53 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             : $"Lark message delivery rejected: {detail}";
     }
 
+    /// <summary>
+    /// Best-effort delivery of a failure-notification message after the run has already failed.
+    /// Issue #423 §C: when the primary outbound proxy was just rejected with a structural code
+    /// (e.g. cross-tenant <c>99992364</c>), retrying through the same proxy obviously also
+    /// fails. If a failure-notification slug was captured at agent-create time (the inbound
+    /// channel-bot the user just successfully messaged), try IT first so the user actually
+    /// sees that the run failed; on its failure, fall back to the primary slug as a last
+    /// resort so single-tenant deployments (no separate failure slug) still get the same
+    /// single-attempt behavior they had before this fix.
+    /// </summary>
+    /// <remarks>
+    /// All exceptions are swallowed — by definition we are already in the failure path, and a
+    /// failed notification must not raise above HandleTriggerAsync's own
+    /// <c>SkillRunnerExecutionFailedEvent</c> persist (which is what surfaces
+    /// <c>last_error</c> in <c>/agent-status</c> regardless of whether the user got a Lark
+    /// message). Logs a warning for each unsuccessful attempt so the regression is observable.
+    /// </remarks>
     private async Task TrySendFailureAsync(string error, CancellationToken ct)
     {
-        try { await SendOutputAsync($"Skill runner failed: {error}", ct); }
+        var message = $"Skill runner failed: {error}";
+        var failureSlug = State.OutboundConfig?.FailureNotificationProviderSlug?.Trim();
+        var primarySlug = State.OutboundConfig?.NyxProviderSlug?.Trim();
+
+        // Try the captured failure-notification slug first when it is set AND distinct from
+        // the primary slug. Equal values would just hit the same proxy again, so we skip the
+        // duplicate POST and go straight to the primary path.
+        if (!string.IsNullOrEmpty(failureSlug) &&
+            !string.Equals(failureSlug, primarySlug, StringComparison.Ordinal))
+        {
+            try
+            {
+                await SendOutputAsync(message, providerSlugOverride: failureSlug, ct);
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(
+                    ex,
+                    "Skill runner {ActorId} failed-notification via failure-notification slug rejected; falling back to primary slug",
+                    Id);
+            }
+        }
+
+        try
+        {
+            await SendOutputAsync(message, providerSlugOverride: null, ct);
+        }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Skill runner {ActorId} failed to send failure notification", Id);

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerOutputChunker.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerOutputChunker.cs
@@ -1,0 +1,115 @@
+namespace Aevatar.GAgents.Scheduled;
+
+/// <summary>
+/// Splits a SkillRunner output into Lark-deliverable chunks when the report exceeds the
+/// platform body cap. Issue #423 §C: prior to this helper, outputs &gt; 30 KB were truncated
+/// at the cap with a marker, which silently dropped the tail of richer reports. The chunker
+/// preserves the full content by splitting at paragraph (<c>\n\n</c>) boundaries when one
+/// exists within the per-chunk budget, falling back to a character-boundary split for
+/// pathological no-paragraph inputs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cap budget reserves headroom for continuation markers ("part k/N") so the rendered
+/// chunks (raw + markers) still fit under <see cref="SkillRunnerStreamingReplySink.MaxLarkTextLength"/>
+/// — without the reservation a chunk filling the budget would re-overflow once the marker
+/// was prepended/appended.
+/// </para>
+/// <para>
+/// The chunker is a pure function: no I/O, no allocations beyond the result list. The actual
+/// dispatch loop lives in <c>SkillRunnerGAgent.ExecuteSkillAsync</c>, which sends chunk[0]
+/// through the streaming-edit sink (so the in-flight message lands as part 1) and chunks
+/// 1..N as fresh one-shot POSTs through <c>SendOutputAsync</c>.
+/// </para>
+/// </remarks>
+internal static class SkillRunnerOutputChunker
+{
+    private const string ContinuesSuffixFormat = "\n\n[part {0}/{1} • continues ↓]";
+    private const string ContinuedPrefixFormat = "[part {0}/{1} • continued ↑]\n\n";
+
+    /// <summary>
+    /// Reserved per-chunk overhead for continuation markers. The longest rendered marker
+    /// (e.g. <c>"\n\n[part 99/99 • continues ↓]"</c>) is well under this; 60 chars is a
+    /// safe ceiling that does not need to track marker template width.
+    /// </summary>
+    private const int MarkerOverhead = 60;
+
+    /// <summary>
+    /// Splits <paramref name="output"/> into one or more chunks suitable for Lark text
+    /// delivery. When <paramref name="output"/> already fits, returns a single-element list
+    /// containing the input verbatim — callers can therefore use the same dispatch loop for
+    /// both single-message and chunked-message paths.
+    /// </summary>
+    public static IReadOnlyList<string> Split(string output)
+    {
+        if (string.IsNullOrEmpty(output))
+            return [output ?? string.Empty];
+
+        if (output.Length <= SkillRunnerStreamingReplySink.MaxLarkTextLength)
+            return [output];
+
+        var contentBudget = SkillRunnerStreamingReplySink.MaxLarkTextLength - MarkerOverhead;
+        if (contentBudget < 100)
+            // Defensive: keep the algorithm well-formed if MaxLarkTextLength ever shrinks.
+            // Content must always have positive room or the loop cannot make progress.
+            contentBudget = SkillRunnerStreamingReplySink.MaxLarkTextLength;
+
+        var rawChunks = SplitRaw(output, contentBudget);
+        var total = rawChunks.Count;
+        if (total == 1)
+            return rawChunks;
+
+        var rendered = new List<string>(total);
+        for (var i = 0; i < total; i++)
+        {
+            var partNum = i + 1;
+            var prefix = i > 0 ? string.Format(ContinuedPrefixFormat, partNum, total) : string.Empty;
+            var suffix = i < total - 1 ? string.Format(ContinuesSuffixFormat, partNum, total) : string.Empty;
+            rendered.Add(prefix + rawChunks[i] + suffix);
+        }
+
+        return rendered;
+    }
+
+    private static List<string> SplitRaw(string output, int contentBudget)
+    {
+        var chunks = new List<string>();
+        var offset = 0;
+        while (offset < output.Length)
+        {
+            var remaining = output.Length - offset;
+            if (remaining <= contentBudget)
+            {
+                chunks.Add(output[offset..]);
+                break;
+            }
+
+            // C# `LastIndexOf(value, startIndex, count)` searches the inclusive range
+            // [startIndex - count + 1, startIndex] backwards. We want the latest "\n\n" in
+            // [offset, offset + contentBudget - 1] so partial matches at the end of the
+            // window (e.g. at offset + contentBudget - 1, where only the first '\n' falls
+            // inside the budget) are still considered. The `count` argument intentionally
+            // overshoots by 1 at the trailing edge so a "\n\n" anchored at
+            // (offset + contentBudget - 1) with its second '\n' just outside the budget is
+            // still picked up — the chunk content ends BEFORE the boundary so the second
+            // '\n' is consumed by `offset = boundary + 2` regardless.
+            var searchAnchor = offset + contentBudget - 1;
+            var boundary = output.LastIndexOf("\n\n", searchAnchor, contentBudget, StringComparison.Ordinal);
+            if (boundary <= offset)
+            {
+                // No paragraph boundary in budget (or boundary is at the very start, which
+                // would produce an empty chunk). Hard-split at the budget — pathological
+                // inputs (no \n\n at all, or a runaway single paragraph) still get
+                // delivered chunked, just at character-boundary precision.
+                chunks.Add(output[offset..(offset + contentBudget)]);
+                offset += contentBudget;
+            }
+            else
+            {
+                chunks.Add(output[offset..boundary]);
+                offset = boundary + 2; // skip the "\n\n"
+            }
+        }
+        return chunks;
+    }
+}

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -33,6 +33,17 @@ message SkillRunnerOutboundConfig {
   // Caller scope captured at create time. Replaces owner_nyx_user_id+platform
   // for new agents; the deprecated scattered fields remain for legacy state.
   OwnerScope owner_scope = 11;
+  // NyxID outbound proxy slug to use when delivering a failure-notification
+  // message after a primary outbound delivery has been rejected. Captured at
+  // agent-create time from the inbound channel-bot's slug — by definition
+  // the user can be reached through that bot, since they just messaged it
+  // (issue #423 §C). Empty when (a) the agent was created before this field
+  // existed, (b) the inbound slug equals the primary slug (no benefit), or
+  // (c) the inbound slug is not registered as a per-user UserService row
+  // and therefore cannot be added to the agent API key's allowed_service_ids.
+  // SkillRunnerGAgent.TrySendFailureAsync attempts the failure-notification
+  // slug FIRST when set, then falls back to the primary slug.
+  string failure_notification_provider_slug = 12;
 }
 
 message SkillRunnerState {

--- a/docs/canon/daily-command-pipeline.md
+++ b/docs/canon/daily-command-pipeline.md
@@ -305,8 +305,8 @@ catch (Exception ex) {
 - 主备对在创建时由 `ResolveDeliveryTarget(conversationId, agentId)` 决定：
   - 主：通常 `chat_id`（`oc_*`）
   - 备：通常 `union_id`（`on_*`，跨 app 也能找到用户）
-- `99992361`（open_id cross app）和 `99992364`（union_id cross tenant）不会触发 fallback，会直接进入失败路径并给 `/agent-status` 留下带重建提示的 `last_error`。
-- **已知短板**（issue #423 § C）：失败通知 `TrySendFailureAsync` 走的也是同一条 `s/api-lark-bot` proxy，主链路 99992361/99992364 时通知通常也会丢。
+- `99992361`（open_id cross app）和 `99992364`（union_id cross tenant）不会触发 receive_id fallback，会直接进入失败路径并给 `/agent-status` 留下带重建提示的 `last_error`。
+- **失败通知通道**（issue #423 § C，已落地）：`TrySendFailureAsync` 优先走 `OutboundConfig.FailureNotificationProviderSlug`（创建 agent 时从入站 channel-bot 的 `nyx_provider_slug` 抓住的旁路 proxy）。当主投递因 99992361/99992364 在 `s/api-lark-bot` 拒绝时，这条旁路 slug 是用户最近一次成功消息的 bot——按定义可达。仅当 (a) 入站 slug 与主 slug 相同（同一个 proxy 没有恢复价值），或 (b) 入站 slug 不在用户 `UserService` 列表里（API key 无法授权 routing），才回退到原本的"和主投递走同一 proxy"的单次尝试。失败通知本身吞所有异常，不会盖掉 `SkillRunnerExecutionFailedEvent` 持久化。
 
 ---
 
@@ -330,6 +330,8 @@ string lark_receive_id = 7;        // 主投递目标
 string lark_receive_id_type = 8;
 string lark_receive_id_fallback = 9;
 string lark_receive_id_type_fallback = 10;
+OwnerScope owner_scope = 11;
+string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入站 channel-bot），失败通知用
 ```
 
 ### `SkillRunnerState`
@@ -415,7 +417,7 @@ string lark_receive_id_type_fallback = 10;
 
 **One-shot 兜底（无 streaming sink 时）**：当 `NyxIdApiClient` 未注入或 `OutboundConfig` 缺关键字段（`NyxApiKey`/`NyxProviderSlug`/`ConversationId`），`ExecuteSkillAsync` 会回退到原本的一次性 `SendOutputAsync(POST)` 路径——同步发整段文本，沿用同样的 230002 fallback 重试。失败通知 `TrySendFailureAsync` 始终走这条 one-shot 路径（无需 streaming，且失败文案本来就短）。
 
-**长度上限**：流入 sink 的累积文本超过 `SkillRunnerStreamingReplySink.MaxLarkTextLength=30000` 字符时被截断并尾缀 `…[truncated]`。Lark 平台文本 body 实际上限远高于这个值，但 JSON 包装 + 多字节 UTF-8 余量下 30K 安全。富报告若需要更细粒度的分段（按 section 拆成多条消息），目前未实现，跟踪在 issue #423 §C。
+**长度上限 / 分段投递**（issue #423 §C，已落地）：流入 sink 的累积文本超过 `SkillRunnerStreamingReplySink.MaxLarkTextLength=30000` 字符时仍会在 sink 内截断（运行时安全网）。但 `ExecuteSkillAsync` 在 stream 结束后会用 `SkillRunnerOutputChunker.Split()` 按段落（`\n\n`）边界把整段输出切成 ≤30K 的若干 chunk：chunk[0] 经流式编辑落地（用户看到的那条消息），chunk[1..N] 各自通过 `SendOutputAsync` 走主 `nyx_provider_slug` 投递成新消息。每个非首/末段附 `[part k/N • continued ↑/continues ↓]` 标记，无段落边界（病态长段落）的输入退化为字符级硬切——结果仍可投递，只是切点没有段落对齐。任一段失败抛 `InvalidOperationException`，主链路 catch 进失败持久化路径；先落地的段保留在用户聊天里，是有意的部分可见——Lark 没有事务式多消息投递。
 
 **已知边界**（已记入 issues，QA 复测时要能判别）：
 - `lark_receive_id*` 在 agent 创建时被冻结。如果用户从 chat A 创建 agent，后来 chat A 解散或机器人被踢，agent 投递就永远失败 → 必须 `/delete-agent` + 重建。
@@ -446,7 +448,7 @@ string lark_receive_id_type_fallback = 10;
 ### 9.3 用户看不到（更隐蔽，需要查日志或 `/agent-status` 才能发现）
 - **Issue #440**：首次执行成功后 `/agent-status` 的 `Last run` / `Next run` 一直 `n/a`。
 - **Issue #398**：webhook 完全没到 aevatar——aevatar 日志里只有 K8s liveness 探活，无 `POST /api/webhooks/nyxid-relay`。
-- 出站失败被 `TrySendFailureAsync` 通知，但通知本身走同一条 proxy → 通知也丢（issue #423 §C）。
+- 出站主投递失败时 `TrySendFailureAsync` 优先走 `OutboundConfig.FailureNotificationProviderSlug`（入站 channel-bot 抓住的旁路 proxy，issue #423 §C）。仅当未捕获到旁路 slug、或入站与主 slug 相同（同一 proxy 没有恢复价值）、或两路都拒绝时，用户才完全看不到失败——剩余的可观测路径是 `/agent-status` 的 `last_error` 文案。
 
 ### 9.4 重试相关
 - 每次执行 fail，`MaxRetryAttempts=1`，30 秒后自动重试 1 次
@@ -482,7 +484,7 @@ string lark_receive_id_type_fallback = 10;
 | ~~#436~~ ✅ | 高（同上 #437 的工程分析） | GitHub username binding shared across all Lark users（last writer wins） | 同上 | 同上 |
 | #439 | 高（语义错） | SkillRunner masks GitHub tool failures as silent "no activity" success | prompt + nyxid_proxy 工具 + runner 的"非空即成功"路径 | 强制 GitHub 接口返回 4xx/5xx，验证报告必须显式标错而不是出 `No X surfaced` |
 | #440 | 中（运维可见性） | `/agent-status` 首次执行不刷新 `Last run`/`Next run` | UserAgentCatalogGAgent.HandleExecutionUpdateAsync early-return guard | `/daily X`（run_immediately）→ 30s 后 `/agent-status <id>` 看 `Last run` 应非 n/a |
-| #423 | 中（增强 + 失败通知短板） | richer report content + progressive delivery；副带失败通知通道脆弱 | prompt + SendOutputAsync + TrySendFailureAsync | 当前一次性投递；除 ✓ reaction 外缺少进度反馈，创建确认也可能延迟到首次执行尝试之后；构造投递失败场景看通知是否能到 |
+| ~~#423~~ ✅ | 中（增强 + 失败通知短板） | richer report content + progressive delivery + chunked + 失败通知旁路 | prompt（§A，#458 已合）+ streaming-edit（§B，#469 已合）+ chunked + failure-notification slug（§C，本 PR） | 已落地：`/daily` 报告流式编辑、>30K 自动分段、出站失败时优先经入站 channel-bot 投递失败通知 |
 | #398 | 高（链路断） | Lark relay callbacks never reach aevatar | NyxID 侧 callback_url 配置 / 多副本 ingress / Lark 订阅状态 | 用户发消息无任何反应，aevatar 日志只有 K8s liveness |
 
 每条 bug 在对应 issue 描述里都有完整 acceptance criteria，QA 用例可直接对齐。
@@ -740,8 +742,8 @@ Lark 开发者后台：
 - GitHub 工具失败需明确暴露给用户（#439 修复后）
 - ~~多 Lark 用户独立 `github_username`~~ ✅ 已由 [#438](https://github.com/aevatarAI/aevatar/pull/438) 修复（composite scope）；结构性升级到 `LarkUserGAgent` 仍是未来选项
 - `/agent-status` 首次执行后秒级反映（#440 修复后）
-- 失败通知通道与主投递解耦，避免一起死（#423 §C；目前 `TrySendFailureAsync` 仍走相同 `s/api-lark-bot` proxy）
-- 富 / 长报告超 Lark 30KB 体限的**分段**处理（截断已实现，按 section 切分多条消息仍是 #423 §C 跟踪项）
+- ~~失败通知通道与主投递解耦~~ ✅ #423 §C 已实现（`OutboundConfig.FailureNotificationProviderSlug` 抓住入站 channel-bot 的 slug，`TrySendFailureAsync` 优先走旁路 proxy；详见 §3 阶段⑥/⑦）
+- ~~富 / 长报告超 Lark 30KB 体限的**分段**处理~~ ✅ #423 §C 已实现（`SkillRunnerOutputChunker.Split()` 按 `\n\n` 段落边界切，每段 ≤30K，`[part k/N]` 标记）
 - 跨 app 部署的 `lark_receive_id` 自动更新（目前只能 `/delete-agent` 重建）
 
 QA 对照本表与 issue 复现步骤即可在每个 PR landing 后系统性回归。

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -1574,6 +1574,347 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_CapturesFailureNotificationSlug_FromInboundChannelBot()
+    {
+        // Issue #423 §C: capture the inbound channel-bot's NyxID provider slug at agent-create
+        // time so SkillRunner.TrySendFailureAsync can route the failure-notification message
+        // through it after a primary outbound rejection (e.g. cross-tenant 99992364). This
+        // test pins:
+        //   - the captured slug ends up on OutboundConfig.FailureNotificationProviderSlug
+        //   - the inbound bot's per-user UserService.id is appended to the API key's
+        //     allowed_service_ids so proxy enforcement (#418) actually permits routing
+        //     through it at runtime
+        //   - the primary outbound slug stays unchanged (failure-notification fallback is a
+        //     separate routing path, not a re-route of the main report)
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionForCallerAsync("skill-runner-fnf", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetForCallerAsync("skill-runner-fnf", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-fnf",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        var workflowAgentPort = Substitute.For<IWorkflowAgentCommandPort>();
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        // The inbound channel-bot's slug (api-lark-bot-channel-loning) is registered as a
+        // separate UserService row alongside the global api-lark-bot used for outbound.
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark-global","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark-channel-loning","slug":"api-lark-bot-channel-loning","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-fnf","full_key":"full-key-fnf"}""");
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
+            """{"resources":{"core":{"limit":5000,"remaining":4999}}}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var servicesCollection = new ServiceCollection();
+        servicesCollection.AddSingleton(queryPort);
+        servicesCollection.AddSingleton(skillRunnerPort);
+        servicesCollection.AddSingleton(workflowAgentPort);
+        servicesCollection.AddSingleton(catalogCommandPort);
+        servicesCollection.AddSingleton(nyxClient);
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        servicesCollection.AddSingleton(callerScopeResolver);
+        var tool = new AgentBuilderTool(servicesCollection.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            ["scope_id"] = "scope-1",
+            // The inbound channel-bot the user just messaged. Distinct from the outbound
+            // default (`api-lark-bot`), simulating the cross-tenant scenario.
+            [ChannelMetadataKeys.InboundChannelBotProxySlug] = "api-lark-bot-channel-loning",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-fnf",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            await skillRunnerPort.Received(1).InitializeAsync(
+                "skill-runner-fnf",
+                Arg.Is<InitializeSkillRunnerCommand>(c =>
+                    // Primary slug stays on the caller-provided default — failure-notification
+                    // is a separate routing path, not a re-route of the main report.
+                    c.OutboundConfig.NyxProviderSlug == "api-lark-bot" &&
+                    c.OutboundConfig.FailureNotificationProviderSlug == "api-lark-bot-channel-loning"),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+
+            var apiKeyRequest = handler.Requests.Should()
+                .ContainSingle(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys")
+                .Subject;
+            using var apiKeyDoc = JsonDocument.Parse(apiKeyRequest.Body!);
+            var allowed = apiKeyDoc.RootElement.GetProperty("allowed_service_ids").EnumerateArray()
+                .Select(static item => item.GetString())
+                .ToArray();
+            // The inbound bot's svc-id MUST be in allowed_service_ids; without it the
+            // runtime POST through the failure-notification slug would 403 at proxy
+            // enforcement (#418) and the user still wouldn't see the failure message.
+            allowed.Should().Contain("svc-lark-channel-loning");
+            allowed.Should().Contain("svc-github");
+            allowed.Should().Contain("svc-lark-global");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_LeavesFailureNotificationSlugEmpty_When_InboundEqualsPrimary()
+    {
+        // Same-proxy fallback gives no recovery benefit — primary rejection at slug X would
+        // also fail at slug X. Pin that AgentBuilderTool detects this and leaves the field
+        // empty so SkillRunner.TrySendFailureAsync skips the redundant double-POST.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionForCallerAsync("skill-runner-same", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetForCallerAsync("skill-runner-same", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-same",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        var workflowAgentPort = Substitute.For<IWorkflowAgentCommandPort>();
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-same","full_key":"full-key-same"}""");
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
+            """{"resources":{"core":{"limit":5000,"remaining":4999}}}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var servicesCollection = new ServiceCollection();
+        servicesCollection.AddSingleton(queryPort);
+        servicesCollection.AddSingleton(skillRunnerPort);
+        servicesCollection.AddSingleton(workflowAgentPort);
+        servicesCollection.AddSingleton(catalogCommandPort);
+        servicesCollection.AddSingleton(nyxClient);
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        servicesCollection.AddSingleton(callerScopeResolver);
+        var tool = new AgentBuilderTool(servicesCollection.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            ["scope_id"] = "scope-1",
+            // Inbound slug equals the default primary slug.
+            [ChannelMetadataKeys.InboundChannelBotProxySlug] = "api-lark-bot",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-same",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            await skillRunnerPort.Received(1).InitializeAsync(
+                "skill-runner-same",
+                Arg.Is<InitializeSkillRunnerCommand>(c =>
+                    c.OutboundConfig.NyxProviderSlug == "api-lark-bot" &&
+                    string.IsNullOrEmpty(c.OutboundConfig.FailureNotificationProviderSlug)),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CreateAgent_DailyReport_LeavesFailureNotificationSlugEmpty_When_InboundSlugMissingFromUserServices()
+    {
+        // Defense-in-depth: if the inbound slug isn't a registered user-service (e.g. an
+        // unusual relay setup, or an inbound bot that was disconnected between webhook arrival
+        // and agent-create), we cannot grant proxy access at API-key creation time. Including
+        // it would either fail the create with `service_not_connected` (regression) OR pass
+        // creation but 403 at runtime when SkillRunner tries to use it. Both are worse than
+        // leaving the failure-notification slug empty and degrading to single-attempt failure
+        // notification (current behavior). Pin the latter.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetStateVersionForCallerAsync("skill-runner-missing", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<long?>(null), Task.FromResult<long?>(1));
+        queryPort.GetForCallerAsync("skill-runner-missing", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogEntry?>(new UserAgentCatalogEntry
+            {
+                AgentId = "skill-runner-missing",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily_report",
+                Status = SkillRunnerDefaults.StatusRunning,
+            }));
+
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        var workflowAgentPort = Substitute.For<IWorkflowAgentCommandPort>();
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+
+        var handler = new RoutingJsonHandler();
+        handler.Add(HttpMethod.Get, "/api/v1/users/me", """{"user":{"id":"user-1"}}""");
+        handler.Add(HttpMethod.Get, "/api/v1/providers/my-tokens", """
+            {
+              "tokens": [
+                {"provider_id":"provider-github","provider_name":"GitHub","provider_slug":"github","provider_type":"oauth2","status":"active","connected_at":"2026-04-15T00:00:00Z"}
+              ]
+            }
+            """);
+        // The inbound slug is NOT among the user's registered services.
+        handler.Add(HttpMethod.Get, "/api/v1/user-services", """
+            {
+              "services": [
+                {"id":"svc-github","slug":"api-github","is_active":true,"credential_source":{"type":"personal"}},
+                {"id":"svc-lark","slug":"api-lark-bot","is_active":true,"credential_source":{"type":"personal"}}
+              ]
+            }
+            """);
+        handler.Add(HttpMethod.Post, "/api/v1/api-keys", """{"id":"key-missing","full_key":"full-key-missing"}""");
+        handler.Add(HttpMethod.Get, "/api/v1/proxy/s/api-github/rate_limit",
+            """{"resources":{"core":{"limit":5000,"remaining":4999}}}""");
+
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(handler) { BaseAddress = new Uri("https://nyx.example.com") });
+
+        var servicesCollection = new ServiceCollection();
+        servicesCollection.AddSingleton(queryPort);
+        servicesCollection.AddSingleton(skillRunnerPort);
+        servicesCollection.AddSingleton(workflowAgentPort);
+        servicesCollection.AddSingleton(catalogCommandPort);
+        servicesCollection.AddSingleton(nyxClient);
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        servicesCollection.AddSingleton(callerScopeResolver);
+        var tool = new AgentBuilderTool(servicesCollection.BuildServiceProvider());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+            [ChannelMetadataKeys.ChatType] = "p2p",
+            [ChannelMetadataKeys.ConversationId] = "oc_chat_1",
+            [ChannelMetadataKeys.SenderId] = "ou_user_1",
+            ["scope_id"] = "scope-1",
+            // Inbound slug points at a bot that isn't in the user's user-services list.
+            [ChannelMetadataKeys.InboundChannelBotProxySlug] = "api-lark-bot-channel-disconnected",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "create_agent",
+                  "template": "daily_report",
+                  "agent_id": "skill-runner-missing",
+                  "github_username": "alice",
+                  "schedule_cron": "0 9 * * *",
+                  "schedule_timezone": "UTC"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            // Creation must NOT fail just because an optional fallback slug isn't connected.
+            doc.RootElement.GetProperty("status").GetString().Should().Be("created");
+
+            await skillRunnerPort.Received(1).InitializeAsync(
+                "skill-runner-missing",
+                Arg.Is<InitializeSkillRunnerCommand>(c =>
+                    string.IsNullOrEmpty(c.OutboundConfig.FailureNotificationProviderSlug)),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
+
+            // The disconnected slug must not leak into allowed_service_ids — that would
+            // create a permanent runtime 403 on the failure-notification path AND silently
+            // expand the agent's proxy reach beyond what the spec requires.
+            var apiKeyRequest = handler.Requests.Should()
+                .ContainSingle(x => x.Method == HttpMethod.Post && x.Path == "/api/v1/api-keys")
+                .Subject;
+            using var apiKeyDoc = JsonDocument.Parse(apiKeyRequest.Body!);
+            var allowed = apiKeyDoc.RootElement.GetProperty("allowed_service_ids").EnumerateArray()
+                .Select(static item => item.GetString())
+                .ToArray();
+            allowed.Should().BeEquivalentTo(["svc-github", "svc-lark"]);
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_CreateAgent_DailyReport_PicksEligibleRow_When_DuplicateSlugRowsExist()
     {
         // Codex review (PR #418 r3141846173): a user with mixed bindings can have multiple

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -443,6 +443,170 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         assertion.WithMessage("*/daily*");
     }
 
+    [Fact]
+    public async Task TrySendFailureAsync_ShouldUseFailureNotificationSlug_WhenSetAndDistinctFromPrimary()
+    {
+        // Issue #423 §C: when a primary outbound delivery has just been rejected (e.g. cross-
+        // tenant 99992364), retrying the failure notification through the SAME slug also
+        // fails. The fix routes failure-notifications through the inbound channel-bot's slug
+        // captured at agent-create time — by definition reachable, since the user just
+        // messaged it. This test pins that the routing actually changes the proxy slug in
+        // the outbound URL while the receive_id, body, and api key stay identical.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_dm_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+            FailureNotificationProviderSlug = "api-lark-bot-channel-loning",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"code":0,"msg":"success","data":{"message_id":"om_failure"}}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        await InvokeTrySendFailureAsync(_agent, "Lark message delivery rejected (code=99992364): user id cross tenant.");
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Be("https://nyx.example.com/api/v1/proxy/s/api-lark-bot-channel-loning/open-apis/im/v1/messages?receive_id_type=open_id");
+        using var body = JsonDocument.Parse(handler.LastBody!);
+        body.RootElement.GetProperty("receive_id").GetString().Should().Be("ou_user_1");
+        // The failure-notification message itself should carry the original error so the user
+        // sees the actionable hint in chat, not just an unsubscribe ping.
+        var contentJson = body.RootElement.GetProperty("content").GetString();
+        contentJson.Should().Contain("99992364");
+        contentJson.Should().Contain("Skill runner failed");
+    }
+
+    [Fact]
+    public async Task TrySendFailureAsync_ShouldFallBackToPrimarySlug_WhenFailureNotificationSlugRejects()
+    {
+        // Defense-in-depth: the failure-notification slug MAY have been valid at create time
+        // (in user-services) but become inactive (token revoked, bot uninstalled, etc.) by
+        // the time the agent fires. If its send rejects, we still try the primary slug as
+        // a last-resort attempt — better than the user seeing nothing.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_dm_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+            FailureNotificationProviderSlug = "api-lark-bot-channel-revoked",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new SequencedHandler(
+            // Failure-notification slug rejects with a Nyx envelope error (e.g. 401 on the proxy)
+            """{"error":true,"message":"upstream auth failed"}""",
+            // Primary slug succeeds — best-effort recovery.
+            """{"code":0,"msg":"success","data":{"message_id":"om_primary_failure"}}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        await InvokeTrySendFailureAsync(_agent, "report rejected at primary");
+
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[0].RequestUri!.ToString()
+            .Should().Contain("/proxy/s/api-lark-bot-channel-revoked/");
+        handler.Requests[1].RequestUri!.ToString()
+            .Should().Contain("/proxy/s/api-lark-bot/");
+    }
+
+    [Fact]
+    public async Task TrySendFailureAsync_ShouldSkipFailureSlug_WhenEqualToPrimary()
+    {
+        // No-op fallback: if the inbound slug equals the primary slug there is no recovery
+        // benefit — same proxy = same rejection mode. AgentBuilderTool leaves the field
+        // empty in this case, but pin the runtime guard too so a future
+        // mis-capture doesn't pay double-POST cost just to fail twice.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_dm_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+            FailureNotificationProviderSlug = "api-lark-bot",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"code":0,"msg":"success"}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        await InvokeTrySendFailureAsync(_agent, "primary failed");
+
+        // Exactly one POST — no double-attempt against the same slug.
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Contain("/proxy/s/api-lark-bot/");
+    }
+
+    [Fact]
+    public async Task TrySendFailureAsync_ShouldUsePrimary_WhenFailureNotificationSlugIsEmpty()
+    {
+        // Backwards compat: agents created before #423 §C have an empty
+        // FailureNotificationProviderSlug. The runtime must transparently fall back to the
+        // existing single-attempt behavior — this test is the regression guard against the
+        // failure-notification fallback ever introducing a hidden dependency on the new
+        // field being populated.
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_dm_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+            // FailureNotificationProviderSlug intentionally not set (legacy state shape).
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new RecordingHandler("""{"code":0,"msg":"success"}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        await InvokeTrySendFailureAsync(_agent, "primary failed");
+
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.RequestUri!.ToString()
+            .Should().Contain("/proxy/s/api-lark-bot/");
+    }
+
+    [Fact]
+    public async Task TrySendFailureAsync_ShouldSwallow_WhenBothSlugsReject()
+    {
+        // Final guarantee: TrySendFailureAsync MUST NOT throw, ever. HandleTriggerAsync is
+        // already in the failure-event-persist path; an exception here would mask the
+        // SkillRunnerExecutionFailedEvent persist (which surfaces last_error in
+        // /agent-status, the one path users have to recover regardless of Lark visibility).
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig = new SkillRunnerOutboundConfig
+        {
+            ConversationId = "oc_dm_chat_1",
+            NyxProviderSlug = "api-lark-bot",
+            NyxApiKey = "nyx-api-key",
+            LarkReceiveId = "ou_user_1",
+            LarkReceiveIdType = "open_id",
+            FailureNotificationProviderSlug = "api-lark-bot-channel-loning",
+        };
+        await _agent.HandleInitializeAsync(initialize);
+
+        var handler = new SequencedHandler(
+            """{"error":true,"message":"failure-slug down"}""",
+            """{"code":99992364,"msg":"user id cross tenant"}""");
+        AttachNyxIdApiClient(_agent, handler);
+
+        // Should complete (not throw) even though both attempts fail.
+        Func<Task> act = () => InvokeTrySendFailureAsync(_agent, "both broken");
+
+        await act.Should().NotThrowAsync();
+        handler.Requests.Should().HaveCount(2);
+    }
+
     private static void AttachNyxIdApiClient(SkillRunnerGAgent agent, HttpMessageHandler handler)
     {
         var client = new NyxIdApiClient(
@@ -457,11 +621,27 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
     private static Task InvokeSendOutputAsync(SkillRunnerGAgent agent, string output)
     {
+        // Disambiguate against the 3-arg `SendOutputAsync(output, providerSlugOverride, ct)`
+        // overload introduced for the failure-notification fallback (#423 §C). The 2-arg
+        // overload still routes through the primary `NyxProviderSlug`, which is what every
+        // existing test exercises.
         var method = typeof(SkillRunnerGAgent).GetMethod(
             "SendOutputAsync",
-            BindingFlags.Instance | BindingFlags.NonPublic);
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(string), typeof(CancellationToken)],
+            modifiers: null);
         method.Should().NotBeNull();
         return (Task)method!.Invoke(agent, [output, CancellationToken.None])!;
+    }
+
+    private static Task InvokeTrySendFailureAsync(SkillRunnerGAgent agent, string error)
+    {
+        var method = typeof(SkillRunnerGAgent).GetMethod(
+            "TrySendFailureAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+        return (Task)method!.Invoke(agent, [error, CancellationToken.None])!;
     }
 
     private sealed class RecordingHandler(string responseBody) : HttpMessageHandler

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerOutputChunkerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerOutputChunkerTests.cs
@@ -1,0 +1,166 @@
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+/// <summary>
+/// Pins <see cref="SkillRunnerOutputChunker.Split"/>'s behavior so future copy edits to
+/// continuation markers, MaxLarkTextLength, or the splitting heuristic do not silently
+/// regress the §C chunked-delivery contract from issue #423.
+/// </summary>
+public sealed class SkillRunnerOutputChunkerTests
+{
+    [Fact]
+    public void Split_WhenOutputIsEmpty_ShouldReturnSingleEmptyChunk()
+    {
+        // Empty input is a valid SkillRunner result (e.g. early-return guard in
+        // ExecuteSkillAsync replaces null/whitespace with "No update generated.", but the
+        // chunker is a pure function without that knowledge). Returning a single-element
+        // list with the input verbatim keeps the dispatch loop in ExecuteSkillAsync uniform
+        // for both single-message and chunked paths.
+        SkillRunnerOutputChunker.Split(string.Empty)
+            .Should().ContainSingle().Which.Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Split_WhenOutputFitsInOneMessage_ShouldReturnInputVerbatim()
+    {
+        var output = string.Concat(Enumerable.Repeat("alpha\n", 100));
+
+        var chunks = SkillRunnerOutputChunker.Split(output);
+
+        chunks.Should().ContainSingle();
+        // Verbatim — no continuation markers, no rewriting. The single-chunk path must
+        // be byte-identical to the input so existing single-message tests do not see
+        // markers appended to short outputs as a side effect of #423 §C.
+        chunks[0].Should().Be(output);
+    }
+
+    [Fact]
+    public void Split_AtExactlyMaxLarkTextLength_ShouldReturnSingleChunk()
+    {
+        // Cap is inclusive: a report exactly at MaxLarkTextLength fits, no marker needed.
+        // Pinning this so a future "<=" → "<" off-by-one introduces a spurious chunk-of-one
+        // with continuation markers when the input doesn't actually overflow.
+        var output = new string('x', SkillRunnerStreamingReplySink.MaxLarkTextLength);
+
+        var chunks = SkillRunnerOutputChunker.Split(output);
+
+        chunks.Should().ContainSingle();
+        chunks[0].Length.Should().Be(SkillRunnerStreamingReplySink.MaxLarkTextLength);
+    }
+
+    [Fact]
+    public void Split_WithMultipleParagraphBoundaries_ShouldSplitAtLatestBoundaryWithinBudget()
+    {
+        // Build an output that exceeds the cap and contains paragraph boundaries near the
+        // cap. The chunker must pick the LATEST `\n\n` within budget so each chunk
+        // maximizes throughput per message — picking an earlier boundary would over-split
+        // and stretch the report across more messages than necessary.
+        const int sectionSize = 5_000;
+        var paragraph = new string('p', sectionSize);
+        var output = string.Join("\n\n", Enumerable.Repeat(paragraph, 8));
+        output.Length.Should().BeGreaterThan(SkillRunnerStreamingReplySink.MaxLarkTextLength);
+
+        var chunks = SkillRunnerOutputChunker.Split(output);
+
+        chunks.Should().HaveCountGreaterThan(1);
+
+        // Every rendered chunk must fit under the wire limit (raw content + markers).
+        foreach (var chunk in chunks)
+            chunk.Length.Should().BeLessThanOrEqualTo(SkillRunnerStreamingReplySink.MaxLarkTextLength);
+
+        // First chunk has only the trailing "[part 1/N • continues ↓]" marker; later
+        // chunks have a leading "[part k/N • continued ↑]" prefix. Continuation marker
+        // structure is part of the user-visible UX so worth pinning explicitly.
+        chunks[0].Should().Contain($"[part 1/{chunks.Count}");
+        chunks[0].Should().Contain("continues");
+        chunks[^1].Should().Contain($"[part {chunks.Count}/{chunks.Count}");
+        chunks[^1].Should().Contain("continued");
+    }
+
+    [Fact]
+    public void Split_WithNoParagraphBoundaries_ShouldHardSplitAtBudget()
+    {
+        // Pathological input — single huge run of characters with no `\n\n`. The chunker
+        // falls back to character-boundary splitting so the report still lands instead of
+        // being silently truncated at the cap. A regression here would either drop the
+        // tail (the pre-#423 behavior) or loop forever; the test pins both.
+        var output = new string('z', SkillRunnerStreamingReplySink.MaxLarkTextLength * 2 + 5_000);
+
+        var chunks = SkillRunnerOutputChunker.Split(output);
+
+        // Three chunks: two near-full (content budget = MaxLarkTextLength - markerOverhead)
+        // plus a small tail.
+        chunks.Should().HaveCount(3);
+        foreach (var chunk in chunks)
+            chunk.Length.Should().BeLessThanOrEqualTo(SkillRunnerStreamingReplySink.MaxLarkTextLength);
+
+        // Round-trip the raw content (strip markers) by reading just the 'z' characters.
+        // If the chunker drops or duplicates content, this character count check fails.
+        var totalZs = chunks.Sum(c => c.Count(ch => ch == 'z'));
+        totalZs.Should().Be(output.Length);
+    }
+
+    [Fact]
+    public void Split_PreservesAllContent_AcrossParagraphAwareSplit()
+    {
+        // Build a #423-shaped report: 9 numbered sections separated by blank lines, with
+        // each section padded to push the total over the cap. The chunker splits at the
+        // section seams (which is exactly what `\n\n` captures for the daily prompt's
+        // output schema), so reassembling the chunks (stripping markers) must produce
+        // the original content byte-for-byte minus the consumed `\n\n` separators.
+        var sections = new[]
+        {
+            "Daily report — alice — last 24h",
+            "Shipped:\n" + string.Concat(Enumerable.Repeat("- [aevatarAI/aevatar#100] feat\n", 400)),
+            "In flight:\n" + string.Concat(Enumerable.Repeat("- [aevatarAI/aevatar#200] open pr\n", 400)),
+            "Reviews:\n" + string.Concat(Enumerable.Repeat("- approved 2 / commented 1\n", 400)),
+            "Issues:\n" + string.Concat(Enumerable.Repeat("- closed bug\n", 400)),
+            "CI:\nNo failing runs.",
+            "Trend: shipped 7 (+2), reviews 4 (-1)",
+            "Blockers: No blockers.",
+            "Source health: github.api 200ok",
+        };
+        var output = string.Join("\n\n", sections);
+        output.Length.Should().BeGreaterThan(SkillRunnerStreamingReplySink.MaxLarkTextLength);
+
+        var chunks = SkillRunnerOutputChunker.Split(output);
+        chunks.Should().HaveCountGreaterThan(1);
+
+        // Strip markers from each chunk by removing the bracketed "[part k/N • ...]" lines
+        // and rejoin. The result should still contain every section's body — the chunker
+        // must not drop or duplicate any content.
+        foreach (var section in sections)
+        {
+            var combined = string.Join("\n\n", chunks);
+            combined.Should().Contain(section.AsSpan(0, Math.Min(60, section.Length)).ToString(),
+                $"section starting `{section[..Math.Min(40, section.Length)]}` should appear in some chunk");
+        }
+    }
+
+    [Fact]
+    public void Split_OnlyOverflowingTailGetsItsOwnChunk_NotEntireInput()
+    {
+        // When the input barely exceeds the cap (cap + a few KB), we still split into ≥2
+        // chunks (we cannot fit it all in one message), but the second chunk should be
+        // SMALL — most of the content rode out on chunk 0. A regression that always
+        // 50/50 split, for example, would surface on this test. Use distinct *body*
+        // characters that do NOT appear in the continuation markers ("[part k/N • continues ↓]" /
+        // "[part k/N • continued ↑]"); 'X' and 'Y' are good — comparing 't' vs 'h' would
+        // double-count the marker copy of "part" / "continues" / "continued".
+        var head = new string('X', SkillRunnerStreamingReplySink.MaxLarkTextLength - 1_000);
+        var tail = new string('Y', 5_000);
+        var output = head + "\n\n" + tail;
+
+        var chunks = SkillRunnerOutputChunker.Split(output);
+
+        chunks.Should().HaveCount(2);
+        // chunk[0] holds the head; no Y body characters from the tail leak in.
+        chunks[0].Count(ch => ch == 'X').Should().Be(head.Length);
+        chunks[0].Count(ch => ch == 'Y').Should().Be(0);
+        // chunk[1] holds the tail; no X body characters from the head leak in.
+        chunks[1].Count(ch => ch == 'Y').Should().Be(tail.Length);
+        chunks[1].Count(ch => ch == 'X').Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the remaining acceptance items on #423 — the §C cross-cutting safety net.
After PRs #458 (§A structured prompt) and #469 (§B streaming-edit), this PR
delivers the last two items so the issue can close cleanly:

1. **§C-1 Failure-notification cross-tenant fallback.** When the primary outbound
   proxy is structurally rejected (e.g. cross-tenant `99992364`), the previous
   `TrySendFailureAsync` retried through the *same* proxy and the user saw
   nothing. Now the agent captures the inbound channel-bot's NyxID slug at
   create time — by definition reachable, since the user just messaged it —
   and `TrySendFailureAsync` tries that slug first, falling back to the primary
   only when the captured slug also rejects (or wasn't captured / equals
   primary).

2. **§C-2 Section-boundary chunked delivery.** Outputs > 30 KB used to be
   truncated at the cap with a `…[truncated]` marker. The new
   `SkillRunnerOutputChunker.Split()` paragraph-aware splitter keeps the full
   report by emitting `[part k/N • continued ↑/continues ↓]` chunks. chunk[0]
   flows through the existing streaming-edit sink (the in-flight message
   lands as part 1); chunks 1..N go as fresh one-shot POSTs.

## Implementation

| Layer | Change |
|---|---|
| Proto (`skill_runner.proto`) | `SkillRunnerOutboundConfig.failure_notification_provider_slug` (field 12) |
| Channel runtime (`ChannelMetadataKeys.cs`, `ChannelConversationTurnRunner.cs`) | New `InboundChannelBotProxySlug` key; `BuildReplyMetadata` populates it from `ChannelInboundEvent.NyxProviderSlug` |
| Agent builder (`AgentBuilderTool.cs`) | Refactored `ResolveProxyServiceIdsAsync` to also return the eligible slug map (no second `/user-services` round-trip). `ResolveFailureNotificationContext` decides whether to capture the inbound slug + expand `allowed_service_ids` to include its `UserService.id` |
| Skill runner (`SkillRunnerGAgent.cs`) | `SendOutputAsync` parameterized by `providerSlugOverride`; `TrySendFailureAsync` tries failure slug first then falls back to primary; `ExecuteSkillAsync` invokes `SkillRunnerOutputChunker.Split()` and dispatches chunk[0] via sink + chunks 1..N via `SendOutputAsync` |
| Output chunker (`SkillRunnerOutputChunker.cs`, new) | Pure-function paragraph-boundary splitter with char-boundary fallback for runaway single-paragraph inputs |
| Docs (`docs/canon/daily-command-pipeline.md`) | §3, §8, §9.3, §11, §17 updated to mark §C landed and reflect the new flow |

The two paths are independent and could ship separately, but they're both
small and both close the same issue, so one PR keeps the change ergonomically
scoped to "everything #423 §C asked for".

## Out of scope (deliberate)

- **Catalog (`UserAgentCatalogEntry`) not extended.** Runtime routing reads from
  actor State; the catalog is for listing/status. If a future workflow agent
  needs the same fallback exposed at the catalog reader level, add the field
  then — premature now.
- **Streaming sink does NOT mid-stream switch messages when accumulated text
  passes 30 KB.** Truncate-and-finalize-then-chunk keeps the streaming-edit
  UX (one growing message) for the common case and only fans out to N
  messages after the LLM finishes. The issue text recommends "split on section
  boundaries, send N messages" — this is what landed. A future enhancement
  could do multi-message streaming-edit, but it's a bigger surface and not
  required for §C.

## Test coverage

- **15 new tests, 633 existing tests still pass:**
  - `SkillRunnerOutputChunkerTests` (7) — empty, exactly-at-cap, multi-paragraph, no-paragraph hard split, content preservation, tail-only overflow, all-content-round-trip
  - `SkillRunnerGAgentTests` (5) — primary distinct → failure slug used; failure slug rejects → fall back; failure slug == primary → no double POST; empty failure slug (legacy) → primary path; both reject → swallowed
  - `AgentBuilderToolTests` (3) — captured + svc-id in `allowed_service_ids`; inbound == primary → empty; inbound missing from user-services → empty + creation succeeds + allowed_service_ids unchanged

## Test plan

- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/...` — 648 passed
- [x] `dotnet test test/Aevatar.AI.Tests/...` — 483 passed
- [x] `dotnet test test/Aevatar.AI.Core.Tests/...` — 68 passed
- [x] `dotnet test test/Aevatar.Architecture.Tests/...` — 105 passed
- [x] `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/...` — 123 passed
- [x] Targeted CI guards (query_projection_priming, projection_state_version, projection_state_mirror_current_state, workflow_binding_boundary, test_stability) — all pass
- [x] `bash tools/docs/lint.sh` — 32 files, 0 errors
- [ ] Manual smoke: revoke outbound `s/api-lark-bot` access for a test user → trigger `/run-agent` → verify the failure message lands via the inbound channel-bot slug
- [ ] Manual smoke: force a > 30 KB daily report → verify chunked delivery (streamed part 1 + N additional messages with continuation markers)

Closes #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)