### PR TITLE
Fix script member lifecycle Build navigation

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -190,6 +190,43 @@ function mockBuildServiceRevisionCatalog(
   };
 }
 
+function mockBuildScriptServiceRevisionCatalog(
+  overrides?: Partial<{
+    scopeId: string;
+    serviceId: string;
+    displayName: string;
+    scriptId: string;
+    revisionId: string;
+  }>
+) {
+  const scriptId = overrides?.scriptId ?? "script-alpha";
+  const revisionId = overrides?.revisionId ?? "rev-script-1";
+  const catalog = mockBuildServiceRevisionCatalog({
+    scopeId: overrides?.scopeId,
+    serviceId: overrides?.serviceId ?? scriptId,
+    displayName: overrides?.displayName ?? scriptId,
+    workflowName: "",
+    revisionId,
+  });
+
+  return {
+    ...catalog,
+    revisions: [
+      {
+        ...catalog.revisions[0],
+        implementationKind: "script",
+        workflowName: "",
+        workflowDefinitionActorId: "",
+        inlineWorkflowCount: 0,
+        scriptId,
+        scriptRevision: revisionId,
+        scriptDefinitionActorId: "definition-1",
+        scriptSourceHash: "hash-1",
+      },
+    ],
+  };
+}
+
 function mockBuildServiceRunSummary(
   overrides?: Partial<{
     scopeId: string;
@@ -702,7 +739,7 @@ jest.mock("@/shared/studio/api", () => ({
             : matchedMember?.implementationKind === "script"
               ? {
                   implementationKind: "script",
-                  scriptId: matchedMember.displayName,
+                  scriptId: matchedMember.scriptId || matchedMember.displayName,
                   scriptRevision: matchedMember.lastBoundRevisionId,
                 }
               : {
@@ -5254,6 +5291,92 @@ describe("StudioPage", () => {
     expect(await screen.findByLabelText("Script ID")).toBeTruthy();
     expect(screen.getByTestId("studio-script-build-panel")).toBeTruthy();
     expect(screen.getByText("Script source")).toBeTruthy();
+  });
+
+  it("returns from Bind to the selected Script build surface", async () => {
+    (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
+      ...defaultStudioAppContext,
+      features: {
+        ...defaultStudioAppContext.features,
+        scripts: true,
+      },
+      scopeId: "scope-1",
+      scopeResolved: true,
+    });
+    mockStudioMembers = [
+      ...mockStudioMembers,
+      {
+        memberId: "script-member",
+        scopeId: "scope-1",
+        displayName: "draft-test",
+        description: "Script member",
+        implementationKind: "script",
+        scriptId: "script-alpha",
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "service-script-alpha",
+        lastBoundRevisionId: "rev-script-1",
+        createdAt: "2026-04-27T08:00:00Z",
+        updatedAt: "2026-04-27T08:05:00Z",
+      },
+    ];
+    (scriptsApi.listScripts as jest.Mock).mockResolvedValue([
+      {
+        available: true,
+        scopeId: "scope-1",
+        script: {
+          scopeId: "scope-1",
+          scriptId: "script-alpha",
+          catalogActorId: "catalog-1",
+          definitionActorId: "definition-1",
+          activeRevision: "rev-script-1",
+          activeSourceHash: "hash-1",
+          updatedAt: "2026-03-18T00:00:00Z",
+        },
+        source: {
+          sourceText: "using System;",
+          definitionActorId: "definition-1",
+          revision: "rev-script-1",
+          sourceHash: "hash-1",
+        },
+      },
+    ]);
+    mockServicesApi.listServices.mockResolvedValue([
+      {
+        serviceId: "service-script-alpha",
+        displayName: "draft-test",
+        deploymentStatus: "Active",
+        primaryActorId: "actor-script-alpha",
+        endpoints: [
+          {
+            endpointId: "script-command",
+            displayName: "Script command",
+            kind: "command",
+            description: "Invoke the script command.",
+            requestTypeUrl: "type.googleapis.com/example.ScriptCommand",
+            responseTypeUrl: "type.googleapis.com/example.ScriptResult",
+          },
+        ],
+      },
+    ]);
+    mockScopeRuntimeApi.getServiceRevisions.mockImplementation(
+      async (_scopeId: string, serviceId: string) =>
+        serviceId === "service-script-alpha"
+          ? mockBuildScriptServiceRevisionCatalog({ serviceId, scriptId: "script-alpha" })
+          : mockBuildServiceRevisionCatalog({ serviceId })
+    );
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&memberId=script-member&step=bind&tab=bindings"
+    );
+
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Build" }));
+
+    expect(await screen.findByTestId("studio-script-build-panel")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Script ID")).toHaveValue("script-alpha");
+    });
+    expect(screen.queryByTestId("studio-workflow-build-panel")).toBeNull();
   });
 
   it("binds a catalog-applied Script build candidate through the script binding API", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -110,6 +110,7 @@ import type { ServiceCatalogSnapshot } from '@/shared/models/services';
 import type {
   StudioExecutionDetail,
   StudioExecutionSummary,
+  StudioMemberBindingRevision,
   StudioMemberSummary,
   StudioValidationFinding,
   StudioWorkflowDocument,
@@ -1153,11 +1154,156 @@ function readInitialBuildSurface(state: StudioRouteState): BuildSurface {
   }
 
   const buildFocus = parseStudioBuildFocus(state.focusKey);
-  if (state.tab === 'scripts' || buildFocus.kind === 'script') {
+  const routeMember = parseStudioRouteMember(state.memberKey);
+  if (
+    state.tab === 'scripts' ||
+    buildFocus.kind === 'script' ||
+    routeMember.kind === 'script'
+  ) {
     return 'scripts';
   }
 
   return 'editor';
+}
+
+function findPublishedStudioMemberByMemberKey(
+  memberKey: string,
+  publishedMembers: readonly PublishedStudioMemberRecord[],
+): PublishedStudioMemberRecord | null {
+  const normalizedMemberKey = trimOptional(memberKey);
+  const memberToken = readMemberIdFromMemberKey(normalizedMemberKey);
+  if (!memberToken) {
+    return null;
+  }
+
+  return (
+    publishedMembers.find(
+      ({ memberSummary, service }) =>
+        trimOptional(memberSummary?.memberId) === memberToken ||
+        trimOptional(memberSummary?.publishedServiceId) === memberToken ||
+        trimOptional(service.serviceId) === memberToken,
+    ) ?? null
+  );
+}
+
+function resolveLifecycleScriptId(
+  memberKey: string,
+  publishedMembers: readonly PublishedStudioMemberRecord[],
+  studioScopeMembers: readonly StudioMemberSummary[],
+): string {
+  const directScriptId = readScriptIdFromMemberKey(memberKey);
+  if (directScriptId) {
+    return directScriptId;
+  }
+
+  const publishedScriptId = trimOptional(
+    findPublishedStudioMemberByMemberKey(memberKey, publishedMembers)?.matchedScript
+      ?.script?.scriptId,
+  );
+  if (publishedScriptId) {
+    return publishedScriptId;
+  }
+
+  const memberSummary = resolveStudioMemberSummaryFromMemberKey(
+    memberKey,
+    publishedMembers,
+    studioScopeMembers,
+  );
+  if (
+    normalizeStudioMemberBindingImplementationKind(
+      memberSummary?.implementationKind,
+    ) === 'script'
+  ) {
+    return trimOptional(memberSummary?.publishedServiceId)
+      ? ''
+      : trimOptional(memberSummary?.displayName);
+  }
+
+  return '';
+}
+
+function resolveLifecycleWorkflowId(
+  memberKey: string,
+  publishedMembers: readonly PublishedStudioMemberRecord[],
+  studioScopeMembers: readonly StudioMemberSummary[],
+): string {
+  const workflowRouteValue = readWorkflowMemberRouteValueFromMemberKey(memberKey);
+  if (workflowRouteValue) {
+    return workflowRouteValue;
+  }
+
+  const publishedWorkflowId = trimOptional(
+    findPublishedStudioMemberByMemberKey(memberKey, publishedMembers)?.matchedWorkflow
+      ?.workflowId,
+  );
+  if (publishedWorkflowId) {
+    return publishedWorkflowId;
+  }
+
+  const memberSummary = resolveStudioMemberSummaryFromMemberKey(
+    memberKey,
+    publishedMembers,
+    studioScopeMembers,
+  );
+  if (
+    normalizeStudioMemberBindingImplementationKind(
+      memberSummary?.implementationKind,
+    ) === 'workflow'
+  ) {
+    return trimOptional(memberSummary?.displayName);
+  }
+
+  return '';
+}
+
+function resolveLifecycleBuildSurface(input: {
+  readonly fallback: BuildSurface;
+  readonly memberKey: string;
+  readonly publishedMembers: readonly PublishedStudioMemberRecord[];
+  readonly studioScopeMembers: readonly StudioMemberSummary[];
+}): BuildSurface {
+  const normalizedMemberKey = trimOptional(input.memberKey);
+  if (normalizedMemberKey.startsWith('script:')) {
+    return 'scripts';
+  }
+
+  if (normalizedMemberKey.startsWith('workflow:')) {
+    return 'editor';
+  }
+
+  const memberSummary = resolveStudioMemberSummaryFromMemberKey(
+    normalizedMemberKey,
+    input.publishedMembers,
+    input.studioScopeMembers,
+  );
+  const implementationKind = normalizeStudioMemberBindingImplementationKind(
+    memberSummary?.implementationKind,
+  );
+  if (implementationKind === 'script') {
+    return 'scripts';
+  }
+
+  if (implementationKind === 'workflow') {
+    return 'editor';
+  }
+
+  const publishedMember = findPublishedStudioMemberByMemberKey(
+    normalizedMemberKey,
+    input.publishedMembers,
+  );
+  if (publishedMember?.matchedScript?.script?.scriptId) {
+    return 'scripts';
+  }
+
+  if (publishedMember?.matchedWorkflow?.workflowId) {
+    return 'editor';
+  }
+
+  if (publishedMember?.revision?.implementationKind === 'gagent') {
+    return 'gagent';
+  }
+
+  return input.fallback;
 }
 
 function normalizeObserveRunStatus(status: string | null | undefined): string {
@@ -1797,6 +1943,7 @@ type PublishedStudioMemberRecord = {
       readonly scriptId?: string | null;
     } | null;
   } | null;
+  readonly revision?: StudioMemberBindingRevision | null;
 };
 
 function resolveStudioMemberSummaryFromMemberKey(
@@ -5196,53 +5343,6 @@ const StudioPage: React.FC = () => {
       studioScopeMembers,
     ],
   );
-  const handleSelectLifecycleStep = useCallback(
-    async (stepKey: string) => {
-      const normalizedStep = stepKey.trim().toLowerCase();
-      const targetStudioSurface: StudioSurface =
-        normalizedStep === 'observe'
-          ? 'observe'
-          : normalizedStep === 'bind'
-            ? 'bind'
-            : normalizedStep === 'invoke'
-              ? 'invoke'
-              : 'build';
-      const isCurrentBuildSurface =
-        targetStudioSurface === 'build' && studioSurface === 'build';
-      if (isCurrentBuildSurface) {
-        return;
-      }
-      if (!(await confirmScriptsStudioLeave())) {
-        return;
-      }
-
-      if (stepKey === 'build') {
-        applyStudioTarget('build', buildSurface);
-        return;
-      }
-
-      if (stepKey === 'bind') {
-        applyStudioTarget('bind');
-        return;
-      }
-
-      if (stepKey === 'invoke') {
-        applyStudioTarget('invoke');
-        return;
-      }
-
-      if (stepKey === 'observe') {
-        applyStudioTarget('observe');
-      }
-    },
-    [
-      applyStudioTarget,
-      buildSurface,
-      confirmScriptsStudioLeave,
-      studioSurface,
-    ],
-  );
-
   const pageTitle =
     isBuildEditorSurface
       ? 'Workflow 构建'
@@ -5445,6 +5545,47 @@ const StudioPage: React.FC = () => {
   const currentFocusMemberKey =
     studioSurface === 'build' ? buildSurfaceMemberKey : lifecycleSurfaceMemberKey;
   useEffect(() => {
+    if (
+      studioSurface !== 'build' ||
+      (buildSurface !== 'editor' && buildSurface !== 'scripts')
+    ) {
+      return;
+    }
+
+    const memberSummary = resolveStudioMemberSummaryFromMemberKey(
+      lifecycleSurfaceMemberKey,
+      publishedScopeMembers,
+      studioScopeMembers,
+    );
+    if (
+      normalizeStudioMemberBindingImplementationKind(
+        memberSummary?.implementationKind,
+      ) !== 'script'
+    ) {
+      return;
+    }
+
+    const scriptId = resolveLifecycleScriptId(
+      lifecycleSurfaceMemberKey,
+      publishedScopeMembers,
+      studioScopeMembers,
+    );
+    if (!scriptId) {
+      return;
+    }
+
+    setSelectedWorkflowId('');
+    setSelectedScriptId(scriptId);
+    setTemplateWorkflow('');
+    setBuildSurface('scripts');
+  }, [
+    buildSurface,
+    lifecycleSurfaceMemberKey,
+    publishedScopeMembers,
+    studioScopeMembers,
+    studioSurface,
+  ]);
+  useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
@@ -5617,6 +5758,141 @@ const StudioPage: React.FC = () => {
       ? currentServiceRevisionByServiceId.get(serviceId) ?? null
       : null;
   }, [currentServiceRevisionByServiceId, workbenchPublishedService?.serviceId]);
+  useEffect(() => {
+    if (studioSurface !== 'build' || buildSurface !== 'editor') {
+      return;
+    }
+
+    const implementationKind = normalizeStudioMemberBindingImplementationKind(
+      workbenchStudioMemberDetailQuery.data?.implementationRef
+        ?.implementationKind ||
+        workbenchStudioMember?.implementationKind ||
+        workbenchPublishedServiceRevision?.implementationKind,
+    );
+    if (implementationKind !== 'script') {
+      return;
+    }
+
+    const scriptId =
+      trimOptional(
+        workbenchStudioMemberDetailQuery.data?.implementationRef?.scriptId,
+      ) ||
+      trimOptional(workbenchPublishedServiceRevision?.scriptId) ||
+      (trimOptional(workbenchStudioMember?.publishedServiceId)
+        ? ''
+        : trimOptional(workbenchStudioMember?.displayName));
+
+    setSelectedWorkflowId('');
+    if (scriptId) {
+      setSelectedScriptId(scriptId);
+    }
+    setTemplateWorkflow('');
+    setBuildSurface('scripts');
+  }, [
+    buildSurface,
+    studioSurface,
+    workbenchPublishedServiceRevision?.implementationKind,
+    workbenchPublishedServiceRevision?.scriptId,
+    workbenchStudioMember?.displayName,
+    workbenchStudioMember?.implementationKind,
+    workbenchStudioMember?.publishedServiceId,
+    workbenchStudioMemberDetailQuery.data?.implementationRef?.implementationKind,
+    workbenchStudioMemberDetailQuery.data?.implementationRef?.scriptId,
+  ]);
+  const handleSelectLifecycleStep = useCallback(
+    async (stepKey: string) => {
+      const normalizedStep = stepKey.trim().toLowerCase();
+      const targetStudioSurface: StudioSurface =
+        normalizedStep === 'observe'
+          ? 'observe'
+          : normalizedStep === 'bind'
+            ? 'bind'
+            : normalizedStep === 'invoke'
+              ? 'invoke'
+              : 'build';
+      const isCurrentBuildSurface =
+        targetStudioSurface === 'build' && studioSurface === 'build';
+      if (isCurrentBuildSurface) {
+        return;
+      }
+      if (!(await confirmScriptsStudioLeave())) {
+        return;
+      }
+
+      if (stepKey === 'build') {
+        const lifecycleMemberKey =
+          lifecycleSurfaceMemberKey || currentFocusMemberKey;
+        const lifecycleScriptId =
+          trimOptional(
+            workbenchStudioMemberDetailQuery.data?.implementationRef?.scriptId,
+          ) ||
+          trimOptional(workbenchPublishedServiceRevision?.scriptId) ||
+          resolveLifecycleScriptId(
+            lifecycleMemberKey,
+            publishedScopeMembers,
+            studioScopeMembers,
+          ) ||
+          (readScriptIdFromMemberKey(lifecycleMemberKey)
+            ? trimOptional(selectedScriptId)
+            : '');
+        const resolvedBuildSurface = resolveLifecycleBuildSurface({
+          fallback: lifecycleScriptId ? 'scripts' : buildSurface,
+          memberKey: lifecycleMemberKey,
+          publishedMembers: publishedScopeMembers,
+          studioScopeMembers,
+        });
+        if (lifecycleScriptId) {
+          setSelectedWorkflowId('');
+          setSelectedScriptId(lifecycleScriptId);
+          setTemplateWorkflow('');
+        } else if (resolvedBuildSurface === 'scripts') {
+          setSelectedWorkflowId('');
+          setSelectedScriptId('');
+          setTemplateWorkflow('');
+        } else {
+          const lifecycleWorkflowId = resolveLifecycleWorkflowId(
+            lifecycleMemberKey,
+            publishedScopeMembers,
+            studioScopeMembers,
+          );
+          if (lifecycleWorkflowId) {
+            setSelectedWorkflowId(lifecycleWorkflowId);
+            setSelectedScriptId('');
+            setTemplateWorkflow('');
+          }
+        }
+        applyStudioTarget('build', resolvedBuildSurface);
+        return;
+      }
+
+      if (stepKey === 'bind') {
+        applyStudioTarget('bind');
+        return;
+      }
+
+      if (stepKey === 'invoke') {
+        applyStudioTarget('invoke');
+        return;
+      }
+
+      if (stepKey === 'observe') {
+        applyStudioTarget('observe');
+      }
+    },
+    [
+      applyStudioTarget,
+      buildSurface,
+      confirmScriptsStudioLeave,
+      currentFocusMemberKey,
+      lifecycleSurfaceMemberKey,
+      publishedScopeMembers,
+      selectedScriptId,
+      studioSurface,
+      studioScopeMembers,
+      workbenchPublishedServiceRevision?.scriptId,
+      workbenchStudioMemberDetailQuery.data?.implementationRef?.scriptId,
+    ],
+  );
   useEffect(() => {
     if (!resolvedStudioScopeId || !workbenchPublishedServiceId) {
       return;


### PR DESCRIPTION
## Problem
Script members could return to the workflow build flow when users clicked the top lifecycle `Build` button from `Bind`. This was especially visible when the member display name, published service id, and real script id differed.

Closes #514

## Solution
- Resolve the lifecycle Build target from the selected member implementation kind instead of reusing the previous build surface.
- Prefer authoritative script identity from `implementationRef.scriptId` or the current published service revision.
- Avoid falling back to `publishedServiceId` or display name as a script id for already-bound script members.
- Keep workflow members routed back to the workflow editor.

## Impact Paths
- `apps/aevatar-console-web/src/pages/studio/index.tsx`
- `apps/aevatar-console-web/src/pages/studio/index.test.tsx`

## Validation
- `npm --prefix apps/aevatar-console-web run jest -- --selectProjects jsdom --runTestsByPath src/pages/studio/index.test.tsx --runInBand`
- `npm --prefix apps/aevatar-console-web run tsc`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`