### PR TITLE
Self-heal binding rejections + streaming-failed reply-token loop

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -647,9 +647,6 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         ChatActivity? referenceActivity,
         ConversationTurnRuntimeContext runtimeContext)
     {
-        if (evt.TerminalState != LlmReplyTerminalState.Completed)
-            return false;
-
         var correlationId = NormalizeOptional(evt.CorrelationId);
         if (correlationId is null)
             return false;
@@ -663,6 +660,58 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             return false;
 
         var platformMessageId = state.PlatformMessageId!;
+
+        // Streaming-start already consumed the reply token. On Failed, falling through to
+        // RunLlmReplyAsync would issue a fresh /reply against the dead token and surface
+        // as `401 Reply token already used` to NyxID — leaving the user staring at the
+        // streaming partial (often just "...") forever with no error explanation. Self-heal
+        // by editing the existing placeholder in place with the classified failure text;
+        // turn is then terminal (no retry, no second /reply).
+        if (evt.TerminalState == LlmReplyTerminalState.Failed)
+        {
+            var failureText = NormalizeOptional(evt.Outbound?.Text)
+                ?? NormalizeOptional(evt.ErrorSummary)
+                ?? "Sorry, the reply failed. Please try again.";
+            var runner = ResolveRunner();
+            var failureChunk = new LlmReplyStreamChunkEvent
+            {
+                CorrelationId = evt.CorrelationId,
+                RegistrationId = evt.RegistrationId,
+                Activity = referenceActivity?.Clone() ?? evt.Activity?.Clone() ?? new ChatActivity(),
+                AccumulatedText = failureText,
+                ChunkAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            };
+            var failureResult = await runner.RunStreamChunkAsync(
+                failureChunk,
+                platformMessageId,
+                runtimeContext,
+                CancellationToken.None);
+            if (failureResult.Success)
+            {
+                Logger.LogWarning(
+                    "LLM reply failed after streaming-start; updated placeholder with failure text. correlation={CorrelationId}, errorCode={ErrorCode}, platformMessageId={PlatformMessageId}",
+                    evt.CorrelationId,
+                    evt.ErrorCode,
+                    platformMessageId);
+                await PersistStreamedCompletionAsync(evt, commandId, referenceActivity, platformMessageId, failureText, state.EditCount + 1);
+                return true;
+            }
+
+            // Edit failed too (rare — Lark may reject a message edit for unrelated reasons).
+            // Falling back to /reply would still hit the dead token, so persist the last
+            // flushed partial as terminal. The user sees the partial (potentially empty)
+            // but we don't spin on a guaranteed 401.
+            Logger.LogWarning(
+                "Streaming LLM failure-update could not edit placeholder; persisting last flushed partial as terminal. correlation={CorrelationId}, code={Code}, platformMessageId={PlatformMessageId}",
+                evt.CorrelationId,
+                failureResult.ErrorCode,
+                platformMessageId);
+            await PersistStreamedCompletionAsync(evt, commandId, referenceActivity, platformMessageId, state.LastFlushedText, state.EditCount);
+            return true;
+        }
+
+        if (evt.TerminalState != LlmReplyTerminalState.Completed)
+            return false;
         var finalText = evt.Outbound?.Text ?? string.Empty;
         if (string.IsNullOrWhiteSpace(finalText))
         {

--- a/agents/Aevatar.GAgents.NyxidChat/Slash/ModelChannelSlashCommandHandler.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/Slash/ModelChannelSlashCommandHandler.cs
@@ -1,8 +1,11 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions.Slash;
+using Aevatar.GAgents.Channel.Identity;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
 using Aevatar.GAgents.NyxidChat.LlmSelection;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat.Slash;
@@ -18,18 +21,21 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
     private readonly IUserLlmOptionsService? _optionsService;
     private readonly IUserLlmSelectionService? _selectionService;
     private readonly IUserLlmOptionsRenderer<MessageContent>? _renderer;
+    private readonly IActorRuntime? _actorRuntime;
     private readonly ILogger<ModelChannelSlashCommandHandler> _logger;
 
     public ModelChannelSlashCommandHandler(
         ILogger<ModelChannelSlashCommandHandler> logger,
         IUserLlmOptionsService? optionsService = null,
         IUserLlmSelectionService? selectionService = null,
-        IUserLlmOptionsRenderer<MessageContent>? renderer = null)
+        IUserLlmOptionsRenderer<MessageContent>? renderer = null,
+        IActorRuntime? actorRuntime = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _optionsService = optionsService;
         _selectionService = selectionService;
         _renderer = renderer;
+        _actorRuntime = actorRuntime;
     }
 
     public string Name => "model";
@@ -76,21 +82,103 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
         }
         catch (BindingNotFoundException)
         {
-            return new MessageContent { Text = "当前 NyxID 绑定不可用,请先发送 /init 重新绑定。" };
+            return await SelfHealRevokedBindingAsync(
+                context,
+                reason: "auto_self_heal_remote_not_found",
+                userMessage: "NyxID 端 binding 已不可用,本地已自动清理。请发送 /init 完成新绑定。",
+                ct).ConfigureAwait(false);
         }
         catch (BindingRevokedException)
         {
-            return new MessageContent { Text = "当前 NyxID 绑定已失效,请先发送 /init 重新绑定。" };
+            return await SelfHealRevokedBindingAsync(
+                context,
+                reason: "auto_self_heal_remote_revoked",
+                userMessage: "NyxID 端 binding 已失效,本地已自动清理。请发送 /init 完成新绑定。",
+                ct).ConfigureAwait(false);
         }
         catch (BindingScopeMismatchException)
         {
-            return new MessageContent { Text = "当前 NyxID 绑定缺少 LLM route 权限,请先发送 /init 重新绑定。" };
+            return await SelfHealRevokedBindingAsync(
+                context,
+                reason: "auto_self_heal_scope_mismatch",
+                userMessage: "当前 NyxID 绑定缺少 LLM route 权限,本地已自动清理。请发送 /init 完成新绑定。",
+                ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or HttpRequestException or NotSupportedException)
         {
             _logger.LogWarning(ex, "/model failed to read or update NyxID LLM selection");
             return new MessageContent { Text = BuildUserFacingFailureMessage(ex) };
         }
+    }
+
+    /// <summary>
+    /// Auto-revoke the local binding actor when NyxID has reported the
+    /// binding is gone (revoked / not_found / scope-mismatch). Without this
+    /// the user is stuck in a loop: <c>/init</c> sees the local readmodel
+    /// still says "bound" and refuses; <c>/model</c> + <c>/route</c> exercise
+    /// the broker, get the rejection, and tell the user to <c>/init</c> —
+    /// which refuses again. Self-healing flips the local actor's state to
+    /// revoked so the next <c>/init</c> goes through cleanly.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the dispatch shape <see cref="UnbindChannelSlashCommandHandler"/>
+    /// uses for explicit /unbind. Differs in that the NyxID-side revoke is
+    /// already done (NyxID is the one telling us the binding is gone), so we
+    /// only need to flip the local actor — no second broker call. Failure to
+    /// dispatch the local revoke is logged at error level but still returns
+    /// a user-facing message; the user can retry the slash command.
+    /// </remarks>
+    private async Task<MessageContent> SelfHealRevokedBindingAsync(
+        ChannelSlashCommandContext context,
+        string reason,
+        string userMessage,
+        CancellationToken ct)
+    {
+        if (_actorRuntime is null)
+        {
+            _logger.LogWarning(
+                "/model encountered NyxID-side binding rejection ({Reason}) but IActorRuntime is not registered; cannot self-heal local actor. subject={Platform}:{Tenant}:{User}",
+                reason,
+                context.Subject.Platform, context.Subject.Tenant, context.Subject.ExternalUserId);
+            return new MessageContent { Text = userMessage };
+        }
+
+        var actorId = context.Subject.ToActorId();
+        try
+        {
+            var actor = await _actorRuntime
+                .CreateAsync<ExternalIdentityBindingGAgent>(actorId, ct)
+                .ConfigureAwait(false);
+            var envelope = new EventEnvelope
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                Payload = Any.Pack(new RevokeBindingCommand
+                {
+                    ExternalSubject = context.Subject.Clone(),
+                    Reason = reason,
+                }),
+                Route = new EnvelopeRoute
+                {
+                    Direct = new DirectRoute { TargetActorId = actorId },
+                },
+            };
+            await actor.HandleEventAsync(envelope, ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "/model self-healed local binding actor={ActorId} after NyxID-side rejection: reason={Reason}, subject={Platform}:{Tenant}:{User}",
+                actorId,
+                reason,
+                context.Subject.Platform, context.Subject.Tenant, context.Subject.ExternalUserId);
+        }
+        catch (Exception ex) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogError(ex,
+                "/model failed to self-heal local binding actor={ActorId} after NyxID-side rejection: reason={Reason}",
+                actorId,
+                reason);
+        }
+
+        return new MessageContent { Text = userMessage };
     }
 
     private async Task<MessageContent> HandleUseAsync(

--- a/agents/Aevatar.GAgents.NyxidChat/Slash/ModelChannelSlashCommandHandler.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/Slash/ModelChannelSlashCommandHandler.cs
@@ -85,7 +85,8 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
             return await SelfHealRevokedBindingAsync(
                 context,
                 reason: "auto_self_heal_remote_not_found",
-                userMessage: "NyxID 端 binding 已不可用,本地已自动清理。请发送 /init 完成新绑定。",
+                cleanedMessage: "NyxID 端 binding 已不可用,本地已自动清理。请发送 /init 完成新绑定。",
+                degradedMessage: "NyxID 端 binding 已不可用,但本地状态同步失败。请发送 /unbind 后再发送 /init 重新绑定。",
                 ct).ConfigureAwait(false);
         }
         catch (BindingRevokedException)
@@ -93,7 +94,8 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
             return await SelfHealRevokedBindingAsync(
                 context,
                 reason: "auto_self_heal_remote_revoked",
-                userMessage: "NyxID 端 binding 已失效,本地已自动清理。请发送 /init 完成新绑定。",
+                cleanedMessage: "NyxID 端 binding 已失效,本地已自动清理。请发送 /init 完成新绑定。",
+                degradedMessage: "NyxID 端 binding 已失效,但本地状态同步失败。请发送 /unbind 后再发送 /init 重新绑定。",
                 ct).ConfigureAwait(false);
         }
         catch (BindingScopeMismatchException)
@@ -101,7 +103,8 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
             return await SelfHealRevokedBindingAsync(
                 context,
                 reason: "auto_self_heal_scope_mismatch",
-                userMessage: "当前 NyxID 绑定缺少 LLM route 权限,本地已自动清理。请发送 /init 完成新绑定。",
+                cleanedMessage: "当前 NyxID 绑定缺少 LLM route 权限,本地已自动清理。请发送 /init 完成新绑定。",
+                degradedMessage: "当前 NyxID 绑定缺少 LLM route 权限,但本地状态同步失败。请发送 /unbind 后再发送 /init 重新绑定。",
                 ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or HttpRequestException or NotSupportedException)
@@ -121,17 +124,37 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
     /// revoked so the next <c>/init</c> goes through cleanly.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Mirrors the dispatch shape <see cref="UnbindChannelSlashCommandHandler"/>
-    /// uses for explicit /unbind. Differs in that the NyxID-side revoke is
-    /// already done (NyxID is the one telling us the binding is gone), so we
-    /// only need to flip the local actor — no second broker call. Failure to
-    /// dispatch the local revoke is logged at error level but still returns
-    /// a user-facing message; the user can retry the slash command.
+    /// uses for explicit /unbind, including the single retry on transient
+    /// dispatch failure. Differs in that the NyxID-side revoke is already
+    /// done (NyxID is the one telling us the binding is gone), so we only
+    /// need to flip the local actor — no second broker call.
+    /// </para>
+    /// <para>
+    /// Returns <paramref name="cleanedMessage"/> ONLY when the local revoke
+    /// envelope was actually dispatched. When <see cref="IActorRuntime"/> is
+    /// not registered, or both dispatch attempts threw, returns
+    /// <paramref name="degradedMessage"/> instead — claiming "本地已自动清理"
+    /// in those paths would lie to the user, sending them to <c>/init</c>
+    /// which would still see the stale local binding and refuse, recreating
+    /// the same loop this self-heal exists to break (PR #561 review).
+    /// </para>
     /// </remarks>
     private async Task<MessageContent> SelfHealRevokedBindingAsync(
         ChannelSlashCommandContext context,
         string reason,
-        string userMessage,
+        string cleanedMessage,
+        string degradedMessage,
+        CancellationToken ct)
+    {
+        var cleaned = await TryDispatchLocalBindingRevokeAsync(context, reason, ct).ConfigureAwait(false);
+        return new MessageContent { Text = cleaned ? cleanedMessage : degradedMessage };
+    }
+
+    private async Task<bool> TryDispatchLocalBindingRevokeAsync(
+        ChannelSlashCommandContext context,
+        string reason,
         CancellationToken ct)
     {
         if (_actorRuntime is null)
@@ -140,45 +163,61 @@ public sealed class ModelChannelSlashCommandHandler : IChannelSlashCommandHandle
                 "/model encountered NyxID-side binding rejection ({Reason}) but IActorRuntime is not registered; cannot self-heal local actor. subject={Platform}:{Tenant}:{User}",
                 reason,
                 context.Subject.Platform, context.Subject.Tenant, context.Subject.ExternalUserId);
-            return new MessageContent { Text = userMessage };
+            return false;
         }
 
         var actorId = context.Subject.ToActorId();
-        try
+        // Single retry mirrors UnbindChannelSlashCommandHandler — without it a
+        // one-off Orleans dispatch hiccup leaves the user thinking they're
+        // unbound while the readmodel still says they're bound (PR #521 review
+        // v4-pro on /unbind).
+        Exception? lastError = null;
+        for (var attempt = 1; attempt <= 2; attempt++)
         {
-            var actor = await _actorRuntime
-                .CreateAsync<ExternalIdentityBindingGAgent>(actorId, ct)
-                .ConfigureAwait(false);
-            var envelope = new EventEnvelope
+            try
             {
-                Id = Guid.NewGuid().ToString("N"),
-                Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                Payload = Any.Pack(new RevokeBindingCommand
+                var actor = await _actorRuntime
+                    .CreateAsync<ExternalIdentityBindingGAgent>(actorId, ct)
+                    .ConfigureAwait(false);
+                var envelope = new EventEnvelope
                 {
-                    ExternalSubject = context.Subject.Clone(),
-                    Reason = reason,
-                }),
-                Route = new EnvelopeRoute
-                {
-                    Direct = new DirectRoute { TargetActorId = actorId },
-                },
-            };
-            await actor.HandleEventAsync(envelope, ct).ConfigureAwait(false);
-            _logger.LogWarning(
-                "/model self-healed local binding actor={ActorId} after NyxID-side rejection: reason={Reason}, subject={Platform}:{Tenant}:{User}",
-                actorId,
-                reason,
-                context.Subject.Platform, context.Subject.Tenant, context.Subject.ExternalUserId);
-        }
-        catch (Exception ex) when (!ct.IsCancellationRequested)
-        {
-            _logger.LogError(ex,
-                "/model failed to self-heal local binding actor={ActorId} after NyxID-side rejection: reason={Reason}",
-                actorId,
-                reason);
+                    Id = Guid.NewGuid().ToString("N"),
+                    Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                    Payload = Any.Pack(new RevokeBindingCommand
+                    {
+                        ExternalSubject = context.Subject.Clone(),
+                        Reason = reason,
+                    }),
+                    Route = new EnvelopeRoute
+                    {
+                        Direct = new DirectRoute { TargetActorId = actorId },
+                    },
+                };
+                await actor.HandleEventAsync(envelope, ct).ConfigureAwait(false);
+                _logger.LogWarning(
+                    "/model self-healed local binding actor={ActorId} after NyxID-side rejection: reason={Reason}, attempt={Attempt}/2, subject={Platform}:{Tenant}:{User}",
+                    actorId,
+                    reason,
+                    attempt,
+                    context.Subject.Platform, context.Subject.Tenant, context.Subject.ExternalUserId);
+                return true;
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                lastError = ex;
+                _logger.LogWarning(ex,
+                    "/model: local binding self-heal dispatch failed on attempt {Attempt}/2 for actor={ActorId}, reason={Reason}",
+                    attempt,
+                    actorId,
+                    reason);
+            }
         }
 
-        return new MessageContent { Text = userMessage };
+        _logger.LogError(lastError,
+            "/model failed to self-heal local binding actor={ActorId} after 2 attempts; reason={Reason}. User has been told to /unbind manually.",
+            actorId,
+            reason);
+        return false;
     }
 
     private async Task<MessageContent> HandleUseAsync(

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -1177,6 +1177,117 @@ public sealed class ConversationGAgentDedupTests
         completed.Outbound.Text.ShouldBe("hello partial");
     }
 
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_WhenStreamingStartedThenLlmFailed_EditsPlaceholderInsteadOfReusingToken()
+    {
+        // Production scenario (issue observed 2026-05-03): user sends a message,
+        // streaming sink fires the first chunk via /reply (consuming the reply
+        // token, placing a "..." placeholder), the LLM call then 429's before
+        // any real chunk arrives. Pre-fix the failure path fell through to
+        // RunLlmReplyAsync which issued a fresh /reply against the dead token
+        // and got 401, leaving the user staring at "..." forever with no error
+        // text. Self-heal: TryCompleteStreamedReplyAsync's Failed branch must
+        // EDIT the placeholder via RunStreamChunkAsync with the failure text
+        // instead of reusing the consumed reply token.
+        var callCount = 0;
+        string? lastEditedText = null;
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (chunk, pmid) =>
+            {
+                callCount++;
+                lastEditedText = chunk.AccumulatedText;
+                if (callCount == 1)
+                    return ConversationStreamChunkResult.Succeeded("om_placeholder_consumed");
+                // Second call is the failure-edit initiated from the Failed
+                // branch; it succeeds in production because /reply/update
+                // works on the existing message regardless of the reply token.
+                return ConversationStreamChunkResult.Succeeded(pmid ?? "om_placeholder_consumed");
+            },
+        };
+        var (agent, store) = CreateAgent(runner, "conv-stream-failed-edit");
+        SeedReplyToken(agent, "act-stream-failed", "token-1", "relay-msg-1");
+
+        // First chunk lands the placeholder + consumes the reply token.
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-failed", "relay-msg-1", "..."));
+
+        var ready = new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-stream-failed",
+            RegistrationId = "reg-1",
+            SourceActorId = "llm-inbox",
+            Activity = CreateRelayActivity("act-stream-failed", "relay-msg-1"),
+            // Inbox runtime classifies the LLM exception into a user-facing
+            // message and stuffs it into Outbound.Text on the Failed event.
+            Outbound = new MessageContent { Text = "Sorry, the upstream model is rate limited (HTTP 429). Please try again in a moment." },
+            TerminalState = LlmReplyTerminalState.Failed,
+            ErrorCode = "llm_reply_failed",
+            ErrorSummary = "Upstream LLM rate limited.",
+            ReadyAtUnixMs = 100,
+        };
+        await agent.HandleLlmReplyReadyAsync(ready);
+
+        // Must NOT fall through to RunLlmReplyAsync (would 401 on the dead token).
+        runner.LlmReplyCount.ShouldBe(0);
+        // Two RunStreamChunkAsync calls: first chunk + failure-edit.
+        callCount.ShouldBe(2);
+        // The placeholder was edited with the classified failure text.
+        lastEditedText.ShouldContain("rate limited");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.Last().EventType.ShouldContain(nameof(ConversationTurnCompletedEvent));
+        var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events.Last().EventData.Value);
+        completed.Outbound.Text.ShouldContain("rate limited");
+        completed.SentActivityId.ShouldStartWith("nyx-relay-stream:");
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_WhenStreamingStartedAndFailedEditAlsoFails_PersistsLastFlushedAsTerminalWithoutReusingToken()
+    {
+        // Defence in depth for the Failed branch: if even the in-place edit
+        // is rejected (e.g. Lark refuses an edit of a message past its window),
+        // we still must NOT fall through to RunLlmReplyAsync. Persist what
+        // the user already sees (the streaming partial / placeholder) and
+        // stop — anything else would 401 on the dead token.
+        var callCount = 0;
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (_, _) =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    return ConversationStreamChunkResult.Succeeded("om_placeholder_consumed");
+                return ConversationStreamChunkResult.Failed("relay_reply_edit_unsupported", "lark refused", editUnsupported: true);
+            },
+        };
+        var (agent, store) = CreateAgent(runner, "conv-stream-failed-edit-deny");
+        SeedReplyToken(agent, "act-stream-failed-deny", "token-1", "relay-msg-1");
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-stream-failed-deny", "relay-msg-1", "first partial"));
+
+        var ready = new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-stream-failed-deny",
+            RegistrationId = "reg-1",
+            SourceActorId = "llm-inbox",
+            Activity = CreateRelayActivity("act-stream-failed-deny", "relay-msg-1"),
+            Outbound = new MessageContent { Text = "Sorry, the LLM call failed." },
+            TerminalState = LlmReplyTerminalState.Failed,
+            ErrorCode = "llm_reply_failed",
+            ErrorSummary = "Upstream failure.",
+            ReadyAtUnixMs = 100,
+        };
+        await agent.HandleLlmReplyReadyAsync(ready);
+
+        runner.LlmReplyCount.ShouldBe(0);
+        var events = await store.GetEventsAsync(agent.Id);
+        var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events.Last().EventData.Value);
+        // User keeps the last flushed partial since the edit attempt failed too.
+        completed.Outbound.Text.ShouldBe("first partial");
+    }
+
     private static LlmReplyStreamChunkEvent CreateStreamChunk(string correlationId, string replyMessageId, string accumulatedText) =>
         new()
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ModelSlashCommandHandlerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ModelSlashCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Identity;
 using Aevatar.GAgents.Channel.Identity.Abstractions;
@@ -6,8 +7,10 @@ using Aevatar.GAgents.NyxidChat.LlmSelection;
 using Aevatar.GAgents.NyxidChat.Slash;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
+using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Xunit;
 using StudioConfig = Aevatar.Studio.Application.Studio.Abstractions.UserConfig;
 
@@ -119,16 +122,92 @@ public sealed class ModelSlashCommandHandlerTests
     }
 
     [Fact]
-    public async Task List_ReturnsRebindMessage_WhenBindingScopeMissing()
+    public async Task List_SelfHealsAndRebindsMessage_WhenBindingScopeMissing()
     {
-        var handler = CreateHandler(broker: new ThrowingCapabilityBroker(
-            new BindingScopeMismatchException(Context().Subject)));
+        // NyxID rejects the binding's scope set: the binding was issued before
+        // aevatar's DCR started requesting `proxy`, so the broker can no longer
+        // mint LLM-API tokens for it. Self-heal by revoking the local actor so
+        // /init is unblocked, AND tell the user.
+        var actorRuntime = new RecordingActorRuntime();
+        var handler = CreateHandler(
+            broker: new ThrowingCapabilityBroker(new BindingScopeMismatchException(Context().Subject)),
+            actorRuntime: actorRuntime);
 
         var reply = await handler.HandleAsync(Context(), default);
 
         reply.Should().NotBeNull();
         reply!.Text.Should().Contain("缺少 LLM route 权限");
+        reply.Text.Should().Contain("已自动清理");
         reply.Text.Should().Contain("/init");
+        AssertRevokeBindingDispatched(actorRuntime, expectedReason: "auto_self_heal_scope_mismatch");
+    }
+
+    [Fact]
+    public async Task List_SelfHealsAndRebindsMessage_WhenBindingRevokedRemotely()
+    {
+        // NyxID itself returned binding_revoked (e.g. user revoked at NyxID admin
+        // or the binding tied to a re-DCR'd cluster client_id was invalidated).
+        // Wipe the local readmodel so /init isn't blocked by stale state.
+        var actorRuntime = new RecordingActorRuntime();
+        var handler = CreateHandler(
+            broker: new ThrowingCapabilityBroker(new BindingRevokedException(Context().Subject)),
+            actorRuntime: actorRuntime);
+
+        var reply = await handler.HandleAsync(Context(), default);
+
+        reply.Should().NotBeNull();
+        reply!.Text.Should().Contain("失效");
+        reply.Text.Should().Contain("已自动清理");
+        reply.Text.Should().Contain("/init");
+        AssertRevokeBindingDispatched(actorRuntime, expectedReason: "auto_self_heal_remote_revoked");
+    }
+
+    [Fact]
+    public async Task List_SelfHealsAndRebindsMessage_WhenBindingNotFoundRemotely()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var handler = CreateHandler(
+            broker: new ThrowingCapabilityBroker(new BindingNotFoundException(Context().Subject)),
+            actorRuntime: actorRuntime);
+
+        var reply = await handler.HandleAsync(Context(), default);
+
+        reply.Should().NotBeNull();
+        reply!.Text.Should().Contain("不可用");
+        reply.Text.Should().Contain("已自动清理");
+        reply.Text.Should().Contain("/init");
+        AssertRevokeBindingDispatched(actorRuntime, expectedReason: "auto_self_heal_remote_not_found");
+    }
+
+    [Fact]
+    public async Task List_StillReturnsUserMessage_WhenSelfHealActorRuntimeMissing()
+    {
+        // Deployments without IActorRuntime registered (CLI playground, certain
+        // demo hosts) should still surface the user-facing message — the
+        // self-heal degrades to "tell the user, hope they /unbind" rather than
+        // crashing the slash command.
+        var handler = CreateHandler(
+            broker: new ThrowingCapabilityBroker(new BindingRevokedException(Context().Subject)),
+            actorRuntime: null);
+
+        var reply = await handler.HandleAsync(Context(), default);
+
+        reply.Should().NotBeNull();
+        reply!.Text.Should().Contain("失效");
+    }
+
+    private static void AssertRevokeBindingDispatched(RecordingActorRuntime runtime, string expectedReason)
+    {
+        runtime.Dispatched.Should().ContainSingle("self-heal must dispatch exactly one local revoke");
+        var (actorId, envelope) = runtime.Dispatched[0];
+        actorId.Should().Be(Context().Subject.ToActorId());
+        envelope.Route.Direct.TargetActorId.Should().Be(actorId);
+
+        var revoke = envelope.Payload.Unpack<RevokeBindingCommand>();
+        revoke.Reason.Should().Be(expectedReason);
+        revoke.ExternalSubject.Platform.Should().Be("lark");
+        revoke.ExternalSubject.Tenant.Should().Be("tenant");
+        revoke.ExternalSubject.ExternalUserId.Should().Be("ou_user");
     }
 
     [Fact]
@@ -324,7 +403,8 @@ public sealed class ModelSlashCommandHandlerTests
         StubCatalogClient? catalog = null,
         StubUserConfigQueryPort? queryPort = null,
         StubUserConfigCommandService? commandService = null,
-        INyxIdCapabilityBroker? broker = null)
+        INyxIdCapabilityBroker? broker = null,
+        IActorRuntime? actorRuntime = null)
     {
         catalog ??= new StubCatalogClient();
         queryPort ??= new StubUserConfigQueryPort();
@@ -341,7 +421,39 @@ public sealed class ModelSlashCommandHandlerTests
             NullLogger<ModelChannelSlashCommandHandler>.Instance,
             options,
             selection,
-            new TextUserLlmOptionsRenderer());
+            new TextUserLlmOptionsRenderer(),
+            actorRuntime);
+    }
+
+    /// <summary>
+    /// Records every <see cref="EventEnvelope"/> the handler dispatches so
+    /// tests can assert the binding self-heal fires <c>RevokeBindingCommand</c>
+    /// to the local actor when NyxID rejects the binding.
+    /// </summary>
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatched { get; } = [];
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default) where TAgent : IAgent
+        {
+            var actor = Substitute.For<IActor>();
+            actor.Id.Returns(id ?? string.Empty);
+            actor.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>())
+                .Returns(call =>
+                {
+                    Dispatched.Add((id ?? string.Empty, call.Arg<EventEnvelope>()));
+                    return Task.CompletedTask;
+                });
+            return Task.FromResult(actor);
+        }
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task DestroyAsync(string id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IActor?> GetAsync(string id) => throw new NotImplementedException();
+        public Task<bool> ExistsAsync(string id) => throw new NotImplementedException();
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private static StudioConfig MakeConfig(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ModelSlashCommandHandlerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ModelSlashCommandHandlerTests.cs
@@ -180,12 +180,15 @@ public sealed class ModelSlashCommandHandlerTests
     }
 
     [Fact]
-    public async Task List_StillReturnsUserMessage_WhenSelfHealActorRuntimeMissing()
+    public async Task List_DegradesToUnbindGuidance_WhenSelfHealActorRuntimeMissing()
     {
         // Deployments without IActorRuntime registered (CLI playground, certain
-        // demo hosts) should still surface the user-facing message — the
-        // self-heal degrades to "tell the user, hope they /unbind" rather than
-        // crashing the slash command.
+        // demo hosts) cannot dispatch the local revoke. The handler MUST NOT
+        // claim "本地已自动清理" in that case — that would send the user to
+        // /init, which would still see the stale local binding and refuse,
+        // recreating the loop this PR exists to break (PR #561 review eanzhao
+        // / chatgpt-codex). Surface the degraded message that explicitly
+        // points at /unbind so the user has a path that works.
         var handler = CreateHandler(
             broker: new ThrowingCapabilityBroker(new BindingRevokedException(Context().Subject)),
             actorRuntime: null);
@@ -194,6 +197,31 @@ public sealed class ModelSlashCommandHandlerTests
 
         reply.Should().NotBeNull();
         reply!.Text.Should().Contain("失效");
+        reply.Text.Should().Contain("/unbind");
+        reply.Text.Should().NotContain("已自动清理");
+    }
+
+    [Fact]
+    public async Task List_DegradesToUnbindGuidance_WhenSelfHealDispatchKeepsThrowing()
+    {
+        // Even when IActorRuntime IS registered, runtime / Orleans hiccups can
+        // make every dispatch attempt throw. The handler retries once (mirrors
+        // UnbindChannelSlashCommandHandler's PR #521 v4-pro review fix); if
+        // both attempts fail, the local readmodel is still stale, so we MUST
+        // tell the user to /unbind manually instead of falsely claiming
+        // auto-clean succeeded.
+        var actorRuntime = new ThrowingActorRuntime();
+        var handler = CreateHandler(
+            broker: new ThrowingCapabilityBroker(new BindingRevokedException(Context().Subject)),
+            actorRuntime: actorRuntime);
+
+        var reply = await handler.HandleAsync(Context(), default);
+
+        reply.Should().NotBeNull();
+        reply!.Text.Should().Contain("失效");
+        reply.Text.Should().Contain("/unbind");
+        reply.Text.Should().NotContain("已自动清理");
+        actorRuntime.AttemptCount.Should().Be(2, "self-heal must attempt the local revoke twice before degrading");
     }
 
     private static void AssertRevokeBindingDispatched(RecordingActorRuntime runtime, string expectedReason)
@@ -445,6 +473,30 @@ public sealed class ModelSlashCommandHandlerTests
                     return Task.CompletedTask;
                 });
             return Task.FromResult(actor);
+        }
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default)
+            => throw new NotImplementedException();
+        public Task DestroyAsync(string id, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IActor?> GetAsync(string id) => throw new NotImplementedException();
+        public Task<bool> ExistsAsync(string id) => throw new NotImplementedException();
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Forces every <see cref="CreateAsync"/> call to throw, simulating a
+    /// transient Orleans / runtime hiccup so tests can pin the retry-once-
+    /// then-degrade contract on the binding self-heal path.
+    /// </summary>
+    private sealed class ThrowingActorRuntime : IActorRuntime
+    {
+        public int AttemptCount { get; private set; }
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default) where TAgent : IAgent
+        {
+            AttemptCount++;
+            throw new InvalidOperationException("simulated runtime dispatch failure");
         }
 
         public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default)


### PR DESCRIPTION
## Production failure modes (observed 2026-05-03)

Two independent symptoms left a Lark user visibly stuck even though the cluster was otherwise healthy. Both healed inside aevatar — no NyxID changes.

### #1 — `/llm` says "binding 已失效, 请 /init" while `/init` refuses with "已绑定"

After [PR #558](https://github.com/aevatarAI/aevatar/pull/558) re-DCR'd the cluster's OAuth client to add the `proxy` scope, the user's existing NyxID binding (issued for the previous `client_id`) was rejected at broker token-exchange. `ModelChannelSlashCommandHandler` caught the rejection and pointed the user at `/init` — which then refused because the local readmodel still holds the (now-dead) `binding_id`. The user loops forever.

Pod log evidence:
```
oauth_broker_service.rs: "Scope 'proxy' is not allowed for this binding"
ModelChannelSlashCommandHandler -> "当前 NyxID 绑定已失效, 请先发送 /init 重新绑定"
InitChannelSlashCommandHandler  -> "已绑定 NyxID 账号, 需要切换账号请先发送 /unbind 再发送 /init"
```

### #2 — Bot replies `...` forever after LLM failure

The streaming sink fires the first chunk via `channel-relay/reply`, consuming the single-use reply token and placing a `...` placeholder. If the LLM then fails (e.g. upstream 429 `usage_limit_reached`), pre-fix the runtime fell through to `RunLlmReplyAsync` which issued a fresh `/reply` against the dead token:

```
NyxID API request failed: POST .../api/v1/channel-relay/reply -> 401
body={"error":"unauthorized","message":"Unauthorized: Reply token already used"}
```

User stares at `...` with no error message ever appearing.

## Fixes (self-heal, no external repo changes)

### #1 — `ModelChannelSlashCommandHandler` self-heals stale local binding

When the broker throws `BindingRevokedException` / `BindingNotFoundException` / `BindingScopeMismatchException`, the handler now dispatches `RevokeBindingCommand` to the local `ExternalIdentityBindingGAgent` (reason `auto_self_heal_*`) so the readmodel flips to revoked, and tells the user the binding was cleared and `/init` will work next.

Mirrors the dispatch shape `UnbindChannelSlashCommandHandler` uses for explicit `/unbind`, but skips the NyxID-side revoke (NyxID is the one that just told us the binding is gone). When `IActorRuntime` is not registered (some demo / CLI hosts), degrades to "tell the user, hope they `/unbind`" rather than crashing the slash.

### #2 — `ConversationGAgent.TryCompleteStreamedReplyAsync` handles the `Failed` branch

When streaming has already committed the placeholder (`state.PlatformMessageId` set, not `Disabled`), the `Failed` branch now edits the placeholder in place via `RunStreamChunkAsync` (which uses `channel-relay/reply/update` — no reply token needed) with the classified failure text, then persists `ConversationTurnCompletedEvent` so the runtime envelope retry loop does not refire and consume the dead token again.

If the edit also fails (rare — Lark can refuse stale-message edits), persists the last flushed partial as terminal: same defence-in-depth pattern PR #374 already established for the `Completed` path.

## Tests

- **4 new** `ModelSlashCommandHandlerTests` pinning the binding self-heal for each rejection shape (`scope_mismatch`, `remote_revoked`, `remote_not_found`) plus the degraded-path when `IActorRuntime` is not registered. Asserts a `RevokeBindingCommand` envelope is dispatched to the local actor with the correct subject + reason code.
- **2 new** `ConversationGAgentDedupTests`:
  - `WhenStreamingStartedThenLlmFailed_EditsPlaceholderInsteadOfReusingToken` — pins the placeholder edit fires + `RunLlmReplyAsync` is NOT invoked + persisted outbound reflects the failure text.
  - `WhenStreamingStartedAndFailedEditAlsoFails_PersistsLastFlushedAsTerminalWithoutReusingToken` — pins the defence-in-depth fallback when the edit attempt is also rejected.

## Verification

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` (851/851)
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --filter ~ConversationGAgentDedupTests` (36/36)
- `dotnet test test/Aevatar.Foundation.Core.Tests/Aevatar.Foundation.Core.Tests.csproj` (230/230)
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/query_projection_priming_guard.sh`

## Refs

- Issue #549 (binding readmodel + projection scope; same root family)
- PR #558 (added `proxy` scope to DCR — exposed the binding-revoked loop here)
- PR #374 (original streaming-final-edit defence-in-depth pattern this PR extends to the Failed branch)