### PR TITLE
fix: stabilize Studio script lifecycle binding flow

### DIFF
--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -620,7 +620,7 @@ public sealed class DraftBehavior : ScriptBehavior<AppScriptReadModel, AppScript
     expect(header).toBeTruthy();
 
     const headerScope = within(header as HTMLElement);
-    expect(headerScope.getByText(/^draft-/)).toBeTruthy();
+    expect(headerScope.getByText('not saved')).toBeTruthy();
     expect(headerScope.getByText('嵌入式 Host')).toBeTruthy();
     expect(headerScope.getByText('Scope 1626c177…b0d6')).toBeTruthy();
     expect(headerScope.getByRole('button', { name: 'New draft' })).toBeTruthy();
@@ -747,9 +747,9 @@ public sealed class DraftBehavior : ScriptBehavior<AppScriptReadModel, AppScript
       expect(mockedStudioApi.bindScopeScript).toHaveBeenCalledWith({
         scopeId: 'scope-1',
         displayName: 'script-1',
+        serviceId: 'script-1',
         scriptId: 'script-1',
         scriptRevision: 'rev-1',
-        revisionId: 'script-1-rev-1',
       });
     });
 
@@ -795,7 +795,7 @@ public sealed class DraftBehavior : ScriptBehavior<AppScriptReadModel, AppScript
       expect(mockedScriptsApi.runDraftScript).toHaveBeenCalledWith({
         scopeId: 'scope-1',
         scriptId: 'script-1',
-        scriptRevision: expect.stringMatching(/^draft-/),
+        scriptRevision: undefined,
         source: expect.any(String),
         package: expect.objectContaining({
           format: 'aevatar.scripting.package.v1',

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -771,6 +771,67 @@ public sealed class DraftBehavior : ScriptBehavior<AppScriptReadModel, AppScript
     );
   });
 
+  it('blocks scope binding when the saved script has no applied revision', async () => {
+    window.localStorage.setItem(
+      'aevatar:console:scripts-studio:v1',
+      JSON.stringify([
+        {
+          key: 'script-without-revision',
+          scriptId: 'script-1',
+          revision: '',
+          baseRevision: '',
+          input: '',
+          package: {
+            csharpSources: [
+              {
+                path: 'Behavior.cs',
+                content: 'public sealed class DemoScript {}',
+              },
+            ],
+            protoFiles: [],
+            entryBehaviorTypeName: 'DraftBehavior',
+            entrySourcePath: 'Behavior.cs',
+          },
+          selectedFilePath: 'Behavior.cs',
+          definitionActorId: 'definition-1',
+          runtimeActorId: 'runtime-1',
+          updatedAtUtc: '2026-03-24T00:00:00Z',
+          lastSourceHash: 'hash-1',
+          scopeDetail: {
+            available: true,
+            scopeId: 'scope-1',
+            script: {
+              scopeId: 'scope-1',
+              scriptId: 'script-1',
+              catalogActorId: 'catalog-1',
+              definitionActorId: 'definition-1',
+              activeRevision: '',
+              activeSourceHash: 'hash-1',
+              updatedAt: '2026-03-24T00:00:00Z',
+            },
+            source: {
+              sourceText: 'public sealed class DemoScript {}',
+              definitionActorId: 'definition-1',
+              revision: '',
+              sourceHash: 'hash-1',
+            },
+          },
+        },
+      ]),
+    );
+
+    renderPage({
+      mode: 'embedded',
+      scopeId: 'scope-1',
+    });
+
+    const bindButton = await screen.findByRole('button', {
+      name: 'Update default route',
+    });
+    expect(bindButton).toBeDisabled();
+    expect(mockedStudioApi.bindScopeScript).not.toHaveBeenCalled();
+  });
+
   it('runs the current script draft without rebinding the scope service', async () => {
     renderPage({
       mode: 'embedded',

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
@@ -287,6 +287,10 @@ function normalizeStudioId(value: string, fallbackPrefix: string): string {
     .slice(0, 14)}`;
 }
 
+function trimOptional(value: string | null | undefined): string {
+  return String(value || '').trim();
+}
+
 function createStarterPackage(): ScriptPackage {
   return createSingleSourcePackage(STARTER_SOURCE);
 }
@@ -1757,10 +1761,16 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     }
 
     const scriptId = normalizeStudioId(scopeScript.scriptId || selectedDraft.scriptId, 'script');
-    const scriptRevision = normalizeStudioId(
+    const scriptRevision = trimOptional(
       scopeScript.activeRevision || selectedDraft.revision,
-      'rev',
     );
+    if (!scriptRevision) {
+      setNotice({
+        type: 'warning',
+        message: 'Save the current script into the scope before binding it.',
+      });
+      return;
+    }
 
     setBindPending(true);
     setNotice(null);
@@ -2371,8 +2381,15 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       (selectedDraft.scopeDetail?.script?.activeRevision || selectedDraft.baseRevision),
   );
   const scopeBindingScript = selectedDraft?.scopeDetail?.script || null;
+  const scopeBindingRevision = trimOptional(
+    scopeBindingScript?.activeRevision || selectedDraft?.revision,
+  );
   const canBindScope = Boolean(
-    selectedDraft && scopeBacked && scopeBindingScript && !bindPending,
+    selectedDraft &&
+      scopeBacked &&
+      scopeBindingScript &&
+      scopeBindingRevision &&
+      !bindPending,
   );
   const scopeSelectionId = selectedDraft?.scopeDetail?.script?.scriptId || '';
   const hasScopeChanges = isScopeDetailDirty(selectedDraft);
@@ -3253,7 +3270,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
             <div className="console-scripts-eyebrow">Script</div>
             <div className="console-scripts-detail-copy">
               {scopeBindingScript?.scriptId || selectedDraft?.scriptId || '-'} ·{' '}
-              {scopeBindingScript?.activeRevision || selectedDraft?.revision || '-'}
+              {scopeBindingRevision || 'save required'}
             </div>
           </div>
           <div style={{ marginTop: 16 }}>

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
@@ -248,10 +248,6 @@ function createDraftKey(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${draftCounter.toString(36)}`;
 }
 
-function createRevisionSeed(): string {
-  return `draft-${new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}`;
-}
-
 function buildScopePageHref(
   path: string,
   scopeId: string,
@@ -289,13 +285,6 @@ function normalizeStudioId(value: string, fallbackPrefix: string): string {
     .toISOString()
     .replace(/[-:.TZ]/g, '')
     .slice(0, 14)}`;
-}
-
-function buildScopeScriptBindingRevisionId(
-  scriptId: string,
-  scriptRevision: string,
-): string {
-  return normalizeStudioId(`${scriptId}-${scriptRevision}`, 'rev');
 }
 
 function createStarterPackage(): ScriptPackage {
@@ -369,7 +358,7 @@ function createDraft(index: number, seed: Partial<ScriptDraft> = {}): ScriptDraf
   return {
     key: seed.key || createDraftKey('script_draft'),
     scriptId: seed.scriptId || `script-${index}`,
-    revision: seed.revision || createRevisionSeed(),
+    revision: seed.revision || '',
     baseRevision: seed.baseRevision || '',
     reason: seed.reason || '',
     input: seed.input || '',
@@ -427,7 +416,7 @@ function readStoredDrafts(): ScriptDraft[] {
       return {
         key: String(item.key || createDraftKey(`script_draft_${index + 1}`)),
         scriptId: String(item.scriptId || `script-${index + 1}`),
-        revision: String(item.revision || createRevisionSeed()),
+        revision: String(item.revision || ''),
         baseRevision: String(item.baseRevision || ''),
         reason: String(item.reason || ''),
         input: String(item.input || ''),
@@ -624,7 +613,7 @@ function hydrateDraftFromScopeDetail(
     detail.script?.activeRevision ||
     detail.source?.revision ||
     existing?.revision ||
-    createRevisionSeed();
+    '';
 
   return createDraft(index, {
     key: existing?.key,
@@ -1108,7 +1097,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
 
     return JSON.stringify({
       scriptId: selectedDraft.scriptId,
-      scriptRevision: selectedDraft.revision,
+      scriptRevision: selectedDraft.revision || undefined,
       source: serializePersistedSource(selectedDraft.package),
       package: selectedDraft.package,
     });
@@ -1130,7 +1119,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       try {
         const payload = JSON.parse(deferredValidationPayload) as {
           scriptId: string;
-          scriptRevision: string;
+          scriptRevision?: string;
           source: string;
           package: ScriptPackage;
         };
@@ -1568,7 +1557,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     try {
       const result = await scriptsApi.validateDraft({
         scriptId: selectedDraft.scriptId,
-        scriptRevision: selectedDraft.revision,
+        scriptRevision: selectedDraft.revision || undefined,
         source: serializePersistedSource(selectedDraft.package),
         package: selectedDraft.package,
       });
@@ -1607,7 +1596,6 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     const persistedSource = serializePersistedSource(selectedDraft.package);
     const accepted = await scriptsApi.saveScript(resolvedScopeId, {
       scriptId: normalizeStudioId(selectedDraft.scriptId, 'script'),
-      revisionId: normalizeStudioId(selectedDraft.revision, 'rev'),
       expectedBaseRevision: selectedDraft.baseRevision || undefined,
       sourceText: persistedSource,
     });
@@ -1615,6 +1603,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     updateSelectedDraft((draft) => ({
       ...draft,
       scriptId: accepted.acceptedScript.scriptId || draft.scriptId,
+      revision: accepted.acceptedScript.revisionId || draft.revision,
       definitionActorId:
         accepted.acceptedScript.definitionActorId || draft.definitionActorId,
       lastSourceHash: accepted.acceptedScript.sourceHash || draft.lastSourceHash,
@@ -1772,10 +1761,6 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       scopeScript.activeRevision || selectedDraft.revision,
       'rev',
     );
-    const bindingRevisionId = buildScopeScriptBindingRevisionId(
-      scriptId,
-      scriptRevision,
-    );
 
     setBindPending(true);
     setNotice(null);
@@ -1783,9 +1768,9 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       const result = await studioApi.bindScopeScript({
         scopeId: resolvedScopeId,
         displayName: bindDisplayNameDraft.trim() || scriptId,
+        serviceId: scriptId,
         scriptId,
         scriptRevision,
-        revisionId: bindingRevisionId,
       });
 
       setBindModalOpen(false);
@@ -1861,7 +1846,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       const result = await scriptsApi.runDraftScript({
         scopeId: resolvedScopeId,
         scriptId: normalizeStudioId(selectedDraft.scriptId, 'script'),
-        scriptRevision: normalizeStudioId(selectedDraft.revision, 'draft'),
+        scriptRevision: selectedDraft.revision.trim() || undefined,
         source: serializePersistedSource(selectedDraft.package),
         package: selectedDraft.package,
         input: runInputDraft,
@@ -1945,7 +1930,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       const scriptId = normalizeStudioId(selectedDraft.scriptId, 'script');
       const response = await scriptsApi.proposeEvolution(resolvedScopeId, scriptId, {
         baseRevision,
-        candidateRevision: normalizeStudioId(selectedDraft.revision, 'rev'),
+        candidateRevision: selectedDraft.revision.trim() || undefined,
         candidateSource: serializePersistedSource(selectedDraft.package),
         reason: promotionReasonDraft || selectedDraft.reason || undefined,
       });
@@ -2369,8 +2354,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     selectedDraft &&
       scopeBacked &&
       !savePending &&
-      selectedDraft.scriptId.trim() &&
-      selectedDraft.revision.trim(),
+      selectedDraft.scriptId.trim(),
   );
   const canRun = Boolean(
     selectedDraft &&
@@ -2420,7 +2404,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     : validationError ||
       visibleProblems[0]?.message ||
       'Clean';
-  const headerRevisionLabel = selectedDraft?.revision || 'draft revision';
+  const headerRevisionLabel = selectedDraft?.revision || 'not saved';
   const headerScopeLabel = scopeBacked
     ? `Scope ${compactHeaderValue(resolvedScopeId)}`
     : 'Local draft';
@@ -2979,12 +2963,6 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
             <div className="console-scripts-drawer-body">
               <ScriptsPackagePanel
                 selectedDraft={selectedDraft}
-                onRevisionChange={(value) =>
-                  updateSelectedDraft((draft) => ({
-                    ...draft,
-                    revision: normalizeStudioId(value, 'rev'),
-                  }))
-                }
                 onBaseRevisionChange={(value) =>
                   updateSelectedDraft((draft) => ({
                     ...draft,

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptInspectorPanel.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptInspectorPanel.tsx
@@ -86,9 +86,9 @@ const ScriptInspectorPanel: React.FC<ScriptInspectorPanelProps> = ({
               </div>
             </div>
             <div className="console-scripts-field">
-              <div className="console-scripts-field-label">版本</div>
+              <div className="console-scripts-field-label">已保存版本</div>
               <div className="console-scripts-field-value">
-                {selectedDraft.revision}
+                {renderValue(selectedDraft.revision)}
               </div>
             </div>
             <div className="console-scripts-field">

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsPackagePanel.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsPackagePanel.tsx
@@ -7,7 +7,6 @@ import type { ScriptDraft } from '@/shared/studio/scriptsModels';
 
 type ScriptsPackagePanelProps = {
   selectedDraft: ScriptDraft | null;
-  onRevisionChange: (value: string) => void;
   onBaseRevisionChange: (value: string) => void;
   onEntryBehaviorTypeChange: (value: string) => void;
   onDeleteDraft: () => void;
@@ -16,7 +15,6 @@ type ScriptsPackagePanelProps = {
 
 const ScriptsPackagePanel: React.FC<ScriptsPackagePanelProps> = ({
   selectedDraft,
-  onRevisionChange,
   onBaseRevisionChange,
   onEntryBehaviorTypeChange,
   onDeleteDraft,
@@ -42,15 +40,12 @@ const ScriptsPackagePanel: React.FC<ScriptsPackagePanelProps> = ({
       <div className="console-scripts-package-summary">
         <div className="console-scripts-section-label">Entry contract</div>
         <div className="console-scripts-detail-grid" style={{ marginTop: 12 }}>
-          <label className="console-scripts-field">
-            <span className="console-scripts-field-label">Revision</span>
-            <input
-              className="console-scripts-input"
-              placeholder="rev-..."
-              value={selectedDraft.revision}
-              onChange={(event) => onRevisionChange(event.target.value)}
-            />
-          </label>
+          <div className="console-scripts-field">
+            <div className="console-scripts-field-label">Saved Revision</div>
+            <div className="console-scripts-copy-value">
+              {selectedDraft.revision || 'Generated on save'}
+            </div>
+          </div>
           <label className="console-scripts-field">
             <span className="console-scripts-field-label">Base Revision</span>
             <input

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsResourceRail.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsResourceRail.tsx
@@ -110,7 +110,7 @@ const ScriptsResourceRail: React.FC<ScriptsResourceRailProps> = ({
                   key={draft.key}
                   active={draft.key === selectedDraftKey}
                   title={draft.scriptId}
-                  meta={draft.revision}
+                  meta={draft.revision || 'local draft'}
                   summary={formatScriptDateTime(draft.updatedAtUtc)}
                   status={dirty ? 'dirty' : draft.scopeDetail?.script ? 'scope' : ''}
                   onClick={() => onSelectDraft(draft)}

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.test.tsx
@@ -480,7 +480,7 @@ describe('StudioWorkflowBuildPanel', () => {
 
     expect(screen.getByText('Validate current source')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue to Bind' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Save revision' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save script' })).toBeDisabled();
   });
 
   it('offers Add script from the empty Script build state', () => {
@@ -546,7 +546,7 @@ describe('StudioWorkflowBuildPanel', () => {
       (screen.getByLabelText('Mock script code editor') as HTMLTextAreaElement).value,
     ).toContain('DraftBehavior');
     expect(screen.getByText('Validate current source')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Save revision' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save script' })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
 
@@ -559,9 +559,9 @@ describe('StudioWorkflowBuildPanel', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Save revision' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Save script' })).toBeEnabled();
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save revision' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save script' }));
 
     await waitFor(() => {
       expect(mockedScriptsApi.saveScript).toHaveBeenCalledWith(
@@ -572,6 +572,9 @@ describe('StudioWorkflowBuildPanel', () => {
         }),
       );
     });
+    expect(mockedScriptsApi.saveScript.mock.calls[0]?.[1]).not.toHaveProperty(
+      'revisionId',
+    );
     await waitFor(() => {
       expect(handleDraftSaved).toHaveBeenCalledWith('orders-script');
     });
@@ -718,11 +721,11 @@ describe('StudioWorkflowBuildPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
     await waitFor(
       () => {
-        expect(screen.getByRole('button', { name: 'Save revision' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Save script' })).toBeEnabled();
       },
       { timeout: 3000 },
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Save revision' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save script' }));
 
     expect(await screen.findByText(/Waiting for catalog/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Continue to Bind' })).toBeDisabled();
@@ -774,11 +777,11 @@ describe('StudioWorkflowBuildPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
     await waitFor(
       () => {
-        expect(screen.getByRole('button', { name: 'Save revision' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Save script' })).toBeEnabled();
       },
       { timeout: 3000 },
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Save revision' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save script' }));
 
     expect(await screen.findByText('Catalog rejected the revision.')).toBeInTheDocument();
     expect(screen.getByText('Save needs attention')).toBeInTheDocument();
@@ -848,11 +851,11 @@ describe('StudioWorkflowBuildPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
     await waitFor(
       () => {
-        expect(screen.getByRole('button', { name: 'Save revision' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Save script' })).toBeEnabled();
       },
       { timeout: 3000 },
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Save revision' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save script' }));
 
     expect(await screen.findByText(/checking again in 1s/)).toBeInTheDocument();
     await waitFor(
@@ -921,9 +924,9 @@ describe('StudioWorkflowBuildPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Validate' }));
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Save revision' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Save script' })).toBeEnabled();
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Save revision' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save script' }));
     await waitFor(() => {
       expect(mockedScriptsApi.observeSaveScript).toHaveBeenCalled();
     });
@@ -953,7 +956,7 @@ describe('StudioWorkflowBuildPanel', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Save revision' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Save script' })).toBeDisabled();
     });
     expect(screen.queryByText(/Save applied/)).toBeNull();
     expect(screen.getByRole('button', { name: 'Continue to Bind' })).toBeDisabled();

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -2008,7 +2008,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
     () =>
       activeScript?.source?.revision ||
       activeScript?.script?.activeRevision ||
-      'draft-1',
+      '',
     [activeScript?.script?.activeRevision, activeScript?.source?.revision],
   );
   const selectedPackageEntry = React.useMemo(
@@ -2165,12 +2165,12 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
         : isDirty && validationStatus !== 'valid'
           ? 'Validate current source'
           : isDirty
-            ? 'Save revision'
+            ? 'Save script'
         : effectiveSaveStatus === 'accepted'
           ? 'Waiting for catalog'
           : scriptReadyToBind
             ? 'Ready to bind'
-            : 'Save revision';
+            : 'Save script';
   const saveObservationInFlight =
     saveObservationStatus === 'accepted' || saveObservationStatus === 'pending';
   const saveNoticeType =
@@ -2273,7 +2273,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
     try {
       const result = await scriptsApi.validateDraft({
         scriptId: activeScript.script.scriptId,
-        scriptRevision: currentRevision,
+        scriptRevision: currentRevision || undefined,
         source: serializePersistedSource(scriptPackage),
         package: scriptPackage,
       });
@@ -2420,7 +2420,6 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
     try {
       const accepted = await scriptsApi.saveScript(scopeId, {
         scriptId: savingScriptId,
-        revisionId: currentRevision,
         expectedBaseRevision: activeScriptIsDraft
           ? undefined
           : activeScript.script.activeRevision || undefined,
@@ -2448,7 +2447,6 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
     activeScript?.script?.scriptId,
     activeScriptIsDraft,
     cancelSaveObservationPoll,
-    currentRevision,
     pollSaveObservation,
     scopeId,
     scriptPackage,
@@ -2526,7 +2524,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
         activeScript.script.scriptId,
         {
           baseRevision: activeScript.script.activeRevision || undefined,
-          candidateRevision: currentRevision,
+          candidateRevision: currentRevision || undefined,
           candidateSource: serializePersistedSource(scriptPackage),
           reason: promotionReason.trim() || undefined,
         },
@@ -2562,7 +2560,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
       const result = await scriptsApi.runDraftScript({
         scopeId,
         scriptId: activeScript.script.scriptId,
-        scriptRevision: currentRevision,
+        scriptRevision: currentRevision || undefined,
         source: serializePersistedSource(scriptPackage),
         input: runInput,
         definitionActorId:
@@ -2682,7 +2680,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
                 loading={savePending}
                 onClick={() => void handleSave()}
               >
-                Save revision
+                Save script
               </Button>
             </Space>
           </div>
@@ -2719,7 +2717,8 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             >
               <Typography.Text type="secondary">
                 {activeScript?.script?.scriptId || '-'} · {lifecycleStatus} · validation{' '}
-                {validationStatus} · save {saveObservationStatus} · rev {currentRevision}
+                {validationStatus} · save {saveObservationStatus} · rev{' '}
+                {currentRevision || 'generated on save'}
               </Typography.Text>
             </div>
           ) : null}

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -273,7 +273,7 @@ describe('StudioMemberBindPanel', () => {
     expect(bindSurfaceStyle).not.toContain('height');
     const primaryGrid = screen.getByTestId('studio-bind-primary-grid');
     expect(primaryGrid).toHaveStyle({
-      alignItems: 'start',
+      alignItems: 'stretch',
       display: 'grid',
     });
     expect(primaryGrid.contains(supportingDetailsTitle)).toBe(false);
@@ -409,6 +409,53 @@ describe('StudioMemberBindPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue to Invoke' }));
     expect(handleContinueToInvoke).toHaveBeenCalledWith('default', 'chat');
+  });
+
+  it('allows continuing to Invoke while endpoint discovery is pending', async () => {
+    const handleContinueToInvoke = jest.fn();
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        scopeId: 'scope-1',
+        preferredServiceId: 'script-4',
+        onContinueToInvoke: handleContinueToInvoke,
+        services: [
+          {
+            serviceKey: 'scope-1:default:script-4',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'script-4',
+            displayName: 'script-4',
+            defaultServingRevisionId: 'rev-script-1',
+            activeServingRevisionId: 'rev-script-1',
+            deploymentId: '',
+            primaryActorId: 'actor-script-4',
+            deploymentStatus: 'Active',
+            endpoints: [],
+            policyIds: [],
+            updatedAt: '2026-04-29T08:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    expect(await screen.findByText('No endpoint data available')).toBeTruthy();
+    const continueButton = screen.getByRole('button', {
+      name: 'Continue to Invoke',
+    });
+    expect(continueButton).not.toBeDisabled();
+
+    fireEvent.click(continueButton);
+
+    expect(handleContinueToInvoke).toHaveBeenCalledWith('script-4', 'chat');
   });
 
   it('does not block current draft smoke tests on published endpoint auth state', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -1,4 +1,9 @@
-import { CheckCircleOutlined, CopyOutlined, LinkOutlined } from '@ant-design/icons';
+import {
+  ApiOutlined,
+  CheckCircleOutlined,
+  CopyOutlined,
+  LinkOutlined,
+} from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
 import { Alert, Button, Collapse, Empty, Input, Select, Space, Tag, Typography, message } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -85,14 +90,15 @@ const rootStyle: React.CSSProperties = {
 };
 
 const controlsGridStyle: React.CSSProperties = {
+  alignItems: 'stretch',
   display: 'grid',
-  gap: 12,
-  gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr) auto',
+  gap: 14,
+  gridTemplateColumns: 'minmax(240px, 1fr) minmax(240px, 1fr)',
 };
 
 const pageFlowStyle: React.CSSProperties = {
   display: 'grid',
-  gap: 16,
+  gap: 14,
   width: '100%',
 };
 
@@ -102,10 +108,55 @@ const contractSectionStyle: React.CSSProperties = {
 };
 
 const workflowGridStyle: React.CSSProperties = {
+  alignItems: 'stretch',
   display: 'grid',
   gap: 14,
   gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 360px), 1fr))',
-  alignItems: 'start',
+  width: '100%',
+};
+
+const sourcePanelStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: 14,
+};
+
+const sourceSummaryStyle: React.CSSProperties = {
+  alignItems: 'center',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+  justifyContent: 'space-between',
+};
+
+const sourceStatusStyle: React.CSSProperties = {
+  alignItems: 'center',
+  color: '#475569',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 6,
+  minWidth: 0,
+};
+
+const contractAndActionsGridStyle: React.CSSProperties = {
+  alignItems: 'stretch',
+  display: 'grid',
+  gap: 14,
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 380px), 1fr))',
+};
+
+const equalHeightPanelStyle: React.CSSProperties = {
+  height: '100%',
+};
+
+const sourceControlStackStyle: React.CSSProperties = {
+  display: 'grid',
+  gap: 8,
+  gridTemplateRows: 'auto minmax(58px, 1fr)',
+  minWidth: 0,
+};
+
+const sourceControlSelectStyle: React.CSSProperties = {
+  height: 58,
   width: '100%',
 };
 
@@ -118,13 +169,14 @@ const parameterGridStyle: React.CSSProperties = {
 const surfaceCardStyle: React.CSSProperties = {
   background: '#ffffff',
   border: '1px solid #eef2f7',
-  borderRadius: 12,
+  borderRadius: 10,
 };
 
 const valueCardStyle: React.CSSProperties = {
   ...surfaceCardStyle,
   display: 'grid',
   gap: 3,
+  minHeight: 58,
   minWidth: 0,
   padding: 12,
 };
@@ -188,6 +240,36 @@ const compactCardStyle: React.CSSProperties = {
 
 const smokeInputStyle: React.CSSProperties = {
   fontFamily: monoFontFamily,
+};
+
+const contractUrlCardStyle: React.CSSProperties = {
+  ...surfaceCardStyle,
+  display: 'grid',
+  gridTemplateColumns: '82px minmax(0, 1fr)',
+  overflow: 'hidden',
+};
+
+const contractMethodStyle: React.CSSProperties = {
+  alignItems: 'center',
+  background: '#111827',
+  color: '#fffdf8',
+  display: 'flex',
+  fontFamily: monoFontFamily,
+  fontSize: 12,
+  fontWeight: 700,
+  justifyContent: 'center',
+  minWidth: 0,
+  padding: '10px 12px',
+};
+
+const contractUrlStyle: React.CSSProperties = {
+  color: '#0f172a',
+  fontFamily: monoFontFamily,
+  fontSize: 12.5,
+  minWidth: 0,
+  overflowX: 'auto',
+  padding: '10px 14px',
+  whiteSpace: 'nowrap',
 };
 
 const revisionCardStyle: React.CSSProperties = {
@@ -577,6 +659,13 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
   const bindingList = bindingCatalog?.bindings ?? [];
   const hasMultiplePublishedServices = services.length > 1;
   const revisionList = revisionCatalogQuery.data?.revisions ?? [];
+  const hasEndpointOptions = Boolean(selectedService?.endpoints.length);
+  const endpointUnavailableMessage =
+    selectedService && !hasEndpointOptions
+      ? 'This published service has no endpoint data available yet.'
+      : '';
+  const invokeEndpointId =
+    selectedEndpoint?.endpointId || (selectedService && !hasEndpointOptions ? 'chat' : '');
   const bindSurfaceIdentity = useMemo(() => {
     const pendingCandidateIdentity = pendingBindingCandidate
       ? `candidate:${scopeId}:${pendingBindingCandidate.kind}:${pendingBindingCandidate.displayName}`
@@ -746,94 +835,155 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
         <AevatarPanel
           layoutMode="document"
           padding={14}
-          title="Current member contract"
-          titleHelp="Keep only the callable essentials here so the page opens with the method, URL, auth, and revision at a glance."
+          title="Published contract source"
+          titleHelp="Choose the service and endpoint first. The invoke URL, smoke test, and snippets all follow this selection."
           extra={
-            <Button
-              icon={<CopyOutlined />}
-              onClick={() => void copyText(bindContract?.invokeUrl || '')}
-            >
-              Copy URL
-            </Button>
+            <Space wrap size={[6, 6]}>
+              <Tag color={bindContract ? 'green' : 'default'}>
+                {bindContract ? 'contract selected' : 'needs endpoint'}
+              </Tag>
+              {revisionList.length > 0 ? (
+                <Tag>revisions · {revisionList.length}</Tag>
+              ) : null}
+            </Space>
           }
         >
-          <div
-            data-testid="studio-bind-contract-section"
-            style={contractSectionStyle}
-          >
-            <Typography.Text type="secondary">
-              {runsCurrentWorkflowDraft
-                ? 'Keep the current draft in focus here; the smoke test and snippets below are the two fastest follow-up actions.'
-                : 'Keep the active invoke contract in focus here; the smoke test and snippets below are the two fastest follow-up actions.'}
-            </Typography.Text>
-            {bindContract ? (
-              <>
-                <div
-                  data-testid="studio-bind-contract-card"
-                  style={{
-                    ...surfaceCardStyle,
-                    display: 'grid',
-                    gridTemplateColumns: '88px minmax(0, 1fr)',
-                  }}
+          <div style={sourcePanelStyle}>
+            <div style={sourceSummaryStyle}>
+              <div style={sourceStatusStyle}>
+                <ApiOutlined />
+                <Typography.Text strong>
+                  {selectedService?.displayName ||
+                    selectedService?.serviceId ||
+                    'No published service'}
+                </Typography.Text>
+                {selectedEndpoint ? (
+                  <Typography.Text type="secondary">
+                    / {selectedEndpoint.displayName || selectedEndpoint.endpointId}
+                  </Typography.Text>
+                ) : null}
+              </div>
+              {bindContract ? (
+                <Button
+                  icon={<CopyOutlined />}
+                  onClick={() => void copyText(bindContract.invokeUrl)}
                 >
-                  <div
-                    style={{
-                      alignItems: 'center',
-                      background: '#f8fafc',
-                      borderRight: '1px solid #eef2f7',
-                      color: '#475569',
-                      display: 'flex',
-                      fontFamily: monoFontFamily,
-                      fontSize: 12,
-                      fontWeight: 700,
-                      justifyContent: 'center',
-                      minWidth: 0,
-                      padding: '10px 12px',
+                  Copy URL
+                </Button>
+              ) : null}
+            </div>
+            <div style={controlsGridStyle}>
+              <div style={sourceControlStackStyle}>
+                <Typography.Text type="secondary">Published service</Typography.Text>
+                {hasMultiplePublishedServices ? (
+                  <Select
+                    options={serviceOptions}
+                    placeholder="Select a published service"
+                    style={sourceControlSelectStyle}
+                    value={selectedServiceId || undefined}
+                    onChange={(value) => {
+                      setSelectedServiceId(String(value || ''));
+                      setSelectedEndpointId('');
                     }}
-                  >
-                    {bindContract.method}
+                  />
+                ) : (
+                  <div style={valueCardStyle}>
+                    <Typography.Text strong style={{ wordBreak: 'break-word' }}>
+                      {selectedService?.displayName ||
+                        selectedService?.serviceId ||
+                        'No published service'}
+                    </Typography.Text>
+                    <Typography.Text type="secondary">
+                      {selectedService?.serviceId || 'No service id'}
+                    </Typography.Text>
                   </div>
-                  <div
-                    style={{
-                      color: '#0f172a',
-                      flex: 1,
-                      fontFamily: monoFontFamily,
-                      fontSize: 12.5,
-                      minWidth: 0,
-                      overflowX: 'auto',
-                      padding: '10px 14px',
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {bindContract.invokeUrl}
-                  </div>
-                </div>
-                <Space wrap size={[6, 6]}>
-                  <Tag>auth · {bindContract.authLabel}</Tag>
-                  <Tag>revision · {bindContract.revisionId}</Tag>
-                  {bindContract.streaming.sse ? (
-                    <Tag color="gold">stream · text/event-stream</Tag>
-                  ) : (
-                    <Tag>response · application/json</Tag>
-                  )}
-                  {bindContract.streaming.aguiFrames ? (
-                    <Tag color="geekblue">AGUI frames</Tag>
-                  ) : null}
-                </Space>
-              </>
-            ) : (
-              <Empty
-                description="Inspect the published contract in focus to reveal its invoke URL and endpoint details."
-                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                )}
+              </div>
+              <div style={sourceControlStackStyle}>
+                <Typography.Text type="secondary">Endpoint</Typography.Text>
+                <Select
+                  disabled={!selectedService || !hasEndpointOptions}
+                  options={endpointOptions}
+                  placeholder={
+                    hasEndpointOptions
+                      ? 'Select an endpoint'
+                      : 'No endpoint data available'
+                  }
+                  style={sourceControlSelectStyle}
+                  value={selectedEndpointId || undefined}
+                  onChange={(value) => setSelectedEndpointId(String(value || ''))}
+                />
+              </div>
+            </div>
+            {endpointUnavailableMessage ? (
+              <Alert
+                showIcon
+                message={endpointUnavailableMessage}
+                description="The service revision history can still load, but Invoke needs endpoint data on the selected service contract."
+                type="warning"
               />
-            )}
+            ) : null}
           </div>
         </AevatarPanel>
 
-        <div data-testid="studio-bind-primary-grid" style={workflowGridStyle}>
+        <div style={contractAndActionsGridStyle}>
           <AevatarPanel
             layoutMode="document"
             padding={14}
+            style={equalHeightPanelStyle}
+            title="Current member contract"
+            titleHelp="Keep only the callable essentials here so the page opens with the method, URL, auth, and revision at a glance."
+          >
+            <div
+              data-testid="studio-bind-contract-section"
+              style={contractSectionStyle}
+            >
+              <Typography.Text type="secondary">
+                {runsCurrentWorkflowDraft
+                  ? 'Keep the current draft in focus here; the smoke test and snippets below are the two fastest follow-up actions.'
+                  : 'Keep the active invoke contract in focus here; the smoke test and snippets below are the two fastest follow-up actions.'}
+              </Typography.Text>
+              {bindContract ? (
+                <>
+                  <div
+                    data-testid="studio-bind-contract-card"
+                    style={contractUrlCardStyle}
+                  >
+                    <div style={contractMethodStyle}>
+                      {bindContract.method}
+                    </div>
+                    <div style={contractUrlStyle}>
+                      {bindContract.invokeUrl}
+                    </div>
+                  </div>
+                  <Space wrap size={[6, 6]}>
+                    <Tag>auth · {bindContract.authLabel}</Tag>
+                    <Tag>revision · {bindContract.revisionId}</Tag>
+                    {bindContract.streaming.sse ? (
+                      <Tag color="gold">stream · text/event-stream</Tag>
+                    ) : (
+                      <Tag>response · application/json</Tag>
+                    )}
+                    {bindContract.streaming.aguiFrames ? (
+                      <Tag color="geekblue">AGUI frames</Tag>
+                    ) : null}
+                  </Space>
+                </>
+              ) : (
+                <Alert
+                  showIcon
+                  message="Select an endpoint to reveal the invoke contract."
+                  description="The contract URL, revision badge, snippets, and smoke test are generated from the selected service endpoint."
+                  type="info"
+                />
+              )}
+            </div>
+          </AevatarPanel>
+
+          <AevatarPanel
+            layoutMode="document"
+            padding={14}
+            style={equalHeightPanelStyle}
             title="Quick smoke test"
             titleHelp={
               runsCurrentWorkflowDraft
@@ -915,15 +1065,15 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 <Button
                   block
                   icon={<LinkOutlined />}
-                  disabled={!selectedService || !selectedEndpoint}
+                  disabled={!selectedService}
                   onClick={() => {
-                    if (!selectedService || !selectedEndpoint) {
+                    if (!selectedService) {
                       return;
                     }
 
                     onContinueToInvoke?.(
                       selectedService.serviceId,
-                      selectedEndpoint.endpointId,
+                      invokeEndpointId,
                     );
                   }}
                 >
@@ -986,10 +1136,13 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
               ) : null}
             </div>
           </AevatarPanel>
+        </div>
 
+        <div data-testid="studio-bind-primary-grid" style={workflowGridStyle}>
           <AevatarPanel
             layoutMode="document"
             padding={14}
+            style={equalHeightPanelStyle}
             title="Integration snippets"
             titleHelp="Give the user a ready-to-copy call shape right away, without making them hunt through the support sections."
           >
@@ -1052,56 +1205,6 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
               defaultActiveKey={[]}
               ghost
               items={[
-              {
-                key: 'published-contract-source',
-                label: 'Published contract source',
-                children: (
-                  <div style={{ display: 'grid', gap: 12 }}>
-                    <Typography.Text type="secondary">
-                      Studio still resolves invoke URL, revisions, and governance details through
-                      the published service surface. Keep this section nearby when you need to
-                      switch the active contract source.
-                    </Typography.Text>
-                    <div style={controlsGridStyle}>
-                      <div style={{ display: 'grid', gap: 8 }}>
-                        <Typography.Text type="secondary">Published service</Typography.Text>
-                        {hasMultiplePublishedServices ? (
-                          <Select
-                            options={serviceOptions}
-                            placeholder="Select a published service"
-                            value={selectedServiceId || undefined}
-                            onChange={(value) => {
-                              setSelectedServiceId(String(value || ''));
-                              setSelectedEndpointId('');
-                            }}
-                          />
-                        ) : (
-                          <div style={valueCardStyle}>
-                            <Typography.Text strong style={{ wordBreak: 'break-word' }}>
-                              {selectedService?.displayName ||
-                                selectedService?.serviceId ||
-                                'No published service'}
-                            </Typography.Text>
-                            <Typography.Text type="secondary">
-                              {selectedService?.serviceId || 'No service id'}
-                            </Typography.Text>
-                          </div>
-                        )}
-                      </div>
-                      <div style={{ display: 'grid', gap: 8 }}>
-                        <Typography.Text type="secondary">Endpoint</Typography.Text>
-                        <Select
-                          disabled={!selectedService}
-                          options={endpointOptions}
-                          placeholder="Select an endpoint"
-                          value={selectedEndpointId || undefined}
-                          onChange={(value) => setSelectedEndpointId(String(value || ''))}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                ),
-              },
               {
                 key: 'contract-details',
                 label: 'Contract details',

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -664,7 +664,8 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
     selectedService && !hasEndpointOptions
       ? 'This published service has no endpoint data available yet.'
       : '';
-  const invokeEndpointId =
+  // Temporary placeholder while #511 adds a real scope-owned endpoint catalog.
+  const fallbackEndpointId =
     selectedEndpoint?.endpointId || (selectedService && !hasEndpointOptions ? 'chat' : '');
   const bindSurfaceIdentity = useMemo(() => {
     const pendingCandidateIdentity = pendingBindingCandidate
@@ -1065,7 +1066,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 <Button
                   block
                   icon={<LinkOutlined />}
-                  disabled={!selectedService}
+                  disabled={!selectedService || (hasEndpointOptions && !selectedEndpoint)}
                   onClick={() => {
                     if (!selectedService) {
                       return;
@@ -1073,7 +1074,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
 
                     onContinueToInvoke?.(
                       selectedService.serviceId,
-                      invokeEndpointId,
+                      fallbackEndpointId,
                     );
                   }}
                 >

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -3520,7 +3520,7 @@ describe("StudioPage", () => {
     });
     expect(
       screen.getByText(
-        "Script starts as a named draft. It becomes a callable member only after Save revision is catalog-applied and Bind succeeds.",
+        "Script starts as a named draft. It becomes a callable member only after Save script is catalog-applied and Bind succeeds.",
       ),
     ).toBeTruthy();
     expect(screen.getByText(/Script id: refund-handler/)).toBeTruthy();
@@ -3811,6 +3811,30 @@ describe("StudioPage", () => {
       expect(screen.getByText("services:default")).toBeTruthy();
     });
     expect(screen.queryByText("services:default,billing-api")).toBeNull();
+  });
+
+  it("keeps Invoke open for a bound member while endpoint discovery is pending", async () => {
+    mockServicesApi.listServices.mockResolvedValueOnce([
+      {
+        serviceId: "script-alpha",
+        displayName: "script-alpha",
+        deploymentStatus: "Active",
+        primaryActorId: "actor-script-alpha",
+        endpoints: [],
+      },
+    ]);
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&memberId=script-alpha&step=invoke&tab=invoke"
+    );
+
+    expect(await screen.findByTestId("studio-invoke-surface")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("service:script-alpha")).toBeTruthy();
+      expect(screen.getByText("services:script-alpha")).toBeTruthy();
+      expect(screen.getByText("endpoint:chat")).toBeTruthy();
+    });
+    expect(screen.queryByText(/还不能直接调用/)).toBeNull();
   });
 
   it("surfaces the current workflow as a bind candidate before any published service exists", async () => {
@@ -5455,9 +5479,9 @@ describe("StudioPage", () => {
         expect.objectContaining({
           scopeId: "scope-1",
           displayName: "script-alpha",
+          serviceId: "script-alpha",
           scriptId: "script-alpha",
           scriptRevision: "rev-1",
-          revisionId: "rev-1",
         })
       );
     });

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -1062,14 +1062,13 @@ jest.mock("@/shared/studio/api", () => ({
       displayName?: string;
       scriptId: string;
       scriptRevision: string;
-      revisionId?: string;
     }) => ({
       scopeId: input.scopeId,
       serviceId: input.scriptId,
       displayName: input.displayName || input.scriptId,
       targetKind: "script",
       targetName: input.scriptId,
-      revisionId: input.revisionId || "rev-script-binding",
+      revisionId: "rev-script-binding",
       script: {
         scriptId: input.scriptId,
         scriptRevision: input.scriptRevision,

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -2649,10 +2649,13 @@ const StudioPage: React.FC = () => {
       return;
     }
 
-    const scriptId = trimOptional(routeMember?.publishedServiceId)
-      ? ''
-      : trimOptional(routeMember?.displayName);
+    const scriptId =
+      trimOptional(routeMember?.publishedServiceId) ||
+      trimOptional(routeMember?.displayName);
     if (!scriptId) {
+      return;
+    }
+    if (selectedScriptId === scriptId) {
       return;
     }
 
@@ -3779,7 +3782,6 @@ const StudioPage: React.FC = () => {
           scriptRevision:
             trimOptional(effectiveScriptState.scriptRevision) ||
             trimOptional(effectiveScriptState.revisionId),
-          revisionId: null,
         };
       }
     }
@@ -6443,6 +6445,17 @@ const StudioPage: React.FC = () => {
         return matchedService;
       }
 
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        console.warn(
+          '[Studio] Using temporary chat endpoint fallback while scope service endpoint discovery is pending (#511).',
+          {
+            serviceId: invokeTargetServiceId,
+          },
+        );
+      }
       return createEndpointDiscoveryPendingInvokeService({
         label: currentMemberLabel,
         serviceId: invokeTargetServiceId,

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -62,6 +62,7 @@ import {
   buildScopeConsoleServiceOptions,
   scopeServiceAppId,
   scopeServiceNamespace,
+  type ScopeConsoleServiceOption,
 } from '@/shared/runs/scopeConsole';
 import {
   applyStepInspectorDraft,
@@ -2055,6 +2056,33 @@ function resolveStudioServiceDefaultEndpointId(
   );
 }
 
+function createEndpointDiscoveryPendingInvokeService(input: {
+  readonly label?: string;
+  readonly serviceId: string;
+}): ScopeConsoleServiceOption {
+  const serviceId = trimOptional(input.serviceId);
+  const label = trimOptional(input.label) || serviceId;
+  return {
+    deploymentStatus: '',
+    displayName: label,
+    endpoints: [
+      {
+        description:
+          'Temporary chat endpoint hint used while backend endpoint discovery is pending.',
+        displayName: 'Chat',
+        endpointId: 'chat',
+        kind: 'chat',
+        requestTypeUrl: '',
+        responseTypeUrl: '',
+      },
+    ],
+    kind: 'service',
+    namespace: scopeServiceNamespace,
+    primaryActorId: '',
+    serviceId,
+  };
+}
+
 function resolvePublishedServiceIdFromMemberKey(
   memberKey: string,
   publishedMembers: readonly PublishedStudioMemberRecord[],
@@ -2604,6 +2632,34 @@ const StudioPage: React.FC = () => {
     () => studioMembersQuery.data?.members ?? [],
     [studioMembersQuery.data?.members],
   );
+  useEffect(() => {
+    const routeMemberId = trimOptional(routeState.memberId);
+    if (!routeMemberId || selectedScriptId) {
+      return;
+    }
+
+    const routeMember = studioScopeMembers.find(
+      (member) => trimOptional(member.memberId) === routeMemberId,
+    );
+    if (
+      normalizeStudioMemberBindingImplementationKind(
+        routeMember?.implementationKind,
+      ) !== 'script'
+    ) {
+      return;
+    }
+
+    const scriptId = trimOptional(routeMember?.publishedServiceId)
+      ? ''
+      : trimOptional(routeMember?.displayName);
+    if (!scriptId) {
+      return;
+    }
+
+    setSelectedWorkflowId('');
+    setSelectedScriptId(scriptId);
+    setTemplateWorkflow('');
+  }, [routeState.memberId, selectedScriptId, studioScopeMembers]);
   const studioMemberByPublishedServiceId = useMemo(() => {
     const members = new Map<string, (typeof studioScopeMembers)[number]>();
     for (const member of studioScopeMembers) {
@@ -3723,7 +3779,7 @@ const StudioPage: React.FC = () => {
           scriptRevision:
             trimOptional(effectiveScriptState.scriptRevision) ||
             trimOptional(effectiveScriptState.revisionId),
-          revisionId: trimOptional(effectiveScriptState.revisionId),
+          revisionId: null,
         };
       }
     }
@@ -3835,9 +3891,9 @@ const StudioPage: React.FC = () => {
         : await studioApi.bindScopeScript({
             scopeId: resolvedStudioScopeId,
             displayName: buildPendingBindCandidate.displayName,
+            serviceId: buildPendingBindCandidate.scriptId,
             scriptId: buildPendingBindCandidate.scriptId,
             scriptRevision: buildPendingBindCandidate.scriptRevision,
-            revisionId: buildPendingBindCandidate.revisionId,
           });
     await queryClient.invalidateQueries({
       queryKey: ['studio-scope-members', resolvedStudioScopeId],
@@ -3867,12 +3923,15 @@ const StudioPage: React.FC = () => {
       optimisticBoundServiceId;
 
     if (boundServiceId) {
+      const buildCandidateMemberKey =
+        buildPendingBindCandidate.kind === 'script'
+          ? trimOptional(selectedScriptId)
+            ? `script:${trimOptional(selectedScriptId)}`
+            : ''
+          : trimOptional(selectedWorkflowMemberKey);
       const boundMemberKey =
         (resolvedBuildMemberId ? `member:${resolvedBuildMemberId}` : '') ||
-        trimOptional(selectedWorkflowMemberKey) ||
-        (trimOptional(selectedScriptId)
-          ? `script:${trimOptional(selectedScriptId)}`
-          : '') ||
+        buildCandidateMemberKey ||
         trimOptional(routeState.memberKey) ||
         (trimOptional(routeState.memberId)
           ? `member:${trimOptional(routeState.memberId)}`
@@ -6371,13 +6430,25 @@ const StudioPage: React.FC = () => {
     trimOptional(routeState.memberId) ||
     currentSelectedMemberServiceId;
   const invokeTargetService = useMemo(
-    () =>
-      invokeTargetServiceId
-        ? runtimeConsoleServices.find(
-            (service) => service.serviceId === invokeTargetServiceId,
-          ) ?? null
-        : null,
-    [invokeTargetServiceId, runtimeConsoleServices],
+    () => {
+      if (!invokeTargetServiceId) {
+        return null;
+      }
+
+      const matchedService =
+        runtimeConsoleServices.find(
+          (service) => service.serviceId === invokeTargetServiceId,
+        ) ?? null;
+      if (matchedService) {
+        return matchedService;
+      }
+
+      return createEndpointDiscoveryPendingInvokeService({
+        label: currentMemberLabel,
+        serviceId: invokeTargetServiceId,
+      });
+    },
+    [currentMemberLabel, invokeTargetServiceId, runtimeConsoleServices],
   );
   const invokeTargetServices = useMemo(
     () => (invokeTargetService ? [invokeTargetService] : []),
@@ -7937,7 +8008,7 @@ const StudioPage: React.FC = () => {
                         Script id: {createScriptId || 'enter-a-script-name'}
                         {createScriptIdAlreadyExists
                           ? ' · already exists in this scope'
-                          : ' · saved after Validate and Save revision'}
+                          : ' · saved after Validate and Save script'}
                       </div>
                     ) : null}
                   </label>
@@ -7946,7 +8017,7 @@ const StudioPage: React.FC = () => {
                   {createMemberKind === 'workflow'
                     ? 'Workflow members currently start from a blank workflow draft with an empty canvas, and Studio also registers the member authority in backend once the draft is created.'
                     : createMemberKind === 'script'
-                      ? 'Script starts as a named draft. It becomes a callable member only after Save revision is catalog-applied and Bind succeeds.'
+                      ? 'Script starts as a named draft. It becomes a callable member only after Save script is catalog-applied and Bind succeeds.'
                       : 'GAgent member authority exists on backend, but this modal still hands off through Build > GAgent for implementation editing and binding prep.'}
                 </div>
                 {createMemberKind === 'workflow' ? (

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -743,7 +743,6 @@ describe('studioApi host-session requests', () => {
       serviceId: 'script-1',
       scriptId: 'script-1',
       scriptRevision: 'rev-1',
-      revisionId: 'rev-1',
     });
 
     expect(result.implementationKind).toBe('script');
@@ -772,7 +771,6 @@ describe('studioApi host-session requests', () => {
         scriptId: 'script-1',
         scriptRevision: 'rev-1',
       },
-      revisionId: 'rev-1',
     });
   });
 

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -740,6 +740,7 @@ describe('studioApi host-session requests', () => {
     const result = await studioApi.bindScopeScript({
       scopeId: 'scope-1',
       displayName: 'script-1',
+      serviceId: 'script-1',
       scriptId: 'script-1',
       scriptRevision: 'rev-1',
       revisionId: 'rev-1',
@@ -766,6 +767,7 @@ describe('studioApi host-session requests', () => {
     expect(JSON.parse(String(init?.body))).toEqual({
       implementationKind: 'script',
       displayName: 'script-1',
+      serviceId: 'script-1',
       script: {
         scriptId: 'script-1',
         scriptRevision: 'rev-1',

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -1452,7 +1452,6 @@ export const studioApi = {
               scriptId: input.scriptId.trim(),
               scriptRevision: input.scriptRevision.trim(),
             }),
-            revisionId: trimOptional(input.revisionId),
           })
         ),
       }

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -1447,6 +1447,7 @@ export const studioApi = {
           compactObject({
             implementationKind: "script",
             displayName: trimOptional(input.displayName),
+            serviceId: trimOptional(input.serviceId),
             script: compactObject({
               scriptId: input.scriptId.trim(),
               scriptRevision: input.scriptRevision.trim(),

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -506,7 +506,6 @@ export interface StudioScopeScriptBindingInput {
   readonly serviceId?: string | null;
   readonly scriptId: string;
   readonly scriptRevision: string;
-  readonly revisionId?: string | null;
 }
 
 export type StudioScopeScriptBindingResult = StudioScopeBindingResult;

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -503,6 +503,7 @@ export const getStudioDefaultRouteTargetCurrentRevision =
 export interface StudioScopeScriptBindingInput {
   readonly scopeId: string;
   readonly displayName?: string | null;
+  readonly serviceId?: string | null;
   readonly scriptId: string;
   readonly scriptRevision: string;
   readonly revisionId?: string | null;

--- a/apps/aevatar-console-web/src/shared/studio/scriptsApi.ts
+++ b/apps/aevatar-console-web/src/shared/studio/scriptsApi.ts
@@ -192,7 +192,7 @@ export const scriptsApi = {
   validateDraft(
     payload: {
       scriptId: string;
-      scriptRevision: string;
+      scriptRevision?: string;
       source?: string;
       package?: ScriptPackage | null;
     },


### PR DESCRIPTION
## Summary

- Keep Script save/bind revision semantics separate from service revision identity, so user-entered Script revisions such as `draft-1` are not sent as top-level binding revision ids.
- Send the Script service id when binding a Script member, preventing refresh-time binds from falling back to the default service key.
- Improve the Bind page layout for endpoint-discovery-pending states and allow the lifecycle to continue to Invoke while #511 is unresolved, without presenting the temporary endpoint as a real discovered contract.

## Issue links

Related to #507
Refs #511
Refs #514

## Validation

- `npm --prefix apps/aevatar-console-web run tsc`
- `npm --prefix apps/aevatar-console-web test -- --runTestsByPath src/shared/studio/api.test.ts src/pages/studio/index.test.tsx src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx --runInBand` (112 tests passed)
- `npm --prefix apps/aevatar-console-web test -- --runTestsByPath src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx --runInBand` (6 tests passed)
- `git diff --check`

## Notes

This PR intentionally does not close #507 because final end-to-end verification still depends on the backend endpoint/catalog follow-up tracked in #511.