### PR TITLE
chore: add CODEOWNERS to enforce peer review on critical paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Default fallback — any path with no other rule routes here
+*                                                       @loning
+
+# ─── Architecture canon & ADRs (CEO sign-off) ──────────────
+/CLAUDE.md                                              @loning
+/docs/canon/                                            @loning
+/docs/adr/                                              @loning
+
+# ─── Core actor / channel runtime (highest blast radius) ───
+/agents/Aevatar.GAgents.ChannelRuntime/                 @louis4li @loning
+/agents/channels/                                       @louis4li @loning
+/agents/Aevatar.GAgents.NyxidChat/                      @louis4li @loning
+/agents/Aevatar.GAgents.NyxIdRelay/                     @louis4li @loning
+**/*.proto                                              @louis4li @loning
+
+# ─── Platform internals (CQRS, projection, scripting) ──────
+/src/platform/                                          @louis4li
+/src/Aevatar.Studio.Application/                        @louis4li @loning
+
+# ─── Studio frontend (existing review pair) ────────────────
+/apps/aevatar-console-web/                              @AbigailDeng @potter-sun
+
+# ─── CI guards & engineering discipline ────────────────────
+/tools/ci/                                              @louis4li @loning
+/.github/workflows/                                     @louis4li @loning
+/.github/CODEOWNERS                                     @loning

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,29 @@
 # Default fallback — any path with no other rule routes here
-*                                                       @loning
+*                                                       @louis4li
 
-# ─── Architecture canon & ADRs (CEO sign-off) ──────────────
-/CLAUDE.md                                              @loning
-/docs/canon/                                            @loning
-/docs/adr/                                              @loning
+# ─── Architecture canon & ADRs ─────────────────────────────
+# Two backend leads as joint owners — one of them must approve
+/CLAUDE.md                                              @louis4li @eanzhao
+/docs/canon/                                            @louis4li @eanzhao
+/docs/adr/                                              @louis4li @eanzhao
 
 # ─── Core actor / channel runtime (highest blast radius) ───
-/agents/Aevatar.GAgents.ChannelRuntime/                 @louis4li @loning
-/agents/channels/                                       @louis4li @loning
-/agents/Aevatar.GAgents.NyxidChat/                      @louis4li @loning
-/agents/Aevatar.GAgents.NyxIdRelay/                     @louis4li @loning
-**/*.proto                                              @louis4li @loning
+# louis4li + eanzhao mutual review pair: when one authors,
+# only the other can satisfy the code-owner approval.
+/agents/Aevatar.GAgents.ChannelRuntime/                 @louis4li @eanzhao
+/agents/channels/                                       @louis4li @eanzhao
+/agents/Aevatar.GAgents.NyxidChat/                      @louis4li @eanzhao
+/agents/Aevatar.GAgents.NyxIdRelay/                     @louis4li @eanzhao
+**/*.proto                                              @louis4li @eanzhao
 
 # ─── Platform internals (CQRS, projection, scripting) ──────
-/src/platform/                                          @louis4li
-/src/Aevatar.Studio.Application/                        @louis4li @loning
+/src/platform/                                          @louis4li @eanzhao
+/src/Aevatar.Studio.Application/                        @louis4li @eanzhao
 
 # ─── Studio frontend (existing review pair) ────────────────
 /apps/aevatar-console-web/                              @AbigailDeng @potter-sun
 
 # ─── CI guards & engineering discipline ────────────────────
-/tools/ci/                                              @louis4li @loning
-/.github/workflows/                                     @louis4li @loning
-/.github/CODEOWNERS                                     @loning
+/tools/ci/                                              @louis4li @eanzhao
+/.github/workflows/                                     @louis4li @eanzhao
+/.github/CODEOWNERS                                     @louis4li @eanzhao

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,29 @@
 # Default fallback — any path with no other rule routes here
-*                                                       @louis4li
+*                                                       @louis4li @jason-aelf
 
 # ─── Architecture canon & ADRs ─────────────────────────────
-# Two backend leads as joint owners — one of them must approve
-/CLAUDE.md                                              @louis4li @eanzhao
-/docs/canon/                                            @louis4li @eanzhao
-/docs/adr/                                              @louis4li @eanzhao
+# Three backend leads as joint owners — any one of them must approve
+/CLAUDE.md                                              @louis4li @eanzhao @jason-aelf
+/docs/canon/                                            @louis4li @eanzhao @jason-aelf
+/docs/adr/                                              @louis4li @eanzhao @jason-aelf
 
 # ─── Core actor / channel runtime (highest blast radius) ───
-# louis4li + eanzhao mutual review pair: when one authors,
-# only the other can satisfy the code-owner approval.
-/agents/Aevatar.GAgents.ChannelRuntime/                 @louis4li @eanzhao
-/agents/channels/                                       @louis4li @eanzhao
-/agents/Aevatar.GAgents.NyxidChat/                      @louis4li @eanzhao
-/agents/Aevatar.GAgents.NyxIdRelay/                     @louis4li @eanzhao
-**/*.proto                                              @louis4li @eanzhao
+# louis4li / eanzhao / jason-aelf — author cannot self-approve,
+# so any non-author owner satisfies the code-owner gate.
+/agents/Aevatar.GAgents.ChannelRuntime/                 @louis4li @eanzhao @jason-aelf
+/agents/channels/                                       @louis4li @eanzhao @jason-aelf
+/agents/Aevatar.GAgents.NyxidChat/                      @louis4li @eanzhao @jason-aelf
+/agents/Aevatar.GAgents.NyxIdRelay/                     @louis4li @eanzhao @jason-aelf
+**/*.proto                                              @louis4li @eanzhao @jason-aelf
 
 # ─── Platform internals (CQRS, projection, scripting) ──────
-/src/platform/                                          @louis4li @eanzhao
-/src/Aevatar.Studio.Application/                        @louis4li @eanzhao
+/src/platform/                                          @louis4li @eanzhao @jason-aelf
+/src/Aevatar.Studio.Application/                        @louis4li @eanzhao @jason-aelf
 
 # ─── Studio frontend (existing review pair) ────────────────
 /apps/aevatar-console-web/                              @AbigailDeng @potter-sun
 
 # ─── CI guards & engineering discipline ────────────────────
-/tools/ci/                                              @louis4li @eanzhao
-/.github/workflows/                                     @louis4li @eanzhao
-/.github/CODEOWNERS                                     @louis4li @eanzhao
+/tools/ci/                                              @louis4li @eanzhao @jason-aelf
+/.github/workflows/                                     @louis4li @eanzhao @jason-aelf
+/.github/CODEOWNERS                                     @louis4li @eanzhao @jason-aelf


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so GitHub knows who owns each critical path. **The file is inert until branch protection turns on `require_code_owner_reviews`** (separate follow-up change).

## Why

- 90 day self-merge rate: **94%** (94/100 PRs)
- Mainline contributor (eanzhao, 81% of commits) has 0 peer-reviewed PRs in 90 days
- PR #496 self-merged despite an AI review citing prior CQRS closure ADR — because no machine gate enforces the verbal "互相 review" rule

## Path → owner mapping

CEO is intentionally not in the per-PR review loop. Backend critical paths route through three joint owners (any one signs); the existing AbigailDeng ↔ potter-sun frontend pair is preserved.

| Path | Owners |
|---|---|
| `agents/Aevatar.GAgents.ChannelRuntime/`, `agents/channels/`, NyxidChat / NyxIdRelay, `**/*.proto` | @louis4li @eanzhao @jason-aelf |
| `src/platform/`, `src/Aevatar.Studio.Application/` | @louis4li @eanzhao @jason-aelf |
| `CLAUDE.md`, `docs/canon/`, `docs/adr/`, `tools/ci/`, `.github/workflows/`, `.github/CODEOWNERS` | @louis4li @eanzhao @jason-aelf |
| `apps/aevatar-console-web/` | @AbigailDeng @potter-sun |
| Default fallback | @louis4li @jason-aelf |

GitHub blocks an author from approving their own PR, so the practical effect is: when one of the three authors a backend PR, one of the other two satisfies the code-owner gate. This makes the existing #452 / #359 cross-review pattern a default rather than an occasional good behavior.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: follow-up change flips dev/master branch protection to require code-owner review + dismiss stale reviews + enforce_admins
- [ ] Smoke-test by pushing a small PR to a CODEOWNERS-covered path; confirm the merge button is blocked without an owner approval

## Notes

- File location is `.github/CODEOWNERS` (GitHub's preferred location).
- Owners use exact case-sensitive GitHub logins, verified via `gh api users/<login>`.
- This file is inert until `require_code_owner_reviews: true` is set on branch protection.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>