### PR TITLE
Fix Elasticsearch script catalog sort mapping

### DIFF
--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStorePayloadSupport.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStorePayloadSupport.cs
@@ -185,7 +185,7 @@ internal static class ElasticsearchProjectionDocumentStorePayloadSupport
                 : fieldPathResolver(defaultSortField.Trim());
             var defaultClauses = new List<object>
             {
-                BuildSortClause(primarySortField, ProjectionDocumentSortDirection.Desc, includeMissingHints: true),
+                BuildSortClause(primarySortField, ProjectionDocumentSortDirection.Desc),
             };
             defaultClauses.AddRange(BuildTiebreakSortClauses());
             return defaultClauses.ToArray();
@@ -194,8 +194,7 @@ internal static class ElasticsearchProjectionDocumentStorePayloadSupport
         var clauses = query.Sorts
             .Select(sort => BuildSortClause(
                 fieldPathResolver(sort.FieldPath),
-                sort.Direction,
-                includeMissingHints: false))
+                sort.Direction))
             .ToList();
         clauses.AddRange(BuildTiebreakSortClauses());
         return clauses.ToArray();
@@ -203,24 +202,37 @@ internal static class ElasticsearchProjectionDocumentStorePayloadSupport
 
     private static object BuildSortClause(
         string fieldPath,
-        ProjectionDocumentSortDirection direction,
-        bool includeMissingHints)
+        ProjectionDocumentSortDirection direction)
     {
         var spec = new Dictionary<string, object?>
         {
             ["order"] = direction == ProjectionDocumentSortDirection.Asc ? "asc" : "desc",
+            ["missing"] = "_last",
+            ["unmapped_type"] = ResolveSortUnmappedType(fieldPath),
         };
-
-        if (includeMissingHints)
-        {
-            spec["missing"] = "_last";
-            spec["unmapped_type"] = "date";
-        }
 
         return new Dictionary<string, object?>
         {
             [fieldPath] = spec,
         };
+    }
+
+    private static string ResolveSortUnmappedType(string fieldPath)
+    {
+        var normalizedFieldPath = fieldPath.Trim();
+        if (normalizedFieldPath.EndsWith(".keyword", StringComparison.Ordinal))
+            return "keyword";
+
+        var lastSegmentIndex = normalizedFieldPath.LastIndexOf('.');
+        var fieldName = lastSegmentIndex >= 0
+            ? normalizedFieldPath[(lastSegmentIndex + 1)..]
+            : normalizedFieldPath;
+
+        return fieldName.EndsWith("_utc_value", StringComparison.Ordinal) ||
+               fieldName.EndsWith("At", StringComparison.Ordinal) ||
+               fieldName.EndsWith("_at", StringComparison.Ordinal)
+            ? "date"
+            : "keyword";
     }
 
     private static IEnumerable<object> BuildTiebreakSortClauses()

--- a/src/Aevatar.Scripting.Projection/Metadata/ScriptCatalogEntryDocumentMetadataProvider.cs
+++ b/src/Aevatar.Scripting.Projection/Metadata/ScriptCatalogEntryDocumentMetadataProvider.cs
@@ -10,6 +10,17 @@ public sealed class ScriptCatalogEntryDocumentMetadataProvider
         Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["dynamic"] = true,
+            ["properties"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["created_at_utc_value"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "date",
+                },
+                ["updated_at_utc_value"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["type"] = "date",
+                },
+            },
         },
         Settings: new Dictionary<string, object?>(StringComparer.Ordinal),
         Aliases: new Dictionary<string, object?>(StringComparer.Ordinal));

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionDocumentStoreBehaviorTests.cs
@@ -124,6 +124,72 @@ public sealed class ElasticsearchProjectionDocumentStoreBehaviorTests
     }
 
     [Fact]
+    public async Task QueryAsync_WhenUsingExplicitTimestampSort_ShouldIncludeMissingAndUnmappedHints()
+    {
+        var handler = new ScriptedHttpMessageHandler();
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"hits":{"hits":[]}}"""));
+
+        using var store = CreateStore(
+            new ElasticsearchProjectionDocumentStoreOptions
+            {
+                AutoCreateIndex = false,
+            },
+            handler);
+
+        _ = await store.QueryAsync(new ProjectionDocumentQuery
+        {
+            Sorts =
+            [
+                new ProjectionDocumentSort
+                {
+                    FieldPath = nameof(TestStoreReadModel.UpdatedAt),
+                    Direction = ProjectionDocumentSortDirection.Desc,
+                },
+            ],
+        });
+
+        var searchRequest = handler.CapturedRequests.Should().ContainSingle().Subject;
+        searchRequest.Body.Should().Contain("\"updated_at_utc_value\"");
+        searchRequest.Body.Should().Contain("\"missing\":\"_last\"");
+        searchRequest.Body.Should().Contain("\"unmapped_type\":\"date\"");
+    }
+
+    [Fact]
+    public async Task QueryAsync_WhenUsingExplicitStringSort_ShouldUseKeywordUnmappedHint()
+    {
+        var handler = new ScriptedHttpMessageHandler();
+        handler.EnqueueResponse(_ => CreateJsonResponse(
+            HttpStatusCode.OK,
+            """{"hits":{"hits":[]}}"""));
+
+        using var store = CreateStore(
+            new ElasticsearchProjectionDocumentStoreOptions
+            {
+                AutoCreateIndex = false,
+            },
+            handler);
+
+        _ = await store.QueryAsync(new ProjectionDocumentQuery
+        {
+            Sorts =
+            [
+                new ProjectionDocumentSort
+                {
+                    FieldPath = nameof(TestStoreReadModel.Value),
+                    Direction = ProjectionDocumentSortDirection.Asc,
+                },
+            ],
+        });
+
+        var searchRequest = handler.CapturedRequests.Should().ContainSingle().Subject;
+        searchRequest.Body.Should().Contain("\"value\"");
+        searchRequest.Body.Should().Contain("\"missing\":\"_last\"");
+        searchRequest.Body.Should().Contain("\"unmapped_type\":\"keyword\"");
+    }
+
+    [Fact]
     public async Task QueryAsync_WhenFieldHasExplicitKeywordMapping_ShouldNotAppendKeywordSuffix()
     {
         var handler = new ScriptedHttpMessageHandler();

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptCatalogEntryMetadataProviderTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptCatalogEntryMetadataProviderTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Text;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
+using Aevatar.Scripting.Projection.Metadata;
+using Aevatar.Scripting.Projection.ReadModels;
+using FluentAssertions;
+
+namespace Aevatar.Scripting.Core.Tests.Projection;
+
+public sealed class ScriptCatalogEntryMetadataProviderTests
+{
+    [Fact]
+    public async Task ElasticsearchIndexInitialization_ShouldIncludeSortableTimestampMappings()
+    {
+        var handler = new ScriptedHttpMessageHandler();
+        handler.EnqueueResponse(_ => CreateJsonResponse(HttpStatusCode.OK, """{"acknowledged":true}"""));
+        handler.EnqueueResponse(_ => CreateJsonResponse(HttpStatusCode.NotFound, """{"found":false}"""));
+        handler.EnqueueResponse(_ => CreateJsonResponse(HttpStatusCode.OK, """{"result":"created"}"""));
+
+        var options = new ElasticsearchProjectionDocumentStoreOptions
+        {
+            AutoCreateIndex = true,
+        };
+        options.Endpoints = ["http://localhost:9200"];
+
+        using var store = new ElasticsearchProjectionDocumentStore<ScriptCatalogEntryDocument, string>(
+            options,
+            new ScriptCatalogEntryDocumentMetadataProvider().Metadata,
+            keySelector: document => document.Id,
+            keyFormatter: key => key,
+            httpMessageHandler: handler);
+
+        await store.UpsertAsync(new ScriptCatalogEntryDocument
+        {
+            Id = "catalog:script-1",
+            CatalogActorId = "catalog",
+            ScriptId = "script-1",
+            StateVersion = 1,
+            LastEventId = "event-1",
+            CreatedAt = DateTimeOffset.Parse("2026-04-30T00:00:00Z"),
+            UpdatedAt = DateTimeOffset.Parse("2026-04-30T00:00:01Z"),
+        });
+
+        handler.CapturedRequests.Should().HaveCount(3);
+        var indexInitialization = handler.CapturedRequests[0];
+        indexInitialization.Method.Should().Be("PUT");
+        indexInitialization.PathAndQuery.Should().Be("/aevatar-script-catalog-entries");
+        indexInitialization.Body.Should().Contain("\"created_at_utc_value\":{\"type\":\"date\"}");
+        indexInitialization.Body.Should().Contain("\"updated_at_utc_value\":{\"type\":\"date\"}");
+    }
+
+    private static HttpResponseMessage CreateJsonResponse(HttpStatusCode statusCode, string json)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        };
+    }
+
+    private sealed class ScriptedHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> _responses = new();
+
+        public List<CapturedRequest> CapturedRequests { get; } = [];
+
+        public void EnqueueResponse(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        {
+            _responses.Enqueue(responseFactory);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var requestBody = request.Content == null
+                ? ""
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            CapturedRequests.Add(new CapturedRequest(
+                request.Method.Method,
+                request.RequestUri?.PathAndQuery ?? "",
+                requestBody));
+
+            if (_responses.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"No scripted response available for request '{request.Method} {request.RequestUri}'.");
+            }
+
+            return _responses.Dequeue().Invoke(request);
+        }
+    }
+
+    private sealed record CapturedRequest(string Method, string PathAndQuery, string Body);
+}

--- a/test/Aevatar.Scripting.Core.Tests/ScriptingProjectWiringTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/ScriptingProjectWiringTests.cs
@@ -9,6 +9,7 @@ using Aevatar.Scripting.Core.Ports;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Hosting.DependencyInjection;
 using Aevatar.Scripting.Projection.Materialization;
+using Aevatar.Scripting.Projection.Metadata;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.Projectors;
 using FluentAssertions;
@@ -48,5 +49,35 @@ public sealed class ScriptingProjectWiringTests
             .And.Contain(x => x is ScriptCatalogEntryProjector);
         provider.GetServices<ICurrentStateProjectionMaterializer<ScriptEvolutionMaterializationContext>>()
             .Should().ContainSingle(x => x is ScriptEvolutionReadModelProjector);
+    }
+
+    [Fact]
+    public void ScriptCatalogEntryDocumentMetadataProvider_ShouldDeclareSortableTimestampMappings()
+    {
+        var provider = new ScriptCatalogEntryDocumentMetadataProvider();
+
+        provider.Metadata.IndexName.Should().Be("script-catalog-entries");
+        provider.Metadata.Mappings.Should().ContainKey("dynamic").WhoseValue.Should().Be(true);
+        provider.Metadata.Mappings.Should().ContainKey("properties");
+
+        var properties = provider.Metadata.Mappings["properties"].Should()
+            .BeAssignableTo<IReadOnlyDictionary<string, object?>>()
+            .Subject;
+        properties.Should().ContainKey("created_at_utc_value");
+        properties.Should().ContainKey("updated_at_utc_value");
+        GetFieldType(properties, "created_at_utc_value").Should().Be("date");
+        GetFieldType(properties, "updated_at_utc_value").Should().Be("date");
+        provider.Metadata.Settings.Should().BeEmpty();
+        provider.Metadata.Aliases.Should().BeEmpty();
+    }
+
+    private static object? GetFieldType(
+        IReadOnlyDictionary<string, object?> properties,
+        string fieldName)
+    {
+        var field = properties[fieldName].Should()
+            .BeAssignableTo<IReadOnlyDictionary<string, object?>>()
+            .Subject;
+        return field["type"];
     }
 }


### PR DESCRIPTION
## Problem

Mainnet `/api/health` can report `gagent-service` as unhealthy when the script catalog health probe queries Elasticsearch with an explicit `UpdatedAt` sort. Empty or not-yet-mapped `script-catalog-entries` indices fail with `No mapping found for [updated_at_utc_value] in order to sort on`.

## Solution

- Add `missing` and inferred `unmapped_type` hints to every Elasticsearch projection sort clause so existing empty/unmapped indices remain queryable.
- Declare `created_at_utc_value` and `updated_at_utc_value` as `date` mappings for new `script-catalog-entries` indices.
- Add regression coverage for explicit sort hints and script catalog index initialization payload mappings.

## Follow-up

Opened #533 to standardize Elasticsearch projection mappings for stable read model fields across providers.

## Validation

- `dotnet test test/Aevatar.Scripting.Core.Tests/Aevatar.Scripting.Core.Tests.csproj --nologo`
- `dotnet test test/Aevatar.CQRS.Projection.Core.Tests/Aevatar.CQRS.Projection.Core.Tests.csproj --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`
- `dotnet build src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj --nologo`