### PR TITLE
Self-heal EventSourcingBehavior version drift + Lark mirror recovery runbook

### DIFF
--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
@@ -285,11 +285,17 @@ public static class ChannelCallbackEndpoints
     ///
     /// Direct HTTP equivalent of the LLM-tool path
     /// <c>channel_registrations action=repair_lark_mirror</c>; see
-    /// <c>docs/operations/2026-04-29-lark-mirror-recovery-runbook.md</c>.
+    /// <c>docs/operations/2026-04-29-lark-mirror-recovery-runbook.md</c>. The
+    /// preflight (<c>already_registered</c> short-circuit, scope-mismatch
+    /// reject, empty-scope id reuse) MUST mirror the LLM-tool path —
+    /// otherwise repeated calls without a <c>registration_id</c> mint a fresh
+    /// id every time, and the resolver will later see multiple distinct
+    /// scope ids for one Nyx api-key and refuse to route relay traffic.
     /// </summary>
     private static async Task<IResult> HandleRepairLarkMirrorAsync(
         HttpContext http,
         [FromServices] INyxLarkProvisioningService provisioningService,
+        [FromServices] IChannelBotRegistrationQueryPort queryPort,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -324,16 +330,85 @@ public static class ChannelCallbackEndpoints
         if (scopeResolution.Error is not null)
             return Results.BadRequest(new { error = scopeResolution.Error });
 
+        var nyxChannelBotId = request.NyxChannelBotId.Trim();
+        var nyxAgentApiKeyId = request.NyxAgentApiKeyId.Trim();
+        var nyxConversationRouteId = request.NyxConversationRouteId?.Trim() ?? string.Empty;
+        var requestedRegistrationId = request.RegistrationId?.Trim() ?? string.Empty;
+
+        // Preflight against the local mirror so repeated calls converge on the
+        // same registration id instead of minting a fresh one each time. Any
+        // existing same-scope mirror short-circuits; cross-scope matches are
+        // rejected to prevent api-key hijack via repair; empty-scope mirrors
+        // (legacy entries from before scope was tracked) get reused so the
+        // backfill path attaches a scope rather than diverging.
+        ChannelBotRegistrationEntry? existing = null;
+        try
+        {
+            var registrations = await queryPort.QueryAllAsync(ct);
+            existing = registrations.FirstOrDefault(entry =>
+                string.Equals(entry.Platform, "lark", StringComparison.OrdinalIgnoreCase) &&
+                MatchesNyxIdentity(entry, nyxChannelBotId, nyxAgentApiKeyId, nyxConversationRouteId));
+            if (existing is not null)
+            {
+                var existingScopeId = NormalizeOptional(existing.ScopeId);
+                if (existingScopeId is not null)
+                {
+                    if (!string.Equals(existingScopeId, scopeResolution.ScopeId, StringComparison.Ordinal))
+                    {
+                        logger.LogWarning(
+                            "Lark mirror repair rejected: matching mirror belongs to a different scope. registrationId={RegistrationId} existingScopeId={ExistingScopeId} requestedScopeId={RequestedScopeId}",
+                            existing.Id,
+                            existingScopeId,
+                            scopeResolution.ScopeId);
+                        return Results.BadRequest(new
+                        {
+                            error = "matching local Aevatar mirror belongs to a different scope_id",
+                            registration_id = existing.Id,
+                        });
+                    }
+
+                    return Results.Ok(new
+                    {
+                        status = "already_registered",
+                        registration_id = existing.Id,
+                        nyx_channel_bot_id = existing.NyxChannelBotId,
+                        nyx_agent_api_key_id = existing.NyxAgentApiKeyId,
+                        nyx_conversation_route_id = existing.NyxConversationRouteId,
+                        webhook_url = existing.WebhookUrl,
+                        nyx_provider_slug = string.IsNullOrWhiteSpace(existing.NyxProviderSlug)
+                            ? "api-lark-bot"
+                            : existing.NyxProviderSlug,
+                        note = "Matching local Aevatar mirror already exists.",
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Repair must remain usable when the read side is degraded —
+            // logging only, falling through to the dispatch path.
+            logger.LogWarning(
+                ex,
+                "Lark mirror repair preflight failed; falling through to dispatch without short-circuit. nyxChannelBotId={NyxChannelBotId}",
+                nyxChannelBotId);
+        }
+
+        // Reuse the existing registration id when an empty-scope mirror exists
+        // and the caller did not supply one, so the backfill path attaches a
+        // scope instead of producing a parallel registration.
+        if (string.IsNullOrWhiteSpace(requestedRegistrationId) && existing is not null)
+            requestedRegistrationId = existing.Id;
+
         var result = await provisioningService.RepairLocalMirrorAsync(
             new NyxLarkMirrorRepairRequest(
                 AccessToken: accessToken,
-                RequestedRegistrationId: request.RegistrationId?.Trim() ?? string.Empty,
+                RequestedRegistrationId: requestedRegistrationId,
                 ScopeId: scopeResolution.ScopeId!,
                 NyxProviderSlug: request.NyxProviderSlug?.Trim() ?? string.Empty,
                 WebhookBaseUrl: request.WebhookBaseUrl.Trim(),
-                NyxChannelBotId: request.NyxChannelBotId.Trim(),
-                NyxAgentApiKeyId: request.NyxAgentApiKeyId.Trim(),
-                NyxConversationRouteId: request.NyxConversationRouteId?.Trim() ?? string.Empty),
+                NyxChannelBotId: nyxChannelBotId,
+                NyxAgentApiKeyId: nyxAgentApiKeyId,
+                NyxConversationRouteId: nyxConversationRouteId),
             ct);
 
         var payload = new
@@ -357,6 +432,34 @@ public static class ChannelCallbackEndpoints
             statusCode,
             result.Error);
         return Results.Json(payload, statusCode: statusCode);
+    }
+
+    private static bool MatchesNyxIdentity(
+        ChannelBotRegistrationEntry entry,
+        string nyxChannelBotId,
+        string nyxAgentApiKeyId,
+        string nyxConversationRouteId)
+    {
+        var hasConstraint = false;
+
+        if (!MatchesIfProvided(entry.NyxChannelBotId, nyxChannelBotId, ref hasConstraint))
+            return false;
+        if (!MatchesIfProvided(entry.NyxAgentApiKeyId, nyxAgentApiKeyId, ref hasConstraint))
+            return false;
+        if (!MatchesIfProvided(entry.NyxConversationRouteId, nyxConversationRouteId, ref hasConstraint))
+            return false;
+
+        return hasConstraint;
+    }
+
+    private static bool MatchesIfProvided(string actual, string expected, ref bool hasConstraint)
+    {
+        if (string.IsNullOrWhiteSpace(expected))
+            return true;
+
+        hasConstraint = true;
+        return !string.IsNullOrWhiteSpace(actual) &&
+               string.Equals(actual, expected, StringComparison.Ordinal);
     }
 
     private static string? ResolveBearerAccessToken(HttpContext http)

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
@@ -29,6 +29,7 @@ public static class ChannelCallbackEndpoints
         group.MapPost("/registrations", HandleRegisterAsync).RequireAuthorization();
         group.MapGet("/registrations", HandleListRegistrationsAsync).RequireAuthorization();
         group.MapPost("/registrations/rebuild", HandleRebuildRegistrationsAsync).RequireAuthorization();
+        group.MapPost("/registrations/repair-lark-mirror", HandleRepairLarkMirrorAsync).RequireAuthorization();
         group.MapDelete("/registrations/{registrationId}", HandleDeleteRegistrationAsync).RequireAuthorization();
 
         // Diagnostic: test reply path without going through full LLM chat
@@ -273,6 +274,91 @@ public static class ChannelCallbackEndpoints
         });
     }
 
+    /// <summary>
+    /// Repairs the local <c>channel-bot-registration-store</c> mirror for a Lark
+    /// bot whose Nyx-side resources (api-key, channel-bot, conversation-route)
+    /// already exist but whose local <see cref="ChannelBotRegistrationDocument"/>
+    /// is missing — typically after a namespace migration that destroyed the
+    /// authoritative actor and left no entry to project. Idempotent: re-running
+    /// against an already-mirrored registration returns <c>already_registered</c>
+    /// without dispatching another <c>ChannelBotRegisterCommand</c>.
+    ///
+    /// Direct HTTP equivalent of the LLM-tool path
+    /// <c>channel_registrations action=repair_lark_mirror</c>; see
+    /// <c>docs/operations/2026-04-29-lark-mirror-recovery-runbook.md</c>.
+    /// </summary>
+    private static async Task<IResult> HandleRepairLarkMirrorAsync(
+        HttpContext http,
+        [FromServices] INyxLarkProvisioningService provisioningService,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Aevatar.ChannelRuntime.Repair");
+
+        RepairLarkMirrorRequest? request;
+        try
+        {
+            request = await http.Request.ReadFromJsonAsync<RepairLarkMirrorRequest>(RegistrationJsonOptions, ct);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Invalid repair-lark-mirror request payload");
+            return Results.BadRequest(new { error = "Invalid JSON" });
+        }
+
+        if (request is null)
+            return Results.BadRequest(new { error = "request body is required" });
+
+        if (string.IsNullOrWhiteSpace(request.NyxChannelBotId))
+            return Results.BadRequest(new { error = "nyx_channel_bot_id is required" });
+        if (string.IsNullOrWhiteSpace(request.NyxAgentApiKeyId))
+            return Results.BadRequest(new { error = "nyx_agent_api_key_id is required" });
+        if (string.IsNullOrWhiteSpace(request.WebhookBaseUrl))
+            return Results.BadRequest(new { error = "webhook_base_url is required" });
+
+        var accessToken = ResolveBearerAccessToken(http);
+        if (string.IsNullOrWhiteSpace(accessToken))
+            return Results.Unauthorized();
+
+        var scopeResolution = ResolveScopeId(http, request.ScopeId, required: true);
+        if (scopeResolution.Error is not null)
+            return Results.BadRequest(new { error = scopeResolution.Error });
+
+        var result = await provisioningService.RepairLocalMirrorAsync(
+            new NyxLarkMirrorRepairRequest(
+                AccessToken: accessToken,
+                RequestedRegistrationId: request.RegistrationId?.Trim() ?? string.Empty,
+                ScopeId: scopeResolution.ScopeId!,
+                NyxProviderSlug: request.NyxProviderSlug?.Trim() ?? string.Empty,
+                WebhookBaseUrl: request.WebhookBaseUrl.Trim(),
+                NyxChannelBotId: request.NyxChannelBotId.Trim(),
+                NyxAgentApiKeyId: request.NyxAgentApiKeyId.Trim(),
+                NyxConversationRouteId: request.NyxConversationRouteId?.Trim() ?? string.Empty),
+            ct);
+
+        var payload = new
+        {
+            status = result.Status,
+            registration_id = result.RegistrationId ?? string.Empty,
+            nyx_channel_bot_id = result.NyxChannelBotId ?? string.Empty,
+            nyx_agent_api_key_id = result.NyxAgentApiKeyId ?? string.Empty,
+            nyx_conversation_route_id = result.NyxConversationRouteId ?? string.Empty,
+            webhook_url = result.WebhookUrl ?? string.Empty,
+            error = result.Error ?? string.Empty,
+            note = result.Note ?? string.Empty,
+        };
+
+        if (result.Succeeded)
+            return Results.Accepted(value: payload);
+
+        var statusCode = ResolveProvisioningFailureStatusCode(result.Error);
+        logger.LogWarning(
+            "Lark mirror repair rejected: statusCode={StatusCode}, error={Error}",
+            statusCode,
+            result.Error);
+        return Results.Json(payload, statusCode: statusCode);
+    }
+
     private static string? ResolveBearerAccessToken(HttpContext http)
     {
         var accessToken = http.Request.Headers.Authorization.ToString();
@@ -442,6 +528,15 @@ public static class ChannelCallbackEndpoints
         string? NyxAgentApiKeyId,
         string? Reason,
         bool Force);
+
+    private sealed record RepairLarkMirrorRequest(
+        string? RegistrationId,
+        string? ScopeId,
+        string? NyxProviderSlug,
+        string? WebhookBaseUrl,
+        string? NyxChannelBotId,
+        string? NyxAgentApiKeyId,
+        string? NyxConversationRouteId);
 
     private sealed record RegistrationRequest(
         string? Platform,

--- a/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
+++ b/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
@@ -35,13 +35,23 @@ If both lines hold, this runbook is the right one.
   `projection.durable.scope:*` actor — that's the Orleans pub/sub stale-state
   issue covered by PR #501.
 - `EventStoreOptimisticConcurrencyException: expected N, actual N+1` — that's
-  the version-key drift issue covered by issue #502 (and is now self-healing
-  in `EventSourcingBehavior` after that PR lands).
+  the version-key drift issue covered by issue #502. After PR #503 lands,
+  `EventSourcingBehavior.ConfirmEventsAsync` self-heals on conflict by
+  refreshing `_currentVersion` and dropping the rejected batch from
+  `_pending` (handler re-execution replays it on the runtime envelope retry,
+  no duplicates). On replay, drift is fatal by default (throws
+  `EventStoreVersionDriftException`); projection scope actors opt in via
+  `EventSourcingRuntimeOptions.ShouldRecoverFromVersionDriftOnReplay` (wired
+  in `Aevatar.Foundation.Runtime.Hosting` to recover only
+  `projection.{durable,session}.scope:*` ids). Domain GAgents still throw —
+  see the runbook for #502 for the manual repair procedure if you hit drift
+  on a non-projection actor.
 - `Optimistic concurrency conflict` followed by relay 401 in the SAME silo
-  start — that's a chained failure where the projection scope is stuck. Run
-  the version-key drift recovery first (delete the three Garnet keys for the
-  scope actor, restart the silo), THEN come back here if registrations are
-  still `[]`.
+  start — that's a chained failure where the projection scope is stuck.
+  Projection scope drift is now self-recovered on activation; if it still
+  wedges, capture the `EventStoreVersionDriftException` (or the
+  `Event sourcing replay recovering from version drift` warning) for triage,
+  then come back here if registrations are still `[]`.
 
 ## Why the data went missing
 
@@ -242,10 +252,18 @@ projection scope health (issue #502 territory).
 ## When to stop using this runbook
 
 The version-key drift symptoms covered in the "What is NOT this runbook"
-section are now self-healing in `EventSourcingBehavior` as of issue #502,
-so step 5 should rarely be preceded by a manual Garnet reset. Keep this
-runbook as long as the data-loss path through retired-actor cleanup is
-still possible — i.e. as long as `RetiredActorCleanupHostedService` can
-destroy `channel-bot-registration-store` and migrate to a new actor type
-without a parallel data-migration path. If that gap closes, this runbook
-becomes obsolete.
+section are now self-healing for projection scope actors only:
+`EventSourcingBehavior.ConfirmEventsAsync` recovers from the conflict loop
+universally, while `ReplayAsync` recovers from drift only for actor ids
+matching the `projection.{durable,session}.scope:` prefixes (see
+`Aevatar.Foundation.Runtime.Hosting`'s
+`ShouldRecoverFromVersionDriftOnReplay` wiring). Step 5 should rarely be
+preceded by a manual Garnet reset for projection scope actors; for any
+other actor that hits drift, the activation throws
+`EventStoreVersionDriftException` and the operator must repair the store
+manually. Keep this runbook as long as the data-loss path through
+retired-actor cleanup is still possible — i.e. as long as
+`RetiredActorCleanupHostedService` can destroy
+`channel-bot-registration-store` and migrate to a new actor type without a
+parallel data-migration path. If that gap closes, this runbook becomes
+obsolete.

--- a/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
+++ b/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
@@ -1,0 +1,211 @@
+# Lark Channel-Bot Local Mirror Recovery Runbook
+
+This runbook covers the case where Lark messages reach
+`/api/webhooks/nyxid-relay` and authenticate successfully, but Aevatar replies
+with `401 Unauthorized` because the local `ChannelBotRegistrationDocument` for
+the bot's NyxID api-key is missing. The Nyx-side bot, route, and api-key all
+still exist and are working; only the Aevatar mirror was lost.
+
+This is the recovery path used during the 2026-04-28 incident
+(see issue #502 for the underlying drivers).
+
+## Symptom signature (grep this exactly)
+
+In console-backend logs:
+
+```
+warn: Aevatar.NyxId.Chat.Relay[0]
+      Relay callback authentication succeeded but did not resolve a canonical scope id:
+      message=<uuid>, apiKeyId=<uuid>
+HTTP/1.1 POST .../api/webhooks/nyxid-relay - 401
+```
+
+And the local registrations list comes back empty:
+
+```bash
+aevatar-cli api GET /api/channels/registrations
+# []
+```
+
+If both lines hold, this runbook is the right one.
+
+## What is NOT this runbook
+
+- `RegisterAsStreamProducer failed` / `InconsistentStateException` for a
+  `projection.durable.scope:*` actor — that's the Orleans pub/sub stale-state
+  issue covered by PR #501.
+- `EventStoreOptimisticConcurrencyException: expected N, actual N+1` — that's
+  the version-key drift issue covered by issue #502 (and is now self-healing
+  in `EventSourcingBehavior` after that PR lands).
+- `Optimistic concurrency conflict` followed by relay 401 in the SAME silo
+  start — that's a chained failure where the projection scope is stuck. Run
+  the version-key drift recovery first (delete the three Garnet keys for the
+  scope actor, restart the silo), THEN come back here if registrations are
+  still `[]`.
+
+## Why the data went missing
+
+The `channel-bot-registration-store` actor lives at one stable id under
+`Aevatar.GAgents.Channel.Runtime`. Past namespace migrations (e.g.
+`ChannelRuntime` → `Channel.Runtime`) routed retired-actor cleanup through
+`RetiredActorCleanupHostedService`, which destroyed the old actor + reset its
+event stream. The migration replaces the actor binding but does not migrate
+the registration entries into a new actor — `state.Registrations` on the
+new-namespace actor is empty, so the query-side
+`ChannelBotRegistrationDocument` index has nothing to project.
+
+Anything that triggered a destroy+reset of `channel-bot-registration-store`
+without re-mirroring from Nyx (manual cleanup, retired-cleanup, accidental
+key wipe in Garnet) lands you here.
+
+## Prerequisites
+
+- `aevatar-cli` installed and authenticated against the affected environment.
+- `nyxid` CLI installed and logged in to the NyxID account that owns the bot.
+- The NyxID account must have admin/list access to the channel-bot in
+  question. For personal scopes this is the same user that originally
+  provisioned the bot.
+
+## Recovery steps
+
+### 1. Confirm the diagnosis
+
+```bash
+aevatar-cli env                        # confirm env is the one you expect
+aevatar-cli whoami
+aevatar-cli api GET /api/channels/registrations
+```
+
+If the last command returns `[]`, the local mirror is empty as expected.
+
+### 2. Find the Nyx-side identifiers
+
+`repair_lark_mirror` needs four pieces of data:
+`nyx_channel_bot_id`, `nyx_agent_api_key_id`, `nyx_conversation_route_id`,
+and `scope_id`. The relay 401 log line gives you `apiKeyId` for free; the
+others come from the NyxID CLI.
+
+```bash
+# The Lark bot itself.
+nyxid channel-bot list --output json
+# Find the lark bot whose label/api-key match the failing webhook.
+# nyx_channel_bot_id = bots[i].id
+
+# Conversation route attached to the bot.
+nyxid channel-bot route list --bot-id <nyx_channel_bot_id> --output json
+# nyx_conversation_route_id = conversations[0].id
+
+# Sanity-check the api-key matches the apiKeyId in the relay 401 log.
+nyxid api-key show <nyx_agent_api_key_id> --output json
+# Confirm:
+#   - callback_url ends in /api/webhooks/nyxid-relay on the right host
+#   - is_active = true
+```
+
+If the api-key is inactive or the channel-bot is not present in Nyx, this
+runbook does not apply — the bot needs to be re-provisioned from scratch
+through `channel_registrations action=register_lark_via_nyx` (see the cutover
+runbook). Stop here.
+
+### 3. (Optional) Recover the original `registration_id`
+
+If you want the rebuilt mirror to keep the pre-incident registration id
+(useful when external systems already reference it), the id can be recovered
+from two prefixes that surface in the Nyx-side resources:
+
+- The bot label is `Aevatar Lark Bot {registrationId[..8]}`.
+- The api-key name is `aevatar-lark-relay-{registrationId[..12]}`.
+
+So the bot label `Aevatar Lark Bot 4c829032` plus api-key name
+`aevatar-lark-relay-4c829032a027` together expose 12 hex characters of the
+original 32-char registration id (`4c829032a027...`). If a historical
+projection-store delete log is still around, the FULL id is in the
+Elasticsearch delete trace:
+
+```
+Projection read-model delete completed.
+   readModelType=Aevatar.GAgents.Channel.Runtime.ChannelBotRegistrationDocument
+   key=4c829032a02746cbb85f3ab871a2c4d6  result=Applied
+```
+
+Otherwise it's safe to let `repair_lark_mirror` mint a new registration id —
+the apiKey-based relay routing does not depend on it.
+
+### 4. Find your Aevatar `scope_id`
+
+```bash
+aevatar-cli api GET /api/auth/me
+# scopeId = ... (this is what `repair_lark_mirror` needs)
+```
+
+For personal scopes this is your NyxID `sub`. Pin this scope as active so
+chat works:
+
+```bash
+aevatar-cli scopes use <scope_id>
+```
+
+### 5. Trigger `repair_lark_mirror` via the NyxidChat agent
+
+`repair_lark_mirror` is an LLM tool, not a direct HTTP endpoint. Open a chat
+conversation in the bound scope and ask the agent to call it with the IDs
+collected above:
+
+```bash
+aevatar-cli chat new --title "repair-lark-mirror"
+aevatar-cli chat "Run channel_registrations action=repair_lark_mirror with:
+- nyx_channel_bot_id=<from step 2>
+- nyx_agent_api_key_id=<from step 2>
+- nyx_conversation_route_id=<from step 2>
+- registration_id=<from step 3, or omit to mint a new one>
+- scope_id=<from step 4>
+- nyx_provider_slug=api-lark-bot
+- webhook_base_url=<aevatar host>
+
+The local Aevatar mirror is missing for this Lark bot; Nyx already has all
+the resources. Just call repair_lark_mirror to rebuild the local mirror."
+```
+
+The `aevatar-cli chat` rendering may print `[unknown frame: message]` lines
+while the SSE stream is in flight. That's a known cosmetic gap — the call
+still completes. Verify by re-querying the registrations list:
+
+```bash
+aevatar-cli api GET /api/channels/registrations
+```
+
+The bot should now appear with the correct `nyx_agent_api_key_id`.
+
+### 6. Verify Lark replies
+
+Send a message to the Lark bot. Watch the console-backend logs:
+
+- Relay webhook returns `200`/`202` (no more 401 on the canonical-scope-id
+  branch).
+- `Resolved relay callback scope id from relay scope resolver` info log fires.
+- The bot replies in Lark.
+
+If the relay is still 401 at this point, the registration is in the local
+mirror but the projection write hasn't reached Elasticsearch yet —
+`ChannelBotRegistrationProjector` writes asynchronously through the
+projection scope. Wait ~5–10 seconds and retry; if it persists, check
+projection scope health (issue #502 territory).
+
+## What you must NOT do as a shortcut
+
+- **Do not call `POST /api/channels/registrations`** to "re-register" the
+  bot. That endpoint goes through `INyxChannelBotProvisioningService.ProvisionAsync`,
+  which is **not idempotent** and creates a new Nyx api-key + channel-bot +
+  route every time. The original Nyx resources stay alive but orphaned, and
+  the Lark Developer Console webhook URL no longer matches the new bot.
+- **Do not delete the Nyx api-key/bot/route to "force a clean state"**.
+  Lark is configured to deliver to the Nyx webhook URL tied to the existing
+  Nyx channel-bot id. Deleting it requires reconfiguring Lark.
+
+## When to stop using this runbook
+
+Once issue #502's `EventSourcingBehavior` hardening is deployed AND a
+direct authenticated HTTP repair endpoint is added (proposed in #502),
+recovery becomes a single API call against `repair_lark_mirror` without
+needing a chat session or scope binding. Update or delete this runbook
+when that lands.

--- a/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
+++ b/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
@@ -145,11 +145,46 @@ chat works:
 aevatar-cli scopes use <scope_id>
 ```
 
-### 5. Trigger `repair_lark_mirror` via the NyxidChat agent
+### 5. Trigger the repair
 
-`repair_lark_mirror` is an LLM tool, not a direct HTTP endpoint. Open a chat
-conversation in the bound scope and ask the agent to call it with the IDs
-collected above:
+There are two equivalent ways to trigger `repair_lark_mirror`. Pick the
+direct HTTP endpoint when the silo is healthy enough to serve requests; fall
+back to the LLM tool path if it isn't (e.g. NyxidChat agent is the only
+known-working interface).
+
+#### 5a. Direct HTTP endpoint (preferred)
+
+`POST /api/channels/registrations/repair-lark-mirror` is the authenticated
+direct equivalent of the LLM tool. It validates Nyx-side resources and
+dispatches the local `ChannelBotRegisterCommand` exactly like the tool does,
+without needing a chat session or a scope-bound NyxidChat agent.
+
+```bash
+aevatar-cli api POST /api/channels/registrations/repair-lark-mirror --json '{
+  "registration_id": "<from step 3, optional>",
+  "scope_id": "<from step 4>",
+  "nyx_provider_slug": "api-lark-bot",
+  "webhook_base_url": "https://<aevatar-host>",
+  "nyx_channel_bot_id": "<from step 2>",
+  "nyx_agent_api_key_id": "<from step 2>",
+  "nyx_conversation_route_id": "<from step 2>"
+}'
+```
+
+Successful response is `202 Accepted` with the registration id and the IDs
+echoed back. Failures map to the same status codes used by `POST
+/api/channels/registrations`:
+
+- `400` — missing required field, scope mismatch, malformed JSON
+- `401` — no Authorization bearer token
+- `502` — Nyx-side resource lookup failed (api-key inactive, channel-bot
+  deleted, route mismatch)
+- `500` — `nyx_base_url_not_configured` (host misconfiguration, escalate)
+
+#### 5b. LLM-tool fallback (`channel_registrations action=repair_lark_mirror`)
+
+Same operation, routed through the `NyxidChat` agent's tool surface. Use
+this if the direct endpoint is unavailable on the deployed version.
 
 ```bash
 aevatar-cli chat new --title "repair-lark-mirror"
@@ -168,7 +203,9 @@ the resources. Just call repair_lark_mirror to rebuild the local mirror."
 
 The `aevatar-cli chat` rendering may print `[unknown frame: message]` lines
 while the SSE stream is in flight. That's a known cosmetic gap — the call
-still completes. Verify by re-querying the registrations list:
+still completes.
+
+#### Verify either path
 
 ```bash
 aevatar-cli api GET /api/channels/registrations
@@ -204,8 +241,11 @@ projection scope health (issue #502 territory).
 
 ## When to stop using this runbook
 
-Once issue #502's `EventSourcingBehavior` hardening is deployed AND a
-direct authenticated HTTP repair endpoint is added (proposed in #502),
-recovery becomes a single API call against `repair_lark_mirror` without
-needing a chat session or scope binding. Update or delete this runbook
-when that lands.
+The version-key drift symptoms covered in the "What is NOT this runbook"
+section are now self-healing in `EventSourcingBehavior` as of issue #502,
+so step 5 should rarely be preceded by a manual Garnet reset. Keep this
+runbook as long as the data-loss path through retired-actor cleanup is
+still possible — i.e. as long as `RetiredActorCleanupHostedService` can
+destroy `channel-bot-registration-store` and migrate to a new actor type
+without a parallel data-migration path. If that gap closes, this runbook
+becomes obsolete.

--- a/src/Aevatar.Foundation.Abstractions/Persistence/EventStoreVersionDriftException.cs
+++ b/src/Aevatar.Foundation.Abstractions/Persistence/EventStoreVersionDriftException.cs
@@ -1,0 +1,33 @@
+namespace Aevatar.Foundation.Abstractions.Persistence;
+
+/// <summary>
+/// Raised by ReplayAsync when the event store's version key is ahead of the
+/// last applied event/snapshot version — trailing events are missing from
+/// the events sequence, the snapshot lags the store, or the events sorted
+/// set was wiped while the version counter survived. Activating the actor
+/// in this state would build new authoritative facts on top of an
+/// incomplete history. Default behavior is to throw and let an operator
+/// decide; opt in via <c>EventSourcingRuntimeOptions.RecoverFromVersionDriftOnReplay</c>
+/// when the actor's transitions are idempotent (e.g. projection scopes).
+/// </summary>
+public sealed class EventStoreVersionDriftException : InvalidOperationException
+{
+    public EventStoreVersionDriftException(
+        string agentId,
+        long replayedVersion,
+        long storeVersion)
+        : base(
+            $"Event store version drift detected for agent '{agentId}': replayed up to version {replayedVersion}, store version is {storeVersion}. " +
+            $"Activating would skip {storeVersion - replayedVersion} committed event(s). Set EventSourcingRuntimeOptions.RecoverFromVersionDriftOnReplay=true to recover at the store version with stale state, or repair the store.")
+    {
+        AgentId = agentId ?? string.Empty;
+        ReplayedVersion = replayedVersion;
+        StoreVersion = storeVersion;
+    }
+
+    public string AgentId { get; }
+
+    public long ReplayedVersion { get; }
+
+    public long StoreVersion { get; }
+}

--- a/src/Aevatar.Foundation.Core/EventSourcing/DefaultEventSourcingBehaviorFactory.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/DefaultEventSourcingBehaviorFactory.cs
@@ -44,6 +44,9 @@ public sealed class DefaultEventSourcingBehaviorFactory<TState>
             ? new IntervalSnapshotStrategy(_options.SnapshotInterval)
             : NeverSnapshotStrategy.Instance;
 
+        var recoverFromVersionDrift = _options.RecoverFromVersionDriftOnReplay
+            || (_options.ShouldRecoverFromVersionDriftOnReplay?.Invoke(agentId) ?? false);
+
         return new DelegatingEventSourcingBehavior(
             _eventStore,
             agentId,
@@ -53,7 +56,8 @@ public sealed class DefaultEventSourcingBehaviorFactory<TState>
             _logger,
             _options.EnableEventCompaction,
             _options.RetainedEventsAfterSnapshot,
-            _compactionScheduler);
+            _compactionScheduler,
+            recoverFromVersionDrift);
     }
 
     private sealed class DelegatingEventSourcingBehavior : EventSourcingBehavior<TState>
@@ -69,7 +73,8 @@ public sealed class DefaultEventSourcingBehaviorFactory<TState>
             ILogger<EventSourcingBehavior<TState>>? logger,
             bool enableEventCompaction,
             int retainedEventsAfterSnapshot,
-            IEventStoreCompactionScheduler? compactionScheduler)
+            IEventStoreCompactionScheduler? compactionScheduler,
+            bool recoverFromVersionDriftOnReplay)
             : base(
                 eventStore,
                 agentId,
@@ -78,7 +83,8 @@ public sealed class DefaultEventSourcingBehaviorFactory<TState>
                 logger,
                 enableEventCompaction,
                 retainedEventsAfterSnapshot,
-                compactionScheduler)
+                compactionScheduler,
+                recoverFromVersionDriftOnReplay)
         {
             _transitionState = transitionState;
         }

--- a/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs
@@ -26,6 +26,7 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
     private readonly IEventStoreCompactionScheduler? _compactionScheduler;
     private readonly bool _enableEventCompaction;
     private readonly int _retainedEventsAfterSnapshot;
+    private readonly bool _recoverFromVersionDriftOnReplay;
     private readonly ILogger<EventSourcingBehavior<TState>> _logger;
     private readonly List<IMessage> _pending = [];
     private readonly string _agentId;
@@ -39,7 +40,8 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
         ILogger<EventSourcingBehavior<TState>>? logger = null,
         bool enableEventCompaction = false,
         int retainedEventsAfterSnapshot = 0,
-        IEventStoreCompactionScheduler? compactionScheduler = null)
+        IEventStoreCompactionScheduler? compactionScheduler = null,
+        bool recoverFromVersionDriftOnReplay = false)
     {
         _eventStore = eventStore;
         _agentId = agentId;
@@ -48,6 +50,7 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
         _compactionScheduler = compactionScheduler;
         _enableEventCompaction = enableEventCompaction;
         _retainedEventsAfterSnapshot = Math.Max(0, retainedEventsAfterSnapshot);
+        _recoverFromVersionDriftOnReplay = recoverFromVersionDriftOnReplay;
         _logger = logger ?? NullLogger<EventSourcingBehavior<TState>>.Instance;
     }
 
@@ -111,16 +114,23 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
             // runtime envelope retry policy) recomputes versions and commits
             // cleanly.
             //
-            // Pending events are left intact: this catch path assumes the
-            // store implementation guarantees full-batch atomicity on conflict
-            // (Garnet via the AppendScript Lua transaction; InMemoryEventStore
-            // via its lock-and-check). Under that contract no events from this
-            // batch made it to the store, so the next attempt safely re-stamps
-            // _pending with versions computed from the refreshed
-            // _currentVersion. A future store with partial-commit semantics
-            // would need to extend this catch to drop the already-committed
-            // prefix from _pending, otherwise the retry would duplicate
-            // domain events.
+            // Drop the prefix that was supposed to commit in this batch from
+            // _pending. The runtime envelope retry replays the same envelope,
+            // which re-executes the handler — the handler will call
+            // RaiseEvent again for the same logical events, so leaving the
+            // committed-prefix in _pending would duplicate them on the next
+            // commit. The suffix raised mid-flight (existing
+            // ConfirmEventsAsync_WhenNewEventIsRaisedDuringAppend contract)
+            // is preserved.
+            //
+            // This trims based on the assumption that the store guarantees
+            // full-batch atomicity on conflict (Garnet's AppendScript Lua
+            // transaction; InMemoryEventStore's lock-and-check) — no events
+            // from this batch made it to the store, and the entire prefix
+            // will be re-raised by the handler on retry. A future store with
+            // partial-commit semantics would need to compute the actual
+            // committed-prefix length (e.g. ex.ActualVersion - fromVersion)
+            // and trim only that many entries.
             //
             // Guard against a malformed exception that reports an
             // ActualVersion behind the in-memory _currentVersion: silently
@@ -144,14 +154,16 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
             {
                 _logger.LogWarning(
                     ex,
-                    "Event sourcing commit hit optimistic concurrency conflict; refreshing _currentVersion so the next retry can recover. agentId={AgentId} eventType={EventType} expectedVersion={ExpectedVersion} actualVersion={ActualVersion} elapsedMs={ElapsedMs}",
+                    "Event sourcing commit hit optimistic concurrency conflict; refreshing _currentVersion and dropping the rejected batch from _pending so handler re-execution can replay it. agentId={AgentId} eventType={EventType} expectedVersion={ExpectedVersion} actualVersion={ActualVersion} droppedFromPending={DroppedFromPending} elapsedMs={ElapsedMs}",
                     _agentId,
                     eventType,
                     ex.ExpectedVersion,
                     ex.ActualVersion,
+                    pendingEvents.Length,
                     Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds);
             }
             _currentVersion = refreshed;
+            RemoveCommittedPendingPrefix(pendingEvents.Length);
             throw;
         }
         catch (Exception ex)
@@ -210,39 +222,16 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
         long? fromVersion = snapshot?.Version;
         var events = await _eventStore.GetEventsAsync(agentId, fromVersion, ct);
 
-        // Use the store's authoritative version key as a floor for
-        // _currentVersion. The events sequence and the version key can drift
-        // (interrupted Lua append in Garnet, snapshot+compaction that wiped
-        // events but left the version key, externally-seeded store, etc.) — if
-        // we trust events[^1].Version alone, the actor reactivates with a
-        // _currentVersion that's behind the store and every subsequent
-        // AppendAsync hits EventStoreOptimisticConcurrencyException
-        // permanently. State may be slightly stale (transitions for missing
-        // events are not applied), but commits make forward progress and
-        // ConfirmEventsAsync's catch path can refresh further on conflict.
-        //
-        // The version-key probe is unconditional rather than gated behind
-        // events.Count == 0. Partial compaction can leave the events sorted
-        // set with valid (but trailing) entries while the version key is
-        // ahead — events[^1].Version < storeVersion is a real shape, not
-        // just the empty-events case. Skipping the probe in the
-        // events.Count > 0 branch would miss it. The cost is one extra
-        // store read per activation; for Garnet that's a single Redis GET
-        // co-located with the events query, which is negligible relative
-        // to the actor activation envelope.
+        // Always probe the store's authoritative version key. Partial
+        // compaction can leave the events sorted set with valid (but
+        // trailing) entries while the version key is ahead —
+        // events[^1].Version < storeVersion is a real shape, not just the
+        // empty-events case. Skipping the probe in the events.Count > 0
+        // branch would miss it. The cost is one extra store read per
+        // activation; for Garnet that's a single Redis GET co-located with
+        // the events query, which is negligible relative to the actor
+        // activation envelope.
         var storeVersion = await _eventStore.GetVersionAsync(agentId, ct);
-
-        if (events.Count == 0)
-        {
-            if (snapshot == null)
-            {
-                _currentVersion = storeVersion;
-                return null;
-            }
-
-            _currentVersion = Math.Max(snapshot.Version, storeVersion);
-            return snapshot.State;
-        }
 
         var state = snapshot?.State ?? new TState();
         foreach (var stateEvent in events)
@@ -251,8 +240,47 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
                 state = TransitionState(state, stateEvent.EventData);
         }
 
-        _currentVersion = Math.Max(events[^1].Version, storeVersion);
-        return state;
+        var replayedVersion = events.Count > 0
+            ? events[^1].Version
+            : (snapshot?.Version ?? 0);
+
+        if (storeVersion > replayedVersion)
+        {
+            // Drift: trailing committed events are missing from the events
+            // sequence (interrupted Lua append, partial compaction that
+            // wiped events but left the version key, externally-seeded
+            // store, etc.). Activating at replayedVersion would
+            // permanently conflict on every AppendAsync; activating at
+            // storeVersion would silently build new authoritative state on
+            // top of facts that were never applied. Default to throwing so
+            // the operator decides; only recover automatically when the
+            // host has opted into RecoverFromVersionDriftOnReplay (see
+            // EventSourcingRuntimeOptions for the safety contract).
+            if (!_recoverFromVersionDriftOnReplay)
+            {
+                _logger.LogError(
+                    "Event sourcing replay detected version drift and recovery is disabled. agentId={AgentId} replayedVersion={ReplayedVersion} storeVersion={StoreVersion} eventsCount={EventsCount} hasSnapshot={HasSnapshot}",
+                    agentId,
+                    replayedVersion,
+                    storeVersion,
+                    events.Count,
+                    snapshot != null);
+                throw new EventStoreVersionDriftException(agentId, replayedVersion, storeVersion);
+            }
+
+            _logger.LogWarning(
+                "Event sourcing replay recovering from version drift; activating at the store version with stale state. agentId={AgentId} replayedVersion={ReplayedVersion} storeVersion={StoreVersion} eventsCount={EventsCount} hasSnapshot={HasSnapshot}",
+                agentId,
+                replayedVersion,
+                storeVersion,
+                events.Count,
+                snapshot != null);
+            _currentVersion = storeVersion;
+            return events.Count == 0 && snapshot == null ? null : state;
+        }
+
+        _currentVersion = replayedVersion;
+        return events.Count == 0 && snapshot == null ? null : state;
     }
 
     /// <summary>

--- a/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs
@@ -101,6 +101,28 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
                 "ok");
             return commitResult;
         }
+        catch (EventStoreOptimisticConcurrencyException ex)
+        {
+            // In-memory _currentVersion is behind the store's authoritative
+            // version. Without refreshing, every retry would rebuild the same
+            // stateEvents at the same expectedVersion and conflict again,
+            // wedging the actor until it deactivates. Update to the store's
+            // version so the next ConfirmEventsAsync (typically driven by the
+            // runtime envelope retry policy) recomputes versions and commits
+            // cleanly. Pending events are left intact: they have not yet been
+            // accepted, and the next attempt will re-stamp them with versions
+            // computed from the refreshed _currentVersion.
+            _logger.LogWarning(
+                ex,
+                "Event sourcing commit hit optimistic concurrency conflict; refreshing _currentVersion so the next retry can recover. agentId={AgentId} eventType={EventType} expectedVersion={ExpectedVersion} actualVersion={ActualVersion} elapsedMs={ElapsedMs}",
+                _agentId,
+                eventType,
+                ex.ExpectedVersion,
+                ex.ActualVersion,
+                Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds);
+            _currentVersion = ex.ActualVersion;
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(
@@ -156,12 +178,28 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
         var snapshot = await TryLoadSnapshotAsync(agentId, ct);
         long? fromVersion = snapshot?.Version;
         var events = await _eventStore.GetEventsAsync(agentId, fromVersion, ct);
+
+        // Use the store's authoritative version key as a floor for
+        // _currentVersion. The events sequence and the version key can drift
+        // (interrupted Lua append in Garnet, snapshot+compaction that wiped
+        // events but left the version key, externally-seeded store, etc.) — if
+        // we trust events[^1].Version alone, the actor reactivates with a
+        // _currentVersion that's behind the store and every subsequent
+        // AppendAsync hits EventStoreOptimisticConcurrencyException
+        // permanently. State may be slightly stale (transitions for missing
+        // events are not applied), but commits make forward progress and
+        // ConfirmEventsAsync's catch path can refresh further on conflict.
+        var storeVersion = await _eventStore.GetVersionAsync(agentId, ct);
+
         if (events.Count == 0)
         {
             if (snapshot == null)
+            {
+                _currentVersion = storeVersion;
                 return null;
+            }
 
-            _currentVersion = snapshot.Version;
+            _currentVersion = Math.Max(snapshot.Version, storeVersion);
             return snapshot.State;
         }
 
@@ -172,7 +210,7 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
                 state = TransitionState(state, stateEvent.EventData);
         }
 
-        _currentVersion = events[^1].Version;
+        _currentVersion = Math.Max(events[^1].Version, storeVersion);
         return state;
     }
 

--- a/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingBehavior.cs
@@ -109,18 +109,49 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
             // wedging the actor until it deactivates. Update to the store's
             // version so the next ConfirmEventsAsync (typically driven by the
             // runtime envelope retry policy) recomputes versions and commits
-            // cleanly. Pending events are left intact: they have not yet been
-            // accepted, and the next attempt will re-stamp them with versions
-            // computed from the refreshed _currentVersion.
-            _logger.LogWarning(
-                ex,
-                "Event sourcing commit hit optimistic concurrency conflict; refreshing _currentVersion so the next retry can recover. agentId={AgentId} eventType={EventType} expectedVersion={ExpectedVersion} actualVersion={ActualVersion} elapsedMs={ElapsedMs}",
-                _agentId,
-                eventType,
-                ex.ExpectedVersion,
-                ex.ActualVersion,
-                Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds);
-            _currentVersion = ex.ActualVersion;
+            // cleanly.
+            //
+            // Pending events are left intact: this catch path assumes the
+            // store implementation guarantees full-batch atomicity on conflict
+            // (Garnet via the AppendScript Lua transaction; InMemoryEventStore
+            // via its lock-and-check). Under that contract no events from this
+            // batch made it to the store, so the next attempt safely re-stamps
+            // _pending with versions computed from the refreshed
+            // _currentVersion. A future store with partial-commit semantics
+            // would need to extend this catch to drop the already-committed
+            // prefix from _pending, otherwise the retry would duplicate
+            // domain events.
+            //
+            // Guard against a malformed exception that reports an
+            // ActualVersion behind the in-memory _currentVersion: silently
+            // accepting it would rewind the actor and likely corrupt the
+            // event sequence on the next commit. Keep _currentVersion as the
+            // higher of the two values and log loudly so the underlying
+            // contract violation surfaces.
+            var refreshed = Math.Max(_currentVersion, ex.ActualVersion);
+            if (refreshed != ex.ActualVersion)
+            {
+                _logger.LogError(
+                    ex,
+                    "Event sourcing commit hit optimistic concurrency conflict reporting an ActualVersion below in-memory _currentVersion. Keeping the larger value to avoid rewinding state. agentId={AgentId} eventType={EventType} expectedVersion={ExpectedVersion} actualVersion={ActualVersion} currentVersion={CurrentVersion}",
+                    _agentId,
+                    eventType,
+                    ex.ExpectedVersion,
+                    ex.ActualVersion,
+                    _currentVersion);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Event sourcing commit hit optimistic concurrency conflict; refreshing _currentVersion so the next retry can recover. agentId={AgentId} eventType={EventType} expectedVersion={ExpectedVersion} actualVersion={ActualVersion} elapsedMs={ElapsedMs}",
+                    _agentId,
+                    eventType,
+                    ex.ExpectedVersion,
+                    ex.ActualVersion,
+                    Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds);
+            }
+            _currentVersion = refreshed;
             throw;
         }
         catch (Exception ex)
@@ -189,6 +220,16 @@ public class EventSourcingBehavior<TState> : IEventSourcingBehavior<TState>
         // permanently. State may be slightly stale (transitions for missing
         // events are not applied), but commits make forward progress and
         // ConfirmEventsAsync's catch path can refresh further on conflict.
+        //
+        // The version-key probe is unconditional rather than gated behind
+        // events.Count == 0. Partial compaction can leave the events sorted
+        // set with valid (but trailing) entries while the version key is
+        // ahead — events[^1].Version < storeVersion is a real shape, not
+        // just the empty-events case. Skipping the probe in the
+        // events.Count > 0 branch would miss it. The cost is one extra
+        // store read per activation; for Garnet that's a single Redis GET
+        // co-located with the events query, which is negligible relative
+        // to the actor activation envelope.
         var storeVersion = await _eventStore.GetVersionAsync(agentId, ct);
 
         if (events.Count == 0)

--- a/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingRuntimeOptions.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingRuntimeOptions.cs
@@ -25,4 +25,39 @@ public sealed class EventSourcingRuntimeOptions
     /// 0 means delete all events up to snapshot version.
     /// </summary>
     public int RetainedEventsAfterSnapshot { get; set; } = 0;
+
+    /// <summary>
+    /// When ReplayAsync detects that the store's version key is ahead of the
+    /// last applied event/snapshot version (events lost between snapshot and
+    /// store version, trailing events lost after compaction, or partial Lua
+    /// append), the default behavior is to throw <see
+    /// cref="Aevatar.Foundation.Abstractions.Persistence.EventStoreVersionDriftException"/>
+    /// and refuse to activate the actor. Silently advancing to the store
+    /// version would build new authoritative state on top of facts that were
+    /// never applied — for a non-idempotent domain GAgent this is worse than
+    /// failing closed because the divergence is invisible to operators.
+    ///
+    /// Set this flag to <c>true</c> only when every actor sharing this
+    /// options instance can tolerate replaying with stale state at the
+    /// store-side version. Prefer <see
+    /// cref="ShouldRecoverFromVersionDriftOnReplay"/> for per-actor opt-in
+    /// (e.g. only projection scope actors) and leave this off as the safe
+    /// global default. With recovery active, ReplayAsync logs the drift at
+    /// warning, sets <c>_currentVersion</c> to the store version, and lets
+    /// the next commit proceed; the ConfirmEventsAsync catch path remains a
+    /// second line of defense.
+    /// </summary>
+    public bool RecoverFromVersionDriftOnReplay { get; set; }
+
+    /// <summary>
+    /// Per-agent opt-in predicate evaluated at behavior construction time.
+    /// Returning <c>true</c> for a given agent id enables drift recovery on
+    /// replay for that actor regardless of the global
+    /// <see cref="RecoverFromVersionDriftOnReplay"/> flag. Use this to scope
+    /// recovery to actor families that are known to be idempotent (e.g.
+    /// <c>agentId =&gt; agentId.StartsWith("projection.durable.scope:")</c>)
+    /// without granting the same affordance to domain GAgents that hold
+    /// non-idempotent state.
+    /// </summary>
+    public Func<string, bool>? ShouldRecoverFromVersionDriftOnReplay { get; set; }
 }

--- a/src/Aevatar.Foundation.Runtime.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -143,6 +143,18 @@ public static class ServiceCollectionExtensions
             $"Unsupported Orleans stream backend '{options.OrleansStreamBackend}'.");
     }
 
+    // Projection scope actor IDs use these well-known prefixes (durable
+    // materialization scopes and ephemeral session scopes). The actors
+    // observe committed facts and re-converge on replay, so it is safe for
+    // them to recover from version-key/sorted-set drift by activating at the
+    // store version with stale state — production incident #502 hit this
+    // exact wedge. Domain GAgents are NOT in this set: they keep the safe
+    // default of throwing EventStoreVersionDriftException so the divergence
+    // surfaces to operators instead of silently building new authoritative
+    // state on incomplete history.
+    private const string ProjectionDurableScopeActorIdPrefix = "projection.durable.scope:";
+    private const string ProjectionSessionScopeActorIdPrefix = "projection.session.scope:";
+
     private static void AddAevatarRuntimeWithEventSourcingOptions(
         IServiceCollection services,
         AevatarActorRuntimeOptions options)
@@ -153,6 +165,9 @@ public static class ServiceCollectionExtensions
             eventSourcingOptions.SnapshotInterval = options.EventSourcingSnapshotInterval;
             eventSourcingOptions.EnableEventCompaction = options.EventSourcingEnableEventCompaction;
             eventSourcingOptions.RetainedEventsAfterSnapshot = options.EventSourcingRetainedEventsAfterSnapshot;
+            eventSourcingOptions.ShouldRecoverFromVersionDriftOnReplay = static agentId =>
+                agentId.StartsWith(ProjectionDurableScopeActorIdPrefix, StringComparison.Ordinal)
+                || agentId.StartsWith(ProjectionSessionScopeActorIdPrefix, StringComparison.Ordinal);
         });
     }
 

--- a/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
@@ -221,15 +221,17 @@ public class EventSourcingBehaviorTests
     }
 
     [Fact]
-    public async Task ConfirmEventsAsync_WhenStoreVersionIsAhead_ShouldRefreshCurrentVersionAndAllowRetry()
+    public async Task ConfirmEventsAsync_WhenStoreVersionIsAhead_ShouldRefreshCurrentVersionAndAllowRetryViaHandlerReExecution()
     {
         // Reproduces the prod incident behind issue #502: a previous activation
         // committed up to v=N in the store, but this behavior's in-memory
-        // _currentVersion is behind. Without the catch-path refresh, every
-        // retry rebuilds stateEvents at the same expectedVersion and conflicts
-        // forever. Verify (1) the conflict surfaces, (2) _currentVersion is
-        // refreshed to ex.ActualVersion, (3) the next ConfirmEventsAsync uses
-        // the refreshed version and commits cleanly.
+        // _currentVersion is behind. Without the catch-path refresh + pending
+        // cleanup, the runtime envelope retry would either (a) wedge on the
+        // same conflict forever, or (b) succeed but with duplicate events.
+        // Models the real runtime envelope retry shape: handler runs, raises
+        // event, ConfirmEventsAsync conflicts, handler runs AGAIN (envelope
+        // redelivery), raises the same event, ConfirmEventsAsync succeeds —
+        // exactly one logical event is committed at the refreshed version.
         var store = new InMemoryEventStore();
         var behavior = new CounterEventSourcingBehavior(store, "agent-conflict");
 
@@ -243,7 +245,7 @@ public class EventSourcingBehaviorTests
             [BuildEvent(version: 2, amount: 20)],
             expectedVersion: 1);
 
-        // behavior thinks store is at v=0, raises one event, attempts commit.
+        // First handler invocation: raises event, attempts commit, conflicts.
         behavior.RaiseEvent(new IncrementEvent { Amount = 30 });
 
         await Should.ThrowAsync<EventStoreOptimisticConcurrencyException>(
@@ -251,9 +253,10 @@ public class EventSourcingBehaviorTests
 
         behavior.CurrentVersion.ShouldBe(2);
 
-        // Retry without re-raising: _pending is preserved so the runtime
-        // envelope retry policy gets to drive recovery without the caller
-        // duplicating the event.
+        // Envelope redelivery → handler runs again → raises the same event.
+        // Without _pending cleanup in the catch path, this would commit two
+        // copies of IncrementEvent { Amount = 30 } at v=3 and v=4.
+        behavior.RaiseEvent(new IncrementEvent { Amount = 30 });
         await behavior.ConfirmEventsAsync();
 
         behavior.CurrentVersion.ShouldBe(3);
@@ -263,6 +266,39 @@ public class EventSourcingBehaviorTests
         events.Count.ShouldBe(3);
         events[^1].Version.ShouldBe(3);
         events[^1].EventData.Unpack<IncrementEvent>().Amount.ShouldBe(30);
+        // Critical assertion: only ONE Amount=30 event in the stream, not two.
+        events.Count(evt => evt.EventData.Unpack<IncrementEvent>().Amount == 30).ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ConfirmEventsAsync_OnConflict_DropsRejectedBatchFromPendingSoEnvelopeRetryDoesNotDuplicate()
+    {
+        // Direct regression for the duplicate-events-on-conflict-retry bug
+        // raised in PR #503 review (comment 3158219396): leaving _pending
+        // intact across the conflict, then relying on Orleans envelope
+        // redelivery to re-execute the handler, produced two copies of one
+        // logical event in the stream. Asserting the catch path actively
+        // clears the rejected batch keeps the contract honest.
+        var store = new InMemoryEventStore();
+        var behavior = new CounterEventSourcingBehavior(store, "agent-pending-cleanup");
+
+        await store.AppendAsync(
+            "agent-pending-cleanup",
+            [BuildEvent(version: 1, amount: 7)],
+            expectedVersion: 0);
+
+        behavior.RaiseEvent(new IncrementEvent { Amount = 99 });
+
+        await Should.ThrowAsync<EventStoreOptimisticConcurrencyException>(
+            () => behavior.ConfirmEventsAsync());
+
+        // After conflict, _pending should be empty — calling ConfirmEventsAsync
+        // again without re-raising must be a no-op (no events to commit).
+        var noop = await behavior.ConfirmEventsAsync();
+        noop.LatestVersion.ShouldBe(1);
+        var afterNoop = await store.GetEventsAsync("agent-pending-cleanup");
+        afterNoop.Count.ShouldBe(1);
+        afterNoop[0].EventData.Unpack<IncrementEvent>().Amount.ShouldBe(7);
     }
 
     [Fact]
@@ -296,15 +332,44 @@ public class EventSourcingBehaviorTests
     }
 
     [Fact]
-    public async Task ReplayAsync_WhenStoreVersionIsAheadOfEvents_ShouldUseStoreVersionAsAuthority()
+    public async Task ReplayAsync_WhenStoreVersionIsAheadOfEvents_AndRecoveryDisabled_ShouldThrowDriftException()
+    {
+        // PR #503 review (comment 3158223163): silently advancing
+        // _currentVersion past missing committed events is unsafe for
+        // arbitrary domain GAgents because it builds new authoritative state
+        // on top of facts that were never applied. Default behavior must
+        // surface the drift so an operator decides; the projection-scope
+        // recovery path is opt-in via RecoverFromVersionDriftOnReplay.
+        var store = new InMemoryEventStore();
+        var behavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
+
+        behavior.RaiseEvent(new IncrementEvent { Amount = 1 });
+        behavior.RaiseEvent(new IncrementEvent { Amount = 2 });
+        behavior.RaiseEvent(new IncrementEvent { Amount = 3 });
+        behavior.RaiseEvent(new IncrementEvent { Amount = 4 });
+        await behavior.ConfirmEventsAsync();
+
+        await store.DeleteEventsUpToAsync("agent-version-drift", 4);
+
+        var freshBehavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
+
+        var ex = await Should.ThrowAsync<EventStoreVersionDriftException>(
+            () => freshBehavior.ReplayAsync("agent-version-drift"));
+        ex.AgentId.ShouldBe("agent-version-drift");
+        ex.ReplayedVersion.ShouldBe(0);
+        ex.StoreVersion.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task ReplayAsync_WhenStoreVersionIsAheadOfEvents_AndRecoveryEnabled_ShouldUseStoreVersionAsAuthority()
     {
         // The exact production failure mode behind issue #502: after a partial
         // compaction (events sorted set wiped, version key intact) the actor
         // reactivates with no events to replay but the store's version key
-        // ahead of the in-memory _currentVersion. ReplayAsync must reconcile
-        // _currentVersion to the store-authoritative version, otherwise the
-        // first AppendAsync expects v=0 against an actual v=N and conflicts
-        // permanently.
+        // ahead of the in-memory _currentVersion. With opt-in recovery enabled
+        // (e.g. for projection scope actors), ReplayAsync reconciles
+        // _currentVersion to the store-authoritative version so the first
+        // AppendAsync doesn't conflict permanently.
         var store = new InMemoryEventStore();
         var behavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
 
@@ -323,7 +388,10 @@ public class EventSourcingBehaviorTests
         versionKey.ShouldBe(4);
         (await store.GetEventsAsync("agent-version-drift")).Count.ShouldBe(0);
 
-        var freshBehavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
+        var freshBehavior = new CounterEventSourcingBehavior(
+            store,
+            "agent-version-drift",
+            recoverFromVersionDriftOnReplay: true);
         var replayed = await freshBehavior.ReplayAsync("agent-version-drift");
 
         replayed.ShouldBeNull();
@@ -337,11 +405,12 @@ public class EventSourcingBehaviorTests
     }
 
     [Fact]
-    public async Task ReplayAsync_WhenSnapshotPresentAndStoreVersionAhead_ShouldUseStoreVersionAsFloor()
+    public async Task ReplayAsync_WhenSnapshotPresentAndStoreVersionAhead_AndRecoveryDisabled_ShouldThrowDriftException()
     {
-        // Mirror of the no-snapshot drift case but with a snapshot present:
-        // snapshot.Version may be ≤ store version after compaction; using
-        // snapshot.Version alone keeps _currentVersion stale.
+        // Mirror of the no-snapshot drift case with a snapshot present: by
+        // default the actor refuses to activate at the store version because
+        // events between the snapshot and the store version represent
+        // unrecoverable history for non-idempotent transitions.
         var store = new InMemoryEventStore();
         var snapshotStore = new InMemoryEventSourcingSnapshotStore<CounterState>();
 
@@ -351,7 +420,6 @@ public class EventSourcingBehaviorTests
                 new CounterState { Count = 6, Name = "snap" },
                 Version: 2));
 
-        // Seed a higher store version with no events past the snapshot.
         await store.AppendAsync(
             "agent-snapshot-drift",
             [BuildEvent(version: 1, amount: 1), BuildEvent(version: 2, amount: 2), BuildEvent(version: 3, amount: 3)],
@@ -362,6 +430,76 @@ public class EventSourcingBehaviorTests
             store,
             "agent-snapshot-drift",
             snapshotStore: snapshotStore);
+
+        var ex = await Should.ThrowAsync<EventStoreVersionDriftException>(
+            () => behavior.ReplayAsync("agent-snapshot-drift"));
+        ex.ReplayedVersion.ShouldBe(2);
+        ex.StoreVersion.ShouldBe(3);
+    }
+
+    [Fact]
+    public async Task DefaultEventSourcingBehaviorFactory_AppliesPerAgentRecoveryPredicate()
+    {
+        // Per-actor opt-in (EventSourcingRuntimeOptions.ShouldRecoverFromVersionDriftOnReplay)
+        // is the production wiring point for projection scope actors: they
+        // get drift recovery while domain GAgents keep the safe default.
+        var store = new InMemoryEventStore();
+        var options = new EventSourcingRuntimeOptions
+        {
+            EnableSnapshots = false,
+            EnableEventCompaction = false,
+            ShouldRecoverFromVersionDriftOnReplay = id => id.StartsWith("recoverable:", StringComparison.Ordinal),
+        };
+        var factory = new DefaultEventSourcingBehaviorFactory<CounterState>(store, options);
+
+        await store.AppendAsync(
+            "recoverable:agent-1",
+            [BuildEvent(version: 1, amount: 5)],
+            expectedVersion: 0);
+        await store.DeleteEventsUpToAsync("recoverable:agent-1", 1);
+
+        var recoverable = factory.Create("recoverable:agent-1", static (state, _) => state);
+        var recovered = await recoverable.ReplayAsync("recoverable:agent-1");
+        recovered.ShouldBeNull();
+        recoverable.CurrentVersion.ShouldBe(1);
+
+        await store.AppendAsync(
+            "strict:agent-2",
+            [BuildEvent(version: 1, amount: 7)],
+            expectedVersion: 0);
+        await store.DeleteEventsUpToAsync("strict:agent-2", 1);
+
+        var strict = factory.Create("strict:agent-2", static (state, _) => state);
+        await Should.ThrowAsync<EventStoreVersionDriftException>(
+            () => strict.ReplayAsync("strict:agent-2"));
+    }
+
+    [Fact]
+    public async Task ReplayAsync_WhenSnapshotPresentAndStoreVersionAhead_AndRecoveryEnabled_ShouldUseStoreVersionAsFloor()
+    {
+        // Same drift shape but with opt-in recovery: the actor activates at
+        // the snapshot state with _currentVersion floored to the store
+        // version, so the first AppendAsync proceeds without conflict.
+        var store = new InMemoryEventStore();
+        var snapshotStore = new InMemoryEventSourcingSnapshotStore<CounterState>();
+
+        await snapshotStore.SaveAsync(
+            "agent-snapshot-drift",
+            new EventSourcingSnapshot<CounterState>(
+                new CounterState { Count = 6, Name = "snap" },
+                Version: 2));
+
+        await store.AppendAsync(
+            "agent-snapshot-drift",
+            [BuildEvent(version: 1, amount: 1), BuildEvent(version: 2, amount: 2), BuildEvent(version: 3, amount: 3)],
+            expectedVersion: 0);
+        await store.DeleteEventsUpToAsync("agent-snapshot-drift", 3);
+
+        var behavior = new CounterEventSourcingBehavior(
+            store,
+            "agent-snapshot-drift",
+            snapshotStore: snapshotStore,
+            recoverFromVersionDriftOnReplay: true);
 
         var replayed = await behavior.ReplayAsync("agent-snapshot-drift");
 
@@ -439,7 +577,8 @@ public class EventSourcingBehaviorTests
             ISnapshotStrategy? snapshotStrategy = null,
             bool enableEventCompaction = false,
             int retainedEventsAfterSnapshot = 0,
-            IEventStoreCompactionScheduler? compactionScheduler = null)
+            IEventStoreCompactionScheduler? compactionScheduler = null,
+            bool recoverFromVersionDriftOnReplay = false)
             : base(
                 eventStore,
                 agentId,
@@ -447,7 +586,8 @@ public class EventSourcingBehaviorTests
                 snapshotStrategy,
                 enableEventCompaction: enableEventCompaction,
                 retainedEventsAfterSnapshot: retainedEventsAfterSnapshot,
-                compactionScheduler: compactionScheduler) { }
+                compactionScheduler: compactionScheduler,
+                recoverFromVersionDriftOnReplay: recoverFromVersionDriftOnReplay) { }
 
         public override CounterState TransitionState(CounterState current, IMessage evt)
             => StateTransitionMatcher

--- a/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
@@ -266,6 +266,36 @@ public class EventSourcingBehaviorTests
     }
 
     [Fact]
+    public async Task ConfirmEventsAsync_WhenConflictReportsLowerActualVersion_ShouldNotRewindCurrentVersion()
+    {
+        // Defensive guard: a store implementation that reports a malformed
+        // EventStoreOptimisticConcurrencyException (ActualVersion < the actor's
+        // in-memory _currentVersion) must not silently rewind the actor.
+        // Rewinding would cause the next commit to assign duplicate event
+        // versions and corrupt the stream. The catch path keeps the larger of
+        // the two values so the next retry still surfaces a conflict (which is
+        // the correct outcome — the underlying store is broken).
+        var store = new MalformedConflictEventStore(reportedActualVersion: 1);
+        var behavior = new CounterEventSourcingBehavior(store, "agent-malformed");
+
+        // Seed _currentVersion=5 via a successful commit on the inner store
+        // before we engage the malformed-conflict mode.
+        for (var i = 1; i <= 5; i++)
+            behavior.RaiseEvent(new IncrementEvent { Amount = i });
+        await behavior.ConfirmEventsAsync();
+        behavior.CurrentVersion.ShouldBe(5);
+
+        store.NextAppendThrowsConflict = true;
+        behavior.RaiseEvent(new IncrementEvent { Amount = 6 });
+
+        await Should.ThrowAsync<EventStoreOptimisticConcurrencyException>(
+            () => behavior.ConfirmEventsAsync());
+
+        // _currentVersion must NOT regress to the malformed ActualVersion=1.
+        behavior.CurrentVersion.ShouldBe(5);
+    }
+
+    [Fact]
     public async Task ReplayAsync_WhenStoreVersionIsAheadOfEvents_ShouldUseStoreVersionAsAuthority()
     {
         // The exact production failure mode behind issue #502: after a partial
@@ -472,6 +502,51 @@ public class EventSourcingBehaviorTests
             _ = ct;
             throw new InvalidOperationException("snapshot-store-failure");
         }
+    }
+
+    private sealed class MalformedConflictEventStore : IEventStore
+    {
+        private readonly InMemoryEventStore _inner = new();
+        private readonly long _reportedActualVersion;
+
+        public MalformedConflictEventStore(long reportedActualVersion)
+        {
+            _reportedActualVersion = reportedActualVersion;
+        }
+
+        public bool NextAppendThrowsConflict { get; set; }
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            if (NextAppendThrowsConflict)
+            {
+                NextAppendThrowsConflict = false;
+                throw new EventStoreOptimisticConcurrencyException(
+                    agentId,
+                    expectedVersion,
+                    _reportedActualVersion);
+            }
+            return _inner.AppendAsync(agentId, events, expectedVersion, ct);
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default) =>
+            _inner.GetEventsAsync(agentId, fromVersion, ct);
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default) =>
+            _inner.GetVersionAsync(agentId, ct);
+
+        public Task<long> DeleteEventsUpToAsync(
+            string agentId,
+            long toVersion,
+            CancellationToken ct = default) =>
+            _inner.DeleteEventsUpToAsync(agentId, toVersion, ct);
     }
 
     private sealed class ReentrantAppendEventStore : IEventStore

--- a/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
@@ -221,6 +221,136 @@ public class EventSourcingBehaviorTests
     }
 
     [Fact]
+    public async Task ConfirmEventsAsync_WhenStoreVersionIsAhead_ShouldRefreshCurrentVersionAndAllowRetry()
+    {
+        // Reproduces the prod incident behind issue #502: a previous activation
+        // committed up to v=N in the store, but this behavior's in-memory
+        // _currentVersion is behind. Without the catch-path refresh, every
+        // retry rebuilds stateEvents at the same expectedVersion and conflicts
+        // forever. Verify (1) the conflict surfaces, (2) _currentVersion is
+        // refreshed to ex.ActualVersion, (3) the next ConfirmEventsAsync uses
+        // the refreshed version and commits cleanly.
+        var store = new InMemoryEventStore();
+        var behavior = new CounterEventSourcingBehavior(store, "agent-conflict");
+
+        // Out-of-band commits that leave the store ahead of behavior's view.
+        await store.AppendAsync(
+            "agent-conflict",
+            [BuildEvent(version: 1, amount: 10)],
+            expectedVersion: 0);
+        await store.AppendAsync(
+            "agent-conflict",
+            [BuildEvent(version: 2, amount: 20)],
+            expectedVersion: 1);
+
+        // behavior thinks store is at v=0, raises one event, attempts commit.
+        behavior.RaiseEvent(new IncrementEvent { Amount = 30 });
+
+        await Should.ThrowAsync<EventStoreOptimisticConcurrencyException>(
+            () => behavior.ConfirmEventsAsync());
+
+        behavior.CurrentVersion.ShouldBe(2);
+
+        // Retry without re-raising: _pending is preserved so the runtime
+        // envelope retry policy gets to drive recovery without the caller
+        // duplicating the event.
+        await behavior.ConfirmEventsAsync();
+
+        behavior.CurrentVersion.ShouldBe(3);
+        var version = await store.GetVersionAsync("agent-conflict");
+        version.ShouldBe(3);
+        var events = await store.GetEventsAsync("agent-conflict");
+        events.Count.ShouldBe(3);
+        events[^1].Version.ShouldBe(3);
+        events[^1].EventData.Unpack<IncrementEvent>().Amount.ShouldBe(30);
+    }
+
+    [Fact]
+    public async Task ReplayAsync_WhenStoreVersionIsAheadOfEvents_ShouldUseStoreVersionAsAuthority()
+    {
+        // The exact production failure mode behind issue #502: after a partial
+        // compaction (events sorted set wiped, version key intact) the actor
+        // reactivates with no events to replay but the store's version key
+        // ahead of the in-memory _currentVersion. ReplayAsync must reconcile
+        // _currentVersion to the store-authoritative version, otherwise the
+        // first AppendAsync expects v=0 against an actual v=N and conflicts
+        // permanently.
+        var store = new InMemoryEventStore();
+        var behavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
+
+        behavior.RaiseEvent(new IncrementEvent { Amount = 1 });
+        behavior.RaiseEvent(new IncrementEvent { Amount = 2 });
+        behavior.RaiseEvent(new IncrementEvent { Amount = 3 });
+        behavior.RaiseEvent(new IncrementEvent { Amount = 4 });
+        await behavior.ConfirmEventsAsync();
+
+        // Simulate compaction that drained the events sorted set without
+        // rewinding the version key — InMemoryEventStore.DeleteEventsUpToAsync
+        // mirrors the Garnet semantics exactly.
+        await store.DeleteEventsUpToAsync("agent-version-drift", 4);
+
+        var versionKey = await store.GetVersionAsync("agent-version-drift");
+        versionKey.ShouldBe(4);
+        (await store.GetEventsAsync("agent-version-drift")).Count.ShouldBe(0);
+
+        var freshBehavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
+        var replayed = await freshBehavior.ReplayAsync("agent-version-drift");
+
+        replayed.ShouldBeNull();
+        freshBehavior.CurrentVersion.ShouldBe(4);
+
+        // And subsequent commits proceed from the floor instead of conflicting.
+        freshBehavior.RaiseEvent(new IncrementEvent { Amount = 5 });
+        await freshBehavior.ConfirmEventsAsync();
+        freshBehavior.CurrentVersion.ShouldBe(5);
+        (await store.GetVersionAsync("agent-version-drift")).ShouldBe(5);
+    }
+
+    [Fact]
+    public async Task ReplayAsync_WhenSnapshotPresentAndStoreVersionAhead_ShouldUseStoreVersionAsFloor()
+    {
+        // Mirror of the no-snapshot drift case but with a snapshot present:
+        // snapshot.Version may be ≤ store version after compaction; using
+        // snapshot.Version alone keeps _currentVersion stale.
+        var store = new InMemoryEventStore();
+        var snapshotStore = new InMemoryEventSourcingSnapshotStore<CounterState>();
+
+        await snapshotStore.SaveAsync(
+            "agent-snapshot-drift",
+            new EventSourcingSnapshot<CounterState>(
+                new CounterState { Count = 6, Name = "snap" },
+                Version: 2));
+
+        // Seed a higher store version with no events past the snapshot.
+        await store.AppendAsync(
+            "agent-snapshot-drift",
+            [BuildEvent(version: 1, amount: 1), BuildEvent(version: 2, amount: 2), BuildEvent(version: 3, amount: 3)],
+            expectedVersion: 0);
+        await store.DeleteEventsUpToAsync("agent-snapshot-drift", 3);
+
+        var behavior = new CounterEventSourcingBehavior(
+            store,
+            "agent-snapshot-drift",
+            snapshotStore: snapshotStore);
+
+        var replayed = await behavior.ReplayAsync("agent-snapshot-drift");
+
+        replayed.ShouldNotBeNull();
+        replayed!.Count.ShouldBe(6);
+        behavior.CurrentVersion.ShouldBe(3);
+    }
+
+    private static StateEvent BuildEvent(long version, int amount) => new()
+    {
+        EventId = $"e-{version}",
+        Timestamp = TimestampHelper.Now(),
+        Version = version,
+        EventType = typeof(IncrementEvent).FullName ?? nameof(IncrementEvent),
+        EventData = Any.Pack(new IncrementEvent { Amount = amount }),
+        AgentId = "agent-conflict",
+    };
+
+    [Fact]
     public async Task ReplayAsync_WhenSnapshotExists_ShouldReplayOnlyDeltaEvents()
     {
         var store = new InMemoryEventStore();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -579,6 +579,189 @@ public sealed class ChannelCallbackEndpointsTests
     }
 
     [Fact]
+    public async Task HandleRepairLarkMirrorAsync_DispatchesRepairAndReturnsAccepted()
+    {
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        provisioningService.RepairLocalMirrorAsync(
+                Arg.Any<NyxLarkMirrorRepairRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new NyxLarkMirrorRepairResult(
+                Succeeded: true,
+                Status: "accepted",
+                RegistrationId: "reg-1",
+                NyxChannelBotId: "bot-1",
+                NyxAgentApiKeyId: "key-1",
+                NyxConversationRouteId: "route-1",
+                WebhookUrl: "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1",
+                Note: "Existing Nyx relay resources were verified.")));
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "registration_id":"reg-1",
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "nyx_conversation_route_id":"route-1",
+              "webhook_base_url":"https://aevatar.example.com",
+              "nyx_provider_slug":"api-lark-bot"
+            }
+            """,
+            "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        response.Body.Should().Contain("\"registration_id\":\"reg-1\"");
+        response.Body.Should().Contain("\"nyx_agent_api_key_id\":\"key-1\"");
+        await provisioningService.Received(1).RepairLocalMirrorAsync(
+            Arg.Is<NyxLarkMirrorRepairRequest>(r =>
+                r.AccessToken == "test-token" &&
+                r.ScopeId == "scope-1" &&
+                r.RequestedRegistrationId == "reg-1" &&
+                r.NyxChannelBotId == "bot-1" &&
+                r.NyxAgentApiKeyId == "key-1" &&
+                r.NyxConversationRouteId == "route-1" &&
+                r.WebhookBaseUrl == "https://aevatar.example.com" &&
+                r.NyxProviderSlug == "api-lark-bot"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_RejectsMissingNyxIdentity()
+    {
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+
+        var http = CreateJsonHttpContext(
+            """{"webhook_base_url":"https://aevatar.example.com"}""",
+            "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        response.Body.Should().Contain("nyx_channel_bot_id is required");
+        await provisioningService.DidNotReceive().RepairLocalMirrorAsync(
+            Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_ReturnsUnauthorized_WhenAccessTokenMissing()
+    {
+        // Even though the route is RequireAuthorization, the handler also reads
+        // the bearer token to forward to Nyx for ownership verification — a
+        // missing/empty Authorization header must short-circuit before the
+        // provisioning service is touched.
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-1");
+        // Authorization deliberately omitted.
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        await provisioningService.DidNotReceive().RepairLocalMirrorAsync(
+            Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_ReturnsBadGateway_WhenNyxFails()
+    {
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        provisioningService.RepairLocalMirrorAsync(
+                Arg.Any<NyxLarkMirrorRepairRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new NyxLarkMirrorRepairResult(
+                Succeeded: false,
+                Status: "error",
+                Error: "channel_bot_lookup_failed nyx_status=404 body=channel_bot_not_found")));
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "nyx_channel_bot_id":"bot-missing",
+              "nyx_agent_api_key_id":"key-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
+        response.Body.Should().Contain("\"status\":\"error\"");
+        response.Body.Should().Contain("channel_bot_not_found");
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_RejectsScopeMismatch()
+    {
+        // Mirror of the existing register / rebuild scope-mismatch tests: the
+        // body's scope_id must equal the JWT's scope_id claim, otherwise
+        // a malicious caller could repair a registration into someone else's
+        // scope and intercept their relay traffic.
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "scope_id":"scope-attacker",
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-victim");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        response.Body.Should().Contain("scope_id does not match");
+        await provisioningService.DidNotReceive().RepairLocalMirrorAsync(
+            Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task HandleGetDiagnosticErrorsAsync_ExposesEntries()
     {
         var diagnostics = new InMemoryChannelRuntimeDiagnostics();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -595,6 +595,10 @@ public sealed class ChannelCallbackEndpointsTests
                 WebhookUrl: "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1",
                 Note: "Existing Nyx relay resources were verified.")));
 
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([]));
+
         var http = CreateJsonHttpContext(
             """
             {
@@ -613,6 +617,7 @@ public sealed class ChannelCallbackEndpointsTests
             "HandleRepairLarkMirrorAsync",
             http,
             provisioningService,
+            queryPort,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -637,6 +642,7 @@ public sealed class ChannelCallbackEndpointsTests
     public async Task HandleRepairLarkMirrorAsync_RejectsMissingNyxIdentity()
     {
         var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
 
         var http = CreateJsonHttpContext(
             """{"webhook_base_url":"https://aevatar.example.com"}""",
@@ -647,6 +653,7 @@ public sealed class ChannelCallbackEndpointsTests
             "HandleRepairLarkMirrorAsync",
             http,
             provisioningService,
+            queryPort,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -665,6 +672,7 @@ public sealed class ChannelCallbackEndpointsTests
         // missing/empty Authorization header must short-circuit before the
         // provisioning service is touched.
         var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
 
         var http = CreateJsonHttpContext(
             """
@@ -681,6 +689,7 @@ public sealed class ChannelCallbackEndpointsTests
             "HandleRepairLarkMirrorAsync",
             http,
             provisioningService,
+            queryPort,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -702,6 +711,10 @@ public sealed class ChannelCallbackEndpointsTests
                 Status: "error",
                 Error: "channel_bot_lookup_failed nyx_status=404 body=channel_bot_not_found")));
 
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>([]));
+
         var http = CreateJsonHttpContext(
             """
             {
@@ -717,6 +730,7 @@ public sealed class ChannelCallbackEndpointsTests
             "HandleRepairLarkMirrorAsync",
             http,
             provisioningService,
+            queryPort,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -734,6 +748,7 @@ public sealed class ChannelCallbackEndpointsTests
         // a malicious caller could repair a registration into someone else's
         // scope and intercept their relay traffic.
         var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
 
         var http = CreateJsonHttpContext(
             """
@@ -751,6 +766,7 @@ public sealed class ChannelCallbackEndpointsTests
             "HandleRepairLarkMirrorAsync",
             http,
             provisioningService,
+            queryPort,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         var response = await ExecuteResultAsync(result);
@@ -758,6 +774,230 @@ public sealed class ChannelCallbackEndpointsTests
         response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         response.Body.Should().Contain("scope_id does not match");
         await provisioningService.DidNotReceive().RepairLocalMirrorAsync(
+            Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_ShortCircuits_WhenSameScopeMirrorAlreadyExists()
+    {
+        // PR #503 review (comment 3158220132): without preflight, repeated
+        // calls without a registration_id mint a fresh id every time. A
+        // matching same-scope mirror must short-circuit with
+        // already_registered and NOT redispatch ChannelBotRegisterCommand.
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-existing",
+                    Platform = "lark",
+                    NyxProviderSlug = "api-lark-bot",
+                    ScopeId = "scope-1",
+                    WebhookUrl = "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1",
+                    NyxChannelBotId = "bot-1",
+                    NyxAgentApiKeyId = "key-1",
+                    NyxConversationRouteId = "route-1",
+                },
+            ]));
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "nyx_conversation_route_id":"route-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            queryPort,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        response.Body.Should().Contain("\"status\":\"already_registered\"");
+        response.Body.Should().Contain("\"registration_id\":\"reg-existing\"");
+        await provisioningService.DidNotReceive().RepairLocalMirrorAsync(
+            Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_RejectsCrossScopeMatch()
+    {
+        // PR #503 review (comment 3158220132): an api-key whose existing
+        // mirror lives in scope A must not be re-pointed to scope B — a
+        // successful repair routes all subsequent relay traffic for the
+        // api-key into the requested scope, so a cross-scope repair is
+        // effectively a hijack vector even when the body and JWT scope
+        // agree.
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-other-scope",
+                    Platform = "lark",
+                    NyxProviderSlug = "api-lark-bot",
+                    ScopeId = "scope-other",
+                    WebhookUrl = "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1",
+                    NyxChannelBotId = "bot-1",
+                    NyxAgentApiKeyId = "key-1",
+                    NyxConversationRouteId = "route-1",
+                },
+            ]));
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "nyx_conversation_route_id":"route-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-attacker");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            queryPort,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        response.Body.Should().Contain("matching local Aevatar mirror belongs to a different scope_id");
+        await provisioningService.DidNotReceive().RepairLocalMirrorAsync(
+            Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_ReusesEmptyScopeRegistrationId()
+    {
+        // PR #503 review (comment 3158220132): legacy mirrors with empty
+        // ScopeId (from before scope was tracked) must be reused so the
+        // backfill path attaches a scope. Without this, the dispatch would
+        // mint a new id and leave the empty-scope entry orphaned.
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        provisioningService.RepairLocalMirrorAsync(
+                Arg.Any<NyxLarkMirrorRepairRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new NyxLarkMirrorRepairResult(
+                Succeeded: true,
+                Status: "accepted",
+                RegistrationId: "reg-empty-scope",
+                NyxChannelBotId: "bot-1",
+                NyxAgentApiKeyId: "key-1",
+                NyxConversationRouteId: "route-1",
+                WebhookUrl: "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1")));
+
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(
+            [
+                new ChannelBotRegistrationEntry
+                {
+                    Id = "reg-empty-scope",
+                    Platform = "lark",
+                    NyxProviderSlug = "api-lark-bot",
+                    ScopeId = string.Empty,
+                    WebhookUrl = "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1",
+                    NyxChannelBotId = "bot-1",
+                    NyxAgentApiKeyId = "key-1",
+                    NyxConversationRouteId = "route-1",
+                },
+            ]));
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "nyx_conversation_route_id":"route-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            queryPort,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        await provisioningService.Received(1).RepairLocalMirrorAsync(
+            Arg.Is<NyxLarkMirrorRepairRequest>(r =>
+                r.RequestedRegistrationId == "reg-empty-scope" &&
+                r.ScopeId == "scope-1"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleRepairLarkMirrorAsync_FallsThroughToDispatch_WhenQuerySideIsUnavailable()
+    {
+        // Mirror of the LLM-tool's "still repairs when query side is
+        // unavailable" contract: a degraded read model must not block the
+        // operational repair path.
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        provisioningService.RepairLocalMirrorAsync(
+                Arg.Any<NyxLarkMirrorRepairRequest>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new NyxLarkMirrorRepairResult(
+                Succeeded: true,
+                Status: "accepted",
+                RegistrationId: "reg-1",
+                NyxChannelBotId: "bot-1",
+                NyxAgentApiKeyId: "key-1",
+                NyxConversationRouteId: "route-1",
+                WebhookUrl: "https://nyx.example.com/api/v1/webhooks/channel/lark/bot-1")));
+
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<ChannelBotRegistrationEntry>>(
+                new InvalidOperationException("projection reader unavailable")));
+
+        var http = CreateJsonHttpContext(
+            """
+            {
+              "registration_id":"reg-1",
+              "nyx_channel_bot_id":"bot-1",
+              "nyx_agent_api_key_id":"key-1",
+              "nyx_conversation_route_id":"route-1",
+              "webhook_base_url":"https://aevatar.example.com"
+            }
+            """,
+            "scope-1");
+        http.Request.Headers.Authorization = "Bearer test-token";
+
+        var result = await InvokeAsync(
+            "HandleRepairLarkMirrorAsync",
+            http,
+            provisioningService,
+            queryPort,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var response = await ExecuteResultAsync(result);
+
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        await provisioningService.Received(1).RepairLocalMirrorAsync(
             Arg.Any<NyxLarkMirrorRepairRequest>(), Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
Closes #502

## Summary

- `EventSourcingBehavior.ConfirmEventsAsync` now catches `EventStoreOptimisticConcurrencyException` specifically and refreshes `_currentVersion = ex.ActualVersion` before rethrowing. The runtime envelope retry replays with versions recomputed from the refreshed baseline instead of wedging on the same conflict forever.
- `EventSourcingBehavior.ReplayAsync` now treats `GetVersionAsync(agentId)` as the authoritative floor (`_currentVersion = max(events[^1].Version, store_version)`). When the events sorted set and the store's version key drift apart (interrupted Lua append, partial compaction, externally seeded store), the actor reactivates at the store-side version and makes forward progress instead of conflict-looping.
- Adds 3 tests mirroring the prod scenarios: out-of-band store writes leaving the in-memory version stale, version-key-ahead-of-events drift after compaction, and the same drift with a snapshot present.
- **Adds `POST /api/channels/registrations/repair-lark-mirror`** as the direct authenticated HTTP equivalent of the LLM-tool path `channel_registrations action=repair_lark_mirror`. Same `INyxLarkProvisioningService.RepairLocalMirrorAsync` under the hood — Nyx-side ownership verification, ChannelBotRegisterCommand dispatch — so recovery no longer requires a working NyxidChat agent or scope-bound chat session.
- Adds `docs/operations/2026-04-29-lark-mirror-recovery-runbook.md` capturing the recovery procedure used during the 2026-04-28 incident, with the direct HTTP endpoint as the preferred path and the LLM tool kept as a fallback.

## Why

Production silo on 2026-04-28 hit:

```
Event sourcing commit failed.
   agentId=projection.durable.scope:channel-bot-registration:channel-bot-registration-store
   eventType=ProjectionScopeWatermarkAdvancedEvent version=3
   errorType=EventStoreOptimisticConcurrencyException
   Optimistic concurrency conflict: expected 3, actual 4
```

Permanent loop — the projection scope's `_currentVersion=3` while Garnet's version key was at 4 (events sorted set only contained 1–3, so `ReplayAsync` set `_currentVersion = events[^1].Version = 3` instead of seeing the 4 from the version key). Every retry rebuilt the same `stateEvents` at the same `expectedVersion` and conflicted again. Recovery required manually deleting the three Garnet keys and restarting the silo.

Once the version drift was cleared, a separate problem surfaced: `state.Registrations` on `channel-bot-registration-store` was empty (lost during a prior `ChannelRuntime` → `Channel.Runtime` namespace migration cleanup), so the relay still 401'd. Recovering required calling the LLM tool `channel_registrations action=repair_lark_mirror` through `aevatar-cli chat` against a NyxidChat agent — which only worked because the operator happened to have the right scope already.

This PR closes both gaps:

1. The runtime path (catch on conflict) and the activation path (Replay floor) self-heal version drift, so the same drift is invisible to operators on the next occurrence.
2. The direct HTTP repair endpoint removes the operational dependency on a working LLM agent + chat session, so recovery is a single authenticated `aevatar-cli api POST` instead of a multi-step chat orchestration.

The runbook covers the full procedure end-to-end so the next operator hitting the symptom doesn't have to rediscover it.

## Risks

- **State staleness when `events.Count==0` but version key is ahead.** The actor reactivates with empty/snapshot state at the store version. For idempotent projection scopes (the prod case here) this is the correct behavior — observations get re-delivered and the materializer reconverges. For domain GAgents with non-idempotent transitions, missing event replays could leave state inconsistent. Mitigation: this only triggers when events actually went missing from the store, which is already a corruption case where any choice loses information; surfacing as drift-recovered-state-with-correct-version is strictly better than wedge-forever-with-correct-state.
- **`_pending` is intentionally NOT cleared on conflict.** The next retry re-stamps the same logical events with new versions computed from `ex.ActualVersion`. This preserves the existing "events raised during commit are kept for the next confirm" contract (covered by the existing `ConfirmEventsAsync_WhenNewEventIsRaisedDuringAppend_ShouldKeepUncommittedSuffix` test).
- **Log level downgrade for conflicts.** Conflicts now log at `Warning` (with a self-heal-applied message) rather than `Error`. Other persistence failures still log at `Error`. If alerts/dashboards key on the previous error log, they'll need to update.
- **Repair endpoint scope-hijack vector.** A successful mirror repair routes all subsequent relay traffic for the api-key into the requested scope, so a scope-mismatched repair would let an attacker hijack another tenant's relay flow. The endpoint enforces `body.scope_id == JWT.scope_id` (same check used by the existing register/rebuild endpoints) and a dedicated test (`HandleRepairLarkMirrorAsync_RejectsScopeMismatch`) pins this.

## Test plan

- [x] `dotnet build aevatar.slnx --nologo` — succeeds, 0 errors.
- [x] `dotnet test test/Aevatar.Foundation.Core.Tests/...` — 170 tests pass (including 3 new EventSourcingBehavior drift tests).
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/...` — 711 tests pass (including 5 new repair-endpoint tests).
- [x] `dotnet test test/Aevatar.Foundation.Runtime.Hosting.Tests/...` (excluding integration/garnet/kafka) — 117 tests pass.
- [x] `bash tools/ci/test_stability_guards.sh` — passes.
- [x] `bash tools/ci/architecture_guards.sh` — all guards through `workflow_binding_boundary_guard` pass. `playground_asset_drift_guard.sh` fails locally (pre-existing environment issue: frontend node_modules not installed in this worktree, unrelated to this PR — no frontend files touched).
- [ ] After merge + deploy, monitor for `Event sourcing commit hit optimistic concurrency conflict; refreshing _currentVersion` warnings — those indicate the self-heal is engaging in the wild and we should investigate the underlying drift source.
- [ ] After merge + deploy, validate the repair endpoint end-to-end: delete the local Lark mirror in a non-prod env, hit `POST /api/channels/registrations/repair-lark-mirror` with the right body, confirm `GET /api/channels/registrations` shows the bot, send a Lark message, confirm the bot replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)