### PR TITLE
Propagate reasoning_content through LLM pipeline (fixes #563)

### DIFF
--- a/src/Aevatar.AI.Abstractions/LLMProviders/LLMRequest.cs
+++ b/src/Aevatar.AI.Abstractions/LLMProviders/LLMRequest.cs
@@ -67,6 +67,9 @@ public sealed class ChatMessage
     /// <summary>Text content; for the tool role, this represents the tool execution result.</summary>
     public string? Content { get; init; }
 
+    /// <summary>思考内容（如果适用）。</summary>
+    public string? ReasoningContent { get; init; }
+
     /// <summary>Multimodal content parts (text/image). When present, the provider should construct the message from the parts first.</summary>
     public IReadOnlyList<ContentPart>? ContentParts { get; init; }
 
@@ -83,7 +86,7 @@ public sealed class ChatMessage
     public static ChatMessage User(string content) => new() { Role = "user", Content = content };
 
     /// <summary>Creates an assistant-role message.</summary>
-    public static ChatMessage Assistant(string content) => new() { Role = "assistant", Content = content };
+    public static ChatMessage Assistant(string content, string? reasoningContent = null) => new() { Role = "assistant", Content = content, ReasoningContent = reasoningContent };
 
     /// <summary>Creates a tool-role message carrying the tool execution result.</summary>
     /// <param name="callId">The corresponding tool_call Id.</param>

--- a/src/Aevatar.AI.Abstractions/LLMProviders/LLMResponse.cs
+++ b/src/Aevatar.AI.Abstractions/LLMProviders/LLMResponse.cs
@@ -11,6 +11,9 @@ public sealed class LLMResponse
     /// <summary>LLM 生成的文本内容。</summary>
     public string? Content { get; init; }
 
+    /// <summary>LLM 生成的思考内容（如果适用）。</summary>
+    public string? ReasoningContent { get; init; }
+
     /// <summary>LLM 生成的多模态内容分片。</summary>
     public IReadOnlyList<ContentPart>? ContentParts { get; init; }
 

--- a/src/Aevatar.AI.Core/Chat/ChatHistory.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatHistory.cs
@@ -68,6 +68,7 @@ public sealed class ChatHistory
         {
             Role = m.Role,
             Content = m.Content,
+            ReasoningContent = m.ReasoningContent,
             ContentParts = m.ContentParts?.Select(ClonePart).ToArray(),
             ToolCallId = m.ToolCallId,
             ToolCalls = m.ToolCalls?.Select(CloneToolCall).ToArray(),
@@ -84,6 +85,7 @@ public sealed class ChatHistory
             {
                 Role = m.Role,
                 Content = m.Content,
+                ReasoningContent = m.ReasoningContent,
                 ContentParts = m.ContentParts?.Select(ClonePart).ToArray(),
                 ToolCallId = m.ToolCallId,
                 ToolCalls = m.ToolCalls?.Select(CloneToolCall).ToArray(),
@@ -120,6 +122,7 @@ public sealed class SerializableMessage
 {
     public required string Role { get; init; }
     public string? Content { get; init; }
+    public string? ReasoningContent { get; init; }
     public IReadOnlyList<ContentPart>? ContentParts { get; init; }
     public string? ToolCallId { get; init; }
     public IReadOnlyList<ToolCall>? ToolCalls { get; init; }

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -315,7 +315,7 @@ public sealed class ChatRuntime
                         if (roundResult.Terminated)
                         {
                             streamingExecutor.Discard();
-                            AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, roundResult.ToolCalls);
+                            AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, roundResult.ReasoningContent, roundResult.ToolCalls);
                             finalContent = roundResult.Content;
                             break;
                         }
@@ -352,12 +352,12 @@ public sealed class ChatRuntime
 
                                     if (fallbackBlocked)
                                     {
-                                        AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, toolCalls: null);
+                                        AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, reasoningContent: null, toolCalls: null);
                                         finalContent = parsed.CleanedContent;
                                         break;
                                     }
 
-                                    AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, toolCalls: null);
+                                    AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, reasoningContent: null, toolCalls: null);
 
                                     var textToolCallMsg = new ChatMessage
                                     {
@@ -388,7 +388,7 @@ public sealed class ChatRuntime
                             if (ToolCallLoop.IsLengthTruncated(roundResult.FinishReason)
                                 && lengthRecoveryCount < ToolCallLoop.MaxLengthRecoveries)
                             {
-                                AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, toolCalls: null);
+                                AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, roundResult.ReasoningContent, toolCalls: null);
                                 var nudge = ChatMessage.User(ToolCallLoop.LengthRecoveryNudge);
                                 messages.Add(nudge);
                                 pendingHistoryMessages.Add(nudge);
@@ -396,7 +396,7 @@ public sealed class ChatRuntime
                                 continue;
                             }
 
-                            AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, toolCalls: null);
+                            AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, roundResult.ReasoningContent, toolCalls: null);
                             finalContent = roundResult.Content;
                             break;
                         }
@@ -421,7 +421,7 @@ public sealed class ChatRuntime
                             if (postSamplingCtx.Items.TryGetValue("block_tool_calls", out var block)
                                 && block is true)
                             {
-                                AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, toolCalls: null);
+                                AppendAssistantMessage(messages, pendingHistoryMessages, roundResult.Content, roundResult.ReasoningContent, toolCalls: null);
                                 finalContent = roundResult.Content;
                                 break;
                             }
@@ -488,7 +488,7 @@ public sealed class ChatRuntime
                             : null;
                         if (finalParsed?.ToolCalls.Count > 0)
                         {
-                            AppendAssistantMessage(messages, pendingHistoryMessages, finalParsed.CleanedContent, toolCalls: null);
+                            AppendAssistantMessage(messages, pendingHistoryMessages, finalParsed.CleanedContent, reasoningContent: null, toolCalls: null);
 
                             var finalToolCallMsg = new ChatMessage
                             {
@@ -527,12 +527,12 @@ public sealed class ChatRuntime
                             var summaryRound = await StreamLlmRoundAsync(
                                 provider, summaryRequest, channel.Writer, runToken,
                                 () => wroteOutput = true);
-                            AppendAssistantMessage(messages, pendingHistoryMessages, summaryRound.Content, toolCalls: null);
+                            AppendAssistantMessage(messages, pendingHistoryMessages, summaryRound.Content, summaryRound.ReasoningContent, toolCalls: null);
                             finalContent = summaryRound.Content;
                         }
                         else
                         {
-                            AppendAssistantMessage(messages, pendingHistoryMessages, finalRound.Content, toolCalls: null);
+                            AppendAssistantMessage(messages, pendingHistoryMessages, finalRound.Content, finalRound.ReasoningContent, toolCalls: null);
                             finalContent = finalRound.Content;
                         }
                     }
@@ -635,6 +635,7 @@ public sealed class ChatRuntime
         AnnotateRequestIdentity(llmCallContext);
 
         string? streamedContent = null;
+        string? streamedReasoningContent = null;
         TokenUsage? streamedUsage = null;
         IReadOnlyList<ToolCall>? streamedToolCalls = null;
         string? streamedFinishReason = null;
@@ -644,6 +645,7 @@ public sealed class ChatRuntime
             if (llmCallContext.Terminate) return;
 
             var full = new StringBuilder();
+            var fullReasoning = new StringBuilder();
             TokenUsage? usage = null;
             string? finishReason = null;
             var toolCalls = onToolCallCompleted != null
@@ -652,7 +654,7 @@ public sealed class ChatRuntime
 
             await foreach (var chunk in provider.ChatStreamAsync(llmCallContext.Request, ct))
             {
-                var normalizedChunk = NormalizeStreamChunk(chunk, toolCalls, full, ref usage, ref finishReason);
+                var normalizedChunk = NormalizeStreamChunk(chunk, toolCalls, full, fullReasoning, ref usage, ref finishReason);
                 if (normalizedChunk == null)
                     continue;
 
@@ -661,6 +663,7 @@ public sealed class ChatRuntime
             }
 
             streamedContent = full.Length > 0 ? full.ToString() : null;
+            streamedReasoningContent = fullReasoning.Length > 0 ? fullReasoning.ToString() : null;
             streamedUsage = usage;
             streamedFinishReason = finishReason;
             var finalizedToolCalls = toolCalls.BuildToolCalls();
@@ -668,6 +671,7 @@ public sealed class ChatRuntime
             llmCallContext.Response = new LLMResponse
             {
                 Content = streamedContent,
+                ReasoningContent = streamedReasoningContent,
                 Usage = streamedUsage,
                 ToolCalls = streamedToolCalls,
                 FinishReason = finishReason,
@@ -677,6 +681,7 @@ public sealed class ChatRuntime
         if (llmCallContext.Terminate)
         {
             streamedContent = llmCallContext.Response?.Content;
+            streamedReasoningContent = llmCallContext.Response?.ReasoningContent;
             streamedUsage = llmCallContext.Response?.Usage;
             streamedToolCalls = llmCallContext.Response?.ToolCalls;
 
@@ -693,6 +698,7 @@ public sealed class ChatRuntime
         var response = llmCallContext.Response ?? new LLMResponse
         {
             Content = streamedContent,
+            ReasoningContent = streamedReasoningContent,
             Usage = streamedUsage,
             ToolCalls = streamedToolCalls,
         };
@@ -700,22 +706,24 @@ public sealed class ChatRuntime
         llmHookContext.LLMResponse = response;
         if (_hooks != null) await _hooks.RunLLMRequestEndAsync(llmHookContext, ct);
 
-        return new StreamingRoundResult(response.Content, response.ToolCalls, llmCallContext.Terminate, response.FinishReason ?? streamedFinishReason);
+        return new StreamingRoundResult(response.Content, response.ReasoningContent, response.ToolCalls, llmCallContext.Terminate, response.FinishReason ?? streamedFinishReason);
     }
 
     private static void AppendAssistantMessage(
         List<ChatMessage> messages,
         List<ChatMessage> pendingHistoryMessages,
         string? content,
+        string? reasoningContent,
         IReadOnlyList<ToolCall>? toolCalls)
     {
-        if (string.IsNullOrEmpty(content) && toolCalls is not { Count: > 0 })
+        if (string.IsNullOrEmpty(content) && string.IsNullOrEmpty(reasoningContent) && toolCalls is not { Count: > 0 })
             return;
 
         var assistantMessage = new ChatMessage
         {
             Role = "assistant",
             Content = content,
+            ReasoningContent = reasoningContent,
             ToolCalls = toolCalls,
         };
         messages.Add(assistantMessage);
@@ -798,6 +806,7 @@ public sealed class ChatRuntime
         LLMStreamChunk chunk,
         StreamingToolCallAccumulator toolCalls,
         StringBuilder fullContent,
+        StringBuilder fullReasoningContent,
         ref TokenUsage? usage,
         ref string? finishReason)
     {
@@ -807,6 +816,9 @@ public sealed class ChatRuntime
 
         if (!string.IsNullOrEmpty(chunk.DeltaContent))
             fullContent.Append(chunk.DeltaContent);
+
+        if (!string.IsNullOrEmpty(chunk.DeltaReasoningContent))
+            fullReasoningContent.Append(chunk.DeltaReasoningContent);
 
         if (chunk.Usage != null)
             usage = chunk.Usage;
@@ -913,6 +925,7 @@ public sealed class ChatRuntime
 
     private sealed record StreamingRoundResult(
         string? Content,
+        string? ReasoningContent,
         IReadOnlyList<ToolCall>? ToolCalls,
         bool Terminated,
         string? FinishReason);

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -352,12 +352,12 @@ public sealed class ChatRuntime
 
                                     if (fallbackBlocked)
                                     {
-                                        AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, reasoningContent: null, toolCalls: null);
+                                        AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, roundResult.ReasoningContent, toolCalls: null);
                                         finalContent = parsed.CleanedContent;
                                         break;
                                     }
 
-                                    AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, reasoningContent: null, toolCalls: null);
+                                    AppendAssistantMessage(messages, pendingHistoryMessages, parsed.CleanedContent, roundResult.ReasoningContent, toolCalls: null);
 
                                     var textToolCallMsg = new ChatMessage
                                     {
@@ -850,6 +850,9 @@ public sealed class ChatRuntime
     private static IReadOnlyList<LLMStreamChunk> BuildSyntheticChunks(LLMResponse response)
     {
         var chunks = new List<LLMStreamChunk>();
+
+        if (!string.IsNullOrEmpty(response.ReasoningContent))
+            chunks.Add(new LLMStreamChunk { DeltaReasoningContent = response.ReasoningContent });
 
         if (!string.IsNullOrEmpty(response.Content))
             chunks.Add(new LLMStreamChunk { DeltaContent = response.Content });

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -111,7 +111,7 @@ public sealed class ToolCallLoop
                     && block is true)
                 {
                     if (response.Content != null)
-                        messages.Add(ChatMessage.Assistant(response.Content));
+                        messages.Add(ChatMessage.Assistant(response.Content, response.ReasoningContent));
                     return response.Content;
                 }
             }
@@ -144,13 +144,13 @@ public sealed class ToolCallLoop
                                 && block is true)
                             {
                                 if (parsed.CleanedContent != null)
-                                    messages.Add(ChatMessage.Assistant(parsed.CleanedContent));
+                                    messages.Add(ChatMessage.Assistant(parsed.CleanedContent, response.ReasoningContent));
                                 return parsed.CleanedContent;
                             }
                         }
 
                         if (!string.IsNullOrWhiteSpace(parsed.CleanedContent))
-                            messages.Add(ChatMessage.Assistant(parsed.CleanedContent));
+                            messages.Add(ChatMessage.Assistant(parsed.CleanedContent, response.ReasoningContent));
                         messages.Add(new ChatMessage { Role = "assistant", ToolCalls = parsed.ToolCalls });
                         await ExecuteToolCallsCoreAsync(parsed.ToolCalls, messages, ct);
                         accumulatedContent = null;
@@ -168,7 +168,7 @@ public sealed class ToolCallLoop
                     {
                         accumulatedContent ??= new StringBuilder();
                         accumulatedContent.Append(response.Content);
-                        messages.Add(ChatMessage.Assistant(response.Content));
+                        messages.Add(ChatMessage.Assistant(response.Content, response.ReasoningContent));
                     }
                     messages.Add(ChatMessage.User(LengthRecoveryNudge));
                     lengthRecoveryCount++;
@@ -186,7 +186,7 @@ public sealed class ToolCallLoop
                 }
 
                 if (resultContent != null)
-                    messages.Add(ChatMessage.Assistant(resultContent));
+                    messages.Add(ChatMessage.Assistant(resultContent, response.ReasoningContent));
                 return resultContent;
             }
 
@@ -222,7 +222,7 @@ public sealed class ToolCallLoop
             if (finalParsed.ToolCalls.Count > 0)
             {
                 if (!string.IsNullOrWhiteSpace(finalParsed.CleanedContent))
-                    messages.Add(ChatMessage.Assistant(finalParsed.CleanedContent));
+                    messages.Add(ChatMessage.Assistant(finalParsed.CleanedContent, finalResponse?.ReasoningContent));
                 messages.Add(new ChatMessage { Role = "assistant", ToolCalls = finalParsed.ToolCalls });
                 await ExecuteToolCallsCoreAsync(finalParsed.ToolCalls, messages, ct);
 
@@ -241,11 +241,11 @@ public sealed class ToolCallLoop
                 var (summaryResponse, _) = await InvokeLlmAsync(provider, summaryRequest, ct);
                 var summaryContent = summaryResponse?.Content;
                 if (summaryContent != null)
-                    messages.Add(ChatMessage.Assistant(summaryContent));
+                    messages.Add(ChatMessage.Assistant(summaryContent, summaryResponse?.ReasoningContent));
                 return summaryContent;
             }
 
-            messages.Add(ChatMessage.Assistant(finalContent));
+            messages.Add(ChatMessage.Assistant(finalContent, finalResponse?.ReasoningContent));
         }
 
         return finalContent;

--- a/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs
@@ -440,6 +440,7 @@ public sealed class MEAILLMProvider : ILLMProvider
         // ChatResponse.Messages contains all reply messages
         var lastMessage = response.Messages.LastOrDefault();
         var content = ExtractMessageText(lastMessage);
+        var reasoningContent = ExtractReasoningContent(lastMessage);
         List<ToolCall>? toolCalls = null;
         List<ContentPart>? contentParts = null;
 
@@ -478,6 +479,7 @@ public sealed class MEAILLMProvider : ILLMProvider
         return new LLMResponse
         {
             Content = content,
+            ReasoningContent = reasoningContent,
             ContentParts = contentParts,
             ToolCalls = toolCalls,
             Usage = usage,
@@ -505,6 +507,22 @@ public sealed class MEAILLMProvider : ILLMProvider
         return textParts.Count == 0
             ? message.Text
             : string.Concat(textParts);
+    }
+
+    private static string? ExtractReasoningContent(Microsoft.Extensions.AI.ChatMessage? message)
+    {
+        if (message?.Contents is not { Count: > 0 })
+            return null;
+
+        var reasoningParts = message.Contents
+            .OfType<TextReasoningContent>()
+            .Select(part => part.Text)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .ToList();
+
+        return reasoningParts.Count == 0
+            ? null
+            : string.Concat(reasoningParts);
     }
 
     private static ToolCall ConvertFunctionCall(FunctionCallContent functionCall)

--- a/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs
@@ -242,10 +242,15 @@ public sealed class MEAILLMProvider : ILLMProvider
                 meaiMsg.Contents.Add(new FunctionResultContent(msg.ToolCallId, BuildToolResultPayload(msg)));
             }
 
+            if (msg.Role == "assistant" && !string.IsNullOrEmpty(msg.ReasoningContent))
+                meaiMsg.Contents.Add(new TextReasoningContent(msg.ReasoningContent));
+
             // Handle assistant tool calls
             if (msg.ToolCalls is { Count: > 0 })
             {
                 meaiMsg.Contents.Clear();
+                if (!string.IsNullOrEmpty(msg.ReasoningContent))
+                    meaiMsg.Contents.Add(new TextReasoningContent(msg.ReasoningContent));
                 if (msg.ContentParts is { Count: > 0 })
                     AppendContentParts(meaiMsg, msg.ContentParts);
                 else if (msg.Content != null)

--- a/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
@@ -53,6 +53,98 @@ public class AIComponentCoverageTests
     }
 
     [Fact]
+    public void ChatHistory_ShouldPreserveReasoningContentOnExportImport()
+    {
+        var history = new ChatHistory();
+        history.Add(new AevatarChatMessage { Role = "assistant", Content = "hello", ReasoningContent = "thinking..." });
+        history.Add(new AevatarChatMessage { Role = "user", Content = "follow-up" });
+
+        var exported = history.Export();
+        exported[0].ReasoningContent.Should().Be("thinking...");
+        exported[1].ReasoningContent.Should().BeNull();
+
+        var imported = new ChatHistory();
+        imported.Import(exported);
+        imported.Messages[0].ReasoningContent.Should().Be("thinking...");
+        imported.Messages[1].ReasoningContent.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MEAILLMProvider_ConvertMessages_ShouldIncludeReasoningContent()
+    {
+        IReadOnlyList<MeaiChatMessage>? capturedMessages = null;
+        var client = new StubChatClient
+        {
+            OnGetResponse = (messages, _, _) =>
+            {
+                capturedMessages = messages.ToList();
+                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "ok")));
+            },
+        };
+
+        var provider = new MEAILLMProvider("meai-reasoning-outbound", client);
+        await provider.ChatAsync(new LLMRequest
+        {
+            Messages =
+            [
+                new AevatarChatMessage { Role = "user", Content = "hi" },
+                new AevatarChatMessage { Role = "assistant", Content = "thought", ReasoningContent = "reasoning-text" },
+            ],
+        });
+
+        capturedMessages.Should().NotBeNull();
+        capturedMessages!.Should().HaveCount(2);
+        var assistantMsg = capturedMessages[1];
+        assistantMsg.Role.Should().Be(ChatRole.Assistant);
+        assistantMsg.Contents.OfType<TextReasoningContent>().Should().ContainSingle()
+            .Which.Text.Should().Be("reasoning-text");
+    }
+
+    [Fact]
+    public async Task MEAILLMProvider_ConvertMessages_ShouldIncludeReasoningContentWithToolCalls()
+    {
+        IReadOnlyList<MeaiChatMessage>? capturedMessages = null;
+        var client = new StubChatClient
+        {
+            OnGetResponse = (messages, _, _) =>
+            {
+                capturedMessages = messages.ToList();
+                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "ok")));
+            },
+        };
+
+        var provider = new MEAILLMProvider("meai-reasoning-tools", client);
+        await provider.ChatAsync(new LLMRequest
+        {
+            Messages =
+            [
+                new AevatarChatMessage { Role = "user", Content = "hi" },
+                new AevatarChatMessage
+                {
+                    Role = "assistant",
+                    Content = "using tool",
+                    ReasoningContent = "thinking about tools",
+                    ToolCalls =
+                    [
+                        new Aevatar.AI.Abstractions.LLMProviders.ToolCall
+                        {
+                            Id = "tc1", Name = "search", ArgumentsJson = "{}",
+                        },
+                    ],
+                },
+                new AevatarChatMessage { Role = "tool", ToolCallId = "tc1", Content = "result" },
+            ],
+        });
+
+        capturedMessages.Should().NotBeNull();
+        var assistantWithTools = capturedMessages![1];
+        assistantWithTools.Role.Should().Be(ChatRole.Assistant);
+        assistantWithTools.Contents.OfType<TextReasoningContent>().Should().ContainSingle()
+            .Which.Text.Should().Be("thinking about tools");
+        assistantWithTools.Contents.OfType<FunctionCallContent>().Should().ContainSingle();
+    }
+
+    [Fact]
     public void PromptTemplate_Render_ShouldApplyDefaultsAndRuntimeAndExamples()
     {
         var template = new PromptTemplate

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -350,6 +350,37 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
+    public async Task ChatStreamAsync_WhenLlmMiddlewareTerminates_ShouldEmitReasoningContentChunk()
+    {
+        var provider = new StreamingProvider(["ignored"]);
+        var runtime = CreateRuntime(
+            provider,
+            streamBufferCapacity: 2,
+            llmMiddlewares:
+            [
+                new DelegateLlmCallMiddleware((context, _) =>
+                {
+                    context.Terminate = true;
+                    context.Response = new LLMResponse
+                    {
+                        Content = "answer",
+                        ReasoningContent = "thinking-step",
+                    };
+                    return Task.CompletedTask;
+                }),
+            ]);
+        var chunks = new List<LLMStreamChunk>();
+
+        await foreach (var chunk in runtime.ChatStreamAsync("hello"))
+            chunks.Add(chunk);
+
+        chunks.Should().Contain(x => x.DeltaReasoningContent == "thinking-step");
+        chunks.Should().Contain(x => x.DeltaContent == "answer");
+        chunks.Should().Contain(x => x.IsLast);
+        provider.StreamCallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task ChatStreamAsync_WhenProviderEmitsEmptyNonTerminalChunk_ShouldFilterItOut()
     {
         var provider = new StreamingProvider(

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -470,6 +470,107 @@ public class ToolCallLoopTests
         ToolCallLoop.IsLengthTruncated("").Should().BeFalse();
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenNoToolCalls_ShouldPropagateReasoningContent()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse { Content = "answer", ReasoningContent = "thinking-step" },
+        ]);
+        var loop = new ToolCallLoop(new ToolManager());
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 2, CancellationToken.None);
+
+        result.Should().Be("answer");
+        messages.Should().ContainSingle(m => m.Role == "assistant");
+        var assistant = messages.Single(m => m.Role == "assistant");
+        assistant.Content.Should().Be("answer");
+        assistant.ReasoningContent.Should().Be("thinking-step");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenToolCallThenFollowUp_ShouldPropagateReasoningOnBothRounds()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                Content = "will use tool",
+                ReasoningContent = "first-thought",
+                ToolCalls =
+                [
+                    new ToolCall { Id = "tc-1", Name = "echo", ArgumentsJson = "{}" },
+                ],
+            },
+            new LLMResponse { Content = "final", ReasoningContent = "second-thought" },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("echo", _ => "ok"));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 3, CancellationToken.None);
+
+        result.Should().Be("final");
+        var finalAssistant = messages.Last(m => m.Role == "assistant");
+        finalAssistant.ReasoningContent.Should().Be("second-thought");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenLengthRecovery_ShouldPropagateReasoningContent()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                Content = "partial",
+                ReasoningContent = "thinking-partial",
+                FinishReason = "length",
+            },
+            new LLMResponse
+            {
+                Content = " continued",
+                ReasoningContent = "thinking-continued",
+            },
+        ]);
+        var loop = new ToolCallLoop(new ToolManager());
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 3, CancellationToken.None);
+
+        result.Should().Be("partial continued");
+        var partialAssistant = messages.First(m => m.Role == "assistant");
+        partialAssistant.ReasoningContent.Should().Be("thinking-partial");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenMaxRoundsExhausted_ShouldPropagateReasoningInFinalCall()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                ToolCalls = [new ToolCall { Id = "tc-1", Name = "echo", ArgumentsJson = "{}" }],
+            },
+            new LLMResponse { Content = "summary", ReasoningContent = "final-thought" },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("echo", _ => "ok"));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 1, CancellationToken.None);
+
+        result.Should().Be("summary");
+        var lastAssistant = messages.Last(m => m.Role == "assistant");
+        lastAssistant.ReasoningContent.Should().Be("final-thought");
+    }
+
     [Theory]
     [InlineData("base64")]
     [InlineData("data")]

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -571,6 +571,100 @@ public class ToolCallLoopTests
         lastAssistant.ReasoningContent.Should().Be("final-thought");
     }
 
+    [Fact]
+    public async Task ExecuteAsync_WhenHookBlocksToolCalls_ShouldPropagateReasoningContent()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                Content = "blocked-content",
+                ReasoningContent = "blocked-thinking",
+                ToolCalls = [new ToolCall { Id = "tc-1", Name = "echo", ArgumentsJson = "{}" }],
+            },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("echo", _ => "ok"));
+        var hook = new BlockPostSamplingHook();
+        var loop = new ToolCallLoop(tools, new AgentHookPipeline([hook]));
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 2, CancellationToken.None);
+
+        result.Should().Be("blocked-content");
+        var assistant = messages.Single(m => m.Role == "assistant");
+        assistant.Content.Should().Be("blocked-content");
+        assistant.ReasoningContent.Should().Be("blocked-thinking");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDsmlTextToolCalls_ShouldPropagateReasoningContent()
+    {
+        var dsmlContent = "I will search now.\n<function_calls><invoke name=\"echo\"><parameter name=\"q\">test</parameter></invoke></function_calls>";
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse { Content = dsmlContent, ReasoningContent = "dsml-thinking" },
+            new LLMResponse { Content = "final-after-dsml", ReasoningContent = "final-thinking" },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("echo", _ => "echo-result"));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 3, CancellationToken.None);
+
+        result.Should().Be("final-after-dsml");
+        var dsmlAssistant = messages.First(m => m.Role == "assistant" && m.ReasoningContent == "dsml-thinking");
+        dsmlAssistant.Should().NotBeNull();
+        var finalAssistant = messages.Last(m => m.Role == "assistant");
+        finalAssistant.ReasoningContent.Should().Be("final-thinking");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDsmlToolCallBlockedByHook_ShouldPropagateReasoningContent()
+    {
+        var dsmlContent = "I will search now.\n<function_calls><invoke name=\"echo\"><parameter name=\"q\">test</parameter></invoke></function_calls>";
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse { Content = dsmlContent, ReasoningContent = "blocked-dsml-thinking" },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("echo", _ => "ok"));
+        var hook = new BlockPostSamplingHook();
+        var loop = new ToolCallLoop(tools, new AgentHookPipeline([hook]));
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 2, CancellationToken.None);
+
+        messages.Should().Contain(m => m.Role == "assistant" && m.ReasoningContent == "blocked-dsml-thinking");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenMaxRoundsExhaustedAndDsmlInFinalCall_ShouldPropagateReasoning()
+    {
+        var dsmlContent = "Final search.\n<function_calls><invoke name=\"echo\"><parameter name=\"q\">final</parameter></invoke></function_calls>";
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse { ToolCalls = [new ToolCall { Id = "tc-1", Name = "echo", ArgumentsJson = "{}" }] },
+            new LLMResponse { Content = dsmlContent, ReasoningContent = "final-dsml-thinking" },
+            new LLMResponse { Content = "summary", ReasoningContent = "summary-thinking" },
+        ]);
+        var tools = new ToolManager();
+        tools.Register(new DelegateTool("echo", _ => "ok"));
+        var loop = new ToolCallLoop(tools);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 1, CancellationToken.None);
+
+        result.Should().Be("summary");
+        var lastAssistant = messages.Last(m => m.Role == "assistant");
+        lastAssistant.ReasoningContent.Should().Be("summary-thinking");
+    }
+
     [Theory]
     [InlineData("base64")]
     [InlineData("data")]
@@ -701,6 +795,18 @@ public class ToolCallLoopTests
             }
 
             await next();
+        }
+    }
+
+    private sealed class BlockPostSamplingHook : IAIGAgentExecutionHook
+    {
+        public string Name => "block-post-sampling";
+        public int Priority => 0;
+
+        public Task OnPostSamplingAsync(AIGAgentExecutionHookContext ctx, CancellationToken ct)
+        {
+            ctx.Items["block_tool_calls"] = true;
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `ReasoningContent` field to `ChatMessage`, `LLMResponse`, and `LLMStreamChunk` to carry thinking-mode reasoning content through the pipeline
- Propagates reasoning content through `ChatRuntime` streaming rounds and appends it to conversation history for multi-turn conversations
- Implements `ExtractReasoningContent` in `MEAILLMProvider` for both streaming and non-streaming paths
- Fixes DeepSeek v4-pro HTTP 400: "The `reasoning_content` in the thinking mode must be passed back to the API"

## Impact

- `src/Aevatar.AI.Abstractions/LLMProviders/LLMRequest.cs` — `ChatMessage.ReasoningContent`
- `src/Aevatar.AI.Abstractions/LLMProviders/LLMResponse.cs` — `LLMResponse.ReasoningContent`, `LLMStreamChunk.DeltaReasoningContent`
- `src/Aevatar.AI.Core/Chat/ChatRuntime.cs` — streaming round propagation + history append
- `src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs` — `ExtractReasoningContent` + `ConvertResponse` wiring

## Verification

- `dotnet build` — 0 errors
- `dotnet test test/Aevatar.AI.Tests` — 500 passed, 0 failed
- `bash tools/ci/architecture_guards.sh` — all passed

Closes #563