### PR TITLE
fix: add scope service catalog endpoint

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -246,7 +246,6 @@ public static class ScopeServiceEndpoints
             take.GetValueOrDefault(200),
             ct);
 
-
         return Results.Ok(services);
     }
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -76,6 +76,7 @@ public static class ScopeServiceEndpoints
         group.MapPost("/{scopeId}/runs/{runId}:resume", HandleResumeDefaultRunAsync);
         group.MapPost("/{scopeId}/runs/{runId}:signal", HandleSignalDefaultRunAsync);
         group.MapPost("/{scopeId}/runs/{runId}:stop", HandleStopDefaultRunAsync);
+        group.MapGet("/{scopeId}/services", HandleListScopeServicesAsync);
         group.MapPost("/{scopeId}/services/{serviceId}/invoke/{endpointId}:stream", HandleInvokeStreamAsync);
         group.MapPost("/{scopeId}/services/{serviceId}/invoke/{endpointId}", HandleInvokeAsync);
         group.MapGet("/{scopeId}/services/{serviceId}/revisions", HandleGetServiceRevisionsAsync);
@@ -215,6 +216,38 @@ public static class ScopeServiceEndpoints
                 message = ex.Message,
             });
         }
+    }
+
+    private static async Task<IResult> HandleListScopeServicesAsync(
+        HttpContext http,
+        string scopeId,
+        string? appId,
+        int? take,
+        [FromServices] IServiceLifecycleQueryPort lifecycleQueryPort,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
+        var normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(scopeId, nameof(scopeId));
+        var resolvedAppId = NormalizeOptional(appId)
+            ?? ScopeWorkflowCapabilityOptions.NormalizeRequired(
+                options.Value.ServiceAppId,
+                nameof(ScopeWorkflowCapabilityOptions.ServiceAppId));
+        var resolvedNamespace = ScopeWorkflowCapabilityOptions.NormalizeRequired(
+            options.Value.ServiceNamespace,
+            nameof(ScopeWorkflowCapabilityOptions.ServiceNamespace));
+
+        var services = await lifecycleQueryPort.ListServicesAsync(
+            normalizedScopeId,
+            resolvedAppId,
+            resolvedNamespace,
+            take.GetValueOrDefault(200),
+            ct);
+
+
+        return Results.Ok(services);
     }
 
     private static async Task<IResult> HandleGetBindingAsync(

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -188,6 +188,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs/{runId}:resume");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs/{runId}:signal");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs/{runId}:stop");
+        endpoints.Should().Contain("/api/scopes/{scopeId}/services");
         endpoints.Should().Contain("/api/scopes/{scopeId}/services/{serviceId}/invoke/{endpointId}:stream");
         endpoints.Should().Contain("/api/scopes/{scopeId}/services/{serviceId}/revisions/{revisionId}");
         endpoints.Should().Contain("/api/scopes/{scopeId}/services/{serviceId}/revisions/{revisionId}:retire");

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -268,6 +268,20 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ListScopeServicesEndpoint_ShouldUseExplicitAppId()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.GetAsync("/api/scopes/scope-a/services?appId=%20customApp%20");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        host.LifecycleQueryPort.LastListTenantId.Should().Be("scope-a");
+        host.LifecycleQueryPort.LastListAppId.Should().Be("customApp");
+        host.LifecycleQueryPort.LastListNamespace.Should().Be("default");
+        host.LifecycleQueryPort.LastListTake.Should().Be(200);
+    }
+
+    [Fact]
     public async Task ListScopeServicesEndpoint_ShouldRejectMismatchedAuthenticatedScope()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -223,6 +223,64 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ListScopeServicesEndpoint_ShouldReturnScopeServiceCatalog()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.LifecycleQueryPort.Services =
+        [
+            new ServiceCatalogSnapshot(
+                "scope-a:default:default:orders",
+                "scope-a",
+                "default",
+                "default",
+                "orders",
+                "Orders",
+                "rev-1",
+                "rev-1",
+                "dep-1",
+                "orders-actor",
+                "Active",
+                [
+                    new ServiceEndpointSnapshot(
+                        "run",
+                        "Run",
+                        "command",
+                        Any.Pack(new StringValue()).TypeUrl,
+                        string.Empty,
+                        "Run command"),
+                ],
+                [],
+                DateTimeOffset.UtcNow),
+        ];
+
+        var response = await host.Client.GetAsync("/api/scopes/scope-a/services?take=25");
+        var body = await response.Content.ReadFromJsonAsync<IReadOnlyList<ServiceCatalogSnapshot>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!.Should().ContainSingle();
+        body[0].ServiceId.Should().Be("orders");
+        body[0].Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        host.LifecycleQueryPort.LastListTenantId.Should().Be("scope-a");
+        host.LifecycleQueryPort.LastListAppId.Should().Be("default");
+        host.LifecycleQueryPort.LastListNamespace.Should().Be("default");
+        host.LifecycleQueryPort.LastListTake.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task ListScopeServicesEndpoint_ShouldRejectMismatchedAuthenticatedScope()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/scopes/scope-a/services");
+        request.Headers.Add("X-Test-Scope-Id", "scope-b");
+
+        var response = await host.Client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        host.LifecycleQueryPort.LastListTenantId.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetBindingEndpoint_ShouldReturnDefaultScopeBindingSummary()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -4776,11 +4834,21 @@ public sealed class ScopeServiceEndpointsTests
 
         public ServiceDeploymentCatalogSnapshot? Deployments { get; set; }
 
+        public IReadOnlyList<ServiceCatalogSnapshot> Services { get; set; } = [];
+
         public ServiceIdentity? LastServiceIdentity { get; private set; }
 
         public ServiceIdentity? LastRevisionsIdentity { get; private set; }
 
         public ServiceIdentity? LastDeploymentsIdentity { get; private set; }
+
+        public string? LastListTenantId { get; private set; }
+
+        public string? LastListAppId { get; private set; }
+
+        public string? LastListNamespace { get; private set; }
+
+        public int LastListTake { get; private set; }
 
         public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
         {
@@ -4793,8 +4861,14 @@ public sealed class ScopeServiceEndpointsTests
             string appId,
             string @namespace,
             int take = 200,
-            CancellationToken ct = default) =>
-            throw new NotSupportedException();
+            CancellationToken ct = default)
+        {
+            LastListTenantId = tenantId;
+            LastListAppId = appId;
+            LastListNamespace = @namespace;
+            LastListTake = take;
+            return Task.FromResult(Services);
+        }
 
         public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(ServiceIdentity identity, CancellationToken ct = default)
         {


### PR DESCRIPTION
## Summary

- Add a scope-scoped service catalog endpoint: `GET /api/scopes/{scopeId}/services`.
- Resolve service catalog reads through the existing `IServiceLifecycleQueryPort.ListServicesAsync(...)` read-model path, using the route `scopeId` as the tenant boundary.
- Keep `/api/services` global service-identity behavior unchanged while giving Studio/NyxID flows a scope-authorized catalog surface that includes service `endpoints`.
- Add focused integration coverage for successful scope catalog reads, endpoint payload visibility, scope mismatch rejection, and capability route registration.

## Issue

Fixes #511.

## Validation

- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter "FullyQualifiedName~ScopeServiceEndpointsTests.ListScopeServicesEndpoint|FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests.AddGAgentServiceCapabilityBundle_ShouldRegisterEndpoints" --nologo` — 2 passed
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter "FullyQualifiedName~GAgentServiceHostingServiceCollectionExtensionsTests.AddGAgentServiceCapabilityBundle_ShouldRegisterCapabilityAndMapServiceRoutes" --nologo` — 1 passed
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --filter "FullyQualifiedName~ScopeServiceEndpointsTests" --no-build --nologo` — 90 passed
- `bash tools/ci/test_stability_guards.sh` — passed

## Notes

- The new endpoint uses `AevatarScopeAccessGuard`, so authenticated Studio/NyxID callers are authorized by `scope_id` / `workflow.scope_id` matching the route `scopeId`.
- The endpoint does not accept a caller-supplied `tenantId`; this keeps the requested scope as the only tenant boundary for the catalog read.
- `appId` remains an optional query parameter and defaults to `ScopeWorkflowCapabilityOptions.ServiceAppId`; namespace is resolved from `ScopeWorkflowCapabilityOptions.ServiceNamespace`.
- The response reuses the existing `ServiceCatalogSnapshot[]` shape, including `endpoints`, so Studio Bind/Invoke can stop depending on the global `/api/services?tenantId=...&appId=...&namespace=...` call that requires service identity claims.
