### PR TITLE
Fix StudioTeam DI gap and prevent regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,24 @@ jobs:
       - name: EventSourcing Regression
         run: bash tools/ci/event_sourcing_regression.sh
 
+  host-composition-smoke:
+    if: |
+      github.event_name != 'schedule' && (
+        github.event_name == 'pull_request' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare Runner
+        uses: ./.github/actions/prepare-runner
+
+      - name: Host Composition Smoke (DI ValidateOnBuild)
+        run: bash tools/ci/host_composition_smoke.sh
+
   coverage-quality:
     if: |
       github.event_name == 'pull_request' ||

--- a/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Aevatar.GAgents.Registry;
 using Aevatar.GAgents.RoleCatalog;
 using Aevatar.GAgents.StreamingProxyParticipant;
 using Aevatar.GAgents.StudioMember;
+using Aevatar.GAgents.StudioTeam;
 using Aevatar.GAgents.UserConfig;
 using Aevatar.GAgents.UserMemory;
 using Aevatar.Studio.Projection.ReadModels;
@@ -68,6 +69,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             RegisterElasticsearch<StreamingProxyParticipantCurrentStateDocument>(services, configuration);
             RegisterElasticsearch<UserConfigCurrentStateDocument>(services, configuration);
             RegisterElasticsearch<StudioMemberCurrentStateDocument>(services, configuration);
+            RegisterElasticsearch<StudioTeamCurrentStateDocument>(services, configuration);
         }
         else
         {
@@ -80,6 +82,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             RegisterInMemory<StreamingProxyParticipantCurrentStateDocument>(services);
             RegisterInMemory<UserConfigCurrentStateDocument>(services);
             RegisterInMemory<StudioMemberCurrentStateDocument>(services);
+            RegisterInMemory<StudioTeamCurrentStateDocument>(services);
         }
 
         return services;
@@ -128,7 +131,8 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
                && HasDocumentReaderForProvider<UserMemoryCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<StreamingProxyParticipantCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind)
-               && HasDocumentReaderForProvider<StudioMemberCurrentStateDocument>(services, providerKind);
+               && HasDocumentReaderForProvider<StudioMemberCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<StudioTeamCurrentStateDocument>(services, providerKind);
     }
 
     private static bool HasAnyDocumentReader<TDoc>(IServiceCollection services)
@@ -211,7 +215,8 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             StreamingProxyParticipantGAgentState.Descriptor,
             ChatHistoryIndexState.Descriptor,
             ChatConversationState.Descriptor,
-            StudioMemberState.Descriptor);
+            StudioMemberState.Descriptor,
+            StudioTeamState.Descriptor);
     }
 
     private enum DocumentProviderKind

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -90,6 +90,7 @@ bash "${SCRIPT_DIR}/channel_inbox_gagent_guard.sh"
 bash "${SCRIPT_DIR}/channel_relay_nyx_chat_direct_create_guard.sh"
 bash "${SCRIPT_DIR}/channel_tombstone_proto_field_guard.sh"
 bash "${SCRIPT_DIR}/agent_tool_delivery_target_reader_guard.sh"
+bash "${SCRIPT_DIR}/studio_projection_readmodel_registration_guard.sh"
 
 secret_store_scan_roots=()
 while IFS= read -r host_dir; do

--- a/tools/ci/host_composition_smoke.sh
+++ b/tools/ci/host_composition_smoke.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Host composition smoke — fails fast if Mainnet.Host.Api can't pass
+# ValidateOnBuild.
+#
+# Aevatar.Mainnet.Host.Api enables ValidateOnBuild + ValidateScopes so the
+# container reports missing registrations at startup rather than the first
+# request. That's the right policy for a production host, but it means a
+# missing IProjectionDocumentReader<TDoc, string> (or any other transitive
+# Singleton dependency) is invisible to module-level unit tests and only
+# surfaces when the pod starts.
+#
+# This smoke runs MainnetHostCompositionTests, which actually builds the
+# full Aevatar.Mainnet.Host.Api container with InMemory providers. Cheap
+# (~30s build + 1s test) so it runs on every PR.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+dotnet test test/Aevatar.Hosting.Tests/Aevatar.Hosting.Tests.csproj \
+  --nologo \
+  --tl:off \
+  -p:UseSharedCompilation=false \
+  -p:NuGetAudit=false \
+  --filter "FullyQualifiedName~MainnetHostCompositionTests"

--- a/tools/ci/studio_projection_readmodel_registration_guard.sh
+++ b/tools/ci/studio_projection_readmodel_registration_guard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Studio projection read-model registration guard.
+#
+# Every concrete IProjectionReadModel<TDoc> implementation under
+# src/Aevatar.Studio.Projection/ReadModels/ must be registered in
+# src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+# with all three of:
+#
+#   - RegisterElasticsearch<TDoc>(...)
+#   - RegisterInMemory<TDoc>(...)
+#   - HasDocumentReaderForProvider<TDoc>(...)   (inside HasAllStudioDocumentReaders)
+#
+# Without these, IProjectionDocumentReader<TDoc, string> stays unresolved in DI,
+# and Mainnet host startup fails ValidateOnBuild as soon as a query port that
+# consumes it is pulled into the container. The Studio module's own unit tests
+# stub IProjectionDocumentReader<TDoc, string> directly, so they pass, and
+# the gap only surfaces at host startup — which is exactly what bit ADR-0017
+# step 6+9 (StudioTeamCurrentStateDocument).
+#
+# Failure mode this prevents: a new TDoc + projector + query port lands in
+# Studio.Projection without the hosting registration; module tests stay green;
+# Mainnet host can't start.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+readmodel_dir="src/Aevatar.Studio.Projection/ReadModels"
+hosting_file="src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs"
+
+if [ ! -d "${readmodel_dir}" ] || [ ! -f "${hosting_file}" ]; then
+  echo "studio_projection_readmodel_registration_guard: skipping (paths absent)"
+  exit 0
+fi
+
+# Extract every TDoc named in `IProjectionReadModel<TDoc>` under the read-model
+# directory. The `<` after `IProjectionReadModel` excludes interface-member
+# references like `string IProjectionReadModel.ActorId`. Generic doc-comment
+# references use `{TDoc}` not `<TDoc>` so they don't match either.
+docs="$(
+  rg --type cs -No --no-filename --pcre2 \
+     '\bIProjectionReadModel<\s*(\w+)\s*>' \
+     "${readmodel_dir}" \
+     -r '$1' \
+  | sort -u || true
+)"
+
+if [ -z "${docs}" ]; then
+  echo "studio_projection_readmodel_registration_guard: no IProjectionReadModel<TDoc> declarations found (skipping)"
+  exit 0
+fi
+
+missing=""
+while IFS= read -r doc; do
+  [ -z "${doc}" ] && continue
+  for pattern in \
+    "RegisterElasticsearch<${doc}>" \
+    "RegisterInMemory<${doc}>" \
+    "HasDocumentReaderForProvider<${doc}>" \
+  ; do
+    if ! rg -q --fixed-strings "${pattern}" "${hosting_file}"; then
+      missing+="  ${doc}: ${pattern}(...) is not called"$'\n'
+    fi
+  done
+done <<< "${docs}"
+
+if [ -n "${missing}" ]; then
+  echo "studio_projection_readmodel_registration_guard: incomplete read-model registration in ${hosting_file}:"
+  echo
+  echo "${missing}"
+  echo "Each Studio IProjectionReadModel<TDoc> must be wired through all three:"
+  echo "  - RegisterElasticsearch<TDoc>(services, configuration)"
+  echo "  - RegisterInMemory<TDoc>(services)"
+  echo "  - HasDocumentReaderForProvider<TDoc>(services, providerKind)   (inside HasAllStudioDocumentReaders)"
+  echo
+  echo "Without these, IProjectionDocumentReader<TDoc, string> stays unresolved and"
+  echo "Mainnet host startup fails ValidateOnBuild as soon as a query port pulls it in."
+  exit 1
+fi
+
+echo "studio_projection_readmodel_registration_guard: ok"


### PR DESCRIPTION
## Problem

Mainnet host startup fails on dev:

```
Unable to resolve service for type
'Aevatar.CQRS.Projection.Stores.Abstractions.IProjectionDocumentReader`2[
Aevatar.Studio.Projection.ReadModels.StudioTeamCurrentStateDocument, System.String]'
while attempting to activate
'Aevatar.Studio.Projection.QueryPorts.ProjectionStudioTeamQueryPort'.
```

ADR-0017 step 6+9 (`StudioTeam` projection + application service layer) added the
read model, projector, metadata provider, query port, and command port but
missed wiring `StudioTeamCurrentStateDocument` into
`StudioProjectionReadModelServiceCollectionExtensions`. With
`ValidateOnBuild = true` on `Aevatar.Mainnet.Host.Api`, the container build
fails immediately and the pod can't start.

Unrelated to PR #495 — that merge happened to be the dev tip when the gap
surfaced.

## Solution

### Fix the DI gap (`StudioProjectionReadModelServiceCollectionExtensions`)

- `RegisterElasticsearch<StudioTeamCurrentStateDocument>(...)`
- `RegisterInMemory<StudioTeamCurrentStateDocument>(...)`
- Extend `HasAllStudioDocumentReaders` predicate to require both providers.
- Add `StudioTeamState.Descriptor` to `BuildStudioStateTypeRegistry` (ES
  state-event deserialization).

### Prevent regression (two layers, both validated)

**Static guard** —
`tools/ci/studio_projection_readmodel_registration_guard.sh`:
scans every `IProjectionReadModel<TDoc>` under
`src/Aevatar.Studio.Projection/ReadModels/` and requires the hosting file
to call `RegisterElasticsearch<TDoc>`, `RegisterInMemory<TDoc>`, and
`HasDocumentReaderForProvider<TDoc>`. Wired into `architecture_guards.sh`
(runs in `fast-gates`). Cheap and immediate.

**Composition smoke** — new CI job `host-composition-smoke`:
runs `MainnetHostCompositionTests` on every PR. The existing test exercises
the full `Aevatar.Mainnet.Host.Api` container with InMemory providers and
would have caught this gap — but the test only ran in `slow-test-guards` /
`split-test-guards`, both gated to `schedule` / `workflow_dispatch`.
Adding a dedicated job ensures every PR validates DI composition.

The two layers are intentional: the guard catches the specific Studio
projection registration pattern at lint speed; the composition smoke catches
the broader class of "any singleton's transitive dep is missing".

## Impact Paths

- `src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs`
- `tools/ci/studio_projection_readmodel_registration_guard.sh` (new)
- `tools/ci/host_composition_smoke.sh` (new)
- `tools/ci/architecture_guards.sh`
- `.github/workflows/ci.yml`

## Validation

- `bash tools/ci/studio_projection_readmodel_registration_guard.sh`
  - FAILS against pre-fix state with the exact missing-call list.
  - PASSES against fixed state.
- `bash tools/ci/host_composition_smoke.sh`
  - FAILS against pre-fix state with the `ValidateService` stack trace
    matching prod.
  - PASSES against fixed state (3 tests in `MainnetHostCompositionTests`,
    all green).
- `dotnet build src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj`
  succeeds.

## Test plan

- [ ] CI green on this PR (architecture_guards + new host-composition-smoke).
- [ ] Deploy to staging, confirm pod starts past `ValidateOnBuild`.
- [ ] Verify `/api/studio/teams/...` endpoints respond (proves the registered
      reader actually serves queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
