### PR TITLE
fix(mainnet): bind NyxIdSpecCatalog SpecFetchToken and skip refresh when absent

### DIFF
--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdSpecCatalog.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdSpecCatalog.cs
@@ -22,12 +22,21 @@ public sealed class NyxIdSpecCatalog : IDisposable
         _http = httpClient ?? new HttpClient();
         _logger = logger ?? NullLogger<NyxIdSpecCatalog>.Instance;
 
-        if (!string.IsNullOrWhiteSpace(_options.BaseUrl))
+        if (string.IsNullOrWhiteSpace(_options.BaseUrl))
+            return;
+
+        if (string.IsNullOrWhiteSpace(_options.SpecFetchToken))
         {
-            _ = InitialFetchAsync();
-            _refreshTimer = new Timer(_ => _ = RefreshAsync(), null,
-                TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(30));
+            // NyxID's /api/v1/docs/openapi.json is human-only; without a token
+            // every fetch returns 401. Skip the timer to avoid 30-min noise.
+            _logger.LogInformation(
+                "NyxIdSpecCatalog: SpecFetchToken not configured; skipping background refresh, catalog will remain empty");
+            return;
         }
+
+        _ = InitialFetchAsync();
+        _refreshTimer = new Timer(_ => _ = RefreshAsync(), null,
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(30));
     }
 
     public OperationCard[] Operations => Volatile.Read(ref _catalog);
@@ -109,9 +118,7 @@ public sealed class NyxIdSpecCatalog : IDisposable
         var url = $"{baseUrl}/api/v1/docs/openapi.json";
 
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        var specToken = _options.SpecFetchToken;
-        if (!string.IsNullOrWhiteSpace(specToken))
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", specToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.SpecFetchToken!);
 
         using var response = await _http.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
@@ -7,9 +7,13 @@ public sealed class NyxIdToolOptions
     public string? BaseUrl { get; set; }
 
     /// <summary>
-    /// Optional token for fetching the OpenAPI spec from NyxID.
-    /// Used by NyxIdSpecCatalog when the spec endpoint requires auth.
-    /// If null, the spec fetch is attempted without auth (public endpoint).
+    /// Bearer token used by <see cref="NyxIdSpecCatalog"/> to fetch
+    /// <c>{BaseUrl}/api/v1/docs/openapi.json</c>. NyxID enforces this endpoint
+    /// as human-only (rejects service-account and delegated tokens), so this
+    /// must be a real user's API key or access token. When unset the catalog
+    /// stays empty and the background refresh is skipped — generic capability
+    /// discovery (<c>nyxid_search_capabilities</c>, <c>nyxid_proxy</c>) is
+    /// unavailable but specialized NyxID tools continue to work.
     /// </summary>
     public string? SpecFetchToken { get; set; }
 }

--- a/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs
@@ -12,7 +12,7 @@ public sealed class NyxIdToolOptions
     /// as human-only (rejects service-account and delegated tokens), so this
     /// must be a real user's API key or access token. When unset the catalog
     /// stays empty and the background refresh is skipped — generic capability
-    /// discovery (<c>nyxid_search_capabilities</c>, <c>nyxid_proxy</c>) is
+    /// discovery (<c>nyxid_search_capabilities</c>, <c>nyxid_proxy_execute</c>) is
     /// unavailable but specialized NyxID tools continue to work.
     /// </summary>
     public string? SpecFetchToken { get; set; }

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -98,6 +98,7 @@ public static class MainnetHostBuilderExtensions
             o.BaseUrl = builder.Configuration["Aevatar:NyxId:Authority"]
                         ?? builder.Configuration["Cli:App:NyxId:Authority"]
                         ?? builder.Configuration["Aevatar:Authentication:Authority"];
+            o.SpecFetchToken = builder.Configuration["Aevatar:NyxId:SpecFetchToken"];
         });
         builder.Services.AddLarkTools(o =>
         {

--- a/test/Aevatar.AI.Tests/NyxIdSpecCatalogTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdSpecCatalogTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using Aevatar.AI.ToolProviders.NyxId;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public class NyxIdSpecCatalogTests
+{
+    [Fact]
+    public void Constructor_NoBaseUrl_DoesNotFetch()
+    {
+        var handler = new FakeHttpHandler();
+        var http = new HttpClient(handler);
+        var options = new NyxIdToolOptions { BaseUrl = null, SpecFetchToken = "ignored" };
+
+        using var catalog = new NyxIdSpecCatalog(options, http);
+
+        handler.RequestCount.Should().Be(0);
+        catalog.Operations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_BaseUrlWithoutSpecFetchToken_SkipsBackgroundRefresh()
+    {
+        // Regression guard: NyxID's /api/v1/docs/openapi.json is human-only and
+        // returns 401 without a real user's API key. A configured BaseUrl alone
+        // must not trigger a fetch — otherwise prod logs fill with 30-min 401s.
+        var handler = new FakeHttpHandler();
+        var http = new HttpClient(handler);
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyx.test", SpecFetchToken = null };
+
+        using var catalog = new NyxIdSpecCatalog(options, http);
+
+        handler.RequestCount.Should().Be(0);
+        catalog.Operations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_WhitespaceSpecFetchToken_TreatedAsMissing()
+    {
+        var handler = new FakeHttpHandler();
+        var http = new HttpClient(handler);
+        var options = new NyxIdToolOptions { BaseUrl = "https://nyx.test", SpecFetchToken = "   " };
+
+        using var catalog = new NyxIdSpecCatalog(options, http);
+
+        handler.RequestCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Constructor_BaseUrlAndSpecFetchToken_FetchesWithBearer()
+    {
+        const string spec = """
+            {
+              "openapi": "3.1.0",
+              "paths": {
+                "/things": {
+                  "get": { "operationId": "list_things", "summary": "List things" }
+                }
+              }
+            }
+            """;
+        var handler = new FakeHttpHandler(spec);
+        var http = new HttpClient(handler);
+        var options = new NyxIdToolOptions
+        {
+            BaseUrl = "https://nyx.test",
+            SpecFetchToken = "user-api-key-xyz",
+        };
+
+        using var catalog = new NyxIdSpecCatalog(options, http);
+
+        await handler.FirstRequestReceived.Task;
+
+        handler.LastRequestUri.Should().Be("https://nyx.test/api/v1/docs/openapi.json");
+        handler.LastAuthHeader.Should().Be("Bearer user-api-key-xyz");
+    }
+
+    private sealed class FakeHttpHandler : HttpMessageHandler
+    {
+        private readonly string? _responseBody;
+        private readonly HttpStatusCode _statusCode;
+
+        public int RequestCount { get; private set; }
+        public string? LastRequestUri { get; private set; }
+        public string? LastAuthHeader { get; private set; }
+        public TaskCompletionSource<bool> FirstRequestReceived { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public FakeHttpHandler(string? responseBody = null, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _responseBody = responseBody;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            RequestCount++;
+            LastRequestUri = request.RequestUri?.ToString();
+            LastAuthHeader = request.Headers.Authorization?.ToString();
+            FirstRequestReceived.TrySetResult(true);
+
+            var response = new HttpResponseMessage(_statusCode);
+            if (_responseBody is not null)
+                response.Content = new StringContent(_responseBody, System.Text.Encoding.UTF8, "application/json");
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/Aevatar.AI.Tests/NyxIdSpecCatalogTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdSpecCatalogTests.cs
@@ -70,7 +70,7 @@ public class NyxIdSpecCatalogTests
 
         using var catalog = new NyxIdSpecCatalog(options, http);
 
-        await handler.FirstRequestReceived.Task;
+        await handler.FirstRequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
         handler.LastRequestUri.Should().Be("https://nyx.test/api/v1/docs/openapi.json");
         handler.LastAuthHeader.Should().Be("Bearer user-api-key-xyz");


### PR DESCRIPTION
## 问题

生产 `aismart-app-mainnet/aevatar-console-backend` 日志中，`NyxIdSpecCatalog` 每 30 分钟刷新一次，每次 3 次重试全部 401，catalog 始终为空，导致：

- `nyxid_proxy` LLM tool 完全不可用（任何 `operation_id` 查找失败）
- `nyxid_search_capabilities` 走"catalog is empty" fallback 分支，本质失效

详细调研见 #522。

## 根因

1. NyxID 的 `/api/v1/docs/openapi.json` 在 `api_v1_human_only` 路由组，挂了 `reject_service_account_tokens` + `reject_delegated_tokens`，**只接受真人用户 JWT 或 API key**，不再是公开端点。
2. `MainnetHostBuilderExtensions.AddNyxIdTools` 调用只绑了 `BaseUrl`，**完全没有绑 `SpecFetchToken`**；catalog 因此发不带 `Authorization` 的请求 → 401。
3. `NyxIdToolOptions.SpecFetchToken` 的 XML doc 注释还停留在"public endpoint"假设，已经过时。
4. 即便没有 token，catalog 也照样开 30 min 定时器去打 401，纯噪声。

## 改动

| 文件 | 改动 |
|---|---|
| `src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs` | `AddNyxIdTools` 中绑定 `Aevatar:NyxId:SpecFetchToken` |
| `src/Aevatar.AI.ToolProviders.NyxId/NyxIdSpecCatalog.cs` | 构造时若 `SpecFetchToken` 为空/空白，跳过 initial fetch + 定时器，记 Information 日志；`FetchAndUpdateAsync` 总是带 Bearer（删除冗余空判） |
| `src/Aevatar.AI.ToolProviders.NyxId/NyxIdToolOptions.cs` | 更新 `SpecFetchToken` XML doc，去掉 "public endpoint" 表述，明确 human-only 约束 |
| `test/Aevatar.AI.Tests/NyxIdSpecCatalogTests.cs` | 新增 4 个用例：无 BaseUrl / 无 Token / 空白 Token / 正常带 Token 走 Bearer |

## 验证

```bash
dotnet build src/Aevatar.AI.ToolProviders.NyxId/Aevatar.AI.ToolProviders.NyxId.csproj  # 0 errors
dotnet build test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj                            # 0 errors
dotnet build src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj             # 0 errors

dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj \
  --filter "FullyQualifiedName~NyxIdSpecCatalogTests"                                  # 4/4 passed
dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj \
  --filter "FullyQualifiedName~NyxId|FullyQualifiedName~ConnectedService|FullyQualifiedName~OpenApiSpec"
                                                                                       # 205/205 passed

bash tools/ci/test_stability_guards.sh                                                 # passed
```

## 部署侧 follow-up（不在本 PR 范围）

合 PR 之后还需要 ops/SRE：

1. 在 NyxID 上发一个用户级 API key（read scope 即可），落地到 mainnet 集群的 secret/configmap。
2. 在 helm values / `appsettings.*.json` 里通过 `Aevatar:NyxId:SpecFetchToken` 把这个 key 注入 console-backend。
3. 重启 pod 后用以下条件验证：
   - 日志里出现 `NyxIdSpecCatalog updated: N operations`（成功）或者 `SpecFetchToken not configured; skipping...`（仍未配置）
   - 不再出现 `NyxIdSpecCatalog refresh attempt N/3 failed`

## 长期方案（NyxID 侧）

human-only 这一约束让 catalog 不得不绑某个真实用户。更干净的做法是 NyxID 把 spec endpoint 移出 `human_only`，允许 service account token，或者出一个无鉴权的"catalog only / 不含敏感字段"的子集 spec 端点。这块留给 NyxID 团队评估，**不在本 PR 范围**。

## 关联

- closes（部分）#522 — silent fallback 这一类的整改还需要 NyxID 侧配合
- 上下文：#171（OpenAPI-driven NyxIdChatGAgent，引入此 catalog）