### PR TITLE
fix: make scope script save observation visible after upsert

### DIFF
--- a/src/platform/Aevatar.GAgentService.Application/Scripts/ScopeScriptCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Scripts/ScopeScriptCommandApplicationService.cs
@@ -11,15 +11,18 @@ public sealed class ScopeScriptCommandApplicationService : IScopeScriptCommandPo
 {
     private readonly IScriptDefinitionCommandPort _definitionCommandPort;
     private readonly IScriptCatalogCommandPort _catalogCommandPort;
+    private readonly IScriptAuthorityReadModelActivationPort _authorityReadModelActivationPort;
     private readonly ScopeScriptCapabilityOptions _options;
 
     public ScopeScriptCommandApplicationService(
         IScriptDefinitionCommandPort definitionCommandPort,
         IScriptCatalogCommandPort catalogCommandPort,
+        IScriptAuthorityReadModelActivationPort authorityReadModelActivationPort,
         IOptions<ScopeScriptCapabilityOptions> options)
     {
         _definitionCommandPort = definitionCommandPort ?? throw new ArgumentNullException(nameof(definitionCommandPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
+        _authorityReadModelActivationPort = authorityReadModelActivationPort ?? throw new ArgumentNullException(nameof(authorityReadModelActivationPort));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value ?? throw new InvalidOperationException("Scope script capability options are required.");
     }
@@ -39,6 +42,9 @@ public sealed class ScopeScriptCommandApplicationService : IScopeScriptCommandPo
         var catalogActorId = _options.BuildCatalogActorId(normalizedScopeId);
         var sourceHash = ComputeSha256(sourceText);
         var proposalId = BuildProposalId(normalizedScopeId, normalizedScriptId, revisionId);
+
+        await _authorityReadModelActivationPort.ActivateAsync(definitionActorId, ct);
+        await _authorityReadModelActivationPort.ActivateAsync(catalogActorId, ct);
 
         var definitionUpsert = await _definitionCommandPort.UpsertDefinitionWithSnapshotAsync(
             normalizedScriptId,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeScriptCapabilityServiceTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeScriptCapabilityServiceTests.cs
@@ -35,9 +35,11 @@ public sealed class ScopeScriptApplicationServicesTests
                 new ScriptingCommandAcceptedReceipt(expectedDefinitionActorId, "definition-command-1", "definition-correlation-1")),
         };
         var catalogCommandPort = new FakeScriptCatalogCommandPort();
+        var authorityReadModelActivationPort = new RecordingScriptAuthorityReadModelActivationPort();
         var service = new ScopeScriptCommandApplicationService(
             definitionCommandPort,
             catalogCommandPort,
+            authorityReadModelActivationPort,
             Options.Create(options));
 
         var result = await service.UpsertAsync(
@@ -57,6 +59,7 @@ public sealed class ScopeScriptApplicationServicesTests
         result.DefinitionActorId.Should().Be(expectedDefinitionActorId);
         result.DefinitionCommand.CommandId.Should().Be("definition-command-1");
         result.CatalogCommand.CommandId.Should().Be("catalog-command-1");
+        authorityReadModelActivationPort.Calls.Should().Equal(expectedDefinitionActorId, expectedCatalogActorId);
 
         definitionCommandPort.LastRequest.Should().BeEquivalentTo(
             new FakeScriptDefinitionCommandPort.Request(
@@ -424,6 +427,18 @@ public sealed class ScopeScriptApplicationServicesTests
             string SourceHash,
             string? DefinitionActorId,
             string? ScopeId);
+    }
+
+    private sealed class RecordingScriptAuthorityReadModelActivationPort : IScriptAuthorityReadModelActivationPort
+    {
+        public List<string> Calls { get; } = [];
+
+        public Task ActivateAsync(string actorId, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Calls.Add(actorId);
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class FakeScriptCatalogCommandPort : IScriptCatalogCommandPort

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeScriptSaveObservationRuntimeTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeScriptSaveObservationRuntimeTests.cs
@@ -1,0 +1,140 @@
+using Aevatar.Foundation.Runtime.Implementations.Local.DependencyInjection;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Hosting.DependencyInjection;
+using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Core.Ports;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgentService.Integration.Tests;
+
+public sealed class ScopeScriptSaveObservationRuntimeTests
+{
+    private static readonly TimeSpan ObservationTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ObservationPollInterval = TimeSpan.FromMilliseconds(50);
+
+    [Fact]
+    public async Task UpsertAsync_ShouldMakeAcceptedCatalogPromotionObservable_WithRealInMemoryProjection()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["GAgentService:Demo:Enabled"] = "false",
+                ["Projection:Document:Providers:InMemory:Enabled"] = "true",
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+                ["Projection:Graph:Providers:InMemory:Enabled"] = "true",
+                ["Projection:Graph:Providers:Neo4j:Enabled"] = "false",
+                ["Projection:Policies:Environment"] = "Development",
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddAevatarRuntime();
+        services.AddGAgentServiceCapability(configuration);
+
+        await using var provider = services.BuildServiceProvider();
+        var commandPort = provider.GetRequiredService<IScopeScriptCommandPort>();
+        var observationPort = provider.GetRequiredService<IScopeScriptSaveObservationPort>();
+        var queryPort = provider.GetRequiredService<IScopeScriptQueryPort>();
+        var definitionSnapshotPort = provider.GetRequiredService<IScriptDefinitionSnapshotPort>();
+
+        var scopeId = $"scope-{Guid.NewGuid():N}";
+        var scriptId = $"script-{Guid.NewGuid():N}";
+        const string revisionId = "draft-1";
+        var accepted = await commandPort.UpsertAsync(
+            new ScopeScriptUpsertRequest(
+                scopeId,
+                scriptId,
+                CatalogOnlyBehaviorSource,
+                revisionId),
+            CancellationToken.None);
+        var observationRequest = new ScopeScriptSaveObservationRequest(
+            accepted.RevisionId,
+            accepted.DefinitionActorId,
+            accepted.SourceHash,
+            accepted.AcceptedScript.ProposalId,
+            accepted.AcceptedScript.ExpectedBaseRevision,
+            accepted.AcceptedScript.AcceptedAt);
+
+        var observation = await WaitForObservationAsync(
+            token => observationPort.ObserveAsync(scopeId, scriptId, observationRequest, token),
+            CancellationToken.None);
+        var scripts = await queryPort.ListAsync(scopeId, CancellationToken.None);
+        var definitionSnapshot = await WaitForDefinitionSnapshotAsync(
+            token => definitionSnapshotPort.TryGetAsync(accepted.DefinitionActorId, revisionId, token),
+            CancellationToken.None);
+
+        observation.Status.Should().Be(ScopeScriptSaveObservationStatuses.Applied);
+        observation.CurrentScript.Should().NotBeNull();
+        observation.CurrentScript!.ScriptId.Should().Be(scriptId);
+        observation.CurrentScript.ActiveRevision.Should().Be(revisionId);
+        scripts.Should().ContainSingle(script => script.ScriptId == scriptId);
+        definitionSnapshot.ScriptId.Should().Be(scriptId);
+        definitionSnapshot.Revision.Should().Be(revisionId);
+    }
+
+    private static async Task<ScopeScriptSaveObservationResult> WaitForObservationAsync(
+        Func<CancellationToken, Task<ScopeScriptSaveObservationResult>> observeAsync,
+        CancellationToken ct)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ObservationTimeout);
+
+        ScopeScriptSaveObservationResult? last = null;
+        try
+        {
+            while (true)
+            {
+                last = await observeAsync(timeoutCts.Token);
+                if (string.Equals(last.Status, ScopeScriptSaveObservationStatuses.Applied, StringComparison.Ordinal))
+                    return last;
+
+                await Task.Delay(ObservationPollInterval, timeoutCts.Token);
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"Script save observation did not apply before timeout. last_status={last?.Status ?? "<none>"}");
+        }
+    }
+
+    private static async Task<ScriptDefinitionSnapshot> WaitForDefinitionSnapshotAsync(
+        Func<CancellationToken, Task<ScriptDefinitionSnapshot?>> readAsync,
+        CancellationToken ct)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(ObservationTimeout);
+
+        try
+        {
+            while (true)
+            {
+                var snapshot = await readAsync(timeoutCts.Token);
+                if (snapshot != null)
+                    return snapshot;
+
+                await Task.Delay(ObservationPollInterval, timeoutCts.Token);
+            }
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new InvalidOperationException("Script definition snapshot did not appear before timeout.");
+        }
+    }
+
+    private const string CatalogOnlyBehaviorSource =
+        """
+        using Google.Protobuf.WellKnownTypes;
+        using Aevatar.Scripting.Abstractions.Behaviors;
+
+        public sealed class CatalogOnlyBehavior : ScriptBehavior<StringValue, StringValue>
+        {
+            protected override void Configure(IScriptBehaviorBuilder<StringValue, StringValue> builder)
+            {
+                builder.ProjectState(static (state, _) => state ?? new StringValue());
+            }
+        }
+        """;
+}

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeScriptCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeScriptCommandApplicationServiceTests.cs
@@ -36,6 +36,27 @@ public sealed class ScopeScriptCommandApplicationServiceTests
     }
 
     [Fact]
+    public async Task UpsertAsync_ShouldActivateAuthorityReadModelsBeforeWritingDefinitionAndCatalog()
+    {
+        var executionLog = new List<string>();
+        var definitionPort = new RecordingDefinitionCommandPort(executionLog);
+        var catalogPort = new RecordingCatalogCommandPort(executionLog);
+        var activationPort = new RecordingScriptAuthorityReadModelActivationPort(executionLog);
+        var service = BuildService(definitionPort, catalogPort, activationPort);
+        var expectedDefinitionActorId = DefaultOptions.BuildDefinitionActorId("scope-1", "my-script", "rev-1");
+        var expectedCatalogActorId = DefaultOptions.BuildCatalogActorId("scope-1");
+
+        await service.UpsertAsync(new ScopeScriptUpsertRequest("scope-1", "my-script", "source", "rev-1"));
+
+        activationPort.Calls.Should().Equal(expectedDefinitionActorId, expectedCatalogActorId);
+        executionLog.Should().Equal(
+            $"authority-activate:{expectedDefinitionActorId}",
+            $"authority-activate:{expectedCatalogActorId}",
+            "definition-upsert",
+            "catalog-promote");
+    }
+
+    [Fact]
     public async Task UpsertAsync_ShouldComputeSourceHash()
     {
         var definitionPort = new RecordingDefinitionCommandPort();
@@ -121,14 +142,39 @@ public sealed class ScopeScriptCommandApplicationServiceTests
 
     private static ScopeScriptCommandApplicationService BuildService(
         IScriptDefinitionCommandPort definitionPort,
-        IScriptCatalogCommandPort catalogPort) =>
+        IScriptCatalogCommandPort catalogPort,
+        IScriptAuthorityReadModelActivationPort? authorityReadModelActivationPort = null) =>
         new(
             definitionPort,
             catalogPort,
+            authorityReadModelActivationPort ?? new RecordingScriptAuthorityReadModelActivationPort(),
             Options.Create(DefaultOptions));
+
+    private sealed class RecordingScriptAuthorityReadModelActivationPort : IScriptAuthorityReadModelActivationPort
+    {
+        private readonly List<string>? _executionLog;
+
+        public RecordingScriptAuthorityReadModelActivationPort(List<string>? executionLog = null) =>
+            _executionLog = executionLog;
+
+        public List<string> Calls { get; } = [];
+
+        public Task ActivateAsync(string actorId, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            Calls.Add(actorId);
+            _executionLog?.Add($"authority-activate:{actorId}");
+            return Task.CompletedTask;
+        }
+    }
 
     private sealed class RecordingDefinitionCommandPort : IScriptDefinitionCommandPort
     {
+        private readonly List<string>? _executionLog;
+
+        public RecordingDefinitionCommandPort(List<string>? executionLog = null) =>
+            _executionLog = executionLog;
+
         public string ResultActorId { get; } = "def-actor-1";
 
         public List<(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, string? scopeId)> Calls { get; } = [];
@@ -141,6 +187,7 @@ public sealed class ScopeScriptCommandApplicationServiceTests
             string? definitionActorId,
             CancellationToken ct)
         {
+            _executionLog?.Add("definition-upsert");
             Calls.Add((scriptId, scriptRevision, sourceText, sourceHash, definitionActorId, null));
             return Task.FromResult(new ScriptDefinitionUpsertResult(
                 ResultActorId,
@@ -159,6 +206,7 @@ public sealed class ScopeScriptCommandApplicationServiceTests
             string? scopeId,
             CancellationToken ct)
         {
+            _executionLog?.Add("definition-upsert");
             Calls.Add((scriptId, scriptRevision, sourceText, sourceHash, definitionActorId, scopeId));
             return Task.FromResult(new ScriptDefinitionUpsertResult(
                 ResultActorId,
@@ -172,6 +220,11 @@ public sealed class ScopeScriptCommandApplicationServiceTests
 
     private sealed class RecordingCatalogCommandPort : IScriptCatalogCommandPort
     {
+        private readonly List<string>? _executionLog;
+
+        public RecordingCatalogCommandPort(List<string>? executionLog = null) =>
+            _executionLog = executionLog;
+
         public DateTimeOffset AcceptedAt { get; } = new(2026, 4, 13, 9, 0, 0, TimeSpan.Zero);
 
         public List<(string? catalogActorId, string scriptId, string expectedBaseRevision, string revision, string definitionActorId, string sourceHash, string proposalId, string? scopeId)> Calls { get; } = [];
@@ -186,6 +239,7 @@ public sealed class ScopeScriptCommandApplicationServiceTests
             string proposalId,
             CancellationToken ct)
         {
+            _executionLog?.Add("catalog-promote");
             Calls.Add((catalogActorId, scriptId, expectedBaseRevision, revision, definitionActorId, sourceHash, proposalId, null));
             return Task.FromResult(new ScriptingCommandAcceptedReceipt(
                 catalogActorId ?? "catalog-actor-1",
@@ -205,6 +259,7 @@ public sealed class ScopeScriptCommandApplicationServiceTests
             string? scopeId,
             CancellationToken ct)
         {
+            _executionLog?.Add("catalog-promote");
             Calls.Add((catalogActorId, scriptId, expectedBaseRevision, revision, definitionActorId, sourceHash, proposalId, scopeId));
             return Task.FromResult(new ScriptingCommandAcceptedReceipt(
                 catalogActorId ?? "catalog-actor-1",

--- a/tools/ci/test_polling_allowlist.txt
+++ b/tools/ci/test_polling_allowlist.txt
@@ -3,6 +3,7 @@ test/Aevatar.Foundation.Runtime.Hosting.Tests/DistributedClusterConsistencyInteg
 test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
 test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationTestKit.cs
 test/Aevatar.Integration.Tests/ScriptReadModelVisibilityTestHelper.cs
+test/Aevatar.GAgentService.Integration.Tests/ScopeScriptSaveObservationRuntimeTests.cs
 test/Aevatar.Foundation.Runtime.Hosting.Tests/DistributedMixedVersionClusterIntegrationTests.cs
 test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansMassTransitRuntimeIntegrationTests.cs
 test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansKafkaProviderRuntimeIntegrationTests.cs


### PR DESCRIPTION
## Summary

- Activate script authority read models for both the definition actor and catalog actor before dispatching scope script definition/catalog write commands.
- Ensure accepted scope script saves can become visible through the existing catalog read model and definition snapshot projection path.
- Add focused unit and integration coverage for authority read-model activation order and real in-memory projection observation after script save.

## Issue

Fixes #488.

## Validation

- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter ScopeScriptCommandApplicationServiceTests` — 7 passed
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "ScopeScriptApplicationServicesTests|ScopeScriptSaveObservationRuntimeTests"` — 8 passed
- `bash tools/ci/test_stability_guards.sh` — passed
- `bash tools/ci/query_projection_priming_guard.sh` — passed

## Notes

- The new integration test uses in-memory runtime/projection settings to match the issue investigation environment.
- The test includes polling because it validates cross-component eventual consistency through the real in-memory projection path; the file is added to `tools/ci/test_polling_allowlist.txt`.