### PR TITLE
Activate binding projection scope + materialize legacy bindings on commit

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -75,6 +75,15 @@ public static class IdentityServiceCollectionExtensions
             ExternalIdentityBindingDocumentMetadataProvider>();
         services.TryAddSingleton<IExternalIdentityBindingQueryPort, ExternalIdentityBindingProjectionQueryPort>();
         services.TryAddSingleton<IProjectionReadinessPort, ExternalIdentityBindingProjectionReadinessPort>();
+        // Projection scope activator for the per-binding actor — callback
+        // handler calls EnsureProjectionForActorAsync(bindingActorId) before
+        // dispatching CommitBindingCommand so the projector subscribes to
+        // the actor's committed events and the readmodel materializes.
+        // Without this the binding readmodel stays empty, the readiness
+        // wait in /api/oauth/nyxid-callback times out, and the next
+        // inbound message's gate keeps re-sending the binding card. See
+        // issue #549 follow-up observed 2026-05-01.
+        services.TryAddSingleton<ExternalIdentityBindingProjectionPort>();
 
         // ─── Cluster-singleton OAuth client projection ───
         services.AddProjectionMaterializationRuntimeCore<

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -225,6 +225,36 @@ public static class IdentityOAuthEndpoints
         }
         catch (TimeoutException)
         {
+            // Distinguish two timeout shapes (PR #555 review): the actor's
+            // discard branch (legacy already-bound) keeps State.BindingId =
+            // existing != incoming, so WaitForBindingStateAsync NEVER matches
+            // — but the rebuild event we now emit has materialized the
+            // existing binding into the readmodel, so a final ResolveAsync
+            // here distinguishes:
+            //   1. ResolveAsync returns active binding != exchange.BindingId
+            //      → actor took the discard path; the incoming binding NyxID
+            //        just issued is an orphan. Revoke it and return the same
+            //        already_bound shape the up-front check above produces.
+            //   2. ResolveAsync still returns null → readmodel really has not
+            //      caught up yet; surface the existing pending-propagation
+            //      hint so the user retries.
+            // Without this branch the legacy heal path would (a) leave
+            // bnd_incoming as a permanent orphan at NyxID on every /init
+            // retry and (b) frustrate the user with binding_pending_propagation
+            // even though their existing binding is now visible.
+            var resolvedAfterTimeout = await queryPort.ResolveAsync(subject, ct).ConfigureAwait(false);
+            if (resolvedAfterTimeout is not null
+                && !string.Equals(resolvedAfterTimeout.Value, exchange.BindingId, StringComparison.Ordinal))
+            {
+                logger.LogInformation(
+                    "OAuth callback observed legacy already-bound on actor={ActorId}: existing={ExistingBindingId}, incoming={IncomingBindingId}; revoking the incoming binding so it does not orphan at NyxID.",
+                    actorId,
+                    resolvedAfterTimeout.Value,
+                    exchange.BindingId);
+                await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
+                return Results.Ok(new { status = "already_bound", detail = "已绑定 NyxID 账号,可以回到 Lark 继续对话" });
+            }
+
             logger.LogWarning(
                 "Projection readiness timed out for actor={ActorId}, expected binding={BindingId}",
                 actorId,

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -48,6 +48,7 @@ public static class IdentityOAuthEndpoints
         [FromServices] IExternalIdentityBindingQueryPort queryPort,
         [FromServices] IActorRuntime actorRuntime,
         [FromServices] IProjectionReadinessPort projectionReadiness,
+        [FromServices] ExternalIdentityBindingProjectionPort bindingProjectionPort,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -139,6 +140,18 @@ public static class IdentityOAuthEndpoints
         }
 
         var actorId = subject.ToActorId();
+
+        // Activate the binding projection scope BEFORE any readmodel query
+        // or actor dispatch. Without an active scope, the projector never
+        // subscribes to this actor's committed events and the readmodel
+        // stays empty — the next two checks (ResolveAsync below; the
+        // post-dispatch WaitForBindingStateAsync) would both miss the
+        // binding and the user gets stuck on the binding card forever.
+        // Same lifecycle pattern AevatarOAuthClientBootstrapService uses
+        // for the cluster-singleton OAuth client (issue #549 follow-up
+        // observed 2026-05-01).
+        await bindingProjectionPort.EnsureProjectionForActorAsync(actorId, ct).ConfigureAwait(false);
+
         if (await queryPort.ResolveAsync(subject, ct).ConfigureAwait(false) is not null)
         {
             // Concurrent /init protection: if the subject is already bound,

--- a/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
@@ -19,27 +19,22 @@ namespace Aevatar.GAgents.Channel.Identity;
 public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalIdentityBindingState>
 {
     /// <inheritdoc />
-    protected override ExternalIdentityBindingState TransitionState(ExternalIdentityBindingState current, IMessage evt)
-    {
-        // Log unrecognised event types so a proto schema drift (or stale
-        // event store entry from a removed event type) surfaces in operator
-        // dashboards rather than silently being dropped via OrCurrent().
-        // Production deployments should treat these as a regression signal.
-        if (evt is not null
-            && evt is not ExternalIdentityBoundEvent
-            && evt is not ExternalIdentityBindingRevokedEvent)
-        {
-            Logger.LogWarning(
-                "ExternalIdentityBindingGAgent received unrecognised event type {EventType}; state unchanged",
-                evt.GetType().FullName);
-        }
-
-        return StateTransitionMatcher
+    /// <remarks>
+    /// <see cref="StateTransitionMatcher"/> handles <c>Any</c>-wrapped payloads
+    /// transparently via <c>ProtobufContractCompatibility.TryUnpack</c>, so the
+    /// event-store's wrapped form ("type.googleapis.com/...") is matched the
+    /// same as a directly-typed instance. No "unrecognised event type"
+    /// pre-check fires here — the earlier guard incorrectly classified every
+    /// Any-wrapped event as unknown and produced noisy warnings on every
+    /// activation replay.
+    /// </remarks>
+    protected override ExternalIdentityBindingState TransitionState(ExternalIdentityBindingState current, IMessage evt) =>
+        StateTransitionMatcher
             .Match(current, evt)
             .On<ExternalIdentityBoundEvent>(ApplyBound)
             .On<ExternalIdentityBindingRevokedEvent>(ApplyRevoked)
+            .On<ExternalIdentityBindingProjectionRebuildRequestedEvent>(static (state, _) => state)
             .OrCurrent();
-    }
 
     // ─── Commands ───
 
@@ -82,8 +77,23 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
 
         if (!string.IsNullOrEmpty(State.BindingId))
         {
+            // Steady-state branch: persist a no-op rebuild request so the
+            // projector materializes the existing binding into the readmodel.
+            // Without this, a legacy binding actor whose projection scope
+            // was never activated (issue #549 follow-up: the binding scope
+            // missed an EnsureProjectionForActorAsync wiring while every
+            // other GAgent had one) leaves the readmodel empty, the OAuth
+            // callback's readiness wait times out, and the next inbound
+            // message's binding gate keeps re-sending the user back to /init.
+            // Apply is identity, so the binding facts are not mutated by
+            // this event.
+            await PersistDomainEventAsync(new ExternalIdentityBindingProjectionRebuildRequestedEvent
+            {
+                Reason = "commit_already_bound",
+                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            });
             Logger.LogInformation(
-                "CommitBinding discarded: already bound for {Platform}:{Tenant}:{User} (existing={ExistingBindingId}, incoming={IncomingBindingId})",
+                "CommitBinding discarded: already bound for {Platform}:{Tenant}:{User} (existing={ExistingBindingId}, incoming={IncomingBindingId}); rebuild requested so the projector materializes the existing binding",
                 cmd.ExternalSubject.Platform,
                 cmd.ExternalSubject.Tenant,
                 cmd.ExternalSubject.ExternalUserId,

--- a/agents/Aevatar.GAgents.Channel.Identity/Projection/ExternalIdentityBindingProjectionPort.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Projection/ExternalIdentityBindingProjectionPort.cs
@@ -1,0 +1,47 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+
+namespace Aevatar.GAgents.Channel.Identity;
+
+/// <summary>
+/// Activates the projection materialization scope for a per-(platform,
+/// tenant, external_user_id) <see cref="ExternalIdentityBindingGAgent"/>.
+/// MUST be called before <see cref="ExternalIdentityBindingProjectionQueryPort"/>
+/// /<see cref="ExternalIdentityBindingProjectionReadinessPort"/> can return
+/// the binding for that actor — without an active scope, the projector
+/// never subscribes to the actor's committed event stream and the
+/// readmodel stays empty.
+/// </summary>
+/// <remarks>
+/// Mirrors <see cref="Aevatar.GAgents.Channel.Identity.AevatarOAuthClientProjectionPort"/>.
+/// Pre-this-port, the binding scope was never activated for any actor and
+/// every legacy cluster's binding readmodel was empty even when the
+/// actor's State held an active binding — the OAuth callback's readiness
+/// wait would time out, and the next inbound message's binding gate would
+/// keep sending the user back to /init forever (issue #549 follow-up
+/// observed 2026-05-01: <c>CommitBinding discarded: already bound</c>
+/// without a corresponding readmodel materialization).
+/// </remarks>
+public sealed class ExternalIdentityBindingProjectionPort
+    : MaterializationProjectionPortBase<ExternalIdentityBindingMaterializationRuntimeLease>
+{
+    public const string ProjectionKind = "external-identity-binding";
+
+    public ExternalIdentityBindingProjectionPort(
+        IProjectionScopeActivationService<ExternalIdentityBindingMaterializationRuntimeLease> activationService)
+        : base(static () => true, activationService)
+    {
+    }
+
+    public Task<ExternalIdentityBindingMaterializationRuntimeLease?> EnsureProjectionForActorAsync(
+        string actorId,
+        CancellationToken ct = default) =>
+        EnsureProjectionAsync(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = actorId,
+                ProjectionKind = ProjectionKind,
+                Mode = ProjectionRuntimeMode.DurableMaterialization,
+            },
+            ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
@@ -58,6 +58,19 @@ message ExternalIdentityBindingRevokedEvent {
   string reason = 3;
 }
 
+// Persisted when an inbound CommitBindingCommand is discarded because the
+// actor already holds an active binding_id, OR when a deploy needs to re-
+// publish the authoritative state root for a legacy binding actor whose
+// projection scope was never activated. Apply is identity — the binding
+// facts are not mutated. The projector still sees a state-root publication
+// and materializes the existing binding into the readmodel, fixing the
+// 2026-05-01 production regression where the binding scope was missing
+// (issue #549 follow-up).
+message ExternalIdentityBindingProjectionRebuildRequestedEvent {
+  string reason = 1;
+  google.protobuf.Timestamp requested_at = 2;
+}
+
 // Stateless OAuth `state` token payload (HMAC-sealed, never in grain state).
 // Carries the correlation id, the originating external subject, the PKCE
 // verifier, and the absolute expiry. See ADR-0018 §Implementation Notes #1.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
@@ -98,10 +98,15 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
             ExternalSubject = subject,
             BindingId = "bnd_first",
         });
+        var afterFirstVersion = _agent.EventSourcing!.CurrentVersion;
 
         // Second concurrent /init wins the race after the first one already
         // committed. The actor MUST keep the existing binding_id and discard
-        // the second one (ADR-0018 §Implementation Notes #2).
+        // the second one (ADR-0018 §Implementation Notes #2). It also emits
+        // a no-op rebuild event so the projector materializes the existing
+        // binding into the readmodel — necessary on legacy clusters whose
+        // binding projection scope was activated for the first time after
+        // the bind already happened (issue #549 follow-up 2026-05-01).
         await _agent.HandleCommitBinding(new CommitBindingCommand
         {
             ExternalSubject = subject,
@@ -109,6 +114,9 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         });
 
         _agent.State.BindingId.Should().Be("bnd_first");
+        _agent.EventSourcing!.CurrentVersion.Should().Be(
+            afterFirstVersion + 1,
+            "the discard branch must emit a rebuild event so the projector re-publishes the existing binding's state root");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthCallbackEndpointTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthCallbackEndpointTests.cs
@@ -1,0 +1,217 @@
+using System.Text;
+using System.Text.Json;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Broker;
+using Aevatar.GAgents.Channel.Identity.Endpoints;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+/// <summary>
+/// Behaviour tests for <see cref="IdentityOAuthEndpoints.HandleNyxIdOAuthCallbackAsync"/>
+/// covering the legacy already-bound heal path. ADR-0018 §Implementation
+/// Notes #2 + PR #555 review (eanzhao): when a sender's binding actor was
+/// committed in a previous deploy and the projection scope is being
+/// activated for the first time, the actor takes its discard branch on
+/// <c>CommitBindingCommand</c>; the readiness wait then can never observe
+/// the incoming binding_id (the actor kept its existing one). The callback
+/// MUST recognise that shape, revoke the orphan binding NyxID just minted
+/// for the incoming code, and surface <c>already_bound</c> instead of the
+/// pending-propagation hint — otherwise every retry leaks another orphan
+/// at NyxID and the user sees the wrong message.
+/// </summary>
+public sealed class IdentityOAuthCallbackEndpointTests
+{
+    [Fact]
+    public async Task LegacyAlreadyBound_OnReadinessTimeout_RevokesIncomingAndReturnsAlreadyBound()
+    {
+        var existing = new BindingId { Value = "bnd_existing" };
+        const string incoming = "bnd_incoming";
+        var subject = SampleSubject();
+        var broker = NewBroker(subject, incoming);
+        var queryPort = Substitute.For<IExternalIdentityBindingQueryPort>();
+        // Up-front check (before scope activation has materialised the doc):
+        // returns null. Post-timeout check (after rebuild has fired): returns
+        // the existing binding actor State holds.
+        queryPort.ResolveAsync(Arg.Any<ExternalSubjectRef>(), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult<BindingId?>(null),
+                Task.FromResult<BindingId?>(existing));
+        var readiness = Substitute.For<IProjectionReadinessPort>();
+        readiness.WaitForBindingStateAsync(
+                Arg.Any<ExternalSubjectRef>(),
+                incoming,
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new TimeoutException("readiness")));
+
+        var (result, _) = await InvokeCallbackAsync(broker, queryPort, readiness);
+
+        await broker.Received(1).RevokeBindingByIdAsync(incoming, Arg.Any<CancellationToken>());
+        await ReadJsonAsync(result).ContinueWith(t =>
+            t.Result.RootElement.GetProperty("status").GetString().Should().Be("already_bound"));
+    }
+
+    [Fact]
+    public async Task PendingPropagation_WhenReadinessTimesOutAndReadmodelStillEmpty()
+    {
+        var subject = SampleSubject();
+        var broker = NewBroker(subject, "bnd_incoming");
+        var queryPort = Substitute.For<IExternalIdentityBindingQueryPort>();
+        queryPort.ResolveAsync(Arg.Any<ExternalSubjectRef>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<BindingId?>(null));
+        var readiness = Substitute.For<IProjectionReadinessPort>();
+        readiness.WaitForBindingStateAsync(
+                Arg.Any<ExternalSubjectRef>(),
+                Arg.Any<string?>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new TimeoutException("readiness")));
+
+        var (result, _) = await InvokeCallbackAsync(broker, queryPort, readiness);
+
+        await broker.DidNotReceive().RevokeBindingByIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        var doc = await ReadJsonAsync(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("binding_pending_propagation");
+    }
+
+    [Fact]
+    public async Task HappyPath_WaitForBindingSucceeds_ReturnsBound()
+    {
+        const string incoming = "bnd_incoming";
+        var subject = SampleSubject();
+        var broker = NewBroker(subject, incoming);
+        var queryPort = Substitute.For<IExternalIdentityBindingQueryPort>();
+        // Up-front check returns null; post-success path must NOT call
+        // ResolveAsync a second time, so this single value is enough.
+        queryPort.ResolveAsync(Arg.Any<ExternalSubjectRef>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<BindingId?>(null));
+        var readiness = Substitute.For<IProjectionReadinessPort>();
+        readiness.WaitForBindingStateAsync(
+                Arg.Any<ExternalSubjectRef>(),
+                incoming,
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var (result, _) = await InvokeCallbackAsync(broker, queryPort, readiness);
+
+        await broker.DidNotReceive().RevokeBindingByIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await queryPort.Received(1).ResolveAsync(Arg.Any<ExternalSubjectRef>(), Arg.Any<CancellationToken>());
+        var doc = await ReadJsonAsync(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("bound");
+    }
+
+    // ─── Test plumbing ───
+
+    private static ExternalSubjectRef SampleSubject() => new()
+    {
+        Platform = "lark",
+        Tenant = "ou_tenant_x",
+        ExternalUserId = "ou_user_y",
+    };
+
+    private static INyxIdBrokerCallbackClient NewBroker(ExternalSubjectRef subject, string bindingId)
+    {
+        var broker = Substitute.For<INyxIdBrokerCallbackClient>();
+        broker.TryDecodeStateTokenAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(CallbackStateDecode.Ok(
+                correlationId: "correlation-1",
+                subject: subject,
+                verifier: "pkce-verifier")));
+        broker.ExchangeAuthorizationCodeAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new BrokerAuthorizationCodeResult(bindingId, IdToken: null, AccessToken: null)));
+        return broker;
+    }
+
+    private static ExternalIdentityBindingProjectionPort NewProjectionPort()
+    {
+        var activationService = Substitute.For<IProjectionScopeActivationService<ExternalIdentityBindingMaterializationRuntimeLease>>();
+        activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<ExternalIdentityBindingMaterializationRuntimeLease?>(
+                new ExternalIdentityBindingMaterializationRuntimeLease(
+                    new ExternalIdentityBindingMaterializationContext
+                    {
+                        RootActorId = "test-actor",
+                        ProjectionKind = ExternalIdentityBindingProjectionPort.ProjectionKind,
+                    }))!);
+        return new ExternalIdentityBindingProjectionPort(activationService);
+    }
+
+    private static IActorRuntime NewActorRuntime()
+    {
+        var noopActor = Substitute.For<IActor>();
+        noopActor.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var runtime = Substitute.For<IActorRuntime>();
+        runtime.CreateAsync<ExternalIdentityBindingGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(noopActor));
+        runtime.CreateAsync<AevatarOAuthClientGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IActor>(noopActor));
+        return runtime;
+    }
+
+    private static async Task<(IResult Result, HttpContext Context)> InvokeCallbackAsync(
+        INyxIdBrokerCallbackClient broker,
+        IExternalIdentityBindingQueryPort queryPort,
+        IProjectionReadinessPort readiness)
+    {
+        var actorRuntime = NewActorRuntime();
+        var projectionPort = NewProjectionPort();
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        var result = await IdentityOAuthEndpoints.HandleNyxIdOAuthCallbackAsync(
+            code: "auth-code",
+            state: "state-token",
+            error: null,
+            brokerCallback: broker,
+            queryPort: queryPort,
+            actorRuntime: actorRuntime,
+            projectionReadiness: readiness,
+            bindingProjectionPort: projectionPort,
+            loggerFactory: loggerFactory,
+            ct: CancellationToken.None);
+
+        return (result, NewHttpContext());
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(IResult result)
+    {
+        var context = NewHttpContext();
+        await result.ExecuteAsync(context);
+        context.Response.Body.Position = 0;
+        var text = await new StreamReader(context.Response.Body, Encoding.UTF8).ReadToEndAsync();
+        return JsonDocument.Parse(text);
+    }
+
+    private static HttpContext NewHttpContext()
+    {
+        // Minimal-API IResult.ExecuteAsync (Json/Ok/etc.) resolves
+        // ILoggerFactory and JsonOptions from RequestServices. Wire up a
+        // tiny ServiceCollection so the result-types can render.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var provider = services.BuildServiceProvider();
+        return new DefaultHttpContext
+        {
+            RequestServices = provider,
+            Response =
+            {
+                Body = new MemoryStream(),
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Problem
After PR #552 merged, production still loops users back to /init forever. Pod logs from `aevatar-console-backend` 2026-05-01:

```
ExternalIdentityBindingGAgent[0]: CommitBinding discarded: already bound for
  lark:...:ou_937adb03f3538c5e041bb3034c4e348e
  (existing=bnd_41ebae..., incoming=bnd_7fbc76ed...)
warn: Aevatar.Channel.Identity.OAuthCallback[0]: Projection readiness timed out
  for actor=external-identity-binding:..., expected binding=bnd_7fbc76ed...
```

The binding actor's `State` already holds `bnd_41ebae` from a previous deploy, but the binding readmodel is empty. The OAuth callback's `WaitForBindingStateAsync` polls for the new `bnd_7fbc76ed` (or any matching binding) and times out, returning `binding_pending_propagation`. The next inbound message's gate also queries the empty readmodel and re-sends the `/init` card. Loop.

## Root cause
Every other GAgent (`AevatarOAuthClient`, `ChannelBotRegistration`, `Device`, `UserAgentCatalog`) has an explicit `EnsureProjectionForActorAsync` wiring; `ExternalIdentityBindingGAgent` never did. Without it the projector never subscribes to the binding actor's committed event stream, so even a perfectly-committed binding never lands in the readmodel.

This is the same shape as PR #539 fixed for `AevatarOAuthClientGAgent` — the binding scope was simply missed when that PR went out.

## Solution
1. **`ExternalIdentityBindingProjectionPort`** wrapping `MaterializationProjectionPortBase`. Registered as singleton in `IdentityServiceCollectionExtensions`.
2. **`HandleNyxIdOAuthCallbackAsync` calls `EnsureProjectionForActorAsync(bindingActorId)`** before the `queryPort.ResolveAsync` check and the `actor.HandleEventAsync` dispatch — so the projector is subscribed before any read or write touches that actor.
3. **`ExternalIdentityBindingProjectionRebuildRequestedEvent`** (Apply identity). `HandleCommitBinding`'s "already bound" discard branch now persists this event instead of returning silently. The projector sees the state-root republication and materializes the existing binding — so legacy actors heal on the next `/init` even though no new `ExternalIdentityBoundEvent` fires.
4. **`TransitionState` cleanup**: drop the misleading `unrecognised event type Any` warning (`StateTransitionMatcher.TryExtract` already unwraps Any), add `ExternalIdentityBindingProjectionRebuildRequestedEvent` as identity in the apply switch.

## Tests
- `HandleCommitBinding_IsIdempotentUnderConcurrentInit` extended to assert the version advances by one when the second commit is "already bound" — pins that the discard branch must emit a rebuild event so the projector re-publishes the existing binding's state root.
- Existing 8 binding-actor behaviour tests still pass without modification.

## Verification
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo` (828/828)
- `dotnet test test/Aevatar.Foundation.Core.Tests/Aevatar.Foundation.Core.Tests.csproj --nologo` (230/230)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`

## Refs
Issue #549 (binding-projection-scope-missing follow-up). PR #552 fixed the OAuth-client side of this same pattern.