### PR TITLE
fix(channel-identity): activate OAuth-client projection scope at bootstrap

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -94,6 +94,14 @@ public static class IdentityServiceCollectionExtensions
             IProjectionDocumentMetadataProvider<AevatarOAuthClientDocument>,
             AevatarOAuthClientDocumentMetadataProvider>();
         services.TryAddSingleton<IAevatarOAuthClientProvider, AevatarOAuthClientProjectionProvider>();
+        // Projection scope activator — bootstrap calls EnsureProjectionForActorAsync
+        // before dispatching the provisioning command so the projector
+        // subscribes to the actor's committed event stream and materializes
+        // the readmodel. Without this the OAuth-client document never
+        // appears and the provider keeps throwing
+        // AevatarOAuthClientNotProvisionedException even after DCR succeeds
+        // (production regression observed 2026-04-30 in aismart-app-mainnet).
+        services.TryAddSingleton<AevatarOAuthClientProjectionPort>();
 
         // ─── Broker (self-bootstrapping, no appsettings dependency) ───
         // Register broker as a *singleton* and inject IHttpClientFactory so

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -43,6 +43,7 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
     internal static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(30);
 
     private readonly IAevatarOAuthClientProvider _clientProvider;
+    private readonly AevatarOAuthClientProjectionPort _projectionPort;
     private readonly IActorRuntime _actorRuntime;
     private readonly ILogger<AevatarOAuthClientBootstrapService> _logger;
     private readonly IConfiguration _configuration;
@@ -51,6 +52,7 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
 
     public AevatarOAuthClientBootstrapService(
         IAevatarOAuthClientProvider clientProvider,
+        AevatarOAuthClientProjectionPort projectionPort,
         IActorRuntime actorRuntime,
         IConfiguration configuration,
         ILogger<AevatarOAuthClientBootstrapService> logger)
@@ -62,6 +64,7 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         // catches scoped → singleton at resolve time, not at AddHostedService
         // wiring time).
         _clientProvider = clientProvider ?? throw new ArgumentNullException(nameof(clientProvider));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -163,6 +166,22 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
     private async Task EnsureProvisionedAsync(CancellationToken ct)
     {
         var authority = NyxIdAuthorityResolver.Resolve(_logger);
+
+        // Activate the projection scope FIRST so the projector subscribes
+        // to the actor's committed events before we dispatch the
+        // provisioning command. Without this the AevatarOAuthClient
+        // readmodel never materializes and IAevatarOAuthClientProvider
+        // keeps throwing AevatarOAuthClientNotProvisionedException long
+        // after DCR succeeded (production regression observed
+        // 2026-04-30 in aismart-app-mainnet — the bootstrap log showed
+        // "Provisioned aevatar OAuth client via DCR" + "Seeded HMAC key"
+        // immediately after the silo started, but every /init still
+        // returned "正在初始化" because no consumer was watching the
+        // event stream).
+        await _projectionPort
+            .EnsureProjectionForActorAsync(AevatarOAuthClientGAgent.WellKnownId, ct)
+            .ConfigureAwait(false);
+
         AevatarOAuthClientSnapshot? cached = null;
         try
         {

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -39,7 +39,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         if (evt is not null
             && evt is not AevatarOAuthClientProvisionedEvent
             && evt is not AevatarOAuthClientHmacKeyRotatedEvent
-            && evt is not AevatarOAuthClientBrokerCapabilityObservedEvent)
+            && evt is not AevatarOAuthClientBrokerCapabilityObservedEvent
+            && evt is not AevatarOAuthClientProjectionRebuildRequestedEvent)
         {
             Logger.LogWarning(
                 "AevatarOAuthClientGAgent received unrecognised event type {EventType}; state unchanged",
@@ -51,6 +52,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             .On<AevatarOAuthClientProvisionedEvent>(ApplyProvisioned)
             .On<AevatarOAuthClientHmacKeyRotatedEvent>(ApplyHmacKeyRotated)
             .On<AevatarOAuthClientBrokerCapabilityObservedEvent>(ApplyBrokerCapabilityObserved)
+            .On<AevatarOAuthClientProjectionRebuildRequestedEvent>(static (state, _) => state)
             .OrCurrent();
     }
 
@@ -89,7 +91,18 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             {
                 await PersistDomainEventAsync(BuildHmacKeyRotatedEvent());
                 Logger.LogInformation("Seeded HMAC key for aevatar OAuth client (existing client_id)");
+                return;
             }
+
+            await PersistDomainEventAsync(new AevatarOAuthClientProjectionRebuildRequestedEvent
+            {
+                Reason = "ensure_already_provisioned",
+                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            });
+            Logger.LogInformation(
+                "Requested aevatar OAuth client projection rebuild: actorId={ActorId}, authority={Authority}",
+                Id,
+                cmd.NyxidAuthority);
             return;
         }
 

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -87,6 +87,9 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         {
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
+            // Returning here is intentional: HmacKeyRotatedEvent itself
+            // re-publishes the state root, so the projector materializes the
+            // readmodel without needing an additional rebuild trigger.
             if (State.HmacKey.Length == 0)
             {
                 await PersistDomainEventAsync(BuildHmacKeyRotatedEvent());
@@ -94,6 +97,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 return;
             }
 
+            // Steady-state branch: nothing changed at NyxID, but a freshly-
+            // booted silo may have an empty projection (codex PR #539 P1 —
+            // happens after the projection-scope-activation fix is deployed
+            // to a cluster whose actor was already provisioned by an earlier
+            // build that never activated the scope). Persist a no-op rebuild
+            // event so the now-attached projector has a state-root
+            // publication to materialize. Apply is identity, so the OAuth
+            // client facts are not mutated.
             await PersistDomainEventAsync(new AevatarOAuthClientProjectionRebuildRequestedEvent
             {
                 Reason = "ensure_already_provisioned",

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionPort.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionPort.cs
@@ -1,0 +1,36 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+
+namespace Aevatar.GAgents.Channel.Identity;
+
+/// <summary>
+/// Activates the projection materialization scope for the cluster-singleton
+/// <see cref="AevatarOAuthClientGAgent"/>. MUST be called before any reader
+/// hits <see cref="AevatarOAuthClientProjectionProvider"/> — without an
+/// active scope, the projector never subscribes to the actor's committed
+/// event stream and the readmodel stays empty (so /init keeps reporting
+/// "still bootstrapping" forever even after DCR succeeds).
+/// </summary>
+public sealed class AevatarOAuthClientProjectionPort
+    : MaterializationProjectionPortBase<AevatarOAuthClientMaterializationRuntimeLease>
+{
+    public const string ProjectionKind = "aevatar-oauth-client";
+
+    public AevatarOAuthClientProjectionPort(
+        IProjectionScopeActivationService<AevatarOAuthClientMaterializationRuntimeLease> activationService)
+        : base(static () => true, activationService)
+    {
+    }
+
+    public Task<AevatarOAuthClientMaterializationRuntimeLease?> EnsureProjectionForActorAsync(
+        string actorId,
+        CancellationToken ct = default) =>
+        EnsureProjectionAsync(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = actorId,
+                ProjectionKind = ProjectionKind,
+                Mode = ProjectionRuntimeMode.DurableMaterialization,
+            },
+            ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -81,6 +81,15 @@ message RotateAevatarOAuthClientHmacKeyCommand {}
 // broker_capability_enabled on this client.
 message ObserveBrokerCapabilityCommand {}
 
+// Persisted when bootstrap needs to re-emit the authoritative state root for
+// the OAuth client projection without changing business state. This repairs a
+// missing/stale readmodel after the projection scope is activated, while
+// keeping rebuild semantics owned by the actor rather than query-time replay.
+message AevatarOAuthClientProjectionRebuildRequestedEvent {
+  string reason = 1;
+  google.protobuf.Timestamp requested_at = 2;
+}
+
 // Persisted on successful provision. Carries the client_id + issuance
 // timestamp + authority so the projector can materialize the readmodel.
 message AevatarOAuthClientProvisionedEvent {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -92,12 +92,18 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         await _agent.HandleEnsureProvisioned(cmd);
         var firstClientId = _agent.State.ClientId;
         var firstHmacKey = _agent.State.HmacKey;
+        var beforeRefreshState = _agent.State.Clone();
+        var beforeRefreshVersion = _agent.EventSourcing!.CurrentVersion;
 
         await _agent.HandleEnsureProvisioned(cmd);
 
         _registrar.Calls.Should().HaveCount(1, "actor must serialize the DCR side-effect");
         _agent.State.ClientId.Should().Be(firstClientId);
         _agent.State.HmacKey.Should().BeEquivalentTo(firstHmacKey);
+        _agent.State.Should().BeEquivalentTo(beforeRefreshState,
+            "projection rebuild is a state-root refresh and must not mutate OAuth client facts");
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeRefreshVersion + 1,
+            "already-provisioned ensure must re-emit the authoritative state root so an empty projection can materialize");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Production regression on PR #521: `aismart-app-mainnet` 2026-04-30 — every `/init` returned `"aevatar 正在初始化 NyxID 客户端"` even after the bootstrap log showed DCR registered the client + seeded the HMAC key.
- Root cause: `AddChannelIdentity` wired the projection runtime + projector + document store but never **activated** the `aevatar-oauth-client` projection scope. Without activation the projector never subscribed to the actor's committed event stream, so the readmodel stayed empty and `IAevatarOAuthClientProvider.GetAsync` kept throwing `AevatarOAuthClientNotProvisionedException`.
- Other modules (Channel.Runtime / Device / UserAgentCatalog) ship a startup hosted service that calls `EnsureProjectionForActorAsync`. Identity shipped without one — this PR closes the gap.

## What changed

- New `AevatarOAuthClientProjectionPort` (mirror of `ChannelBotRegistrationProjectionPort`) wraps scope activation.
- `AevatarOAuthClientBootstrapService` now calls `port.EnsureProjectionForActorAsync(WellKnownId)` **before** dispatching `EnsureAevatarOAuthClientProvisionedCommand`. Projector subscribes first, then DCR runs, then the `Provisioned` + `HmacKeyRotated` events materialize immediately.
- Port registered as singleton in `AddChannelIdentity` and injected into the bootstrap.

## Pod log evidence

`kubectl logs -n aismart-app-mainnet aevatar-console-backend-…`:

```
EnsureProvisioned dispatched to aevatar-oauth-client (authority=https://nyx.chrono-ai.fun)
Registered aevatar OAuth client at NyxID: client_id=c7f5cf02-c87b-45b9-86af-7e52baf7f987
Provisioned aevatar OAuth client via DCR: client_id=c7f5cf02-c87b-45b9-86af-7e52baf7f987
Seeded HMAC key for aevatar OAuth client
…
AevatarOAuthClientNotProvisionedException: Aevatar OAuth client has not been provisioned at NyxID.   ← /init still failing
```

DCR succeeded, but `IAevatarOAuthClientProvider` (projection-backed) kept reporting unprovisioned because the projector wasn't running.

## Test plan

- [x] Unit + integration tests in `test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/` pass (83 tests).
- [x] Full ChannelRuntime suite: 800+ tests pass.
- [ ] After deploy: send `/init` to a Lark bot in `aismart-app-mainnet`, confirm authorize URL is returned on the first attempt (no `"正在初始化"` loop).
- [ ] `GET /api/oauth/aevatar-client/status` returns the existing `client_id=c7f5cf02-…` (the actor state from the previous deployment is event-sourced and rehydrates cleanly once the projector runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)