### PR TITLE
Reset Orleans pub/sub rendezvous state during retired-actor cleanup

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/ScheduledRetiredActorSpec.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ScheduledRetiredActorSpec.cs
@@ -46,7 +46,20 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
             ],
             CleanupReadModels: true),
         new(
-            $"projection.durable.scope:agent-registry:{UserAgentCatalogGAgent.WellKnownId}",
+            $"projection.durable.scope:{UserAgentCatalogStorageContracts.LegacyDurableProjectionKind}:{UserAgentCatalogGAgent.WellKnownId}",
+            [
+                "Aevatar.GAgents.ChannelRuntime.UserAgentCatalogMaterializationContext",
+                "Aevatar.GAgents.ChannelRuntime.AgentRegistryMaterializationContext",
+            ],
+            SourceStreamId: UserAgentCatalogGAgent.WellKnownId),
+        // Mid-migration deploys may have created the durable projection scope at
+        // the new scope key (DurableProjectionKind) while still bound to the old
+        // ChannelRuntime materialization context type, leaving the new
+        // Aevatar.GAgents.Scheduled scope unable to recreate. Cover that case
+        // explicitly so retired cleanup wipes the actor + its stream pub/sub
+        // rendezvous state on next startup.
+        new(
+            $"projection.durable.scope:{UserAgentCatalogStorageContracts.DurableProjectionKind}:{UserAgentCatalogGAgent.WellKnownId}",
             [
                 "Aevatar.GAgents.ChannelRuntime.UserAgentCatalogMaterializationContext",
                 "Aevatar.GAgents.ChannelRuntime.AgentRegistryMaterializationContext",

--- a/src/Aevatar.CQRS.Projection.Core/Aevatar.CQRS.Projection.Core.csproj
+++ b/src/Aevatar.CQRS.Projection.Core/Aevatar.CQRS.Projection.Core.csproj
@@ -29,4 +29,7 @@
     <Protobuf Include="projection_scope_messages.proto" GrpcServices="None" AdditionalImportDirs="..\Aevatar.Foundation.Abstractions" />
     <Protobuf Include="projection_session_event_transport.proto" GrpcServices="None" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aevatar.CQRS.Projection.Core.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Aevatar.CQRS.Projection.Core/DependencyInjection/EventSinkProjectionRuntimeRegistration.cs
+++ b/src/Aevatar.CQRS.Projection.Core/DependencyInjection/EventSinkProjectionRuntimeRegistration.cs
@@ -1,8 +1,10 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.CQRS.Projection.Core.DependencyInjection;
 
@@ -40,7 +42,9 @@ public static class EventSinkProjectionRuntimeRegistration
                     ProjectionRuntimeMode.SessionObservation,
                     request.SessionId)),
                 (_, context) => leaseFactory(context),
-                sp.GetService<Aevatar.Foundation.Abstractions.TypeSystem.IAgentTypeVerifier>()));
+                sp.GetService<Aevatar.Foundation.Abstractions.TypeSystem.IAgentTypeVerifier>(),
+                sp.GetService<IStreamPubSubMaintenance>(),
+                sp.GetService<ILoggerFactory>()));
         services.TryAddSingleton<IProjectionScopeReleaseService<TRuntimeLease>>(sp =>
             new ProjectionScopeReleaseService<
                 TRuntimeLease,

--- a/src/Aevatar.CQRS.Projection.Core/DependencyInjection/ProjectionMaterializationRuntimeRegistration.cs
+++ b/src/Aevatar.CQRS.Projection.Core/DependencyInjection/ProjectionMaterializationRuntimeRegistration.cs
@@ -1,7 +1,9 @@
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.CQRS.Projection.Core.DependencyInjection;
 
@@ -37,7 +39,9 @@ public static class ProjectionMaterializationRuntimeRegistration
                     request.ProjectionKind,
                     ProjectionRuntimeMode.DurableMaterialization)),
                 (_, context) => leaseFactory(context),
-                sp.GetService<Aevatar.Foundation.Abstractions.TypeSystem.IAgentTypeVerifier>()));
+                sp.GetService<Aevatar.Foundation.Abstractions.TypeSystem.IAgentTypeVerifier>(),
+                sp.GetService<IStreamPubSubMaintenance>(),
+                sp.GetService<ILoggerFactory>()));
         services.TryAddSingleton<IProjectionScopeReleaseService<TRuntimeLease>>(sp =>
             new ProjectionScopeReleaseService<
                 TRuntimeLease,

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActivationService.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActivationService.cs
@@ -1,4 +1,6 @@
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.CQRS.Projection.Core.Orchestration;
 
@@ -17,9 +19,16 @@ public sealed class ProjectionScopeActivationService<TLease, TContext, TScopeAge
         IActorDispatchPort dispatchPort,
         Func<ProjectionScopeStartRequest, TContext> contextFactory,
         Func<ProjectionRuntimeScopeKey, TContext, TLease> leaseFactory,
-        IAgentTypeVerifier? agentTypeVerifier = null)
+        IAgentTypeVerifier? agentTypeVerifier = null,
+        IStreamPubSubMaintenance? streamPubSubMaintenance = null,
+        ILoggerFactory? loggerFactory = null)
     {
-        _scopeRuntime = new ProjectionScopeActorRuntime<TScopeAgent>(runtime, dispatchPort, agentTypeVerifier);
+        _scopeRuntime = new ProjectionScopeActorRuntime<TScopeAgent>(
+            runtime,
+            dispatchPort,
+            agentTypeVerifier,
+            streamPubSubMaintenance,
+            loggerFactory?.CreateLogger<ProjectionScopeActorRuntime<TScopeAgent>>());
         _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
         _leaseFactory = leaseFactory ?? throw new ArgumentNullException(nameof(leaseFactory));
     }

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActorRuntime.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActorRuntime.cs
@@ -55,8 +55,32 @@ internal sealed class ProjectionScopeActorRuntime<TScopeAgent>
             typeof(TScopeAgent).FullName);
 
         await _runtime.DestroyAsync(actorId, ct).ConfigureAwait(false);
+
+        // Pub/sub reset is best-effort: at this point the old actor is already
+        // destroyed, so a future IStreamPubSubMaintenance impl that throws must
+        // not block the recreate — failing here would leave us strictly worse
+        // than the pre-self-heal state (the type mismatch at least had an actor).
+        // Matches RetiredActorCleanupHostedService.CleanupStreamPubSubBestEffortAsync.
         if (_streamPubSubMaintenance != null)
-            await _streamPubSubMaintenance.ResetActorStreamPubSubAsync(actorId, ct).ConfigureAwait(false);
+        {
+            try
+            {
+                await _streamPubSubMaintenance
+                    .ResetActorStreamPubSubAsync(actorId, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Stream pub/sub state reset failed during projection scope self-heal for {ActorId}; proceeding with recreate.",
+                    actorId);
+            }
+        }
 
         _ = await _runtime.CreateAsync<TScopeAgent>(actorId, ct).ConfigureAwait(false);
     }

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActorRuntime.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActorRuntime.cs
@@ -1,4 +1,7 @@
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.CQRS.Projection.Core.Orchestration;
 
@@ -8,15 +11,21 @@ internal sealed class ProjectionScopeActorRuntime<TScopeAgent>
     private readonly IActorRuntime _runtime;
     private readonly IActorDispatchPort _dispatchPort;
     private readonly IAgentTypeVerifier? _agentTypeVerifier;
+    private readonly IStreamPubSubMaintenance? _streamPubSubMaintenance;
+    private readonly ILogger<ProjectionScopeActorRuntime<TScopeAgent>> _logger;
 
     public ProjectionScopeActorRuntime(
         IActorRuntime runtime,
         IActorDispatchPort dispatchPort,
-        IAgentTypeVerifier? agentTypeVerifier = null)
+        IAgentTypeVerifier? agentTypeVerifier = null,
+        IStreamPubSubMaintenance? streamPubSubMaintenance = null,
+        ILogger<ProjectionScopeActorRuntime<TScopeAgent>>? logger = null)
     {
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _agentTypeVerifier = agentTypeVerifier;
+        _streamPubSubMaintenance = streamPubSubMaintenance;
+        _logger = logger ?? NullLogger<ProjectionScopeActorRuntime<TScopeAgent>>.Instance;
     }
 
     public async Task EnsureExistsAsync(ProjectionRuntimeScopeKey scopeKey, CancellationToken ct)
@@ -28,12 +37,28 @@ internal sealed class ProjectionScopeActorRuntime<TScopeAgent>
             return;
         }
 
-        if (_agentTypeVerifier != null &&
-            !await _agentTypeVerifier.IsExpectedAsync(actorId, typeof(TScopeAgent), ct).ConfigureAwait(false))
-        {
-            throw new InvalidOperationException(
-                $"Actor '{actorId}' is not a `{typeof(TScopeAgent).FullName}` projection scope actor.");
-        }
+        if (_agentTypeVerifier == null)
+            return;
+
+        if (await _agentTypeVerifier.IsExpectedAsync(actorId, typeof(TScopeAgent), ct).ConfigureAwait(false))
+            return;
+
+        // Stale runtime type at this scope key — most often after an actor type
+        // migration where a retired-cleanup pass missed the new scope key.
+        // Destroy the old actor (which also resets its event stream) and reset
+        // the stream pub/sub rendezvous state so the recreated scope actor's
+        // RegisterAsStreamProducer can succeed without an etag conflict, then
+        // recreate as the expected type.
+        _logger.LogWarning(
+            "Projection scope actor {ActorId} has unexpected runtime type; destroying and recreating as {ExpectedType}.",
+            actorId,
+            typeof(TScopeAgent).FullName);
+
+        await _runtime.DestroyAsync(actorId, ct).ConfigureAwait(false);
+        if (_streamPubSubMaintenance != null)
+            await _streamPubSubMaintenance.ResetActorStreamPubSubAsync(actorId, ct).ConfigureAwait(false);
+
+        _ = await _runtime.CreateAsync<TScopeAgent>(actorId, ct).ConfigureAwait(false);
     }
 
     public async Task<bool> ExistsAsync(ProjectionRuntimeScopeKey scopeKey, CancellationToken ct)

--- a/src/Aevatar.Foundation.Abstractions/Streaming/IStreamPubSubMaintenance.cs
+++ b/src/Aevatar.Foundation.Abstractions/Streaming/IStreamPubSubMaintenance.cs
@@ -1,0 +1,25 @@
+namespace Aevatar.Foundation.Abstractions.Streaming;
+
+/// <summary>
+/// Maintenance-only stream pub/sub state operations.
+///
+/// Stream backends that persist subscription/producer rendezvous state (e.g.
+/// Orleans + Redis PubSubStore) can leak stale entries after ungraceful
+/// deactivations or actor type migrations. The retained etag then blocks fresh
+/// stream-producer registration on the next silo wave with
+/// <c>InconsistentStateException</c>, breaking projection pipelines that depend
+/// on the stream.
+///
+/// This contract lets cleanup code (retired-actor cleanup, projection scope
+/// self-heal) reset that state without coupling to a specific backend.
+/// In-memory implementations are no-ops.
+/// </summary>
+public interface IStreamPubSubMaintenance
+{
+    /// <summary>
+    /// Resets stream pub/sub rendezvous state for the actor's self-stream so a
+    /// fresh stream-producer registration can succeed without an etag conflict.
+    /// </summary>
+    /// <returns><c>true</c> when stale state was cleared; <c>false</c> when nothing was found.</returns>
+    Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default);
+}

--- a/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/Maintenance/RetiredActorCleanupHostedService.cs
@@ -1,9 +1,11 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Maintenance;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -40,6 +42,7 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
     private readonly IStreamProvider _streamProvider;
     private readonly IEventStore _eventStore;
     private readonly IEventStoreMaintenance _eventStoreMaintenance;
+    private readonly IStreamPubSubMaintenance? _streamPubSubMaintenance;
     private readonly IServiceProvider _services;
     private readonly RetiredActorCleanupOptions _options;
     private readonly ILogger<RetiredActorCleanupHostedService> _logger;
@@ -62,6 +65,9 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
         _eventStoreMaintenance = eventStoreMaintenance ?? throw new ArgumentNullException(nameof(eventStoreMaintenance));
         _services = services ?? throw new ArgumentNullException(nameof(services));
+        // Pub/sub maintenance is optional — backends without persistent
+        // rendezvous state (in-memory streams) don't register an implementation.
+        _streamPubSubMaintenance = services.GetService<IStreamPubSubMaintenance>();
         _options = RetiredActorCleanupOptions.FromConfiguration(configuration);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -179,6 +185,11 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
         if (_options.ResetEventStreams)
             await _eventStoreMaintenance.ResetStreamAsync(target.ActorId, ct).ConfigureAwait(false);
 
+        // Reset stream pub/sub rendezvous state AFTER the actor + event stream
+        // are gone so the next silo wave's stream-producer registration does
+        // not collide with stale etag from the previous incarnation.
+        await CleanupStreamPubSubBestEffortAsync(spec, target.ActorId, ct).ConfigureAwait(false);
+
         _logger.LogInformation(
             "Retired actor cleaned. specId={SpecId} actorId={ActorId} runtimeType={RuntimeType} cleanupReason={CleanupReason}",
             spec.SpecId,
@@ -253,6 +264,29 @@ public sealed class RetiredActorCleanupHostedService : IHostedService
             _logger.LogWarning(
                 ex,
                 "Retired actor read-model cleanup failed and will be skipped. specId={SpecId} actorId={ActorId}",
+                spec.SpecId,
+                actorId);
+        }
+    }
+
+    private async Task CleanupStreamPubSubBestEffortAsync(IRetiredActorSpec spec, string actorId, CancellationToken ct)
+    {
+        if (_streamPubSubMaintenance == null)
+            return;
+
+        try
+        {
+            await _streamPubSubMaintenance.ResetActorStreamPubSubAsync(actorId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Retired actor stream pub/sub state reset failed and will be skipped. specId={SpecId} actorId={ActorId}",
                 spec.SpecId,
                 actorId);
         }

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Aevatar.Foundation.Runtime.Implementations.Orleans.csproj
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Aevatar.Foundation.Runtime.Implementations.Orleans.csproj
@@ -31,4 +31,7 @@
     <PackageReference Include="Microsoft.Orleans.Serialization.Protobuf" />
     <PackageReference Include="Google.Protobuf" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aevatar.Foundation.Runtime.Hosting.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/DependencyInjection/ServiceCollectionExtensions.cs
@@ -48,6 +48,12 @@ public static class ServiceCollectionExtensions
             {
                 garnetOptions.ConnectionString = options.GarnetConnectionString;
             });
+
+            // Garnet hosts both the event store and Orleans's PubSubStore (see
+            // EnsurePersistentStreamPubSubStorage). Stale rendezvous state from
+            // an earlier silo wave / retired actor type can otherwise block
+            // RegisterAsStreamProducer with InconsistentStateException.
+            services.TryAddSingleton<IStreamPubSubMaintenance, OrleansRedisStreamPubSubMaintenance>();
         }
         else
         {

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Streaming/OrleansRedisStreamPubSubMaintenance.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Streaming/OrleansRedisStreamPubSubMaintenance.cs
@@ -1,0 +1,91 @@
+using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orleans.Configuration;
+using StackExchange.Redis;
+
+namespace Aevatar.Foundation.Runtime.Implementations.Orleans;
+
+/// <summary>
+/// Resets stale entries left in the Orleans <c>PubSubRendezvousGrain</c> redis
+/// state for an actor's self-stream when the actor itself was already torn down.
+///
+/// Orleans's normal grain deactivation path tries to unsubscribe from the
+/// rendezvous, but ungraceful shutdowns (silo crash, deactivation exceptions
+/// the grain swallows as <c>ObjectDisposedException</c>/
+/// <c>OrleansMessageRejectionException</c>) and actor type migrations both
+/// leave behind state with a non-empty etag. The next silo wave then fails
+/// <c>RegisterAsStreamProducer</c> with <c>InconsistentStateException</c>,
+/// blocking the projection pipeline that depends on that stream.
+///
+/// We delete the rendezvous redis key directly so the next producer
+/// registration writes from a clean slate.
+/// </summary>
+internal sealed class OrleansRedisStreamPubSubMaintenance : IStreamPubSubMaintenance
+{
+    private readonly IConnectionMultiplexer _connection;
+    private readonly AevatarOrleansRuntimeOptions _options;
+    private readonly string _serviceId;
+    private readonly ILogger<OrleansRedisStreamPubSubMaintenance> _logger;
+
+    public OrleansRedisStreamPubSubMaintenance(
+        IConnectionMultiplexer connection,
+        AevatarOrleansRuntimeOptions options,
+        IOptions<ClusterOptions> clusterOptions,
+        ILogger<OrleansRedisStreamPubSubMaintenance>? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(clusterOptions);
+
+        _connection = connection;
+        _options = options;
+        _serviceId = clusterOptions.Value.ServiceId
+            ?? throw new InvalidOperationException(
+                "ClusterOptions.ServiceId is required to compute Orleans pub/sub rendezvous redis keys.");
+        _logger = logger ?? NullLogger<OrleansRedisStreamPubSubMaintenance>.Instance;
+    }
+
+    public async Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
+        ct.ThrowIfCancellationRequested();
+
+        // Orleans Redis grain storage default key format (verified against
+        // Microsoft.Orleans.Persistence.Redis 10.0.x DefaultGetStorageKey):
+        //   "{grainId}/{serviceId}"
+        // PubSubRendezvousGrain id format is:
+        //   "pubsubrendezvous/{streamProvider}/{streamNamespace}/{streamKey}"
+        // and an actor self-stream uses the actor id as the streamKey.
+        var grainId =
+            $"pubsubrendezvous/{_options.StreamProviderName}/{_options.ActorEventNamespace}/{actorId}";
+        var redisKey = (RedisKey)$"{grainId}/{_serviceId}";
+
+        try
+        {
+            var deleted = await _connection.GetDatabase().KeyDeleteAsync(redisKey).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            _logger.LogInformation(
+                "Orleans pub/sub rendezvous state reset. actorId={ActorId} key={Key} deleted={Deleted}",
+                actorId,
+                (string)redisKey!,
+                deleted);
+            return deleted;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Orleans pub/sub rendezvous state reset failed. actorId={ActorId} key={Key}",
+                actorId,
+                (string)redisKey!);
+            return false;
+        }
+    }
+}

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Streaming/OrleansRedisStreamPubSubMaintenance.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Streaming/OrleansRedisStreamPubSubMaintenance.cs
@@ -59,6 +59,12 @@ internal sealed class OrleansRedisStreamPubSubMaintenance : IStreamPubSubMainten
         // PubSubRendezvousGrain id format is:
         //   "pubsubrendezvous/{streamProvider}/{streamNamespace}/{streamKey}"
         // and an actor self-stream uses the actor id as the streamKey.
+        //
+        // CAUTION: Both the "pubsubrendezvous" grain type token and the
+        // "{grainId}/{serviceId}" key format are Orleans-internal. Bumping
+        // Microsoft.Orleans.Persistence.Redis must re-verify both — the
+        // OrleansRedisStreamPubSubMaintenanceTests reflection guard pins the
+        // format and will fail loudly when Orleans changes either.
         var grainId =
             $"pubsubrendezvous/{_options.StreamProviderName}/{_options.ActorEventNamespace}/{actorId}";
         var redisKey = (RedisKey)$"{grainId}/{_serviceId}";

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeActorRuntimeTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeActorRuntimeTests.cs
@@ -1,0 +1,206 @@
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Foundation.Abstractions.TypeSystem;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.CQRS.Projection.Core.Tests;
+
+public sealed class ProjectionScopeActorRuntimeTests
+{
+    [Fact]
+    public async Task EnsureExistsAsync_ShouldCreate_WhenActorMissing()
+    {
+        var runtime = new RecordingRuntime();
+        var dispatchPort = new NoopDispatchPort();
+        var verifier = new StubAgentTypeVerifier(_ => true);
+        var sut = new ProjectionScopeActorRuntime<DummyAgent>(
+            runtime,
+            dispatchPort,
+            verifier,
+            streamPubSubMaintenance: null,
+            logger: NullLogger<ProjectionScopeActorRuntime<DummyAgent>>.Instance);
+
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "agent-registry-store",
+            "user-agent-catalog-read-model",
+            ProjectionRuntimeMode.DurableMaterialization);
+
+        await sut.EnsureExistsAsync(scopeKey, CancellationToken.None);
+
+        var actorId = ProjectionScopeActorId.Build(scopeKey);
+        runtime.CreatedActorIds.Should().Equal(actorId);
+        runtime.DestroyedActorIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnsureExistsAsync_ShouldNoOp_WhenActorExistsWithExpectedType()
+    {
+        var actorId = ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+            "agent-registry-store",
+            "user-agent-catalog-read-model",
+            ProjectionRuntimeMode.DurableMaterialization));
+        var runtime = new RecordingRuntime();
+        runtime.SeedExisting(actorId);
+        var verifier = new StubAgentTypeVerifier(_ => true);
+        var sut = new ProjectionScopeActorRuntime<DummyAgent>(
+            runtime,
+            new NoopDispatchPort(),
+            verifier,
+            streamPubSubMaintenance: null,
+            logger: NullLogger<ProjectionScopeActorRuntime<DummyAgent>>.Instance);
+
+        await sut.EnsureExistsAsync(new ProjectionRuntimeScopeKey(
+            "agent-registry-store",
+            "user-agent-catalog-read-model",
+            ProjectionRuntimeMode.DurableMaterialization),
+            CancellationToken.None);
+
+        runtime.CreatedActorIds.Should().BeEmpty();
+        runtime.DestroyedActorIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EnsureExistsAsync_ShouldDestroyResetAndRecreate_WhenActorTypeIsStale()
+    {
+        // Mid-migration scope actors hold an older materialization context type
+        // (e.g. ChannelRuntime → Scheduled rename). The original behaviour threw
+        // InvalidOperationException, blocking projection startup forever. We now
+        // self-heal: destroy the stale actor, reset its stream pub/sub
+        // rendezvous (so RegisterAsStreamProducer doesn't hit the leaked etag),
+        // then recreate as the expected type.
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "agent-registry-store",
+            "user-agent-catalog-read-model",
+            ProjectionRuntimeMode.DurableMaterialization);
+        var actorId = ProjectionScopeActorId.Build(scopeKey);
+        var runtime = new RecordingRuntime();
+        runtime.SeedExisting(actorId);
+        var verifier = new StubAgentTypeVerifier(_ => false);
+        var pubSub = new RecordingPubSubMaintenance();
+        var sut = new ProjectionScopeActorRuntime<DummyAgent>(
+            runtime,
+            new NoopDispatchPort(),
+            verifier,
+            pubSub,
+            NullLogger<ProjectionScopeActorRuntime<DummyAgent>>.Instance);
+
+        await sut.EnsureExistsAsync(scopeKey, CancellationToken.None);
+
+        runtime.DestroyedActorIds.Should().Equal(actorId);
+        pubSub.ResetActorIds.Should().Equal(actorId);
+        runtime.CreatedActorIds.Should().Equal(actorId);
+        // Order matters: destroy → pub/sub reset → recreate. Otherwise the
+        // recreated actor's RegisterAsStreamProducer would still see the stale
+        // etag from the previous incarnation.
+        runtime.OperationLog.Should().Equal("destroy:" + actorId, "create:" + actorId);
+    }
+
+    [Fact]
+    public async Task EnsureExistsAsync_ShouldStillSelfHeal_WhenPubSubMaintenanceUnavailable()
+    {
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "agent-registry-store",
+            "user-agent-catalog-read-model",
+            ProjectionRuntimeMode.DurableMaterialization);
+        var actorId = ProjectionScopeActorId.Build(scopeKey);
+        var runtime = new RecordingRuntime();
+        runtime.SeedExisting(actorId);
+        var verifier = new StubAgentTypeVerifier(_ => false);
+        var sut = new ProjectionScopeActorRuntime<DummyAgent>(
+            runtime,
+            new NoopDispatchPort(),
+            verifier,
+            streamPubSubMaintenance: null,
+            logger: NullLogger<ProjectionScopeActorRuntime<DummyAgent>>.Instance);
+
+        await sut.EnsureExistsAsync(scopeKey, CancellationToken.None);
+
+        runtime.DestroyedActorIds.Should().Equal(actorId);
+        runtime.CreatedActorIds.Should().Equal(actorId);
+    }
+
+    private sealed class DummyAgent : IAgent
+    {
+        public string Id => "dummy";
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string> GetDescriptionAsync() => Task.FromResult("dummy");
+        public Task<IReadOnlyList<Type>> GetSubscribedEventTypesAsync() =>
+            Task.FromResult<IReadOnlyList<Type>>([]);
+    }
+
+    private sealed class RecordingRuntime : IActorRuntime
+    {
+        private readonly HashSet<string> _existing = new(StringComparer.Ordinal);
+
+        public List<string> CreatedActorIds { get; } = [];
+        public List<string> DestroyedActorIds { get; } = [];
+        public List<string> OperationLog { get; } = [];
+
+        public void SeedExisting(string actorId) => _existing.Add(actorId);
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent
+        {
+            ArgumentNullException.ThrowIfNull(id);
+            CreatedActorIds.Add(id);
+            OperationLog.Add("create:" + id);
+            _existing.Add(id);
+            return Task.FromResult<IActor>(new StubActor(id));
+        }
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default) =>
+            CreateAsync<DummyAgent>(id, ct);
+
+        public Task DestroyAsync(string id, CancellationToken ct = default)
+        {
+            DestroyedActorIds.Add(id);
+            OperationLog.Add("destroy:" + id);
+            _existing.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(_existing.Contains(id) ? new StubActor(id) : null);
+        public Task<bool> ExistsAsync(string id) => Task.FromResult(_existing.Contains(id));
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+
+        private sealed class StubActor(string id) : IActor
+        {
+            public string Id => id;
+            public IAgent Agent => new DummyAgent();
+            public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+            public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+            public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+            public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+            public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+                Task.FromResult<IReadOnlyList<string>>([]);
+        }
+    }
+
+    private sealed class StubAgentTypeVerifier(Func<string, bool> matcher) : IAgentTypeVerifier
+    {
+        public Task<bool> IsExpectedAsync(string actorId, Type expectedType, CancellationToken ct = default) =>
+            Task.FromResult(matcher(actorId));
+    }
+
+    private sealed class RecordingPubSubMaintenance : IStreamPubSubMaintenance
+    {
+        public List<string> ResetActorIds { get; } = [];
+
+        public Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default)
+        {
+            ResetActorIds.Add(actorId);
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class NoopDispatchPort : IActorDispatchPort
+    {
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+}

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeActorRuntimeTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeActorRuntimeTests.cs
@@ -12,7 +12,8 @@ public sealed class ProjectionScopeActorRuntimeTests
     [Fact]
     public async Task EnsureExistsAsync_ShouldCreate_WhenActorMissing()
     {
-        var runtime = new RecordingRuntime();
+        var operationLog = new List<string>();
+        var runtime = new RecordingRuntime(operationLog);
         var dispatchPort = new NoopDispatchPort();
         var verifier = new StubAgentTypeVerifier(_ => true);
         var sut = new ProjectionScopeActorRuntime<DummyAgent>(
@@ -41,7 +42,8 @@ public sealed class ProjectionScopeActorRuntimeTests
             "agent-registry-store",
             "user-agent-catalog-read-model",
             ProjectionRuntimeMode.DurableMaterialization));
-        var runtime = new RecordingRuntime();
+        var operationLog = new List<string>();
+        var runtime = new RecordingRuntime(operationLog);
         runtime.SeedExisting(actorId);
         var verifier = new StubAgentTypeVerifier(_ => true);
         var sut = new ProjectionScopeActorRuntime<DummyAgent>(
@@ -75,10 +77,11 @@ public sealed class ProjectionScopeActorRuntimeTests
             "user-agent-catalog-read-model",
             ProjectionRuntimeMode.DurableMaterialization);
         var actorId = ProjectionScopeActorId.Build(scopeKey);
-        var runtime = new RecordingRuntime();
+        var operationLog = new List<string>();
+        var runtime = new RecordingRuntime(operationLog);
         runtime.SeedExisting(actorId);
         var verifier = new StubAgentTypeVerifier(_ => false);
-        var pubSub = new RecordingPubSubMaintenance();
+        var pubSub = new RecordingPubSubMaintenance(operationLog);
         var sut = new ProjectionScopeActorRuntime<DummyAgent>(
             runtime,
             new NoopDispatchPort(),
@@ -88,13 +91,43 @@ public sealed class ProjectionScopeActorRuntimeTests
 
         await sut.EnsureExistsAsync(scopeKey, CancellationToken.None);
 
-        runtime.DestroyedActorIds.Should().Equal(actorId);
-        pubSub.ResetActorIds.Should().Equal(actorId);
-        runtime.CreatedActorIds.Should().Equal(actorId);
-        // Order matters: destroy → pub/sub reset → recreate. Otherwise the
-        // recreated actor's RegisterAsStreamProducer would still see the stale
-        // etag from the previous incarnation.
-        runtime.OperationLog.Should().Equal("destroy:" + actorId, "create:" + actorId);
+        // Order matters across all three operations: destroy → pub/sub reset →
+        // recreate. Reordering pub/sub reset to before destroy or after create
+        // leaves the recreated actor's RegisterAsStreamProducer hitting the
+        // stale etag from the previous incarnation.
+        operationLog.Should().Equal(
+            "destroy:" + actorId,
+            "pubsub-reset:" + actorId,
+            "create:" + actorId);
+    }
+
+    [Fact]
+    public async Task EnsureExistsAsync_ShouldStillRecreate_WhenPubSubResetThrows()
+    {
+        // Pub/sub reset is best-effort. Once we've destroyed the stale actor,
+        // a maintenance impl that throws must not block the recreate — failing
+        // here would leave the cluster strictly worse than the pre-self-heal
+        // state (the type mismatch at least had an actor).
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "agent-registry-store",
+            "user-agent-catalog-read-model",
+            ProjectionRuntimeMode.DurableMaterialization);
+        var actorId = ProjectionScopeActorId.Build(scopeKey);
+        var operationLog = new List<string>();
+        var runtime = new RecordingRuntime(operationLog);
+        runtime.SeedExisting(actorId);
+        var verifier = new StubAgentTypeVerifier(_ => false);
+        var pubSub = new ThrowingPubSubMaintenance();
+        var sut = new ProjectionScopeActorRuntime<DummyAgent>(
+            runtime,
+            new NoopDispatchPort(),
+            verifier,
+            pubSub,
+            NullLogger<ProjectionScopeActorRuntime<DummyAgent>>.Instance);
+
+        await sut.EnsureExistsAsync(scopeKey, CancellationToken.None);
+
+        operationLog.Should().Equal("destroy:" + actorId, "create:" + actorId);
     }
 
     [Fact]
@@ -105,7 +138,8 @@ public sealed class ProjectionScopeActorRuntimeTests
             "user-agent-catalog-read-model",
             ProjectionRuntimeMode.DurableMaterialization);
         var actorId = ProjectionScopeActorId.Build(scopeKey);
-        var runtime = new RecordingRuntime();
+        var operationLog = new List<string>();
+        var runtime = new RecordingRuntime(operationLog);
         runtime.SeedExisting(actorId);
         var verifier = new StubAgentTypeVerifier(_ => false);
         var sut = new ProjectionScopeActorRuntime<DummyAgent>(
@@ -117,8 +151,7 @@ public sealed class ProjectionScopeActorRuntimeTests
 
         await sut.EnsureExistsAsync(scopeKey, CancellationToken.None);
 
-        runtime.DestroyedActorIds.Should().Equal(actorId);
-        runtime.CreatedActorIds.Should().Equal(actorId);
+        operationLog.Should().Equal("destroy:" + actorId, "create:" + actorId);
     }
 
     private sealed class DummyAgent : IAgent
@@ -132,13 +165,13 @@ public sealed class ProjectionScopeActorRuntimeTests
             Task.FromResult<IReadOnlyList<Type>>([]);
     }
 
-    private sealed class RecordingRuntime : IActorRuntime
+    private sealed class RecordingRuntime(List<string> operationLog) : IActorRuntime
     {
         private readonly HashSet<string> _existing = new(StringComparer.Ordinal);
+        private readonly List<string> _operationLog = operationLog;
 
         public List<string> CreatedActorIds { get; } = [];
         public List<string> DestroyedActorIds { get; } = [];
-        public List<string> OperationLog { get; } = [];
 
         public void SeedExisting(string actorId) => _existing.Add(actorId);
 
@@ -147,7 +180,7 @@ public sealed class ProjectionScopeActorRuntimeTests
         {
             ArgumentNullException.ThrowIfNull(id);
             CreatedActorIds.Add(id);
-            OperationLog.Add("create:" + id);
+            _operationLog.Add("create:" + id);
             _existing.Add(id);
             return Task.FromResult<IActor>(new StubActor(id));
         }
@@ -158,7 +191,7 @@ public sealed class ProjectionScopeActorRuntimeTests
         public Task DestroyAsync(string id, CancellationToken ct = default)
         {
             DestroyedActorIds.Add(id);
-            OperationLog.Add("destroy:" + id);
+            _operationLog.Add("destroy:" + id);
             _existing.Remove(id);
             return Task.CompletedTask;
         }
@@ -187,15 +220,21 @@ public sealed class ProjectionScopeActorRuntimeTests
             Task.FromResult(matcher(actorId));
     }
 
-    private sealed class RecordingPubSubMaintenance : IStreamPubSubMaintenance
+    private sealed class RecordingPubSubMaintenance(List<string> operationLog) : IStreamPubSubMaintenance
     {
-        public List<string> ResetActorIds { get; } = [];
+        private readonly List<string> _operationLog = operationLog;
 
         public Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default)
         {
-            ResetActorIds.Add(actorId);
+            _operationLog.Add("pubsub-reset:" + actorId);
             return Task.FromResult(true);
         }
+    }
+
+    private sealed class ThrowingPubSubMaintenance : IStreamPubSubMaintenance
+    {
+        public Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default) =>
+            throw new InvalidOperationException("pub/sub backend offline");
     }
 
     private sealed class NoopDispatchPort : IActorDispatchPort

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansRedisStreamPubSubMaintenanceTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansRedisStreamPubSubMaintenanceTests.cs
@@ -1,0 +1,119 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Aevatar.Foundation.Runtime.Implementations.Orleans;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Orleans.Configuration;
+using Orleans.Persistence;
+using Orleans.Runtime;
+using StackExchange.Redis;
+
+namespace Aevatar.Foundation.Runtime.Hosting.Tests;
+
+/// <summary>
+/// Pins our pub/sub redis-key format to Orleans's actual
+/// <see cref="RedisGrainStorage"/> key derivation. If Orleans ever changes the
+/// format the test breaks immediately rather than silently leaking stale state
+/// after a deploy.
+/// </summary>
+public sealed class OrleansRedisStreamPubSubMaintenanceTests
+{
+    private const string ServiceId = "aevatar-mainnet-host-api";
+    private const string StreamProvider = "AevatarOrleansStreamProvider";
+    private const string StreamNamespace = "aevatar.actor.events";
+    private const string ActorId = "projection.durable.scope:channel-bot-registration:channel-bot-registration-store";
+
+    [Fact]
+    public async Task ResetActorStreamPubSubAsync_ShouldDeleteRedisKey_MatchingOrleansDefaultStorageKey()
+    {
+        var capturedKeys = new List<RedisKey>();
+        var database = Substitute.For<IDatabase>();
+        database.KeyDeleteAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(call =>
+            {
+                capturedKeys.Add(call.Arg<RedisKey>());
+                return Task.FromResult(true);
+            });
+        var connection = Substitute.For<IConnectionMultiplexer>();
+        connection.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
+
+        var sut = new OrleansRedisStreamPubSubMaintenance(
+            connection,
+            new AevatarOrleansRuntimeOptions
+            {
+                StreamProviderName = StreamProvider,
+                ActorEventNamespace = StreamNamespace,
+            },
+            Options.Create(new ClusterOptions { ServiceId = ServiceId }),
+            NullLogger<OrleansRedisStreamPubSubMaintenance>.Instance);
+
+        var deleted = await sut.ResetActorStreamPubSubAsync(ActorId);
+
+        deleted.Should().BeTrue();
+        capturedKeys.Should().HaveCount(1);
+
+        var actualKey = capturedKeys[0].ToString()!;
+        var expectedKey = ComputeOrleansDefaultStorageKey(ServiceId, StreamProvider, StreamNamespace, ActorId);
+        actualKey.Should().Be(expectedKey);
+    }
+
+    [Fact]
+    public async Task ResetActorStreamPubSubAsync_ShouldNotThrow_WhenRedisDeleteFails()
+    {
+        var database = Substitute.For<IDatabase>();
+        database.KeyDeleteAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns<Task<bool>>(_ =>
+                throw new RedisConnectionException(ConnectionFailureType.UnableToConnect, "boom"));
+        var connection = Substitute.For<IConnectionMultiplexer>();
+        connection.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(database);
+
+        var sut = new OrleansRedisStreamPubSubMaintenance(
+            connection,
+            new AevatarOrleansRuntimeOptions
+            {
+                StreamProviderName = StreamProvider,
+                ActorEventNamespace = StreamNamespace,
+            },
+            Options.Create(new ClusterOptions { ServiceId = ServiceId }),
+            NullLogger<OrleansRedisStreamPubSubMaintenance>.Instance);
+
+        var deleted = await sut.ResetActorStreamPubSubAsync(ActorId);
+        deleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Construction_ShouldThrow_WhenServiceIdMissing()
+    {
+        var act = () => new OrleansRedisStreamPubSubMaintenance(
+            Substitute.For<IConnectionMultiplexer>(),
+            new AevatarOrleansRuntimeOptions(),
+            Options.Create(new ClusterOptions { ServiceId = null! }),
+            NullLogger<OrleansRedisStreamPubSubMaintenance>.Instance);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ServiceId is required*");
+    }
+
+    private static string ComputeOrleansDefaultStorageKey(
+        string serviceId, string streamProvider, string streamNamespace, string actorId)
+    {
+        var grainId = GrainId.Create("pubsubrendezvous", $"{streamProvider}/{streamNamespace}/{actorId}");
+        var method = typeof(RedisGrainStorage)
+            .GetMethod(
+                "DefaultGetStorageKey",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        if (method == null)
+            throw new InvalidOperationException("RedisGrainStorage.DefaultGetStorageKey not found.");
+
+        // The method has an instance-method signature but does not actually use
+        // any instance state (verified against Microsoft.Orleans.Persistence.Redis 10.0.x).
+        // We invoke it on an uninitialized instance to derive the canonical key
+        // without spinning up a redis backend.
+        var instance = RuntimeHelpers.GetUninitializedObject(typeof(RedisGrainStorage));
+        var redisKey = (RedisKey)method.Invoke(instance, [serviceId, grainId])!;
+        return redisKey.ToString()!;
+    }
+}

--- a/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
+++ b/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
@@ -414,6 +414,104 @@ public sealed class RetiredActorCleanupHostedServiceTests
     }
 
     [Fact]
+    public async Task StartAsync_ShouldDestroyMidMigrationProjectionScope_AtNewScopeKey()
+    {
+        // Mid-migration deploys may have created the durable projection scope
+        // actor at the *new* scope key (UserAgentCatalog: user-agent-catalog-read-model)
+        // while still bound to the old ChannelRuntime materialization context.
+        // The retired-cleanup spec must target both the old and new scope keys
+        // so a single deploy auto-recovers without manual redis surgery.
+        var newScopeKeyActorId =
+            "projection.durable.scope:user-agent-catalog-read-model:agent-registry-store";
+        var eventStore = new InMemoryEventStore();
+        await AppendSingleEventAsync(eventStore, newScopeKeyActorId);
+        var typeProbe = new StubActorTypeProbe(new Dictionary<string, string?>
+        {
+            [newScopeKeyActorId] =
+                "Aevatar.CQRS.Projection.Core.Orchestration.ProjectionMaterializationScopeGAgent`1[[Aevatar.GAgents.ChannelRuntime.UserAgentCatalogMaterializationContext, Aevatar.GAgents.ChannelRuntime]], Aevatar.CQRS.Projection.Core",
+        });
+        var runtime = new RecordingActorRuntime();
+        var service = CreateService(
+            typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateScheduledSpec());
+
+        await service.StartAsync(CancellationToken.None);
+
+        runtime.DestroyedActorIds.Should().Contain(newScopeKeyActorId);
+        (await eventStore.GetVersionAsync(newScopeKeyActorId)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldResetStreamPubSub_ForEachCleanedActor()
+    {
+        // Stream pub/sub state (Orleans PubSubRendezvousGrain) lives outside the
+        // event store and the GAgent. Skipping its reset leaves stale rendezvous
+        // entries behind, which then block the next silo wave's
+        // RegisterAsStreamProducer with InconsistentStateException — the bug
+        // this hosted service is meant to prevent. Exercise that the cleanup
+        // calls the IStreamPubSubMaintenance hook for every cleaned actor.
+        var eventStore = new InMemoryEventStore();
+        await AppendSingleEventAsync(eventStore, "channel-bot-registration-store");
+        await AppendSingleEventAsync(
+            eventStore,
+            "projection.durable.scope:channel-bot-registration:channel-bot-registration-store");
+        var typeProbe = new StubActorTypeProbe(new Dictionary<string, string?>
+        {
+            ["channel-bot-registration-store"] =
+                "Aevatar.GAgents.ChannelRuntime.ChannelBotRegistrationGAgent, Aevatar.GAgents.ChannelRuntime",
+            ["projection.durable.scope:channel-bot-registration:channel-bot-registration-store"] =
+                "Aevatar.CQRS.Projection.Core.Orchestration.ProjectionMaterializationScopeGAgent`1[[Aevatar.GAgents.ChannelRuntime.ChannelBotRegistrationMaterializationContext, Aevatar.GAgents.ChannelRuntime]], Aevatar.CQRS.Projection.Core",
+        });
+        var runtime = new RecordingActorRuntime();
+        var pubSub = new RecordingStreamPubSubMaintenance();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<Aevatar.Foundation.Abstractions.Persistence.IEventStore>(eventStore);
+        serviceCollection.AddSingleton<IActorTypeProbe>(typeProbe);
+        serviceCollection.AddSingleton<IStreamPubSubMaintenance>(pubSub);
+        var service = CreateService(
+            typeProbe,
+            runtime,
+            new RecordingStreamProvider(),
+            eventStore,
+            CreateChannelRuntimeSpec(),
+            serviceCollection.BuildServiceProvider());
+
+        await service.StartAsync(CancellationToken.None);
+
+        pubSub.ResetActorIds.Should().Contain("channel-bot-registration-store");
+        pubSub.ResetActorIds.Should().Contain(
+            "projection.durable.scope:channel-bot-registration:channel-bot-registration-store");
+    }
+
+    [Fact]
+    public async Task StartAsync_ShouldContinue_WhenStreamPubSubResetThrows()
+    {
+        var eventStore = new InMemoryEventStore();
+        await AppendSingleEventAsync(eventStore, "channel-bot-registration-store");
+        var typeProbe = new StubActorTypeProbe(new Dictionary<string, string?>
+        {
+            ["channel-bot-registration-store"] =
+                "Aevatar.GAgents.ChannelRuntime.ChannelBotRegistrationGAgent, Aevatar.GAgents.ChannelRuntime",
+        });
+        var runtime = new RecordingActorRuntime();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<Aevatar.Foundation.Abstractions.Persistence.IEventStore>(eventStore);
+        serviceCollection.AddSingleton<IActorTypeProbe>(typeProbe);
+        serviceCollection.AddSingleton<IStreamPubSubMaintenance>(new ThrowingStreamPubSubMaintenance());
+        var service = CreateService(
+            typeProbe,
+            runtime,
+            new RecordingStreamProvider(),
+            eventStore,
+            CreateChannelRuntimeSpec(),
+            serviceCollection.BuildServiceProvider());
+
+        await service.StartAsync(CancellationToken.None);
+
+        runtime.DestroyedActorIds.Should().Contain("channel-bot-registration-store");
+        (await eventStore.GetVersionAsync("channel-bot-registration-store")).Should().Be(0);
+    }
+
+    [Fact]
     public async Task StartAsync_ShouldRunEachRegisteredSpec()
     {
         var eventStore = new InMemoryEventStore();
@@ -764,5 +862,23 @@ public sealed class RetiredActorCleanupHostedServiceTests
 
         public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
             Task.FromResult(ProjectionWriteResult.Applied());
+    }
+
+    private sealed class RecordingStreamPubSubMaintenance : IStreamPubSubMaintenance
+    {
+        public List<string> ResetActorIds { get; } = [];
+
+        public Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            ResetActorIds.Add(actorId);
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class ThrowingStreamPubSubMaintenance : IStreamPubSubMaintenance
+    {
+        public Task<bool> ResetActorStreamPubSubAsync(string actorId, CancellationToken ct = default) =>
+            throw new InvalidOperationException("pub/sub state reset failed");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `IStreamPubSubMaintenance` abstraction + Orleans+Redis implementation that deletes the `PubSubRendezvousGrain` redis key after retired-actor destroy. Pinned to Orleans 10.0.x's actual `RedisGrainStorage.DefaultGetStorageKey` format via reflection in tests.
- `RetiredActorCleanupHostedService` now invokes pub/sub reset after `DestroyAsync` + event-stream reset for every cleaned actor (best-effort; tolerant of missing impl + transient failures).
- `ProjectionScopeActorRuntime.EnsureExistsAsync` self-heals on type mismatch — destroy → pub/sub reset → recreate — instead of throwing `InvalidOperationException` that blocks projection startup forever.
- `ScheduledRetiredActorSpec.Targets` adds the new `user-agent-catalog-read-model` scope key so mid-migration deploys with the old `ChannelRuntime.UserAgentCatalogMaterializationContext` type marker still bound auto-recover.

## Why

Production silo logs (`aevatar-console-backend-6595d78756-2wm8z`) show:
```
fail: Orleans.Persistence.RedisGrainStorage[102203]
   Error from storage provider RedisGrainStorage.PubSubRendezvousGrain during WriteStateAsync
   for grain pubsubrendezvous/AevatarOrleansStreamProvider/aevatar.actor.events/projection.durable.scope:channel-bot-registration:channel-bot-registration-store
   InconsistentStateException: Version conflict ETag=094c8944... Expected= Received=
fail: Orleans.Streams.AevatarOrleansStreamProvider[103317]
   RegisterAsStreamProducer failed
```

Followed by:
```
warn: Aevatar.NyxId.Chat.Relay[0]
   Relay callback authentication succeeded but did not resolve a canonical scope id:
   message=154ad6e4-..., apiKeyId=585c742f-1ecd-4bfc-8991-d8ca6ddd6f72
HTTP/1.1 POST /api/webhooks/nyxid-relay - 401
```

Cause chain:
1. `RetiredActorCleanupHostedService` cleared `channel-bot-registration-store` GAgent state + event store, but Orleans's `PubSubRendezvousGrain` (separate `PubSubStore` redis key) still holds the previous silo's etag.
2. New silo's pull agent tries `RegisterAsStreamProducer` → `InconsistentStateException`.
3. Projection scope can't drive the pipeline → `ChannelBotRegistrationDocument` never materializes.
4. `NyxIdRelayScopeResolver.ListByNyxAgentApiKeyIdAsync` returns empty → relay 401 → Lark bot reply never delivered.

`UserAgentCatalogStartupService` 5x failure with `Actor 'projection.durable.scope:user-agent-catalog-read-model:agent-registry-store' is not a 'ProjectionMaterializationScopeGAgent<Scheduled.UserAgentCatalogMaterializationContext>' projection scope actor` is the same class of bug at the new scope key.

## Test plan

- [x] `dotnet build aevatar.slnx --nologo` — succeeds, 0 errors
- [x] `dotnet test test/Aevatar.Foundation.Runtime.Hosting.Tests/...` — 117 tests pass (incl. 3 new `OrleansRedisStreamPubSubMaintenanceTests`)
- [x] `dotnet test test/Aevatar.Hosting.Tests/...` — 49 tests pass (incl. 3 new cleanup tests covering pub/sub reset, throw-tolerance, mid-migration scope key)
- [x] `dotnet test test/Aevatar.CQRS.Projection.Core.Tests/...` — 85 tests pass (incl. 4 new self-heal tests)
- [x] `dotnet test test/Aevatar.Architecture.Tests/...` — 105 tests pass
- [x] `bash tools/ci/architecture_guards.sh` — all guards pass through workflow_binding_boundary_guard. `playground_asset_drift_guard.sh` fails locally with stale demos/wwwroot assets vs cli playground build — pre-existing on this machine, unrelated to this PR (no frontend files touched).
- [x] Verified pub/sub redis key format (`{grainId}/{serviceId}`) by invoking Orleans 10.0.1's actual `RedisGrainStorage.DefaultGetStorageKey` via reflection — test pins the format so future Orleans updates surface as test failure rather than silent stale-state leak.

## Rollout

After merge + deploy, restart the affected silo. `RetiredActorCleanupHostedService` will sweep `projection.durable.scope:user-agent-catalog-read-model:agent-registry-store` and any orphaned pub/sub state during startup; subsequent `RegisterAsStreamProducer` writes from a clean slate. Lark bot reply path recovers on next webhook. No manual redis surgery required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)