### PR TITLE
fix(skill-runner): treat zero-tool-call runs as failure for fetch-and-summarize skills (#439)

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTemplates.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTemplates.cs
@@ -53,7 +53,14 @@ public static class AgentBuilderTemplates
             skillPrompt,
             executionPrompt,
             ["api-github", "api-lark-bot"],
-            repoList);
+            repoList,
+            // daily_report is a fetch-and-summarize skill: every legitimate run must hit
+            // the GitHub proxy at least once. A run that finishes with zero nyxid_proxy
+            // successes means the LLM bypassed tools and produced text from prior context,
+            // which is exactly the fake-success path issue #439 was filed for. The runner-
+            // layer safety net reads this flag in EnsureToolStatusAllowsCompletion and
+            // downgrades a 0/0 run to SkillRunnerExecutionFailedEvent.
+            RequiresNyxidProxySuccess: true);
         return true;
     }
 
@@ -303,7 +310,8 @@ public sealed record DailyReportTemplateSpec(
     string SkillContent,
     string ExecutionPrompt,
     IReadOnlyList<string> RequiredServiceSlugs,
-    IReadOnlyList<string> Repositories);
+    IReadOnlyList<string> Repositories,
+    bool RequiresNyxidProxySuccess);
 
 public sealed record SocialMediaTemplateSpec(
     string WorkflowId,

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -363,6 +363,7 @@ public sealed class AgentBuilderTool : IAgentTool
             MaxToolRounds = SkillRunnerDefaults.DefaultMaxToolRounds,
             MaxHistoryMessages = SkillRunnerDefaults.DefaultMaxHistoryMessages,
             OutboundConfig = outboundConfig,
+            RequiresNyxidProxySuccess = templateSpec.RequiresNyxidProxySuccess,
         };
 
         var runImmediatelyRequested = args.Bool("run_immediately") == true;

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -414,6 +414,18 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     /// </summary>
     private SkillRunnerStreamingReplySink? TryCreateStreamingSink()
     {
+        // Issue #439 (PR #569 review, codex P1 on SkillRunnerGAgent.cs:351): when the run
+        // is gated by EnsureToolStatusAllowsCompletion (RequiresNyxidProxySuccess set),
+        // streaming each delta would POST/PUT the partial text to Lark live — i.e. a
+        // hallucinated daily report would already be visible in the user's DM by the
+        // time the guard fires, and each retry would repost it. Disable live streaming
+        // for those skills so the message only POSTs through the chunked-dispatch path
+        // AFTER the guard has confirmed at least one nyxid_proxy success. Trade-off: the
+        // user no longer sees the report grow live, but output integrity wins over the
+        // streaming-edit UX for fetch-and-summarize skills.
+        if (State.RequiresNyxidProxySuccess)
+            return null;
+
         var client = _nyxIdApiClient ?? Services.GetService<NyxIdApiClient>();
         if (client is null)
         {
@@ -831,7 +843,15 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.ScopeId = evt.ScopeId ?? string.Empty;
         next.ProviderName = NormalizeProviderName(evt.ProviderName);
         next.Model = evt.Model ?? string.Empty;
-        next.RequiresNyxidProxySuccess = evt.RequiresNyxidProxySuccess;
+        // Legacy actors created before proto field 16 existed replay an init event whose
+        // RequiresNyxidProxySuccess deserializes as false, which would let them keep the
+        // pre-#439 zero-tool-call fake-success path — making post-fix behavior depend on
+        // creation time rather than template semantics. Derive the effective flag from
+        // the template name so known fetch-and-summarize skills get the safety net on
+        // replay regardless of when the actor was created. New templates that need this
+        // protection should be added to RequiresProxySuccessByTemplate.
+        next.RequiresNyxidProxySuccess = evt.RequiresNyxidProxySuccess
+            || RequiresProxySuccessByTemplate(evt.TemplateName);
 
         // Missing sampling fields intentionally use upstream model defaults;
         // missing runner limits fall back to SkillRunner defaults.
@@ -889,6 +909,16 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.Enabled = true;
         return next;
     }
+
+    /// <summary>
+    /// Templates whose runs MUST observe at least one successful nyxid_proxy call to be
+    /// considered successful. Used by <see cref="ApplyInitialized"/> as the legacy-actor
+    /// default when the persisted init event predates proto field 16. Add new templates
+    /// here when they're fetch-and-summarize style (the LLM bypassing tools and producing
+    /// text from prior context is a fake-success failure mode for them).
+    /// </summary>
+    internal static bool RequiresProxySuccessByTemplate(string? templateName) =>
+        string.Equals(templateName, "daily_report", StringComparison.Ordinal);
 
     private static string NormalizeProviderName(string? providerName) =>
         string.IsNullOrWhiteSpace(providerName) ? SkillRunnerDefaults.DefaultProviderName : providerName.Trim();

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -164,6 +164,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             ScopeId = command.ScopeId?.Trim() ?? string.Empty,
             ProviderName = NormalizeProviderName(command.ProviderName),
             Model = command.Model?.Trim() ?? string.Empty,
+            RequiresNyxidProxySuccess = command.RequiresNyxidProxySuccess,
         };
 
         if (command.HasTemperature)
@@ -329,13 +330,25 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             if (string.IsNullOrWhiteSpace(output))
                 output = "No update generated.";
 
-            // Issue #439 safety net (PR #471): if EVERY nyxid_proxy tool call in this run
-            // failed, the LLM's plain-text output is structurally indistinguishable from a
-            // real "no activity" report. Throw before delivery so HandleTriggerAsync's catch
-            // path persists `SkillRunnerExecutionFailedEvent` instead of recording a fake
-            // success — must fire BEFORE chunked dispatch so we don't post part-1 of a
-            // report that we're about to flag as failed.
-            EnsureToolStatusAllowsCompletion(_toolFailureCounter.FailureCount, _toolFailureCounter.SuccessCount);
+            // Issue #439 safety net (PR #471 + this PR): refuse to record fake-success runs.
+            // Two failure modes are caught here:
+            //   * all-fail — every nyxid_proxy call failed, the LLM's plain-text output is
+            //     structurally indistinguishable from a real "no activity" report;
+            //   * never-called — when State.RequiresNyxidProxySuccess is set, a run that
+            //     completes with zero successful nyxid_proxy calls means the LLM bypassed
+            //     tools entirely and produced text from prior context (the original #439
+            //     symptom: 52 commits in 24h reported as "No meaningful public GitHub
+            //     activity"). The original safety net only covered the all-fail case
+            //     (failureCount > 0); this gap was flagged in PR #471 review and is closed
+            //     here for fetch-and-summarize templates that opt in.
+            // Throw before delivery so HandleTriggerAsync's catch path persists
+            // SkillRunnerExecutionFailedEvent instead of a clean SkillRunnerExecutionCompletedEvent —
+            // must fire BEFORE chunked dispatch so we don't post part-1 of a report
+            // we're about to flag as failed.
+            EnsureToolStatusAllowsCompletion(
+                _toolFailureCounter.FailureCount,
+                _toolFailureCounter.SuccessCount,
+                State.RequiresNyxidProxySuccess);
 
             // Issue #423 §C — chunked delivery for outputs that exceed the Lark body cap.
             // For ≤30 KB outputs the chunker returns a single-element list and the dispatch
@@ -448,25 +461,49 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     }
 
     /// <summary>
-    /// Runner-layer safety net for issue #439: when every nyxid_proxy call in a run failed,
-    /// the LLM's plain-text output is structurally indistinguishable from a real "no
-    /// activity" report — the prompt-layer §9 Source health footer can be silently dropped
-    /// by a weaker model, and the runner has no other way to tell. Throwing here routes
-    /// through HandleTriggerAsync's existing catch path, which preserves the retry budget
-    /// and (after retries are exhausted) persists SkillRunnerExecutionFailedEvent so
-    /// <c>/agent-status</c> reports a non-zero <c>error_count</c> with a meaningful
-    /// <c>last_error</c> instead of a fake-success run.
-    /// Mixed runs (any successful nyxid_proxy call) still complete normally — partial data
-    /// is more useful to the user than a blanket failure, and the prompt-layer Source
-    /// health footer surfaces the failed queries.
+    /// Runner-layer safety net for issue #439. Two fake-success modes are caught here:
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <b>all-fail</b> (<paramref name="failureCount"/> &gt; 0, <paramref name="successCount"/> == 0):
+    ///     every nyxid_proxy call failed, but the LLM's plain-text output is structurally
+    ///     indistinguishable from a real "no activity" report. The prompt-layer §9 Source
+    ///     health footer can be dropped by a weaker model, and the runner has no other way
+    ///     to tell.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>never-called</b> (<paramref name="requiresNyxidProxySuccess"/> == true,
+    ///     <paramref name="successCount"/> == 0): the LLM bypassed tools entirely and produced
+    ///     text from prior context. For fetch-and-summarize skills like daily_report this is
+    ///     exactly the original #439 symptom (52 commits in 24h reported as "No meaningful
+    ///     public GitHub activity"). Skills that don't depend on tool data (e.g. pure LLM
+    ///     transformations) leave the flag false and pass through.
+    ///   </description></item>
+    /// </list>
+    /// Throwing here routes through HandleTriggerAsync's existing catch path, which preserves
+    /// the retry budget and (after retries are exhausted) persists SkillRunnerExecutionFailedEvent
+    /// so <c>/agent-status</c> reports a non-zero <c>error_count</c> with a meaningful
+    /// <c>last_error</c> instead of a fake-success run. Mixed runs (any successful nyxid_proxy
+    /// call) still complete normally — partial data is more useful than a blanket failure, and
+    /// the prompt-layer Source health footer surfaces the failed queries.
     /// </summary>
-    internal static void EnsureToolStatusAllowsCompletion(int failureCount, int successCount)
+    internal static void EnsureToolStatusAllowsCompletion(
+        int failureCount,
+        int successCount,
+        bool requiresNyxidProxySuccess)
     {
         if (failureCount > 0 && successCount == 0)
         {
             throw new InvalidOperationException(
                 $"All {failureCount} nyxid_proxy tool call(s) in this run failed; refusing to record an empty-day report as a successful execution. " +
                 "Inspect the previous attempt's tool output for the underlying NyxID/upstream error envelope.");
+        }
+
+        if (requiresNyxidProxySuccess && successCount == 0)
+        {
+            throw new InvalidOperationException(
+                "Skill requires at least one successful nyxid_proxy tool call but completed with zero. " +
+                "The LLM produced output without fetching source data (e.g. hallucinated a daily report from prior context). " +
+                "Refusing to record this run as a successful execution.");
         }
     }
 
@@ -794,6 +831,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         next.ScopeId = evt.ScopeId ?? string.Empty;
         next.ProviderName = NormalizeProviderName(evt.ProviderName);
         next.Model = evt.Model ?? string.Empty;
+        next.RequiresNyxidProxySuccess = evt.RequiresNyxidProxySuccess;
 
         // Missing sampling fields intentionally use upstream model defaults;
         // missing runner limits fall back to SkillRunner defaults.

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -67,6 +67,13 @@ message SkillRunnerState {
   optional int32 max_tokens = 18;
   optional int32 max_tool_rounds = 19;
   optional int32 max_history_messages = 20;
+  // When true, a run that completes with zero successful nyxid_proxy calls is
+  // treated as a failure (the LLM bypassed tools and produced output from prior
+  // context, which for fetch-and-summarize skills like daily_report means the
+  // report was hallucinated). Issue #439 review follow-up — closes the gap left
+  // by the original safety net, which only fired when ≥1 nyxid_proxy call had
+  // failed. Skills that don't fan out to nyxid_proxy at all leave this false.
+  bool requires_nyxid_proxy_success = 21;
 }
 
 message InitializeSkillRunnerCommand {
@@ -85,6 +92,8 @@ message InitializeSkillRunnerCommand {
   optional int32 max_tokens = 13;
   optional int32 max_tool_rounds = 14;
   optional int32 max_history_messages = 15;
+  // See SkillRunnerState.requires_nyxid_proxy_success for semantics.
+  bool requires_nyxid_proxy_success = 16;
 }
 
 message SkillRunnerInitializedEvent {
@@ -103,6 +112,8 @@ message SkillRunnerInitializedEvent {
   optional int32 max_tokens = 13;
   optional int32 max_tool_rounds = 14;
   optional int32 max_history_messages = 15;
+  // See SkillRunnerState.requires_nyxid_proxy_success for semantics.
+  bool requires_nyxid_proxy_success = 16;
 }
 
 message TriggerSkillRunnerExecutionCommand {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -136,6 +136,14 @@ public sealed class AgentBuilderToolTests
         // and must explicitly skip the CI section (no global Actions run endpoint exists).
         skillContent.Should().Contain("/search/commits?q=author:{username}+author-date:>={iso_date}");
         skillContent.Should().Contain("CI section is omitted in no-repo mode");
+
+        // Issue #439 follow-up: daily_report is a fetch-and-summarize skill, so the spec
+        // must opt in to the runner-layer never-called safety net. A run that completes
+        // with zero successful nyxid_proxy calls means the LLM hallucinated the report
+        // from prior context — exactly the original #439 symptom — and must be downgraded
+        // to SkillRunnerExecutionFailedEvent. Pin so a future template refactor doesn't
+        // silently drop the flag.
+        spec.RequiresNyxidProxySuccess.Should().BeTrue();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -91,6 +91,60 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleInitializeAsync_DailyReportLegacyEvent_DerivesProxySuccessRequiredFromTemplate()
+    {
+        // PR #569 review (codex P1 + eanzhao on SkillRunnerGAgent.cs:834): legacy actors
+        // created before proto field 16 existed replay an init event whose
+        // RequiresNyxidProxySuccess deserializes as false. ApplyInitialized must derive
+        // the effective flag from the template name so a daily_report actor that replays
+        // post-deploy is gated by the safety net regardless of when it was created.
+        var command = CreateInitializeCommand();
+        command.RequiresNyxidProxySuccess = false; // simulate legacy event
+        command.TemplateName = "daily_report";
+
+        await _agent.HandleInitializeAsync(command);
+
+        _agent.State.RequiresNyxidProxySuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HandleInitializeAsync_NonFetchTemplate_DoesNotDeriveProxySuccessFromTemplate()
+    {
+        // The legacy default applies only to known fetch-and-summarize templates. Skills
+        // that don't depend on tool data (future pure-LLM transformations) must not be
+        // falsely failed when they legitimately fan out zero nyxid_proxy calls.
+        var command = CreateInitializeCommand();
+        command.RequiresNyxidProxySuccess = false;
+        command.TemplateName = "future_pure_llm_template";
+
+        await _agent.HandleInitializeAsync(command);
+
+        _agent.State.RequiresNyxidProxySuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryCreateStreamingSink_WhenRequiresNyxidProxySuccess_ReturnsNull()
+    {
+        // PR #569 review (codex P1 on SkillRunnerGAgent.cs:351): when the run is gated by
+        // EnsureToolStatusAllowsCompletion, streaming each delta to Lark would post the
+        // hallucinated text live before the guard ran, then repost it on each retry.
+        // TryCreateStreamingSink must short-circuit so chunked dispatch (which only fires
+        // AFTER the guard) is the only path that reaches Lark for daily_report runs.
+        AttachNyxIdApiClient(_agent, new RecordingHandler("""{"code":0,"msg":"success"}"""));
+        var command = CreateInitializeCommand(); // template=daily_report → flag derived true
+        await _agent.HandleInitializeAsync(command);
+        _agent.State.RequiresNyxidProxySuccess.Should().BeTrue();
+
+        var method = typeof(SkillRunnerGAgent).GetMethod(
+            "TryCreateStreamingSink",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+        var sink = method!.Invoke(_agent, []);
+
+        sink.Should().BeNull();
+    }
+
+    [Fact]
     public async Task HandleInitializeAsync_ShouldAwaitUpsertDispatchBeforeFiringExecutionUpdate()
     {
         // Issue #440 regression: pre-PR #451 the SkillRunner reached the catalog via

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerToolFailureSafetyNetTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerToolFailureSafetyNetTests.cs
@@ -249,7 +249,8 @@ public class SkillRunnerToolFailureSafetyNetTests
         // InvalidOperationException is what HandleTriggerAsync catches and converts into
         // SkillRunnerExecutionFailedEvent (after the retry budget is exhausted), so
         // /agent-status reports a meaningful error_count and last_error.
-        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(failureCount: 3, successCount: 0);
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 3, successCount: 0, requiresNyxidProxySuccess: false);
 
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*All 3 nyxid_proxy tool call(s)*failed*");
@@ -261,7 +262,8 @@ public class SkillRunnerToolFailureSafetyNetTests
         // (b) mixed case: partial data is more useful than a blanket failure. The
         // prompt-layer §9 Source health footer surfaces which queries failed; the runner
         // simply lets the run complete normally.
-        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(failureCount: 2, successCount: 4);
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 2, successCount: 4, requiresNyxidProxySuccess: false);
 
         act.Should().NotThrow();
     }
@@ -272,23 +274,76 @@ public class SkillRunnerToolFailureSafetyNetTests
         // (c) genuine empty-day case: every nyxid_proxy call returned 2xx with no matching
         // items, so the runner records the LLM's "No measurable activity" output as a
         // legitimate success.
-        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(failureCount: 0, successCount: 7);
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 0, successCount: 7, requiresNyxidProxySuccess: false);
 
         act.Should().NotThrow();
     }
 
     [Fact]
-    public void Policy_NoToolCallsAtAll_Allows()
+    public void Policy_NoToolCallsAtAll_FlagOff_Allows()
     {
         // Skills that don't fan out to nyxid_proxy at all (e.g. pure LLM transformations)
-        // must not be tripped by the safety net. Note: this also lets a pathological run
-        // through where the LLM ignored all tools and hallucinated a report. The reviewer
-        // flagged this for the daily-report skill specifically; addressing "expected tool
-        // never called" is out of scope for this PR — it would need per-skill policy that
-        // doesn't generalize to other scheduled skills.
-        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(failureCount: 0, successCount: 0);
+        // leave RequiresNyxidProxySuccess false and pass through. The flag-on case below
+        // covers the daily_report path that was flagged in PR #471 review as the remaining
+        // hallucinated-report failure mode.
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 0, successCount: 0, requiresNyxidProxySuccess: false);
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Policy_NoToolCallsAtAll_FlagOn_Throws()
+    {
+        // Closes the gap left by the original safety net (PR #471 review): when a
+        // fetch-and-summarize skill like daily_report completes with zero successful
+        // nyxid_proxy calls, the LLM produced text from prior context — the original
+        // #439 symptom (52 commits in 24h reported as "No meaningful public GitHub
+        // activity") with no tool errors to count.
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 0, successCount: 0, requiresNyxidProxySuccess: true);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*requires at least one successful nyxid_proxy tool call*");
+    }
+
+    [Fact]
+    public void Policy_MixedSuccessAndFailure_FlagOn_Allows()
+    {
+        // Flag is only consulted when successCount == 0. Any successful nyxid_proxy call
+        // means the LLM did fetch real source data, so partial-data behavior matches the
+        // flag-off mixed case (delegated to prompt §9).
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 2, successCount: 4, requiresNyxidProxySuccess: true);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Policy_GenuinelyEmpty_FlagOn_Allows()
+    {
+        // Genuine empty-day stays a success regardless of the flag — every nyxid_proxy
+        // call returned 2xx with no matching items, the LLM did fetch source data, and
+        // "No measurable activity" is the correct prompt fallback.
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 0, successCount: 7, requiresNyxidProxySuccess: true);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Policy_AllFailures_FlagOn_AllFailMessageWins()
+    {
+        // When both the all-fail and never-called branches would fire (failureCount > 0,
+        // successCount == 0, flag = true), the all-fail message is more actionable — it
+        // names the count of failed tool calls so the operator knows where to look. Pin
+        // that ordering so a future refactor doesn't accidentally swap them.
+        var act = () => SkillRunnerGAgent.EnsureToolStatusAllowsCompletion(
+            failureCount: 3, successCount: 0, requiresNyxidProxySuccess: true);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*All 3 nyxid_proxy tool call(s)*failed*");
     }
 
     // ─── End-to-end wiring ───

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerToolFailureSafetyNetTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerToolFailureSafetyNetTests.cs
@@ -332,6 +332,28 @@ public class SkillRunnerToolFailureSafetyNetTests
         act.Should().NotThrow();
     }
 
+    // ─── Legacy actor default (PR #569 review) ───
+
+    [Theory]
+    [InlineData("daily_report", true)]
+    [InlineData("DAILY_REPORT", false)]   // case-sensitive: only the canonical name opts in
+    [InlineData("social_media", false)]   // workflow template — no nyxid_proxy fanout
+    [InlineData("future_pure_llm", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void RequiresProxySuccessByTemplate_DerivesDefaultFromTemplateName(
+        string? templateName, bool expected)
+    {
+        // Closes the gap flagged on PR #569 (codex P1 + eanzhao on SkillRunnerGAgent.cs:834):
+        // actors created before proto field 16 existed replay an init event whose
+        // RequiresNyxidProxySuccess deserializes as false. Without a template-derived default,
+        // those actors keep the pre-#439 zero-tool-call fake-success behavior even after this
+        // fix ships, so production behavior would depend on creation time rather than
+        // template semantics. ApplyInitialized ORs the explicit flag with this helper, so a
+        // legacy daily_report actor that replays today is gated by the safety net on activation.
+        SkillRunnerGAgent.RequiresProxySuccessByTemplate(templateName).Should().Be(expected);
+    }
+
     [Fact]
     public void Policy_AllFailures_FlagOn_AllFailMessageWins()
     {


### PR DESCRIPTION
## Summary

Closes the remaining gap in issue #439's fake-success failure mode that PR #471 review (SkillRunnerGAgent.cs:407) flagged: when the LLM bypasses `nyxid_proxy` entirely and produces output from prior context, both `failureCount` and `successCount` stay at zero, and the runner-layer safety net waved the run through as clean success.

PR #471 covered the **all-fail** mode (every `nyxid_proxy` call returned 4xx/5xx). This PR covers the **never-called** mode (the LLM hallucinated a report with no tool errors to count) for fetch-and-summarize skills like `daily_report`.

## Approach

A per-skill `RequiresNyxidProxySuccess` flag carried on `SkillRunnerState` / `InitializeSkillRunnerCommand` / `SkillRunnerInitializedEvent` (proto field 21 / 16 / 16). When set, `EnsureToolStatusAllowsCompletion` throws on `successCount == 0` regardless of `failureCount`, routing the run through `HandleTriggerAsync`'s existing catch path so `/agent-status` reports `error_count > 0` and a meaningful `last_error`.

- `daily_report` template opts in (the original #439 symptom was on this skill).
- Skills that don't depend on tool data (future pure-LLM transformations) leave the flag false and pass through unchanged.
- All-fail and never-called branches don't conflict: when both would fire, the all-fail message wins because it names the failed-call count, which is more actionable for the operator.

## Why a flag, not always-on

`Policy_NoToolCallsAtAll_FlagOff_Allows` exists for a reason: the SkillRunner is a generic scheduled-skill runtime, and a pure-LLM skill that legitimately fans out zero tool calls would be falsely failed by an unconditional "success ≥ 1" rule. The flag makes the contract explicit at the template-spec level — the place where "this is a fetch-and-summarize skill" semantics already live (next to `RequiredServiceSlugs`).

## Affected code

- `agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto` — new `requires_nyxid_proxy_success` field on `SkillRunnerState` (#21), `InitializeSkillRunnerCommand` (#16), `SkillRunnerInitializedEvent` (#16)
- `agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs` — `HandleInitializeAsync` and `ApplyInitialized` plumb the flag, `ExecuteSkillAsync` passes `State.RequiresNyxidProxySuccess` to the safety net, `EnsureToolStatusAllowsCompletion` enforces it
- `agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTemplates.cs` — `DailyReportTemplateSpec` adds `RequiresNyxidProxySuccess: true`
- `agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs` — propagates the spec field onto `InitializeSkillRunnerCommand`
- `test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerToolFailureSafetyNetTests.cs` — split `Policy_NoToolCallsAtAll_*` into flag-on (throws) / flag-off (allows), pin all-fail-message-wins ordering when both branches would fire, plus three flag-on counterparts of the existing policy tests
- `test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs` — pin that `daily_report` spec carries `RequiresNyxidProxySuccess: true`

## Test plan

- [x] `dotnet build aevatar.slnx --nologo` — 0 errors, 154 warnings (all pre-existing)
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — **863 passed, 0 failed** (full suite)
- [x] `dotnet test … --filter "FullyQualifiedName~SkillRunnerToolFailureSafetyNetTests|FullyQualifiedName~AgentBuilderToolTests"` — 75 passed
- [x] `bash tools/ci/test_stability_guards.sh` — passed
- [x] All backend-relevant `architecture_guards.sh` checks pass (proto lint, projection state version, projection route mapping, channel guards, workflow guards, etc.). The playground asset drift guard requires the unrelated pnpm/vite frontend build (no frontend files in this diff — same constraint noted in PR #471's test plan).

## Issue acceptance criteria revisited (#439)

The original four boxes were already ticked by PR #458 (prompt) + PR #471 (tool/runner). This PR plugs the gap that PR #471 review explicitly noted as out of scope at the time:

- Original symptom (52 commits → "No meaningful public GitHub activity") could occur via either (a) all `nyxid_proxy` calls failing or (b) the LLM never calling `nyxid_proxy` at all. PR #471 caught (a). This PR catches (b) for daily_report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)