### PR TITLE
Refactor streaming proxy room command

### DIFF
--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -1,0 +1,136 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
+
+public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomCommandService
+{
+    private const string DefaultRoomName = "Group Chat";
+
+    private readonly IActorRuntime _actorRuntime;
+    private readonly IGAgentActorRegistryCommandPort _registryCommandPort;
+    private readonly ILogger<StreamingProxyRoomCommandService> _logger;
+
+    public StreamingProxyRoomCommandService(
+        IActorRuntime actorRuntime,
+        IGAgentActorRegistryCommandPort registryCommandPort,
+        ILogger<StreamingProxyRoomCommandService> logger)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+        _registryCommandPort = registryCommandPort ?? throw new ArgumentNullException(nameof(registryCommandPort));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
+        StreamingProxyRoomCreateCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var scopeId = NormalizeRequiredScopeId(command.ScopeId);
+        var roomName = NormalizeRoomName(command.RoomName);
+        var roomId = StreamingProxyDefaults.GenerateRoomId();
+        var targetCreated = false;
+
+        try
+        {
+            var actor = await _actorRuntime.CreateAsync<StreamingProxyGAgent>(roomId, cancellationToken);
+            targetCreated = true;
+
+            var envelope = BuildRoomInitializedEnvelope(actor.Id, roomName);
+            await actor.HandleEventAsync(envelope, cancellationToken);
+
+            var receipt = await _registryCommandPort.RegisterActorAsync(
+                new GAgentActorRegistration(scopeId, StreamingProxyDefaults.GAgentTypeName, roomId),
+                cancellationToken);
+            if (!receipt.IsAdmissionVisible)
+            {
+                await TryRollbackRoomCreationAsync(scopeId, roomId, CancellationToken.None);
+                return new StreamingProxyRoomCreateResult(
+                    StreamingProxyRoomCreateStatus.AdmissionUnavailable,
+                    roomId,
+                    roomName);
+            }
+
+            return new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Created,
+                roomId,
+                roomName);
+        }
+        catch (OperationCanceledException)
+        {
+            if (targetCreated)
+                await TryRollbackRoomCreationAsync(scopeId, roomId, CancellationToken.None);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create streaming proxy room {RoomId}", roomId);
+            if (targetCreated)
+                await TryRollbackRoomCreationAsync(scopeId, roomId, CancellationToken.None);
+            return new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Failed,
+                roomId,
+                roomName);
+        }
+    }
+
+    private static string NormalizeRequiredScopeId(string? scopeId)
+    {
+        var normalized = scopeId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException("ScopeId is required.", nameof(StreamingProxyRoomCreateCommand.ScopeId));
+
+        return normalized;
+    }
+
+    private static string NormalizeRoomName(string? roomName)
+    {
+        var normalized = roomName?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? DefaultRoomName : normalized;
+    }
+
+    private static EventEnvelope BuildRoomInitializedEnvelope(string actorId, string roomName)
+    {
+        var initEvent = new GroupChatRoomInitializedEvent { RoomName = roomName };
+        return new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(initEvent),
+            Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actorId } },
+        };
+    }
+
+    private async Task TryRollbackRoomCreationAsync(
+        string scopeId,
+        string roomId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _registryCommandPort.UnregisterActorAsync(
+                new GAgentActorRegistration(
+                    scopeId,
+                    StreamingProxyDefaults.GAgentTypeName,
+                    roomId),
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to unregister room {RoomId} from registry during rollback", roomId);
+            return;
+        }
+
+        try
+        {
+            await _actorRuntime.DestroyAsync(roomId, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to destroy room actor {RoomId} during rollback", roomId);
+        }
+    }
+}

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
@@ -1,0 +1,24 @@
+namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
+
+public interface IStreamingProxyRoomCommandService
+{
+    Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
+        StreamingProxyRoomCreateCommand command,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record StreamingProxyRoomCreateCommand(
+    string ScopeId,
+    string? RoomName);
+
+public sealed record StreamingProxyRoomCreateResult(
+    StreamingProxyRoomCreateStatus Status,
+    string? RoomId,
+    string? RoomName);
+
+public enum StreamingProxyRoomCreateStatus
+{
+    Created = 0,
+    AdmissionUnavailable = 1,
+    Failed = 2,
+}

--- a/agents/Aevatar.GAgents.StreamingProxy/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Runtime.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -23,6 +24,7 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<StreamingProxyNyxParticipantCoordinator>();
+        services.TryAddSingleton<IStreamingProxyRoomCommandService, StreamingProxyRoomCommandService>();
         services.AddProjectionReadModelRuntime();
         services.TryAddSingleton<IProjectionClock, SystemProjectionClock>();
 

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -3,6 +3,7 @@ using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
 using Aevatar.Hosting;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
@@ -50,64 +51,30 @@ public static class StreamingProxyEndpoints
         HttpContext http,
         string scopeId,
         [FromBody] CreateRoomRequest? request,
-        [FromServices] IGAgentActorRegistryCommandPort registryCommandPort,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] ILoggerFactory loggerFactory,
+        [FromServices] IStreamingProxyRoomCommandService roomCommandService,
         CancellationToken ct)
     {
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
-        var logger = loggerFactory.CreateLogger("Aevatar.GAgents.StreamingProxy.Endpoints");
-        var roomName = request?.RoomName?.Trim();
-        if (string.IsNullOrWhiteSpace(roomName))
-            roomName = "Group Chat";
+        var result = await roomCommandService.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand(scopeId, request?.RoomName),
+            ct);
 
-        var roomId = StreamingProxyDefaults.GenerateRoomId();
-        var targetCreated = false;
-        try
+        return result.Status switch
         {
-            var actor = await actorRuntime.CreateAsync<StreamingProxyGAgent>(roomId, ct);
-            targetCreated = true;
-
-            var initEvent = new GroupChatRoomInitializedEvent { RoomName = roomName };
-            var envelope = new EventEnvelope
+            StreamingProxyRoomCreateStatus.Created => Results.Ok(new
             {
-                Id = Guid.NewGuid().ToString("N"),
-                Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                Payload = Any.Pack(initEvent),
-                Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actor.Id } },
-            };
-            await actor.HandleEventAsync(envelope, ct);
-
-            var receipt = await registryCommandPort.RegisterActorAsync(
-                new GAgentActorRegistration(scopeId, StreamingProxyDefaults.GAgentTypeName, roomId),
-                ct);
-            if (!receipt.IsAdmissionVisible)
-            {
-                await TryRollbackRoomCreationAsync(scopeId, roomId, registryCommandPort, actorRuntime, logger);
-                return Results.Json(
-                    new { error = "Failed to create room" },
-                    statusCode: StatusCodes.Status503ServiceUnavailable);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            if (targetCreated)
-                await TryRollbackRoomCreationAsync(scopeId, roomId, registryCommandPort, actorRuntime, logger);
-            throw;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to create room {RoomId}", roomId);
-            if (targetCreated)
-                await TryRollbackRoomCreationAsync(scopeId, roomId, registryCommandPort, actorRuntime, logger);
-            return Results.Json(
+                roomId = result.RoomId,
+                roomName = result.RoomName,
+            }),
+            StreamingProxyRoomCreateStatus.AdmissionUnavailable => Results.Json(
                 new { error = "Failed to create room" },
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-
-        return Results.Ok(new { roomId, roomName });
+                statusCode: StatusCodes.Status503ServiceUnavailable),
+            _ => Results.Json(
+                new { error = "Failed to create room" },
+                statusCode: StatusCodes.Status500InternalServerError),
+        };
     }
 
     private static async Task<IResult> HandleListRoomsAsync(
@@ -935,38 +902,6 @@ public static class StreamingProxyEndpoints
         }
 
         return false;
-    }
-
-    private static async Task TryRollbackRoomCreationAsync(
-        string scopeId,
-        string roomId,
-        IGAgentActorRegistryCommandPort registryCommandPort,
-        IActorRuntime actorRuntime,
-        ILogger logger)
-    {
-        try
-        {
-            await registryCommandPort.UnregisterActorAsync(
-                new GAgentActorRegistration(
-                    scopeId,
-                    StreamingProxyDefaults.GAgentTypeName,
-                    roomId),
-                CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to unregister room {RoomId} from registry during rollback", roomId);
-            return;
-        }
-
-        try
-        {
-            await actorRuntime.DestroyAsync(roomId, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to destroy room actor {RoomId} during rollback", roomId);
-        }
     }
 
     private static async Task<IResult?> AuthorizeRoomAsync(

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -17,6 +17,7 @@ using Google.Protobuf;
 using Any = Google.Protobuf.WellKnownTypes.Any;
 using Google.Protobuf.WellKnownTypes;
 using Aevatar.GAgents.StreamingProxy;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -45,6 +46,8 @@ public class StreamingProxyCoverageTests
             d.ServiceType == typeof(IStreamingProxyRoomSessionProjectionPort));
         var terminalQueryDescriptor = services.FirstOrDefault(d =>
             d.ServiceType == typeof(IStreamingProxyChatSessionTerminalQueryPort));
+        var roomCommandDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IStreamingProxyRoomCommandService));
 
         coordinatorDescriptor.Should().NotBeNull();
         coordinatorDescriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
@@ -52,6 +55,8 @@ public class StreamingProxyCoverageTests
         projectionDescriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
         terminalQueryDescriptor.Should().NotBeNull();
         terminalQueryDescriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+        roomCommandDescriptor.Should().NotBeNull();
+        roomCommandDescriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
     }
 
     [Fact]
@@ -82,8 +87,11 @@ public class StreamingProxyCoverageTests
     [Fact]
     public async Task HandleCreateRoomAsync_ShouldCreateRoomAndInitActor()
     {
-        var actorStore = new StubGAgentActorStore();
-        var runtime = new StubActorRuntime();
+        var roomCommandService = new StubRoomCommandService(
+            new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Created,
+                "room-project-x",
+                "Project X"));
         var request = new CreateRoomRequest("Project X");
 
         var result = await InvokeResultAsync(
@@ -91,19 +99,15 @@ public class StreamingProxyCoverageTests
             CreateScopedHttpContext(),
             "scope-a",
             request,
-            actorStore,
-            runtime,
-            NullLoggerFactory.Instance,
+            roomCommandService,
             CancellationToken.None);
 
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         response.Body.Should().Contain("roomName");
-        actorStore.AddedActors.Should().ContainSingle(x =>
-            x.scopeId == "scope-a" &&
-            x.gagentType == StreamingProxyDefaults.GAgentTypeName);
-        runtime.CreateCalls.Should().ContainSingle();
-        runtime.CreateCalls[0].agentType.Should().Be(typeof(StreamingProxyGAgent));
+        response.Body.Should().Contain("room-project-x");
+        roomCommandService.Commands.Should().ContainSingle();
+        roomCommandService.Commands[0].Should().Be(new StreamingProxyRoomCreateCommand("scope-a", "Project X"));
     }
 
     [Fact]
@@ -1508,6 +1512,21 @@ public class StreamingProxyCoverageTests
             ScopeResourceTarget target,
             CancellationToken cancellationToken = default)
             => Task.FromResult(ScopeResourceAdmissionResult.Allowed());
+    }
+
+    private sealed class StubRoomCommandService(StreamingProxyRoomCreateResult result)
+        : IStreamingProxyRoomCommandService
+    {
+        public List<StreamingProxyRoomCreateCommand> Commands { get; } = [];
+
+        public Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
+            StreamingProxyRoomCreateCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Commands.Add(command);
+            return Task.FromResult(result);
+        }
     }
 
     private sealed class StubParticipantStore : IStreamingProxyParticipantStore

--- a/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Text;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.StreamingProxy;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using FluentAssertions;
@@ -26,171 +27,72 @@ public sealed class StreamingProxyEndpointsCoverageTests
         ?? throw new InvalidOperationException("HandleListParticipantsAsync not found.");
 
     [Fact]
-    public async Task HandleCreateRoomAsync_ShouldRegisterAndInitializeRoomOnSuccess()
+    public async Task HandleCreateRoomAsync_ShouldDelegateRoomCreationToCommandService()
     {
-        var operations = new List<string>();
-        var actor = new RecordingActor("created-room", operations);
-        var actorStore = new RecordingGAgentActorStore(operations);
-        var runtime = new RecordingActorRuntime(operations, actor);
-        var loggerFactory = LoggerFactory.Create(_ => { });
+        var service = new RecordingRoomCommandService(
+            new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Created,
+                "room-123",
+                "Daily Standup"));
 
         var result = await InvokeHandleCreateRoomAsync(
             CreateScopedHttpContext(),
             "scope-a",
             new StreamingProxyEndpoints.CreateRoomRequest("  Daily Standup  "),
-            actorStore,
-            runtime,
-            loggerFactory,
+            service,
             CancellationToken.None);
 
         var (statusCode, body) = await ExecuteResultAsync(result);
 
         statusCode.Should().Be(StatusCodes.Status200OK);
-        actorStore.AddedActors.Should().ContainSingle();
-        actorStore.AddedActors[0].ScopeId.Should().Be("scope-a");
-        var registeredActorId = actorStore.AddedActors[0].ActorId;
-        operations.Should().ContainInOrder(
-            $"runtime:create:{registeredActorId}",
-            $"actor:init:{registeredActorId}",
-            $"store:add:{registeredActorId}");
-        runtime.LastCreatedActor.Should().NotBeNull();
-        runtime.LastCreatedActor!.ReceivedEnvelopes.Should().ContainSingle();
-        runtime.LastCreatedActor.ReceivedEnvelopes[0].Payload.Unpack<GroupChatRoomInitializedEvent>().RoomName.Should().Be("Daily Standup");
-        body.Should().Contain(registeredActorId);
+        service.Commands.Should().ContainSingle();
+        service.Commands[0].Should().Be(new StreamingProxyRoomCreateCommand("scope-a", "  Daily Standup  "));
+        body.Should().Contain("room-123");
         body.Should().Contain("Daily Standup");
     }
 
     [Fact]
-    public async Task HandleCreateRoomAsync_ShouldRollbackRegistration_WhenActivationFails()
+    public async Task HandleCreateRoomAsync_ShouldMapAdmissionUnavailableToServiceUnavailable()
     {
-        var operations = new List<string>();
-        var actorStore = new RecordingGAgentActorStore(operations);
-        var runtime = new RecordingActorRuntime(
-            operations,
-            new RecordingActor("created-room"))
-        {
-            ThrowOnCreate = new InvalidOperationException("boom"),
-        };
-        var loggerFactory = LoggerFactory.Create(_ => { });
+        var service = new RecordingRoomCommandService(
+            new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.AdmissionUnavailable,
+                null,
+                "Incident Room"));
 
         var result = await InvokeHandleCreateRoomAsync(
             CreateScopedHttpContext(),
             "scope-a",
             new StreamingProxyEndpoints.CreateRoomRequest("Incident Room"),
-            actorStore,
-            runtime,
-            loggerFactory,
-            CancellationToken.None);
-
-        var (statusCode, body) = await ExecuteResultAsync(result);
-
-        statusCode.Should().Be(StatusCodes.Status500InternalServerError);
-        actorStore.AddedActors.Should().BeEmpty();
-        actorStore.RemovedActors.Should().BeEmpty();
-        runtime.DestroyedActorIds.Should().BeEmpty();
-        operations.Should().ContainSingle(operation => operation.StartsWith("runtime:create:", StringComparison.Ordinal));
-        body.Should().Contain("Failed to create room");
-    }
-
-    [Fact]
-    public async Task HandleCreateRoomAsync_ShouldRollbackCreatedRoom_WhenCreationIsCanceled()
-    {
-        var operations = new List<string>();
-        var actor = new RecordingActor("created-room", operations);
-        var actorStore = new RecordingGAgentActorStore(operations)
-        {
-            ThrowOnRegister = new OperationCanceledException("client disconnected before registry ack")
-        };
-        var runtime = new RecordingActorRuntime(operations, actor);
-        var loggerFactory = LoggerFactory.Create(_ => { });
-
-        var act = async () => await InvokeHandleCreateRoomAsync(
-            CreateScopedHttpContext(),
-            "scope-a",
-            new StreamingProxyEndpoints.CreateRoomRequest("Incident Room"),
-            actorStore,
-            runtime,
-            loggerFactory,
-            CancellationToken.None);
-
-        await act.Should().ThrowAsync<OperationCanceledException>();
-        runtime.DestroyedActorIds.Should().ContainSingle(actorStore.AddedActors.Single().ActorId);
-        actorStore.RemovedActors.Should().ContainSingle();
-        operations.Should().ContainInOrder(
-            $"runtime:create:{actorStore.AddedActors.Single().ActorId}",
-            $"actor:init:{actorStore.AddedActors.Single().ActorId}",
-            $"store:add:{actorStore.AddedActors.Single().ActorId}",
-            $"store:remove:{actorStore.AddedActors.Single().ActorId}",
-            $"runtime:destroy:{actorStore.AddedActors.Single().ActorId}");
-    }
-
-    [Fact]
-    public async Task HandleCreateRoomAsync_ShouldNotDestroyCreatedRoom_WhenRollbackUnregisterFails()
-    {
-        var operations = new List<string>();
-        var actor = new RecordingActor("created-room", operations);
-        var actorStore = new RecordingGAgentActorStore(operations)
-        {
-            ThrowOnRegister = new InvalidOperationException("registry unavailable"),
-            ThrowOnUnregister = new InvalidOperationException("registry unregister unavailable")
-        };
-        var runtime = new RecordingActorRuntime(operations, actor);
-        var loggerFactory = LoggerFactory.Create(_ => { });
-
-        var result = await InvokeHandleCreateRoomAsync(
-            CreateScopedHttpContext(),
-            "scope-a",
-            new StreamingProxyEndpoints.CreateRoomRequest("Incident Room"),
-            actorStore,
-            runtime,
-            loggerFactory,
-            CancellationToken.None);
-
-        var (statusCode, body) = await ExecuteResultAsync(result);
-
-        statusCode.Should().Be(StatusCodes.Status500InternalServerError);
-        body.Should().Contain("Failed to create room");
-        actorStore.RemovedActors.Should().ContainSingle();
-        runtime.DestroyedActorIds.Should().BeEmpty();
-        operations.Should().ContainInOrder(
-            $"runtime:create:{actorStore.AddedActors.Single().ActorId}",
-            $"actor:init:{actorStore.AddedActors.Single().ActorId}",
-            $"store:add:{actorStore.AddedActors.Single().ActorId}",
-            $"store:remove:{actorStore.AddedActors.Single().ActorId}");
-    }
-
-    [Fact]
-    public async Task HandleCreateRoomAsync_ShouldNotDestroyRoom_WhenRollbackCannotUnregister()
-    {
-        var operations = new List<string>();
-        var actor = new RecordingActor("created-room", operations);
-        var actorStore = new RecordingGAgentActorStore(operations)
-        {
-            RegisterStage = GAgentActorRegistryCommandStage.AcceptedForDispatch,
-            ThrowOnUnregister = new InvalidOperationException("registry unavailable")
-        };
-        var runtime = new RecordingActorRuntime(operations, actor);
-        var loggerFactory = LoggerFactory.Create(_ => { });
-
-        var result = await InvokeHandleCreateRoomAsync(
-            CreateScopedHttpContext(),
-            "scope-a",
-            new StreamingProxyEndpoints.CreateRoomRequest("Incident Room"),
-            actorStore,
-            runtime,
-            loggerFactory,
+            service,
             CancellationToken.None);
 
         var (statusCode, body) = await ExecuteResultAsync(result);
 
         statusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
         body.Should().Contain("Failed to create room");
-        runtime.DestroyedActorIds.Should().BeEmpty();
-        operations.Should().ContainInOrder(
-            $"runtime:create:{actorStore.AddedActors.Single().ActorId}",
-            $"actor:init:{actorStore.AddedActors.Single().ActorId}",
-            $"store:add:{actorStore.AddedActors.Single().ActorId}",
-            $"store:remove:{actorStore.AddedActors.Single().ActorId}");
+    }
+
+    [Fact]
+    public async Task HandleCreateRoomAsync_ShouldMapCommandFailureToServerError()
+    {
+        var service = new RecordingRoomCommandService(
+            new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Failed,
+                null,
+                "Incident Room"));
+
+        var result = await InvokeHandleCreateRoomAsync(
+            CreateScopedHttpContext(),
+            "scope-a",
+            new StreamingProxyEndpoints.CreateRoomRequest("Incident Room"),
+            service,
+            CancellationToken.None);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+
+        statusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        body.Should().Contain("Failed to create room");
     }
 
     [Fact]
@@ -246,18 +148,17 @@ public sealed class StreamingProxyEndpointsCoverageTests
     [Fact]
     public async Task HandleCreateRoomAsync_ShouldRejectMismatchedAuthenticatedScope()
     {
-        var operations = new List<string>();
-        var actorStore = new RecordingGAgentActorStore(operations);
-        var runtime = new RecordingActorRuntime(operations, new RecordingActor("created-room"));
-        var loggerFactory = LoggerFactory.Create(_ => { });
+        var service = new RecordingRoomCommandService(
+            new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Created,
+                "room-denied",
+                "Denied Room"));
 
         var result = await InvokeHandleCreateRoomAsync(
             CreateScopedHttpContext("scope-b"),
             "scope-a",
             new StreamingProxyEndpoints.CreateRoomRequest("Denied Room"),
-            actorStore,
-            runtime,
-            loggerFactory,
+            service,
             CancellationToken.None);
 
         var (statusCode, body) = await ExecuteResultAsync(result);
@@ -265,7 +166,7 @@ public sealed class StreamingProxyEndpointsCoverageTests
         statusCode.Should().Be(StatusCodes.Status403Forbidden);
         body.Should().Contain("SCOPE_ACCESS_DENIED");
         body.Should().Contain("Authenticated scope does not match requested scope.");
-        actorStore.AddedActors.Should().BeEmpty();
+        service.Commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -293,14 +194,12 @@ public sealed class StreamingProxyEndpointsCoverageTests
         HttpContext context,
         string scopeId,
         StreamingProxyEndpoints.CreateRoomRequest? request,
-        IGAgentActorRegistryCommandPort actorStore,
-        IActorRuntime actorRuntime,
-        ILoggerFactory loggerFactory,
+        IStreamingProxyRoomCommandService roomCommandService,
         CancellationToken ct)
     {
         return await (Task<IResult>)HandleCreateRoomAsyncMethod.Invoke(
             null,
-            [context, scopeId, request, actorStore, actorRuntime, loggerFactory, ct])!;
+            [context, scopeId, request, roomCommandService, ct])!;
     }
 
     private static async Task<IResult> InvokeHandleListParticipantsAsync(
@@ -403,6 +302,21 @@ public sealed class StreamingProxyEndpointsCoverageTests
             ScopeResourceTarget target,
             CancellationToken cancellationToken = default)
             => Task.FromResult(ScopeResourceAdmissionResult.Allowed());
+    }
+
+    private sealed class RecordingRoomCommandService(StreamingProxyRoomCreateResult result)
+        : IStreamingProxyRoomCommandService
+    {
+        public List<StreamingProxyRoomCreateCommand> Commands { get; } = [];
+
+        public Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
+            StreamingProxyRoomCreateCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Commands.Add(command);
+            return Task.FromResult(result);
+        }
     }
 
     private sealed class RecordingParticipantStore : IStreamingProxyParticipantStore

--- a/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
@@ -1,0 +1,320 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgents.StreamingProxy;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class StreamingProxyRoomCommandServiceTests
+{
+    [Fact]
+    public async Task CreateRoomAsync_ShouldCreateInitializeAndRegisterRoom()
+    {
+        var operations = new List<string>();
+        var actor = new RecordingActor("room-created", operations);
+        var runtime = new RecordingActorRuntime(operations, actor);
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            registry,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("scope-a", "Daily Standup"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomCreateStatus.Created);
+        result.RoomName.Should().Be("Daily Standup");
+        result.RoomId.Should().NotBeNullOrWhiteSpace();
+        registry.RegisteredActors.Should().ContainSingle();
+        registry.RegisteredActors[0].Should().Be(new GAgentActorRegistration(
+            "scope-a",
+            StreamingProxyDefaults.GAgentTypeName,
+            result.RoomId!));
+        runtime.LastCreatedActor.Should().NotBeNull();
+        runtime.LastCreatedActor!.ReceivedEnvelopes.Should().ContainSingle();
+        var envelope = runtime.LastCreatedActor.ReceivedEnvelopes[0];
+        envelope.Route.Direct.TargetActorId.Should().Be(result.RoomId);
+        envelope
+            .Payload
+            .Unpack<GroupChatRoomInitializedEvent>()
+            .RoomName
+            .Should()
+            .Be("Daily Standup");
+        operations.Should().ContainInOrder(
+            $"runtime:create:{result.RoomId}",
+            $"actor:init:{result.RoomId}",
+            $"registry:register:{result.RoomId}");
+    }
+
+    [Fact]
+    public async Task CreateRoomAsync_ShouldRejectBlankScopeBeforeCreatingActor()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            registry,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var act = async () => await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("  ", "Incident Room"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("ScopeId");
+        operations.Should().BeEmpty();
+        registry.RegisteredActors.Should().BeEmpty();
+        registry.UnregisteredActors.Should().BeEmpty();
+        runtime.DestroyedActorIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateRoomAsync_ShouldDefaultBlankRoomNameInApplicationLayer()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            registry,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("scope-a", "  "),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomCreateStatus.Created);
+        result.RoomName.Should().Be("Group Chat");
+        runtime.LastCreatedActor!.ReceivedEnvelopes[0]
+            .Payload
+            .Unpack<GroupChatRoomInitializedEvent>()
+            .RoomName
+            .Should()
+            .Be("Group Chat");
+    }
+
+    [Fact]
+    public async Task CreateRoomAsync_ShouldRollbackCreatedRoom_WhenRegistrationIsNotAdmissionVisible()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations)
+        {
+            RegisterStage = GAgentActorRegistryCommandStage.AcceptedForDispatch,
+        };
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            registry,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("scope-a", "Incident Room"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomCreateStatus.AdmissionUnavailable);
+        registry.UnregisteredActors.Should().ContainSingle();
+        runtime.DestroyedActorIds.Should().ContainSingle(result.RoomId);
+        operations.Should().ContainInOrder(
+            $"runtime:create:{result.RoomId}",
+            $"actor:init:{result.RoomId}",
+            $"registry:register:{result.RoomId}",
+            $"registry:unregister:{result.RoomId}",
+            $"runtime:destroy:{result.RoomId}");
+    }
+
+    [Fact]
+    public async Task CreateRoomAsync_ShouldNotDestroyRoom_WhenRollbackUnregisterFails()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations)
+        {
+            ThrowOnRegister = new InvalidOperationException("registry unavailable"),
+            ThrowOnUnregister = new InvalidOperationException("registry unregister unavailable"),
+        };
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            registry,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("scope-a", "Incident Room"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomCreateStatus.Failed);
+        registry.UnregisteredActors.Should().ContainSingle();
+        runtime.DestroyedActorIds.Should().BeEmpty();
+        operations.Should().ContainInOrder(
+            $"runtime:create:{result.RoomId}",
+            $"actor:init:{result.RoomId}",
+            $"registry:register:{result.RoomId}",
+            $"registry:unregister:{result.RoomId}");
+    }
+
+    [Fact]
+    public async Task CreateRoomAsync_ShouldRollbackCreatedRoomAndRethrow_WhenRegistrationIsCanceled()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations)
+        {
+            ThrowOnRegister = new OperationCanceledException("client disconnected"),
+        };
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            registry,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var act = async () => await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("scope-a", "Incident Room"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        registry.UnregisteredActors.Should().ContainSingle();
+        runtime.DestroyedActorIds.Should().ContainSingle();
+        var unregisterIndex = operations.FindIndex(x => x.StartsWith("registry:unregister:", StringComparison.Ordinal));
+        var destroyIndex = operations.FindIndex(x => x.StartsWith("runtime:destroy:", StringComparison.Ordinal));
+        unregisterIndex.Should().BeGreaterThanOrEqualTo(0);
+        destroyIndex.Should().BeGreaterThan(unregisterIndex);
+    }
+
+    private sealed class RecordingGAgentActorRegistryCommandPort(List<string> operations)
+        : IGAgentActorRegistryCommandPort
+    {
+        public List<GAgentActorRegistration> RegisteredActors { get; } = [];
+        public List<GAgentActorRegistration> UnregisteredActors { get; } = [];
+        public Exception? ThrowOnRegister { get; init; }
+        public Exception? ThrowOnUnregister { get; init; }
+        public GAgentActorRegistryCommandStage RegisterStage { get; init; } =
+            GAgentActorRegistryCommandStage.AdmissionVisible;
+
+        public Task<GAgentActorRegistryCommandReceipt> RegisterActorAsync(
+            GAgentActorRegistration registration,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            operations.Add($"registry:register:{registration.ActorId}");
+            RegisteredActors.Add(registration);
+            if (ThrowOnRegister is not null)
+                throw ThrowOnRegister;
+
+            return Task.FromResult(new GAgentActorRegistryCommandReceipt(registration, RegisterStage));
+        }
+
+        public Task<GAgentActorRegistryCommandReceipt> UnregisterActorAsync(
+            GAgentActorRegistration registration,
+            CancellationToken cancellationToken = default)
+        {
+            operations.Add($"registry:unregister:{registration.ActorId}");
+            UnregisteredActors.Add(registration);
+            if (ThrowOnUnregister is not null)
+                throw ThrowOnUnregister;
+
+            return Task.FromResult(new GAgentActorRegistryCommandReceipt(
+                registration,
+                GAgentActorRegistryCommandStage.AdmissionRemoved));
+        }
+    }
+
+    private sealed class RecordingActorRuntime(List<string> operations, IActor actor) : IActorRuntime
+    {
+        public List<string> DestroyedActorIds { get; } = [];
+        public RecordingActor? LastCreatedActor { get; private set; }
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            CreateAsync(typeof(TAgent), id, ct);
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default)
+        {
+            agentType.Should().Be(typeof(StreamingProxyGAgent));
+            ct.ThrowIfCancellationRequested();
+            var actorId = id ?? throw new InvalidOperationException("Actor id is required for this test.");
+            operations.Add($"runtime:create:{actorId}");
+            LastCreatedActor = actor is RecordingActor recordingActor && recordingActor.Id == actorId
+                ? recordingActor
+                : new RecordingActor(actorId, operations);
+            return Task.FromResult<IActor>(LastCreatedActor);
+        }
+
+        public Task DestroyAsync(string id, CancellationToken ct = default)
+        {
+            operations.Add($"runtime:destroy:{id}");
+            DestroyedActorIds.Add(id);
+            return Task.CompletedTask;
+        }
+
+        public Task<IActor?> GetAsync(string id)
+        {
+            _ = id;
+            return Task.FromResult<IActor?>(null);
+        }
+
+        public Task<bool> ExistsAsync(string id)
+        {
+            _ = id;
+            return Task.FromResult(false);
+        }
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default)
+        {
+            _ = parentId;
+            _ = childId;
+            return Task.CompletedTask;
+        }
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default)
+        {
+            _ = childId;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingActor(string id, List<string> operations) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent { get; } = new StubAgent(id);
+        public List<EventEnvelope> ReceivedEnvelopes { get; } = [];
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            operations.Add($"actor:init:{Id}");
+            ReceivedEnvelopes.Add(envelope);
+            return Task.CompletedTask;
+        }
+
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class StubAgent(string id) : IAgent
+    {
+        public string Id { get; } = id;
+
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
+        {
+            _ = envelope;
+            return Task.CompletedTask;
+        }
+
+        public Task<string> GetDescriptionAsync() => Task.FromResult(string.Empty);
+
+        public Task<IReadOnlyList<Type>> GetSubscribedEventTypesAsync() =>
+            Task.FromResult<IReadOnlyList<Type>>([]);
+
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Problem

Issue #463 calls out that the streaming proxy room creation endpoint was carrying core lifecycle orchestration directly in the host/API surface. That made the endpoint responsible for actor creation, initialization, registry admission, and rollback.

## Solution

- Add a typed application command surface for streaming proxy room creation.
- Move actor creation, initialization envelope construction, registry admission, and rollback into `StreamingProxyRoomCommandService`.
- Keep the endpoint focused on scope access checks and HTTP result mapping.
- Register the command service through DI.
- Update endpoint coverage tests to verify delegation and result mapping.
- Add command service tests for success ordering, admission rollback, failure rollback, cancellation rollback, blank scope validation, and envelope target routing.

## Impact

This keeps the host/API layer as composition and protocol mapping only, while the application layer owns the command lifecycle. Rollback now validates ownership first by unregistering registry ownership before destroying the actor.

## Validation

- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --no-restore --filter "FullyQualifiedName~StreamingProxyRoomCommandServiceTests|FullyQualifiedName~StreamingProxyEndpointsCoverageTests|FullyQualifiedName~StreamingProxyCoverageTests" --nologo` passed: 45/45.
- `dotnet build agents/Aevatar.GAgents.StreamingProxy/Aevatar.GAgents.StreamingProxy.csproj --no-restore --nologo` passed with NuGet warnings only.
- `bash tools/ci/test_stability_guards.sh` passed.
- `git diff --check` passed.
- Manual smoke with `src/Aevatar.Mainnet.Host.Api` in Development/InMemory/no-auth mode passed:
  - `POST /api/scopes/smoke-scope/streaming-proxy/rooms` returned `200 OK` with `roomId=streaming-proxy-8303b49646664caebadc98fe04c51238` and `roomName=Review Smoke Room`.
  - `GET /api/scopes/smoke-scope/streaming-proxy/rooms` returned `200 OK`, `stateVersion=1`, and the created room in `rooms`.
- `bash tools/ci/architecture_guards.sh` passed the C# architecture guards, then failed in the unrelated CLI playground asset build because `@tanstack/react-virtual` could not be resolved from `tools/Aevatar.Tools.Cli/Frontend/src/runtime/ScopePage.tsx`.

## Review

Ran the `superpowers:requesting-code-review` flow. The reviewer found no critical issues and raised one P2 risk around blank `ScopeId` validation happening after actor creation. This PR includes the fix and a regression test that rejects blank scope before any actor side effect.