### PR TITLE
Fix drifted NyxID OAuth client recovery

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Broker/NyxIdRemoteCapabilityBroker.cs
@@ -81,13 +81,16 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         ExternalSubjectRefExtensions.EnsureValid(externalSubject);
 
         var snapshot = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
+        var redirectUri = ResolveRedirectUri();
+        EnsureRedirectUriCurrent(snapshot, redirectUri);
+
         var pkce = PkceHelper.GeneratePair();
         var correlationId = Guid.NewGuid().ToString("N");
         var stateToken = await _stateTokenCodec
             .EncodeAsync(correlationId, externalSubject, pkce.CodeVerifier, ct)
             .ConfigureAwait(false);
 
-        var url = BuildAuthorizeUrl(snapshot, stateToken, pkce.CodeChallenge);
+        var url = BuildAuthorizeUrl(snapshot, redirectUri, stateToken, pkce.CodeChallenge);
         var expiresAt = _timeProvider.GetUtcNow().Add(_options.StateTokenLifetime).ToUnixTimeSeconds();
         return new BindingChallenge
         {
@@ -243,6 +246,7 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
 
         var snapshot = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
         var redirectUri = ResolveRedirectUri();
+        EnsureRedirectUriCurrent(snapshot, redirectUri);
 
         var form = new List<KeyValuePair<string, string>>
         {
@@ -284,9 +288,12 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
         return new BrokerAuthorizationCodeResult(payload.BindingId, payload.IdToken, payload.AccessToken);
     }
 
-    private string BuildAuthorizeUrl(AevatarOAuthClientSnapshot snapshot, string stateToken, string codeChallenge)
+    private string BuildAuthorizeUrl(
+        AevatarOAuthClientSnapshot snapshot,
+        string redirectUri,
+        string stateToken,
+        string codeChallenge)
     {
-        var redirectUri = ResolveRedirectUri();
         var queryParts = new List<string>
         {
             "response_type=code",
@@ -298,6 +305,18 @@ public sealed class NyxIdRemoteCapabilityBroker : INyxIdCapabilityBroker, INyxId
             "code_challenge_method=S256",
         };
         return $"{snapshot.NyxIdAuthority.TrimEnd('/')}{AuthorizeEndpoint}?{string.Join("&", queryParts)}";
+    }
+
+    private static void EnsureRedirectUriCurrent(AevatarOAuthClientSnapshot snapshot, string resolvedRedirectUri)
+    {
+        if (!string.IsNullOrEmpty(snapshot.RedirectUri)
+            && string.Equals(snapshot.RedirectUri, resolvedRedirectUri, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        throw new AevatarOAuthClientNotProvisionedException(
+            "Aevatar OAuth client redirect_uri is not current. Bootstrap must re-run DCR before issuing NyxID authorize URLs.");
     }
 
     private static bool IsInvalidGrant(string body)

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -229,9 +229,12 @@ public static class IdentityOAuthEndpoints
             var resolvedRedirectUri = NyxIdRedirectUriResolver.Resolve();
             var redirectUriDrifted = string.IsNullOrEmpty(snapshot.RedirectUri)
                 || !string.Equals(snapshot.RedirectUri, resolvedRedirectUri, StringComparison.Ordinal);
+            var status = redirectUriDrifted
+                ? "redirect_uri_drifted"
+                : snapshot.BrokerCapabilityObserved ? "ready" : "broker_capability_pending";
             return Results.Ok(new
             {
-                status = snapshot.BrokerCapabilityObserved ? "ready" : "broker_capability_pending",
+                status,
                 client_id = snapshot.ClientId,
                 client_id_issued_at = snapshot.ClientIdIssuedAt,
                 nyxid_authority = snapshot.NyxIdAuthority,

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -88,6 +88,26 @@ public static class IdentityOAuthEndpoints
         {
             exchange = await brokerCallback.ExchangeAuthorizationCodeAsync(code, verifier, ct).ConfigureAwait(false);
         }
+        catch (AevatarOAuthClientNotProvisionedException ex)
+        {
+            // The broker now refuses to exchange a code when the snapshot's
+            // redirect_uri doesn't match the resolver's output (drift state
+            // protection added in this PR). This is the same "still
+            // initializing / drift not yet healed" condition the state-token
+            // decoder surfaces above, so route it to the same retry-friendly
+            // 400 path instead of letting the generic catch return 502
+            // token_exchange_failed — that misclassifies a self-recoverable
+            // condition as a NyxID outage.
+            logger.LogWarning(
+                ex,
+                "OAuth callback rejected because the OAuth client snapshot is missing or drifted; bootstrap is still healing. correlation={CorrelationId}",
+                decode.CorrelationId);
+            return Results.BadRequest(new
+            {
+                error = "client_not_provisioned",
+                detail = "Aevatar 集群正在初始化 NyxID 客户端,请 30 秒后回到 Lark 重新发送 /init。",
+            });
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "OAuth callback authorization-code exchange failed for correlation {CorrelationId}", decode.CorrelationId);

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -41,6 +41,10 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
     /// </summary>
     internal static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(30);
 
+    internal static readonly TimeSpan ProvisioningObservationTimeout = TimeSpan.FromMinutes(2);
+
+    private static readonly TimeSpan ProvisioningObservationPollDelay = TimeSpan.FromSeconds(2);
+
     private readonly IAevatarOAuthClientProvider _clientProvider;
     private readonly AevatarOAuthClientProjectionPort _projectionPort;
     private readonly IActorRuntime _actorRuntime;
@@ -244,6 +248,8 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
             "Production deployments must enable broker_capability_enabled on this client at NyxID admin (one-time per cluster).",
             AevatarOAuthClientGAgent.WellKnownId,
             authority);
+
+        await WaitForProvisionedReadModelAsync(authority, redirectUri, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -257,4 +263,48 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
     private static bool RedirectUriDrifted(string? stored, string resolved) =>
         string.IsNullOrEmpty(stored)
         || !string.Equals(stored, resolved, StringComparison.Ordinal);
+
+    private async Task WaitForProvisionedReadModelAsync(
+        string authority,
+        string redirectUri,
+        CancellationToken ct)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(ProvisioningObservationTimeout);
+        AevatarOAuthClientSnapshot? lastSnapshot = null;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var snapshot = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
+                lastSnapshot = snapshot;
+                if (string.Equals(snapshot.NyxIdAuthority, authority, StringComparison.Ordinal)
+                    && !string.IsNullOrEmpty(snapshot.ClientId)
+                    && !RedirectUriDrifted(snapshot.RedirectUri, redirectUri))
+                {
+                    _logger.LogInformation(
+                        "Aevatar OAuth client provisioning observed in readmodel: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
+                        snapshot.ClientId,
+                        snapshot.NyxIdAuthority,
+                        snapshot.RedirectUri);
+                    return;
+                }
+            }
+            catch (AevatarOAuthClientNotProvisionedException)
+            {
+                // Projection has not materialized the first state root yet.
+            }
+
+            await Task.Delay(ProvisioningObservationPollDelay, ct).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            "Aevatar OAuth client provisioning did not become visible in the readmodel " +
+            $"within {ProvisioningObservationTimeout.TotalSeconds:n0}s " +
+            $"(authority='{authority}', expected_redirect_uri='{redirectUri}', " +
+            $"last_client_id='{lastSnapshot?.ClientId ?? "<none>"}', " +
+            $"last_redirect_uri='{lastSnapshot?.RedirectUri ?? "<none>"}').");
+    }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -159,38 +159,34 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             .RegisterPublicClientAsync(cmd.NyxidAuthority, clientName, cmd.RedirectUri, CancellationToken.None)
             .ConfigureAwait(false);
 
-        try
-        {
-            await PersistDomainEventAsync(new AevatarOAuthClientProvisionedEvent
+        // Cluster-shared Garnet event store + brief two-pod overlap during
+        // a K8s rolling deploy lets two grain activations of this well-
+        // known actor each replay v=N, each call DCR (each getting its own
+        // client_id from NyxID), and each try to commit Provisioned at
+        // expectedVersion=N. One wins, one sees OCC. See issue #549.
+        //
+        // Pass an absorber callback to PersistDomainEventAsync rather than
+        // catching OCC ourselves: the framework refreshes State from the
+        // store before invoking the callback, and there is no protected
+        // "replay state" helper a future handler could misuse outside an
+        // active commit path (PR #552 review codex/glm-5.1).
+        await PersistDomainEventAsync(
+            new AevatarOAuthClientProvisionedEvent
             {
                 ClientId = registration.ClientId,
                 ClientIdIssuedAtUnix = registration.IssuedAt.ToUnixTimeSeconds(),
                 NyxidAuthority = cmd.NyxidAuthority,
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 RedirectUri = cmd.RedirectUri,
-            });
-        }
-        catch (EventStoreOptimisticConcurrencyException occ)
-        {
-            // Cluster-shared Garnet event store + brief two-pod overlap
-            // during a K8s rolling deploy lets two grain activations of
-            // this well-known actor each replay v=N, each call DCR (each
-            // getting its own client_id from NyxID), and each try to
-            // commit Provisioned at expectedVersion=N. One wins, one
-            // sees OCC. See issue #549 for the full causal chain.
-            //
-            // The losing handler must NOT retry the DCR — that would
-            // create another orphan client at NyxID on every backoff
-            // attempt. Refresh state from the store and check whether
-            // the peer's commit already matches what this command
-            // intended to install (same authority + same redirect URI).
-            // If yes, log the orphan client_id we just created so ops
-            // can delete it, and return success. The peer's record is
-            // the cluster-authoritative one going forward.
-            if (await TryAbsorbPeerDcrProvisioningAsync(cmd, registration.ClientId, occ).ConfigureAwait(false))
-                return;
-            throw;
-        }
+            },
+            onOptimisticConcurrencyConflict: occ => AbsorbPeerDcrProvisioningAsync(cmd, registration.ClientId, occ));
+
+        // The loser absorber path returned (peer committed the same
+        // shape). Detect that by comparing State.ClientId — if it is the
+        // peer's id, this handler must NOT continue with the post-
+        // Provisioned HMAC seed against state we did not produce.
+        if (!string.Equals(State.ClientId, registration.ClientId, StringComparison.Ordinal))
+            return;
 
         Logger.LogInformation(
             "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
@@ -200,55 +196,28 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
         if (State.HmacKey.Length == 0)
         {
-            try
-            {
-                await PersistDomainEventAsync(BuildHmacKeyRotatedEvent());
-                Logger.LogInformation("Seeded HMAC key for aevatar OAuth client");
-            }
-            catch (EventStoreOptimisticConcurrencyException occ)
-            {
-                // Distinct race shape from the DCR commit OCC: this
-                // handler ALREADY successfully committed Provisioned, so
-                // registration.ClientId is the active cluster client —
-                // not an orphan. A peer wrote at v+2 between our
-                // Provisioned commit and this seed (e.g. their own HMAC
-                // seed). Absorb without orphan messaging when the peer's
-                // events leave the store with a non-empty HMAC; the
-                // cluster has one valid key.
-                if (await TryAbsorbPeerHmacSeedAsync(occ).ConfigureAwait(false))
-                    return;
-                throw;
-            }
+            // Distinct race shape from the DCR commit OCC: this handler
+            // ALREADY successfully committed Provisioned, so
+            // registration.ClientId is the active cluster client — not
+            // an orphan. A peer wrote at v+2 between our Provisioned
+            // commit and this seed (e.g. their own HMAC seed). Absorb
+            // without orphan messaging when the post-replay state has a
+            // non-empty HMAC.
+            await PersistDomainEventAsync(
+                BuildHmacKeyRotatedEvent(),
+                onOptimisticConcurrencyConflict: AbsorbPeerHmacSeedAsync);
+            Logger.LogInformation("Seeded HMAC key for aevatar OAuth client");
         }
     }
 
-    /// <summary>
-    /// Refreshes <see cref="State"/> from the event store after the
-    /// drift-branch <c>AevatarOAuthClientProvisionedEvent</c> commit lost
-    /// an OCC race, then checks whether the peer that won already
-    /// installed a Provisioned record matching the command's authority +
-    /// redirect URI. Returns <c>true</c> when the cluster is already in
-    /// the desired shape (caller should treat the OCC as a successful
-    /// no-op); returns <c>false</c> when the peer's commit was something
-    /// else and the caller should rethrow so the bootstrap retry loop
-    /// re-evaluates against fresh state.
-    /// </summary>
-    /// <remarks>
-    /// Logs <paramref name="orphanClientId"/> so ops can delete the
-    /// loser's NyxID client without searching by hand. This is the
-    /// orphan-aware path: only the DCR commit catch should call it,
-    /// because only that catch holds a fresh-from-DCR client_id that the
-    /// peer's commit makes orphan. The HMAC-seed catch (which runs after
-    /// THIS handler already committed Provisioned) uses
-    /// <see cref="TryAbsorbPeerHmacSeedAsync"/> instead.
-    /// </remarks>
-    private async Task<bool> TryAbsorbPeerDcrProvisioningAsync(
+    private Task<bool> AbsorbPeerDcrProvisioningAsync(
         EnsureAevatarOAuthClientProvisionedCommand cmd,
         string orphanClientId,
         EventStoreOptimisticConcurrencyException occ)
     {
-        await RefreshStateAfterOptimisticConcurrencyAsync(occ).ConfigureAwait(false);
-
+        // Framework already refreshed State from the store before invoking
+        // this callback. A peer healed the drift iff the cluster's stored
+        // record now matches the command's intended shape.
         var peerHealed = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
@@ -265,7 +234,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 orphanClientId,
                 occ.ExpectedVersion,
                 occ.ActualVersion);
-            return true;
+            return Task.FromResult(true);
         }
 
         Logger.LogError(
@@ -278,23 +247,11 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             orphanClientId,
             occ.ExpectedVersion,
             occ.ActualVersion);
-        return false;
+        return Task.FromResult(false);
     }
 
-    /// <summary>
-    /// Refreshes <see cref="State"/> after the post-Provisioned HMAC seed
-    /// lost an OCC race, then checks whether the cluster's HMAC slot is
-    /// now non-empty — meaning a peer activation already seeded a key
-    /// that all silos can use. This catch path is reached only after THIS
-    /// handler successfully committed <c>Provisioned</c>, so the actor's
-    /// ClientId is the active cluster client, not an orphan; orphan
-    /// messaging would be misleading and lead ops to delete a live
-    /// registration.
-    /// </summary>
-    private async Task<bool> TryAbsorbPeerHmacSeedAsync(EventStoreOptimisticConcurrencyException occ)
+    private Task<bool> AbsorbPeerHmacSeedAsync(EventStoreOptimisticConcurrencyException occ)
     {
-        await RefreshStateAfterOptimisticConcurrencyAsync(occ).ConfigureAwait(false);
-
         if (State.HmacKey.Length > 0)
         {
             Logger.LogWarning(
@@ -303,7 +260,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 State.ClientId,
                 occ.ExpectedVersion,
                 occ.ActualVersion);
-            return true;
+            return Task.FromResult(true);
         }
 
         Logger.LogError(
@@ -312,7 +269,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             State.ClientId,
             occ.ExpectedVersion,
             occ.ActualVersion);
-        return false;
+        return Task.FromResult(false);
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Google.Protobuf;
@@ -34,27 +35,23 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     public const string InitialHmacKid = "v1";
 
     /// <inheritdoc />
-    protected override AevatarOAuthClientState TransitionState(AevatarOAuthClientState current, IMessage evt)
-    {
-        if (evt is not null
-            && evt is not AevatarOAuthClientProvisionedEvent
-            && evt is not AevatarOAuthClientHmacKeyRotatedEvent
-            && evt is not AevatarOAuthClientBrokerCapabilityObservedEvent
-            && evt is not AevatarOAuthClientProjectionRebuildRequestedEvent)
-        {
-            Logger.LogWarning(
-                "AevatarOAuthClientGAgent received unrecognised event type {EventType}; state unchanged",
-                evt.GetType().FullName);
-        }
-
-        return StateTransitionMatcher
+    /// <remarks>
+    /// <see cref="StateTransitionMatcher"/> handles <c>Any</c>-wrapped payloads
+    /// transparently via <c>ProtobufContractCompatibility.TryUnpack</c>, so the
+    /// event-store's wrapped form ("type.googleapis.com/...") is matched the
+    /// same as a directly-typed instance. No "unrecognised event type"
+    /// pre-check fires here — the earlier guard incorrectly classified every
+    /// Any-wrapped event as unknown and produced noisy warnings on every
+    /// activation replay (one warning per persisted event).
+    /// </remarks>
+    protected override AevatarOAuthClientState TransitionState(AevatarOAuthClientState current, IMessage evt) =>
+        StateTransitionMatcher
             .Match(current, evt)
             .On<AevatarOAuthClientProvisionedEvent>(ApplyProvisioned)
             .On<AevatarOAuthClientHmacKeyRotatedEvent>(ApplyHmacKeyRotated)
             .On<AevatarOAuthClientBrokerCapabilityObservedEvent>(ApplyBrokerCapabilityObserved)
             .On<AevatarOAuthClientProjectionRebuildRequestedEvent>(static (state, _) => state)
             .OrCurrent();
-    }
 
     // ─── Commands ───
 
@@ -162,14 +159,39 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             .RegisterPublicClientAsync(cmd.NyxidAuthority, clientName, cmd.RedirectUri, CancellationToken.None)
             .ConfigureAwait(false);
 
-        await PersistDomainEventAsync(new AevatarOAuthClientProvisionedEvent
+        try
         {
-            ClientId = registration.ClientId,
-            ClientIdIssuedAtUnix = registration.IssuedAt.ToUnixTimeSeconds(),
-            NyxidAuthority = cmd.NyxidAuthority,
-            PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            RedirectUri = cmd.RedirectUri,
-        });
+            await PersistDomainEventAsync(new AevatarOAuthClientProvisionedEvent
+            {
+                ClientId = registration.ClientId,
+                ClientIdIssuedAtUnix = registration.IssuedAt.ToUnixTimeSeconds(),
+                NyxidAuthority = cmd.NyxidAuthority,
+                PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                RedirectUri = cmd.RedirectUri,
+            });
+        }
+        catch (EventStoreOptimisticConcurrencyException occ)
+        {
+            // Cluster-shared Garnet event store + brief two-pod overlap
+            // during a K8s rolling deploy lets two grain activations of
+            // this well-known actor each replay v=N, each call DCR (each
+            // getting its own client_id from NyxID), and each try to
+            // commit Provisioned at expectedVersion=N. One wins, one
+            // sees OCC. See issue #549 for the full causal chain.
+            //
+            // The losing handler must NOT retry the DCR — that would
+            // create another orphan client at NyxID on every backoff
+            // attempt. Refresh state from the store and check whether
+            // the peer's commit already matches what this command
+            // intended to install (same authority + same redirect URI).
+            // If yes, log the orphan client_id we just created so ops
+            // can delete it, and return success. The peer's record is
+            // the cluster-authoritative one going forward.
+            if (await TryAbsorbPeerProvisioningAsync(cmd, registration.ClientId, occ).ConfigureAwait(false))
+                return;
+            throw;
+        }
+
         Logger.LogInformation(
             "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
             registration.ClientId,
@@ -178,9 +200,77 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
 
         if (State.HmacKey.Length == 0)
         {
-            await PersistDomainEventAsync(BuildHmacKeyRotatedEvent());
-            Logger.LogInformation("Seeded HMAC key for aevatar OAuth client");
+            try
+            {
+                await PersistDomainEventAsync(BuildHmacKeyRotatedEvent());
+                Logger.LogInformation("Seeded HMAC key for aevatar OAuth client");
+            }
+            catch (EventStoreOptimisticConcurrencyException occ)
+            {
+                // Same race shape: a peer wrote at v+2 (e.g. their own
+                // HMAC seed) between our Provisioned commit and this
+                // seed. Refresh — if HMAC is now non-empty, the peer
+                // already seeded; absorb. The cluster has one valid key.
+                if (await TryAbsorbPeerProvisioningAsync(cmd, registration.ClientId, occ).ConfigureAwait(false))
+                    return;
+                throw;
+            }
         }
+    }
+
+    /// <summary>
+    /// Refreshes <see cref="State"/> from the event store after an
+    /// <see cref="EventStoreOptimisticConcurrencyException"/> raised by a
+    /// drift-branch commit, then checks whether the peer that won the race
+    /// already installed a Provisioned record matching the command's
+    /// authority + redirect URI. Returns <c>true</c> when the cluster is
+    /// already in the desired shape (caller should treat the OCC as a
+    /// successful no-op); returns <c>false</c> when the peer's commit was
+    /// something else and the caller should rethrow so the bootstrap retry
+    /// loop re-evaluates against fresh state.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately scoped to the DCR commit path — see issue #549. The
+    /// orphan_client_id field is logged so ops can delete the loser's
+    /// NyxID client without searching by hand.
+    /// </remarks>
+    private async Task<bool> TryAbsorbPeerProvisioningAsync(
+        EnsureAevatarOAuthClientProvisionedCommand cmd,
+        string orphanClientId,
+        EventStoreOptimisticConcurrencyException occ)
+    {
+        await RefreshStateFromStoreAsync().ConfigureAwait(false);
+
+        var peerHealed = !string.IsNullOrEmpty(State.ClientId)
+            && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
+            && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+            && State.HmacKey.Length > 0;
+
+        if (peerHealed)
+        {
+            Logger.LogWarning(
+                "Aevatar OAuth client OCC race resolved by peer commit; absorbing this attempt as a no-op. "
+                + "peer_client_id={PeerClientId}, orphan_client_id={OrphanClientId}, "
+                + "expected_version={Expected}, actual_version={Actual}. "
+                + "Ops should delete the orphan client at NyxID admin so it stops counting against the registration list.",
+                State.ClientId,
+                orphanClientId,
+                occ.ExpectedVersion,
+                occ.ActualVersion);
+            return true;
+        }
+
+        Logger.LogError(
+            "Aevatar OAuth client OCC race did not converge on the desired shape after replay; rethrowing so the bootstrap retry path can re-evaluate. "
+            + "stored_client_id={StoredClientId}, stored_redirect_uri={StoredRedirect}, expected_redirect_uri={ExpectedRedirect}, "
+            + "orphan_client_id={OrphanClientId}, expected_version={Expected}, actual_version={Actual}.",
+            State.ClientId,
+            State.RedirectUri,
+            cmd.RedirectUri,
+            orphanClientId,
+            occ.ExpectedVersion,
+            occ.ActualVersion);
+        return false;
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -187,7 +187,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             // If yes, log the orphan client_id we just created so ops
             // can delete it, and return success. The peer's record is
             // the cluster-authoritative one going forward.
-            if (await TryAbsorbPeerProvisioningAsync(cmd, registration.ClientId, occ).ConfigureAwait(false))
+            if (await TryAbsorbPeerDcrProvisioningAsync(cmd, registration.ClientId, occ).ConfigureAwait(false))
                 return;
             throw;
         }
@@ -207,11 +207,15 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             }
             catch (EventStoreOptimisticConcurrencyException occ)
             {
-                // Same race shape: a peer wrote at v+2 (e.g. their own
-                // HMAC seed) between our Provisioned commit and this
-                // seed. Refresh — if HMAC is now non-empty, the peer
-                // already seeded; absorb. The cluster has one valid key.
-                if (await TryAbsorbPeerProvisioningAsync(cmd, registration.ClientId, occ).ConfigureAwait(false))
+                // Distinct race shape from the DCR commit OCC: this
+                // handler ALREADY successfully committed Provisioned, so
+                // registration.ClientId is the active cluster client —
+                // not an orphan. A peer wrote at v+2 between our
+                // Provisioned commit and this seed (e.g. their own HMAC
+                // seed). Absorb without orphan messaging when the peer's
+                // events leave the store with a non-empty HMAC; the
+                // cluster has one valid key.
+                if (await TryAbsorbPeerHmacSeedAsync(occ).ConfigureAwait(false))
                     return;
                 throw;
             }
@@ -219,27 +223,31 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     }
 
     /// <summary>
-    /// Refreshes <see cref="State"/> from the event store after an
-    /// <see cref="EventStoreOptimisticConcurrencyException"/> raised by a
-    /// drift-branch commit, then checks whether the peer that won the race
-    /// already installed a Provisioned record matching the command's
-    /// authority + redirect URI. Returns <c>true</c> when the cluster is
-    /// already in the desired shape (caller should treat the OCC as a
-    /// successful no-op); returns <c>false</c> when the peer's commit was
-    /// something else and the caller should rethrow so the bootstrap retry
-    /// loop re-evaluates against fresh state.
+    /// Refreshes <see cref="State"/> from the event store after the
+    /// drift-branch <c>AevatarOAuthClientProvisionedEvent</c> commit lost
+    /// an OCC race, then checks whether the peer that won already
+    /// installed a Provisioned record matching the command's authority +
+    /// redirect URI. Returns <c>true</c> when the cluster is already in
+    /// the desired shape (caller should treat the OCC as a successful
+    /// no-op); returns <c>false</c> when the peer's commit was something
+    /// else and the caller should rethrow so the bootstrap retry loop
+    /// re-evaluates against fresh state.
     /// </summary>
     /// <remarks>
-    /// Deliberately scoped to the DCR commit path — see issue #549. The
-    /// orphan_client_id field is logged so ops can delete the loser's
-    /// NyxID client without searching by hand.
+    /// Logs <paramref name="orphanClientId"/> so ops can delete the
+    /// loser's NyxID client without searching by hand. This is the
+    /// orphan-aware path: only the DCR commit catch should call it,
+    /// because only that catch holds a fresh-from-DCR client_id that the
+    /// peer's commit makes orphan. The HMAC-seed catch (which runs after
+    /// THIS handler already committed Provisioned) uses
+    /// <see cref="TryAbsorbPeerHmacSeedAsync"/> instead.
     /// </remarks>
-    private async Task<bool> TryAbsorbPeerProvisioningAsync(
+    private async Task<bool> TryAbsorbPeerDcrProvisioningAsync(
         EnsureAevatarOAuthClientProvisionedCommand cmd,
         string orphanClientId,
         EventStoreOptimisticConcurrencyException occ)
     {
-        await RefreshStateFromStoreAsync().ConfigureAwait(false);
+        await RefreshStateAfterOptimisticConcurrencyAsync(occ).ConfigureAwait(false);
 
         var peerHealed = !string.IsNullOrEmpty(State.ClientId)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
@@ -268,6 +276,40 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             State.RedirectUri,
             cmd.RedirectUri,
             orphanClientId,
+            occ.ExpectedVersion,
+            occ.ActualVersion);
+        return false;
+    }
+
+    /// <summary>
+    /// Refreshes <see cref="State"/> after the post-Provisioned HMAC seed
+    /// lost an OCC race, then checks whether the cluster's HMAC slot is
+    /// now non-empty — meaning a peer activation already seeded a key
+    /// that all silos can use. This catch path is reached only after THIS
+    /// handler successfully committed <c>Provisioned</c>, so the actor's
+    /// ClientId is the active cluster client, not an orphan; orphan
+    /// messaging would be misleading and lead ops to delete a live
+    /// registration.
+    /// </summary>
+    private async Task<bool> TryAbsorbPeerHmacSeedAsync(EventStoreOptimisticConcurrencyException occ)
+    {
+        await RefreshStateAfterOptimisticConcurrencyAsync(occ).ConfigureAwait(false);
+
+        if (State.HmacKey.Length > 0)
+        {
+            Logger.LogWarning(
+                "Aevatar OAuth client HMAC-seed OCC race absorbed: peer activation already seeded a key. "
+                + "active_client_id={ClientId}, expected_version={Expected}, actual_version={Actual}.",
+                State.ClientId,
+                occ.ExpectedVersion,
+                occ.ActualVersion);
+            return true;
+        }
+
+        Logger.LogError(
+            "Aevatar OAuth client HMAC-seed OCC fired but the post-replay state has no HMAC key; rethrowing so the bootstrap retry path can complete the seed. "
+            + "active_client_id={ClientId}, expected_version={Expected}, actual_version={Actual}.",
+            State.ClientId,
             occ.ExpectedVersion,
             occ.ActualVersion);
         return false;

--- a/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
@@ -88,6 +88,24 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
     }
 
     /// <summary>
+    /// Re-reads persisted events from the event store and replaces
+    /// in-memory <see cref="State"/> with the rebuilt result. Intended for
+    /// use from event-handler bodies that have caught
+    /// <c>EventStoreOptimisticConcurrencyException</c> and need to absorb
+    /// peer-committed facts before deciding whether to retry, no-op, or
+    /// rethrow. Does not invoke <see cref="OnStateChangedAsync"/> — the
+    /// projection-publish pipeline is driven by the peer's own
+    /// <c>PersistDomainEventsAsync</c> commit, not by this re-load.
+    /// </summary>
+    protected async Task RefreshStateFromStoreAsync(CancellationToken ct = default)
+    {
+        var eventSourcing = EnsureEventSourcingConfigured();
+        var replayed = await eventSourcing.ReplayAsync(Id, ct).ConfigureAwait(false);
+        using var guard = StateGuard.BeginWriteScope();
+        _state = replayed ?? new TState();
+    }
+
+    /// <summary>
     /// Persist one domain event, then apply it to in-memory state.
     /// </summary>
     protected Task PersistDomainEventAsync<TEvent>(TEvent evt, CancellationToken ct = default)

--- a/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
@@ -4,6 +4,7 @@
 // ─────────────────────────────────────────────────────────────
 
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Core.EventSourcing;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -89,17 +90,31 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
 
     /// <summary>
     /// Re-reads persisted events from the event store and replaces
-    /// in-memory <see cref="State"/> with the rebuilt result. Intended for
-    /// use from event-handler bodies that have caught
-    /// <c>EventStoreOptimisticConcurrencyException</c> and need to absorb
-    /// peer-committed facts before deciding whether to retry, no-op, or
-    /// rethrow. Does not invoke <see cref="OnStateChangedAsync"/> — the
-    /// projection-publish pipeline is driven by the peer's own
-    /// <c>PersistDomainEventsAsync</c> commit, not by this re-load.
+    /// in-memory <see cref="State"/> with the rebuilt result. The
+    /// <paramref name="conflict"/> parameter scopes this helper to OCC
+    /// absorption only: callers must already hold the conflict raised by
+    /// the framework's commit path so the API cannot be casually misused
+    /// as a general-purpose state replay escape hatch from inside ordinary
+    /// event handlers (CLAUDE.md "抽象一旦能被滥用就等于设计未完成").
     /// </summary>
-    protected async Task RefreshStateFromStoreAsync(CancellationToken ct = default)
+    /// <remarks>
+    /// Calls <see cref="IEventSourcingBehavior{TState}.DiscardPendingEvents"/>
+    /// before replay so any handler-raised events that survived as a
+    /// pending suffix on the failed batch (events raised after the
+    /// committed prefix removed by <c>ConfirmEventsAsync</c>) cannot be
+    /// silently committed on a subsequent <c>ConfirmEventsAsync</c>. Does
+    /// not invoke <see cref="OnStateChangedAsync"/> — the projection
+    /// publish pipeline is driven by the peer's own
+    /// <c>PersistDomainEventsAsync</c> commit, not by this re-load.
+    /// </remarks>
+    protected async Task RefreshStateAfterOptimisticConcurrencyAsync(
+        EventStoreOptimisticConcurrencyException conflict,
+        CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(conflict);
+
         var eventSourcing = EnsureEventSourcingConfigured();
+        eventSourcing.DiscardPendingEvents();
         var replayed = await eventSourcing.ReplayAsync(Id, ct).ConfigureAwait(false);
         using var guard = StateGuard.BeginWriteScope();
         _state = replayed ?? new TState();

--- a/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
@@ -89,38 +89,6 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
     }
 
     /// <summary>
-    /// Re-reads persisted events from the event store and replaces
-    /// in-memory <see cref="State"/> with the rebuilt result. The
-    /// <paramref name="conflict"/> parameter scopes this helper to OCC
-    /// absorption only: callers must already hold the conflict raised by
-    /// the framework's commit path so the API cannot be casually misused
-    /// as a general-purpose state replay escape hatch from inside ordinary
-    /// event handlers (CLAUDE.md "抽象一旦能被滥用就等于设计未完成").
-    /// </summary>
-    /// <remarks>
-    /// Calls <see cref="IEventSourcingBehavior{TState}.DiscardPendingEvents"/>
-    /// before replay so any handler-raised events that survived as a
-    /// pending suffix on the failed batch (events raised after the
-    /// committed prefix removed by <c>ConfirmEventsAsync</c>) cannot be
-    /// silently committed on a subsequent <c>ConfirmEventsAsync</c>. Does
-    /// not invoke <see cref="OnStateChangedAsync"/> — the projection
-    /// publish pipeline is driven by the peer's own
-    /// <c>PersistDomainEventsAsync</c> commit, not by this re-load.
-    /// </remarks>
-    protected async Task RefreshStateAfterOptimisticConcurrencyAsync(
-        EventStoreOptimisticConcurrencyException conflict,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(conflict);
-
-        var eventSourcing = EnsureEventSourcingConfigured();
-        eventSourcing.DiscardPendingEvents();
-        var replayed = await eventSourcing.ReplayAsync(Id, ct).ConfigureAwait(false);
-        using var guard = StateGuard.BeginWriteScope();
-        _state = replayed ?? new TState();
-    }
-
-    /// <summary>
     /// Persist one domain event, then apply it to in-memory state.
     /// </summary>
     protected Task PersistDomainEventAsync<TEvent>(TEvent evt, CancellationToken ct = default)
@@ -128,6 +96,62 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
     {
         ArgumentNullException.ThrowIfNull(evt);
         return PersistDomainEventsAsync([evt], ct);
+    }
+
+    /// <summary>
+    /// Persist one domain event with framework-mediated OCC absorption. On
+    /// <see cref="EventStoreOptimisticConcurrencyException"/>, the framework
+    /// drains pending events, replays from the store to refresh
+    /// <see cref="State"/>, and then invokes
+    /// <paramref name="onOptimisticConcurrencyConflict"/> to let the caller
+    /// decide whether the peer's commit already satisfies the intent of
+    /// this command. Returning <c>true</c> swallows the conflict as a
+    /// successful no-op (see <see cref="State"/> for the post-replay
+    /// shape); returning <c>false</c> rethrows so the runtime envelope
+    /// retry path re-evaluates against fresh state.
+    /// </summary>
+    /// <remarks>
+    /// This overload exists so OCC absorption is a *commit-bound*
+    /// capability — actors cannot replay state outside an active commit
+    /// path (CLAUDE.md "抽象一旦能被滥用就等于设计未完成"). The callback
+    /// must be a pure decision function over the refreshed
+    /// <see cref="State"/>; it must not raise new events, persist
+    /// snapshots, or perform external side effects (NyxID DCR / HTTP),
+    /// because the framework has already drained pending events for
+    /// recovery and any callback-raised events would be committed on the
+    /// next handler turn.
+    /// </remarks>
+    protected async Task PersistDomainEventAsync<TEvent>(
+        TEvent evt,
+        Func<EventStoreOptimisticConcurrencyException, Task<bool>> onOptimisticConcurrencyConflict,
+        CancellationToken ct = default)
+        where TEvent : IMessage
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        ArgumentNullException.ThrowIfNull(onOptimisticConcurrencyConflict);
+
+        try
+        {
+            await PersistDomainEventsAsync([evt], ct).ConfigureAwait(false);
+        }
+        catch (EventStoreOptimisticConcurrencyException conflict)
+        {
+            // ConfirmEventsAsync only removes the committed prefix on OCC;
+            // any events raised mid-flight survive as a pending suffix.
+            // Drain them before replay so they cannot be silently committed
+            // on the next ConfirmEventsAsync (PR #552 review kimi).
+            var eventSourcing = EnsureEventSourcingConfigured();
+            eventSourcing.DiscardPendingEvents();
+            var replayed = await eventSourcing.ReplayAsync(Id, ct).ConfigureAwait(false);
+            using (var guard = StateGuard.BeginWriteScope())
+            {
+                _state = replayed ?? new TState();
+            }
+
+            var absorbed = await onOptimisticConcurrencyConflict(conflict).ConfigureAwait(false);
+            if (!absorbed)
+                throw;
+        }
     }
 
     /// <summary>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -1,7 +1,9 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Identity;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -292,6 +294,128 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleEnsureProvisioned_AbsorbsOcc_WhenPeerAlreadyHealedDriftMidDcr()
+    {
+        // Pin issue #549: cluster-shared Garnet event store + brief K8s
+        // rolling-deploy two-pod overlap lets two grain activations of this
+        // well-known actor each call DCR (each getting its own client_id
+        // from NyxID) and each try to commit Provisioned at the same
+        // expectedVersion. One wins, one sees OCC. The losing handler MUST
+        // absorb the OCC as a no-op when the peer's commit already healed
+        // the redirect drift this command came in to fix — otherwise the
+        // losing pod retries and burns yet another orphan client at NyxID
+        // on every backoff attempt.
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "http://+:8080/api/oauth/nyxid-callback",
+        });
+
+        var resolvedRedirect = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback";
+        _registrar.NextClientId = "loser-orphan-client";
+        _registrar.OnRegistered = async () =>
+        {
+            // Simulate the peer pod's grain activation winning the race:
+            // it commits a Provisioned event with the correct redirect URI
+            // to the shared event store while this handler is still mid-
+            // DCR. When this handler comes back from its own DCR HTTP call
+            // and tries to commit at expectedVersion=N, the store is
+            // already at N+1.
+            var store = _serviceProvider.GetRequiredService<IEventStore>();
+            var actorId = _agent.Id;
+            var current = await store.GetVersionAsync(actorId);
+            var peerEvent = new AevatarOAuthClientProvisionedEvent
+            {
+                ClientId = "peer-pod-after-heal",
+                ClientIdIssuedAtUnix = 1700000001,
+                NyxidAuthority = "https://nyxid.test",
+                RedirectUri = resolvedRedirect,
+                PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            };
+            await store.AppendAsync(
+                actorId,
+                new[]
+                {
+                    new StateEvent
+                    {
+                        AgentId = actorId,
+                        Version = current + 1,
+                        EventType = AevatarOAuthClientProvisionedEvent.Descriptor.FullName,
+                        EventData = Any.Pack(peerEvent),
+                        Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                    },
+                },
+                current);
+        };
+
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = resolvedRedirect,
+        });
+
+        // Loser absorbed the OCC: state reflects the peer's commit, NOT
+        // this handler's DCR result (which is now an orphan at NyxID).
+        _agent.State.ClientId.Should().Be("peer-pod-after-heal");
+        _agent.State.RedirectUri.Should().Be(resolvedRedirect);
+        _registrar.Calls.Should().HaveCount(2,
+            "the losing handler called DCR before discovering the peer's commit; that DCR result is logged as an orphan");
+    }
+
+    [Fact]
+    public async Task HandleEnsureProvisioned_RethrowsOcc_WhenPeerCommitDoesNotHealDrift()
+    {
+        // The OCC absorber must NOT swallow conflicts where the peer's
+        // commit was something unrelated (e.g. a future schema event the
+        // actor doesn't know about). In that case the bootstrap retry
+        // path must observe the failure and re-evaluate against fresh
+        // state, otherwise we'd silently leave drift unhealed.
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "http://+:8080/api/oauth/nyxid-callback",
+        });
+
+        _registrar.NextClientId = "loser-orphan-client";
+        _registrar.OnRegistered = async () =>
+        {
+            // Peer's commit is a rebuild request — Apply is identity, so
+            // it does NOT update RedirectUri. State stays drifted after
+            // refresh, the absorber returns false, OCC propagates.
+            var store = _serviceProvider.GetRequiredService<IEventStore>();
+            var actorId = _agent.Id;
+            var current = await store.GetVersionAsync(actorId);
+            var peerEvent = new AevatarOAuthClientProjectionRebuildRequestedEvent
+            {
+                Reason = "peer_rebuild",
+                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            };
+            await store.AppendAsync(
+                actorId,
+                new[]
+                {
+                    new StateEvent
+                    {
+                        AgentId = actorId,
+                        Version = current + 1,
+                        EventType = AevatarOAuthClientProjectionRebuildRequestedEvent.Descriptor.FullName,
+                        EventData = Any.Pack(peerEvent),
+                        Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                    },
+                },
+                current);
+        };
+
+        var act = () => _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback",
+        });
+
+        await act.Should().ThrowAsync<EventStoreOptimisticConcurrencyException>();
+    }
+
+    [Fact]
     public async Task HandleProvision_FirstSeed_DoesNotCarryPreviousKey()
     {
         // Initial seed has no prior key — the previous-key fields stay
@@ -313,6 +437,14 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         public string NextClientId { get; set; } = "client-first";
         public List<(string Authority, string ClientName, string RedirectUri)> Calls { get; } = new();
 
+        /// <summary>
+        /// Hook that runs after the DCR call records the request but before
+        /// the result is returned. Tests use it to simulate a peer pod
+        /// committing to the shared event store while the handler is mid-DCR
+        /// (the cluster-shared Garnet race that issue #549 documents).
+        /// </summary>
+        public Func<Task>? OnRegistered { get; set; }
+
         public NyxIdDynamicClientRegistrationClient AsRegistrar() => new RecordingRegistrar(this);
 
         private sealed class RecordingRegistrar : NyxIdDynamicClientRegistrationClient
@@ -325,11 +457,13 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
                 _owner = owner;
             }
 
-            public override Task<RegistrationResult> RegisterPublicClientAsync(
+            public override async Task<RegistrationResult> RegisterPublicClientAsync(
                 string authority, string clientName, string redirectUri, CancellationToken ct = default)
             {
                 _owner.Calls.Add((authority, clientName, redirectUri));
-                return Task.FromResult(new RegistrationResult(_owner.NextClientId, DateTimeOffset.UtcNow));
+                if (_owner.OnRegistered is not null)
+                    await _owner.OnRegistered().ConfigureAwait(false);
+                return new RegistrationResult(_owner.NextClientId, DateTimeOffset.UtcNow);
             }
         }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityGAgentTestHarness.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityGAgentTestHarness.cs
@@ -70,8 +70,10 @@ internal static class IdentityGAgentTestHarness
 
             var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
             if (currentVersion != expectedVersion)
-                throw new InvalidOperationException(
-                    $"Optimistic concurrency conflict: expected {expectedVersion}, actual {currentVersion}");
+                throw new EventStoreOptimisticConcurrencyException(
+                    agentId,
+                    expectedVersion,
+                    currentVersion);
 
             var appended = events.Select(x => x.Clone()).ToList();
             stream.AddRange(appended);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriEnvCollection.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriEnvCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+/// <summary>
+/// Serializes test classes that mutate <c>AEVATAR_OAUTH_REDIRECT_BASE_URL</c>.
+/// xUnit runs test classes in parallel collections by default; two classes
+/// each saving / overwriting / restoring the same process-wide env var
+/// could race and restore each other's stale values, producing flaky
+/// redirect-URI assertions.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class NyxIdRedirectUriEnvCollection
+{
+    public const string Name = "NyxIdRedirectUriEnv";
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriResolverTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRedirectUriResolverTests.cs
@@ -13,6 +13,7 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 /// the production default and only accepts <c>AEVATAR_OAUTH_REDIRECT_BASE_URL</c>
 /// as override; wildcard hosts are filtered.
 /// </summary>
+[Collection(NyxIdRedirectUriEnvCollection.Name)]
 public sealed class NyxIdRedirectUriResolverTests : IDisposable
 {
     private readonly string? _savedOverride;

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -1,0 +1,126 @@
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
+using FluentAssertions;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
+{
+    private static readonly byte[] HmacKey =
+        Convert.FromHexString("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+    private readonly string? _savedOverride;
+
+    public NyxIdRemoteCapabilityBrokerTests()
+    {
+        _savedOverride = Environment.GetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar);
+        Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _savedOverride);
+    }
+
+    [Fact]
+    public async Task StartExternalBindingAsync_RejectsSnapshotWithMissingRedirectUri()
+    {
+        var broker = NewBroker(NewSnapshot(redirectUri: null));
+
+        var act = () => broker.StartExternalBindingAsync(SampleSubject());
+
+        await act.Should()
+            .ThrowAsync<AevatarOAuthClientNotProvisionedException>()
+            .WithMessage("*redirect_uri*");
+    }
+
+    [Fact]
+    public async Task StartExternalBindingAsync_RejectsSnapshotWithMismatchedRedirectUri()
+    {
+        var broker = NewBroker(NewSnapshot("https://old.example.com/api/oauth/nyxid-callback"));
+
+        var act = () => broker.StartExternalBindingAsync(SampleSubject());
+
+        await act.Should()
+            .ThrowAsync<AevatarOAuthClientNotProvisionedException>()
+            .WithMessage("*redirect_uri*");
+    }
+
+    [Fact]
+    public async Task StartExternalBindingAsync_EmitsAuthorizeUrlOnlyWhenRedirectUriMatches()
+    {
+        var expectedRedirectUri = NyxIdRedirectUriResolver.Resolve();
+        var broker = NewBroker(NewSnapshot(expectedRedirectUri));
+
+        var challenge = await broker.StartExternalBindingAsync(SampleSubject());
+
+        var uri = new Uri(challenge.AuthorizeUrl);
+        uri.GetLeftPart(UriPartial.Path).Should().Be("https://nyxid.test/oauth/authorize");
+        var query = QueryHelpers.ParseQuery(uri.Query);
+        query["client_id"].Should().ContainSingle().Which.Should().Be("client-1");
+        query["redirect_uri"].Should().ContainSingle().Which.Should().Be(expectedRedirectUri);
+        query["scope"].Should().ContainSingle().Which.Should().Be("openid urn:nyxid:scope:broker_binding");
+        query["state"].Should().ContainSingle();
+        query["code_challenge"].Should().ContainSingle();
+        query["code_challenge_method"].Should().ContainSingle().Which.Should().Be("S256");
+    }
+
+    private static NyxIdRemoteCapabilityBroker NewBroker(AevatarOAuthClientSnapshot snapshot)
+    {
+        var provider = new FakeOAuthClientProvider(snapshot);
+        return new NyxIdRemoteCapabilityBroker(
+            new FakeHttpClientFactory(),
+            provider,
+            Options.Create(new NyxIdBrokerOptions()),
+            new StateTokenCodec(provider),
+            new EmptyBindingQueryPort(),
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-04-30T10:00:00Z")),
+            NullLogger<NyxIdRemoteCapabilityBroker>.Instance);
+    }
+
+    private static AevatarOAuthClientSnapshot NewSnapshot(string? redirectUri) => new(
+        ClientId: "client-1",
+        ClientIdIssuedAt: DateTimeOffset.Parse("2026-04-30T09:00:00Z"),
+        HmacKid: "v1",
+        HmacKey: HmacKey,
+        HmacKeyRotatedAt: DateTimeOffset.Parse("2026-04-30T09:00:00Z"),
+        NyxIdAuthority: "https://nyxid.test",
+        BrokerCapabilityObserved: true,
+        BrokerCapabilityObservedAt: DateTimeOffset.Parse("2026-04-30T09:00:00Z"),
+        RedirectUri: redirectUri);
+
+    private static ExternalSubjectRef SampleSubject() => new()
+    {
+        Platform = "lark",
+        Tenant = "ou_tenant_x",
+        ExternalUserId = "ou_user_y",
+    };
+
+    private sealed class FakeOAuthClientProvider : IAevatarOAuthClientProvider
+    {
+        private readonly AevatarOAuthClientSnapshot _snapshot;
+
+        public FakeOAuthClientProvider(AevatarOAuthClientSnapshot snapshot) => _snapshot = snapshot;
+
+        public Task<AevatarOAuthClientSnapshot> GetAsync(CancellationToken ct = default) =>
+            Task.FromResult(_snapshot);
+    }
+
+    private sealed class EmptyBindingQueryPort : IExternalIdentityBindingQueryPort
+    {
+        public Task<BindingId?> ResolveAsync(ExternalSubjectRef externalSubject, CancellationToken ct = default) =>
+            Task.FromResult<BindingId?>(null);
+    }
+
+    private sealed class FakeHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/NyxIdRemoteCapabilityBrokerTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 
+[Collection(NyxIdRedirectUriEnvCollection.Name)]
 public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
 {
     private static readonly byte[] HmacKey =
@@ -47,6 +48,38 @@ public sealed class NyxIdRemoteCapabilityBrokerTests : IDisposable
         var broker = NewBroker(NewSnapshot("https://old.example.com/api/oauth/nyxid-callback"));
 
         var act = () => broker.StartExternalBindingAsync(SampleSubject());
+
+        await act.Should()
+            .ThrowAsync<AevatarOAuthClientNotProvisionedException>()
+            .WithMessage("*redirect_uri*");
+    }
+
+    [Fact]
+    public async Task ExchangeAuthorizationCodeAsync_RejectsSnapshotWithMissingRedirectUri()
+    {
+        // The token-exchange path has the same EnsureRedirectUriCurrent
+        // guard as the authorize path. A code in flight is the higher-
+        // impact failure mode — the user already clicked the broker URL
+        // and NyxID has issued the code. If the code hits the broker with
+        // a stale snapshot, redirect_uri at /oauth/token would diverge
+        // from what NyxID recorded at /authorize and the exchange would
+        // fail with `invalid_grant`. Pin the early refusal so we never
+        // burn an authorization code against a known-stale snapshot.
+        var broker = NewBroker(NewSnapshot(redirectUri: null));
+
+        var act = () => broker.ExchangeAuthorizationCodeAsync("auth-code", "verifier");
+
+        await act.Should()
+            .ThrowAsync<AevatarOAuthClientNotProvisionedException>()
+            .WithMessage("*redirect_uri*");
+    }
+
+    [Fact]
+    public async Task ExchangeAuthorizationCodeAsync_RejectsSnapshotWithMismatchedRedirectUri()
+    {
+        var broker = NewBroker(NewSnapshot("https://old.example.com/api/oauth/nyxid-callback"));
+
+        var act = () => broker.ExchangeAuthorizationCodeAsync("auth-code", "verifier");
 
         await act.Should()
             .ThrowAsync<AevatarOAuthClientNotProvisionedException>()


### PR DESCRIPTION
## Problem
Production /init can stay broken on every deploy: `/api/oauth/aevatar-client/status` reports a client with `redirect_uri_registered = null` and `redirect_uri_drifted = true` while the Lark card's authorize URL keeps pointing at the stale client id, and NyxID rejects the flow with `invalid_redirect_uri`.

Root cause is a multi-layer issue tracked in issue #549:

1. **Bootstrap declared success too early**: returned as soon as the actor command was published to the stream. If the actor handler / projection failed afterwards, no signal made it back and the cluster kept serving the broken readmodel.
2. **Broker still issued authorize URLs against drifted snapshots**: even when the runtime knew the redirect URI was stale, the broker built and returned the authorize URL anyway, which NyxID rejected.
3. **Status endpoint masked drift as `ready`**: the boolean check on broker observation hid the drift state from ops triage.
4. **Actor died on optimistic concurrency** instead of absorbing it — when a peer pod won the rolling-deploy race the loser propagated the OCC and the bootstrap retry burned another orphan client at NyxID on every backoff attempt.
5. **Cosmetic noise**: every persisted event triggered a "unrecognised event type Any" warning at activation replay because the actor's pre-check did not account for the framework's Any wrapping.

## Solution
- Bootstrap keeps retrying until the OAuth client readmodel actually observes a non-drifted `redirect_uri` (`WaitForProvisionedReadModelAsync` polling).
- `NyxIdRemoteCapabilityBroker` now refuses to issue authorize URLs or exchange codes while the snapshot redirect URI is missing or drifted; callers surface this as the existing "initializing NyxID client, retry later" path.
- Status endpoint reports `redirect_uri_drifted` instead of `ready` when stored ≠ resolved.
- `AevatarOAuthClientGAgent.HandleEnsureProvisioned` catches `EventStoreOptimisticConcurrencyException` at the drift-branch DCR commit (and the follow-up HMAC seed), refreshes State from the store via a new `GAgentBase<TState>.RefreshStateFromStoreAsync` helper, and absorbs the race as a no-op when the peer's commit already matches the command's intended (authority, redirect_uri, hmac-seeded) shape. The orphan `client_id` is logged so ops can clean it up. If the peer's commit was something unrelated (e.g. a stray rebuild request that did not heal drift), the absorber returns `false` and OCC propagates so the bootstrap retry loop re-evaluates against fresh state.
- Drop the misleading "unrecognised event type Any" warning in `AevatarOAuthClientGAgent.TransitionState`. The framework's `StateTransitionMatcher.TryExtract` already unwraps Any payloads via `ProtobufContractCompatibility.TryUnpack`.
- Test harness `InMemoryEventStore` now throws the proper `EventStoreOptimisticConcurrencyException` so the OCC absorber can be exercised end-to-end.

## Tests
- New broker tests pin "do not emit authorize URL for missing/mismatched redirect URI".
- New OAuth client GAgent tests pin the OCC absorber:
  - peer-healed: handler absorbs OCC, State reflects peer's commit, loser's DCR is logged as orphan.
  - peer-not-healed: handler rethrows OCC so bootstrap retry kicks in.

## Out of scope (tracked in issue #549 layered fix)
- Distributed lock around the DCR call so only one pod runs DCR per cluster-membership transition (eliminates orphan creation entirely instead of just absorbing the loser).
- Replace the bootstrap's fire-and-forget stream-produce dispatch with a synchronous grain RPC (Orleans turn-based serialization works for direct grain calls; stream produce is what breaks it).
- Actor rebuild admin command + endpoint for ops recovery from any wedged actor.
- Multi-silo + shared event store integration test simulating the K8s rolling-deploy two-pod overlap.

## Verification
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo` (826/826)
- `dotnet test test/Aevatar.Foundation.Core.Tests/Aevatar.Foundation.Core.Tests.csproj --nologo` (230/230)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`
- `git diff --check`