### PR TITLE
Type WorkflowSuspendedEvent.SuspensionType as enum

### DIFF
--- a/demos/Aevatar.Demos.Workflow.Web/Program.cs
+++ b/demos/Aevatar.Demos.Workflow.Web/Program.cs
@@ -1153,8 +1153,7 @@ static object BuildRoleDto(RoleDefinition role) => new
 
 static WorkflowResumedEvent BuildAutoResumedEvent(WorkflowSuspendedEvent suspended, string originalInput)
 {
-    var suspensionType = suspended.SuspensionType ?? string.Empty;
-    if (string.Equals(suspensionType, "human_approval", StringComparison.OrdinalIgnoreCase))
+    if (suspended.SuspensionType == WorkflowSuspensionType.HumanApproval)
     {
         var shouldReject = (suspended.Prompt ?? string.Empty).Contains("AUTO_REJECT", StringComparison.OrdinalIgnoreCase);
 

--- a/src/workflow/Aevatar.Workflow.Abstractions/WorkflowSuspensionTypes.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/WorkflowSuspensionTypes.cs
@@ -1,0 +1,24 @@
+namespace Aevatar.Workflow.Abstractions;
+
+public static class WorkflowSuspensionTypes
+{
+    public const string HumanApprovalWireName = "human_approval";
+    public const string HumanInputWireName = "human_input";
+    public const string SecureInputWireName = "secure_input";
+
+    public static string ToWireName(this WorkflowSuspensionType kind) => kind switch
+    {
+        WorkflowSuspensionType.HumanApproval => HumanApprovalWireName,
+        WorkflowSuspensionType.HumanInput => HumanInputWireName,
+        WorkflowSuspensionType.SecureInput => SecureInputWireName,
+        _ => string.Empty,
+    };
+
+    public static IReadOnlyList<string> DefaultExpectedOptions(this WorkflowSuspensionType kind) => kind switch
+    {
+        WorkflowSuspensionType.HumanApproval => ["approve", "reject"],
+        WorkflowSuspensionType.HumanInput => ["submit"],
+        WorkflowSuspensionType.SecureInput => ["submit"],
+        _ => [],
+    };
+}

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -150,17 +150,26 @@ message SubWorkflowInvocationCompletedEvent
   string output = 4;
   string error = 5;
 }
+enum WorkflowSuspensionType
+{
+  WORKFLOW_SUSPENSION_TYPE_UNSPECIFIED = 0;
+  WORKFLOW_SUSPENSION_TYPE_HUMAN_APPROVAL = 1;
+  WORKFLOW_SUSPENSION_TYPE_HUMAN_INPUT = 2;
+  WORKFLOW_SUSPENSION_TYPE_SECURE_INPUT = 3;
+}
 message WorkflowSuspendedEvent
 {
+  reserved 3;
   string run_id = 1;
   string step_id = 2;
-  string suspension_type = 3;
   string prompt = 4;
   int32 timeout_seconds = 5;
   string variable_name = 6;
   map<string, string> metadata = 7;
   string content = 8;
   string delivery_target_id = 9;
+  WorkflowSuspensionType suspension_type = 10;
+  repeated string expected_options = 11;
 }
 message WorkflowResumedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/HumanApprovalModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/HumanApprovalModule.cs
@@ -72,10 +72,11 @@ public sealed class HumanApprovalModule : IEventModule<IWorkflowExecutionContext
             {
                 RunId = runId,
                 StepId = request.StepId,
-                SuspensionType = "human_approval",
+                SuspensionType = WorkflowSuspensionType.HumanApproval,
                 Prompt = prompt,
                 TimeoutSeconds = timeoutSeconds,
             };
+            suspended.ExpectedOptions.Add(WorkflowSuspensionType.HumanApproval.DefaultExpectedOptions());
             WorkflowSuspensionRequestSupport.ApplyContent(suspended, request.Input);
             WorkflowSuspensionRequestSupport.ApplyDeliveryTarget(suspended, request);
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/HumanInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/HumanInputModule.cs
@@ -74,11 +74,12 @@ public sealed class HumanInputModule : IEventModule<IWorkflowExecutionContext>
             {
                 RunId = runId,
                 StepId = request.StepId,
-                SuspensionType = "human_input",
+                SuspensionType = WorkflowSuspensionType.HumanInput,
                 Prompt = prompt,
                 TimeoutSeconds = timeoutSeconds,
                 VariableName = variable,
             };
+            suspended.ExpectedOptions.Add(WorkflowSuspensionType.HumanInput.DefaultExpectedOptions());
             WorkflowSuspensionRequestSupport.ApplyContent(suspended, request.Input);
             WorkflowSuspensionRequestSupport.ApplyDeliveryTarget(suspended, request);
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
@@ -95,11 +95,12 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
             {
                 RunId = runId,
                 StepId = request.StepId,
-                SuspensionType = Name,
+                SuspensionType = WorkflowSuspensionType.SecureInput,
                 Prompt = prompt,
                 TimeoutSeconds = timeoutSeconds,
                 VariableName = requestVariableName,
             };
+            suspended.ExpectedOptions.Add(WorkflowSuspensionType.SecureInput.DefaultExpectedOptions());
             WorkflowSuspensionRequestSupport.ApplyDeliveryTarget(suspended, request);
             suspended.Metadata["variable"] = requestVariableName;
             suspended.Metadata["secure"] = "true";

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
@@ -614,6 +614,20 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
         foreach (var (key, value) in evt.Metadata)
             metadata[key] = value;
 
+        var customPayload = new WorkflowHumanInputRequestCustomPayload
+        {
+            StepId = evt.StepId,
+            RunId = evt.RunId,
+            SuspensionType = evt.SuspensionType.ToWireName(),
+            Prompt = evt.Prompt,
+            TimeoutSeconds = evt.TimeoutSeconds,
+            VariableName = evt.VariableName,
+            Content = evt.Content,
+            DeliveryTargetId = evt.DeliveryTargetId,
+            Metadata = { metadata },
+        };
+        customPayload.Options.Add(evt.ExpectedOptions);
+
         events =
         [
             new WorkflowRunEventEnvelope
@@ -622,18 +636,7 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
                 Custom = new WorkflowCustomEventPayload
                 {
                     Name = "aevatar.human_input.request",
-                    Payload = Any.Pack(new WorkflowHumanInputRequestCustomPayload
-                    {
-                        StepId = evt.StepId,
-                        RunId = evt.RunId,
-                        SuspensionType = evt.SuspensionType,
-                        Prompt = evt.Prompt,
-                        TimeoutSeconds = evt.TimeoutSeconds,
-                        VariableName = evt.VariableName,
-                        Content = evt.Content,
-                        DeliveryTargetId = evt.DeliveryTargetId,
-                        Metadata = { metadata },
-                    }),
+                    Payload = Any.Pack(customPayload),
                 },
             },
         ];

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
@@ -39,15 +39,19 @@ public sealed class WorkflowHumanInteractionProjector
         foreach (var (key, value) in evt.Metadata)
             annotations[key] = value;
 
+        var options = evt.ExpectedOptions.Count > 0
+            ? (IReadOnlyList<string>)evt.ExpectedOptions.ToArray()
+            : evt.SuspensionType.DefaultExpectedOptions();
+
         var request = new HumanInteractionRequest
         {
             ActorId = context.RootActorId,
             RunId = evt.RunId,
             StepId = evt.StepId,
-            SuspensionType = evt.SuspensionType,
+            SuspensionType = evt.SuspensionType.ToWireName(),
             Prompt = evt.Prompt,
             Content = string.IsNullOrWhiteSpace(evt.Content) ? null : evt.Content,
-            Options = ResolveOptions(evt.SuspensionType),
+            Options = options,
             TimeoutSeconds = evt.TimeoutSeconds,
             Annotations = annotations,
         };
@@ -57,13 +61,4 @@ public sealed class WorkflowHumanInteractionProjector
             evt.DeliveryTargetId,
             ct);
     }
-
-    private static IReadOnlyList<string> ResolveOptions(string suspensionType) =>
-        suspensionType switch
-        {
-            "human_approval" => ["approve", "reject"],
-            "human_input" => ["submit"],
-            "secure_input" => ["submit"],
-            _ => Array.Empty<string>(),
-        };
 }

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
@@ -269,7 +269,8 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
         DateTimeOffset observedAt)
     {
         var step = GetOrCreateStep(readModel.Steps, evt.StepId);
-        step.SuspensionType = evt.SuspensionType ?? string.Empty;
+        var suspensionWireName = evt.SuspensionType.ToWireName();
+        step.SuspensionType = suspensionWireName;
         step.SuspensionPrompt = evt.Prompt ?? string.Empty;
         step.SuspensionTimeoutSeconds = evt.TimeoutSeconds == 0 ? null : evt.TimeoutSeconds;
         step.RequestedVariableName = evt.VariableName ?? string.Empty;
@@ -278,7 +279,7 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
             readModel.Timeline,
             observedAt,
             "workflow.suspended",
-            $"{evt.StepId} ({evt.SuspensionType})",
+            $"{evt.StepId} ({suspensionWireName})",
             readModel.RootActorId,
             evt.StepId,
             step.StepType,

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -640,7 +640,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
 
         var suspended = ctx.Published.Select(x => x.evt).OfType<WorkflowSuspendedEvent>().Single();
         suspended.StepId.Should().Be("approval-1");
-        suspended.SuspensionType.Should().Be("human_approval");
+        suspended.SuspensionType.Should().Be(WorkflowSuspensionType.HumanApproval);
         suspended.Content.Should().Be("original");
         suspended.DeliveryTargetId.Should().Be("agent-approval-1");
         ctx.Published.Clear();
@@ -1017,7 +1017,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             CancellationToken.None);
 
         var suspended = ctx.Published.Select(x => x.evt).OfType<WorkflowSuspendedEvent>().Single();
-        suspended.SuspensionType.Should().Be("secure_input");
+        suspended.SuspensionType.Should().Be(WorkflowSuspensionType.SecureInput);
         suspended.Metadata["secure"].Should().Be("true");
         suspended.Metadata["variable"].Should().Be("api_key");
         suspended.Content.Should().BeEmpty();

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -1063,7 +1063,7 @@ public class WorkflowGAgentCoverageTests
             new WorkflowSuspendedEvent
             {
                 StepId = "step-1",
-                SuspensionType = "human_input",
+                SuspensionType = WorkflowSuspensionType.HumanInput,
             },
             agent.Id,
             TopologyAudience.Self));

--- a/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -314,7 +314,7 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
         {
             RunId = "run-1",
             StepId = "get_context",
-            SuspensionType = "human_input",
+            SuspensionType = WorkflowSuspensionType.HumanInput,
             Prompt = "请提供补充信息",
             Content = "已有上下文",
             TimeoutSeconds = 1800,

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
@@ -330,7 +330,7 @@ public sealed class WorkflowExecutionProjectionProjectorTests
                 new WorkflowSuspendedEvent
                 {
                     StepId = "step-1",
-                    SuspensionType = "human_input",
+                    SuspensionType = WorkflowSuspensionType.HumanInput,
                     Prompt = "Need approval",
                     VariableName = "approval",
                     Metadata =
@@ -673,7 +673,7 @@ public sealed class WorkflowExecutionProjectionProjectorTests
                 new WorkflowSuspendedEvent
                 {
                     StepId = "step-2",
-                    SuspensionType = "approval",
+                    SuspensionType = WorkflowSuspensionType.HumanApproval,
                     Prompt = "approve",
                     TimeoutSeconds = 60,
                     VariableName = "approved",

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
@@ -26,7 +26,7 @@ public sealed class WorkflowHumanInteractionProjectorTests
                 {
                     RunId = "run-1",
                     StepId = "approval-1",
-                    SuspensionType = "human_approval",
+                    SuspensionType = WorkflowSuspensionType.HumanApproval,
                     Prompt = "Need approval",
                     Content = "Please review the summary.",
                     DeliveryTargetId = "agent-delivery-1",
@@ -65,7 +65,7 @@ public sealed class WorkflowHumanInteractionProjectorTests
                 {
                     RunId = "run-2",
                     StepId = "input-1",
-                    SuspensionType = "human_input",
+                    SuspensionType = WorkflowSuspensionType.HumanInput,
                     Prompt = "Need extra details",
                 }),
             },
@@ -90,7 +90,7 @@ public sealed class WorkflowHumanInteractionProjectorTests
                 {
                     RunId = "run-3",
                     StepId = "approval-3",
-                    SuspensionType = "human_approval",
+                    SuspensionType = WorkflowSuspensionType.HumanApproval,
                     Prompt = "Need approval",
                     DeliveryTargetId = "agent-delivery-3",
                 }),
@@ -98,6 +98,36 @@ public sealed class WorkflowHumanInteractionProjectorTests
             CancellationToken.None);
 
         port.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldUseEventExpectedOptions_OverDefaults()
+    {
+        var port = new RecordingHumanInteractionPort();
+        var projector = new WorkflowHumanInteractionProjector(port);
+
+        var suspended = new WorkflowSuspendedEvent
+        {
+            RunId = "run-options",
+            StepId = "approval-options",
+            SuspensionType = WorkflowSuspensionType.HumanApproval,
+            Prompt = "Need approval",
+            DeliveryTargetId = "agent-delivery-options",
+        };
+        suspended.ExpectedOptions.Add(new[] { "accept", "veto" });
+
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-human-options",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-human-interaction-test"),
+                Payload = Any.Pack(suspended),
+            },
+            CancellationToken.None);
+
+        port.Calls.Should().ContainSingle();
+        port.Calls[0].request.Options.Should().Equal("accept", "veto");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
@@ -234,7 +234,7 @@ public sealed class WorkflowProjectionMaterializationTests
                 {
                     RunId = "run-1",
                     StepId = "step-9",
-                    SuspensionType = "wait_signal",
+                    SuspensionType = WorkflowSuspensionType.HumanApproval,
                     Prompt = "Need approval",
                     TimeoutSeconds = 30,
                     VariableName = "approval",
@@ -280,7 +280,7 @@ public sealed class WorkflowProjectionMaterializationTests
         report.CompletionStatus.Should().Be(WorkflowExecutionCompletionStatus.Stopped);
         report.FinalError.Should().Be("manual-stop");
         report.Steps.Should().ContainSingle();
-        report.Steps[0].SuspensionType.Should().Be("wait_signal");
+        report.Steps[0].SuspensionType.Should().Be("human_approval");
         report.Steps[0].SuspensionPrompt.Should().Be("Need approval");
         report.Steps[0].SuspensionTimeoutSeconds.Should().Be(30);
         report.Timeline.Select(x => x.Stage).Should().Contain([
@@ -379,7 +379,7 @@ public sealed class WorkflowProjectionMaterializationTests
                 {
                     RunId = "run-1",
                     StepId = "step-1",
-                    SuspensionType = "human_input",
+                    SuspensionType = WorkflowSuspensionType.HumanInput,
                     Prompt = "confirm",
                     TimeoutSeconds = 15,
                     VariableName = "answer",


### PR DESCRIPTION
## Summary

- Add `WorkflowSuspensionType` proto enum (`HUMAN_APPROVAL` / `HUMAN_INPUT` / `SECURE_INPUT`) to `workflow_execution_messages.proto`; reserve old field 3, type the new field at 10.
- Add `repeated string expected_options = 11` so the suspension-emitting actor declares its expected response options at emission time.
- Modules (`HumanApprovalModule` / `HumanInputModule` / `SecureInputModule`) now emit the typed enum and seed default options via a single `WorkflowSuspensionTypes` helper.
- `WorkflowHumanInteractionProjector` no longer string-switches on suspension type; it copies `evt.ExpectedOptions` and falls back to the helper for hand-built events.
- Downstream protos (`workflow_run_events`, `agui_events`, `workflow_projection_transport`) keep their `string suspension_type` for AGUI/frontend wire stability — the AGUI mapper translates enum → conventional snake-case via `ToWireName()` at the boundary.

Implements rollout step 1 of #553 (finding 5: typed `SuspensionType` enum). Per the issue's `Suggested rollout`, this lands first as a mechanical change to prevent regressions before tackling the typed `WorkflowSuspendedDeliveryTarget` (finding 2) and the rest.

## Test plan

- [x] `dotnet build aevatar.slnx` — clean (0 errors).
- [x] `dotnet test test/Aevatar.Workflow.Host.Api.Tests` — 325 passed.
- [x] `dotnet test test/Aevatar.Integration.Tests` — 286 passed (4 pre-existing skipped).
- [x] `dotnet test test/Aevatar.GAgentService.Integration.Tests` — 286 passed.
- [x] `bash tools/ci/test_stability_guards.sh` — pass.
- [x] `bash tools/ci/workflow_binding_boundary_guard.sh` / `projection_state_version_guard.sh` / `projection_route_mapping_guard.sh` — pass.
- [x] New test `ProjectAsync_ShouldUseEventExpectedOptions_OverDefaults` verifies actor-supplied options override the helper default.
- [x] `playground_asset_drift_guard.sh` skipped (pnpm/tsc not installed in this paseo worktree; baseline also fails — not introduced by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)