### PR TITLE
Add team-first console flows backed by Studio team endpoints

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -7435,8 +7435,10 @@ const StudioPage: React.FC = () => {
     .filter(Boolean);
   const studioReturnHref = resolvedStudioScopeId
     ? buildTeamDetailHref({
+        memberId: workbenchStudioMemberId || undefined,
         scopeId: resolvedStudioScopeId,
         tab: 'advanced',
+        teamId: trimOptional(workbenchStudioMember?.teamId) || undefined,
         serviceId:
           trimOptional(routeState.memberId) ||
           trimOptional(workbenchPublishedService?.serviceId) ||

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1,1258 +1,249 @@
-import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { message } from "antd";
 import React from "react";
-import { scopesApi } from "@/shared/api/scopesApi";
-import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
-import { servicesApi } from "@/shared/api/servicesApi";
-import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
-import { history } from "@/shared/navigation/history";
 import { studioApi } from "@/shared/studio/api";
-import { loadDraftRunPayload } from "@/shared/runs/draftRunSession";
 import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
 import TeamDetailPage from "./detail";
 
-jest.mock("@/shared/graphs/GraphCanvas", () => ({
-  __esModule: true,
-  default: () => {
-    const React = require("react");
-    return React.createElement("div", null, "Graph canvas");
-  },
-}));
-
-function mockCreateRunsCatalog() {
+jest.mock("antd", () => {
+  const actual = jest.requireActual("antd");
   return {
-    scopeId: "scope-1",
-    serviceId: "default",
-    serviceKey: "scope-1:default",
-    displayName: "Support Runtime",
-    runs: [
-      {
-        scopeId: "scope-1",
-        serviceId: "default",
-        runId: "run-current",
-        actorId: "actor-intake",
-        definitionActorId: "definition://support-triage",
-        revisionId: "rev-2",
-        deploymentId: "dep-2",
-        workflowName: "support-triage",
-        completionStatus: "waiting_approval",
-        stateVersion: 2,
-        lastEventId: "evt-2",
-        lastUpdatedAt: "2026-04-09T09:05:00Z",
-        boundAt: "2026-04-09T09:00:00Z",
-        bindingUpdatedAt: "2026-04-09T09:00:00Z",
-        lastSuccess: false,
-        totalSteps: 4,
-        completedSteps: 2,
-        roleReplyCount: 1,
-        lastOutput: "",
-        lastError: "Waiting on approval",
-      },
-      {
-        scopeId: "scope-1",
-        serviceId: "default",
-        runId: "run-good",
-        actorId: "actor-intake-v1",
-        definitionActorId: "definition://support-triage-v1",
-        revisionId: "rev-1",
-        deploymentId: "dep-1",
-        workflowName: "support-triage-v1",
-        completionStatus: "completed",
-        stateVersion: 1,
-        lastEventId: "evt-1",
-        lastUpdatedAt: "2026-04-09T08:55:00Z",
-        boundAt: "2026-04-09T08:50:00Z",
-        bindingUpdatedAt: "2026-04-09T08:50:00Z",
-        lastSuccess: true,
-        totalSteps: 3,
-        completedSteps: 3,
-        roleReplyCount: 1,
-        lastOutput: "Resolved",
-        lastError: "",
-      },
-    ],
-  };
-}
-
-function mockCreateServiceRevisionCatalog(overrides?: Record<string, any>) {
-  return {
-    scopeId: "scope-1",
-    serviceId: "default",
-    serviceKey: "scope-1:default",
-    displayName: "Support Escalation Triage",
-    defaultServingRevisionId: "rev-2",
-    activeServingRevisionId: "rev-2",
-    deploymentId: "dep-2",
-    deploymentStatus: "Active",
-    primaryActorId: "actor-intake",
-    catalogStateVersion: 2,
-    catalogLastEventId: "evt-catalog-2",
-    updatedAt: "2026-04-09T09:00:00Z",
-    revisions: [
-      {
-        revisionId: "rev-2",
-        implementationKind: "workflow",
-        status: "Published",
-        artifactHash: "hash-2",
-        failureReason: "",
-        isDefaultServing: true,
-        isActiveServing: true,
-        isServingTarget: true,
-        allocationWeight: 100,
-        servingState: "Active",
-        deploymentId: "dep-2",
-        primaryActorId: "actor-intake",
-        createdAt: "2026-04-09T08:00:00Z",
-        preparedAt: "2026-04-09T08:01:00Z",
-        publishedAt: "2026-04-09T08:02:00Z",
-        retiredAt: null,
-        workflowName: "support-triage",
-        workflowDefinitionActorId: "definition://support-triage",
-        inlineWorkflowCount: 1,
-        scriptId: "",
-        scriptRevision: "",
-        scriptDefinitionActorId: "",
-        scriptSourceHash: "",
-        staticActorTypeName: "",
-      },
-      {
-        revisionId: "rev-1",
-        implementationKind: "workflow",
-        status: "Published",
-        artifactHash: "hash-1",
-        failureReason: "",
-        isDefaultServing: false,
-        isActiveServing: false,
-        isServingTarget: false,
-        allocationWeight: 0,
-        servingState: "",
-        deploymentId: "",
-        primaryActorId: "actor-intake-v1",
-        createdAt: "2026-04-08T08:00:00Z",
-        preparedAt: "2026-04-08T08:01:00Z",
-        publishedAt: "2026-04-08T08:02:00Z",
-        retiredAt: null,
-        workflowName: "support-triage-v1",
-        workflowDefinitionActorId: "definition://support-triage-v1",
-        inlineWorkflowCount: 1,
-        scriptId: "",
-        scriptRevision: "",
-        scriptDefinitionActorId: "",
-        scriptSourceHash: "",
-        staticActorTypeName: "",
-      },
-    ],
-    ...overrides,
-  };
-}
-
-function mockCreateMembersCatalog() {
-  return {
-    scopeId: "scope-1",
-    members: [
-      {
-        memberId: "member-support",
-        scopeId: "scope-1",
-        displayName: "Support Escalation Triage",
-        description: "负责处理升级工单",
-        implementationKind: "workflow",
-        lifecycleStage: "bind_ready",
-        publishedServiceId: "default",
-        lastBoundRevisionId: "rev-2",
-        createdAt: "2026-04-09T08:00:00Z",
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-    ],
-    nextPageToken: null,
-  };
-}
-
-function mockCreateRunAudit(scopeId: string, runId: string) {
-  return {
-    summary: {
-      scopeId,
-      serviceId: "default",
-      runId,
-      actorId: "actor-intake",
-      definitionActorId: "definition://support-triage",
-      revisionId: runId === "run-current" ? "rev-2" : "rev-1",
-      deploymentId: runId === "run-current" ? "dep-2" : "dep-1",
-      workflowName: "support-triage",
-      completionStatus: runId === "run-current" ? "waiting_approval" : "completed",
-      stateVersion: 2,
-      lastEventId: "evt-2",
-      lastUpdatedAt: "2026-04-09T09:05:00Z",
-      boundAt: "2026-04-09T09:00:00Z",
-      bindingUpdatedAt: "2026-04-09T09:00:00Z",
-      lastSuccess: runId !== "run-current",
-      totalSteps: 4,
-      completedSteps: runId === "run-current" ? 2 : 4,
-      roleReplyCount: 1,
-      lastOutput: runId === "run-current" ? "" : "Resolved",
-      lastError: runId === "run-current" ? "Waiting on approval" : "",
-    },
-    audit: {
-      reportVersion: "1",
-      projectionScope: "service",
-      topologySource: "audit",
-      completionStatus: runId === "run-current" ? "waiting_approval" : "completed",
-      workflowName: "support-triage",
-      rootActorId: "actor-intake",
-      commandId: "cmd-1",
-      stateVersion: 2,
-      lastEventId: "evt-2",
-      createdAt: "2026-04-09T09:00:00Z",
-      updatedAt: "2026-04-09T09:05:00Z",
-      startedAt: "2026-04-09T09:00:00Z",
-      endedAt: null,
-      durationMs: 1000,
-      success: runId !== "run-current",
-      input: "hello",
-      finalOutput: runId === "run-current" ? "" : "Resolved",
-      finalError: runId === "run-current" ? "Waiting on approval" : "",
-      topology:
-        runId === "run-current"
-          ? [
-              {
-                parent: "actor-intake",
-                child: "actor-risk",
-              },
-              {
-                parent: "actor-risk",
-                child: "actor-ops",
-              },
-            ]
-          : [
-              {
-                parent: "actor-intake-v1",
-                child: "actor-risk",
-              },
-            ],
-      steps: [
-        {
-          stepId: "risk_review",
-          stepType: runId === "run-current" ? "human_approval" : "llm_call",
-          targetRole: "operator",
-          requestedAt: "2026-04-09T09:01:00Z",
-          completedAt: runId === "run-current" ? null : "2026-04-09T09:02:00Z",
-          success: runId !== "run-current",
-          workerId: "actor-intake",
-          outputPreview: "",
-          error: "",
-          requestParameters: {},
-          completionAnnotations: {},
-          nextStepId: "",
-          branchKey: "",
-          assignedVariable: "",
-          assignedValue: "",
-          suspensionType: runId === "run-current" ? "human_approval" : "",
-          suspensionPrompt: runId === "run-current" ? "Approve escalation" : "",
-          suspensionTimeoutSeconds: null,
-          requestedVariableName: "",
-          durationMs: null,
-        },
-      ],
-      roleReplies:
-        runId === "run-current"
-          ? [
-              {
-                timestamp: "2026-04-09T09:02:30Z",
-                roleId: "operator",
-                sessionId: "session-1",
-                content: "Escalation needs approval from on-call.",
-                contentLength: 39,
-              },
-            ]
-          : [],
-      timeline:
-        runId === "run-current"
-          ? [
-              {
-                timestamp: "2026-04-09T09:01:30Z",
-                stage: "human_gate",
-                message: "Approval requested from operator",
-                agentId: "actor-intake",
-                stepId: "risk_review",
-                stepType: "human_approval",
-                eventType: "suspension_requested",
-                data: {},
-              },
-            ]
-          : [],
-      summary: {
-        totalSteps: 4,
-        requestedSteps: 2,
-        completedSteps: runId === "run-current" ? 2 : 4,
-        roleReplyCount: 1,
-        stepTypeCounts: {},
-      },
+    ...actual,
+    message: {
+      ...actual.message,
+      success: jest.fn(),
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+      destroy: jest.fn(),
     },
   };
-}
-
-jest.mock("@/shared/api/scopesApi", () => ({
-  scopesApi: {
-    listWorkflows: jest.fn(async () => [
-      {
-        scopeId: "scope-1",
-        workflowId: "workflow-1",
-        displayName: "Support Escalation Triage",
-        serviceKey: "scope-1:default",
-        workflowName: "support-triage",
-        actorId: "actor-intake",
-        activeRevisionId: "rev-2",
-        deploymentId: "dep-2",
-        deploymentStatus: "Active",
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-      {
-        scopeId: "scope-1",
-        workflowId: "workflow-2",
-        displayName: "Support Escalation Triage v1",
-        serviceKey: "scope-1:default",
-        workflowName: "support-triage-v1",
-        actorId: "actor-intake-v1",
-        activeRevisionId: "rev-1",
-        deploymentId: "dep-1",
-        deploymentStatus: "Retired",
-        updatedAt: "2026-04-08T09:00:00Z",
-      },
-    ]),
-    getWorkflowDetail: jest.fn(async () => ({
-      available: true,
-      scopeId: "scope-1",
-      workflow: {
-        scopeId: "scope-1",
-        workflowId: "workflow-1",
-        displayName: "Support Escalation Triage",
-        serviceKey: "scope-1:default",
-        workflowName: "support-triage",
-        actorId: "actor-intake",
-        activeRevisionId: "rev-2",
-        deploymentId: "dep-2",
-        deploymentStatus: "Active",
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-      source: {
-        workflowYaml: "name: support-triage",
-        definitionActorId: "definition://support-triage",
-        inlineWorkflowYamls: null,
-      },
-    })),
-    listScripts: jest.fn(async () => [
-      {
-        scriptId: "script-1",
-      },
-    ]),
-  },
-}));
-
-jest.mock("@/shared/api/servicesApi", () => ({
-  servicesApi: {
-    listServices: jest.fn(async () => [
-      {
-        serviceKey: "scope-1:default",
-        tenantId: "scope-1",
-        appId: "default",
-        namespace: "default",
-        serviceId: "default",
-        displayName: "Support Runtime",
-        defaultServingRevisionId: "rev-2",
-        activeServingRevisionId: "rev-2",
-        deploymentId: "dep-2",
-        primaryActorId: "actor-intake",
-        deploymentStatus: "Active",
-        endpoints: [],
-        policyIds: [],
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-    ]),
-  },
-}));
-
-jest.mock("@/shared/api/runtimeGAgentApi", () => ({
-  runtimeGAgentApi: {
-    listActors: jest.fn(async () => [
-      {
-        gAgentType: "IntakeAgent",
-        actorIds: ["actor-intake"],
-      },
-      {
-        gAgentType: "RiskReviewAgent",
-        actorIds: ["actor-risk"],
-      },
-    ]),
-  },
-}));
-
-jest.mock("@/shared/api/runtimeActorsApi", () => ({
-  runtimeActorsApi: {
-    getActorGraphEnriched: jest.fn(async () => ({
-      snapshot: {
-        actorId: "actor-intake",
-        workflowName: "support-triage",
-        lastCommandId: "cmd-1",
-        completionStatusValue: 1,
-        stateVersion: 2,
-        lastEventId: "evt-2",
-        lastUpdatedAt: "2026-04-09T09:05:00Z",
-        lastSuccess: false,
-        lastOutput: "",
-        lastError: "Waiting on approval",
-        totalSteps: 4,
-        requestedSteps: 2,
-        completedSteps: 2,
-        roleReplyCount: 1,
-      },
-      subgraph: {
-        rootNodeId: "actor-intake",
-        nodes: [
-          {
-            nodeId: "actor-intake",
-            nodeType: "actor",
-            updatedAt: "2026-04-09T09:05:00Z",
-            properties: {
-              role: "triage lead",
-            },
-          },
-          {
-            nodeId: "actor-risk",
-            nodeType: "actor",
-            updatedAt: "2026-04-09T09:05:00Z",
-            properties: {
-              role: "risk review",
-            },
-          },
-        ],
-        edges: [
-          {
-            edgeId: "edge-1",
-            fromNodeId: "actor-intake",
-            toNodeId: "actor-risk",
-            edgeType: "handoff",
-            updatedAt: "2026-04-09T09:05:00Z",
-            properties: {},
-          },
-        ],
-      },
-    })),
-  },
-}));
-
-jest.mock("@/shared/api/scopeRuntimeApi", () => ({
-  scopeRuntimeApi: {
-    getServiceRevisions: jest.fn(async () => mockCreateServiceRevisionCatalog()),
-    listMemberRuns: jest.fn(async () => mockCreateRunsCatalog()),
-    listServiceRuns: jest.fn(async () => mockCreateRunsCatalog()),
-    getMemberRunAudit: jest.fn(async (scopeId: string, _memberId: string, runId: string) =>
-      mockCreateRunAudit(scopeId, runId),
-    ),
-    getServiceRunAudit: jest.fn(async (scopeId: string, _serviceId: string, runId: string) =>
-      mockCreateRunAudit(scopeId, runId),
-    ),
-  },
-}));
+});
 
 jest.mock("@/shared/studio/api", () => ({
   studioApi: {
-    getScopeBinding: jest.fn(async () => ({
-      available: true,
-      scopeId: "scope-1",
-      serviceId: "default",
-      displayName: "Support Escalation Triage",
-      serviceKey: "scope-1:default",
-      defaultServingRevisionId: "rev-2",
-      activeServingRevisionId: "rev-2",
-      deploymentId: "dep-2",
-      deploymentStatus: "Active",
-      primaryActorId: "actor-intake",
-      updatedAt: "2026-04-09T09:00:00Z",
-      revisions: [
-        {
-          revisionId: "rev-2",
-          implementationKind: "workflow",
-          status: "Published",
-          artifactHash: "hash-2",
-          failureReason: "",
-          isDefaultServing: true,
-          isActiveServing: true,
-          isServingTarget: true,
-          allocationWeight: 100,
-          servingState: "Active",
-          deploymentId: "dep-2",
-          primaryActorId: "actor-intake",
-          createdAt: "2026-04-09T08:00:00Z",
-          preparedAt: "2026-04-09T08:01:00Z",
-          publishedAt: "2026-04-09T08:02:00Z",
-          retiredAt: null,
-          workflowName: "support-triage",
-          workflowDefinitionActorId: "definition://support-triage",
-          inlineWorkflowCount: 1,
-          scriptId: "",
-          scriptRevision: "",
-          scriptDefinitionActorId: "",
-          scriptSourceHash: "",
-          staticActorTypeName: "",
-        },
-        {
-          revisionId: "rev-1",
-          implementationKind: "workflow",
-          status: "Published",
-          artifactHash: "hash-1",
-          failureReason: "",
-          isDefaultServing: false,
-          isActiveServing: false,
-          isServingTarget: false,
-          allocationWeight: 0,
-          servingState: "",
-          deploymentId: "",
-          primaryActorId: "actor-intake-v1",
-          createdAt: "2026-04-08T08:00:00Z",
-          preparedAt: "2026-04-08T08:01:00Z",
-          publishedAt: "2026-04-08T08:02:00Z",
-          retiredAt: null,
-          workflowName: "support-triage-v1",
-          workflowDefinitionActorId: "definition://support-triage-v1",
-          inlineWorkflowCount: 1,
-          scriptId: "",
-          scriptRevision: "",
-          scriptDefinitionActorId: "",
-          scriptSourceHash: "",
-          staticActorTypeName: "",
-        },
-      ],
-    })),
-    getDefaultRouteTarget: jest.fn(async () => ({
-      available: true,
-      scopeId: "scope-1",
-      serviceId: "default",
-      displayName: "Support Escalation Triage",
-      serviceKey: "scope-1:default",
-      defaultServingRevisionId: "rev-2",
-      activeServingRevisionId: "rev-2",
-      deploymentId: "dep-2",
-      deploymentStatus: "Active",
-      primaryActorId: "actor-intake",
-      updatedAt: "2026-04-09T09:00:00Z",
-      revisions: [
-        {
-          revisionId: "rev-2",
-          implementationKind: "workflow",
-          status: "Published",
-          artifactHash: "hash-2",
-          failureReason: "",
-          isDefaultServing: true,
-          isActiveServing: true,
-          isServingTarget: true,
-          allocationWeight: 100,
-          servingState: "Active",
-          deploymentId: "dep-2",
-          primaryActorId: "actor-intake",
-          createdAt: "2026-04-09T08:00:00Z",
-          preparedAt: "2026-04-09T08:01:00Z",
-          publishedAt: "2026-04-09T08:02:00Z",
-          retiredAt: null,
-          workflowName: "support-triage",
-          workflowDefinitionActorId: "definition://support-triage",
-          inlineWorkflowCount: 1,
-          scriptId: "",
-          scriptRevision: "",
-          scriptDefinitionActorId: "",
-          scriptSourceHash: "",
-          staticActorTypeName: "",
-        },
-      ],
-    })),
-    getWorkspaceSettings: jest.fn(async () => ({
-      runtimeBaseUrl: "https://runtime.aevatar.test",
-      directories: [
-        {
-          directoryId: "default",
-          label: "Default",
-          path: "/tmp/workflows",
-          isBuiltIn: false,
-        },
-      ],
-    })),
-    getConnectorCatalog: jest.fn(async () => ({
-      homeDirectory: "actor://connector-catalog",
-      filePath: "actor://connector-catalog/connectors",
-      fileExists: true,
-      connectors: [
-        {
-          name: "web-search",
-          type: "http",
-          enabled: true,
-          timeoutMs: 30000,
-          retry: 1,
-          http: {
-            baseUrl: "https://search.example.com",
-            allowedMethods: ["GET"],
-            allowedPaths: ["/search"],
-            allowedInputKeys: ["query"],
-            defaultHeaders: {},
-          },
-        },
-        {
-          name: "ops-terminal",
-          type: "cli",
-          enabled: false,
-          timeoutMs: 30000,
-          retry: 0,
-          cli: {
-            command: "opsctl",
-            fixedArguments: ["tickets"],
-            allowedOperations: ["lookup"],
-            allowedInputKeys: ["ticket"],
-            workingDirectory: "/tmp",
-            environment: {},
-          },
-        },
-      ],
-    })),
-    listMembers: jest.fn(async () => mockCreateMembersCatalog()),
-    parseYaml: jest.fn(async () => ({
-      document: {
-        name: "support-triage",
-        roles: [
-          {
-            id: "triage_operator",
-            name: "triage_operator",
-            connectors: ["web-search", "crm-sync"],
-          },
-        ],
-      },
-      graph: null,
-      findings: [],
-    })),
+    listTeams: jest.fn(),
+    getMember: jest.fn(),
+    getTeam: jest.fn(),
+    listTeamMembers: jest.fn(),
+    listMembers: jest.fn(),
+    updateMemberTeam: jest.fn(),
+    createMember: jest.fn(),
+    updateTeam: jest.fn(),
+    archiveTeam: jest.fn(),
   },
 }));
 
+const teamRoster = {
+  scopeId: "scope-a",
+  teams: [
+    {
+      teamId: "team-support",
+      scopeId: "scope-a",
+      displayName: "Support Team",
+      description: "Handles inbound support requests",
+      lifecycleStage: "active",
+      memberCount: 2,
+      createdAt: "2026-04-30T08:00:00Z",
+      updatedAt: "2026-04-30T09:00:00Z",
+    },
+    {
+      teamId: "team-ops",
+      scopeId: "scope-a",
+      displayName: "Ops Team",
+      description: "Owns escalation follow-through",
+      lifecycleStage: "active",
+      memberCount: 1,
+      createdAt: "2026-04-30T08:10:00Z",
+      updatedAt: "2026-04-30T09:10:00Z",
+    },
+  ],
+  nextPageToken: null,
+};
+
+const teamSummary = {
+  teamId: "team-support",
+  scopeId: "scope-a",
+  displayName: "Support Team",
+  description: "Handles inbound support requests",
+  lifecycleStage: "active",
+  memberCount: 2,
+  createdAt: "2026-04-30T08:00:00Z",
+  updatedAt: "2026-04-30T09:00:00Z",
+};
+
+const teamMembers = {
+  scopeId: "scope-a",
+  members: [
+    {
+      memberId: "member-planner",
+      scopeId: "scope-a",
+      teamId: "team-support",
+      displayName: "Planner",
+      description: "Routes support issues",
+      implementationKind: "workflow",
+      lifecycleStage: "bind_ready",
+      publishedServiceId: "service-planner",
+      lastBoundRevisionId: "rev-1",
+      createdAt: "2026-04-30T08:00:00Z",
+      updatedAt: "2026-04-30T09:00:00Z",
+    },
+    {
+      memberId: "member-responder",
+      scopeId: "scope-a",
+      teamId: "team-support",
+      displayName: "Responder",
+      description: "Drafts answers",
+      implementationKind: "workflow",
+      lifecycleStage: "bind_ready",
+      publishedServiceId: "service-responder",
+      lastBoundRevisionId: "rev-2",
+      createdAt: "2026-04-30T08:10:00Z",
+      updatedAt: "2026-04-30T09:10:00Z",
+    },
+  ],
+  nextPageToken: null,
+};
+
+const allMembers = {
+  scopeId: "scope-a",
+  members: [
+    ...teamMembers.members,
+    {
+      memberId: "member-floater",
+      scopeId: "scope-a",
+      teamId: null,
+      displayName: "Floater",
+      description: "Unassigned helper",
+      implementationKind: "workflow",
+      lifecycleStage: "created",
+      publishedServiceId: "",
+      lastBoundRevisionId: null,
+      createdAt: "2026-04-30T08:20:00Z",
+      updatedAt: "2026-04-30T09:20:00Z",
+    },
+  ],
+  nextPageToken: null,
+};
+
 describe("TeamDetailPage", () => {
   beforeEach(() => {
-    window.history.replaceState({}, "", "/teams/scope-1?scopeId=scope-1");
-    (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockReset();
-    (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockImplementation(
-      async () => mockCreateServiceRevisionCatalog(),
-    );
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockReset();
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockImplementation(
-      async () => mockCreateRunsCatalog(),
-    );
-    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockReset();
-    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockImplementation(
-      async () => mockCreateRunsCatalog(),
-    );
-    (scopeRuntimeApi.getMemberRunAudit as jest.Mock).mockReset();
-    (scopeRuntimeApi.getMemberRunAudit as jest.Mock).mockImplementation(
-      async (scopeId: string, _memberId: string, runId: string) =>
-        mockCreateRunAudit(scopeId, runId),
-    );
-    (scopeRuntimeApi.getServiceRunAudit as jest.Mock).mockReset();
-    (scopeRuntimeApi.getServiceRunAudit as jest.Mock).mockImplementation(
-      async (scopeId: string, _serviceId: string, runId: string) =>
-        mockCreateRunAudit(scopeId, runId),
-    );
-    (studioApi.listMembers as jest.Mock).mockReset();
-    (studioApi.listMembers as jest.Mock).mockImplementation(
-      async () => mockCreateMembersCatalog(),
-    );
-  });
+    window.history.replaceState({}, "", "/teams/scope-a?teamId=team-support");
+    jest.clearAllMocks();
 
-  it("renders the chinese team-first overview shell", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(
-      await screen.findByText((_, node) => {
-        return node?.textContent === "Aevatar / Teams / 团队详情 / 概览";
-      }),
-    ).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Aevatar" })).toBeTruthy();
-    expect(screen.getByRole("link", { name: "Teams" })).toBeTruthy();
-    expect(screen.getByText("scopeId")).toBeTruthy();
-    expect(screen.getByText("scope-1")).toBeTruthy();
-    const currentPostureHeading = screen.getByText("当前态势");
-    const trustHeading = screen.getByText("信任态势");
-    const governanceHeading = screen.getByText("治理快照");
-    const compareHeading = screen.getByText("Run Compare / Change Diff");
-    expect(screen.getByText("团队构成")).toBeTruthy();
-    expect(screen.getByText("运行摘要")).toBeTruthy();
-    expect(currentPostureHeading).toBeTruthy();
-    expect(trustHeading).toBeTruthy();
-    expect(
-      await screen.findByText("Comparing run run-current against baseline run-good."),
-    ).toBeTruthy();
-    expect(screen.getByText("需要人工处理后继续")).toBeTruthy();
-    expect(screen.getByText("等待人工")).toBeTruthy();
-    expect(governanceHeading).toBeTruthy();
-    expect(compareHeading).toBeTruthy();
-    expect(
-      currentPostureHeading.compareDocumentPosition(trustHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      governanceHeading.compareDocumentPosition(compareHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(screen.getByText("Runtime deltas")).toBeTruthy();
-    expect(await screen.findByText("Step deltas")).toBeTruthy();
-    expect(await screen.findByText("Handoff deltas")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "本次对话" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "服务映射" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "高级编辑" })).toBeTruthy();
-  });
-
-  it("keeps compare honest when no successful baseline exists", async () => {
-    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockResolvedValueOnce({
-      ...mockCreateRunsCatalog(),
-      runs: [mockCreateRunsCatalog().runs[0]],
+    (studioApi.listTeams as jest.Mock).mockResolvedValue(teamRoster);
+    (studioApi.getTeam as jest.Mock).mockResolvedValue(teamSummary);
+    (studioApi.listTeamMembers as jest.Mock).mockResolvedValue(teamMembers);
+    (studioApi.listMembers as jest.Mock).mockResolvedValue(allMembers);
+    (studioApi.getMember as jest.Mock).mockResolvedValue({
+      summary: teamMembers.members[0],
+      implementationRef: null,
+      lastBinding: null,
     });
+    (studioApi.updateMemberTeam as jest.Mock).mockResolvedValue({
+      summary: teamMembers.members[0],
+      implementationRef: null,
+      lastBinding: null,
+    });
+    (studioApi.createMember as jest.Mock).mockResolvedValue(teamMembers.members[0]);
+    (studioApi.updateTeam as jest.Mock).mockResolvedValue(teamSummary);
+    (studioApi.archiveTeam as jest.Mock).mockResolvedValue({
+      ...teamSummary,
+      lifecycleStage: "archived",
+    });
+  });
 
+  it("renders team summary and member management around the backend team endpoints", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("信任态势")).toBeTruthy();
+    expect(await screen.findByText("Support Team")).toBeTruthy();
+    expect(screen.getByText("Team Summary")).toBeTruthy();
+    expect(screen.getAllByText("Planner").length).toBeGreaterThan(0);
     expect(
-      (await screen.findAllByText("No successful baseline is available yet.")).length,
+      screen.getAllByText("Handles inbound support requests").length,
     ).toBeGreaterThan(0);
-    expect(screen.getByText("等待基线")).toBeTruthy();
-    expect(screen.getByText("无基线")).toBeTruthy();
-    expect(screen.getByText("暂无成功基线运行")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "Open in Studio" }).length).toBe(2);
+    expect(screen.getAllByRole("button", { name: "Remove from Team" }).length).toBe(2);
+    expect(screen.getByText("Create Member In This Team")).toBeTruthy();
+    expect(screen.getByText("Add Existing Member")).toBeTruthy();
   });
 
-  it("keeps selected run facts aligned without inventing a failed baseline", async () => {
-    window.history.replaceState(
-      {},
-      "",
-      "/teams/scope-1?scopeId=scope-1&runId=run-good",
-    );
-
+  it("creates a new member directly inside the current team", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(
-      (await screen.findAllByText("No successful baseline is available yet.")).length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.queryByText("Comparing run run-current against baseline run-good."),
-    ).toBeNull();
+    fireEvent.change(await screen.findByLabelText("New Member Display Name"), {
+      target: { value: "Analyst" },
+    });
+    fireEvent.change(screen.getByLabelText("New Member ID"), {
+      target: { value: "member-analyst" },
+    });
+    fireEvent.change(screen.getByLabelText("New Member Description"), {
+      target: { value: "Checks support tickets before execution" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Member" }));
 
     await waitFor(() => {
-      const auditedRunIds = (scopeRuntimeApi.getServiceRunAudit as jest.Mock).mock.calls.map(
-        (call) => call[2],
-      );
-      expect(auditedRunIds).toContain("run-good");
-      expect(auditedRunIds).not.toContain("run-current");
-    });
-  });
-
-  it("prefers the explicit workflow display name for the team heading", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(
-      await screen.findByRole("heading", {
-        level: 1,
-        name: "Support Escalation Triage",
-      }),
-    ).toBeTruthy();
-  });
-
-  it("demotes machine-generated long scope ids into compact team metadata", async () => {
-    const longScopeId = "1626c177-917b-4fcc-a5ee-aa74a171b0d6";
-
-    window.history.replaceState(
-      {},
-      "",
-      `/teams/${longScopeId}?scopeId=${longScopeId}`,
-    );
-    (scopesApi.listWorkflows as jest.Mock).mockResolvedValueOnce([]);
-    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
-
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(
-      await screen.findByRole("heading", { level: 1, name: "当前团队" }),
-    ).toBeTruthy();
-    expect(screen.queryByText(`Team ${longScopeId}`)).toBeNull();
-    expect(screen.getByText("scopeId")).toBeTruthy();
-    expect(screen.getByText("1626c177...71b0d6")).toBeTruthy();
-  });
-
-  it("falls back to workflowName when the scope display name is only the workflow id", async () => {
-    (scopesApi.listWorkflows as jest.Mock).mockResolvedValueOnce([
-      {
-        scopeId: "scope-1",
-        workflowId: "workflow-opaque-id",
-        displayName: "workflow-opaque-id",
-        serviceKey: "scope-1:default",
-        workflowName: "support-triage",
-        actorId: "actor-intake",
-        activeRevisionId: "rev-2",
-        deploymentId: "dep-2",
-        deploymentStatus: "Active",
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-    ]);
-    (scopesApi.getWorkflowDetail as jest.Mock).mockResolvedValueOnce({
-      available: true,
-      scopeId: "scope-1",
-      workflow: {
-        scopeId: "scope-1",
-        workflowId: "workflow-opaque-id",
-        displayName: "workflow-opaque-id",
-        serviceKey: "scope-1:default",
-        workflowName: "support-triage",
-        actorId: "actor-intake",
-        activeRevisionId: "rev-2",
-        deploymentId: "dep-2",
-        deploymentStatus: "Active",
-        updatedAt: "2026-04-09T09:00:00Z",
-      },
-      source: {
-        workflowYaml: "name: support-triage",
-        definitionActorId: "definition://support-triage",
-        inlineWorkflowYamls: null,
-      },
+      expect(studioApi.createMember).toHaveBeenCalledWith({
+        scopeId: "scope-a",
+        teamId: "team-support",
+        displayName: "Analyst",
+        description: "Checks support tickets before execution",
+        implementationKind: "workflow",
+        memberId: "member-analyst",
+      });
     });
 
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(
-      await screen.findByRole("heading", {
-        level: 1,
-        name: "support-triage",
-      }),
-    ).toBeTruthy();
-    expect(
-      screen.queryByRole("heading", {
-        level: 1,
-        name: "workflow-opaque-id",
-      }),
-    ).toBeNull();
+    expect(message.success).toHaveBeenCalledWith("成员已创建并加入团队。");
   });
 
-  it("shows full raw identifiers inside overview tooltips", async () => {
-    const longRevisionId =
-      "rev-20260414154556-4d89bc2a3bf347f8b3bde41d716964f3";
-
-    (scopeRuntimeApi.getServiceRevisions as jest.Mock).mockResolvedValueOnce(
-      mockCreateServiceRevisionCatalog({
-        defaultServingRevisionId: longRevisionId,
-        activeServingRevisionId: longRevisionId,
-        revisions: [
-          {
-            ...mockCreateServiceRevisionCatalog().revisions[0],
-            revisionId: longRevisionId,
-          },
-        ],
-      }),
-    );
-
+  it("assigns an existing member into the current team", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByText("运行摘要");
-
-    const revisionNote = await screen.findByText(/revisionId ·/);
-
-    fireEvent.mouseEnter(revisionNote);
-
-    expect(await screen.findByText(`revisionId · ${longRevisionId}`)).toBeTruthy();
-  });
-
-  it("returns to the teams list when clicking the breadcrumb teams link", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("link", { name: "Teams" }));
+    await screen.findByRole("option", {
+      name: "Floater · member-floater · currently unassigned",
+    });
+    fireEvent.change(await screen.findByLabelText("Existing Member Selector"), {
+      target: { value: "member-floater" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Member" }));
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/teams");
-      expect(window.location.search).toContain("scopeId=scope-1");
-    });
-  });
-
-  it("returns to the teams list when clicking the breadcrumb aevatar link", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("link", { name: "Aevatar" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/teams");
-      expect(window.location.search).toContain("scopeId=scope-1");
-    });
-  });
-
-  it("switches tabs inside the detail page", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "Bindings" }));
-
-    expect(await screen.findByText("当前绑定与治理摘要")).toBeTruthy();
-    expect(screen.getByText("Bindings 与连接能力")).toBeTruthy();
-    expect(screen.getByText("当前选中绑定")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "选择绑定 web-search" })).toBeTruthy();
-    expect(window.location.search).toContain("tab=bindings");
-    expect(window.location.search).not.toContain("step=bind");
-  });
-
-  it("canonicalizes legacy service deep links into member-first detail routes", async () => {
-    window.history.replaceState(
-      {},
-      "",
-      "/teams/scope-1?scopeId=scope-1&serviceId=default&tab=events",
-    );
-
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(await screen.findByText("当前任务事件流")).toBeTruthy();
-
-    await waitFor(() => {
-      const params = new URLSearchParams(window.location.search);
-      expect(params.get("memberId")).toBe("member-support");
-      expect(params.get("serviceId")).toBe("default");
-      expect(params.get("tab")).toBe("events");
-    });
-
-    await waitFor(() => {
-      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledWith(
-        "scope-1",
-        "member-support",
-        expect.objectContaining({ take: 12 }),
+      expect(studioApi.updateMemberTeam).toHaveBeenCalledWith(
+        "scope-a",
+        "member-floater",
+        "team-support",
       );
     });
   });
 
-  it("shows the team asset view with workflow and script entries", async () => {
+  it("removes a member from the current team", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "Assets" }));
-
-    expect(await screen.findByText("当前 Team 资产")).toBeTruthy();
-    expect(screen.getAllByText("Workflow 资产").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Script 资产").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "打开 workflow Support Escalation Triage" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "打开 script script-1" })).toBeTruthy();
-  });
-
-  it("shows a team-first configuration view", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "配置" }));
-
-    expect(await screen.findByText("当前配置主线")).toBeTruthy();
-    expect(screen.getByText("当前配置明细")).toBeTruthy();
-    expect(screen.getByText("继续调整这支团队")).toBeTruthy();
-    expect(screen.getAllByText("绑定方式").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("连接器引用").length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("button", { name: "高级编辑" }).length).toBeGreaterThan(0);
-  });
-
-  it("shows a readable team members view", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
-
-    expect(await screen.findByText("参与者结构")).toBeTruthy();
-    expect(screen.getByText("运行时参与者身份")).toBeTruthy();
-    expect(screen.getByText("当前焦点")).toBeTruthy();
-    expect(screen.getByText("可见 Actor")).toBeTruthy();
-    expect(screen.getAllByText("actorId").length).toBeGreaterThan(0);
-    expect(screen.getByText("actor-intake")).toBeTruthy();
-    expect(screen.getAllByText("serviceId").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("default").length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "打开 Services" })).toBeTruthy();
-  });
-
-  it("shows a team-first event stream with member mapping", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件流" }));
-
-    expect(await screen.findByText("当前任务事件流")).toBeTruthy();
-    expect(screen.getByText("本次 Run 成员映射")).toBeTruthy();
-    expect(await screen.findByText("切换 Run")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "运行记录" }).length).toBeGreaterThan(0);
-    expect((await screen.findAllByText(/risk_review/)).length).toBeGreaterThan(0);
-  });
-
-  it("switches runs inside the event stream", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件流" }));
-    await screen.findByText("当前任务事件流");
-
-    fireEvent.click(await screen.findByRole("button", { name: "切换到 run-good" }));
+    const removeButtons = await screen.findAllByRole("button", {
+      name: "Remove from Team",
+    });
+    fireEvent.click(removeButtons[1]);
 
     await waitFor(() => {
-      expect(window.location.search).toContain("runId=run-good");
+      expect(studioApi.updateMemberTeam).toHaveBeenCalledWith(
+        "scope-a",
+        "member-planner",
+        null,
+      );
     });
-    expect(await screen.findByText("LLM_CALL")).toBeTruthy();
   });
 
-  it("syncs tab and run state when the route changes after mount", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-
-    act(() => {
-      history.push("/teams/scope-1?scopeId=scope-1&tab=events&runId=run-good");
-    });
-
-    expect(await screen.findByText("当前任务事件流")).toBeTruthy();
-    expect(await screen.findByText("LLM_CALL")).toBeTruthy();
-  });
-
-  it("surfaces team signal failures without leaking raw runtime errors", async () => {
-    (scopeRuntimeApi.listServiceRuns as jest.Mock).mockRejectedValueOnce(
-      new Error("No stub for /api/scopes/scope-1/services/default/runs"),
-    );
+  it("resolves old member-first deep links into canonical team routes", async () => {
+    window.history.replaceState({}, "", "/teams/scope-a?memberId=member-planner");
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(await screen.findByRole("button", { name: "服务映射" })).toBeTruthy();
-    expect(screen.queryByText("部分团队信号暂不可用")).toBeNull();
-    expect(screen.queryByText("最近团队运行信号暂时无法加载。")).toBeNull();
-    expect(
-      screen.queryByText("No stub for /api/scopes/scope-1/services/default/runs"),
-    ).toBeNull();
-  });
-
-  it("opens a playback run replay with observed session context", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件流" }));
-    await screen.findAllByText(/risk_review/);
-    fireEvent.click(screen.getAllByRole("button", { name: "本次对话" })[0]);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe("/runtime/runs");
+      expect(new URLSearchParams(window.location.search).get("teamId")).toBe(
+        "team-support",
+      );
     });
-    const draftKey = new URLSearchParams(window.location.search).get("draftKey");
-    expect(draftKey).toBeTruthy();
-    expect(loadDraftRunPayload(draftKey)).toMatchObject({
-      kind: "observed_run_session",
-      actorId: "actor-intake",
-      endpointId: "chat",
-      routeName: "support-triage",
-      runId: "run-current",
-      scopeId: "scope-1",
-      serviceOverrideId: "default",
-    });
-  });
 
-  it("opens runtime explorer from the service mapping action", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件拓扑" }));
-    await screen.findByText("团队事件路径");
-    fireEvent.click(screen.getAllByRole("button", { name: "服务映射" })[0]);
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/runtime/explorer/detail");
-    });
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("actorId")).toBe("actor-intake");
-    expect(params.get("runId")).toBe("run-current");
-    expect(params.get("scopeId")).toBe("scope-1");
-    expect(params.get("serviceId")).toBe("default");
-  });
-
-  it("opens Mission Control from the team event stream with run context", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件流" }));
-    await screen.findByText("当前任务事件流");
-    await screen.findByText(/Current playback is centered on risk_review/);
-    fireEvent.click(await screen.findByRole("button", { name: "打开 Mission Control" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/runtime/mission-control");
-    });
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("actorId")).toBe("actor-intake");
-    expect(params.get("autoStream")).toBe("true");
-    expect(params.get("prompt")).toBe("hello");
-    expect(params.get("runId")).toBe("run-current");
-    expect(params.get("scopeId")).toBe("scope-1");
-    expect(params.get("serviceId")).toBe("default");
-  });
-
-  it("updates the topology depth selection when the focus member is available", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件拓扑" }));
-    await screen.findByText("团队事件路径");
-
-    const nearButton = screen.getByRole("button", { name: "近邻" });
-    const expandButton = screen.getByRole("button", { name: "扩展" });
-    const panoramaButton = screen.getByRole("button", { name: "全景" });
-
-    expect(expandButton).toHaveAttribute("aria-pressed", "true");
-    expect(nearButton).toHaveAttribute("aria-pressed", "false");
-    expect(panoramaButton).toHaveAttribute("aria-pressed", "false");
-
-    fireEvent.click(panoramaButton);
-
-    expect(panoramaButton).toHaveAttribute("aria-pressed", "true");
-    expect(expandButton).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("disables topology controls when the current team has no focus member yet", async () => {
-    (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce({
-      available: false,
-      scopeId: "scope-1",
-      serviceId: "",
-      displayName: "",
-      serviceKey: "",
-      defaultServingRevisionId: "",
-      activeServingRevisionId: "",
-      deploymentId: "",
-      deploymentStatus: "",
-      primaryActorId: "",
-      updatedAt: "2026-04-09T09:00:00Z",
-      revisions: [],
-    });
-    (servicesApi.listServices as jest.Mock).mockResolvedValueOnce([]);
-    (runtimeGAgentApi.listActors as jest.Mock).mockResolvedValueOnce([]);
-
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "事件拓扑" }));
-    await screen.findByText("团队事件路径");
-
-    expect(
-      screen.getByText("当前还没有可用的团队成员焦点，待成员或运行信号可见后再切换视角。"),
-    ).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "服务映射" })[0]).toBeDisabled();
-    expect(screen.getByRole("button", { name: "近邻" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "扩展" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "全景" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "打开平台拓扑" })).toBeDisabled();
-    expect(
-      screen.getByText("当前还没有可用的团队成员焦点，所以暂时没有可展开的事件拓扑关系。"),
-    ).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "配置" }));
-    expect(await screen.findByText("继续调整这支团队")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "服务映射" })[0]).toBeDisabled();
-  });
-
-  it("opens platform workbenches from members and bindings", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
-    await screen.findByText("运行时参与者身份");
-    fireEvent.click(screen.getByRole("button", { name: "打开 Services" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/services");
-    });
-    expect(window.location.search).toContain("tenantId=scope-1");
-    expect(window.location.search).toContain("serviceId=default");
-
-    cleanup();
-    window.history.replaceState({}, "", "/teams/scope-1?scopeId=scope-1");
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "Bindings" }));
-    await screen.findByText("当前绑定与治理摘要");
-    fireEvent.click(screen.getByRole("button", { name: "打开 Governance" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/governance");
-    });
-    expect(window.location.search).toContain("serviceId=default");
-    expect(window.location.search).toContain("view=bindings");
-  });
-
-  it("opens Studio in the current team context from the top actions", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    await screen.findByText("Support Escalation Triage");
-    fireEvent.click(screen.getByRole("button", { name: "高级编辑" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/studio");
-    });
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("scopeId")).toBe("scope-1");
-    expect(params.get("member")).toBe("workflow:workflow-1");
-    expect(params.get("memberId")).toBeNull();
-    expect(params.get("focus")).toBeNull();
-    expect(params.get("tab")).toBe("studio");
-  });
-
-  it("opens workflow and script Studio deep links from assets with scope context", async () => {
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByRole("button", { name: "服务映射" });
-    fireEvent.click(screen.getByRole("button", { name: "Assets" }));
-    await screen.findByText("当前 Team 资产");
-
-    fireEvent.click(screen.getByRole("button", { name: "打开 workflow Support Escalation Triage" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/studio");
-    });
-    expect(window.location.search).toContain("scopeId=scope-1");
-    expect(window.location.search).toContain("member=workflow%3Aworkflow-1");
-    expect(window.location.search).not.toContain(
-      "focus=workflow%3Aworkflow-1",
-    );
-
-    cleanup();
-    window.history.replaceState({}, "", "/teams/scope-1?scopeId=scope-1&tab=assets");
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    await screen.findByText("当前 Team 资产");
-    fireEvent.click(await screen.findByRole("button", { name: "打开 script script-1" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/studio");
-    });
-    expect(window.location.search).toContain("scopeId=scope-1");
-    expect(window.location.search).toContain("member=script%3Ascript-1");
-    expect(window.location.search).not.toContain("focus=script%3Ascript-1");
-    expect(window.location.search).toContain("tab=scripts");
-  });
-
-  it("drops stale service and run hints in favor of the requested workflow truth", async () => {
-    window.history.replaceState(
-      {},
-      "",
-      "/teams/scope-1?workflowId=workflow-1&serviceId=stale-service&runId=stale-run",
-    );
-
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(await screen.findByText("Support Escalation Triage")).toBeTruthy();
-    expect(screen.queryByText("路由上下文已自动校正")).toBeNull();
-  });
-
-  it("falls back gracefully when the requested workflow is no longer visible", async () => {
-    window.history.replaceState(
-      {},
-      "",
-      "/teams/scope-1?workflowId=workflow-missing",
-    );
-
-    renderWithQueryClient(React.createElement(TeamDetailPage));
-
-    expect(
-      await screen.findByRole("heading", { level: 1, name: "当前团队" }),
-    ).toBeTruthy();
-    expect(screen.queryByText("路由上下文已自动校正")).toBeNull();
+    expect(studioApi.getMember).toHaveBeenCalledWith("scope-a", "member-planner");
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -1,3665 +1,815 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  type AGUIEvent,
-  AGUIEventType,
-  CustomEventName,
-} from "@aevatar-react-sdk/types";
-import {
-  BranchesOutlined,
-  DeploymentUnitOutlined,
-} from "@ant-design/icons";
-import type { Edge, Node } from "@xyflow/react";
-import { Button, Space, Tooltip, Typography, theme } from "antd";
-import { useQuery } from "@tanstack/react-query";
+  Alert,
+  Button,
+  Empty,
+  Input,
+  Space,
+  Tag,
+  Typography,
+  message,
+} from "antd";
 import React from "react";
-import { scopesApi } from "@/shared/api/scopesApi";
+import { formatCompactDateTime } from "@/shared/datetime/dateTime";
 import {
-  formatCompactDateTime,
-  formatTimeOnly,
-} from "@/shared/datetime/dateTime";
-import GraphCanvas from "@/shared/graphs/GraphCanvas";
-import { buildActorGraphElements } from "@/shared/graphs/buildGraphElements";
-import {
-  getLocationSnapshot,
   history,
   subscribeToLocationChanges,
 } from "@/shared/navigation/history";
 import {
-  buildPlatformDeploymentsHref,
-  buildPlatformGovernanceHref,
-  buildPlatformServicesHref,
-} from "@/shared/navigation/platformRoutes";
-import { buildScopeHref } from "@/shared/navigation/scopeRoutes";
-import {
   buildTeamDetailHref,
   readTeamDetailRouteState,
-  type TeamDetailTab,
 } from "@/shared/navigation/teamRoutes";
-import {
-  buildRuntimeExplorerHref,
-  buildRuntimeMissionControlHref,
-  buildRuntimeRunsHref,
-} from "@/shared/navigation/runtimeRoutes";
-import { saveObservedRunSessionPayload } from "@/shared/runs/draftRunSession";
 import { studioApi } from "@/shared/studio/api";
 import {
-  buildStudioWorkflowMemberKey,
-  buildStudioScriptsWorkspaceRoute,
-  buildStudioWorkflowEditorRoute,
-  buildStudioWorkflowWorkspaceRoute,
-} from "@/shared/studio/navigation";
-import type { StudioWorkflowDocument } from "@/shared/studio/models";
-import {
-  AevatarInspectorEmpty,
-  AevatarPanel,
-} from "@/shared/ui/aevatarPageShells";
+  formatStudioMemberLifecycleStage,
+  formatStudioTeamLifecycleStage,
+  type StudioMemberImplementationKind,
+  type StudioMemberSummary,
+} from "@/shared/studio/models";
+import { buildStudioRoute } from "@/shared/studio/navigation";
+import { AevatarPanel } from "@/shared/ui/aevatarPageShells";
 import { AevatarCompactText } from "@/shared/ui/compactText";
-import {
-  TeamActionRail,
-  TeamDetailEmptyState,
-  TeamDetailShell,
-  type TeamTabOption,
-} from "./components/TeamDetailChrome";
-import {
-  DetailPill,
-  FactLine,
-  factValueFontFamily,
-  SignalCard,
-} from "./components/TeamDetailPrimitives";
-import TeamAdvancedTab from "./tabs/TeamAdvancedTab";
-import TeamAssetsTab, { teamAssetIcons } from "./tabs/TeamAssetsTab";
-import TeamBindingsTab from "./tabs/TeamBindingsTab";
-import TeamEventsTab from "./tabs/TeamEventsTab";
-import TeamMembersTab from "./tabs/TeamMembersTab";
-import TeamOverviewTab from "./tabs/TeamOverviewTab";
-import TeamTopologyTab from "./tabs/TeamTopologyTab";
-import { resolveWorkflowOperationalUnit } from "./workflowOperationalUnits";
-import {
-  deriveTeamIntegrationsSummary,
-  deriveTeamWorkflowRoleBindings,
-} from "./runtime/teamIntegrations";
-import type {
-  TeamHealthStatus,
-  TeamHealthTone,
-  TeamPlaybackSummary,
-} from "./runtime/teamRuntimeLens";
-import { useTeamRuntimeLens } from "./runtime/useTeamRuntimeLens";
+import ConsoleMetricCard from "@/shared/ui/ConsoleMetricCard";
+import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
+import { describeError } from "@/shared/ui/errorText";
+import { buildScopeHref } from "../scopes/components/scopeQuery";
 
-type ObservationStatus = "live" | "delayed" | "partial" | "unavailable";
-
-type ObservationBadge = {
-  label: string;
-  status: ObservationStatus;
-};
-
-type TeamCompositionRow = {
-  key: string;
-  name: string;
-  summary: string;
-  kind: string;
-};
-
-type TopologyNodeKind = "actor" | "connector" | "service";
-
-type TopologyEntitySummary = {
-  badgeText: string;
-  badgeTone: PillTone;
-  id: string;
-  kind: TopologyNodeKind;
-  note: string;
-  summary: string;
-  title: string;
-};
-
-type TopologyDetailRow = {
-  badge: string;
-  label: string;
-  note: string;
-  noteMonospace?: boolean;
-  noteRows?: number;
-  value: string;
-  valueMonospace?: boolean;
-  valueRows?: number;
-};
-
-type MemberLike = {
-  actorId: string;
-  actorType: string;
-};
-
-function trimText(value: string | null | undefined): string {
+function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
 
-function resolveTeamHeading(input: {
-  displayName?: string | null;
-  lensTitle?: string | null;
-  scopeId: string | null | undefined;
-  workflowId?: string | null;
-  workflowName?: string | null;
-}): {
-  metaScopeId?: string;
-  title: string;
-} {
-  const normalizedScopeId = trimText(input.scopeId);
-  const normalizedDisplayName = trimText(input.displayName);
-  const normalizedWorkflowId = trimText(input.workflowId);
-  const normalizedWorkflowName = trimText(input.workflowName);
-  const normalizedLensTitle = trimText(input.lensTitle);
-
-  if (
-    normalizedDisplayName &&
-    normalizedDisplayName !== normalizedWorkflowId
-  ) {
-    return {
-      title: normalizedDisplayName,
-    };
+function readRouteState() {
+  if (typeof window === "undefined") {
+    return readTeamDetailRouteState("", "");
   }
 
-  if (
-    normalizedWorkflowName &&
-    normalizedWorkflowName !== normalizedWorkflowId
-  ) {
-    return {
-      title: normalizedWorkflowName,
-    };
-  }
-
-  const genericLensTitle =
-    normalizedScopeId ? `Team ${normalizedScopeId}` : "";
-  if (normalizedLensTitle === "当前团队") {
-    return {
-      metaScopeId: normalizedScopeId || undefined,
-      title: normalizedLensTitle,
-    };
-  }
-
-  if (
-    normalizedLensTitle &&
-    normalizedLensTitle !== normalizedScopeId &&
-    normalizedLensTitle !== genericLensTitle
-  ) {
-    return {
-      title: normalizedLensTitle,
-    };
-  }
-
-  return {
-    metaScopeId: normalizedScopeId || undefined,
-    title: "团队详情",
-  };
+  return readTeamDetailRouteState(window.location.search, window.location.pathname);
 }
 
-function compactId(value: string | null | undefined): string {
-  const normalized = trimText(value);
-  if (!normalized) {
-    return "n/a";
-  }
-
-  const segment = normalized.split("/").pop() || normalized;
-  const compacted = segment.split(":").pop() || segment;
-  return compacted.length > 24
-    ? `${compacted.slice(0, 12)}…${compacted.slice(-8)}`
-    : compacted;
-}
-
-function formatTeamTabLabel(tab: TeamDetailTab): string {
-  switch (tab) {
-    case "topology":
-      return "事件拓扑";
-    case "events":
-      return "事件流";
-    case "members":
-      return "团队成员";
-    case "bindings":
-      return "Bindings";
-    case "assets":
-      return "Assets";
-    case "advanced":
-      return "配置";
-    default:
-      return "概览";
-  }
-}
-
-function normalizeStatus(value: string | null | undefined): string {
-  return trimText(value).toLowerCase();
-}
-
-function formatFriendlyStatus(value: string | null | undefined): string {
-  const normalized = normalizeStatus(value);
-  if (!normalized) {
-    return "--";
-  }
-
-  switch (normalized) {
-    case "active":
-    case "running":
-    case "processing":
-      return "运行中";
-    case "published":
-      return "已发布";
-    case "default":
-      return "默认版本";
-    case "completed":
-    case "finished":
-    case "succeeded":
-    case "success":
-      return "已完成";
-    case "draft":
-      return "草稿";
-    case "retired":
-      return "已停用";
-    case "failed":
-    case "error":
-    case "cancelled":
-    case "degraded":
-      return "运行异常";
-    case "waiting":
-    case "waiting_signal":
-    case "waiting_approval":
-    case "human_input":
-    case "human_approval":
-    case "suspended":
-    case "blocked":
-      return "等待处理";
-    default:
-      return trimText(value) || "--";
-  }
-}
-
-type MemberPresenceKind = "focus" | "run" | "visible";
-
-function formatMemberPresenceLabel(kind: MemberPresenceKind): string {
-  switch (kind) {
-    case "focus":
-      return "当前焦点";
-    case "run":
-      return "参与本次 Run";
-    default:
-      return "可见 Actor";
-  }
-}
-
-function resolveMemberPresenceTone(kind: MemberPresenceKind): PillTone {
-  switch (kind) {
-    case "focus":
-      return "info";
-    case "run":
-      return "success";
-    default:
-      return "neutral";
-  }
-}
-
-function formatCompositionKind(kind: string): string {
-  switch (normalizeStatus(kind)) {
-    case "workflow role":
-      return "角色";
+function formatMemberImplementation(value: StudioMemberImplementationKind): string {
+  switch (value) {
     case "workflow":
-      return "流程";
-    case "service":
-      return "服务";
-    case "actor":
-      return "Actor";
-    case "runtime":
-      return "运行";
+      return "Workflow";
     case "script":
-      return "脚本";
+      return "Script";
     case "gagent":
-      return "Agent";
+      return "GAgent";
     default:
-      return kind || "--";
+      return "Unknown";
   }
 }
 
-function formatConnectorTypeLabel(kind: string): string {
-  switch (normalizeStatus(kind)) {
-    case "http":
-      return "HTTP API";
-    case "cli":
-      return "CLI";
-    case "mcp":
-      return "MCP";
-    default:
-      return kind || "--";
-  }
-}
-
-function formatConnectorEnabledLabel(enabled: boolean): string {
-  return enabled ? "可用" : "停用";
-}
-
-function formatObservationLabel(status: ObservationStatus): string {
-  switch (status) {
-    case "live":
-      return "实时";
-    case "delayed":
-      return "稍有延迟";
-    case "partial":
-      return "部分可见";
-    default:
-      return "暂不可用";
-  }
-}
-
-function formatTopologyNodeKindLabel(kind: TopologyNodeKind): string {
-  switch (kind) {
-    case "service":
-      return "服务节点";
-    case "connector":
-      return "连接器";
-    default:
-      return "团队成员";
-  }
-}
-
-function formatTopologyDepthLabel(depth: number): string {
-  switch (depth) {
-    case 1:
-      return "近邻";
-    case 3:
-      return "全景";
-    default:
-      return "扩展";
-  }
-}
-
-function summarizeTopologyTitles(
-  titles: readonly string[],
-  emptyLabel: string,
-): string {
-  const visible = [...new Set(titles.map((title) => trimText(title)).filter(Boolean))];
-  if (visible.length === 0) {
-    return emptyLabel;
-  }
-  if (visible.length <= 3) {
-    return visible.join("、");
-  }
-  return `${visible.slice(0, 3).join("、")} 等 ${visible.length} 个`;
-}
-
-function formatTopologyFocusReason(reason: string): string {
-  const normalized = trimText(reason);
-  switch (normalized) {
-    case "Focused on the actor behind the most recent team activity.":
-      return "当前焦点跟随最近一次团队运行里的实际执行成员。";
-    case "Focused on the currently selected service revision actor because no active run was selected.":
-      return "当前还没有选中运行，所以先对齐到当前所选服务版本对应的成员。";
-    case "Focused on the currently selected service actor because no stronger runtime signal was available.":
-      return "当前还没有更强的运行信号，所以先对齐到当前所选服务对应的成员。";
-    case "Focused on the first known team member because no stronger runtime signal was available.":
-      return "当前运行信号不足，先落在当前可见的第一位团队成员。";
-    case "No actor focus is available yet.":
-      return "当前还没有可用的团队成员焦点。";
-    default:
-      return normalized;
-  }
-}
-
-function formatPlaybackSummary(summary: string): string {
-  const normalized = trimText(summary);
-  switch (normalized) {
-    case "No run audit is available for the current team activity.":
-      return "当前还没有可见的运行审计记录。";
-    case "No event timeline is available for the current team activity.":
-      return "当前还没有可见的事件时间线。";
-    case "Timeline reconstructed from the latest visible run steps.":
-      return "当前事件流是根据最近一次可见运行步骤整理的。";
-    default:
-      return normalized;
-  }
-}
-
-function buildDepthMap(
-  rootId: string,
-  edges: readonly { source: string; target: string }[],
-): Map<string, number> {
-  const normalizedRootId = trimText(rootId);
-  if (!normalizedRootId) {
-    return new Map();
-  }
-
-  const adjacency = new Map<string, string[]>();
-  edges.forEach((edge) => {
-    const source = trimText(edge.source);
-    const target = trimText(edge.target);
-    if (!source || !target) {
-      return;
-    }
-
-    const sourceNeighbors = adjacency.get(source) ?? [];
-    sourceNeighbors.push(target);
-    adjacency.set(source, sourceNeighbors);
-
-    const targetNeighbors = adjacency.get(target) ?? [];
-    targetNeighbors.push(source);
-    adjacency.set(target, targetNeighbors);
-  });
-
-  const depths = new Map<string, number>([[normalizedRootId, 0]]);
-  const queue = [normalizedRootId];
-
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    const nextDepth = (depths.get(current) ?? 0) + 1;
-    for (const next of adjacency.get(current) ?? []) {
-      if (depths.has(next)) {
-        continue;
-      }
-      depths.set(next, nextDepth);
-      queue.push(next);
+function sortMembers(left: StudioMemberSummary, right: StudioMemberSummary): number {
+  const rightUpdatedAt = Date.parse(right.updatedAt);
+  const leftUpdatedAt = Date.parse(left.updatedAt);
+  if (Number.isFinite(rightUpdatedAt) && Number.isFinite(leftUpdatedAt)) {
+    if (rightUpdatedAt !== leftUpdatedAt) {
+      return rightUpdatedAt - leftUpdatedAt;
     }
   }
 
-  return depths;
+  return left.displayName.localeCompare(right.displayName);
 }
 
-function formatStepTypeLabel(value: string | null | undefined): string {
-  const normalized = normalizeStatus(value);
-  switch (normalized) {
-    case "human_approval":
-      return "人工确认";
-    case "human_input":
-      return "人工输入";
-    case "llm_call":
-      return "LLM 调用";
-    case "tool_call":
-      return "工具调用";
-    case "branch":
-      return "条件分支";
-    default:
-      return trimText(value) || "--";
-  }
-}
+const detailGridStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 16,
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+};
 
-type PillTone = "danger" | "info" | "neutral" | "success" | "warning";
+const formGridStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 16,
+  gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+};
 
-function resolveTonePillStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  tone: PillTone,
-): React.CSSProperties {
-  switch (tone) {
-    case "success":
-      return {
-        background: "rgba(82, 196, 26, 0.12)",
-        color: token.colorSuccess,
-      };
-    case "info":
-      return {
-        background: "rgba(24, 144, 255, 0.08)",
-        color: token.colorInfo,
-      };
-    case "warning":
-      return {
-        background: "rgba(250, 173, 20, 0.12)",
-        color: token.colorWarning,
-      };
-    case "danger":
-      return {
-        background: "rgba(255, 77, 79, 0.12)",
-        color: token.colorError,
-      };
-    default:
-      return {
-        background: token.colorFillQuaternary,
-        color: token.colorTextSecondary,
-      };
-  }
-}
+const fieldStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 8,
+};
 
-function formatTeamHealthStatusLabel(status: TeamHealthStatus): string {
-  switch (status) {
-    case "healthy":
-      return "可信运行";
-    case "attention":
-      return "需要核验";
-    case "degraded":
-      return "运行降级";
-    case "blocked":
-      return "等待人工";
-    case "human-overridden":
-      return "人工接管";
-    default:
-      return "状态未知";
-  }
-}
+const listItemStyle: React.CSSProperties = {
+  background: "#ffffff",
+  border: "1px solid #eef2f7",
+  borderRadius: 16,
+  display: "grid",
+  gap: 14,
+  padding: 18,
+};
 
-function formatTeamHealthActionLabel(status: TeamHealthStatus): string {
-  switch (status) {
-    case "healthy":
-      return "可继续观察或小步调整";
-    case "attention":
-      return "变更前先核验信号";
-    case "degraded":
-      return "先修复运行异常";
-    case "blocked":
-      return "需要人工处理后继续";
-    case "human-overridden":
-      return "人工介入正在影响判断";
-    default:
-      return "等待更多运行事实";
-  }
-}
-
-function resolveTeamHealthToneStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  tone: TeamHealthTone,
-): React.CSSProperties {
-  switch (tone) {
-    case "success":
-      return resolveTonePillStyle(token, "success");
-    case "warning":
-      return resolveTonePillStyle(token, "warning");
-    case "error":
-      return resolveTonePillStyle(token, "danger");
-    case "info":
-      return resolveTonePillStyle(token, "info");
-    default:
-      return resolveTonePillStyle(token, "neutral");
-  }
-}
-
-function formatTeamHealthDetail(detail: string): string {
-  const normalized = trimText(detail);
-  if (!normalized) {
-    return "--";
-  }
-
-  if (normalized === "A human-in-the-loop step is visible in the current run.") {
-    return "当前运行可见人工介入步骤。";
-  }
-
-  if (normalized.startsWith("Service deployment is ")) {
-    return `服务部署状态：${normalized.replace("Service deployment is ", "").replace(/\.$/, "")}。`;
-  }
-
-  if (normalized === "No recent team activity is available to verify the active deployment.") {
-    return "当前还没有近期团队运行来证明 active deployment 的健康状态。";
-  }
-
-  if (normalized.startsWith("Current run ")) {
-    return normalized
-      .replace(/^Current run /, "当前运行 ")
-      .replace(" is ", " 状态为 ");
-  }
-
-  if (normalized.startsWith("Latest error: ")) {
-    return normalized.replace("Latest error: ", "最近错误：");
-  }
-
-  if (normalized.startsWith("Current run status is ")) {
-    return normalized.replace("Current run status is ", "当前运行状态为 ");
-  }
-
-  return normalized;
-}
-
-function formatPartialSignal(signal: string): string {
-  switch (trimText(signal)) {
-    case "Actor graph unavailable":
-      return "事件拓扑暂不可用";
-    case "No successful baseline run":
-      return "暂无成功基线运行";
-    case "No recent runs":
-      return "暂无近期运行";
-    default:
-      return trimText(signal) || "--";
-  }
-}
-
-function resolveObservationPillStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  status: ObservationStatus,
-): React.CSSProperties {
-  switch (status) {
-    case "live":
-      return resolveTonePillStyle(token, "success");
-    case "delayed":
-      return resolveTonePillStyle(token, "warning");
-    case "partial":
-      return resolveTonePillStyle(token, "info");
-    default:
-      return resolveTonePillStyle(token, "neutral");
-  }
-}
-
-function resolveCompositionKindPillStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  kind: string,
-): React.CSSProperties {
-  switch (normalizeStatus(kind)) {
-    case "workflow role":
-      return resolveTonePillStyle(token, "info");
-    case "workflow":
-      return resolveTonePillStyle(token, "success");
-    case "service":
-      return resolveTonePillStyle(token, "warning");
-    case "actor":
-    case "runtime":
-      return resolveTonePillStyle(token, "neutral");
-    default:
-      return resolveTonePillStyle(token, "neutral");
-  }
-}
-
-function resolveStatusPillStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  value: string | null | undefined,
-): React.CSSProperties {
-  const normalized = normalizeStatus(value);
-
-  if (
-    [
-      "active",
-      "running",
-      "processing",
-      "completed",
-      "finished",
-      "succeeded",
-      "success",
-      "published",
-      "default",
-    ].includes(normalized)
-  ) {
-    return {
-      background: "rgba(24, 144, 255, 0.08)",
-      color: token.colorInfo,
-    };
-  }
-
-  if (
-    [
-      "draft",
-      "waiting",
-      "waiting_signal",
-      "waiting_approval",
-      "human_input",
-      "human_approval",
-      "suspended",
-      "blocked",
-    ].includes(normalized)
-  ) {
-    return {
-      background: "rgba(250, 173, 20, 0.12)",
-      color: token.colorWarning,
-    };
-  }
-
-  if (
-    ["failed", "error", "cancelled", "degraded", "retired"].includes(normalized)
-  ) {
-    return {
-      background: "rgba(255, 77, 79, 0.12)",
-      color: token.colorError,
-    };
-  }
-
-  return {
-    background: token.colorFillQuaternary,
-    color: token.colorTextSecondary,
-  };
-}
-
-function resolveActionButtonStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  tone: "primary" | "secondary" = "secondary",
-): React.CSSProperties {
-  return {
-    background: tone === "secondary" ? token.colorBgContainer : undefined,
-    borderColor: tone === "secondary" ? token.colorBorderSecondary : undefined,
-    borderRadius: 16,
-    boxShadow: "none",
-    color: tone === "secondary" ? token.colorText : undefined,
-    fontWeight: 600,
-    height: 40,
-    paddingInline: 18,
-  };
-}
-
-function resolveSegmentedButtonStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  active: boolean,
-): React.CSSProperties {
-  return {
-    background: active ? token.colorPrimary : "transparent",
-    border: "none",
-    borderRadius: 999,
-    color: active ? token.colorWhite : token.colorTextSecondary,
-    cursor: "pointer",
-    fontFamily: factValueFontFamily,
-    fontSize: 12,
-    fontWeight: 700,
-    padding: "8px 12px",
-    transition: "all 160ms ease",
-  };
-}
-
-function resolveSelectionCardButtonStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  selected: boolean,
-): React.CSSProperties {
-  return {
-    background: selected ? token.colorPrimaryBg : token.colorBgContainer,
-    border: `1px solid ${selected ? token.colorPrimaryBorder : token.colorBorderSecondary}`,
-    borderRadius: 18,
-    boxShadow: selected ? token.boxShadowSecondary : "none",
-    cursor: "pointer",
-    transition: "all 160ms ease",
-  };
-}
-
-function formatEventStreamStageLabel(
-  stage: string | null | undefined,
-  stepType?: string | null,
-): string {
-  const normalizedStage = normalizeStatus(stage);
-  const normalizedStepType = normalizeStatus(stepType);
-
-  const asStageCode = (value: string): string =>
-    trimText(value)
-      .replace(/[^a-zA-Z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .toUpperCase();
-
-  if (
-    normalizedStage.includes("human") ||
-    normalizedStage.includes("wait") ||
-    normalizedStage.includes("suspend") ||
-    normalizedStepType === "human_approval" ||
-    normalizedStepType === "human_input"
-  ) {
-    return "HUMAN_GATE";
-  }
-
-  if (normalizedStepType === "llm_call") {
-    return "LLM_CALL";
-  }
-
-  if (normalizedStepType === "tool_call") {
-    return "TOOL_CALL";
-  }
-
-  if (normalizedStage.includes("route") || normalizedStage.includes("dispatch")) {
-    return "ROUTED";
-  }
-
-  if (normalizedStage.includes("reply")) {
-    return "REPLY";
-  }
-
-  if (normalizedStage.includes("schedule")) {
-    return "SCHEDULE";
-  }
-
-  if (
-    normalizedStage.includes("input") ||
-    normalizedStage.includes("ingress") ||
-    normalizedStage.includes("receive") ||
-    normalizedStage.includes("message")
-  ) {
-    return "MSG_IN";
-  }
-
-  if (normalizedStage === "step") {
-    return "STEP";
-  }
-
-  if (trimText(stage)) {
-    return asStageCode(trimText(stage));
-  }
-
-  return stepType ? asStageCode(stepType) : "RUNTIME";
-}
-
-function resolveEventStreamTone(
-  stage: string | null | undefined,
-  tone: string | null | undefined,
-  stepType?: string | null,
-): PillTone {
-  const normalizedTone = normalizeStatus(tone);
-  if (normalizedTone === "error") {
-    return "danger";
-  }
-  if (normalizedTone === "warning") {
-    return "warning";
-  }
-
-  const normalizedStage = normalizeStatus(stage);
-  const normalizedStepType = normalizeStatus(stepType);
-  if (
-    normalizedStage.includes("human") ||
-    normalizedStage.includes("wait") ||
-    normalizedStage.includes("suspend") ||
-    normalizedStepType === "human_approval" ||
-    normalizedStepType === "human_input"
-  ) {
-    return "warning";
-  }
-  if (normalizedStage.includes("reply")) {
-    return "success";
-  }
-  if (
-    normalizedStage.includes("route") ||
-    normalizedStage.includes("dispatch") ||
-    normalizedStepType === "llm_call" ||
-    normalizedStepType === "tool_call"
-  ) {
-    return "info";
-  }
-  return "neutral";
-}
-
-function formatCompactTimestamp(value: string | null | undefined): string {
-  return formatCompactDateTime(value, "暂无");
-}
-
-function formatClockTimestamp(value: string | null | undefined): string {
-  return formatTimeOnly(value, "--");
-}
-
-function readWorkflowRoleName(role: Record<string, unknown>, index: number): string {
-  return (
-    trimText(typeof role.name === "string" ? role.name : "") ||
-    trimText(typeof role.id === "string" ? role.id : "") ||
-    `role-${index + 1}`
-  );
-}
-
-function readWorkflowRoleConnectors(role: Record<string, unknown>): string[] {
-  const connectors = Array.isArray(role.connectors) ? role.connectors : [];
-  return connectors
-    .map((entry) => {
-      if (typeof entry === "string") {
-        return trimText(entry);
-      }
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-        return "";
-      }
-      const record = entry as Record<string, unknown>;
-      return trimText(
-        typeof record.name === "string"
-          ? record.name
-          : typeof record.id === "string"
-            ? record.id
-            : "",
-      );
-    })
-    .filter(Boolean);
-}
-
-function deriveTeamCompositionRows(input: {
-  documents: readonly StudioWorkflowDocument[];
-  fallbackMembers: readonly MemberLike[];
-  implementationKind: string | null | undefined;
-}): TeamCompositionRow[] {
-  const rows: TeamCompositionRow[] = [];
-  const seen = new Set<string>();
-
-  input.documents.forEach((document) => {
-    const roles = Array.isArray(document.roles) ? document.roles : [];
-    roles.forEach((role, index) => {
-      if (!role || typeof role !== "object" || Array.isArray(role)) {
-        return;
-      }
-
-      const record = role as Record<string, unknown>;
-      const name = readWorkflowRoleName(record, index);
-      const dedupeKey = name.toLowerCase();
-      if (seen.has(dedupeKey)) {
-        return;
-      }
-      seen.add(dedupeKey);
-
-      const connectors = readWorkflowRoleConnectors(record);
-      const provider = trimText(
-        typeof record.provider === "string" ? record.provider : "",
-      );
-      const model = trimText(typeof record.model === "string" ? record.model : "");
-      const summaryParts: string[] = [];
-
-      if (connectors.length > 0) {
-        summaryParts.push(connectors.slice(0, 3).join("、"));
-      }
-      if (provider || model) {
-        summaryParts.push([provider, model].filter(Boolean).join(" / "));
-      }
-      if (summaryParts.length === 0) {
-        summaryParts.push("--");
-      }
-
-      rows.push({
-        key: `role:${name}`,
-        kind: "workflow role",
-        name,
-        summary: summaryParts.join("，"),
-      });
-    });
-  });
-
-  if (rows.length > 0) {
-    return rows;
-  }
-
-  return input.fallbackMembers.map((member) => ({
-    key: `member:${member.actorId}`,
-    kind: trimText(input.implementationKind) || "runtime",
-    name: trimText(member.actorType) || compactId(member.actorId),
-    summary: trimText(member.actorId) || "--",
-  }));
-}
-
-function createObservedPlaybackEvents(
-  playback: Pick<TeamPlaybackSummary, "commandId" | "currentRunId" | "rootActorId">,
-): AGUIEvent[] {
-  const events: AGUIEvent[] = [];
-  const runId = playback.currentRunId?.trim() || "";
-  const actorId = playback.rootActorId?.trim() || "";
-  const commandId = playback.commandId?.trim() || "";
-
-  if (runId) {
-    events.push({
-      runId,
-      threadId: commandId || runId,
-      timestamp: Date.now(),
-      type: AGUIEventType.RUN_STARTED,
-    } as AGUIEvent);
-  }
-
-  if (actorId || commandId) {
-    events.push({
-      name: CustomEventName.RunContext,
-      timestamp: Date.now(),
-      type: AGUIEventType.CUSTOM,
-      value: {
-        actorId: actorId || undefined,
-        commandId: commandId || undefined,
-      },
-    } as AGUIEvent);
-  }
-
-  return events;
-}
-
-const TopologyNodeCard: React.FC<{
-  entity: TopologyEntitySummary;
-}> = ({ entity }) => {
-  const { token } = theme.useToken();
-  const kindStyle =
-    entity.kind === "service"
-      ? resolveTonePillStyle(token, "info")
-      : entity.kind === "connector"
-        ? resolveTonePillStyle(token, "warning")
-        : resolveTonePillStyle(token, "neutral");
-  const kindLabel =
-    entity.kind === "service"
-      ? "服务节点"
-      : entity.kind === "connector"
-        ? "连接器"
-        : "团队成员";
-
-  return (
-    <div
-      style={{
-        background: token.colorBgContainer,
-        borderRadius: 20,
-        display: "flex",
-        flexDirection: "column",
-        gap: 12,
-        minHeight: 132,
-        minWidth: 0,
-        padding: 18,
-      }}
-    >
-      <div
-        style={{
-          alignItems: "flex-start",
-          display: "flex",
-          gap: 10,
-          justifyContent: "space-between",
-        }}
-      >
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 0 }}>
-          <div>
-            <DetailPill compact style={kindStyle} text={kindLabel} />
-          </div>
-          <Typography.Text
-            strong
-            style={{
-              color: token.colorText,
-              display: "block",
-              fontSize: 17,
-              lineHeight: 1.2,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {entity.title}
-          </Typography.Text>
-          <Typography.Text
-            style={{
-              color: token.colorTextTertiary,
-              display: "block",
-              fontSize: 12,
-              lineHeight: 1.45,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {entity.summary}
-          </Typography.Text>
-        </div>
-        <DetailPill
-          compact
-          style={resolveTonePillStyle(token, entity.badgeTone)}
-          text={entity.badgeText}
-        />
-      </div>
-      <Typography.Text
-        style={{
-          color: token.colorTextSecondary,
-          display: "block",
-          fontFamily: factValueFontFamily,
-          fontSize: 12,
-          lineHeight: 1.5,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {entity.note}
-      </Typography.Text>
-    </div>
-  );
+const selectStyle: React.CSSProperties = {
+  background: "#ffffff",
+  border: "1px solid #d9d9d9",
+  borderRadius: 8,
+  minHeight: 40,
+  padding: "0 12px",
+  width: "100%",
 };
 
 const TeamDetailPage: React.FC = () => {
-  const locationSnapshot = React.useSyncExternalStore(
-    subscribeToLocationChanges,
-    getLocationSnapshot,
-    () => "",
-  );
-  const routeState = React.useMemo(() => {
-    if (typeof window === "undefined") {
-      return readTeamDetailRouteState("", "");
-    }
-
-    return readTeamDetailRouteState(window.location.search, window.location.pathname);
-  }, [locationSnapshot]);
-  const scopeId = routeState.scopeId.trim();
-  const teamsListHref = React.useMemo(
-    () => buildScopeHref("/teams", { scopeId }),
-    [scopeId],
-  );
-  const [graphDepth, setGraphDepth] = React.useState(2);
-  const [preferredMemberId, setPreferredMemberId] = React.useState(routeState.memberId);
-  const [preferredServiceId, setPreferredServiceId] = React.useState(
-    routeState.serviceId,
-  );
-  const [preferredRunId, setPreferredRunId] = React.useState(routeState.runId);
-  const [activeTab, setActiveTab] = React.useState<TeamDetailTab>(routeState.tab);
-  const [selectedActorId, setSelectedActorId] = React.useState("");
-  const [selectedConnectorKey, setSelectedConnectorKey] = React.useState("");
-  const [selectedTopologyNodeId, setSelectedTopologyNodeId] = React.useState("");
-  const { token } = theme.useToken();
+  const queryClient = useQueryClient();
+  const [routeState, setRouteState] = React.useState(readRouteState);
+  const [teamDisplayName, setTeamDisplayName] = React.useState("");
+  const [teamDescription, setTeamDescription] = React.useState("");
+  const [newMemberName, setNewMemberName] = React.useState("");
+  const [newMemberDescription, setNewMemberDescription] = React.useState("");
+  const [newMemberId, setNewMemberId] = React.useState("");
+  const [newMemberKind, setNewMemberKind] =
+    React.useState<StudioMemberImplementationKind>("workflow");
+  const [selectedExistingMemberId, setSelectedExistingMemberId] = React.useState("");
+  const [busyAction, setBusyAction] = React.useState("");
 
   React.useEffect(() => {
-    const nextMemberId = trimText(routeState.memberId);
-    const nextServiceId = trimText(routeState.serviceId);
-    const nextRunId = trimText(routeState.runId);
-
-    setPreferredMemberId((currentMemberId) =>
-      trimText(currentMemberId) === nextMemberId ? currentMemberId : nextMemberId,
-    );
-    setPreferredServiceId((currentServiceId) =>
-      trimText(currentServiceId) === nextServiceId ? currentServiceId : nextServiceId,
-    );
-    setPreferredRunId((currentRunId) =>
-      trimText(currentRunId) === nextRunId ? currentRunId : nextRunId,
-    );
-    setActiveTab((currentTab) =>
-      currentTab === routeState.tab ? currentTab : routeState.tab,
-    );
-  }, [routeState.memberId, routeState.runId, routeState.serviceId, routeState.tab]);
-
-  const {
-    actorGraphQuery,
-    actorsQuery,
-    baselineRunAuditQuery,
-    currentRunAuditQuery,
-    lens,
-    runsQuery,
-    preferredMemberSummary,
-    serviceRevisionsQuery,
-    scriptsQuery,
-    servicesQuery,
-    workflowsQuery,
-  } = useTeamRuntimeLens(scopeId, {
-    graphDepth,
-    preferredActorId: selectedActorId || undefined,
-    preferredMemberId,
-    preferredRunId,
-    preferredServiceId,
-  });
-
-  const workspaceSettingsQuery = useQuery({
-    enabled: scopeId.length > 0,
-    queryFn: () => studioApi.getWorkspaceSettings(),
-    queryKey: ["teams", "workspace-settings"],
-    retry: false,
-  });
-
-  const connectorCatalogQuery = useQuery({
-    enabled: scopeId.length > 0,
-    queryFn: () => studioApi.getConnectorCatalog(),
-    queryKey: ["teams", "connector-catalog"],
-    retry: false,
-  });
-
-  const fallbackWorkflowSummary = React.useMemo(() => {
-    if (lens.activeRevision?.implementationKind !== "workflow") {
-      return null;
-    }
-
-    const workflows = workflowsQuery.data ?? [];
-    const workflowNameHints = [
-      trimText(lens.activeRevision.workflowName),
-      trimText(lens.currentRun?.workflowName),
-      trimText(lens.currentRunAudit?.audit.workflowName),
-      trimText(lens.currentRunAudit?.summary.workflowName),
-      trimText(lens.playback.workflowName),
-    ].filter(Boolean);
-
-    for (const workflowNameHint of workflowNameHints) {
-      const matched =
-        workflows.find(
-          (workflow) =>
-            trimText(workflow.workflowName) === workflowNameHint ||
-            trimText(workflow.displayName) === workflowNameHint,
-        ) ?? null;
-      if (matched) {
-        return matched;
-      }
-    }
-
-    return workflows.length === 1 ? workflows[0] : null;
-  }, [
-    lens.activeRevision,
-    lens.currentRun,
-    lens.currentRunAudit,
-    lens.playback.workflowName,
-    workflowsQuery.data,
-  ]);
-
-  const activeWorkflowSummary = React.useMemo(() => {
-    if (trimText(routeState.workflowId)) {
-      return (
-        workflowsQuery.data?.find(
-          (workflow) => trimText(workflow.workflowId) === trimText(routeState.workflowId),
-        ) ?? null
-      );
-    }
-
-    return fallbackWorkflowSummary;
-  }, [fallbackWorkflowSummary, routeState.workflowId, workflowsQuery.data]);
-
-  const focusedOperationalUnit = React.useMemo(() => {
-    if (!activeWorkflowSummary) {
-      return null;
-    }
-
-    const loadedServiceId =
-      trimText(lens.currentService?.serviceId) || trimText(preferredServiceId);
-    return resolveWorkflowOperationalUnit({
-      preferredRunId,
-      preferredServiceId,
-      runs: runsQuery.data?.runs ?? [],
-      services: servicesQuery.data ?? [],
-      signals: {
-        runtimeAvailableByServiceId:
-          runsQuery.isSuccess && loadedServiceId
-            ? new Set([loadedServiceId])
-            : new Set<string>(),
-        servicesAvailable: servicesQuery.isSuccess,
-      },
-      workflow: activeWorkflowSummary,
+    return subscribeToLocationChanges(() => {
+      setRouteState(readRouteState());
     });
-  }, [
-    activeWorkflowSummary,
-    lens.currentService?.serviceId,
-    preferredServiceId,
-    preferredRunId,
-    runsQuery.data?.runs,
-    runsQuery.isSuccess,
-    servicesQuery.data,
-    servicesQuery.isSuccess,
-  ]);
+  }, []);
 
-  React.useEffect(() => {
-    const nextServiceId = trimText(focusedOperationalUnit?.matchedService?.serviceId);
-    if (!trimText(routeState.workflowId) || !nextServiceId) {
-      return;
-    }
-    if (nextServiceId !== trimText(preferredServiceId)) {
-      setPreferredServiceId(nextServiceId);
-    }
-  }, [
-    focusedOperationalUnit?.matchedService?.serviceId,
-    preferredServiceId,
-    routeState.workflowId,
-  ]);
+  const scopeId = trimOptional(routeState.scopeId);
+  const routeTeamId = trimOptional(routeState.teamId);
+  const routeMemberId = trimOptional(routeState.memberId);
 
-  const teamWorkflowDetailQuery = useQuery({
-    enabled:
-      scopeId.length > 0 &&
-      lens.activeRevision?.implementationKind === "workflow" &&
-      trimText(activeWorkflowSummary?.workflowId).length > 0,
-    queryFn: () =>
-      scopesApi.getWorkflowDetail(scopeId, activeWorkflowSummary?.workflowId ?? ""),
-    queryKey: [
-      "teams",
-      "workflow-detail",
-      scopeId,
-      activeWorkflowSummary?.workflowId ?? "",
-      lens.activeRevision?.revisionId ?? "",
-    ],
+  const teamsQuery = useQuery({
+    enabled: scopeId.length > 0,
+    queryKey: ["teams", "roster", scopeId],
+    queryFn: () => studioApi.listTeams(scopeId),
     retry: false,
   });
-
-  const teamWorkflowDocumentsQuery = useQuery({
-    enabled:
-      lens.activeRevision?.implementationKind === "workflow" &&
-      Boolean(teamWorkflowDetailQuery.data?.available) &&
-      trimText(teamWorkflowDetailQuery.data?.source?.workflowYaml).length > 0,
-    queryFn: async (): Promise<StudioWorkflowDocument[]> => {
-      const source = teamWorkflowDetailQuery.data?.source;
-      if (!source) {
-        return [];
-      }
-
-      const workflowYamls = [
-        trimText(source.workflowYaml),
-        ...Object.values(source.inlineWorkflowYamls ?? {}).map((yaml) => trimText(yaml)),
-      ].filter(Boolean);
-      const parsedDocuments = await Promise.all(
-        [...new Set(workflowYamls)].map(async (yaml) => {
-          const parsed = await studioApi.parseYaml({ yaml });
-          return parsed.document ?? null;
-        }),
-      );
-
-      return parsedDocuments.filter(
-        (document): document is StudioWorkflowDocument => Boolean(document),
-      );
-    },
-    queryKey: [
-      "teams",
-      "workflow-documents",
-      scopeId,
-      activeWorkflowSummary?.workflowId ?? "",
-      lens.activeRevision?.revisionId ?? "",
-    ],
-    retry: false,
-  });
-
-  const teamScopedRoleLoading =
-    lens.activeRevision?.implementationKind === "workflow" &&
-    (workflowsQuery.isLoading ||
-      teamWorkflowDetailQuery.isLoading ||
-      teamWorkflowDocumentsQuery.isLoading);
-  const teamScopedRoleUnavailable =
-    lens.activeRevision?.implementationKind === "workflow" &&
-    !teamScopedRoleLoading &&
-    (!activeWorkflowSummary ||
-      teamWorkflowDetailQuery.isError ||
-      teamWorkflowDocumentsQuery.isError ||
-      !teamWorkflowDetailQuery.data?.available ||
-      !teamWorkflowDetailQuery.data?.source);
-
-  const integrations = React.useMemo(
-    () =>
-      deriveTeamIntegrationsSummary({
-        bindingKind: lens.activeRevision?.implementationKind ?? "unknown",
-        connectorCatalog: connectorCatalogQuery.data ?? null,
-        teamWorkflowRoles:
-          lens.activeRevision?.implementationKind !== "workflow"
-            ? []
-            : teamScopedRoleLoading
-              ? undefined
-              : teamScopedRoleUnavailable
-                ? null
-                : deriveTeamWorkflowRoleBindings(teamWorkflowDocumentsQuery.data ?? []),
-        workflowDocumentCount: teamWorkflowDocumentsQuery.data?.length ?? 0,
-        workspaceSettings: workspaceSettingsQuery.data ?? null,
-      }),
-    [
-      connectorCatalogQuery.data,
-      lens.activeRevision?.implementationKind,
-      teamScopedRoleLoading,
-      teamScopedRoleUnavailable,
-      teamWorkflowDocumentsQuery.data,
-      workspaceSettingsQuery.data,
-    ],
+  const teamSelection = React.useMemo(
+    () => [...(teamsQuery.data?.teams ?? [])],
+    [teamsQuery.data?.teams],
   );
+  const implicitSingleTeamId =
+    !routeTeamId && teamSelection.length === 1 ? teamSelection[0].teamId : "";
+  const selectedTeamId = routeTeamId || implicitSingleTeamId;
 
-  const defaultSelectedConnectorKey =
-    integrations.items.find((item) => item.usedByRoles.length > 0)?.key ||
-    integrations.items[0]?.key ||
-    "";
+  const legacyMemberQuery = useQuery({
+    enabled: scopeId.length > 0 && !routeTeamId && routeMemberId.length > 0,
+    queryKey: ["teams", "legacy-member", scopeId, routeMemberId],
+    queryFn: () => studioApi.getMember(scopeId, routeMemberId),
+    retry: false,
+  });
 
   React.useEffect(() => {
-    if (integrations.items.length === 0) {
-      setSelectedConnectorKey("");
+    if (!scopeId || routeTeamId || routeMemberId.length === 0) {
       return;
     }
 
-    if (
-      !selectedConnectorKey ||
-      !integrations.items.some((item) => item.key === selectedConnectorKey)
-    ) {
-      setSelectedConnectorKey(defaultSelectedConnectorKey);
-    }
-  }, [defaultSelectedConnectorKey, integrations.items, selectedConnectorKey]);
-
-  const runtimeServiceId =
-    focusedOperationalUnit?.matchedService?.serviceId ||
-    lens.currentService?.serviceId ||
-    lens.currentRun?.serviceId ||
-    undefined;
-  const currentMemberId =
-    trimText(preferredMemberSummary?.memberId) ||
-    trimText(preferredMemberId);
-  React.useEffect(() => {
-    const canonicalMemberId = trimText(currentMemberId);
-    if (!scopeId || !canonicalMemberId || trimText(routeState.memberId)) {
+    const inferredTeamId = trimOptional(legacyMemberQuery.data?.summary.teamId);
+    if (!inferredTeamId) {
       return;
     }
 
     history.replace(
       buildTeamDetailHref({
-        memberId: canonicalMemberId,
+        memberId: routeState.memberId || undefined,
+        runId: routeState.runId || undefined,
         scopeId,
-        workflowId: trimText(routeState.workflowId) || undefined,
-        serviceId: trimText(routeState.serviceId) || undefined,
-        runId: trimText(routeState.runId) || undefined,
-        tab: routeState.tab === "overview" ? undefined : routeState.tab,
+        serviceId: routeState.serviceId || undefined,
+        tab: routeState.tab,
+        teamId: inferredTeamId,
+        workflowId: routeState.workflowId || undefined,
       }),
     );
   }, [
-    currentMemberId,
+    legacyMemberQuery.data?.summary.teamId,
+    routeMemberId,
     routeState.memberId,
     routeState.runId,
     routeState.serviceId,
     routeState.tab,
     routeState.workflowId,
+    routeTeamId,
     scopeId,
   ]);
-  const currentPlatformService =
-    focusedOperationalUnit?.matchedService || lens.currentService || servicesQuery.data?.[0] || null;
-  const platformRouteIdentity = React.useMemo(
-    () => ({
-      tenantId: trimText(currentPlatformService?.tenantId) || scopeId,
-      appId: trimText(currentPlatformService?.appId) || "default",
-      namespace: trimText(currentPlatformService?.namespace) || "default",
-      serviceId: runtimeServiceId,
-    }),
-    [currentPlatformService?.appId, currentPlatformService?.namespace, currentPlatformService?.tenantId, runtimeServiceId, scopeId],
-  );
-  const selectedStudioMemberId =
-    currentMemberId ||
-    trimText(runtimeServiceId) ||
-    trimText(serviceRevisionsQuery.data?.serviceId) ||
-    trimText(preferredServiceId) ||
-    trimText(servicesQuery.data?.[0]?.serviceId) ||
-    trimText(activeWorkflowSummary?.serviceKey).split(":").pop()?.trim() ||
-    "";
-  const selectedStudioMemberKey =
-    trimText(activeWorkflowSummary?.workflowId).length > 0
-      ? buildStudioWorkflowMemberKey({
-          workflowId: activeWorkflowSummary?.workflowId,
-          workflowName:
-            trimText(activeWorkflowSummary?.displayName) ||
-            trimText(activeWorkflowSummary?.workflowName),
-        })
-      : selectedStudioMemberId
-        ? `member:${selectedStudioMemberId}`
-        : undefined;
-
-  const teamBuilderRoute =
-    trimText(activeWorkflowSummary?.workflowId).length > 0
-      ? buildStudioWorkflowEditorRoute({
-          scopeId,
-          memberKey: selectedStudioMemberKey,
-          workflowId: activeWorkflowSummary?.workflowId,
-        })
-      : buildStudioWorkflowWorkspaceRoute({
-          scopeId,
-          memberKey: selectedStudioMemberKey,
-        });
-
-  const availableActorIds = React.useMemo(
-    () =>
-      Array.from(
-        new Set([
-          ...lens.members.map((member) => member.actorId),
-          ...lens.graph.nodes.map((node) => node.actorId),
-        ]),
-      ).filter(Boolean),
-    [lens.graph.nodes, lens.members],
-  );
-
-  const defaultSelectedActorId =
-    lens.graph.focusActorId || lens.members[0]?.actorId || "";
 
   React.useEffect(() => {
-    if (availableActorIds.length === 0) {
-      setSelectedActorId("");
-      return;
-    }
-    if (!selectedActorId || !availableActorIds.includes(selectedActorId)) {
-      setSelectedActorId(defaultSelectedActorId || availableActorIds[0]);
-    }
-  }, [availableActorIds, defaultSelectedActorId, selectedActorId]);
-
-  const effectiveActorId = selectedActorId || defaultSelectedActorId;
-  const localizedFocusReason = formatTopologyFocusReason(lens.graph.focusReason);
-  const selectedFocusReason =
-    effectiveActorId && effectiveActorId !== lens.graph.focusActorId
-      ? `当前视角已锁定在 ${compactId(effectiveActorId)}。${localizedFocusReason}`
-      : localizedFocusReason;
-
-  const graphProvenance: ObservationBadge = actorGraphQuery.isError
-    ? { label: formatObservationLabel("unavailable"), status: "unavailable" }
-    : lens.graph.available
-      ? { label: formatObservationLabel("live"), status: "live" }
-      : { label: formatObservationLabel("partial"), status: "partial" };
-  const playbackProvenance: ObservationBadge = currentRunAuditQuery.isError
-    ? { label: formatObservationLabel("unavailable"), status: "unavailable" }
-    : lens.playback.available
-      ? { label: formatObservationLabel("delayed"), status: "delayed" }
-      : { label: formatObservationLabel("partial"), status: "partial" };
-  const integrationsProvenance: ObservationBadge =
-    workspaceSettingsQuery.isError && connectorCatalogQuery.isError
-      ? { label: formatObservationLabel("unavailable"), status: "unavailable" }
-      : integrations.available
-        ? { label: formatObservationLabel("delayed"), status: "delayed" }
-        : { label: formatObservationLabel("partial"), status: "partial" };
-
-  const handleOpenPlaybackRun = React.useCallback(
-    (preferredActorId?: string | null) => {
-      const runId = lens.playback.currentRunId?.trim() || "";
-      if (!scopeId || !runId) {
-        return;
-      }
-
-      const actorId =
-        preferredActorId?.trim() ||
-        lens.playback.rootActorId?.trim() ||
-        lens.currentRun?.actorId?.trim() ||
-        "";
-      const observedDraftKey = saveObservedRunSessionPayload({
-        actorId: actorId || undefined,
-        commandId: lens.playback.commandId || undefined,
-        endpointId: "chat",
-        endpointKind: "chat",
-        events: createObservedPlaybackEvents(lens.playback),
-        prompt:
-          lens.playback.launchPrompt ||
-          lens.playback.prompt ||
-          lens.playback.summary,
-        routeName: lens.playback.workflowName || undefined,
-        runId,
-        scopeId,
-        serviceOverrideId: runtimeServiceId,
-      });
-
-      history.push(
-        buildRuntimeRunsHref({
-          actorId: actorId || undefined,
-          draftKey: observedDraftKey || undefined,
-          endpointId: "chat",
-          endpointKind: "chat",
-          prompt: lens.playback.launchPrompt || undefined,
-          route: lens.playback.workflowName || undefined,
-          scopeId,
-          serviceId: runtimeServiceId,
-        }),
-      );
-    },
-    [lens.currentRun?.actorId, lens.playback, runtimeServiceId, scopeId],
-  );
-
-  const handleOpenPlaybackActor = React.useCallback(
-    (actorId?: string | null, runId?: string | null) => {
-      const resolvedActorId =
-        actorId?.trim() || lens.playback.rootActorId?.trim() || "";
-      if (!scopeId || !resolvedActorId) {
-        return;
-      }
-
-      history.push(
-        buildRuntimeExplorerHref({
-          actorId: resolvedActorId,
-          runId: runId?.trim() || lens.playback.currentRunId || undefined,
-          scopeId,
-          serviceId: runtimeServiceId,
-        }),
-      );
-    },
-    [lens.playback.currentRunId, lens.playback.rootActorId, runtimeServiceId, scopeId],
-  );
-
-  const missionControlPrompt =
-    trimText(lens.currentRunAudit?.audit.input) ||
-    trimText(lens.playback.launchPrompt) ||
-    trimText(lens.playback.prompt);
-
-  const handleOpenMissionControl = React.useCallback(() => {
-    const runId =
-      trimText(lens.currentRun?.runId) || trimText(lens.playback.currentRunId);
-    if (!scopeId || !runId) {
+    if (!scopeId || routeTeamId || routeMemberId || teamSelection.length !== 1) {
       return;
     }
 
-    const actorId =
-      trimText(lens.currentRun?.actorId) ||
-      trimText(lens.playback.rootActorId) ||
-      trimText(lens.graph.focusActorId) ||
-      undefined;
-
-    history.push(
-      buildRuntimeMissionControlHref({
-        actorId,
-        autoStream: Boolean(missionControlPrompt),
-        endpointId: "chat",
-        prompt: missionControlPrompt || undefined,
-        runId,
+    history.replace(
+      buildTeamDetailHref({
         scopeId,
-        serviceId: runtimeServiceId,
+        tab: routeState.tab,
+        teamId: teamSelection[0].teamId,
       }),
     );
   }, [
-    lens.currentRun?.actorId,
-    lens.currentRun?.runId,
-    lens.graph.focusActorId,
-    lens.playback.currentRunId,
-    lens.playback.rootActorId,
-    missionControlPrompt,
-    runtimeServiceId,
+    routeMemberId,
+    routeState.tab,
+    routeTeamId,
     scopeId,
+    teamSelection,
   ]);
 
-  const teamHeading = resolveTeamHeading({
-    scopeId,
-    workflowId: activeWorkflowSummary?.workflowId,
-    workflowName: activeWorkflowSummary?.workflowName,
-    displayName:
-      trimText(preferredMemberSummary?.displayName) ||
-      activeWorkflowSummary?.displayName,
-    lensTitle: lens.title,
+  const teamQuery = useQuery({
+    enabled: scopeId.length > 0 && selectedTeamId.length > 0,
+    queryKey: ["teams", "detail", scopeId, selectedTeamId],
+    queryFn: () => studioApi.getTeam(scopeId, selectedTeamId),
+    retry: false,
   });
-  const teamTitle = teamHeading.title;
-  const teamTitleMeta = teamHeading.metaScopeId ? (
-    <Space size={6} wrap>
-      <span style={{ textTransform: "none" }}>scopeId</span>
-      <AevatarCompactText
-        color="inherit"
-        head={8}
-        maxWidth={320}
-        monospace
-        tail={6}
-        value={teamHeading.metaScopeId}
-      />
-    </Space>
-  ) : null;
-  const activeWorkflowId =
-    trimText(activeWorkflowSummary?.workflowId) || trimText(routeState.workflowId);
-  const teamCompositionRows = React.useMemo(
+  const teamMembersQuery = useQuery({
+    enabled: scopeId.length > 0 && selectedTeamId.length > 0,
+    queryKey: ["teams", "detail-members", scopeId, selectedTeamId],
+    queryFn: () => studioApi.listTeamMembers(scopeId, selectedTeamId),
+    retry: false,
+  });
+  const allMembersQuery = useQuery({
+    enabled: scopeId.length > 0 && selectedTeamId.length > 0,
+    queryKey: ["teams", "all-members", scopeId],
+    queryFn: () => studioApi.listMembers(scopeId),
+    retry: false,
+  });
+
+  const team = teamQuery.data ?? null;
+  const teamMembers = React.useMemo(
+    () => [...(teamMembersQuery.data?.members ?? [])].sort(sortMembers),
+    [teamMembersQuery.data?.members],
+  );
+  const assignableMembers = React.useMemo(
     () =>
-      deriveTeamCompositionRows({
-        documents: teamWorkflowDocumentsQuery.data ?? [],
-        fallbackMembers: lens.members,
-        implementationKind: lens.activeRevision?.implementationKind,
-      }),
-    [lens.activeRevision?.implementationKind, lens.members, teamWorkflowDocumentsQuery.data],
+      (allMembersQuery.data?.members ?? [])
+        .filter((member) => member.memberId !== routeMemberId)
+        .filter((member) => trimOptional(member.teamId) !== selectedTeamId)
+        .sort(sortMembers),
+    [allMembersQuery.data?.members, routeMemberId, selectedTeamId],
   );
-  const latestVisibleUpdate =
-    lens.currentRun?.lastUpdatedAt ||
-    lens.currentRunAudit?.summary.lastUpdatedAt ||
-    activeWorkflowSummary?.updatedAt ||
-    "";
-  const latestVisibleUpdateNote = lens.currentRun?.lastUpdatedAt
-    ? trimText(lens.currentRun?.runId)
-      ? `来自 run ${compactId(lens.currentRun?.runId)}`
-      : "来自最近可见运行"
-    : lens.currentRunAudit?.summary.lastUpdatedAt
-      ? "来自最近审计摘要"
-      : activeWorkflowSummary?.updatedAt
-        ? "来自 workflow 更新时间"
-        : "当前还没有可见更新时间";
-  const activeRunId =
-    lens.currentRun?.runId ||
-    lens.playback.currentRunId ||
-    focusedOperationalUnit?.latestRun?.runId ||
-    "";
-  const currentRevisionId = trimText(lens.activeRevision?.revisionId) || "--";
-  const currentRevisionStatus =
-    trimText(lens.activeRevision?.servingState) ||
-    trimText(lens.activeRevision?.status) ||
-    "--";
-  const currentDeploymentStatus =
-    trimText(lens.currentService?.deploymentStatus) ||
-    trimText(lens.activeRevision?.status) ||
-    "--";
-  const currentHeaderStatus =
-    trimText(lens.currentRun?.completionStatus) || currentDeploymentStatus;
-  const currentHeaderStatusFriendly = formatFriendlyStatus(currentHeaderStatus);
-  const currentRevisionFriendly = formatFriendlyStatus(currentRevisionStatus);
-  const currentDeploymentFriendly = formatFriendlyStatus(currentDeploymentStatus);
-  const currentDeploymentId =
-    trimText(lens.activeRevision?.deploymentId) ||
-    trimText(lens.currentService?.deploymentId) ||
-    "--";
-  const currentServiceKey =
-    trimText(lens.currentService?.serviceKey) ||
-    trimText(activeWorkflowSummary?.serviceKey) ||
-    "--";
-  const currentServiceDisplayName =
-    trimText(lens.currentService?.displayName) || "--";
-  const currentRunStatus = trimText(lens.currentRun?.completionStatus) || "--";
-  const currentRunFriendly = activeRunId
-    ? formatFriendlyStatus(currentRunStatus)
-    : "暂无运行";
-  const currentServiceFriendly =
-    currentServiceDisplayName !== "--"
-      ? currentServiceDisplayName
-      : runtimeServiceId || "--";
-  const currentVersionFriendly =
-    currentRevisionFriendly !== "--"
-      ? currentRevisionFriendly
-      : currentDeploymentFriendly;
-  const currentServicePillText =
-    currentServiceFriendly !== "--"
-      ? `服务 · ${currentServiceFriendly}`
-      : "服务待配置";
-  const currentDeploymentPillText =
-    currentVersionFriendly !== "--"
-      ? `版本 · ${currentVersionFriendly}`
-      : "版本待确认";
-  const currentRunPillText = activeRunId
-    ? `运行 · ${currentRunFriendly}`
-    : "暂无近期运行";
-  const currentServiceReference =
-    trimText(runtimeServiceId) ||
-    (currentServiceKey !== "--" ? currentServiceKey : "");
-  const currentServiceCardCaption = runtimeServiceId
-    ? `serviceId · ${runtimeServiceId}`
-    : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
-      ? `serviceKey · ${compactId(currentServiceKey)}`
-      : "当前还没有更多服务标识";
-  const currentServiceCardTooltip = runtimeServiceId
-    ? `serviceId · ${runtimeServiceId}`
-    : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
-      ? `serviceKey · ${currentServiceKey}`
-      : "当前还没有更多服务标识";
-  const currentRunCardCaption = activeRunId
-    ? `runId · ${compactId(activeRunId)}`
-    : "当前还没有可见 run";
-  const currentRunCardTooltip = activeRunId
-    ? `runId · ${activeRunId}`
-    : "当前还没有可见 run";
-  const workflowNameValue =
-    trimText(activeWorkflowSummary?.workflowName) ||
-    trimText(lens.activeRevision?.workflowName) ||
-    "--";
-  const currentActorId =
-    trimText(lens.currentRun?.actorId) ||
-    trimText(lens.activeRevision?.primaryActorId) ||
-    "--";
-  const currentStateVersion =
-    lens.currentRun?.stateVersion != null ? String(lens.currentRun.stateVersion) : "--";
-  const currentLastEventId = trimText(lens.currentRun?.lastEventId) || "--";
-  const currentEndpointCount = lens.currentService?.endpoints.length ?? 0;
-  const currentPolicyCount = lens.currentService?.policyIds.length ?? 0;
-  const enabledConnectorCount = integrations.items.filter((item) => item.enabled).length;
-  const connectorHighlights = React.useMemo(
-    () =>
-      integrations.items
-        .filter((item) => item.usedByRoles.length > 0)
-        .slice(0, 3)
-        .map((item) => item.name),
-    [integrations.items],
-  );
-  const selectedConnector =
-    integrations.items.find((item) => item.key === selectedConnectorKey) ??
-    integrations.items[0] ??
-    null;
-  const selectedConnectorRows = React.useMemo(() => {
-    if (!selectedConnector) {
-      return [];
-    }
 
-    return [
-      {
-        badgeText: formatConnectorTypeLabel(selectedConnector.type),
-        badgeTone: "info" as const,
-        label: "连接器类型",
-        note: selectedConnector.summary,
-        value: selectedConnector.name,
-      },
-      {
-        badgeText: formatConnectorEnabledLabel(selectedConnector.enabled),
-        badgeTone: selectedConnector.enabled ? ("success" as const) : ("neutral" as const),
-        label: "团队使用",
-        note:
-          selectedConnector.usedByRoles.length > 0
-            ? `${selectedConnector.usedByRoles.length} 个角色正在引用`
-            : "当前团队还没有显式引用它",
-        value:
-          selectedConnector.usedByRoles.length > 0
-            ? selectedConnector.usedByRoles.join("、")
-            : "尚未显式引用",
-      },
-      {
-        badgeText: integrations.runtimeHostLabel || "--",
-        badgeTone: integrations.runtimeBaseUrl ? ("info" as const) : ("neutral" as const),
-        label: "工作区环境",
-        note: integrations.workspaceSummary,
-        value:
-          integrations.connectorCount > 0
-            ? `已加载 ${integrations.connectorCount} 个连接器定义`
-            : "当前还没有加载连接器定义",
-      },
-      {
-        badgeText: currentServiceFriendly !== "--" ? "服务入口" : "待配置",
-        badgeTone: currentServiceFriendly !== "--" ? ("success" as const) : ("neutral" as const),
-        label: "默认绑定",
-        note: runtimeServiceId || currentServiceKey || "--",
-        value: currentServiceFriendly !== "--" ? currentServiceFriendly : "当前还没有主服务入口",
-      },
-      {
-        badgeText: `${currentEndpointCount} 个入口`,
-        badgeTone: currentEndpointCount > 0 ? ("info" as const) : ("neutral" as const),
-        label: "Endpoint 暴露",
-        note: `${currentPolicyCount} 条策略`,
-        value:
-          currentEndpointCount > 0
-            ? `${currentEndpointCount} 个 endpoint 已暴露`
-            : "当前还没有可见 endpoint 暴露",
-      },
-    ];
-  }, [
-    currentEndpointCount,
-    currentPolicyCount,
-    currentServiceFriendly,
-    currentServiceKey,
-    integrations.connectorCount,
-    integrations.runtimeBaseUrl,
-    integrations.runtimeHostLabel,
-    integrations.workspaceSummary,
-    runtimeServiceId,
-    selectedConnector,
-  ]);
-  const connectorSummaryCards = React.useMemo(
-    () => [
-      {
-        caption: runtimeServiceId || currentServiceKey || "--",
-        icon: <DeploymentUnitOutlined />,
-        label: "默认绑定",
-        value: currentServiceFriendly,
-      },
-      {
-        caption: `已绑定 ${integrations.linkedConnectorCount} 个 · 工作区可见 ${integrations.items.length} 个`,
-        icon: <BranchesOutlined />,
-        label: "连接能力",
-        value: enabledConnectorCount,
-      },
-      {
-        caption:
-          connectorHighlights.length > 0
-            ? connectorHighlights.join("、")
-            : "当前 workflow 还没有显式引用连接器",
-        label: "团队会用到",
-        value:
-          integrations.linkedConnectorCount > 0
-            ? `${integrations.linkedConnectorCount} 个连接器`
-            : "尚未显式引用",
-      },
-      {
-        caption: currentServiceFriendly !== "--" ? currentServiceFriendly : "等待服务入口",
-        icon: <DeploymentUnitOutlined />,
-        label: "治理摘要",
-        value: `${currentEndpointCount} / ${currentPolicyCount}`,
-      },
-    ],
-    [
-      connectorHighlights,
-      currentEndpointCount,
-      currentPolicyCount,
-      currentServiceFriendly,
-      currentServiceKey,
-      enabledConnectorCount,
-      integrations.items.length,
-      integrations.linkedConnectorCount,
-      runtimeServiceId,
-    ],
-  );
-  const connectorCatalogCards = React.useMemo(
-    () =>
-      integrations.items.map((connector) => ({
-        availabilityLabel: formatConnectorEnabledLabel(connector.enabled),
-        availabilityStyle: resolveTonePillStyle(
-          token,
-          connector.enabled ? "success" : "neutral",
-        ),
-        buttonStyle: resolveSelectionCardButtonStyle(
-          token,
-          connector.key === selectedConnector?.key,
-        ),
-        key: connector.key,
-        name: connector.name,
-        summary: connector.summary,
-        typeLabel: formatConnectorTypeLabel(connector.type),
-        typeStyle: resolveTonePillStyle(token, "info"),
-        usageLabel:
-          connector.usedByRoles.length > 0
-            ? `${connector.usedByRoles.length} 个角色在用`
-            : "团队未显式引用",
-        usageStyle: resolveTonePillStyle(
-          token,
-          connector.usedByRoles.length > 0 ? "info" : "neutral",
-        ),
-        usageSummary:
-          connector.usedByRoles.length > 0
-            ? `当前团队会用到：${connector.usedByRoles.join("、")}`
-            : "当前团队还没有显式引用这个连接器。",
-      })),
-    [integrations.items, selectedConnector?.key, token],
-  );
-  const connectorDetailRows = React.useMemo(
-    () =>
-      selectedConnectorRows.map((row) => ({
-        badgeStyle: resolveTonePillStyle(token, row.badgeTone),
-        badgeText: row.badgeText,
-        label: row.label,
-        note: row.note,
-        value: row.value,
-      })),
-    [selectedConnectorRows, token],
-  );
-  const connectorsEmptyDescription =
-    "一旦当前成员服务、连接器目录或治理策略可见，这里会自动展开成 Bindings 视图。";
-  const configurationDetailRows = React.useMemo(
-    () => [
-      {
-        label: "团队流程",
-        note: `workflowId: ${activeWorkflowId || "--"}`,
-        value: workflowNameValue !== "--" ? workflowNameValue : teamTitle,
-      },
-      {
-        label: "绑定方式",
-        note:
-          currentServiceFriendly !== "--"
-            ? `当前会落到 ${currentServiceFriendly}`
-            : "当前还没有匹配到主服务入口",
-        value: formatCompositionKind(lens.activeRevision?.implementationKind || "runtime"),
-      },
-      {
-        label: "主服务入口",
-        note: `serviceId: ${runtimeServiceId || "--"} · serviceKey: ${currentServiceKey}`,
-        value: currentServiceFriendly,
-      },
-      {
-        label: "部署记录",
-        note: `deploymentId: ${currentDeploymentId}`,
-        value: currentDeploymentFriendly,
-      },
-      {
-        label: "版本标识",
-        note: `revisionId: ${currentRevisionId}`,
-        value: currentVersionFriendly,
-      },
-      {
-        label: "连接器引用",
-        note:
-          connectorHighlights.length > 0
-            ? connectorHighlights.join("、")
-            : integrations.items.length > 0
-              ? `工作区可见 ${integrations.items.length} 个连接器定义`
-              : "当前工作区还没有可见连接器定义",
-        value:
-          integrations.linkedConnectorCount > 0
-            ? `${integrations.linkedConnectorCount} 个已引用`
-            : "未显式引用",
-      },
-      {
-        label: "服务能力",
-        note: `${currentPolicyCount} 条策略`,
-        value: `${currentEndpointCount} 个入口`,
-      },
-    ],
-    [
-      activeWorkflowId,
-      currentDeploymentFriendly,
-      currentDeploymentId,
-      currentEndpointCount,
-      currentPolicyCount,
-      currentRevisionId,
-      currentServiceFriendly,
-      currentServiceKey,
-      currentVersionFriendly,
-      connectorHighlights,
-      integrations.items.length,
-      integrations.linkedConnectorCount,
-      lens.activeRevision?.implementationKind,
-      runtimeServiceId,
-      teamTitle,
-      workflowNameValue,
-    ],
-  );
-  const configurationAdjustmentRows = React.useMemo(
-    () => [
-      {
-        badge: formatCompositionKind(lens.activeRevision?.implementationKind || "runtime"),
-        label: "流程定义",
-        note: activeWorkflowId ? `workflowId: ${activeWorkflowId}` : "当前还没有 workflowId",
-        value: workflowNameValue !== "--" ? workflowNameValue : teamTitle,
-      },
-      {
-        badge: currentDeploymentFriendly,
-        label: "服务映射",
-        note:
-          currentVersionFriendly !== "--"
-            ? `${currentVersionFriendly} · ${currentServiceFriendly}`
-            : currentServiceFriendly,
-        value: currentServiceFriendly,
-      },
-      {
-        badge:
-          integrations.linkedConnectorCount > 0
-            ? `${integrations.linkedConnectorCount} 个已引用`
-            : "未显式引用",
-        label: "连接器引用",
-        note:
-          connectorHighlights.length > 0
-            ? connectorHighlights.join("、")
-            : "当前 workflow 还没有显式引用连接器",
-        value:
-          integrations.linkedConnectorCount > 0
-            ? `${integrations.linkedConnectorCount} 个连接器`
-            : "当前没有显式连接器引用",
-      },
-    ],
-    [
-      activeWorkflowId,
-      connectorHighlights,
-      currentDeploymentFriendly,
-      currentServiceFriendly,
-      currentVersionFriendly,
-      integrations.linkedConnectorCount,
-      lens.activeRevision?.implementationKind,
-      teamTitle,
-      workflowNameValue,
-    ],
-  );
-  const advancedSummaryCards = React.useMemo(
-    () => [
-      {
-        caption: activeWorkflowId || "--",
-        captionMonospace: true,
-        label: "团队流程",
-        value: workflowNameValue !== "--" ? workflowNameValue : teamTitle,
-      },
-      {
-        caption:
-          currentServiceFriendly !== "--"
-            ? `当前会落到 ${currentServiceFriendly}`
-            : "当前还没有匹配到主服务入口",
-        label: "绑定方式",
-        value: formatCompositionKind(lens.activeRevision?.implementationKind || "runtime"),
-      },
-      {
-        caption: currentDeploymentId,
-        captionMonospace: true,
-        label: "部署记录",
-        value: currentDeploymentFriendly,
-      },
-      {
-        caption:
-          connectorHighlights.length > 0
-            ? connectorHighlights.join("、")
-            : "当前 workflow 还没有显式引用连接器",
-        label: "连接器引用",
-        value:
-          integrations.linkedConnectorCount > 0
-            ? `${integrations.linkedConnectorCount} 个已引用`
-            : "未显式引用",
-      },
-    ],
-    [
-      activeWorkflowId,
-      connectorHighlights,
-      currentDeploymentFriendly,
-      currentDeploymentId,
-      currentServiceFriendly,
-      integrations.linkedConnectorCount,
-      lens.activeRevision?.implementationKind,
-      teamTitle,
-      workflowNameValue,
-    ],
-  );
-  const advancedTeamImpactSummary =
-    integrations.linkedConnectorCount > 0
-      ? ` ${integrations.linkedConnectorCount} 个已绑定连接器`
-      : " 当前还没有显式绑定的连接器";
-  const workflowAssetRows = React.useMemo(
-    () =>
-      (workflowsQuery.data ?? []).map((workflow) => {
-        const isCurrent =
-          trimText(workflow.workflowId) === trimText(activeWorkflowId) ||
-          trimText(workflow.workflowId) === trimText(activeWorkflowSummary?.workflowId);
-        const statusLabel = formatFriendlyStatus(workflow.deploymentStatus || "draft");
-        return {
-          actionLabel: "进入 Workflow Studio",
-          badgeLabel: isCurrent ? "当前团队流程" : statusLabel,
-          badgeStyle: resolveTonePillStyle(token, isCurrent ? "success" : "neutral"),
-          buttonStyle: resolveSelectionCardButtonStyle(token, isCurrent),
-          key: workflow.workflowId,
-          primaryMetaLabel: "Revision",
-          primaryMetaValue: workflow.activeRevisionId || "n/a",
-          secondaryMetaLabel: "Entrypoint",
-          secondaryMetaValue: workflow.serviceKey || "未绑定",
-          summary: workflow.displayName
-            ? `${workflow.displayName} 已绑定到 ${workflow.serviceKey || "待发布入口"}`
-            : "当前 workflow 已准备好进入 Studio。",
-          subtitle: workflow.workflowName || "Workflow capability",
-          title: workflow.displayName || workflow.workflowId,
-        };
-      }),
-    [activeWorkflowId, activeWorkflowSummary?.workflowId, token, workflowsQuery.data],
-  );
-  const scriptAssetRows = React.useMemo(
-    () =>
-      (scriptsQuery.data ?? []).map((script) => {
-        const isCurrent =
-          trimText(script.scriptId) === trimText(lens.activeRevision?.scriptId);
-        return {
-          actionLabel: "进入 Script Studio",
-          badgeLabel: isCurrent ? "当前绑定脚本" : script.activeRevision ? "已激活" : "草稿",
-          badgeStyle: resolveTonePillStyle(token, isCurrent ? "success" : "neutral"),
-          buttonStyle: resolveSelectionCardButtonStyle(token, isCurrent),
-          key: script.scriptId,
-          primaryMetaLabel: "Revision",
-          primaryMetaValue: trimText(script.activeRevision) || "n/a",
-          secondaryMetaLabel: "Catalog actor",
-          secondaryMetaValue: trimText(script.catalogActorId) || "n/a",
-          summary:
-            trimText(script.activeSourceHash).length > 0
-              ? `当前脚本 revision 已落在 ${trimText(script.activeSourceHash)}`
-              : "当前脚本已经进入 Team 资产目录。",
-          subtitle: "Script capability",
-          title: script.scriptId || "未命名 Script",
-        };
-      }),
-    [lens.activeRevision?.scriptId, scriptsQuery.data, token],
-  );
-  const assetSummaryCards = React.useMemo(
-    () => [
-      {
-        caption: activeWorkflowId || "--",
-        icon: teamAssetIcons.workflows,
-        label: "Workflow 资产",
-        value: workflowsQuery.data?.length ?? 0,
-      },
-      {
-        caption: trimText(lens.activeRevision?.scriptId) || "--",
-        icon: teamAssetIcons.scripts,
-        label: "Script 资产",
-        value: scriptsQuery.data?.length ?? 0,
-      },
-      {
-        caption: workflowNameValue !== "--" ? workflowNameValue : teamTitle,
-        icon: teamAssetIcons.deployment,
-        label: "当前主流程",
-        value: activeWorkflowSummary?.displayName || workflowNameValue,
-      },
-      {
-        caption: currentServiceFriendly !== "--" ? currentServiceFriendly : "待绑定",
-        icon: <DeploymentUnitOutlined />,
-        label: "服务入口",
-        value: runtimeServiceId || "--",
-      },
-    ],
-    [
-      activeWorkflowId,
-      activeWorkflowSummary?.displayName,
-      currentServiceFriendly,
-      lens.activeRevision?.scriptId,
-      runtimeServiceId,
-      scriptsQuery.data?.length,
-      teamTitle,
-      workflowNameValue,
-      workflowsQuery.data?.length,
-    ],
-  );
-  const topologyConnectors = React.useMemo(
-    () =>
-      integrations.items
-        .filter((item) => item.usedByRoles.length > 0)
-        .slice(0, 2),
-    [integrations.items],
-  );
-  const actorLabelMap = React.useMemo(() => {
-    const entries = new Map<string, string>();
-
-    lens.members.forEach((member) => {
-      if (!trimText(member.actorId)) {
-        return;
-      }
-      entries.set(
-        member.actorId,
-        trimText(member.actorType) || compactId(member.actorId),
-      );
-    });
-
-    (actorGraphQuery.data?.subgraph.nodes ?? []).forEach((node) => {
-      const label =
-        trimText(node.properties.label) ||
-        trimText(node.properties.role) ||
-        entries.get(node.nodeId) ||
-        compactId(node.nodeId);
-      entries.set(node.nodeId, label);
-    });
-
-    return entries;
-  }, [actorGraphQuery.data?.subgraph.nodes, lens.members]);
-  const topologyGraph = React.useMemo(() => {
-    const subgraph = actorGraphQuery.data?.subgraph;
-    const rootActorId =
-      trimText(subgraph?.rootNodeId) || effectiveActorId || defaultSelectedActorId;
-    const actorNodes = subgraph?.nodes ?? [];
-    const actorEdges = subgraph?.edges ?? [];
-    const actorNodeMap = new Map(actorNodes.map((node) => [node.nodeId, node]));
-    const playbackStepsByActor = new Map<string, TeamPlaybackSummary["steps"]>();
-    lens.playback.steps.forEach((step) => {
-      const actorId = trimText(step.actorId);
-      if (!actorId) {
-        return;
-      }
-      const currentSteps = playbackStepsByActor.get(actorId) ?? [];
-      currentSteps.push(step);
-      playbackStepsByActor.set(actorId, currentSteps);
-    });
-    const playbackEventsByActor = new Map<string, TeamPlaybackSummary["events"]>();
-    lens.playback.events.forEach((event) => {
-      const actorId = trimText(event.actorId);
-      if (!actorId) {
-        return;
-      }
-      const currentEvents = playbackEventsByActor.get(actorId) ?? [];
-      currentEvents.push(event);
-      playbackEventsByActor.set(actorId, currentEvents);
-    });
-
-    const baseElements =
-      actorNodes.length > 0
-        ? buildActorGraphElements(actorNodes, actorEdges, rootActorId)
-        : { edges: [] as Edge[], nodes: [] as Node[] };
-
-    const actorDisplayNodes = baseElements.nodes.map((node) => {
-      const rawNode = actorNodeMap.get(node.id);
-      const latestStep = (playbackStepsByActor.get(node.id) ?? [])[0];
-      const label =
-        trimText(rawNode?.properties.label) ||
-        trimText(rawNode?.properties.role) ||
-        actorLabelMap.get(node.id) ||
-        compactId(node.id);
-      const summary =
-        trimText(rawNode?.properties.role) ||
-        (trimText(rawNode?.nodeType) ? `团队成员 · ${trimText(rawNode?.nodeType)}` : "") ||
-        actorLabelMap.get(node.id) ||
-        "团队成员";
-      const badgeText = latestStep
-        ? formatFriendlyStatus(latestStep.status)
-        : node.id === rootActorId
-          ? "焦点成员"
-          : "团队成员";
-      const badgeTone: PillTone = latestStep
-        ? latestStep.status === "failed"
-          ? "danger"
-          : latestStep.status === "waiting"
-            ? "warning"
-            : latestStep.status === "completed"
-              ? "success"
-              : "info"
-        : node.id === rootActorId
-          ? "info"
-          : "neutral";
-      const entity: TopologyEntitySummary = {
-        badgeText,
-        badgeTone,
-        id: node.id,
-        kind: "actor",
-        note: trimText(node.id) || "--",
-        summary,
-        title: label,
-      };
-
-      return {
-        ...node,
-        data: {
-          label: React.createElement(TopologyNodeCard, { entity }),
-        },
-        style: {
-          background: "transparent",
-          border: `1px solid ${
-            node.id === rootActorId ? token.colorPrimaryBorder : token.colorBorderSecondary
-          }`,
-          borderRadius: 22,
-          boxShadow:
-            node.id === rootActorId
-              ? `0 0 0 2px ${token.colorPrimaryBorder}55, ${token.boxShadowSecondary}`
-              : token.boxShadowSecondary,
-          padding: 0,
-          width: 244,
-        },
-      } satisfies Node;
-    });
-
-    const actorDisplayEdges = baseElements.edges.map((edge, index) => ({
-      ...edge,
-      animated: false,
-      label: "",
-      style: {
-        stroke:
-          index % 3 === 0
-            ? token.colorPrimary
-            : index % 3 === 1
-              ? token.colorSuccess
-              : token.colorWarning,
-        strokeWidth: 2.5,
-      },
-    }));
-
-    const positionedActorNodes = actorDisplayNodes;
-    const maxActorX =
-      positionedActorNodes.length > 0
-        ? Math.max(...positionedActorNodes.map((node) => node.position.x))
-        : 0;
-    const focusActorNode =
-      positionedActorNodes.find((node) => node.id === rootActorId) ||
-      positionedActorNodes[0];
-    const focusPosition = focusActorNode?.position ?? { x: 0, y: 0 };
-    const serviceNodeId = trimText(runtimeServiceId)
-      ? `topology-service:${runtimeServiceId}`
-      : "";
-    const hasServiceNode =
-      serviceNodeId.length > 0 && currentServiceFriendly !== "--";
-    const serviceNodeX = maxActorX + 280;
-    const serviceNodeY = focusPosition.y + 70;
-
-    const serviceNode = hasServiceNode
-      ? ({
-          data: {
-            label: React.createElement(TopologyNodeCard, {
-              entity: {
-                badgeText: currentDeploymentFriendly,
-                badgeTone:
-                  currentDeploymentStatus !== "--" ? "success" : "neutral",
-                id: serviceNodeId,
-                kind: "service",
-                note: currentServiceKey,
-                summary: "对外服务入口",
-                title: currentServiceFriendly,
-              },
-            }),
-          },
-          id: serviceNodeId,
-          position: {
-            x: serviceNodeX,
-            y: serviceNodeY,
-          },
-          style: {
-            background: "transparent",
-            border: `1px solid ${token.colorInfoBorder}`,
-            borderRadius: 22,
-            boxShadow: token.boxShadowSecondary,
-            padding: 0,
-            width: 244,
-          },
-          type: "default",
-        } satisfies Node)
-      : null;
-
-    const connectorNodes = topologyConnectors.map((connector, index) => {
-      const connectorNodeId = `topology-connector:${connector.key}`;
-      return {
-        data: {
-          label: React.createElement(TopologyNodeCard, {
-            entity: {
-              badgeText: formatConnectorEnabledLabel(connector.enabled),
-              badgeTone: connector.enabled ? "warning" : "neutral",
-              id: connectorNodeId,
-              kind: "connector",
-              note: connector.usedByRoles.join("、") || connector.summary,
-              summary: `${formatConnectorTypeLabel(connector.type)} 连接器`,
-              title: connector.name,
-            },
-          }),
-        },
-        id: connectorNodeId,
-        position: {
-          x: serviceNodeX + 280,
-          y: serviceNodeY - 90 + index * 180,
-        },
-        style: {
-          background: "transparent",
-          border: `1px solid ${token.colorWarningBorder}`,
-          borderRadius: 22,
-          boxShadow: token.boxShadowSecondary,
-          padding: 0,
-          width: 244,
-        },
-        type: "default",
-      } satisfies Node;
-    });
-
-    const derivedEdges: Edge[] = [];
-    if (hasServiceNode && rootActorId) {
-      derivedEdges.push({
-        id: `derived-actor-service:${rootActorId}`,
-        source: rootActorId,
-        target: serviceNodeId,
-        label: "",
-        style: {
-          stroke: token.colorInfo,
-          strokeDasharray: "6 6",
-          strokeWidth: 2,
-        },
-      });
-    }
-    connectorNodes.forEach((connectorNode) => {
-      if (!hasServiceNode) {
-        return;
-      }
-      derivedEdges.push({
-        id: `derived-service-connector:${connectorNode.id}`,
-        source: serviceNodeId,
-        target: connectorNode.id,
-        label: "",
-        style: {
-          stroke: token.colorWarning,
-          strokeDasharray: "6 6",
-          strokeWidth: 2,
-        },
-      });
-    });
-
-    const nodes = [...positionedActorNodes, ...(serviceNode ? [serviceNode] : []), ...connectorNodes];
-    const edges = [...actorDisplayEdges, ...derivedEdges];
-    const depthMap = buildDepthMap(
-      rootActorId,
-      edges.map((edge) => ({
-        source: String(edge.source),
-        target: String(edge.target),
-      })),
-    );
-
-    const entityMap = new Map<string, TopologyEntitySummary>();
-    positionedActorNodes.forEach((node) => {
-      const rawNode = actorNodeMap.get(node.id);
-      const latestEvent = (playbackEventsByActor.get(node.id) ?? [])[0];
-      const latestStep = (playbackStepsByActor.get(node.id) ?? [])[0];
-      entityMap.set(node.id, {
-        badgeText: latestStep
-          ? formatFriendlyStatus(latestStep.status)
-          : node.id === rootActorId
-            ? "焦点成员"
-            : "团队成员",
-        badgeTone: latestStep
-          ? latestStep.status === "failed"
-            ? "danger"
-            : latestStep.status === "waiting"
-              ? "warning"
-              : latestStep.status === "completed"
-                ? "success"
-                : "info"
-          : node.id === rootActorId
-            ? "info"
-            : "neutral",
-        id: node.id,
-        kind: "actor",
-        note: latestEvent?.message || trimText(node.id) || "--",
-        summary:
-          trimText(rawNode?.properties.role) ||
-          (trimText(rawNode?.nodeType) ? `团队成员 · ${trimText(rawNode?.nodeType)}` : "") ||
-          actorLabelMap.get(node.id) ||
-          "团队成员",
-        title:
-          trimText(rawNode?.properties.label) ||
-          trimText(rawNode?.properties.role) ||
-          actorLabelMap.get(node.id) ||
-          compactId(node.id),
-      });
-    });
-    if (serviceNode) {
-      entityMap.set(serviceNode.id, {
-        badgeText: currentDeploymentFriendly,
-        badgeTone: currentDeploymentStatus !== "--" ? "success" : "neutral",
-        id: serviceNode.id,
-        kind: "service",
-        note: currentServiceKey,
-        summary: "对外服务入口",
-        title: currentServiceFriendly,
-      });
-    }
-    topologyConnectors.forEach((connector) => {
-      entityMap.set(`topology-connector:${connector.key}`, {
-        badgeText: formatConnectorEnabledLabel(connector.enabled),
-        badgeTone: connector.enabled ? "warning" : "neutral",
-        id: `topology-connector:${connector.key}`,
-        kind: "connector",
-        note: connector.usedByRoles.join("、") || connector.summary,
-        summary: `${formatConnectorTypeLabel(connector.type)} 连接器`,
-        title: connector.name,
-      });
-    });
-
-    return {
-      depthMap,
-      entityMap,
-      eventMap: playbackEventsByActor,
-      nodes,
-      rootActorId,
-      stepMap: playbackStepsByActor,
-      edges,
-    };
-  }, [
-    actorGraphQuery.data?.subgraph,
-    actorLabelMap,
-    currentDeploymentFriendly,
-    currentDeploymentStatus,
-    currentServiceFriendly,
-    currentServiceKey,
-    defaultSelectedActorId,
-    effectiveActorId,
-    integrations.items,
-    lens.members,
-    lens.playback.events,
-    lens.playback.steps,
-    runtimeServiceId,
-    token.boxShadowSecondary,
-    token.colorBorderSecondary,
-    token.colorInfo,
-    token.colorInfoBorder,
-    token.colorPrimary,
-    token.colorPrimaryBorder,
-    token.colorSuccess,
-    token.colorWarning,
-    token.colorWarningBorder,
-    topologyConnectors,
-  ]);
-  const topologyNodeIds = React.useMemo(
-    () => topologyGraph.nodes.map((node) => node.id),
-    [topologyGraph.nodes],
-  );
   React.useEffect(() => {
-    if (topologyNodeIds.length === 0) {
-      setSelectedTopologyNodeId("");
+    if (!team) {
       return;
     }
-    if (!selectedTopologyNodeId || !topologyNodeIds.includes(selectedTopologyNodeId)) {
-      setSelectedTopologyNodeId(
-        topologyNodeIds.includes(effectiveActorId)
-          ? effectiveActorId
-          : topologyNodeIds[0],
+
+    setTeamDisplayName(team.displayName);
+    setTeamDescription(team.description);
+  }, [team]);
+
+  const invalidateTeamQueries = React.useCallback(async () => {
+    const invalidations: Array<Promise<unknown>> = [];
+    if (scopeId) {
+      invalidations.push(
+        queryClient.invalidateQueries({ queryKey: ["teams", "roster", scopeId] }),
+      );
+      invalidations.push(
+        queryClient.invalidateQueries({ queryKey: ["teams", "all-members", scopeId] }),
       );
     }
-  }, [effectiveActorId, selectedTopologyNodeId, topologyNodeIds]);
-  const selectedTopologyEntity =
-    topologyGraph.entityMap.get(selectedTopologyNodeId) ??
-    topologyGraph.entityMap.get(effectiveActorId) ??
-    null;
-  const selectedTopologyEvent =
-    (selectedTopologyEntity?.kind === "actor"
-      ? topologyGraph.eventMap.get(selectedTopologyEntity.id)?.[0]
-      : null) ?? null;
-  const selectedTopologyStep =
-    (selectedTopologyEntity?.kind === "actor"
-      ? topologyGraph.stepMap.get(selectedTopologyEntity.id)?.[0]
-      : null) ?? null;
-  const selectedTopologyInboundCount = topologyGraph.edges.filter(
-    (edge) => edge.target === selectedTopologyEntity?.id,
-  ).length;
-  const selectedTopologyOutboundCount = topologyGraph.edges.filter(
-    (edge) => edge.source === selectedTopologyEntity?.id,
-  ).length;
-  const selectedTopologyDepth =
-    topologyGraph.depthMap.get(selectedTopologyEntity?.id || "") ?? 0;
-  const selectedTopologyInboundTitles = React.useMemo(
-    () =>
-      selectedTopologyEntity
-        ? topologyGraph.edges
-            .filter((edge) => edge.target === selectedTopologyEntity.id)
-            .map(
-              (edge) =>
-                topologyGraph.entityMap.get(String(edge.source))?.title ||
-                compactId(String(edge.source)),
-            )
-        : [],
-    [selectedTopologyEntity, topologyGraph.edges, topologyGraph.entityMap],
-  );
-  const selectedTopologyOutboundTitles = React.useMemo(
-    () =>
-      selectedTopologyEntity
-        ? topologyGraph.edges
-            .filter((edge) => edge.source === selectedTopologyEntity.id)
-            .map(
-              (edge) =>
-                topologyGraph.entityMap.get(String(edge.target))?.title ||
-                compactId(String(edge.target)),
-            )
-        : [],
-    [selectedTopologyEntity, topologyGraph.edges, topologyGraph.entityMap],
-  );
-  const selectedTopologyInboundSummary = summarizeTopologyTitles(
-    selectedTopologyInboundTitles,
-    "当前没有上游节点",
-  );
-  const selectedTopologyOutboundSummary = summarizeTopologyTitles(
-    selectedTopologyOutboundTitles,
-    "当前没有下游节点",
-  );
-  const selectedTopologyLatestStepLabel = selectedTopologyStep
-    ? `${selectedTopologyStep.stepId} · ${formatStepTypeLabel(selectedTopologyStep.stepType)}`
-    : "当前还没有可见步骤";
-  const selectedTopologyLatestStepNote = selectedTopologyStep
-    ? [
-        selectedTopologyStep.detail,
-        selectedTopologyStep.timestamp
-          ? `发生于 ${formatCompactTimestamp(selectedTopologyStep.timestamp)}`
-          : "",
-      ]
-        .filter(Boolean)
-        .join(" · ")
-    : selectedTopologyEvent?.message || "当前还没有更多节点运行细节。";
-  const selectedTopologyRows = React.useMemo<TopologyDetailRow[]>(() => {
-    if (!selectedTopologyEntity) {
-      return [];
-    }
-
-    if (selectedTopologyEntity.kind === "service") {
-      return [
-        {
-          badge: "服务",
-          label: "主服务",
-          note: runtimeServiceId || currentServiceKey || "--",
-          noteMonospace: true,
-          noteRows: 1,
-          value: currentServiceFriendly,
-          valueMonospace: false,
-        },
-        {
-          badge: "部署",
-          label: "部署状态",
-          note: currentDeploymentId,
-          noteMonospace: true,
-          noteRows: 1,
-          value: currentDeploymentFriendly,
-          valueMonospace: false,
-        },
-        {
-          badge: `${currentEndpointCount} 个入口`,
-          label: "服务能力",
-          note: `${currentPolicyCount} 条策略`,
-          value: `${currentEndpointCount} 个入口`,
-          valueMonospace: false,
-        },
-        {
-          badge: `${selectedTopologyInboundCount} 条入边`,
-          label: "上游来自",
-          note: `当前深度 ${selectedTopologyDepth} · 出边 ${selectedTopologyOutboundCount}`,
-          value: selectedTopologyInboundSummary,
-          valueMonospace: false,
-        },
-        {
-          badge: `${selectedTopologyOutboundCount} 条出边`,
-          label: "下游连接",
-          note: "当前团队通过这个入口继续流向工具或下游能力",
-          value: selectedTopologyOutboundSummary,
-          valueMonospace: false,
-        },
-      ];
-    }
-
-    if (selectedTopologyEntity.kind === "connector") {
-      const connector = topologyConnectors.find(
-        (item) => `topology-connector:${item.key}` === selectedTopologyEntity.id,
-      );
-      return [
-        {
-          badge: formatConnectorTypeLabel(connector?.type || "--"),
-          label: "连接器",
-          note: connector?.summary || "--",
-          value: connector?.name || selectedTopologyEntity.title,
-          valueMonospace: false,
-        },
-        {
-          badge: formatConnectorEnabledLabel(Boolean(connector?.enabled)),
-          label: "团队使用",
-          note: connector?.usedByRoles.join("、") || "当前团队还没有引用它",
-          value:
-            connector?.usedByRoles.length
-              ? `${connector.usedByRoles.length} 个角色`
-              : "0 个角色",
-          valueMonospace: false,
-        },
-        {
-          badge: `${selectedTopologyInboundCount} 条入边`,
-          label: "上游来自",
-          note: `当前深度 ${selectedTopologyDepth} · 出边 ${selectedTopologyOutboundCount}`,
-          value: selectedTopologyInboundSummary,
-          valueMonospace: false,
-        },
-        {
-          badge: `${selectedTopologyOutboundCount} 条出边`,
-          label: "下游连接",
-          note: "当前节点来自团队配置推导，不直接代表一次实时运行",
-          value: selectedTopologyOutboundSummary,
-          valueMonospace: false,
-        },
-      ];
-    }
-
-    return [
-      {
-        badge: formatTopologyNodeKindLabel(selectedTopologyEntity.kind),
-        label: "角色定位",
-        note: selectedTopologyEntity.id,
-        noteMonospace: true,
-        noteRows: 1,
-        value: selectedTopologyEntity.title,
-        valueMonospace: false,
-      },
-      {
-        badge: selectedTopologyStep
-          ? formatStepTypeLabel(selectedTopologyStep.stepType)
-          : "最近事件",
-        label: "最近一步",
-        note: selectedTopologyLatestStepNote,
-        value: selectedTopologyLatestStepLabel,
-        valueMonospace: false,
-      },
-      {
-        badge: selectedTopologyStep
-          ? formatFriendlyStatus(selectedTopologyStep.status)
-          : selectedTopologyEntity.badgeText,
-        label: "当前状态",
-        note:
-          selectedTopologyEvent?.message ||
-          selectedTopologyEntity.note ||
-          "当前还没有更多节点运行细节。",
-        value: selectedTopologyEntity.summary,
-        valueMonospace: false,
-      },
-      {
-        badge: `${selectedTopologyInboundCount} 条入边`,
-        label: "上游来自",
-        note: `当前深度 ${selectedTopologyDepth} · 出边 ${selectedTopologyOutboundCount}`,
-        value: selectedTopologyInboundSummary,
-        valueMonospace: false,
-      },
-      {
-        badge: `${selectedTopologyOutboundCount} 条出边`,
-        label: "下游流向",
-        note:
-          selectedTopologyEntity.id === topologyGraph.rootActorId
-            ? "这是当前焦点路径的起点"
-            : "这是围绕当前焦点展开的协作节点",
-        value: selectedTopologyOutboundSummary,
-        valueMonospace: false,
-      },
-    ];
-  }, [
-    currentDeploymentFriendly,
-    currentDeploymentId,
-    currentEndpointCount,
-    currentPolicyCount,
-    currentServiceFriendly,
-    currentServiceKey,
-    runtimeServiceId,
-    selectedTopologyDepth,
-    selectedTopologyEntity,
-    selectedTopologyEvent,
-    selectedTopologyInboundCount,
-    selectedTopologyInboundSummary,
-    selectedTopologyOutboundCount,
-    selectedTopologyOutboundSummary,
-    selectedTopologyLatestStepLabel,
-    selectedTopologyLatestStepNote,
-    selectedTopologyStep,
-    topologyConnectors,
-    topologyGraph.rootActorId,
-  ]);
-  const topologyDetailRows = React.useMemo(
-    () =>
-      selectedTopologyRows.map((row) => ({
-        ...row,
-        badgeStyle: resolveTonePillStyle(token, "neutral"),
-      })),
-    [selectedTopologyRows, token],
-  );
-  const compositionDisplayRows = React.useMemo(() => {
-    if (teamCompositionRows.length > 0) {
-      return teamCompositionRows;
-    }
-
-    return [
-      {
-        key: "fallback-workflow",
-        kind: "workflow",
-        name: "团队流程",
-        summary: workflowNameValue !== "--" ? workflowNameValue : activeWorkflowId || "--",
-      },
-      {
-        key: "fallback-actor",
-        kind: "actor",
-        name: "当前执行",
-        summary: activeRunId ? `${currentRunFriendly} · ${compactId(currentActorId)}` : "暂无最近运行",
-      },
-      {
-        key: "fallback-service",
-        kind: "service",
-        name: "主服务",
-        summary: currentServiceFriendly,
-      },
-    ];
-  }, [
-    activeWorkflowId,
-    activeRunId,
-    currentActorId,
-    currentRunFriendly,
-    currentServiceKey,
-    currentServiceFriendly,
-    runtimeServiceId,
-    teamCompositionRows,
-    workflowNameValue,
-  ]);
-  const runtimeSummaryRows = [
-    {
-      badge: currentRevisionFriendly,
-      badgeColor: currentRevisionStatus === "Active" ? "success" : undefined,
-      key: "revisionId",
-      label: "当前版本",
-      note:
-        currentRevisionId !== "--"
-          ? `revisionId · ${compactId(currentRevisionId)}`
-          : "当前还没有可见版本标识",
-      noteMonospace: false,
-      noteTooltip:
-        currentRevisionId !== "--"
-          ? `revisionId · ${currentRevisionId}`
-          : "当前还没有可见版本标识",
-      value: currentRevisionFriendly,
-    },
-    {
-      badge: currentServiceFriendly,
-      badgeColor: runtimeServiceId ? "success" : undefined,
-      key: "serviceKey",
-      label: "主服务",
-      note: currentServiceReference
-        ? `serviceId · ${compactId(currentServiceReference)}`
-        : "当前还没有主服务标识",
-      noteMonospace: false,
-      noteTooltip: currentServiceReference
-        ? `serviceId · ${currentServiceReference}`
-        : "当前还没有主服务标识",
-      value: currentServiceFriendly,
-    },
-    {
-      badge: currentRunFriendly,
-      badgeColor: currentRunStatus !== "--" ? "success" : undefined,
-      key: "runId",
-      label: "最近状态",
-      note: activeRunId
-        ? `runId · ${compactId(activeRunId)}`
-        : currentActorId !== "--"
-          ? `actorId · ${compactId(currentActorId)}`
-          : "当前还没有可见运行身份",
-      noteMonospace: false,
-      noteTooltip: activeRunId
-        ? `runId · ${activeRunId}`
-        : currentActorId !== "--"
-          ? `actorId · ${currentActorId}`
-          : "当前还没有可见运行身份",
-      value: currentRunFriendly,
-    },
-    {
-      badge: currentStateVersion !== "--" ? `v${currentStateVersion}` : "--",
-      key: "lastUpdatedAt",
-      label: "最近更新时间",
-      note: latestVisibleUpdateNote,
-      noteMonospace: false,
-      value: latestVisibleUpdate ? formatCompactTimestamp(latestVisibleUpdate) : "--",
-    },
-    {
-      badge: `${integrations.linkedConnectorCount}`,
-      badgeColor: integrations.linkedConnectorCount > 0 ? "success" : undefined,
-      key: "bindings",
-      label: "Bindings",
-      note:
-        connectorHighlights.length > 0
-          ? connectorHighlights.join("、")
-          : `catalog: ${integrations.items.length}`,
-      noteMonospace: false,
-      value:
-        integrations.linkedConnectorCount > 0
-          ? `${integrations.linkedConnectorCount} 个已绑定`
-          : "未配置",
-    },
-  ];
-  const overviewCompositionRows = React.useMemo(
-    () =>
-      compositionDisplayRows.map((row) => ({
-        key: row.key,
-        kindLabel: formatCompositionKind(row.kind),
-        kindStyle: resolveCompositionKindPillStyle(token, row.kind),
-        name: row.name,
-        summary: row.summary,
-      })),
-    [compositionDisplayRows, token],
-  );
-  const overviewRuntimeSummaryRows = runtimeSummaryRows.map((row) => ({
-    ...row,
-    badgeStyle:
-      row.badgeColor === "success"
-        ? resolveTonePillStyle(token, "success")
-        : resolveStatusPillStyle(token, row.badge),
-  }));
-  const overviewGovernanceRows = [
-    {
-      badge: currentRevisionId !== "--" ? "serving" : "unknown",
-      badgeStyle:
-        currentRevisionId !== "--"
-          ? resolveTonePillStyle(token, "info")
-          : resolveTonePillStyle(token, "neutral"),
-      key: "servingRevision",
-      label: "Serving",
-      note:
-        lens.governance.servingRevision !== "Unknown"
-          ? `serving revision · ${compactId(lens.governance.servingRevision)}`
-          : "当前还没有可见 serving revision。",
-      value:
-        lens.governance.servingRevision !== "Unknown"
-          ? compactId(lens.governance.servingRevision)
-          : "Unknown",
-    },
-    {
-      badge: lens.currentRun ? "可追踪" : "暂无运行",
-      badgeStyle: lens.currentRun
-        ? resolveTonePillStyle(token, "success")
-        : resolveTonePillStyle(token, "neutral"),
-      key: "traceability",
-      label: "审计链路",
-      note: lens.governance.traceability,
-      value: lens.currentRun ? `run ${compactId(lens.currentRun.runId)}` : "暂无近期运行",
-    },
-    {
-      badge: lens.humanInterventionDetected ? "人工介入" : "未介入",
-      badgeStyle: lens.humanInterventionDetected
-        ? resolveTonePillStyle(token, "warning")
-        : resolveTonePillStyle(token, "success"),
-      key: "humanIntervention",
-      label: "人工介入",
-      note: lens.governance.humanIntervention,
-      value: lens.humanInterventionDetected ? "Manual gate active" : "No active override",
-    },
-    {
-      badge: lens.baselineRun ? "有基线" : "无基线",
-      badgeStyle: lens.baselineRun
-        ? resolveTonePillStyle(token, "success")
-        : resolveTonePillStyle(token, "warning"),
-      key: "fallback",
-      label: "回退基线",
-      note: lens.governance.fallback,
-      value: lens.baselineRun ? `run ${compactId(lens.baselineRun.runId)}` : "Fallback unavailable",
-    },
-    {
-      badge: currentDeploymentFriendly,
-      badgeStyle: resolveStatusPillStyle(token, currentDeploymentStatus),
-      key: "rollout",
-      label: "Rollout",
-      note: lens.governance.rollout,
-      value: currentDeploymentFriendly,
-    },
-  ];
-  const overviewCompareStatusLabel = lens.compare.available
-    ? "基线可用"
-    : lens.currentRun
-      ? "等待基线"
-      : "等待运行";
-  const overviewCompareStatusStyle = lens.compare.available
-    ? resolveTonePillStyle(token, "success")
-    : lens.currentRun
-      ? resolveTonePillStyle(token, "warning")
-      : resolveTonePillStyle(token, "info");
-  const overviewHealthDetails = lens.healthDetails.map(formatTeamHealthDetail);
-  const overviewPartialSignals = lens.partialSignals.map(formatPartialSignal);
-  const displayedRunId = lens.currentRun?.runId || preferredRunId || "";
-  const runSwitchOptions = React.useMemo(
-    () =>
-      (runsQuery.data?.runs ?? []).slice(0, 4).map((run) => ({
-        label: `${formatCompactTimestamp(run.lastUpdatedAt)} · ${formatFriendlyStatus(run.completionStatus)}`,
-        runId: run.runId,
-      })),
-    [runsQuery.data?.runs],
-  );
-  const runSwitchDisplayOptions = React.useMemo(
-    () =>
-      runSwitchOptions.map((option) => ({
-        ...option,
-        buttonStyle: resolveSegmentedButtonStyle(
-          token,
-          option.runId === displayedRunId,
-        ),
-      })),
-    [displayedRunId, runSwitchOptions, token],
-  );
-  const playbackStepMap = React.useMemo(
-    () => new Map(lens.playback.steps.map((step) => [step.stepId, step])),
-    [lens.playback.steps],
-  );
-  const eventStreamRows = React.useMemo(
-    () =>
-      lens.playback.events.map((event) => {
-        const relatedStep = event.stepId ? playbackStepMap.get(event.stepId) ?? null : null;
-        const sourceLabel =
-          trimText(event.actorId ? actorLabelMap.get(event.actorId) : "") ||
-          compactId(event.actorId) ||
-          "当前团队";
-        const targetLabel =
-          trimText(relatedStep?.owner) ||
-          trimText(relatedStep?.actorId ? actorLabelMap.get(relatedStep.actorId) : "") ||
-          "";
-        const flowLabel =
-          targetLabel && normalizeStatus(targetLabel) !== normalizeStatus(sourceLabel)
-            ? `${sourceLabel} -> ${targetLabel}`
-            : sourceLabel;
-        const detailNote = [event.detail, relatedStep?.summary || ""]
-          .map((part) => trimText(part))
-          .filter(Boolean)
-          .filter((part, index, items) => items.indexOf(part) === index)
-          .join(" · ");
-
-        return {
-          detail: event.message,
-          detailNote,
-          flowLabel,
-          key: event.key,
-          stageLabel: formatEventStreamStageLabel(event.stage, relatedStep?.stepType),
-          stageTone: resolveEventStreamTone(event.stage, event.tone, relatedStep?.stepType),
-          timeLabel: formatClockTimestamp(event.timestamp),
-        };
-      }),
-    [actorLabelMap, lens.playback.events, playbackStepMap],
-  );
-  const eventStreamDisplayRows = React.useMemo(
-    () =>
-      eventStreamRows.map((row) => ({
-        ...row,
-        stageStyle: resolveTonePillStyle(token, row.stageTone),
-      })),
-    [eventStreamRows, token],
-  );
-  const memberMappingRows = React.useMemo(() => {
-    const memberByActorId = new Map(lens.members.map((member) => [member.actorId, member]));
-    const rows = new Map<
-      string,
-      {
-        implementation: string;
-        key: string;
-        member: string;
-        responsibility: string;
-        serviceLabel: string;
-        serviceNote: string;
-        statusLabel: string;
-        statusNote?: string;
-        statusTone: PillTone;
-      }
-    >();
-
-    lens.playback.steps.forEach((step) => {
-      const actorId = trimText(step.actorId);
-      const member = actorId ? memberByActorId.get(actorId) ?? null : null;
-      const actorLabel =
-        trimText(actorId ? actorLabelMap.get(actorId) : "") ||
-        trimText(step.owner) ||
-        trimText(member?.actorType) ||
-        compactId(actorId) ||
-        "当前成员";
-      const matchingRole =
-        teamCompositionRows.find(
-          (row) =>
-            normalizeStatus(row.name) === normalizeStatus(step.owner) ||
-            normalizeStatus(row.name) === normalizeStatus(actorLabel),
-        ) || null;
-      const rowKey =
-        actorId || `owner:${normalizeStatus(step.owner) || normalizeStatus(actorLabel)}`;
-
-      if (rows.has(rowKey)) {
-        return;
-      }
-
-      rows.set(rowKey, {
-        implementation:
-          trimText(member?.actorType) ||
-          formatCompositionKind(lens.activeRevision?.implementationKind || "runtime"),
-        key: rowKey,
-        member: actorLabel,
-        responsibility: matchingRole?.summary || step.summary || step.detail || "--",
-        serviceLabel: currentServiceFriendly,
-        serviceNote: runtimeServiceId || currentServiceKey || "--",
-        statusLabel: formatMemberPresenceLabel(member?.isFocused ? "focus" : "run"),
-        statusNote: formatFriendlyStatus(step.status),
-        statusTone: resolveMemberPresenceTone(member?.isFocused ? "focus" : "run"),
-      });
-    });
-
-    if (rows.size > 0) {
-      return [...rows.values()];
-    }
-
-    lens.playback.events.forEach((event) => {
-      const actorId = trimText(event.actorId);
-      const member = actorId ? memberByActorId.get(actorId) ?? null : null;
-      const actorLabel =
-        trimText(actorId ? actorLabelMap.get(actorId) : "") ||
-        trimText(member?.actorType) ||
-        compactId(actorId) ||
-        "当前成员";
-      const rowKey = actorId || `event:${event.key}`;
-      if (rows.has(rowKey)) {
-        return;
-      }
-
-      rows.set(rowKey, {
-        implementation:
-          trimText(member?.actorType) ||
-          formatCompositionKind(lens.activeRevision?.implementationKind || "runtime"),
-        key: rowKey,
-        member: actorLabel,
-        responsibility: event.message || event.detail || "--",
-        serviceLabel: currentServiceFriendly,
-        serviceNote: runtimeServiceId || currentServiceKey || "--",
-        statusLabel: formatMemberPresenceLabel(member?.isFocused ? "focus" : "run"),
-        statusNote: formatEventStreamStageLabel(event.stage),
-        statusTone: resolveMemberPresenceTone(member?.isFocused ? "focus" : "run"),
-      });
-    });
-
-    return [...rows.values()];
-  }, [
-    actorLabelMap,
-    currentServiceFriendly,
-    currentServiceKey,
-    lens.activeRevision?.implementationKind,
-    lens.members,
-    lens.playback.events,
-    lens.playback.steps,
-    runtimeServiceId,
-    teamCompositionRows,
-  ]);
-  const memberMappingDisplayRows = React.useMemo(
-    () =>
-      memberMappingRows.map((row) => ({
-        ...row,
-        statusStyle: resolveTonePillStyle(token, row.statusTone),
-      })),
-    [memberMappingRows, token],
-  );
-  const runtimeIdentityRows = React.useMemo(
-    () =>
-      lens.members.map((member) => {
-        const graphNode =
-          lens.graph.nodes.find((node) => node.actorId === member.actorId) ?? null;
-        const implementationKind = formatCompositionKind(
-          lens.activeRevision?.implementationKind || "runtime",
-        );
-        return {
-          actorId: member.actorId,
-          implementationKind: trimText(member.actorType)
-            ? `${implementationKind} · ${trimText(member.actorType)}`
-            : implementationKind,
-          key: member.actorId,
-          member:
-            trimText(actorLabelMap.get(member.actorId)) ||
-            trimText(member.actorType) ||
-            compactId(member.actorId),
-          note:
-            graphNode?.caption ||
-            "当前还没有更多可见的运行时协作关系。",
-          relationLabel:
-            graphNode != null
-              ? `${graphNode.relationCount} 条可见关系`
-              : "暂无可见关系",
-          serviceId: runtimeServiceId || currentServiceKey || "--",
-          statusLabel: formatMemberPresenceLabel(member.isFocused ? "focus" : "visible"),
-          statusTone: resolveMemberPresenceTone(member.isFocused ? "focus" : "visible"),
-        };
-      }),
-    [
-      actorLabelMap,
-      currentServiceKey,
-      lens.activeRevision?.implementationKind,
-      lens.graph.nodes,
-      lens.members,
-      runtimeServiceId,
-    ],
-  );
-  const memberCompositionRows = React.useMemo(
-    () =>
-      teamCompositionRows.map((row) => ({
-        key: row.key,
-        kindLabel: formatCompositionKind(row.kind),
-        kindStyle: resolveCompositionKindPillStyle(token, row.kind),
-        name: row.name,
-        summary: row.summary,
-      })),
-    [teamCompositionRows, token],
-  );
-  const memberIdentityRows = React.useMemo(
-    () =>
-      runtimeIdentityRows.map((row) => ({
-        actorId: row.actorId,
-        cardStyle: resolveSelectionCardButtonStyle(
-          token,
-          row.actorId === effectiveActorId,
-        ),
-        implementationKind: row.implementationKind,
-        key: row.key,
-        member: row.member,
-        note: row.note,
-        relationLabel: row.relationLabel,
-        serviceId: row.serviceId,
-        statusLabel: row.statusLabel,
-        statusStyle: resolveTonePillStyle(token, row.statusTone),
-      })),
-    [effectiveActorId, runtimeIdentityRows, token],
-  );
-
-  const tabOptions: TeamTabOption[] = [
-    { label: "概览", value: "overview" },
-    { label: "事件拓扑", value: "topology" },
-    { label: "事件流", value: "events" },
-    { label: "团队成员", value: "members" },
-    { label: "Bindings", value: "bindings" },
-    { label: "Assets", value: "assets" },
-    { label: "配置", value: "advanced" },
-  ];
-
-  const initialLoading =
-    serviceRevisionsQuery.isLoading ||
-    servicesQuery.isLoading ||
-    actorsQuery.isLoading ||
-    workflowsQuery.isLoading ||
-    scriptsQuery.isLoading;
-
-  const pushTeamTab = React.useCallback(
-    (tab: TeamDetailTab) => {
-      setActiveTab(tab);
-      history.push(
-        buildTeamDetailHref({
-          memberId: currentMemberId || undefined,
-          scopeId,
-          workflowId: activeWorkflowId || undefined,
-          serviceId: runtimeServiceId,
-          runId:
-            preferredRunId ||
-            lens.currentRun?.runId ||
-            lens.playback.currentRunId ||
-            undefined,
-          tab,
+    if (scopeId && selectedTeamId) {
+      invalidations.push(
+        queryClient.invalidateQueries({
+          queryKey: ["teams", "detail", scopeId, selectedTeamId],
         }),
       );
-    },
-    [
-      activeWorkflowId,
-      currentMemberId,
-      lens.currentRun?.runId,
-      lens.playback.currentRunId,
-      preferredRunId,
-      runtimeServiceId,
-      scopeId,
-    ],
-  );
-
-  const handleSelectRun = React.useCallback(
-    (runId: string) => {
-      const normalizedRunId = trimText(runId);
-      setPreferredRunId(normalizedRunId);
-      setSelectedActorId("");
-      setSelectedTopologyNodeId("");
-      history.push(
-        buildTeamDetailHref({
-          memberId: currentMemberId || undefined,
-          scopeId,
-          workflowId: activeWorkflowId || undefined,
-          serviceId: runtimeServiceId,
-          runId: normalizedRunId || undefined,
-          tab: activeTab,
+      invalidations.push(
+        queryClient.invalidateQueries({
+          queryKey: ["teams", "detail-members", scopeId, selectedTeamId],
         }),
       );
-    },
-    [activeTab, activeWorkflowId, currentMemberId, runtimeServiceId, scopeId],
-  );
+    }
+    await Promise.all(invalidations);
+  }, [queryClient, scopeId, selectedTeamId]);
 
-  const handleOpenConversation = React.useCallback(() => {
-    if (lens.playback.currentRunId) {
-      handleOpenPlaybackRun();
+  const handleSaveTeam = async () => {
+    if (!scopeId || !selectedTeamId || !teamDisplayName.trim()) {
       return;
     }
-    history.push(
-      buildRuntimeRunsHref({
+
+    setBusyAction("save-team");
+    try {
+      const updated = await studioApi.updateTeam({
         scopeId,
-        serviceId: runtimeServiceId,
-        actorId: lens.currentRun?.actorId || undefined,
-      }),
-    );
-  }, [
-    handleOpenPlaybackRun,
-    lens.currentRun?.actorId,
-    lens.playback.currentRunId,
-    runtimeServiceId,
-    scopeId,
-  ]);
-  const conversationActionLabel = lens.playback.currentRunId ? "本次对话" : "运行记录";
-  const serviceMappingActionLabel = "服务映射";
-  const teamBuilderActionLabel = "高级编辑";
-  const topologyFocusActorId =
-    trimText(effectiveActorId) ||
-    trimText(lens.graph.focusActorId) ||
-    trimText(lens.playback.rootActorId) ||
-    trimText(lens.currentRun?.actorId) ||
-    "";
-  const canAdjustTopologyDepth = topologyFocusActorId.length > 0;
-  const canOpenPlatformTopology = topologyFocusActorId.length > 0;
-  const topologyDepthLabel = formatTopologyDepthLabel(graphDepth);
-  const topologyControlsHint = canAdjustTopologyDepth
-    ? ""
-    : "当前还没有可用的团队成员焦点，待成员或运行信号可见后再切换视角。";
-  const platformTopologyHint = canOpenPlatformTopology
-    ? ""
-    : "当前还没有可打开的平台拓扑焦点。";
-  const topologyEmptyDescription = canAdjustTopologyDepth
-    ? `当前在${topologyDepthLabel}视角下还没有更多可见的事件拓扑关系。`
-    : "当前还没有可用的团队成员焦点，所以暂时没有可展开的事件拓扑关系。";
-  const handleOpenTeamsList = React.useCallback(() => {
-    history.push(teamsListHref);
-  }, [teamsListHref]);
-
-  const handleOpenServiceMapping = React.useCallback(() => {
-    handleOpenPlaybackActor(
-      topologyFocusActorId,
-      lens.currentRun?.runId || lens.playback.currentRunId,
-    );
-  }, [
-    handleOpenPlaybackActor,
-    lens.currentRun?.actorId,
-    lens.currentRun?.runId,
-    lens.playback.currentRunId,
-    topologyFocusActorId,
-  ]);
-  const handleOpenServices = React.useCallback(() => {
-    history.push(buildPlatformServicesHref(platformRouteIdentity));
-  }, [platformRouteIdentity]);
-  const handleOpenGovernance = React.useCallback(() => {
-    history.push(
-      buildPlatformGovernanceHref({
-        ...platformRouteIdentity,
-        revisionId: currentRevisionId !== "--" ? currentRevisionId : undefined,
-        view: "bindings",
-      }),
-    );
-  }, [currentRevisionId, platformRouteIdentity]);
-  const handleOpenDeployments = React.useCallback(() => {
-    history.push(
-      buildPlatformDeploymentsHref({
-        ...platformRouteIdentity,
-        deploymentId: currentDeploymentId !== "--" ? currentDeploymentId : undefined,
-      }),
-    );
-  }, [currentDeploymentId, platformRouteIdentity]);
-  const handleOpenWorkflowAsset = React.useCallback(
-    (workflowId: string) => {
-      history.push(
-        buildStudioWorkflowEditorRoute({
-          scopeId,
-          memberKey:
-            trimText(workflowId).length > 0 ? `workflow:${trimText(workflowId)}` : undefined,
-          workflowId,
-        }),
+        teamId: selectedTeamId,
+        displayName: teamDisplayName.trim(),
+        description: trimOptional(teamDescription) || null,
+      });
+      setTeamDisplayName(updated.displayName);
+      setTeamDescription(updated.description);
+      await invalidateTeamQueries();
+      void message.success("团队信息已更新。");
+    } catch (error) {
+      void message.error(
+        describeError(error, "更新团队信息失败，请稍后再试。"),
       );
-    },
-    [scopeId],
-  );
-  const handleOpenScriptAsset = React.useCallback(
-    (scriptId: string) => {
-      history.push(
-        buildStudioScriptsWorkspaceRoute({
-          scopeId,
-          memberKey:
-            trimText(scriptId).length > 0 ? `script:${trimText(scriptId)}` : undefined,
-          scriptId,
-        }),
+    } finally {
+      setBusyAction("");
+    }
+  };
+
+  const handleArchiveTeam = async () => {
+    if (!scopeId || !selectedTeamId) {
+      return;
+    }
+
+    setBusyAction("archive-team");
+    try {
+      await studioApi.archiveTeam(scopeId, selectedTeamId);
+      await invalidateTeamQueries();
+      void message.success("团队已归档。");
+    } catch (error) {
+      void message.error(describeError(error, "归档团队失败，请稍后再试。"));
+    } finally {
+      setBusyAction("");
+    }
+  };
+
+  const handleCreateMember = async () => {
+    if (!scopeId || !selectedTeamId || !newMemberName.trim()) {
+      return;
+    }
+
+    setBusyAction("create-member");
+    try {
+      await studioApi.createMember({
+        scopeId,
+        teamId: selectedTeamId,
+        displayName: newMemberName.trim(),
+        description: trimOptional(newMemberDescription) || null,
+        implementationKind: newMemberKind,
+        memberId: trimOptional(newMemberId) || null,
+      });
+      setNewMemberName("");
+      setNewMemberDescription("");
+      setNewMemberId("");
+      setNewMemberKind("workflow");
+      await invalidateTeamQueries();
+      void message.success("成员已创建并加入团队。");
+    } catch (error) {
+      void message.error(
+        describeError(error, "创建成员失败，请稍后再试。"),
       );
-    },
-    [scopeId],
-  );
-
-  const renderOverviewTab = () => {
-    return (
-      <TeamOverviewTab
-        compareAvailable={lens.compare.available}
-        compareSections={lens.compare.sections}
-        compareStatusLabel={overviewCompareStatusLabel}
-        compareStatusStyle={overviewCompareStatusStyle}
-        compareSummary={lens.compare.summary}
-        compareTitle={lens.compare.title}
-        compositionRows={overviewCompositionRows}
-        currentDeploymentPillStyle={resolveStatusPillStyle(token, currentDeploymentStatus)}
-        currentDeploymentPillText={currentDeploymentPillText}
-        currentHeaderStatusFriendly={currentHeaderStatusFriendly}
-        currentHeaderStatusStyle={resolveStatusPillStyle(token, currentHeaderStatus)}
-        currentRunCardCaption={currentRunCardCaption}
-        currentRunCardTooltip={currentRunCardTooltip}
-        currentRunFriendly={currentRunFriendly}
-        currentRunPillStyle={resolveStatusPillStyle(token, currentRunStatus)}
-        currentRunPillText={currentRunPillText}
-        currentServiceCardCaption={currentServiceCardCaption}
-        currentServiceCardTooltip={currentServiceCardTooltip}
-        currentServiceFriendly={currentServiceFriendly}
-        currentServicePillStyle={{
-          background: token.colorInfoBg,
-          border: `1px solid ${token.colorInfoBorder}`,
-          color: token.colorInfo,
-        }}
-        currentServicePillText={currentServicePillText}
-        governanceRows={overviewGovernanceRows}
-        healthActionLabel={formatTeamHealthActionLabel(lens.healthStatus)}
-        healthDetails={overviewHealthDetails}
-        healthStatusLabel={formatTeamHealthStatusLabel(lens.healthStatus)}
-        healthStatusStyle={resolveTeamHealthToneStyle(token, lens.healthTone)}
-        healthSummary={lens.healthSummary}
-        latestVisibleUpdateLabel={formatCompactTimestamp(latestVisibleUpdate)}
-        latestVisibleUpdateNote={latestVisibleUpdateNote}
-        partialSignals={overviewPartialSignals}
-        runtimeSummaryRows={overviewRuntimeSummaryRows}
-      />
-    );
+    } finally {
+      setBusyAction("");
+    }
   };
 
-  const renderTopologyTab = () => {
-    return (
-      <TeamTopologyTab
-        depthControlDisabled={!canAdjustTopologyDepth}
-        depthControlHint={topologyControlsHint || undefined}
-        graphDepth={graphDepth}
-        graphEdgeCount={topologyGraph.edges.length}
-        graphFocusLabel={`${topologyDepthLabel}视角 · 焦点 ${topologyFocusActorId ? compactId(topologyFocusActorId) : "未选中"}`}
-        graphNodeCount={topologyGraph.nodes.length}
-        isError={actorGraphQuery.isError}
-        isLoading={actorGraphQuery.isLoading}
-        onCanvasSelect={() =>
-          setSelectedTopologyNodeId(
-            topologyGraph.entityMap.has(topologyFocusActorId)
-              ? topologyFocusActorId
-              : topologyGraph.nodes[0]?.id || "",
-          )
-        }
-        onNodeSelect={(nodeId) => {
-          setSelectedTopologyNodeId(nodeId);
-          if (topologyGraph.entityMap.get(nodeId)?.kind === "actor") {
-            setSelectedActorId(nodeId);
-          }
-        }}
-        onOpenPlatformTopology={handleOpenServiceMapping}
-        onSetGraphDepth={setGraphDepth}
-        platformTopologyDisabled={!canOpenPlatformTopology}
-        platformTopologyHint={platformTopologyHint || undefined}
-        openPlatformTopologyButtonStyle={{
-          borderRadius: 16,
-          height: 40,
-          paddingInline: 18,
-        }}
-        provenanceLabel={graphProvenance.label}
-        provenanceStyle={resolveObservationPillStyle(token, graphProvenance.status)}
-        selectedEntityBadgeLabel={selectedTopologyEntity?.badgeText}
-        selectedEntityBadgeStyle={
-          selectedTopologyEntity
-            ? resolveTonePillStyle(token, selectedTopologyEntity.badgeTone)
-            : undefined
-        }
-        selectedEntityDetailRows={topologyDetailRows}
-        selectedEntityEmpty={!selectedTopologyEntity}
-        selectedEntityKindLabel={
-          selectedTopologyEntity
-            ? formatTopologyNodeKindLabel(selectedTopologyEntity.kind)
-            : undefined
-        }
-        selectedEntityKindStyle={
-          selectedTopologyEntity
-            ? resolveTonePillStyle(token, "neutral")
-            : undefined
-        }
-        selectedEntitySummary={selectedTopologyEntity?.summary}
-        selectedEntityTitle={selectedTopologyEntity?.title}
-        selectedFocusReason={
-          selectedFocusReason || "围绕当前焦点成员展开团队消息路径。点击左侧节点即可切换视角。"
-        }
-        selectedNodeId={selectedTopologyNodeId || topologyFocusActorId}
-        topologyEmptyDescription={topologyEmptyDescription}
-        topologyEdges={topologyGraph.edges}
-        topologyNodes={topologyGraph.nodes}
-      />
-    );
+  const handleAssignExistingMember = async () => {
+    if (!scopeId || !selectedTeamId || !selectedExistingMemberId.trim()) {
+      return;
+    }
+
+    setBusyAction("assign-member");
+    try {
+      await studioApi.updateMemberTeam(scopeId, selectedExistingMemberId.trim(), selectedTeamId);
+      setSelectedExistingMemberId("");
+      await invalidateTeamQueries();
+      void message.success("成员已加入当前团队。");
+    } catch (error) {
+      void message.error(
+        describeError(error, "加入团队失败，请稍后再试。"),
+      );
+    } finally {
+      setBusyAction("");
+    }
   };
 
-  const renderEventsTab = () => {
-    return (
-      <TeamEventsTab
-        activeRunLabel={lens.currentRun?.runId || "当前还没有可见运行"}
-        activeRunMetaLabel={activeRunId ? `run · ${activeRunId}` : "暂无当前 run"}
-        currentRunStatusLabel={
-          lens.currentRun?.completionStatus
-            ? formatFriendlyStatus(lens.currentRun.completionStatus)
-            : undefined
-        }
-        currentRunStatusStyle={
-          lens.currentRun?.completionStatus
-            ? resolveStatusPillStyle(token, lens.currentRun.completionStatus)
-            : undefined
-        }
-        eventRows={eventStreamDisplayRows}
-        isRunsError={runsQuery.isError}
-        isRunsLoading={runsQuery.isLoading}
-        memberMappingRows={memberMappingDisplayRows}
-        onOpenAudit={() =>
-          handleOpenPlaybackActor(lens.currentRun?.actorId, activeRunId)
-        }
-        onOpenMissionControl={handleOpenMissionControl}
-        onSelectRun={handleSelectRun}
-        openAuditButtonStyle={resolveActionButtonStyle(token)}
-        playbackSummary={formatPlaybackSummary(lens.playback.summary)}
-        provenanceLabel={playbackProvenance.label}
-        provenanceStyle={resolveObservationPillStyle(token, playbackProvenance.status)}
-        runSwitchOptions={runSwitchDisplayOptions}
-        showOpenAudit={Boolean(activeRunId)}
-        showOpenMissionControl={Boolean(activeRunId && missionControlPrompt)}
-      />
-    );
+  const handleRemoveMember = async (memberId: string) => {
+    if (!scopeId || !memberId) {
+      return;
+    }
+
+    setBusyAction(`remove:${memberId}`);
+    try {
+      await studioApi.updateMemberTeam(scopeId, memberId, null);
+      await invalidateTeamQueries();
+      void message.success("成员已移出团队。");
+    } catch (error) {
+      void message.error(
+        describeError(error, "移出团队失败，请稍后再试。"),
+      );
+    } finally {
+      setBusyAction("");
+    }
   };
 
-  const renderMembersTab = () => {
-    return (
-      <TeamMembersTab
-        compositionRows={memberCompositionRows}
-        identityRows={memberIdentityRows}
-        openRuntimeExplorerDisabled={!canOpenPlatformTopology}
-        openRuntimeExplorerHint={platformTopologyHint || undefined}
-        onOpenRuntimeExplorer={handleOpenServiceMapping}
-        onOpenServices={handleOpenServices}
-        onSelectActor={setSelectedActorId}
-      />
-    );
-  };
+  const issueMessages = [
+    teamsQuery.isError
+      ? describeError(teamsQuery.error, "团队列表暂时不可用，请稍后再试。")
+      : "",
+    teamQuery.isError
+      ? describeError(teamQuery.error, "团队详情暂时不可用，请稍后再试。")
+      : "",
+    teamMembersQuery.isError
+      ? describeError(teamMembersQuery.error, "团队成员暂时不可用，请稍后再试。")
+      : "",
+    allMembersQuery.isError
+      ? describeError(allMembersQuery.error, "成员目录暂时不可用，请稍后再试。")
+      : "",
+    legacyMemberQuery.isError
+      ? describeError(legacyMemberQuery.error, "旧成员深链暂时无法解析。")
+      : "",
+  ].filter(Boolean);
 
-  const renderBindingsTab = () => {
-    return (
-      <TeamBindingsTab
-        catalogCards={connectorCatalogCards}
-        emptyDescription={connectorsEmptyDescription}
-        onOpenDeployments={handleOpenDeployments}
-        onOpenGovernance={handleOpenGovernance}
-        onOpenServices={handleOpenServices}
-        onSelectBinding={setSelectedConnectorKey}
-        provenanceLabel={integrationsProvenance.label}
-        provenanceStyle={resolveObservationPillStyle(token, integrationsProvenance.status)}
-        selectedBindingDetailRows={connectorDetailRows}
-        selectedBindingEmpty={!selectedConnector}
-        selectedBindingStatusLabel={
-          selectedConnector
-            ? formatConnectorEnabledLabel(selectedConnector.enabled)
-            : ""
-        }
-        selectedBindingStatusStyle={resolveTonePillStyle(
-          token,
-          selectedConnector?.enabled ? "success" : "neutral",
-        )}
-        selectedBindingName={selectedConnector?.name || ""}
-        selectedBindingSummary={selectedConnector?.summary || ""}
-        summaryCards={connectorSummaryCards}
-      />
-    );
-  };
-
-  const renderAssetsTab = () => {
-    return (
-      <TeamAssetsTab
-        onOpenScriptAsset={handleOpenScriptAsset}
-        onOpenScriptsWorkspace={() =>
-          history.push(
-            buildStudioScriptsWorkspaceRoute({
-              scopeId,
-              memberKey: selectedStudioMemberKey,
-            }),
-          )
-        }
-        onOpenWorkflowAsset={handleOpenWorkflowAsset}
-        onOpenWorkflowWorkspace={() =>
-          history.push(
-            buildStudioWorkflowWorkspaceRoute({
-              scopeId,
-              memberKey: selectedStudioMemberKey,
-            }),
-          )
-        }
-        scriptRows={scriptAssetRows}
-        summaryCards={assetSummaryCards}
-        workflowRows={workflowAssetRows}
-      />
-    );
-  };
-
-  const renderAdvancedTab = () => {
-    return (
-      <TeamAdvancedTab
-        adjustmentBadgeStyle={resolveTonePillStyle(token, "neutral")}
-        configurationAdjustmentRows={configurationAdjustmentRows}
-        configurationDetailRows={configurationDetailRows}
-        conversationActionLabel={conversationActionLabel}
-        currentDeploymentBadgeStyle={resolveStatusPillStyle(token, currentDeploymentStatus)}
-        currentDeploymentFriendly={currentDeploymentFriendly}
-        currentServiceFriendly={currentServiceFriendly}
-        currentVersionFriendly={currentVersionFriendly}
-        onOpenConversation={handleOpenConversation}
-        onOpenServiceMapping={handleOpenServiceMapping}
-        onOpenTeamBuilder={() => history.push(teamBuilderRoute)}
-        serviceMappingDisabled={!canOpenPlatformTopology}
-        serviceMappingHint={platformTopologyHint || undefined}
-        primaryActionButtonStyle={resolveActionButtonStyle(token, "primary")}
-        secondaryActionButtonStyle={resolveActionButtonStyle(token)}
-        serviceMappingActionLabel={serviceMappingActionLabel}
-        summaryCards={advancedSummaryCards}
-        teamBuilderActionLabel={teamBuilderActionLabel}
-        teamImpactSummary={advancedTeamImpactSummary}
-      />
-    );
-  };
-
-  let tabContent: React.ReactNode = renderOverviewTab();
-  switch (activeTab) {
-    case "topology":
-      tabContent = renderTopologyTab();
-      break;
-    case "events":
-      tabContent = renderEventsTab();
-      break;
-    case "members":
-      tabContent = renderMembersTab();
-      break;
-    case "bindings":
-      tabContent = renderBindingsTab();
-      break;
-    case "assets":
-      tabContent = renderAssetsTab();
-      break;
-    case "advanced":
-      tabContent = renderAdvancedTab();
-      break;
-    default:
-      tabContent = renderOverviewTab();
-      break;
-  }
-
-  if (!scopeId) {
-    return <TeamDetailEmptyState />;
-  }
+  const backToTeamsHref = buildScopeHref("/teams", { scopeId });
+  const teamSummary = team ?? teamSelection.find((item) => item.teamId === selectedTeamId) ?? null;
+  const teamName = teamSummary?.displayName || selectedTeamId || "Team Detail";
+  const saveTeamDisabled =
+    busyAction.length > 0 ||
+    !teamSummary ||
+    !teamDisplayName.trim() ||
+    (teamDisplayName.trim() === teamSummary.displayName &&
+      trimOptional(teamDescription) === trimOptional(teamSummary.description));
 
   return (
-    <TeamDetailShell
-      actionRail={
-        <TeamActionRail
-          conversationActionLabel={conversationActionLabel}
-          onOpenConversation={handleOpenConversation}
-          onOpenServiceMapping={handleOpenServiceMapping}
-          onOpenTeamBuilder={() => history.push(teamBuilderRoute)}
-          serviceMappingDisabled={!canOpenPlatformTopology}
-          serviceMappingHint={platformTopologyHint || undefined}
-          serviceMappingActionLabel={serviceMappingActionLabel}
-          teamBuilderActionLabel={teamBuilderActionLabel}
-        />
+    <ConsoleMenuPageShell
+      breadcrumb={`Aevatar / Teams / ${teamName}`}
+      description="Manage the current team record, inspect who is assigned to it, and use the existing member-first backend endpoints to add or remove members."
+      extra={
+        <Space wrap>
+          <Button
+            onClick={() => history.push(backToTeamsHref)}
+            style={{ borderRadius: 12, height: 40, paddingInline: 18 }}
+          >
+            Back to My Teams
+          </Button>
+          {selectedTeamId ? (
+            <Button
+              danger
+              loading={busyAction === "archive-team"}
+              onClick={handleArchiveTeam}
+              style={{ borderRadius: 12, height: 40, paddingInline: 18 }}
+            >
+              Archive Team
+            </Button>
+          ) : null}
+        </Space>
       }
-      activeTab={activeTab}
-      activeTabLabel={formatTeamTabLabel(activeTab)}
-      initialLoading={initialLoading}
-      onOpenTeamsList={handleOpenTeamsList}
-      onSelectTab={pushTeamTab}
-      statusBadge={
-        currentHeaderStatusFriendly !== "--" ? (
-          <DetailPill
-            style={resolveStatusPillStyle(token, currentHeaderStatus)}
-            text={currentHeaderStatusFriendly}
-          />
-        ) : null
-      }
-      tabOptions={tabOptions}
-      teamMeta={teamTitleMeta}
-      teamTitle={teamTitle}
-      teamsListHref={teamsListHref}
+      title={teamName}
     >
-      {tabContent}
-    </TeamDetailShell>
+      <div style={{ display: "grid", gap: 20 }}>
+        {issueMessages.map((issue) => (
+          <Alert key={issue} message={issue} showIcon type="warning" />
+        ))}
+
+        {!scopeId ? (
+          <AevatarPanel layoutMode="document" padding={24} title="Team Detail">
+            <Empty
+              description="Missing scope id in the route. Return to My Teams and reload a scope first."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          </AevatarPanel>
+        ) : null}
+
+        {scopeId && !selectedTeamId && legacyMemberQuery.isLoading ? (
+          <AevatarPanel layoutMode="document" padding={24} title="Resolving Team">
+            <Typography.Text>
+              Resolving the current team from member {routeMemberId}...
+            </Typography.Text>
+          </AevatarPanel>
+        ) : null}
+
+        {scopeId && !selectedTeamId && !legacyMemberQuery.isLoading && teamSelection.length > 1 ? (
+          <AevatarPanel layoutMode="document" padding={24} title="Choose a Team">
+            <div style={{ display: "grid", gap: 16 }}>
+              <Typography.Paragraph style={{ margin: 0 }}>
+                This route did not include a <code>teamId</code>. Pick one team in
+                the current scope and we will reopen the canonical team detail
+                route.
+              </Typography.Paragraph>
+              <div style={formGridStyle}>
+                {teamSelection.map((entry) => (
+                  <div key={entry.teamId} style={listItemStyle}>
+                    <div>
+                      <Typography.Title level={4} style={{ margin: 0 }}>
+                        {entry.displayName}
+                      </Typography.Title>
+                      <Typography.Paragraph
+                        ellipsis={{ rows: 2 }}
+                        style={{ color: "#8c8c8c", margin: "8px 0 0" }}
+                      >
+                        {entry.description || "No team description yet."}
+                      </Typography.Paragraph>
+                    </div>
+                    <Space wrap>
+                      <Tag color={entry.lifecycleStage === "archived" ? "default" : "blue"}>
+                        {formatStudioTeamLifecycleStage(entry.lifecycleStage)}
+                      </Tag>
+                      <Tag>{entry.memberCount} members</Tag>
+                    </Space>
+                    <Button
+                      type="primary"
+                      onClick={() =>
+                        history.push(
+                          buildTeamDetailHref({
+                            memberId: routeState.memberId || undefined,
+                            runId: routeState.runId || undefined,
+                            scopeId,
+                            serviceId: routeState.serviceId || undefined,
+                            tab: routeState.tab,
+                            teamId: entry.teamId,
+                            workflowId: routeState.workflowId || undefined,
+                          }),
+                        )
+                      }
+                    >
+                      Open Team
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </AevatarPanel>
+        ) : null}
+
+        {scopeId &&
+        !selectedTeamId &&
+        !legacyMemberQuery.isLoading &&
+        teamSelection.length === 0 ? (
+          <AevatarPanel layoutMode="document" padding={24} title="No Teams Yet">
+            <Empty
+              description="This scope does not have any teams yet."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          </AevatarPanel>
+        ) : null}
+
+        {scopeId &&
+        !selectedTeamId &&
+        !legacyMemberQuery.isLoading &&
+        teamSelection.length <= 1 &&
+        routeMemberId &&
+        !trimOptional(legacyMemberQuery.data?.summary.teamId) ? (
+          <Alert
+            message="This member is not assigned to a team yet, so the old deep link cannot resolve a team detail page."
+            showIcon
+            type="info"
+          />
+        ) : null}
+
+        {scopeId && selectedTeamId ? (
+          <>
+            <div style={detailGridStyle}>
+              <ConsoleMetricCard
+                label="Members"
+                value={String(teamSummary?.memberCount ?? teamMembers.length)}
+              />
+              <ConsoleMetricCard
+                label="Lifecycle"
+                tone="green"
+                value={formatStudioTeamLifecycleStage(teamSummary?.lifecycleStage)}
+              />
+              <ConsoleMetricCard
+                label="Created"
+                value={formatCompactDateTime(teamSummary?.createdAt, "--")}
+              />
+              <ConsoleMetricCard
+                label="Updated"
+                tone="purple"
+                value={formatCompactDateTime(teamSummary?.updatedAt, "--")}
+              />
+            </div>
+
+            <AevatarPanel layoutMode="document" padding={24} title="Team Summary">
+              <div style={detailGridStyle}>
+                <div>
+                  <Typography.Text type="secondary">Team ID</Typography.Text>
+                  <div>
+                    <AevatarCompactText copyable monospace value={selectedTeamId} />
+                  </div>
+                </div>
+                <div>
+                  <Typography.Text type="secondary">Scope ID</Typography.Text>
+                  <div>
+                    <AevatarCompactText copyable monospace value={scopeId} />
+                  </div>
+                </div>
+                <div>
+                  <Typography.Text type="secondary">Lifecycle</Typography.Text>
+                  <div>
+                    <Tag color={teamSummary?.lifecycleStage === "archived" ? "default" : "blue"}>
+                      {formatStudioTeamLifecycleStage(teamSummary?.lifecycleStage)}
+                    </Tag>
+                  </div>
+                </div>
+                <div>
+                  <Typography.Text type="secondary">Members</Typography.Text>
+                  <div>{String(teamSummary?.memberCount ?? teamMembers.length)}</div>
+                </div>
+                <div>
+                  <Typography.Text type="secondary">Created</Typography.Text>
+                  <div>{formatCompactDateTime(teamSummary?.createdAt, "--")}</div>
+                </div>
+                <div>
+                  <Typography.Text type="secondary">Updated</Typography.Text>
+                  <div>{formatCompactDateTime(teamSummary?.updatedAt, "--")}</div>
+                </div>
+              </div>
+              <Typography.Paragraph style={{ margin: "16px 0 0" }}>
+                {teamSummary?.description || "No team description yet."}
+              </Typography.Paragraph>
+            </AevatarPanel>
+
+            <AevatarPanel layoutMode="document" padding={24} title="Team Members">
+              {teamMembersQuery.isLoading ? (
+                <Typography.Text>Loading team members...</Typography.Text>
+              ) : teamMembers.length === 0 ? (
+                <Empty
+                  description="This team does not have any members yet."
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                />
+              ) : (
+                <div style={{ display: "grid", gap: 16 }}>
+                  {teamMembers.map((member) => (
+                    <div key={member.memberId} style={listItemStyle}>
+                      <div
+                        style={{
+                          alignItems: "flex-start",
+                          display: "flex",
+                          gap: 12,
+                          justifyContent: "space-between",
+                        }}
+                      >
+                        <div style={{ minWidth: 0 }}>
+                          <Typography.Title level={4} style={{ margin: 0 }}>
+                            {member.displayName}
+                          </Typography.Title>
+                          <Typography.Paragraph
+                            ellipsis={{ rows: 2 }}
+                            style={{ color: "#8c8c8c", margin: "8px 0 0" }}
+                          >
+                            {member.description || "No member description yet."}
+                          </Typography.Paragraph>
+                        </div>
+                        <Tag>{formatStudioMemberLifecycleStage(member.lifecycleStage)}</Tag>
+                      </div>
+                      <div style={detailGridStyle}>
+                        <div>
+                          <Typography.Text type="secondary">Member ID</Typography.Text>
+                          <div>
+                            <AevatarCompactText copyable monospace value={member.memberId} />
+                          </div>
+                        </div>
+                        <div>
+                          <Typography.Text type="secondary">Implementation</Typography.Text>
+                          <div>{formatMemberImplementation(member.implementationKind)}</div>
+                        </div>
+                        <div>
+                          <Typography.Text type="secondary">Published Service</Typography.Text>
+                          <div>{trimOptional(member.publishedServiceId) || "--"}</div>
+                        </div>
+                        <div>
+                          <Typography.Text type="secondary">Last Updated</Typography.Text>
+                          <div>{formatCompactDateTime(member.updatedAt, "--")}</div>
+                        </div>
+                      </div>
+                      <Space wrap>
+                        <Button
+                          type="primary"
+                          onClick={() =>
+                            history.push(
+                              buildStudioRoute({
+                                memberId: member.memberId,
+                                scopeId,
+                                tab: "studio",
+                              }),
+                            )
+                          }
+                        >
+                          Open in Studio
+                        </Button>
+                        <Button
+                          loading={busyAction === `remove:${member.memberId}`}
+                          onClick={() => handleRemoveMember(member.memberId)}
+                        >
+                          Remove from Team
+                        </Button>
+                      </Space>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </AevatarPanel>
+
+            <AevatarPanel layoutMode="document" padding={24} title="Create Member In This Team">
+              <div style={formGridStyle}>
+                <div style={fieldStyle}>
+                  <Typography.Text strong>Display Name</Typography.Text>
+                  <Input
+                    aria-label="New Member Display Name"
+                    placeholder="Support Planner"
+                    value={newMemberName}
+                    onChange={(event) => setNewMemberName(event.target.value)}
+                  />
+                </div>
+                <div style={fieldStyle}>
+                  <Typography.Text strong>Implementation Kind</Typography.Text>
+                  <select
+                    aria-label="New Member Implementation Kind"
+                    style={selectStyle}
+                    value={newMemberKind}
+                    onChange={(event) =>
+                      setNewMemberKind(event.target.value as StudioMemberImplementationKind)
+                    }
+                  >
+                    <option value="workflow">Workflow</option>
+                    <option value="script">Script</option>
+                    <option value="gagent">GAgent</option>
+                  </select>
+                </div>
+                <div style={fieldStyle}>
+                  <Typography.Text strong>Custom Member ID</Typography.Text>
+                  <Input
+                    aria-label="New Member ID"
+                    placeholder="optional-member-id"
+                    value={newMemberId}
+                    onChange={(event) => setNewMemberId(event.target.value)}
+                  />
+                </div>
+                <div style={{ ...fieldStyle, gridColumn: "1 / -1" }}>
+                  <Typography.Text strong>Description</Typography.Text>
+                  <Input.TextArea
+                    aria-label="New Member Description"
+                    autoSize={{ minRows: 3, maxRows: 6 }}
+                    placeholder="Describe what this member is responsible for inside the team."
+                    value={newMemberDescription}
+                    onChange={(event) => setNewMemberDescription(event.target.value)}
+                  />
+                </div>
+              </div>
+              <Space style={{ marginTop: 16 }}>
+                <Button
+                  loading={busyAction === "create-member"}
+                  onClick={handleCreateMember}
+                  type="primary"
+                >
+                  Create Member
+                </Button>
+              </Space>
+            </AevatarPanel>
+
+            <AevatarPanel layoutMode="document" padding={24} title="Add Existing Member">
+              <div style={formGridStyle}>
+                <div style={{ ...fieldStyle, gridColumn: "1 / -1" }}>
+                  <Typography.Text strong>Available Members</Typography.Text>
+                  <select
+                    aria-label="Existing Member Selector"
+                    style={selectStyle}
+                    value={selectedExistingMemberId}
+                    onChange={(event) => setSelectedExistingMemberId(event.target.value)}
+                  >
+                    <option value="">Select a member</option>
+                    {assignableMembers.map((member) => {
+                      const currentTeamId = trimOptional(member.teamId);
+                      const suffix = currentTeamId
+                        ? `currently in ${currentTeamId}`
+                        : "currently unassigned";
+                      return (
+                        <option key={member.memberId} value={member.memberId}>
+                          {(trimOptional(member.displayName) || member.memberId) +
+                            ` · ${member.memberId} · ${suffix}`}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </div>
+              </div>
+              <Space style={{ marginTop: 16 }}>
+                <Button
+                  disabled={!selectedExistingMemberId}
+                  loading={busyAction === "assign-member"}
+                  onClick={handleAssignExistingMember}
+                  type="primary"
+                >
+                  Add Member
+                </Button>
+              </Space>
+            </AevatarPanel>
+
+            <AevatarPanel layoutMode="document" padding={24} title="Edit Team">
+              <div style={formGridStyle}>
+                <div style={fieldStyle}>
+                  <Typography.Text strong>Display Name</Typography.Text>
+                  <Input
+                    aria-label="Team Display Name"
+                    value={teamDisplayName}
+                    onChange={(event) => setTeamDisplayName(event.target.value)}
+                  />
+                </div>
+                <div style={{ ...fieldStyle, gridColumn: "1 / -1" }}>
+                  <Typography.Text strong>Description</Typography.Text>
+                  <Input.TextArea
+                    aria-label="Team Description"
+                    autoSize={{ minRows: 4, maxRows: 8 }}
+                    value={teamDescription}
+                    onChange={(event) => setTeamDescription(event.target.value)}
+                  />
+                </div>
+              </div>
+              <Space style={{ marginTop: 16 }}>
+                <Button
+                  disabled={saveTeamDisabled}
+                  loading={busyAction === "save-team"}
+                  onClick={handleSaveTeam}
+                  type="primary"
+                >
+                  Save Team Changes
+                </Button>
+              </Space>
+            </AevatarPanel>
+          </>
+        ) : null}
+      </div>
+    </ConsoleMenuPageShell>
   );
 };
 

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -1,125 +1,93 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
-import { servicesApi } from "@/shared/api/servicesApi";
-import {
-  clearStoredAuthSession,
-  persistAuthSession,
-} from "@/shared/auth/session";
 import { studioApi } from "@/shared/studio/api";
 import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
 import TeamsHomePage from "./home";
 
-jest.mock("@/shared/api/servicesApi", () => ({
-  servicesApi: {
-    listServices: jest.fn(),
-  },
-}));
-
-jest.mock("@/shared/api/scopeRuntimeApi", () => ({
-  scopeRuntimeApi: {
-    listMemberRuns: jest.fn(),
-  },
-}));
-
 jest.mock("@/shared/studio/api", () => ({
   studioApi: {
     getAuthSession: jest.fn(),
+    listTeams: jest.fn(),
     listMembers: jest.fn(),
   },
 }));
 
-const defaultMembers = [
-  {
-    memberId: "member-alpha",
-    scopeId: "scope-a",
-    displayName: "客服团队",
-    description: "负责处理用户问题",
-    implementationKind: "workflow",
-    lifecycleStage: "bind_ready",
-    publishedServiceId: "service-alpha",
-    lastBoundRevisionId: "rev-2",
-    createdAt: "2026-04-13T09:00:00Z",
-    updatedAt: "2026-04-13T10:02:00Z",
-  },
-];
-
-const defaultServices = [
-  {
-    serviceKey: "scope-a:alpha",
-    tenantId: "scope-a",
-    appId: "default",
-    namespace: "default",
-    serviceId: "service-alpha",
-    displayName: "客服运行时",
-    defaultServingRevisionId: "rev-2",
-    activeServingRevisionId: "rev-2",
-    deploymentId: "deploy-1",
-    primaryActorId: "actor://workflow-alpha",
-    deploymentStatus: "Active",
-    endpoints: [],
-    policyIds: [],
-    updatedAt: "2026-04-13T10:01:00Z",
-  },
-];
-
-function buildMemberRunCatalog(memberId: string) {
-  if (memberId === "member-alpha") {
-    return {
+const teamRoster = {
+  scopeId: "scope-a",
+  teams: [
+    {
+      teamId: "team-support",
       scopeId: "scope-a",
-      serviceId: "service-alpha",
-      serviceKey: "scope-a:alpha",
-      displayName: "客服运行时",
-      runs: [
-        {
-          scopeId: "scope-a",
-          serviceId: "service-alpha",
-          runId: "run-latest",
-          actorId: "actor://workflow-alpha",
-          definitionActorId: "definition://workflow-alpha",
-          revisionId: "rev-2",
-          deploymentId: "deploy-1",
-          workflowName: "customer-support-triage",
-          completionStatus: "waiting_approval",
-          stateVersion: 2,
-          lastEventId: "evt-2",
-          lastUpdatedAt: "2026-04-13T10:05:00Z",
-          boundAt: "2026-04-13T10:00:00Z",
-          bindingUpdatedAt: "2026-04-13T10:00:00Z",
-          lastSuccess: false,
-          totalSteps: 4,
-          completedSteps: 2,
-          roleReplyCount: 1,
-          lastOutput: "",
-          lastError: "Waiting on approval",
-        },
-      ],
-    };
-  }
-
-  if (memberId === "member-joker") {
-    return {
+      displayName: "Support Team",
+      description: "Handles inbound support requests",
+      lifecycleStage: "active",
+      memberCount: 2,
+      createdAt: "2026-04-30T08:00:00Z",
+      updatedAt: "2026-04-30T09:00:00Z",
+    },
+    {
+      teamId: "team-ops",
       scopeId: "scope-a",
-      serviceId: "service-joker",
-      serviceKey: "scope-a:joker",
-      displayName: "joker",
-      runs: [],
-    };
-  }
+      displayName: "Ops Team",
+      description: "Owns escalation follow-through",
+      lifecycleStage: "archived",
+      memberCount: 1,
+      createdAt: "2026-04-29T08:00:00Z",
+      updatedAt: "2026-04-29T09:00:00Z",
+    },
+  ],
+  nextPageToken: null,
+};
 
-  return {
-    scopeId: "scope-a",
-    serviceId: "",
-    serviceKey: "",
-    displayName: memberId,
-    runs: [],
-  };
-}
+const memberRoster = {
+  scopeId: "scope-a",
+  members: [
+    {
+      memberId: "member-planner",
+      scopeId: "scope-a",
+      teamId: "team-support",
+      displayName: "Planner",
+      description: "Routes support issues",
+      implementationKind: "workflow",
+      lifecycleStage: "bind_ready",
+      publishedServiceId: "service-planner",
+      lastBoundRevisionId: "rev-1",
+      createdAt: "2026-04-30T08:00:00Z",
+      updatedAt: "2026-04-30T09:00:00Z",
+    },
+    {
+      memberId: "member-responder",
+      scopeId: "scope-a",
+      teamId: "team-support",
+      displayName: "Responder",
+      description: "Drafts answers",
+      implementationKind: "workflow",
+      lifecycleStage: "bind_ready",
+      publishedServiceId: "service-responder",
+      lastBoundRevisionId: "rev-2",
+      createdAt: "2026-04-30T08:10:00Z",
+      updatedAt: "2026-04-30T09:10:00Z",
+    },
+    {
+      memberId: "member-floater",
+      scopeId: "scope-a",
+      teamId: null,
+      displayName: "Floater",
+      description: "Unassigned helper",
+      implementationKind: "workflow",
+      lifecycleStage: "created",
+      publishedServiceId: "",
+      lastBoundRevisionId: null,
+      createdAt: "2026-04-30T08:20:00Z",
+      updatedAt: "2026-04-30T09:20:00Z",
+    },
+  ],
+  nextPageToken: null,
+};
 
 describe("TeamsHomePage", () => {
   beforeEach(() => {
     window.history.replaceState({}, "", "/teams?scopeId=scope-a");
-    clearStoredAuthSession();
     jest.clearAllMocks();
 
     (studioApi.getAuthSession as jest.Mock).mockResolvedValue({
@@ -127,214 +95,59 @@ describe("TeamsHomePage", () => {
       scopeId: "scope-a",
       scopeSource: "nyxid",
     });
-    (studioApi.listMembers as jest.Mock).mockResolvedValue({
-      scopeId: "scope-a",
-      members: defaultMembers,
-      nextPageToken: null,
-    });
-    (servicesApi.listServices as jest.Mock).mockResolvedValue(defaultServices);
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockImplementation(
-      async (_scopeId: string, memberId: string) => buildMemberRunCatalog(memberId),
-    );
+    (studioApi.listTeams as jest.Mock).mockResolvedValue(teamRoster);
+    (studioApi.listMembers as jest.Mock).mockResolvedValue(memberRoster);
   });
 
-  it("renders the team homepage around member-specific runtime facts", async () => {
+  it("renders the current scope team roster instead of the old member-first homepage", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByRole("button", { name: "查看团队" })).toBeTruthy();
-    expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
-    expect(screen.getByText("我的 AI 团队")).toBeTruthy();
-    expect(screen.getByText("当前 Scope")).toBeTruthy();
-    expect(screen.getAllByText("团队成员").length).toBeGreaterThan(0);
-    expect(screen.getByText("运行正常")).toBeTruthy();
-    expect(screen.getByText("需要处理")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
-    expect(screen.getByText("客服团队")).toBeTruthy();
-    expect(screen.getByText("成员标识：member-alpha")).toBeTruthy();
-    expect(screen.getByText("客服运行时")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "切换到列表视图" })).toBeNull();
+    expect(await screen.findByText("Support Team")).toBeTruthy();
+    expect(screen.getByText("My Teams")).toBeTruthy();
+    expect(screen.getByText("Handles inbound support requests")).toBeTruthy();
+    expect(screen.getByText("Planner · Responder")).toBeTruthy();
+    expect(screen.getByText("Ops Team")).toBeTruthy();
+    expect(screen.getByText("Assigned Members")).toBeTruthy();
+    expect(screen.getByText("Unassigned Members")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create Team" })).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "Manage Team" }).length).toBe(2);
   });
 
-  it("opens Studio from the member card without falling back to service-shaped member routes", async () => {
+  it("opens the canonical team detail route with teamId in query", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "更多" }));
-    fireEvent.click(await screen.findByText("进入 Studio"));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/studio");
-    });
-
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("scopeId")).toBe("scope-a");
-    expect(params.get("member")).toBe("member:member-alpha");
-    expect(params.get("tab")).toBe("studio");
-  });
-
-  it("routes Create Team directly into Studio member creation", async () => {
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    fireEvent.click(await screen.findByRole("button", { name: "组建新团队" }));
-
-    expect(window.location.pathname).toBe("/studio");
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("scopeId")).toBe("scope-a");
-    expect(params.get("tab")).toBe("studio");
-    expect(params.get("intent")).toBe("create-member");
-  });
-
-  it("does not show the roster view toggle when only one member is visible", async () => {
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    await screen.findByText("客服团队");
-    expect(screen.queryByRole("button", { name: "切换到列表视图" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "切换到卡片视图" })).toBeNull();
-  });
-
-  it("keeps the homepage visible when member runtime sampling partially fails", async () => {
-    (scopeRuntimeApi.listMemberRuns as jest.Mock).mockRejectedValueOnce(
-      new Error("No stub for /api/scopes/scope-a/members/member-alpha/runs"),
-    );
-
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    expect(await screen.findByText("客服团队")).toBeTruthy();
-    expect(screen.getByText("部分团队信号暂时不可见")).toBeTruthy();
-    expect(
-      screen.queryByText("No stub for /api/scopes/scope-a/members/member-alpha/runs"),
-    ).toBeNull();
-  });
-
-  it("opens the bound member detail handoff from the primary action", async () => {
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    fireEvent.click(await screen.findByRole("button", { name: "查看团队" }));
+    fireEvent.click(await screen.findAllByRole("button", { name: "Manage Team" }).then((buttons) => buttons[0]));
 
     await waitFor(() => {
       expect(window.location.pathname).toBe("/teams/scope-a");
     });
 
     const params = new URLSearchParams(window.location.search);
-    expect(params.get("memberId")).toBe("member-alpha");
-    expect(params.get("serviceId")).toBe("service-alpha");
-    expect(params.get("runId")).toBe("run-latest");
+    expect(params.get("teamId")).toBe("team-support");
   });
 
-  it("falls back to the locally stored auth scope when the live session lookup fails", async () => {
+  it("routes Create Team into the real team creation page with scope context", async () => {
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByText("Support Team")).toBeTruthy();
+    fireEvent.click(await screen.findByRole("button", { name: "Create Team" }));
+
+    expect(window.location.pathname).toBe("/teams/new");
+  });
+
+  it("keeps scope selection manual when the live session lookup has no scope context", async () => {
     window.history.replaceState({}, "", "/teams");
-    persistAuthSession({
-      tokens: {
-        accessToken: "access-token",
-        tokenType: "Bearer",
-        expiresIn: 3600,
-        expiresAt: Date.now() + 3600_000,
-        refreshToken: "refresh-token",
-      },
-      user: {
-        sub: "scope-a",
-        name: "Abigail Deng",
-      },
-    });
-    (studioApi.getAuthSession as jest.Mock).mockRejectedValueOnce(
-      new Error("Error occurred while trying to proxy: localhost:5173/api/auth/me"),
-    );
-
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    expect(await screen.findByText("当前登录态校验失败，已回退到本地 Scope")).toBeTruthy();
-    expect(
-      screen.getByText(
-        "登录状态暂时不可用，请刷新后重试。 当前已回退到本地会话里的 Scope scope-a。",
-      ),
-    ).toBeTruthy();
-
-    await waitFor(() => {
-      expect(new URLSearchParams(window.location.search).get("scopeId")).toBe("scope-a");
-    });
-  });
-
-  it("renders one card per member instead of collapsing the homepage into a scope singleton", async () => {
-    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
-      scopeId: "scope-a",
-      members: [
-        ...defaultMembers,
-        {
-          memberId: "member-joker",
-          scopeId: "scope-a",
-          displayName: "joker",
-          description: "讽刺评论成员",
-          implementationKind: "workflow",
-          lifecycleStage: "bind_ready",
-          publishedServiceId: "service-joker",
-          lastBoundRevisionId: "rev-joker",
-          createdAt: "2026-04-13T09:10:00Z",
-          updatedAt: "2026-04-13T10:10:00Z",
-        },
-      ],
-      nextPageToken: null,
-    });
-    (servicesApi.listServices as jest.Mock).mockResolvedValueOnce([
-      ...defaultServices,
-      {
-        serviceKey: "scope-a:joker",
-        tenantId: "scope-a",
-        appId: "default",
-        namespace: "default",
-        serviceId: "service-joker",
-        displayName: "joker",
-        defaultServingRevisionId: "rev-joker",
-        activeServingRevisionId: "rev-joker",
-        deploymentId: "deploy-joker",
-        primaryActorId: "actor://workflow-joker",
-        deploymentStatus: "Active",
-        endpoints: [],
-        policyIds: [],
-        updatedAt: "2026-04-13T10:09:00Z",
-      },
-    ]);
-
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
-    expect(screen.getByRole("heading", { level: 3, name: "joker" })).toBeTruthy();
-    expect(screen.getByText("成员标识：member-joker")).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "查看团队" })).toHaveLength(2);
-  });
-
-  it("shows an empty member roster state without querying member runs", async () => {
-    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
-      scopeId: "scope-a",
-      members: [],
-      nextPageToken: null,
+    (studioApi.getAuthSession as jest.Mock).mockResolvedValueOnce({
+      enabled: true,
+      authenticated: true,
+      scopeId: null,
+      scopeSource: null,
     });
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(
-      await screen.findByText(
-        "当前 Scope 下还没有创建任何 member。进入 Studio 创建成员后，这里会按成员逐个展示。",
-      ),
-    ).toBeTruthy();
-    expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
-  });
-
-  it("opens Studio from the empty member roster state", async () => {
-    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
-      scopeId: "scope-a",
-      members: [],
-      nextPageToken: null,
-    });
-
-    renderWithQueryClient(React.createElement(TeamsHomePage));
-
-    fireEvent.click(await screen.findByRole("button", { name: "打开 Studio" }));
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/studio");
-    });
-
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("scopeId")).toBe("scope-a");
-    expect(params.get("tab")).toBe("studio");
+    expect(await screen.findByText("Scope Context")).toBeTruthy();
+    expect(window.location.pathname).toBe("/teams");
+    expect(new URLSearchParams(window.location.search).get("scopeId")).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -1,1060 +1,252 @@
-import {
-  AppstoreOutlined,
-  BarsOutlined,
-  MoreOutlined,
-  PlusOutlined,
-} from "@ant-design/icons";
-import { useQueries, useQuery } from "@tanstack/react-query";
-import {
-  Alert,
-  Button,
-  Dropdown,
-  Empty,
-  Space,
-  Tooltip,
-  Typography,
-  theme,
-} from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { Alert, Button, Empty, Space, Tag, Typography } from "antd";
 import React from "react";
-import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
-import { servicesApi } from "@/shared/api/servicesApi";
-import { loadRestorableAuthSession } from "@/shared/auth/session";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
 import { history } from "@/shared/navigation/history";
 import {
+  buildTeamCreateHref,
   buildTeamDetailHref,
 } from "@/shared/navigation/teamRoutes";
-import { buildRuntimeRunsHref } from "@/shared/navigation/runtimeRoutes";
 import { studioApi } from "@/shared/studio/api";
-import type { ScopeServiceRunSummary } from "@/shared/models/runtime/scopeServices";
-import type { ServiceCatalogSnapshot } from "@/shared/models/services";
 import {
-  formatStudioMemberLifecycleStage,
+  formatStudioTeamLifecycleStage,
   type StudioMemberSummary,
+  type StudioTeamSummary,
 } from "@/shared/studio/models";
-import {
-  buildStudioRoute,
-  buildStudioWorkflowWorkspaceRoute,
-} from "@/shared/studio/navigation";
-import {
-  AevatarInspectorEmpty,
-  AevatarPageShell,
-  AevatarPanel,
-} from "@/shared/ui/aevatarPageShells";
+import { AevatarPanel } from "@/shared/ui/aevatarPageShells";
+import { AevatarCompactText } from "@/shared/ui/compactText";
+import ConsoleMetricCard from "@/shared/ui/ConsoleMetricCard";
+import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
 import { describeError } from "@/shared/ui/errorText";
-import { resolveStudioScopeContext } from "../scopes/components/resolvedScope";
 import ScopeQueryCard from "../scopes/components/ScopeQueryCard";
+import { resolveStudioScopeContext } from "../scopes/components/resolvedScope";
 import {
   buildScopeHref,
   normalizeScopeDraft,
   readScopeQueryDraft,
   type ScopeQueryDraft,
 } from "../scopes/components/scopeQuery";
-import {
-  WORKFLOW_RUNTIME_GUARDRAIL,
-  type WorkflowOperationalAttention,
-} from "./workflowOperationalUnits";
-
-const scopeServiceAppId = "default";
-const scopeServiceNamespace = "default";
-const compactTeamRosterThreshold = 6;
-
-type MemberRosterPreview = {
-  readonly attention: WorkflowOperationalAttention;
-  readonly attentionDetail: string;
-  readonly detailHref: string;
-  readonly entryLabel: string;
-  readonly latestRun: ScopeServiceRunSummary | null;
-  readonly memberId: string;
-  readonly moreActions: Array<{ key: string; label: string; onClick: () => void }>;
-  readonly primaryActionLabel: string;
-  readonly serviceId: string;
-  readonly serviceLabel: string;
-  readonly title: string;
-  readonly updatedAt: string | null;
-};
 
 function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
 
-function isPlaceholderTeamLabel(value: string | null | undefined): boolean {
-  const normalized = trimOptional(value).toLowerCase();
-  if (!normalized) {
-    return true;
-  }
-
-  return ["not configured", "unconfigured", "unknown", "n/a"].includes(normalized);
-}
-
-function pickMeaningfulLabel(
-  ...candidates: Array<string | null | undefined>
-): string {
-  for (const candidate of candidates) {
-    const normalized = trimOptional(candidate);
-    if (normalized && !isPlaceholderTeamLabel(normalized)) {
-      return normalized;
-    }
-  }
-
-  return "";
-}
-
-function formatRunStatusLabel(status: string | null | undefined): string {
-  switch (trimOptional(status).toLowerCase()) {
-    case "waiting":
-    case "waiting_approval":
-    case "waiting_signal":
-      return "待关注";
-    case "failed":
-    case "error":
-      return "异常";
-    case "completed":
-      return "稳定";
-    default:
-      return trimOptional(status) || "未知";
-  }
-}
-
-function formatOperationalStatusLabel(
-  status: string | null | undefined,
-  attention: WorkflowOperationalAttention,
-): string {
-  const normalizedStatus = trimOptional(status);
-  if (normalizedStatus) {
-    return formatRunStatusLabel(normalizedStatus);
-  }
-
-  switch (attention) {
-    case "healthy":
-      return "运行中";
-    case "waiting":
-      return "待关注";
-    case "failed":
-      return "异常";
-    case "draft":
-      return "草稿中";
-    case "no-bound-service":
-      return "待绑定";
-    case "no-recent-runs":
-      return "待运行";
-    case "runtime-unresolved":
-      return "待确认";
-    default:
-      return "未知";
-  }
-}
-
-function formatAttentionLabel(attention: WorkflowOperationalAttention): string {
-  switch (attention) {
-    case "failed":
-      return "待处理";
-    case "waiting":
-      return "待关注";
-    case "healthy":
-      return "运行中";
-    case "draft":
-      return "草稿中";
-    case "no-bound-service":
-      return "待绑定";
-    case "no-recent-runs":
-      return "待运行";
-    default:
-      return "待确认";
-  }
-}
-
-function resolveAttentionPillStyle(
-  token: ReturnType<typeof theme.useToken>["token"],
-  attention: WorkflowOperationalAttention,
-): React.CSSProperties {
-  switch (attention) {
-    case "healthy":
-      return {
-        background: "rgba(24, 144, 255, 0.08)",
-        color: token.colorInfo,
-      };
-    case "waiting":
-    case "no-bound-service":
-    case "no-recent-runs":
-      return {
-        background: "rgba(250, 173, 20, 0.12)",
-        color: token.colorWarning,
-      };
-    case "failed":
-      return {
-        background: "rgba(255, 77, 79, 0.12)",
-        color: token.colorError,
-      };
-    case "draft":
-      return {
-        background: token.colorFillQuaternary,
-        color: token.colorTextSecondary,
-      };
-    default:
-      return {
-        background: token.colorFillQuaternary,
-        color: token.colorTextSecondary,
-      };
-  }
-}
-
-function formatShortTime(value: string | null | undefined): string {
-  return formatCompactDateTime(value, "--");
-}
-
-function parseTimestamp(value: string | null | undefined): number {
+function readTimestamp(value: string | null | undefined): number {
   const parsed = Date.parse(value || "");
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function normalizeStatus(value: string | null | undefined): string {
-  return trimOptional(value).toLowerCase();
+function sortTeams(left: StudioTeamSummary, right: StudioTeamSummary): number {
+  const updatedDelta = readTimestamp(right.updatedAt) - readTimestamp(left.updatedAt);
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+
+  return left.displayName.localeCompare(right.displayName);
 }
 
-function compareRuns(
-  left: ScopeServiceRunSummary,
-  right: ScopeServiceRunSummary,
-): number {
-  const rightTime = parseTimestamp(right.lastUpdatedAt);
-  const leftTime = parseTimestamp(left.lastUpdatedAt);
-  if (rightTime !== leftTime) {
-    return rightTime - leftTime;
+function formatMemberPreview(members: readonly StudioMemberSummary[]): string {
+  if (members.length === 0) {
+    return "No members assigned yet";
   }
 
-  if (right.stateVersion !== left.stateVersion) {
-    return right.stateVersion - left.stateVersion;
-  }
-
-  return right.runId.localeCompare(left.runId);
+  const labels = members
+    .slice(0, 3)
+    .map((member) => trimOptional(member.displayName) || member.memberId);
+  return members.length > 3
+    ? `${labels.join(" · ")} +${members.length - 3}`
+    : labels.join(" · ");
 }
 
-function isSuccessfulRun(run: ScopeServiceRunSummary | null | undefined): boolean {
-  if (!run) {
-    return false;
-  }
-
-  if (run.lastSuccess === true) {
-    return true;
-  }
-
-  return ["completed", "finished", "success", "succeeded"].includes(
-    normalizeStatus(run.completionStatus),
-  );
-}
-
-function isWaitingRun(run: ScopeServiceRunSummary | null | undefined): boolean {
-  if (!run) {
-    return false;
-  }
-
-  return [
-    "waiting",
-    "waiting_approval",
-    "waiting_signal",
-    "blocked",
-    "human_approval",
-    "human_input",
-    "suspended",
-  ].includes(normalizeStatus(run.completionStatus));
-}
-
-function isFailedRun(run: ScopeServiceRunSummary | null | undefined): boolean {
-  if (!run) {
-    return false;
-  }
-
-  if (isWaitingRun(run)) {
-    return false;
-  }
-
-  if (run.lastSuccess === false) {
-    return true;
-  }
-
-  return ["failed", "error", "stopped", "timed_out", "timedout"].includes(
-    normalizeStatus(run.completionStatus),
-  );
-}
-
-function stopEvent<T extends (...args: any[]) => void>(handler: T): T {
-  return ((event: React.MouseEvent<HTMLElement>) => {
-    event.stopPropagation();
-    handler();
-  }) as T;
-}
-
-const SummaryStatCard: React.FC<{
-  readonly accent?: boolean;
-  readonly label: string;
-  readonly value: React.ReactNode;
-}> = ({ accent = false, label, value }) => {
-  const { token } = theme.useToken();
-
-  return (
-    <div
-      style={{
-        background: token.colorBgContainer,
-        border: `1px solid ${token.colorBorderSecondary}`,
-        borderRadius: 22,
-        boxShadow: token.boxShadowTertiary,
-        display: "flex",
-        flexDirection: "column",
-        gap: 8,
-        minHeight: 104,
-        padding: 18,
-      }}
-    >
-      <Typography.Title
-        level={2}
-        style={{
-          color: accent ? token.colorPrimary : token.colorText,
-          fontSize: 24,
-          margin: 0,
-        }}
-      >
-        {value}
-      </Typography.Title>
-      <Typography.Text
-        style={{
-          color: token.colorTextSecondary,
-          fontSize: 14,
-        }}
-      >
-        {label}
-      </Typography.Text>
-    </div>
-  );
+const metricGridStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 16,
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
 };
 
-const TeamFact: React.FC<{
-  readonly label: string;
-  readonly value: React.ReactNode;
-}> = ({ label, value }) => (
-  <div
-    style={{
-      display: "flex",
-      flexDirection: "column",
-      gap: 4,
-      minWidth: 0,
-    }}
-  >
-    <Typography.Text
-      strong
-      style={{
-        fontSize: 16,
-        margin: 0,
-        overflowWrap: "anywhere",
-      }}
-    >
-      {value}
-    </Typography.Text>
-    <Typography.Text style={{ fontSize: 13 }} type="secondary">
-      {label}
-    </Typography.Text>
-  </div>
-);
-
-function compareMembers(
-  left: StudioMemberSummary,
-  right: StudioMemberSummary,
-): number {
-  const rightTime = parseTimestamp(right.updatedAt);
-  const leftTime = parseTimestamp(left.updatedAt);
-  if (rightTime !== leftTime) {
-    return rightTime - leftTime;
-  }
-
-  return right.memberId.localeCompare(left.memberId);
-}
-
-function resolveMemberPreviewService(input: {
-  readonly member: StudioMemberSummary;
-  readonly services: readonly ServiceCatalogSnapshot[];
-}): ServiceCatalogSnapshot | null {
-  const boundServiceId = trimOptional(input.member.publishedServiceId);
-  if (!boundServiceId) {
-    return null;
-  }
-
-  return (
-    input.services.find(
-      (service) => trimOptional(service.serviceId) === boundServiceId,
-    ) ?? null
-  );
-}
-
-function resolveRuntimeUnavailable(input: {
-  readonly memberId: string;
-  readonly runtimeAvailableByMemberId?: ReadonlySet<string>;
-  readonly runtimeGuardrailedMemberIds?: ReadonlySet<string>;
-}): boolean {
-  const memberId = trimOptional(input.memberId);
-  if (!memberId) {
-    return false;
-  }
-
-  if (input.runtimeGuardrailedMemberIds?.has(memberId)) {
-    return true;
-  }
-
-  if (!input.runtimeAvailableByMemberId) {
-    return false;
-  }
-
-  return !input.runtimeAvailableByMemberId.has(memberId);
-}
-
-function buildMemberRosterPreview(input: {
-  readonly guardrailedMemberIds?: ReadonlySet<string>;
-  readonly member: StudioMemberSummary;
-  readonly runsByMemberId: Readonly<Record<string, readonly ScopeServiceRunSummary[]>>;
-  readonly runtimeAvailableByMemberId?: ReadonlySet<string>;
-  readonly scopeId: string;
-  readonly services: readonly ServiceCatalogSnapshot[];
-}): MemberRosterPreview {
-  const matchedService = resolveMemberPreviewService({
-    member: input.member,
-    services: input.services,
-  });
-  const memberId = trimOptional(input.member.memberId);
-  const serviceId =
-    trimOptional(input.member.publishedServiceId) ||
-    trimOptional(matchedService?.serviceId);
-  const runtimeRelevant = Boolean(
-    serviceId || trimOptional(input.member.lastBoundRevisionId),
-  );
-  const runtimeUnavailable =
-    runtimeRelevant &&
-    resolveRuntimeUnavailable({
-      memberId,
-      runtimeAvailableByMemberId: input.runtimeAvailableByMemberId,
-      runtimeGuardrailedMemberIds: input.guardrailedMemberIds,
-    });
-  const runs =
-    memberId && !runtimeUnavailable ? input.runsByMemberId[memberId] ?? [] : [];
-  const latestRun = runs.slice().sort(compareRuns)[0] ?? null;
-  const entryLabel = pickMeaningfulLabel(input.member.memberId, input.member.displayName) || "未命名成员";
-  const serviceLabel =
-    pickMeaningfulLabel(trimOptional(matchedService?.displayName), serviceId) ||
-    (trimOptional(input.member.lastBoundRevisionId) ? "已绑定待确认" : "未绑定");
-  const title = pickMeaningfulLabel(input.member.displayName, input.member.memberId) || "未命名成员";
-  const studioHref = buildStudioWorkflowWorkspaceRoute({
-    scopeId: input.scopeId,
-    memberId,
-  });
-
-  let attention: WorkflowOperationalAttention = "draft";
-  let attentionDetail = `当前成员还处于 ${formatStudioMemberLifecycleStage(input.member.lifecycleStage)} 阶段。`;
-
-  if (runtimeUnavailable) {
-    attention = "runtime-unresolved";
-    attentionDetail = "当前成员已经存在绑定事实，但本页暂时没有拿到它的运行信号。";
-  } else if (latestRun && isFailedRun(latestRun)) {
-    attention = "failed";
-    attentionDetail =
-      trimOptional(latestRun.lastError) || "最近一次成员运行处于异常状态。";
-  } else if (latestRun && isWaitingRun(latestRun)) {
-    attention = "waiting";
-    attentionDetail =
-      trimOptional(latestRun.lastError) || "最近一次成员运行正在等待人工或外部信号。";
-  } else if (latestRun && isSuccessfulRun(latestRun)) {
-    attention = "healthy";
-    attentionDetail = "最近一次成员运行正常，可继续进入详情查看。";
-  } else if (serviceId || matchedService) {
-    attention = "no-recent-runs";
-    attentionDetail = "当前成员已经形成绑定，但还没有可见的运行信号。";
-  } else if (
-    trimOptional(input.member.lastBoundRevisionId) ||
-    input.member.lifecycleStage === "bind_ready"
-  ) {
-    attention = "no-bound-service";
-    attentionDetail = "当前成员已经准备好绑定，但还没有稳定的可调用入口。";
-  }
-
-  const detailHref = serviceId
-    ? buildTeamDetailHref({
-        memberId,
-        runId: latestRun?.runId || undefined,
-        scopeId: input.scopeId,
-        serviceId: serviceId || undefined,
-      })
-    : studioHref;
-  const runtimeHref =
-    serviceId.length > 0
-      ? buildRuntimeRunsHref({
-          actorId:
-            latestRun?.actorId ||
-            matchedService?.primaryActorId ||
-            undefined,
-          scopeId: input.scopeId,
-          serviceId,
-        })
-      : "";
-  const moreActions: Array<{ key: string; label: string; onClick: () => void }> = [];
-  if (runtimeHref) {
-    moreActions.push({
-      key: "runtime",
-      label: "查看运行",
-      onClick: () => history.push(runtimeHref),
-    });
-  }
-  moreActions.push({
-    key: "builder",
-    label: "进入 Studio",
-    onClick: () => history.push(studioHref),
-  });
-
-  return {
-    attention,
-    attentionDetail,
-    detailHref,
-    entryLabel,
-    latestRun,
-    memberId,
-    moreActions,
-    primaryActionLabel: serviceId ? "查看团队" : "打开 Studio",
-    serviceId,
-    serviceLabel,
-    title,
-    updatedAt:
-      latestRun?.lastUpdatedAt ||
-      matchedService?.updatedAt ||
-      input.member.updatedAt ||
-      null,
-  };
-}
-
-const MoreActionsButton: React.FC<{
-  readonly actions: Array<{ key: string; label: string; onClick: () => void }>;
-}> = ({ actions }) => (
-  <Dropdown
-    menu={{
-      items: actions.map((action) => ({
-        key: action.key,
-        label: action.label,
-      })),
-      onClick: ({ key, domEvent }) => {
-        domEvent.stopPropagation();
-        const matchedAction = actions.find((action) => action.key === key);
-        if (!matchedAction) {
-          return;
-        }
-
-        matchedAction.onClick();
-      },
-    }}
-    trigger={["click"]}
-  >
-    <Button
-      icon={<MoreOutlined />}
-      onClick={(event) => event.stopPropagation()}
-      size="large"
-    >
-      更多
-    </Button>
-  </Dropdown>
-);
-
-const MemberRosterCard: React.FC<{
-  readonly preview: MemberRosterPreview;
-}> = ({ preview }) => {
-  const { token } = theme.useToken();
-
-  return (
-    <div
-      onClick={() => history.push(preview.detailHref)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          history.push(preview.detailHref);
-        }
-      }}
-      role="button"
-      style={{
-        background: token.colorBgContainer,
-        border: `1px solid ${token.colorBorderSecondary}`,
-        borderRadius: 24,
-        boxShadow: token.boxShadowTertiary,
-        cursor: "pointer",
-        display: "flex",
-        flexDirection: "column",
-        gap: 14,
-        minWidth: 0,
-        padding: 18,
-      }}
-      tabIndex={0}
-    >
-      <div
-        style={{
-          alignItems: "flex-start",
-          display: "flex",
-          gap: 16,
-          justifyContent: "space-between",
-        }}
-      >
-        <div style={{ minWidth: 0 }}>
-          <Typography.Title
-            level={3}
-            style={{
-              fontSize: 22,
-              margin: 0,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {preview.title}
-          </Typography.Title>
-          <Typography.Paragraph
-            ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
-            style={{
-              color: token.colorTextSecondary,
-              fontSize: 14,
-              marginBottom: 0,
-              marginTop: 6,
-            }}
-          >
-            {preview.attentionDetail}
-          </Typography.Paragraph>
-        </div>
-        <span
-          style={{
-            ...resolveAttentionPillStyle(token, preview.attention),
-            borderRadius: 999,
-            display: "inline-flex",
-            fontSize: 12,
-            fontWeight: 600,
-            lineHeight: 1,
-            padding: "8px 12px",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {formatAttentionLabel(preview.attention)}
-        </span>
-      </div>
-
-      <Typography.Text
-        style={{
-          color: token.colorTextSecondary,
-          fontSize: 13,
-        }}
-      >
-        成员标识：{preview.entryLabel}
-      </Typography.Text>
-
-      <div
-        style={{
-          borderTop: `1px solid ${token.colorBorderSecondary}`,
-          display: "grid",
-          gap: 14,
-          gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
-          paddingTop: 14,
-        }}
-      >
-        <TeamFact
-          label="当前状态"
-          value={formatOperationalStatusLabel(
-            preview.latestRun?.completionStatus,
-            preview.attention,
-          )}
-        />
-        <TeamFact
-          label="最近更新"
-          value={formatShortTime(preview.updatedAt)}
-        />
-        <TeamFact label="关联服务" value={preview.serviceLabel} />
-      </div>
-
-      <Space wrap>
-        <Button
-          onClick={stopEvent(() => history.push(preview.detailHref))}
-          size="large"
-          type="primary"
-        >
-          {preview.primaryActionLabel}
-        </Button>
-        <MoreActionsButton actions={preview.moreActions} />
-      </Space>
-    </div>
-  );
+const cardGridStyle: React.CSSProperties = {
+  display: "grid",
+  gap: 16,
+  gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
 };
 
-const MemberRosterRow: React.FC<{
-  readonly preview: MemberRosterPreview;
-}> = ({ preview }) => {
-  const { token } = theme.useToken();
+const teamCardStyle: React.CSSProperties = {
+  background: "#ffffff",
+  border: "1px solid #e8edf5",
+  borderRadius: 18,
+  boxShadow: "0 12px 32px rgba(15, 23, 42, 0.05)",
+  display: "grid",
+  gap: 16,
+  minWidth: 0,
+  padding: 20,
+};
 
-  return (
-    <div
-      onClick={() => history.push(preview.detailHref)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          history.push(preview.detailHref);
-        }
-      }}
-      role="button"
-      style={{
-        alignItems: "center",
-        background: token.colorBgContainer,
-        border: `1px solid ${token.colorBorderSecondary}`,
-        borderRadius: 20,
-        boxShadow: token.boxShadowTertiary,
-        cursor: "pointer",
-        display: "grid",
-        gap: 16,
-        gridTemplateColumns: "minmax(0, 1.8fr) repeat(3, minmax(88px, 120px)) auto",
-        minWidth: 0,
-        padding: 16,
-      }}
-      tabIndex={0}
-    >
-      <div style={{ minWidth: 0 }}>
-        <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
-          <Typography.Title
-            level={4}
-            style={{
-              margin: 0,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {preview.title}
-          </Typography.Title>
-          <span
-            style={{
-              ...resolveAttentionPillStyle(token, preview.attention),
-              borderRadius: 999,
-              display: "inline-flex",
-              fontSize: 12,
-              fontWeight: 600,
-              lineHeight: 1,
-              padding: "7px 10px",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {formatAttentionLabel(preview.attention)}
-          </span>
-        </Space>
-        <Typography.Paragraph
-          ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
-          style={{
-            color: token.colorTextSecondary,
-            fontSize: 13,
-            marginBottom: 0,
-            marginTop: 0,
-          }}
-        >
-          {preview.attentionDetail}
-        </Typography.Paragraph>
-        <Typography.Text
-          style={{
-            color: token.colorTextSecondary,
-            fontSize: 13,
-          }}
-        >
-          成员标识：{preview.entryLabel}
-        </Typography.Text>
-      </div>
+const detailLabelStyle: React.CSSProperties = {
+  color: "#8c8c8c",
+  fontSize: 12,
+  fontWeight: 600,
+  textTransform: "uppercase",
+};
 
-      <TeamFact
-        label="状态"
-        value={formatOperationalStatusLabel(
-          preview.latestRun?.completionStatus,
-          preview.attention,
-        )}
-      />
-      <TeamFact label="更新" value={formatShortTime(preview.updatedAt)} />
-      <TeamFact label="服务" value={preview.serviceLabel} />
-
-      <Space wrap>
-        <Button
-          onClick={stopEvent(() => history.push(preview.detailHref))}
-          type="primary"
-        >
-          {preview.primaryActionLabel}
-        </Button>
-        <MoreActionsButton actions={preview.moreActions} />
-      </Space>
-    </div>
-  );
+const detailValueStyle: React.CSSProperties = {
+  color: "#1d2129",
+  fontSize: 14,
+  lineHeight: 1.5,
 };
 
 const TeamsHomePage: React.FC = () => {
-  const { token } = theme.useToken();
-  const [draft, setDraft] = React.useState<ScopeQueryDraft>(() =>
-    readScopeQueryDraft(),
-  );
+  const [draft, setDraft] = React.useState<ScopeQueryDraft>(() => readScopeQueryDraft());
   const [activeDraft, setActiveDraft] = React.useState<ScopeQueryDraft>(() =>
-    readScopeQueryDraft(),
+    normalizeScopeDraft({ scopeId: "" }),
   );
-  const [manualRosterView, setManualRosterView] = React.useState<
-    "cards" | "list" | null
-  >(null);
   const [showScopePicker, setShowScopePicker] = React.useState(false);
 
   const authSessionQuery = useQuery({
-    queryKey: ["scopes", "auth-session"],
+    queryKey: ["teams", "auth-session"],
     queryFn: () => studioApi.getAuthSession(),
     retry: false,
   });
-  const localScopeId = trimOptional(loadRestorableAuthSession()?.user.sub);
-  const locallyResolvedScope = React.useMemo(() => {
-    if (!localScopeId) {
-      return null;
-    }
-
-    return {
-      scopeId: localScopeId,
-      scopeSource: "local-session",
-    };
-  }, [localScopeId]);
   const resolvedScope = React.useMemo(
-    () => resolveStudioScopeContext(authSessionQuery.data) ?? locallyResolvedScope,
-    [authSessionQuery.data, locallyResolvedScope],
+    () => resolveStudioScopeContext(authSessionQuery.data),
+    [authSessionQuery.data],
   );
-  const authSessionIssue = React.useMemo(() => {
-    if (!authSessionQuery.isError) {
-      return "";
-    }
-
-    return describeError(
-      authSessionQuery.error,
-      "登录状态暂时不可用，请刷新后重试。",
-    );
-  }, [authSessionQuery.error, authSessionQuery.isError]);
 
   React.useEffect(() => {
     if (!resolvedScope?.scopeId) {
       return;
     }
 
-    setDraft((currentDraft) =>
-      currentDraft.scopeId.trim()
-        ? currentDraft
-        : { scopeId: resolvedScope.scopeId },
-    );
-    setActiveDraft((currentDraft) =>
-      currentDraft.scopeId.trim()
-        ? currentDraft
-        : { scopeId: resolvedScope.scopeId },
-    );
+    const nextDraft = normalizeScopeDraft({ scopeId: resolvedScope.scopeId });
+    setDraft(nextDraft);
+    setActiveDraft(nextDraft);
   }, [resolvedScope?.scopeId]);
-
-  const scopeId = activeDraft.scopeId.trim();
 
   React.useEffect(() => {
     history.replace(buildScopeHref("/teams", activeDraft));
   }, [activeDraft]);
 
+  const scopeId = activeDraft.scopeId.trim();
+  const teamsQuery = useQuery({
+    enabled: scopeId.length > 0,
+    queryKey: ["teams", "roster", scopeId],
+    queryFn: () => studioApi.listTeams(scopeId),
+    retry: false,
+  });
   const membersQuery = useQuery({
     enabled: scopeId.length > 0,
     queryKey: ["teams", "members", scopeId],
     queryFn: () => studioApi.listMembers(scopeId),
     retry: false,
   });
-  const servicesQuery = useQuery({
-    enabled: scopeId.length > 0,
-    queryKey: ["teams", "services", scopeId],
-    queryFn: () =>
-      servicesApi.listServices({
-        tenantId: scopeId,
-        appId: scopeServiceAppId,
-        namespace: scopeServiceNamespace,
-    }),
-    retry: false,
-  });
 
-  const studioMembers = React.useMemo(
-    () => [...(membersQuery.data?.members ?? [])].sort(compareMembers),
+  const teams = React.useMemo(
+    () => [...(teamsQuery.data?.teams ?? [])].sort(sortTeams),
+    [teamsQuery.data?.teams],
+  );
+  const membersByTeamId = React.useMemo(() => {
+    const grouped = new Map<string, StudioMemberSummary[]>();
+    for (const member of membersQuery.data?.members ?? []) {
+      const teamId = trimOptional(member.teamId);
+      if (!teamId) {
+        continue;
+      }
+
+      const bucket = grouped.get(teamId);
+      if (bucket) {
+        bucket.push(member);
+      } else {
+        grouped.set(teamId, [member]);
+      }
+    }
+
+    return grouped;
+  }, [membersQuery.data?.members]);
+  const unassignedMembers = React.useMemo(
+    () =>
+      (membersQuery.data?.members ?? []).filter(
+        (member) => !trimOptional(member.teamId),
+      ),
     [membersQuery.data?.members],
   );
-  const runtimeTrackableMembers = React.useMemo(
-    () =>
-      studioMembers.filter(
-        (member) =>
-          Boolean(trimOptional(member.publishedServiceId)) ||
-          Boolean(trimOptional(member.lastBoundRevisionId)),
-      ),
-    [studioMembers],
-  );
-  const runtimeSampleMembers = React.useMemo(
-    () => runtimeTrackableMembers.slice(0, WORKFLOW_RUNTIME_GUARDRAIL),
-    [runtimeTrackableMembers],
-  );
-  const guardrailedMemberIds = React.useMemo(
-    () =>
-      new Set(
-        runtimeTrackableMembers
-          .slice(WORKFLOW_RUNTIME_GUARDRAIL)
-          .map((member) => trimOptional(member.memberId))
-          .filter(Boolean),
-      ),
-    [runtimeTrackableMembers],
-  );
-  const memberRunQueries = useQueries({
-    queries: runtimeSampleMembers.map((member) => ({
-      enabled: scopeId.length > 0 && membersQuery.isSuccess,
-      queryKey: ["teams", "member-runs", scopeId, member.memberId],
-      queryFn: () =>
-        scopeRuntimeApi.listMemberRuns(scopeId, member.memberId, {
-          take: 12,
-        }),
-      retry: false,
-    })),
-  });
-  const runtimeAvailableByMemberId = React.useMemo(() => {
-    const available = new Set<string>();
-    memberRunQueries.forEach((query, index) => {
-      if (query.isSuccess) {
-        available.add(trimOptional(runtimeSampleMembers[index]?.memberId));
-      }
-    });
-    return available;
-  }, [memberRunQueries, runtimeSampleMembers]);
-  const runsByMemberId = React.useMemo(
-    () =>
-      Object.fromEntries(
-        runtimeSampleMembers.map((member, index) => [
-          trimOptional(member.memberId),
-          memberRunQueries[index]?.data?.runs ?? [],
-        ]),
-      ) as Record<string, readonly any[]>,
-    [memberRunQueries, runtimeSampleMembers],
-  );
-  const memberPreviews = React.useMemo(
-    () =>
-      studioMembers.map((member) =>
-        buildMemberRosterPreview({
-          guardrailedMemberIds,
-          member,
-          runsByMemberId,
-          runtimeAvailableByMemberId,
-          scopeId,
-          services: servicesQuery.data ?? [],
-        }),
-      ),
-    [
-      guardrailedMemberIds,
-      runsByMemberId,
-      runtimeAvailableByMemberId,
-      scopeId,
-      servicesQuery.data,
-      studioMembers,
-    ],
-  );
-  const membersPendingBindingCount = React.useMemo(
-    () =>
-      studioMembers.filter(
-        (member) =>
-          !trimOptional(member.publishedServiceId) ||
-          !trimOptional(member.lastBoundRevisionId),
-      ).length,
-    [studioMembers],
-  );
-  const visibleTeamCount = memberPreviews.length;
-  const resolvedRosterView =
-    manualRosterView ??
-    (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
-  const useCompactRoster = resolvedRosterView === "list";
-  const healthyTeamCount = memberPreviews.filter(
-    (preview) => preview.attention === "healthy",
+  const archivedTeamCount = teams.filter(
+    (team) => team.lifecycleStage === "archived",
   ).length;
-  const attentionTeamCount = memberPreviews.filter(
-    (preview) => preview.attention !== "healthy",
+  const activeTeamCount = teams.length - archivedTeamCount;
+  const membersAssignedCount = (membersQuery.data?.members ?? []).filter((member) =>
+    Boolean(trimOptional(member.teamId)),
   ).length;
-  const emptyRosterHint =
-    scopeId.length > 0
-      ? "当前 Scope 下还没有创建任何 member。进入 Studio 创建成员后，这里会按成员逐个展示。"
-      : "先导入一个 Scope，首页才能渲染出这组成员卡片。";
-  const partialIssues = [
-    servicesQuery.isError ? "服务目录暂时不可见。" : null,
-    membersQuery.isError ? "当前 Scope 的成员清单暂时不可见。" : null,
-    ...memberRunQueries.map((query) =>
-      query.isError ? "部分成员运行信号暂时不可见。" : null,
-    ),
-    guardrailedMemberIds.size > 0
-      ? `当前首页只采样前 ${WORKFLOW_RUNTIME_GUARDRAIL} 个已绑定成员的运行信号。`
-      : null,
-  ].filter((issue): issue is string => Boolean(issue));
-
-  const titleNode = (
-    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      <Typography.Text
-        style={{
-          color: token.colorTextSecondary,
-          fontSize: 14,
-        }}
-      >
-        Aevatar / Teams
-      </Typography.Text>
-      <Typography.Title
-        level={1}
-        style={{
-          margin: 0,
-        }}
-      >
-        我的 AI 团队
-      </Typography.Title>
-    </div>
-  );
-  const canCancelScopePicker = showScopePicker && scopeId.length > 0;
+  const queryIssues = [
+    authSessionQuery.isError
+      ? describeError(
+          authSessionQuery.error,
+          "登录状态暂时不可用，请刷新后重试。",
+        )
+      : "",
+    teamsQuery.isError
+      ? describeError(teamsQuery.error, "团队列表暂时不可用，请稍后再试。")
+      : "",
+    membersQuery.isError
+      ? describeError(membersQuery.error, "成员列表暂时不可用，请稍后再试。")
+      : "",
+  ].filter(Boolean);
 
   return (
-    <AevatarPageShell
+    <ConsoleMenuPageShell
+      breadcrumb="Aevatar / Teams"
+      description="Create real team records, inspect each team roster inside the current scope, and hand members off into Studio only when you need to build or bind."
       extra={
         <Space wrap>
+          <Button
+            onClick={() => setShowScopePicker((current) => !current)}
+            style={{ borderRadius: 12, height: 40, paddingInline: 18 }}
+          >
+            {showScopePicker ? "Hide scope" : "Change scope"}
+          </Button>
           <Button
             icon={<PlusOutlined />}
             onClick={() =>
               history.push(
-                buildStudioRoute({
+                buildTeamCreateHref({
                   scopeId:
                     scopeId ||
                     readScopeQueryDraft().scopeId ||
-                    resolvedScope?.scopeId ||
-                    localScopeId,
-                  tab: "studio",
-                  intent: "create-member",
+                    resolvedScope?.scopeId,
                 }),
               )
             }
-            style={{ borderRadius: 16, height: 40, paddingInline: 18 }}
+            style={{ borderRadius: 12, height: 40, paddingInline: 18 }}
             type="primary"
           >
-            组建新团队
+            Create Team
           </Button>
         </Space>
       }
-      layoutMode="document"
-      title={titleNode}
+      title="My Teams"
     >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: 20,
-        }}
-      >
+      <div style={{ display: "grid", gap: 20 }}>
         {(showScopePicker || !scopeId) && (
           <AevatarPanel
             extra={
-              canCancelScopePicker ? (
+              showScopePicker && scopeId ? (
                 <Button
                   onClick={() => {
                     setDraft(normalizeScopeDraft(activeDraft));
                     setShowScopePicker(false);
                   }}
                 >
-                  取消
+                  Cancel
                 </Button>
               ) : null
             }
-            title="Scope 上下文"
-            titleHelp="这一步只负责锁定你当前要查看的 Scope，不把它抢成首页主角。"
+            layoutMode="document"
+            padding={20}
+            title="Scope Context"
           >
             <ScopeQueryCard
               activeScopeId={scopeId}
               draft={draft}
-              loadLabel="导入团队视图"
+              loadLabel="Load team scope"
               onChange={setDraft}
               onLoad={() => {
                 const nextDraft = normalizeScopeDraft(draft);
@@ -1081,240 +273,161 @@ const TeamsHomePage: React.FC = () => {
                 setActiveDraft(nextDraft);
                 setShowScopePicker(false);
               }}
-              resetDisabled={
-                normalizeScopeDraft(draft).scopeId ===
-                  (resolvedScope?.scopeId?.trim() ?? "") &&
-                scopeId === (resolvedScope?.scopeId?.trim() ?? "")
-              }
-              resolvedScopeId={resolvedScope?.scopeId}
-              resolvedScopeSource={resolvedScope?.scopeSource}
+              resolvedScopeId={resolvedScope?.scopeId ?? null}
+              resolvedScopeSource={resolvedScope?.scopeSource ?? null}
             />
           </AevatarPanel>
         )}
 
-        {scopeId && !showScopePicker ? (
-          <div
-            style={{
-              alignItems: "flex-start",
-              background: token.colorBgContainer,
-              border: `1px solid ${token.colorBorderSecondary}`,
-              borderRadius: 22,
-              boxShadow: token.boxShadowTertiary,
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 16,
-              justifyContent: "space-between",
-              padding: 18,
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: 6,
-                minWidth: 0,
-              }}
-            >
-              <Typography.Text type="secondary">当前 Scope</Typography.Text>
-              <Typography.Text
-                strong
-                style={{
-                  fontSize: 16,
-                  overflowWrap: "anywhere",
-                }}
-              >
-                {scopeId}
-              </Typography.Text>
-              <Typography.Text type="secondary">
-                首页按这个 Scope 汇总成员本身的绑定与运行状态，Scope 只做上下文，不再直接当团队名展示。
-              </Typography.Text>
-            </div>
-          </div>
-        ) : null}
+        {queryIssues.map((issue) => (
+          <Alert key={issue} message={issue} showIcon type="warning" />
+        ))}
+
+        <div style={metricGridStyle}>
+          <ConsoleMetricCard label="Teams" value={String(teams.length)} />
+          <ConsoleMetricCard
+            label="Active Teams"
+            tone="green"
+            value={String(activeTeamCount)}
+          />
+          <ConsoleMetricCard
+            label="Assigned Members"
+            tone="purple"
+            value={String(membersAssignedCount)}
+          />
+          <ConsoleMetricCard
+            label="Unassigned Members"
+            value={String(unassignedMembers.length)}
+          />
+        </div>
 
         {!scopeId ? (
-          <Alert
-            showIcon
-            title="先导入一个 Scope，首页才能渲染出这组成员卡片。"
-            type="info"
-          />
-        ) : null}
-
-        {partialIssues.length > 0 ? (
-          <Alert
-            description={partialIssues.join(" ")}
-            showIcon
-            title="部分团队信号暂时不可见"
-            type="warning"
-          />
-        ) : null}
-
-        {authSessionIssue ? (
-          <Alert
-            description={
-              resolvedScope?.scopeId
-                ? `${authSessionIssue} 当前已回退到本地会话里的 Scope ${resolvedScope.scopeId}。`
-                : authSessionIssue
-            }
-            showIcon
-            title={
-              resolvedScope?.scopeId
-                ? "当前登录态校验失败，已回退到本地 Scope"
-                : "当前登录态校验失败"
-            }
-            type="warning"
-          />
-        ) : null}
-
-        {scopeId ? (
-          <>
-            <div
-              style={{
-                display: "grid",
-                gap: 16,
-                gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-              }}
+          <AevatarPanel layoutMode="document" padding={24} title="Team Roster">
+            <Empty
+              description="Load a scope first so we can fetch teams from the backend."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+            />
+          </AevatarPanel>
+        ) : teamsQuery.isLoading ? (
+          <AevatarPanel layoutMode="document" padding={24} title="Team Roster">
+            <Typography.Text>Loading teams...</Typography.Text>
+          </AevatarPanel>
+        ) : teams.length === 0 ? (
+          <AevatarPanel layoutMode="document" padding={24} title="Team Roster">
+            <Empty
+              description="This scope does not have any teams yet."
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
             >
-              <SummaryStatCard accent label="团队成员" value={visibleTeamCount} />
-              <SummaryStatCard label="运行正常" value={healthyTeamCount} />
-              <SummaryStatCard label="需要处理" value={attentionTeamCount} />
-            </div>
-
-            {membersPendingBindingCount > 0 ? (
-              <Alert
-                action={
-                  <Button
-                    onClick={() =>
-                      history.push(
-                        buildStudioWorkflowWorkspaceRoute({
-                          scopeId,
-                        }),
-                      )
-                    }
-                    size="small"
-                    type="primary"
-                  >
-                    打开 Studio
-                  </Button>
+              <Button
+                type="primary"
+                onClick={() =>
+                  history.push(
+                    buildTeamCreateHref({
+                      scopeId,
+                    }),
+                  )
                 }
-                description={`其中 ${membersPendingBindingCount} 个成员还没有完成独立绑定，或还没有形成稳定的可调用入口。`}
-                showIcon
-                title="还有成员待整理"
-                type="info"
-              />
-            ) : null}
+              >
+                Create the first team
+              </Button>
+            </Empty>
+          </AevatarPanel>
+        ) : (
+          <div style={cardGridStyle}>
+            {teams.map((team) => {
+              const teamMembers = membersByTeamId.get(team.teamId) ?? [];
+              return (
+                <div key={team.teamId} style={teamCardStyle}>
+                  <div
+                    style={{
+                      alignItems: "flex-start",
+                      display: "flex",
+                      gap: 12,
+                      justifyContent: "space-between",
+                    }}
+                  >
+                    <div style={{ minWidth: 0 }}>
+                      <Typography.Title level={4} style={{ margin: 0 }}>
+                        {team.displayName}
+                      </Typography.Title>
+                      <Typography.Paragraph
+                        ellipsis={{ rows: 2 }}
+                        style={{ color: "#8c8c8c", margin: "8px 0 0" }}
+                      >
+                        {team.description || "No team description yet."}
+                      </Typography.Paragraph>
+                    </div>
+                    <Tag color={team.lifecycleStage === "archived" ? "default" : "blue"}>
+                      {formatStudioTeamLifecycleStage(team.lifecycleStage)}
+                    </Tag>
+                  </div>
 
-            {membersQuery.isLoading ? (
-              <AevatarInspectorEmpty description="正在整理当前 Scope 的成员清单。" />
-            ) : membersQuery.isError ? (
-              <Alert
-                showIcon
-                title="当前 Scope 的成员清单暂时无法加载。"
-                type="error"
-              />
-            ) : memberPreviews.length > 0 ? (
-              <>
-                <div
-                  style={{
-                    alignItems: "center",
-                    display: "flex",
-                    flexWrap: "wrap",
-                    gap: 12,
-                    justifyContent: "space-between",
-                  }}
-                >
                   <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 4,
-                    }}
-                  >
-                    <Typography.Title
-                      level={4}
-                      style={{
-                        margin: 0,
-                      }}
-                    >
-                      团队成员
-                    </Typography.Title>
-                    <Typography.Text type="secondary">
-                      当前 Scope 下已经登记的成员，以及它们各自的绑定和运行状态。
-                    </Typography.Text>
-                  </div>
-                  {visibleTeamCount > 1 ? (
-                    <Space.Compact>
-                      <Tooltip title="卡片视图">
-                        <Button
-                          aria-label="切换到卡片视图"
-                          icon={<AppstoreOutlined />}
-                          onClick={() => setManualRosterView("cards")}
-                          type={resolvedRosterView === "cards" ? "primary" : "default"}
-                        />
-                      </Tooltip>
-                      <Tooltip title="列表视图">
-                        <Button
-                          aria-label="切换到列表视图"
-                          icon={<BarsOutlined />}
-                          onClick={() => setManualRosterView("list")}
-                          type={resolvedRosterView === "list" ? "primary" : "default"}
-                        />
-                      </Tooltip>
-                    </Space.Compact>
-                  ) : null}
-                </div>
-                {useCompactRoster ? (
-                  <div
-                    aria-label="团队紧凑视图"
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 14,
-                    }}
-                  >
-                    {memberPreviews.map((preview) => (
-                      <MemberRosterRow key={preview.memberId} preview={preview} />
-                    ))}
-                  </div>
-                ) : (
-                  <div
-                    aria-label="团队卡片视图"
                     style={{
                       display: "grid",
-                      gap: 16,
-                      gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
+                      gap: 12,
+                      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
                     }}
                   >
-                    {memberPreviews.map((preview) => (
-                      <MemberRosterCard key={preview.memberId} preview={preview} />
-                    ))}
+                    <div>
+                      <div style={detailLabelStyle}>Team ID</div>
+                      <div style={detailValueStyle}>
+                        <AevatarCompactText copyable monospace value={team.teamId} />
+                      </div>
+                    </div>
+                    <div>
+                      <div style={detailLabelStyle}>Members</div>
+                      <div style={detailValueStyle}>{String(team.memberCount)}</div>
+                    </div>
+                    <div>
+                      <div style={detailLabelStyle}>Last Updated</div>
+                      <div style={detailValueStyle}>
+                        {formatCompactDateTime(team.updatedAt, "--")}
+                      </div>
+                    </div>
+                    <div>
+                      <div style={detailLabelStyle}>Member Preview</div>
+                      <div style={detailValueStyle}>
+                        {formatMemberPreview(teamMembers)}
+                      </div>
+                    </div>
                   </div>
-                )}
-              </>
-            ) : (
-              <Empty
-                description={emptyRosterHint}
-                image={Empty.PRESENTED_IMAGE_SIMPLE}
-              >
-                <Button
-                  onClick={() =>
-                    history.push(
-                      buildStudioWorkflowWorkspaceRoute({
-                        scopeId,
-                      }),
-                    )
-                  }
-                  type="primary"
-                >
-                  打开 Studio
-                </Button>
-              </Empty>
-            )}
 
-          </>
-        ) : null}
+                  <Space wrap>
+                    <Button
+                      type="primary"
+                      onClick={() =>
+                        history.push(
+                          buildTeamDetailHref({
+                            scopeId: team.scopeId,
+                            teamId: team.teamId,
+                          }),
+                        )
+                      }
+                    >
+                      Manage Team
+                    </Button>
+                    <Button
+                      onClick={() =>
+                        history.push(
+                          buildTeamDetailHref({
+                            scopeId: team.scopeId,
+                            teamId: team.teamId,
+                            tab: "members",
+                          }),
+                        )
+                      }
+                    >
+                      View Members
+                    </Button>
+                  </Space>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
-    </AevatarPageShell>
+    </ConsoleMenuPageShell>
   );
 };
 

--- a/apps/aevatar-console-web/src/pages/teams/new.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.test.tsx
@@ -1,12 +1,12 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { message } from 'antd';
-import React from 'react';
-import { studioApi } from '@/shared/studio/api';
-import { renderWithQueryClient } from '../../../tests/reactQueryTestUtils';
-import TeamCreatePage from './new';
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { message } from "antd";
+import React from "react";
+import { studioApi } from "@/shared/studio/api";
+import { renderWithQueryClient } from "../../../tests/reactQueryTestUtils";
+import TeamCreatePage from "./new";
 
-jest.mock('antd', () => {
-  const actual = jest.requireActual('antd');
+jest.mock("antd", () => {
+  const actual = jest.requireActual("antd");
   return {
     ...actual,
     message: {
@@ -20,141 +20,117 @@ jest.mock('antd', () => {
   };
 });
 
-describe('TeamCreatePage', () => {
+jest.mock("@/shared/studio/api", () => ({
+  studioApi: {
+    getAuthSession: jest.fn(),
+    createTeam: jest.fn(),
+  },
+}));
+
+describe("TeamCreatePage", () => {
   beforeEach(() => {
-    window.history.replaceState({}, '', '/teams/new');
+    window.history.replaceState({}, "", "/teams/new?scopeId=scope-a&teamName=Legacy%20Support");
     jest.clearAllMocks();
+
+    (studioApi.getAuthSession as jest.Mock).mockResolvedValue({
+      enabled: false,
+      scopeId: "scope-a",
+      scopeSource: "nyxid",
+    });
   });
 
-  it('renders the hidden compatibility page for saved draft recovery', async () => {
+  it("renders the real team creation form and reuses legacy teamName as the initial display name", async () => {
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    expect(await screen.findByText('Aevatar / Teams')).toBeTruthy();
-    expect(screen.getByText('Saved Draft Recovery')).toBeTruthy();
-    expect(screen.getByText('用途')).toBeTruthy();
-    expect(screen.getByText('恢复对象')).toBeTruthy();
-    expect(screen.getByText('继续位置')).toBeTruthy();
-    expect(screen.getByText('新增后端事实')).toBeTruthy();
-    expect(screen.getByText('Continue initial member draft')).toBeTruthy();
-    expect(screen.getByRole('heading', { level: 3, name: 'Saved draft recovery' })).toBeTruthy();
-    expect(screen.getByLabelText('Legacy team label')).toBeTruthy();
-    expect(screen.getByLabelText('Initial member label')).toBeTruthy();
     expect(
-      screen.getAllByRole('button', { name: 'Continue in Studio' }).length,
-    ).toBeGreaterThan(0);
-    expect(screen.getByRole('button', { name: 'View Behaviors' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Back to My Teams' })).toBeTruthy();
-    expect(
-      screen.getByText(
-        'This compatibility page preserves old Create Team links and saved draft recovery. New team creation now starts in Studio by creating the first member.',
-      ),
+      await screen.findByRole("heading", { level: 2, name: "Create Team" }),
     ).toBeTruthy();
-    expect(screen.queryByText('Team Builder Entry')).toBeNull();
-    expect(screen.queryByText('Start Building')).toBeNull();
-    expect(screen.queryByText('Open Studio')).toBeNull();
-    expect(
-      screen.queryByText(
-        '当前实现不会新增一套独立后端流程，而是复用现有 Studio 工作区先组建团队，再进入 Team Details 查看拓扑和事件流。',
-      ),
-    ).toBeNull();
-    expect(screen.queryByText('Next Steps')).toBeNull();
-    expect(screen.queryByText('Builder 模式')).toBeNull();
-    expect(screen.queryByText('默认入口')).toBeNull();
-    expect(screen.queryByText('后续页')).toBeNull();
-    expect(screen.queryByText('数据源')).toBeNull();
+    expect(screen.getByDisplayValue("scope-a")).toBeTruthy();
+    expect(screen.getByDisplayValue("Legacy Support")).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: "Create Team" }).length).toBe(1);
+    expect(screen.queryByLabelText("Custom Team ID")).toBeNull();
+    expect(screen.queryByText("Saved Draft Recovery")).toBeNull();
   });
 
-  it('opens Studio in member-first build mode without persisting create-team draft params', async () => {
+  it("disables create when the display name is still empty", async () => {
+    window.history.replaceState({}, "", "/teams/new?scopeId=scope-a");
+
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    const openStudioButtons = await screen.findAllByRole('button', {
-      name: 'Continue in Studio',
-    });
-
-    expect(openStudioButtons[0]).toBeDisabled();
-
-    fireEvent.change(screen.getByLabelText('Legacy team label'), {
-      target: { value: '订单助手团队' },
-    });
-    fireEvent.change(screen.getByLabelText('Initial member label'), {
-      target: { value: '订单入口' },
-    });
-
-    expect(openStudioButtons[0]).toBeEnabled();
-    fireEvent.click(openStudioButtons[0]);
-
-    expect(window.location.pathname).toBe('/studio');
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get('tab')).toBe('studio');
-    expect(params.get('focus')).toBeNull();
-    expect(params.get('teamMode')).toBeNull();
-    expect(params.get('teamName')).toBeNull();
-    expect(params.get('entryName')).toBeNull();
-    expect(params.get('draft')).toBeNull();
+    expect(
+      await screen.findByRole("button", { name: "Create Team" }),
+    ).toBeDisabled();
   });
 
-  it('shows the saved draft summary and resumes that draft in Studio without legacy draft route params', async () => {
+  it("does not auto-trust a query scope when auth session exposes no resolved scope", async () => {
+    window.history.replaceState({}, "", "/teams/new?scopeId=scope-a");
+    (studioApi.getAuthSession as jest.Mock).mockResolvedValueOnce({
+      enabled: true,
+      authenticated: true,
+      scopeId: null,
+      scopeSource: null,
+    });
+
+    renderWithQueryClient(React.createElement(TeamCreatePage));
+
+    expect(await screen.findByText("Scope Context")).toBeTruthy();
+    expect(screen.getByDisplayValue("scope-a")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create Team" })).toBeDisabled();
+    expect(window.location.search).toBe("");
+  });
+
+  it("shows an info banner when old draft query params are present", async () => {
     window.history.replaceState(
       {},
-      '',
-      '/teams/new?teamName=%E8%AE%A2%E5%8D%95%E5%8A%A9%E6%89%8B%E5%9B%A2%E9%98%9F&entryName=%E8%AE%A2%E5%8D%95%E5%85%A5%E5%8F%A3&teamDraftWorkflowId=workflow-7&teamDraftWorkflowName=order-entry-draft',
+      "",
+      "/teams/new?scopeId=scope-a&teamName=Legacy%20Support&entryName=entry&teamDraftWorkflowId=workflow-7",
     );
 
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    expect(await screen.findByText('Saved Draft')).toBeTruthy();
-    expect(screen.getByText('已保存草稿')).toBeTruthy();
-    expect(screen.getByText('order-entry-draft')).toBeTruthy();
     expect(
-      screen.getByText(
-        'Delete Draft removes the linked workflow draft. Legacy labels stay in the URL so old links remain understandable.',
+      await screen.findByText(
+        "Legacy Create Team query params detected. This page now creates a real team record; initial member drafts should be continued in Studio separately.",
       ),
     ).toBeTruthy();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Continue Draft' }));
-
-    expect(window.location.pathname).toBe('/studio');
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get('tab')).toBe('studio');
-    expect(params.get('focus')).toBe('workflow:workflow-7');
-    expect(params.get('teamMode')).toBeNull();
-    expect(params.get('teamName')).toBeNull();
-    expect(params.get('entryName')).toBeNull();
-    expect(params.get('teamDraftWorkflowId')).toBeNull();
-    expect(params.get('teamDraftWorkflowName')).toBeNull();
-    expect(params.get('workflow')).toBeNull();
-    expect(params.get('draft')).toBeNull();
   });
 
-  it('deletes the saved draft and keeps the team form values in place', async () => {
-    const deleteWorkflowSpy = jest
-      .spyOn(studioApi, 'deleteWorkflow')
-      .mockResolvedValue(undefined);
-
-    window.history.replaceState(
-      {},
-      '',
-      '/teams/new?teamName=%E8%AE%A2%E5%8D%95%E5%8A%A9%E6%89%8B%E5%9B%A2%E9%98%9F&entryName=%E8%AE%A2%E5%8D%95%E5%85%A5%E5%8F%A3&teamDraftWorkflowId=workflow-7&teamDraftWorkflowName=order-entry-draft',
-    );
+  it("creates a real team record and routes to canonical team detail", async () => {
+    (studioApi.createTeam as jest.Mock).mockResolvedValue({
+      teamId: "team-support",
+      scopeId: "scope-a",
+      displayName: "Support Team",
+      description: "Handles inbound support",
+      lifecycleStage: "active",
+      memberCount: 0,
+      createdAt: "2026-04-30T08:00:00Z",
+      updatedAt: "2026-04-30T08:00:00Z",
+    });
 
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete Draft' }));
+    fireEvent.change(await screen.findByLabelText("Display Name"), {
+      target: { value: "Support Team" },
+    });
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: "Handles inbound support" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Team" }));
 
     await waitFor(() => {
-      expect(deleteWorkflowSpy).toHaveBeenCalledWith('workflow-7');
+      expect(studioApi.createTeam).toHaveBeenCalledWith({
+        scopeId: "scope-a",
+        displayName: "Support Team",
+        description: "Handles inbound support",
+      });
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('Saved Draft')).toBeNull();
+      expect(window.location.pathname).toBe("/teams/scope-a");
     });
 
     const params = new URLSearchParams(window.location.search);
-    expect(window.location.pathname).toBe('/teams/new');
-    expect(params.get('teamName')).toBe('订单助手团队');
-    expect(params.get('entryName')).toBe('订单入口');
-    expect(params.get('teamDraftWorkflowId')).toBeNull();
-    expect(params.get('teamDraftWorkflowName')).toBeNull();
-    expect(message.success).toHaveBeenCalledWith('已删除当前团队草稿。');
+    expect(params.get("teamId")).toBe("team-support");
+    expect(message.success).toHaveBeenCalledWith("团队已创建。");
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -1,326 +1,287 @@
-import { BuildOutlined, RocketOutlined } from '@ant-design/icons';
-import { Button, Input, Space, Typography, message } from 'antd';
-import React from 'react';
-import { history } from '@/shared/navigation/history';
-import { buildTeamCreateHref, buildTeamsHref } from '@/shared/navigation/teamRoutes';
-import { studioApi } from '@/shared/studio/api';
-import { buildStudioRoute } from '@/shared/studio/navigation';
-import { AevatarPanel } from '@/shared/ui/aevatarPageShells';
-import ConsoleMetricCard from '@/shared/ui/ConsoleMetricCard';
-import ConsoleMenuPageShell from '@/shared/ui/ConsoleMenuPageShell';
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { useQuery } from "@tanstack/react-query";
+import { Alert, Button, Input, Space, Typography, message } from "antd";
+import React from "react";
+import { history } from "@/shared/navigation/history";
+import {
+  buildTeamCreateHref,
+  buildTeamDetailHref,
+} from "@/shared/navigation/teamRoutes";
+import { studioApi } from "@/shared/studio/api";
+import { AevatarPanel } from "@/shared/ui/aevatarPageShells";
+import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
+import { describeError } from "@/shared/ui/errorText";
+import ScopeQueryCard from "../scopes/components/ScopeQueryCard";
+import { resolveStudioScopeContext } from "../scopes/components/resolvedScope";
+import {
+  buildScopeHref,
+  normalizeScopeDraft,
+  readScopeQueryDraft,
+  type ScopeQueryDraft,
+} from "../scopes/components/scopeQuery";
 
-const primaryActionButtonStyle: React.CSSProperties = {
-  background: '#6c5ce7',
-  borderColor: '#6c5ce7',
-  borderRadius: 10,
-  color: '#ffffff',
-  fontSize: 14,
-  fontWeight: 600,
-  height: 44,
-  paddingInline: 18,
-};
+function trimOptional(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
 
-const secondaryActionButtonStyle: React.CSSProperties = {
-  borderRadius: 10,
-  fontSize: 14,
-  fontWeight: 500,
-  height: 44,
-  paddingInline: 18,
-};
+function readLegacyTeamName(): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
 
-const stageChipStyle: React.CSSProperties = {
-  alignItems: 'center',
-  background: '#f6f0ff',
-  borderRadius: 20,
-  color: '#6c5ce7',
-  display: 'inline-flex',
-  fontSize: 12,
-  fontWeight: 500,
-  padding: '6px 12px',
-};
+  return trimOptional(new URLSearchParams(window.location.search).get("teamName"));
+}
 
-function readCreateTeamDraftFromLocation(): {
-  readonly teamName: string;
-  readonly entryName: string;
-  readonly teamDraftWorkflowId: string;
-  readonly teamDraftWorkflowName: string;
-} {
-  if (typeof window === 'undefined') {
-    return {
-      teamName: '',
-      entryName: '',
-      teamDraftWorkflowId: '',
-      teamDraftWorkflowName: '',
-    };
+function hasLegacyDraftParams(): boolean {
+  if (typeof window === "undefined") {
+    return false;
   }
 
   const params = new URLSearchParams(window.location.search);
-  return {
-    teamName: params.get('teamName')?.trim() ?? '',
-    entryName: params.get('entryName')?.trim() ?? '',
-    teamDraftWorkflowId: params.get('teamDraftWorkflowId')?.trim() ?? '',
-    teamDraftWorkflowName: params.get('teamDraftWorkflowName')?.trim() ?? '',
-  };
+  return Boolean(
+    trimOptional(params.get("entryName")) ||
+      trimOptional(params.get("teamDraftWorkflowId")) ||
+      trimOptional(params.get("teamDraftWorkflowName")),
+  );
 }
 
 const TeamCreatePage: React.FC = () => {
-  const initialDraft = React.useMemo(readCreateTeamDraftFromLocation, []);
-  const [teamName, setTeamName] = React.useState(initialDraft.teamName);
-  const [entryName, setEntryName] = React.useState(initialDraft.entryName);
-  const [teamDraftWorkflowId, setTeamDraftWorkflowId] = React.useState(
-    initialDraft.teamDraftWorkflowId,
+  const [draft, setDraft] = React.useState<ScopeQueryDraft>(() => readScopeQueryDraft());
+  const [activeDraft, setActiveDraft] = React.useState<ScopeQueryDraft>(() =>
+    normalizeScopeDraft({ scopeId: "" }),
   );
-  const [teamDraftWorkflowName, setTeamDraftWorkflowName] = React.useState(
-    initialDraft.teamDraftWorkflowName,
+  const [displayName, setDisplayName] = React.useState(() => readLegacyTeamName());
+  const [description, setDescription] = React.useState("");
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [showScopePicker, setShowScopePicker] = React.useState(false);
+  const legacyDraftDetected = React.useMemo(hasLegacyDraftParams, []);
+
+  const authSessionQuery = useQuery({
+    queryKey: ["teams", "create", "auth-session"],
+    queryFn: () => studioApi.getAuthSession(),
+    retry: false,
+  });
+  const resolvedScope = React.useMemo(
+    () => resolveStudioScopeContext(authSessionQuery.data),
+    [authSessionQuery.data],
   );
-  const [isDeletingDraft, setIsDeletingDraft] = React.useState(false);
-  const resolvedEntryName = entryName.trim() || teamName.trim();
-  const resolvedDraftWorkflowId = teamDraftWorkflowId.trim();
-  const resolvedDraftWorkflowName =
-    teamDraftWorkflowName.trim() || resolvedDraftWorkflowId;
-  const hasSavedDraft = Boolean(resolvedDraftWorkflowId);
-  const canOpenBuilder = Boolean(teamName.trim());
-  const openBuilder = () =>
-    history.push(
-      buildStudioRoute({
-        teamMode: 'create',
-        teamName: teamName.trim() || undefined,
-        entryName: resolvedEntryName || undefined,
-        teamDraftWorkflowId: resolvedDraftWorkflowId || undefined,
-        teamDraftWorkflowName: resolvedDraftWorkflowName || undefined,
-        focus: resolvedDraftWorkflowId
-          ? `workflow:${resolvedDraftWorkflowId}`
-          : undefined,
-        tab: 'studio',
-      }),
-    );
-  const openBehaviors = () =>
-    history.push(
-      buildStudioRoute({
-        tab: 'workflows',
-      }),
-    );
-  const handleDeleteDraft = async () => {
-    if (!resolvedDraftWorkflowId || isDeletingDraft) {
+
+  React.useEffect(() => {
+    if (!resolvedScope?.scopeId) {
       return;
     }
 
-    setIsDeletingDraft(true);
+    const nextDraft = normalizeScopeDraft({ scopeId: resolvedScope.scopeId });
+    setDraft(nextDraft);
+    setActiveDraft(nextDraft);
+  }, [resolvedScope?.scopeId]);
+
+  React.useEffect(() => {
+    history.replace(
+      buildTeamCreateHref({
+        scopeId: activeDraft.scopeId,
+      }),
+    );
+  }, [activeDraft.scopeId]);
+
+  const scopeId = activeDraft.scopeId.trim();
+  const authIssue = authSessionQuery.isError
+    ? describeError(authSessionQuery.error, "登录状态暂时不可用，请刷新后重试。")
+    : "";
+  const createDisabled = !scopeId || !displayName.trim() || isSubmitting;
+
+  const handleCreate = async () => {
+    if (createDisabled) {
+      return;
+    }
+
+    setIsSubmitting(true);
     try {
-      await studioApi.deleteWorkflow(resolvedDraftWorkflowId);
-      setTeamDraftWorkflowId('');
-      setTeamDraftWorkflowName('');
-      history.replace(
-        buildTeamCreateHref({
-          teamName: teamName.trim() || undefined,
-          entryName: entryName.trim() || undefined,
+      const created = await studioApi.createTeam({
+        scopeId,
+        displayName: displayName.trim(),
+        description: trimOptional(description) || null,
+      });
+      void message.success("团队已创建。");
+      history.push(
+        buildTeamDetailHref({
+          scopeId: created.scopeId,
+          teamId: created.teamId,
         }),
       );
-      void message.success('已删除当前团队草稿。');
     } catch (error) {
-      const errorMessage =
-        error instanceof Error && error.message.trim()
-          ? error.message
-          : '删除草稿失败。';
-      void message.error(errorMessage);
+      void message.error(
+        describeError(error, "创建团队失败，请稍后再试。"),
+      );
     } finally {
-      setIsDeletingDraft(false);
+      setIsSubmitting(false);
     }
   };
 
   return (
     <ConsoleMenuPageShell
       breadcrumb="Aevatar / Teams"
+      description="Create a real team record in the current scope first, then manage members and assignment from the team detail page."
       extra={
-        <Button
-          disabled={!canOpenBuilder}
-          onClick={openBuilder}
-          style={primaryActionButtonStyle}
-        >
-          Continue in Studio
-        </Button>
+        <Space wrap>
+          <Button
+            icon={<ArrowLeftOutlined />}
+            onClick={() =>
+              history.push(
+                buildScopeHref("/teams", {
+                  scopeId,
+                }),
+              )
+            }
+            style={{ borderRadius: 12, height: 40, paddingInline: 18 }}
+          >
+            Back to My Teams
+          </Button>
+        </Space>
       }
-      title="Saved Draft Recovery"
+      title="Create Team"
     >
-      <div
-        style={{
-          display: 'grid',
-          gap: 16,
-          gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
-          marginBottom: 20,
-        }}
-      >
-        <ConsoleMetricCard label="用途" tone="purple" value="旧链接恢复" />
-        <ConsoleMetricCard label="恢复对象" value="初始 member 草稿" />
-        <ConsoleMetricCard label="继续位置" value="Studio" />
-        <ConsoleMetricCard label="新增后端事实" tone="green" value="0" />
-      </div>
+      <div style={{ display: "grid", gap: 20 }}>
+        {authIssue ? <Alert message={authIssue} showIcon type="warning" /> : null}
+        {legacyDraftDetected ? (
+          <Alert
+            message="Legacy Create Team query params detected. This page now creates a real team record; initial member drafts should be continued in Studio separately."
+            showIcon
+            type="info"
+          />
+        ) : null}
 
-      <AevatarPanel
-        layoutMode="document"
-        padding={20}
-        title="Continue initial member draft"
-      >
-        <div
-          style={{
-            alignItems: 'center',
-            display: 'grid',
-            gap: 20,
-            gridTemplateColumns: 'minmax(0, 1fr) auto',
-          }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            <Typography.Title
-              level={3}
-              style={{
-                color: '#1d2129',
-                fontSize: 28,
-                fontWeight: 600,
-                lineHeight: 1.2,
-                margin: 0,
-              }}
-            >
-              Saved draft recovery
-            </Typography.Title>
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: 8,
-              }}
-            >
-              {['旧链接兼容', '草稿恢复', '显式进入 Studio', '不创建团队事实'].map((item) => (
-                <span key={item} style={stageChipStyle}>
-                  {item}
-                </span>
-              ))}
-            </div>
-            <div
-              style={{
-                display: 'grid',
-                gap: 12,
-                gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-                maxWidth: 720,
-              }}
-            >
-              <div style={{ display: 'grid', gap: 8 }}>
-                <Typography.Text strong>Legacy team label</Typography.Text>
-                <Input
-                  aria-label="Legacy team label"
-                  placeholder="例如：订单助手团队"
-                  value={teamName}
-                  onChange={(event) => setTeamName(event.target.value)}
-                />
-              </div>
-              <div style={{ display: 'grid', gap: 8 }}>
-                <Typography.Text strong>Initial member label</Typography.Text>
-                <Input
-                  aria-label="Initial member label"
-                  placeholder="默认复用团队名称"
-                  value={entryName}
-                  onChange={(event) => setEntryName(event.target.value)}
-                />
-              </div>
-              <Typography.Text
-                type="secondary"
-                style={{ gridColumn: '1 / -1', lineHeight: 1.6 }}
-              >
-                This compatibility page preserves old Create Team links and saved
-                draft recovery. New team creation now starts in Studio by creating
-                the first member.
-                {hasSavedDraft
-                  ? ' Continue in Studio to edit the linked initial member draft.'
-                  : ''}
-              </Typography.Text>
-            </div>
-            <Space wrap size={[8, 8]}>
-              <Button
-                icon={<BuildOutlined />}
-                disabled={!canOpenBuilder}
-                onClick={openBuilder}
-                style={primaryActionButtonStyle}
-              >
-                Continue in Studio
-              </Button>
-              <Button
-                icon={<RocketOutlined />}
-                onClick={openBehaviors}
-                style={secondaryActionButtonStyle}
-              >
-                View Behaviors
-              </Button>
-              <Button
-                onClick={() => history.push(buildTeamsHref())}
-                style={secondaryActionButtonStyle}
-              >
-                Back to My Teams
-              </Button>
-            </Space>
-          </div>
-          <div
-            style={{
-              alignItems: 'flex-end',
-              display: 'flex',
-              justifyContent: 'flex-end',
-            }}
+        {(showScopePicker || !scopeId) && (
+          <AevatarPanel
+            extra={
+              showScopePicker && scopeId ? (
+                <Button
+                  onClick={() => {
+                    setDraft(normalizeScopeDraft(activeDraft));
+                    setShowScopePicker(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              ) : null
+            }
+            layoutMode="document"
+            padding={20}
+            title="Scope Context"
           >
-            <Typography.Text
-              style={{
-                color: '#8c8c8c',
-                fontSize: 12,
-                fontWeight: 500,
+            <ScopeQueryCard
+              activeScopeId={scopeId}
+              draft={draft}
+              loadLabel="Use scope"
+              onChange={setDraft}
+              onLoad={() => {
+                const nextDraft = normalizeScopeDraft(draft);
+                setDraft(nextDraft);
+                setActiveDraft(nextDraft);
+                setShowScopePicker(false);
+                history.replace(
+                  buildTeamCreateHref({
+                    scopeId: nextDraft.scopeId,
+                  }),
+                );
               }}
-            >
-              {teamName.trim()
-                ? `Legacy label: ${teamName.trim()}`
-                : 'Use this page only for old links or saved drafts'}
-            </Typography.Text>
-          </div>
-        </div>
-      </AevatarPanel>
+              onReset={() => {
+                const nextDraft = normalizeScopeDraft({
+                  scopeId: resolvedScope?.scopeId ?? "",
+                });
+                setDraft(nextDraft);
+                setActiveDraft(nextDraft);
+                history.replace(
+                  buildTeamCreateHref({
+                    scopeId: nextDraft.scopeId,
+                  }),
+                );
+              }}
+              onUseResolvedScope={() => {
+                if (!resolvedScope?.scopeId) {
+                  return;
+                }
 
-      {hasSavedDraft ? (
+                const nextDraft = normalizeScopeDraft({
+                  scopeId: resolvedScope.scopeId,
+                });
+                setDraft(nextDraft);
+                setActiveDraft(nextDraft);
+                setShowScopePicker(false);
+                history.replace(
+                  buildTeamCreateHref({
+                    scopeId: nextDraft.scopeId,
+                  }),
+                );
+              }}
+              resolvedScopeId={resolvedScope?.scopeId ?? null}
+              resolvedScopeSource={resolvedScope?.scopeSource ?? null}
+            />
+          </AevatarPanel>
+        )}
+
         <AevatarPanel
+          extra={
+            scopeId ? (
+              <Button onClick={() => setShowScopePicker((current) => !current)}>
+                {showScopePicker ? "Hide scope" : "Change scope"}
+              </Button>
+            ) : null
+          }
           layoutMode="document"
-          padding={20}
-          title="Saved Draft"
+          padding={24}
+          title="Team Identity"
         >
           <div
             style={{
-              display: 'grid',
-              gap: 12,
+              display: "grid",
+              gap: 16,
+              gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
             }}
           >
-            <Typography.Text strong>已保存草稿</Typography.Text>
-            <Typography.Text>{resolvedDraftWorkflowName}</Typography.Text>
-            <Typography.Text type="secondary" style={{ lineHeight: 1.6 }}>
-              This workflow draft is linked from an old Create Team flow. Continue
-              in Studio to edit the initial member draft.
-            </Typography.Text>
-            <Space wrap size={[8, 8]}>
-              <Button
-                icon={<BuildOutlined />}
-                disabled={isDeletingDraft}
-                onClick={openBuilder}
-                style={primaryActionButtonStyle}
-              >
-                Continue Draft
-              </Button>
-              <Button
-                loading={isDeletingDraft}
-                onClick={() => void handleDeleteDraft()}
-                style={secondaryActionButtonStyle}
-              >
-                Delete Draft
-              </Button>
-            </Space>
-            <Typography.Text type="secondary" style={{ lineHeight: 1.6 }}>
-              Delete Draft removes the linked workflow draft. Legacy labels stay
-              in the URL so old links remain understandable.
-            </Typography.Text>
+            <div style={{ display: "grid", gap: 8 }}>
+              <Typography.Text strong>Scope ID</Typography.Text>
+              <Input disabled value={scopeId} placeholder="Load a scope first" />
+            </div>
+            <div style={{ display: "grid", gap: 8 }}>
+              <Typography.Text strong>Display Name</Typography.Text>
+              <Input
+                aria-label="Display Name"
+                placeholder="Orders Assistant Team"
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+              />
+            </div>
+            <div style={{ display: "grid", gap: 8, gridColumn: "1 / -1" }}>
+              <Typography.Text strong>Description</Typography.Text>
+              <Input.TextArea
+                aria-label="Description"
+                autoSize={{ minRows: 4, maxRows: 8 }}
+                placeholder="Describe what this team owns, how members collaborate, or which business workflow it supports."
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+              />
+            </div>
           </div>
+          <Space style={{ marginTop: 16 }}>
+            <Button
+              disabled={createDisabled}
+              loading={isSubmitting}
+              onClick={handleCreate}
+              type="primary"
+            >
+              Create Team
+            </Button>
+          </Space>
+          <Typography.Paragraph
+            style={{ color: "#8c8c8c", margin: "16px 0 0" }}
+          >
+            The backend only needs a scope, display name, and optional
+            description. Member creation and member assignment happen after the
+            team record exists.
+          </Typography.Paragraph>
         </AevatarPanel>
-      ) : null}
+      </div>
     </ConsoleMenuPageShell>
   );
 };

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
@@ -11,13 +11,14 @@ describe("teamRoutes", () => {
       buildTeamDetailHref({
         memberId: " member-alpha ",
         scopeId: " scope-alpha ",
+        teamId: " team-support ",
         workflowId: "workflow-1",
         serviceId: "service-1",
         runId: "run-1",
         tab: "events",
       }),
     ).toBe(
-      "/teams/scope-alpha?memberId=member-alpha&workflowId=workflow-1&tab=events&serviceId=service-1&runId=run-1",
+      "/teams/scope-alpha?teamId=team-support&memberId=member-alpha&workflowId=workflow-1&tab=events&serviceId=service-1&runId=run-1",
     );
   });
 
@@ -33,20 +34,21 @@ describe("teamRoutes", () => {
   it("preserves draft team names when returning to the create page", () => {
     expect(
       buildTeamCreateHref({
+        scopeId: "scope-alpha",
         teamName: "订单助手团队",
         entryName: "订单入口",
         teamDraftWorkflowId: "workflow-7",
         teamDraftWorkflowName: "order-entry-draft",
       }),
     ).toBe(
-      "/teams/new?teamName=%E8%AE%A2%E5%8D%95%E5%8A%A9%E6%89%8B%E5%9B%A2%E9%98%9F&entryName=%E8%AE%A2%E5%8D%95%E5%85%A5%E5%8F%A3&teamDraftWorkflowId=workflow-7&teamDraftWorkflowName=order-entry-draft",
+      "/teams/new?scopeId=scope-alpha&teamName=%E8%AE%A2%E5%8D%95%E5%8A%A9%E6%89%8B%E5%9B%A2%E9%98%9F&entryName=%E8%AE%A2%E5%8D%95%E5%85%A5%E5%8F%A3&teamDraftWorkflowId=workflow-7&teamDraftWorkflowName=order-entry-draft",
     );
   });
 
   it("reads the team detail route state from path and query", () => {
     expect(
       readTeamDetailRouteState(
-        "?memberId=member-alpha&workflowId=wf-1&serviceId=service-1&runId=run-1&tab=members",
+        "?teamId=team-alpha&memberId=member-alpha&workflowId=wf-1&serviceId=service-1&runId=run-1&tab=members",
         "/teams/scope-alpha",
       ),
     ).toEqual({
@@ -55,6 +57,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-alpha",
       serviceId: "service-1",
       tab: "members",
+      teamId: "team-alpha",
       workflowId: "wf-1",
     });
   });
@@ -71,6 +74,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-alpha",
       serviceId: "",
       tab: "bindings",
+      teamId: "",
       workflowId: "wf-1",
     });
   });
@@ -87,6 +91,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-query",
       serviceId: "",
       tab: "overview",
+      teamId: "",
       workflowId: "wf-2",
     });
   });
@@ -103,6 +108,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-query",
       serviceId: "",
       tab: "overview",
+      teamId: "",
       workflowId: "wf-2",
     });
   });

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
@@ -14,6 +14,7 @@ type TeamDetailRouteState = {
   readonly scopeId: string;
   readonly serviceId: string;
   readonly tab: TeamDetailTab;
+  readonly teamId: string;
   readonly workflowId: string;
 };
 
@@ -74,12 +75,14 @@ export function buildTeamsHref(): string {
 }
 
 export function buildTeamCreateHref(options?: {
+  scopeId?: string;
   teamName?: string;
   entryName?: string;
   teamDraftWorkflowId?: string;
   teamDraftWorkflowName?: string;
 }): string {
   return buildHref('/teams/new', {
+    scopeId: options?.scopeId,
     teamName: options?.teamName,
     entryName: options?.entryName,
     teamDraftWorkflowId: options?.teamDraftWorkflowId,
@@ -90,6 +93,7 @@ export function buildTeamCreateHref(options?: {
 export function buildTeamDetailHref(options: {
   memberId?: string;
   scopeId: string;
+  teamId?: string;
   tab?: TeamDetailTab;
   serviceId?: string;
   runId?: string;
@@ -101,6 +105,7 @@ export function buildTeamDetailHref(options: {
   }
 
   return buildHref(`/teams/${encodeURIComponent(scopeId)}`, {
+    teamId: options.teamId,
     memberId: options.memberId,
     workflowId: options.workflowId,
     tab: options.tab,
@@ -127,6 +132,7 @@ export function readTeamDetailRouteState(
     scopeId: trimOptional(params.get('scopeId')) || scopeIdFromPath,
     serviceId: trimOptional(params.get('serviceId')),
     tab: parseTeamTab(params.get('tab'), defaultTab),
+    teamId: trimOptional(params.get('teamId')),
     workflowId: trimOptional(params.get('workflowId')),
   };
 }

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -1068,6 +1068,7 @@ describe('studioApi host-session requests', () => {
         {
           memberId: 'joker',
           scopeId: 'scope-1',
+          teamId: null,
           displayName: 'joker',
           description: 'Support workflow member',
           implementationKind: 'workflow',
@@ -1137,6 +1138,7 @@ describe('studioApi host-session requests', () => {
       summary: {
         memberId: 'joker',
         scopeId: 'scope-1',
+        teamId: null,
         displayName: 'joker',
         description: 'Support workflow member',
         implementationKind: 'workflow',
@@ -1189,6 +1191,7 @@ describe('studioApi host-session requests', () => {
       json: async () => ({
         memberId: 'orders-draft',
         scopeId: 'scope-1',
+        teamId: 'team-orders',
         displayName: 'orders-draft',
         description: '',
         implementationKind: 'workflow',
@@ -1206,10 +1209,12 @@ describe('studioApi host-session requests', () => {
         scopeId: 'scope-1',
         displayName: 'orders-draft',
         implementationKind: 'workflow',
+        teamId: 'team-orders',
       }),
     ).resolves.toEqual({
       memberId: 'orders-draft',
       scopeId: 'scope-1',
+      teamId: 'team-orders',
       displayName: 'orders-draft',
       description: '',
       implementationKind: 'workflow',
@@ -1228,6 +1233,194 @@ describe('studioApi host-session requests', () => {
         body: JSON.stringify({
           displayName: 'orders-draft',
           implementationKind: 'workflow',
+          teamId: 'team-orders',
+        }),
+      }),
+    );
+  });
+
+  it('lists teams through the team-first studio endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        scopeId: 'scope-1',
+        teams: [
+          {
+            teamId: 'team-support',
+            scopeId: 'scope-1',
+            displayName: 'Support Team',
+            description: 'Handles inbound support requests',
+            lifecycleStage: 'active',
+            memberCount: 2,
+            createdAt: '2026-04-27T08:00:00Z',
+            updatedAt: '2026-04-27T08:05:00Z',
+          },
+        ],
+        nextPageToken: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(studioApi.listTeams('scope-1')).resolves.toEqual({
+      scopeId: 'scope-1',
+      teams: [
+        {
+          teamId: 'team-support',
+          scopeId: 'scope-1',
+          displayName: 'Support Team',
+          description: 'Handles inbound support requests',
+          lifecycleStage: 'active',
+          memberCount: 2,
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:05:00Z',
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/teams',
+      expect.objectContaining({
+        credentials: 'same-origin',
+      }),
+    );
+  });
+
+  it('creates a team through the team-first studio endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        teamId: 'team-support',
+        scopeId: 'scope-1',
+        displayName: 'Support Team',
+        description: 'Handles inbound support requests',
+        lifecycleStage: 'active',
+        memberCount: 0,
+        createdAt: '2026-04-27T08:00:00Z',
+        updatedAt: '2026-04-27T08:00:00Z',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.createTeam({
+        scopeId: 'scope-1',
+        displayName: 'Support Team',
+        description: 'Handles inbound support requests',
+      }),
+    ).resolves.toEqual({
+      teamId: 'team-support',
+      scopeId: 'scope-1',
+      displayName: 'Support Team',
+      description: 'Handles inbound support requests',
+      lifecycleStage: 'active',
+      memberCount: 0,
+      createdAt: '2026-04-27T08:00:00Z',
+      updatedAt: '2026-04-27T08:00:00Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/teams',
+      expect.objectContaining({
+        credentials: 'same-origin',
+        method: 'POST',
+        body: JSON.stringify({
+          displayName: 'Support Team',
+          description: 'Handles inbound support requests',
+        }),
+      }),
+    );
+  });
+
+  it('updates a member team assignment through the patch endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        summary: {
+          memberId: 'joker',
+          scopeId: 'scope-1',
+          teamId: 'team-support',
+          displayName: 'joker',
+          description: 'Support workflow member',
+          implementationKind: 'workflow',
+          lifecycleStage: 'bind_ready',
+          publishedServiceId: 'member-joker',
+          lastBoundRevisionId: 'rev-2',
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:05:00Z',
+        },
+        implementationRef: null,
+        lastBinding: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.updateMemberTeam('scope-1', 'joker', 'team-support'),
+    ).resolves.toEqual({
+      summary: {
+        memberId: 'joker',
+        scopeId: 'scope-1',
+        teamId: 'team-support',
+        displayName: 'joker',
+        description: 'Support workflow member',
+        implementationKind: 'workflow',
+        lifecycleStage: 'bind_ready',
+        publishedServiceId: 'member-joker',
+        lastBoundRevisionId: 'rev-2',
+        createdAt: '2026-04-27T08:00:00Z',
+        updatedAt: '2026-04-27T08:05:00Z',
+      },
+      implementationRef: null,
+      lastBinding: null,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/members/joker',
+      expect.objectContaining({
+        credentials: 'same-origin',
+        method: 'PATCH',
+        body: JSON.stringify({
+          teamId: 'team-support',
         }),
       }),
     );

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -20,6 +20,9 @@ import type {
   StudioMemberLifecycleStage,
   StudioMemberRoster,
   StudioMemberSummary,
+  StudioTeamLifecycleStage,
+  StudioTeamRoster,
+  StudioTeamSummary,
   StudioParseYamlResult,
   StudioRoleCatalogImportResult,
   StudioRoleCatalog,
@@ -49,6 +52,7 @@ import type {
 } from "./models";
 import {
   normalizeStudioMemberLifecycleStage,
+  normalizeStudioTeamLifecycleStage,
   normalizeStudioScopeBindingImplementationKind,
 } from "./models";
 import type { WorkflowCatalogItemDetail } from "@/shared/api/models";
@@ -951,6 +955,15 @@ function readStudioMemberLifecycle(
   );
 }
 
+function readStudioTeamLifecycle(
+  record: Record<string, unknown>,
+  keys: string | string[]
+): StudioTeamLifecycleStage {
+  return normalizeStudioTeamLifecycleStage(
+    readNullableString(record, keys, "StudioTeamSummary.lifecycleStage")
+  );
+}
+
 function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
   const record = expectRecord(value, "StudioMemberSummary");
   return {
@@ -964,6 +977,12 @@ function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
       ["scopeId", "ScopeId"],
       "StudioMemberSummary.scopeId"
     ),
+    teamId:
+      readNullableString(
+        record,
+        ["teamId", "TeamId"],
+        "StudioMemberSummary.teamId"
+      ) ?? null,
     displayName: readString(
       record,
       ["displayName", "DisplayName"],
@@ -1004,6 +1023,70 @@ function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
       ["updatedAt", "UpdatedAt"],
       "StudioMemberSummary.updatedAt"
     ),
+  };
+}
+
+function decodeStudioTeamSummary(value: unknown): StudioTeamSummary {
+  const record = expectRecord(value, "StudioTeamSummary");
+  return {
+    teamId: readString(record, ["teamId", "TeamId"], "StudioTeamSummary.teamId"),
+    scopeId: readString(
+      record,
+      ["scopeId", "ScopeId"],
+      "StudioTeamSummary.scopeId"
+    ),
+    displayName: readString(
+      record,
+      ["displayName", "DisplayName"],
+      "StudioTeamSummary.displayName"
+    ),
+    description:
+      readNullableString(
+        record,
+        ["description", "Description"],
+        "StudioTeamSummary.description"
+      ) ?? "",
+    lifecycleStage: readStudioTeamLifecycle(record, [
+      "lifecycleStage",
+      "LifecycleStage",
+    ]),
+    memberCount: readNumber(
+      record,
+      ["memberCount", "MemberCount"],
+      "StudioTeamSummary.memberCount"
+    ),
+    createdAt: readString(
+      record,
+      ["createdAt", "CreatedAt"],
+      "StudioTeamSummary.createdAt"
+    ),
+    updatedAt: readString(
+      record,
+      ["updatedAt", "UpdatedAt"],
+      "StudioTeamSummary.updatedAt"
+    ),
+  };
+}
+
+function decodeStudioTeamRoster(value: unknown): StudioTeamRoster {
+  const record = expectRecord(value, "StudioTeamRoster");
+  return {
+    scopeId: readString(
+      record,
+      ["scopeId", "ScopeId"],
+      "StudioTeamRoster.scopeId"
+    ),
+    teams: expectArray(
+      record.teams ?? record.Teams,
+      "StudioTeamRoster.teams",
+      decodeStudioTeamSummary
+    ),
+    nextPageToken:
+      readNullableString(
+        record,
+        ["nextPageToken", "NextPageToken"],
+        "StudioTeamRoster.nextPageToken"
+      ) ?? null,
   };
 }
 
@@ -1152,6 +1235,7 @@ export const studioApi = {
     implementationKind: StudioMemberImplementationKind;
     description?: string | null;
     memberId?: string | null;
+    teamId?: string | null;
   }): Promise<StudioMemberSummary> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members`,
@@ -1165,8 +1249,106 @@ export const studioApi = {
             implementationKind: input.implementationKind,
             description: trimOptional(input.description),
             memberId: trimOptional(input.memberId),
+            teamId: trimOptional(input.teamId),
           })
         ),
+      }
+    );
+  },
+
+  listTeams(scopeId: string): Promise<StudioTeamRoster> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams`,
+      decodeStudioTeamRoster
+    );
+  },
+
+  getTeam(scopeId: string, teamId: string): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams/${encodeURIComponent(teamId.trim())}`,
+      decodeStudioTeamSummary
+    );
+  },
+
+  createTeam(input: {
+    scopeId: string;
+    displayName: string;
+    description?: string | null;
+    teamId?: string | null;
+  }): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/teams`,
+      decodeStudioTeamSummary,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(
+          compactObject({
+            displayName: input.displayName.trim(),
+            description: trimOptional(input.description),
+            teamId: trimOptional(input.teamId),
+          })
+        ),
+      }
+    );
+  },
+
+  updateTeam(input: {
+    scopeId: string;
+    teamId: string;
+    displayName?: string | null;
+    description?: string | null;
+  }): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/teams/${encodeURIComponent(input.teamId.trim())}`,
+      decodeStudioTeamSummary,
+      {
+        method: "PATCH",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(
+          compactObject({
+            displayName: trimOptional(input.displayName),
+            description:
+              input.description === null
+                ? null
+                : trimOptional(input.description),
+          })
+        ),
+      }
+    );
+  },
+
+  archiveTeam(scopeId: string, teamId: string): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams/${encodeURIComponent(teamId.trim())}/archive`,
+      decodeStudioTeamSummary,
+      {
+        method: "POST",
+      }
+    );
+  },
+
+  listTeamMembers(scopeId: string, teamId: string): Promise<StudioMemberRoster> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams/${encodeURIComponent(teamId.trim())}/members`,
+      decodeStudioMemberRoster
+    );
+  },
+
+  updateMemberTeam(
+    scopeId: string,
+    memberId: string,
+    teamId: string | null
+  ): Promise<StudioMemberDetail> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/members/${encodeURIComponent(memberId.trim())}`,
+      decodeStudioMemberDetail,
+      {
+        method: "PATCH",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          teamId,
+        }),
       }
     );
   },

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -434,6 +434,7 @@ export function formatStudioMemberLifecycleStage(
 export interface StudioMemberSummary {
   readonly memberId: string;
   readonly scopeId: string;
+  readonly teamId?: string | null;
   readonly displayName: string;
   readonly description: string;
   readonly implementationKind: StudioMemberImplementationKind;
@@ -469,6 +470,51 @@ export interface StudioMemberDetail {
 export interface StudioMemberRoster {
   readonly scopeId: string;
   readonly members: readonly StudioMemberSummary[];
+  readonly nextPageToken?: string | null;
+}
+
+export type StudioTeamLifecycleStage = 'active' | 'archived' | 'unknown';
+
+export function normalizeStudioTeamLifecycleStage(
+  value: string | null | undefined,
+): StudioTeamLifecycleStage {
+  switch (String(value || '').trim().toLowerCase()) {
+    case 'active':
+      return 'active';
+    case 'archived':
+      return 'archived';
+    default:
+      return 'unknown';
+  }
+}
+
+export function formatStudioTeamLifecycleStage(
+  value: StudioTeamLifecycleStage | string | null | undefined,
+): string {
+  switch (normalizeStudioTeamLifecycleStage(value)) {
+    case 'active':
+      return 'Active';
+    case 'archived':
+      return 'Archived';
+    default:
+      return 'Unknown';
+  }
+}
+
+export interface StudioTeamSummary {
+  readonly teamId: string;
+  readonly scopeId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly lifecycleStage: StudioTeamLifecycleStage;
+  readonly memberCount: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface StudioTeamRoster {
+  readonly scopeId: string;
+  readonly teams: readonly StudioTeamSummary[];
   readonly nextPageToken?: string | null;
 }
 


### PR DESCRIPTION
## Problem

The console Teams area was still member-first and the create-team flow was not wired to the backend team APIs. That left the new Studio team capability effectively unusable from the frontend.

## Solution

- replace the legacy Teams home/create/detail experiences with team-first flows backed by the Studio team endpoints
- add frontend team contracts and API decoding, including `teamId` on member summaries and team-aware routing
- wire team detail actions for listing members, creating members inside a team, assigning existing members, editing team metadata, and archiving teams
- tighten create-team scope handling and page behavior based on the dogfooding issues we found while exercising the new flow

## Verification

- `pnpm test:ui -- src/shared/navigation/teamRoutes.test.ts src/shared/studio/api.test.ts src/pages/teams/home.test.tsx src/pages/teams/new.test.tsx src/pages/teams/detail.test.tsx --runInBand`
- `pnpm exec tsc --noEmit`