### PR TITLE
Add operator rebuild endpoint to unwedge OAuth client at NyxID (#549)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -112,6 +112,14 @@ public static class IdentityServiceCollectionExtensions
         // (production regression observed 2026-04-30 in aismart-app-mainnet).
         services.TryAddSingleton<AevatarOAuthClientProjectionPort>();
 
+        // ─── Operator admin surface (rebuild endpoint, issue #549) ───
+        // Bound from configuration when present; absence keeps the rebuild
+        // endpoint fail-secure (503 with "rebuild not configured"). Production
+        // sets the token via env var ChannelIdentity__Admin__RebuildToken.
+        var adminOptions = services.AddOptions<AevatarOAuthAdminOptions>();
+        if (configuration is not null)
+            adminOptions.Bind(configuration.GetSection(AevatarOAuthAdminOptions.SectionName));
+
         // ─── Broker (self-bootstrapping, no appsettings dependency) ───
         // Register broker as a *singleton* and inject IHttpClientFactory so
         // each call resolves a fresh HttpClient backed by the factory's

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Core;
 using Aevatar.GAgents.Channel.Abstractions;
@@ -9,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aevatar.GAgents.Channel.Identity.Endpoints;
 
@@ -19,6 +22,8 @@ namespace Aevatar.GAgents.Channel.Identity.Endpoints;
 public static class IdentityOAuthEndpoints
 {
     private static readonly TimeSpan ProjectionWaitTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan RebuildObservationTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan RebuildObservationPollDelay = TimeSpan.FromMilliseconds(250);
     private const int MaxWebhookBodyBytes = 64 * 1024;
 
     public static IEndpointRouteBuilder MapIdentityOAuthEndpoints(this IEndpointRouteBuilder app)
@@ -32,6 +37,14 @@ public static class IdentityOAuthEndpoints
             .WithTags("ChannelIdentity")
             .AllowAnonymous();
         app.MapGet("/api/oauth/aevatar-client/status", HandleAevatarOAuthClientStatusAsync)
+            .WithTags("ChannelIdentity")
+            .AllowAnonymous();
+        // Operator-only: rebuild the cluster-singleton OAuth client snapshot
+        // to point at an admin-supplied client_id (issue #549 production
+        // unblock). Auth is by static admin token header — see
+        // AevatarOAuthAdminOptions. AllowAnonymous because the auth check is
+        // done inline; no ASP.NET auth handler is wired for this module.
+        app.MapPost("/api/oauth/aevatar-client/rebuild", HandleAevatarOAuthClientRebuildAsync)
             .WithTags("ChannelIdentity")
             .AllowAnonymous();
 
@@ -326,6 +339,241 @@ public static class IdentityOAuthEndpoints
                 detail = "Bootstrap service has not yet completed NyxID dynamic client registration. Wait or check the host startup logs.",
             }, statusCode: StatusCodes.Status503ServiceUnavailable);
         }
+    }
+
+    // ─── Operator rebuild ───
+
+    /// <summary>
+    /// Body for <c>POST /api/oauth/aevatar-client/rebuild</c>. The operator
+    /// supplies a fresh <c>client_id</c> (typically created via NyxID admin
+    /// after a wedge — see issue #549) and the actor pins its snapshot to
+    /// it. <see cref="RedirectUri"/> + <see cref="OauthScope"/> default to
+    /// the resolver / canonical scopes when omitted so the next bootstrap
+    /// pass observes no drift and does not re-DCR away the operator's pin.
+    /// </summary>
+    public sealed record RebuildAevatarOAuthClientRequest(
+        string? client_id,
+        string? redirect_uri,
+        string? oauth_scope,
+        long? client_id_issued_at_unix);
+
+    internal static Task<IResult> HandleAevatarOAuthClientRebuildAsync(
+        HttpContext http,
+        [FromBody] RebuildAevatarOAuthClientRequest? body,
+        [FromServices] IOptions<AevatarOAuthAdminOptions> adminOptions,
+        [FromServices] IAevatarOAuthClientProvider provider,
+        [FromServices] AevatarOAuthClientProjectionPort projectionPort,
+        [FromServices] IActorRuntime actorRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct) =>
+        HandleAevatarOAuthClientRebuildCoreAsync(
+            http,
+            body,
+            adminOptions,
+            provider,
+            projectionPort,
+            actorRuntime,
+            loggerFactory,
+            observationTimeout: RebuildObservationTimeout,
+            observationPollDelay: RebuildObservationPollDelay,
+            ct);
+
+    /// <summary>
+    /// Implementation seam exposed for tests so the readmodel-propagation
+    /// timeout can be tightened without waiting the full operator-grade
+    /// 30-second budget on every assertion. Production routes call the
+    /// thin overload above with the canonical defaults.
+    /// </summary>
+    internal static async Task<IResult> HandleAevatarOAuthClientRebuildCoreAsync(
+        HttpContext http,
+        RebuildAevatarOAuthClientRequest? body,
+        IOptions<AevatarOAuthAdminOptions> adminOptions,
+        IAevatarOAuthClientProvider provider,
+        AevatarOAuthClientProjectionPort projectionPort,
+        IActorRuntime actorRuntime,
+        ILoggerFactory loggerFactory,
+        TimeSpan observationTimeout,
+        TimeSpan observationPollDelay,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Aevatar.Channel.Identity.OAuthRebuild");
+
+        var configuredToken = adminOptions.Value.RebuildToken;
+        if (string.IsNullOrEmpty(configuredToken))
+        {
+            logger.LogWarning(
+                "Rebuild endpoint invoked but ChannelIdentity:Admin:RebuildToken is unset; refusing fail-secure.");
+            return Results.Json(new
+            {
+                error = "rebuild_not_configured",
+                detail = "ChannelIdentity:Admin:RebuildToken is unset. Configure it (env var ChannelIdentity__Admin__RebuildToken) and redeploy before retrying.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        if (!http.Request.Headers.TryGetValue(AevatarOAuthAdminOptions.RebuildTokenHeader, out var presented)
+            || !ConstantTimeEquals(configuredToken, presented.ToString()))
+        {
+            logger.LogWarning(
+                "Rebuild endpoint rejected: missing or invalid {Header}.",
+                AevatarOAuthAdminOptions.RebuildTokenHeader);
+            return Results.Unauthorized();
+        }
+
+        if (body is null || string.IsNullOrWhiteSpace(body.client_id))
+        {
+            return Results.BadRequest(new
+            {
+                error = "client_id_required",
+                detail = "Body must include client_id (the NyxID-issued OAuth client_id this cluster should pin to).",
+            });
+        }
+
+        var authority = NyxIdAuthorityResolver.Resolve(logger);
+        var redirectUri = string.IsNullOrWhiteSpace(body.redirect_uri)
+            ? NyxIdRedirectUriResolver.Resolve(logger)
+            : body.redirect_uri.Trim();
+        var oauthScope = string.IsNullOrWhiteSpace(body.oauth_scope)
+            ? AevatarOAuthClientScopes.AuthorizationScope
+            : body.oauth_scope.Trim();
+        var issuedAtUnix = body.client_id_issued_at_unix
+            ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        if (!AevatarOAuthClientScopes.ContainsRequiredScopes(oauthScope))
+        {
+            return Results.BadRequest(new
+            {
+                error = "oauth_scope_invalid",
+                detail = $"oauth_scope must contain the canonical scopes ('{AevatarOAuthClientScopes.AuthorizationScope}'). Otherwise the next bootstrap pass would detect drift and re-DCR away the pinned client_id.",
+            });
+        }
+
+        // Activate the projection scope first so the projector subscribes to
+        // the actor's committed events before we dispatch the provision
+        // command — same pattern as AevatarOAuthClientBootstrapService.
+        // Without this the readmodel never updates and the wait loop below
+        // times out even though the actor committed correctly.
+        await projectionPort
+            .EnsureProjectionForActorAsync(AevatarOAuthClientGAgent.WellKnownId, ct)
+            .ConfigureAwait(false);
+
+        Aevatar.Foundation.Abstractions.IActor actor;
+        try
+        {
+            actor = await actorRuntime
+                .CreateAsync<AevatarOAuthClientGAgent>(AevatarOAuthClientGAgent.WellKnownId, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Rebuild endpoint failed to activate AevatarOAuthClientGAgent.");
+            return Results.Json(new
+            {
+                error = "actor_activation_failed",
+                detail = "Failed to activate the cluster-singleton OAuth client actor. Check silo logs.",
+            }, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+
+        var provisionEnvelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(new ProvisionAevatarOAuthClientCommand
+            {
+                ClientId = body.client_id!.Trim(),
+                ClientIdIssuedAtUnix = issuedAtUnix,
+                NyxidAuthority = authority,
+                OauthScope = oauthScope,
+                RedirectUri = redirectUri,
+            }),
+            Route = new EnvelopeRoute
+            {
+                Direct = new DirectRoute { TargetActorId = AevatarOAuthClientGAgent.WellKnownId },
+            },
+        };
+        await actor.HandleEventAsync(provisionEnvelope, ct).ConfigureAwait(false);
+
+        logger.LogWarning(
+            "Operator rebuild dispatched for AevatarOAuthClientGAgent: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}.",
+            body.client_id,
+            authority,
+            redirectUri);
+
+        var observed = await WaitForRebuildObservedAsync(
+                provider,
+                expectedClientId: body.client_id!.Trim(),
+                expectedAuthority: authority,
+                expectedRedirectUri: redirectUri,
+                expectedOauthScope: oauthScope,
+                timeout: observationTimeout,
+                pollDelay: observationPollDelay,
+                ct)
+            .ConfigureAwait(false);
+        if (observed is null)
+        {
+            return Results.Json(new
+            {
+                status = "rebuild_pending_propagation",
+                detail = $"Provision command dispatched but readmodel has not yet caught up within {observationTimeout.TotalSeconds:n0}s. Re-poll /api/oauth/aevatar-client/status; it will reflect the new client_id once the projection materializes.",
+            }, statusCode: StatusCodes.Status202Accepted);
+        }
+
+        return Results.Ok(new
+        {
+            status = "rebuilt",
+            client_id = observed.ClientId,
+            client_id_issued_at = observed.ClientIdIssuedAt,
+            nyxid_authority = observed.NyxIdAuthority,
+            redirect_uri_registered = observed.RedirectUri,
+            oauth_scope_registered = observed.OauthScope,
+            broker_capability_observed = observed.BrokerCapabilityObserved,
+            detail = "OAuth client rebuilt. New /init flows will use the supplied client_id; the previous client_id is now an orphan at NyxID — delete it via NyxID admin to keep the registration list clean.",
+        });
+    }
+
+    private static async Task<AevatarOAuthClientSnapshot?> WaitForRebuildObservedAsync(
+        IAevatarOAuthClientProvider provider,
+        string expectedClientId,
+        string expectedAuthority,
+        string expectedRedirectUri,
+        string expectedOauthScope,
+        TimeSpan timeout,
+        TimeSpan pollDelay,
+        CancellationToken ct)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var snapshot = await provider.GetAsync(ct).ConfigureAwait(false);
+                if (string.Equals(snapshot.ClientId, expectedClientId, StringComparison.Ordinal)
+                    && string.Equals(snapshot.NyxIdAuthority, expectedAuthority, StringComparison.Ordinal)
+                    && string.Equals(snapshot.RedirectUri, expectedRedirectUri, StringComparison.Ordinal)
+                    && string.Equals(snapshot.OauthScope, expectedOauthScope, StringComparison.Ordinal))
+                {
+                    return snapshot;
+                }
+            }
+            catch (AevatarOAuthClientNotProvisionedException)
+            {
+                // Projection has not yet materialized the very first state
+                // root for this actor — possible on a brand-new cluster
+                // where rebuild is the first provisioning event.
+            }
+
+            await Task.Delay(pollDelay, ct).ConfigureAwait(false);
+        }
+        return null;
+    }
+
+    private static bool ConstantTimeEquals(string left, string? right)
+    {
+        if (right is null) return false;
+        var leftBytes = Encoding.UTF8.GetBytes(left);
+        var rightBytes = Encoding.UTF8.GetBytes(right);
+        return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
     }
 
     // ─── Broker revocation webhook ───

--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -22,7 +22,13 @@ namespace Aevatar.GAgents.Channel.Identity.Endpoints;
 public static class IdentityOAuthEndpoints
 {
     private static readonly TimeSpan ProjectionWaitTimeout = TimeSpan.FromSeconds(3);
-    private static readonly TimeSpan RebuildObservationTimeout = TimeSpan.FromSeconds(30);
+    // 15s leaves comfortable margin under typical reverse-proxy idle-timeout
+    // budgets (Cloudflare 100s, AWS ALB 60s default, stricter corporate
+    // proxies 30s) so the operator does not hit a 504 race on the happy path
+    // even when the readmodel takes a few seconds to materialize. Callers
+    // that hit the timeout still get a 202 with a poll URL — see issue #549
+    // PR #570 review (mimo-v2.5-pro / glm-5.1).
+    private static readonly TimeSpan RebuildObservationTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan RebuildObservationPollDelay = TimeSpan.FromMilliseconds(250);
     private const int MaxWebhookBodyBytes = 64 * 1024;
 
@@ -347,14 +353,16 @@ public static class IdentityOAuthEndpoints
     /// Body for <c>POST /api/oauth/aevatar-client/rebuild</c>. The operator
     /// supplies a fresh <c>client_id</c> (typically created via NyxID admin
     /// after a wedge — see issue #549) and the actor pins its snapshot to
-    /// it. <see cref="RedirectUri"/> + <see cref="OauthScope"/> default to
-    /// the resolver / canonical scopes when omitted so the next bootstrap
-    /// pass observes no drift and does not re-DCR away the operator's pin.
+    /// it. <c>redirect_uri</c> and <c>oauth_scope</c> are NOT operator-
+    /// supplied fields: the endpoint always uses
+    /// <see cref="NyxIdRedirectUriResolver"/> and
+    /// <see cref="AevatarOAuthClientScopes.AuthorizationScope"/> respectively,
+    /// otherwise the next bootstrap pass would observe drift and re-DCR
+    /// away the freshly-pinned client (PR #570 review consensus on the
+    /// drift bug + URL-validation surface).
     /// </summary>
     public sealed record RebuildAevatarOAuthClientRequest(
         string? client_id,
-        string? redirect_uri,
-        string? oauth_scope,
         long? client_id_issued_at_unix);
 
     internal static Task<IResult> HandleAevatarOAuthClientRebuildAsync(
@@ -429,22 +437,35 @@ public static class IdentityOAuthEndpoints
         }
 
         var authority = NyxIdAuthorityResolver.Resolve(logger);
-        var redirectUri = string.IsNullOrWhiteSpace(body.redirect_uri)
-            ? NyxIdRedirectUriResolver.Resolve(logger)
-            : body.redirect_uri.Trim();
-        var oauthScope = string.IsNullOrWhiteSpace(body.oauth_scope)
-            ? AevatarOAuthClientScopes.AuthorizationScope
-            : body.oauth_scope.Trim();
-        var issuedAtUnix = body.client_id_issued_at_unix
-            ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var redirectUri = NyxIdRedirectUriResolver.Resolve(logger);
+        var oauthScope = AevatarOAuthClientScopes.AuthorizationScope;
 
-        if (!AevatarOAuthClientScopes.ContainsRequiredScopes(oauthScope))
+        // Validate Unix-seconds before dispatching: AevatarOAuthClient
+        // ProjectionProvider later calls DateTimeOffset.FromUnixTimeSeconds
+        // on the persisted value, which throws ArgumentOutOfRangeException
+        // for values like long.MaxValue. Surface the bad input as a 400
+        // here instead of letting the read path crash on the next status
+        // poll (codex P1 on PR #570).
+        long issuedAtUnix;
+        if (body.client_id_issued_at_unix is { } supplied)
         {
-            return Results.BadRequest(new
+            try
             {
-                error = "oauth_scope_invalid",
-                detail = $"oauth_scope must contain the canonical scopes ('{AevatarOAuthClientScopes.AuthorizationScope}'). Otherwise the next bootstrap pass would detect drift and re-DCR away the pinned client_id.",
-            });
+                _ = DateTimeOffset.FromUnixTimeSeconds(supplied);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "client_id_issued_at_unix_invalid",
+                    detail = "client_id_issued_at_unix must be a Unix-seconds value within DateTimeOffset range.",
+                });
+            }
+            issuedAtUnix = supplied;
+        }
+        else
+        {
+            issuedAtUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         }
 
         // Activate the projection scope first so the projector subscribes to
@@ -473,6 +494,14 @@ public static class IdentityOAuthEndpoints
             }, statusCode: StatusCodes.Status503ServiceUnavailable);
         }
 
+        // The dispatch shape mirrors AevatarOAuthClientBootstrapService —
+        // direct envelope construction + actor.HandleEventAsync — and is a
+        // known CLAUDE.md edge: the rebuild path deliberately skips the
+        // EnsureProvisioned/DCR-mediation flow because the operator already
+        // holds the client_id (no DCR call needed). A future refactor that
+        // extracts both call sites behind an IAevatarOAuthClientAdminService
+        // is tracked as a follow-up to PR #570 — that change should move
+        // bootstrap and rebuild together so they keep sharing one code path.
         var provisionEnvelope = new EventEnvelope
         {
             Id = Guid.NewGuid().ToString("N"),
@@ -568,11 +597,22 @@ public static class IdentityOAuthEndpoints
         return null;
     }
 
+    /// <summary>
+    /// Length-tolerant constant-time string compare. <c>FixedTimeEquals</c>
+    /// itself returns false on length mismatch in O(1), which leaks the
+    /// configured token's length to a timing observer — for an admin
+    /// break-glass surface keyed on a high-entropy token this residual leak
+    /// is acceptable (the attacker still has to brute-force the content).
+    /// The earlier shape returned early on <c>right is null</c>; the call
+    /// site short-circuits via <c>TryGetValue</c> so right is never null in
+    /// practice, but we still treat null as empty to keep the helper's
+    /// signature constant-time-uniform for future callers (PR #570 review,
+    /// 4-model consensus).
+    /// </summary>
     private static bool ConstantTimeEquals(string left, string? right)
     {
-        if (right is null) return false;
         var leftBytes = Encoding.UTF8.GetBytes(left);
-        var rightBytes = Encoding.UTF8.GetBytes(right);
+        var rightBytes = Encoding.UTF8.GetBytes(right ?? string.Empty);
         return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
     }
 

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthAdminOptions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthAdminOptions.cs
@@ -1,0 +1,35 @@
+namespace Aevatar.GAgents.Channel.Identity;
+
+/// <summary>
+/// Operator credentials for the cluster-singleton OAuth client admin
+/// surface. Currently only protects the rebuild endpoint
+/// (<c>POST /api/oauth/aevatar-client/rebuild</c>) — see issue #549 for the
+/// production wedge that motivated it.
+/// </summary>
+/// <remarks>
+/// Bound from configuration section <c>ChannelIdentity:Admin</c>. When
+/// <see cref="RebuildToken"/> is empty the rebuild endpoint refuses to
+/// run (503), so a misconfigured cluster is fail-secure rather than
+/// fail-open. Production deploys set the token via env var
+/// <c>ChannelIdentity__Admin__RebuildToken</c>; tests/dev clusters may
+/// leave it unset and the endpoint stays disabled.
+/// </remarks>
+public sealed class AevatarOAuthAdminOptions
+{
+    /// <summary>
+    /// Configuration section name under <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
+    /// </summary>
+    public const string SectionName = "ChannelIdentity:Admin";
+
+    /// <summary>
+    /// Header callers send the rebuild token in. Constant-time compared to
+    /// <see cref="RebuildToken"/>; mismatch returns 401.
+    /// </summary>
+    public const string RebuildTokenHeader = "X-Aevatar-Admin-Token";
+
+    /// <summary>
+    /// Shared secret required on the rebuild endpoint. Empty disables the
+    /// endpoint entirely (fail-secure default).
+    /// </summary>
+    public string RebuildToken { get; set; } = string.Empty;
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -317,8 +317,16 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             return;
         }
 
-        var redirectUri = cmd.RedirectUri ?? string.Empty;
-        var oauthScope = cmd.OauthScope ?? string.Empty;
+        // Empty cmd field = "field not supplied by this caller", NOT "set
+        // to empty". Otherwise a legacy / pre-redirect_uri caller (e.g.
+        // ProvisionAevatarOAuthClientCommand v1 wire-compatibility, manual
+        // operator scripts that only know client_id + authority) would
+        // overwrite previously-persisted redirect_uri / oauth_scope with
+        // "" — and the next bootstrap pass would observe the cleared
+        // value, detect drift, re-DCR the freshly-pinned client, and
+        // rotate it away. Codex P1 on PR #570.
+        var redirectUri = string.IsNullOrEmpty(cmd.RedirectUri) ? State.RedirectUri : cmd.RedirectUri;
+        var oauthScope = string.IsNullOrEmpty(cmd.OauthScope) ? State.OauthScope : cmd.OauthScope;
         var sameSnapshot = string.Equals(State.ClientId, cmd.ClientId, StringComparison.Ordinal)
             && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
             && string.Equals(State.RedirectUri, redirectUri, StringComparison.Ordinal)

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -289,9 +289,19 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     /// production bootstrap path uses
     /// <see cref="HandleEnsureProvisioned"/> instead so the actor (not the
     /// caller) mediates the DCR call. Idempotent: re-issuing the same
-    /// triple is a no-op. Always seeds a fresh HMAC key when the state has
-    /// none — bootstrap and provisioning are single-step.
+    /// snapshot (client_id + authority + redirect_uri + oauth_scope) is a
+    /// no-op. Always seeds a fresh HMAC key when the state has none —
+    /// bootstrap and provisioning are single-step.
     /// </summary>
+    /// <remarks>
+    /// The same-snapshot check covers redirect_uri + oauth_scope on top of
+    /// client_id + authority because the operator-rebuild path
+    /// (<c>POST /api/oauth/aevatar-client/rebuild</c>, issue #549) must be
+    /// able to heal a wedged actor whose state has the right client_id but
+    /// stale or empty redirect_uri / oauth_scope — leaving those drifted
+    /// would let the next bootstrap re-DCR and replace the operator's
+    /// freshly-pinned client_id with a new (orphan-creating) one.
+    /// </remarks>
     [EventHandler]
     public async Task HandleProvision(ProvisionAevatarOAuthClientCommand cmd)
     {
@@ -307,9 +317,13 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             return;
         }
 
-        var sameClient = string.Equals(State.ClientId, cmd.ClientId, StringComparison.Ordinal)
-            && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal);
-        if (!sameClient)
+        var redirectUri = cmd.RedirectUri ?? string.Empty;
+        var oauthScope = cmd.OauthScope ?? string.Empty;
+        var sameSnapshot = string.Equals(State.ClientId, cmd.ClientId, StringComparison.Ordinal)
+            && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
+            && string.Equals(State.RedirectUri, redirectUri, StringComparison.Ordinal)
+            && string.Equals(State.OauthScope, oauthScope, StringComparison.Ordinal);
+        if (!sameSnapshot)
         {
             await PersistDomainEventAsync(new AevatarOAuthClientProvisionedEvent
             {
@@ -317,12 +331,14 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 ClientIdIssuedAtUnix = cmd.ClientIdIssuedAtUnix,
                 NyxidAuthority = cmd.NyxidAuthority,
                 PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                OauthScope = cmd.OauthScope ?? string.Empty,
+                OauthScope = oauthScope,
+                RedirectUri = redirectUri,
             });
             Logger.LogInformation(
-                "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}",
+                "Provisioned aevatar OAuth client: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
                 cmd.ClientId,
-                cmd.NyxidAuthority);
+                cmd.NyxidAuthority,
+                string.IsNullOrEmpty(redirectUri) ? "<unspecified>" : redirectUri);
         }
 
         if (State.HmacKey.Length == 0)

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -74,16 +74,25 @@ message EnsureAevatarOAuthClientProvisionedCommand {
 }
 
 // Issued by tests / manual operator scripts that already hold a client_id
-// (e.g. seeded fixture, post-rotation retag). Bootstrap NEVER uses this —
-// it always sends EnsureAevatarOAuthClientProvisionedCommand instead so the
-// actor mediates the DCR call.
+// (e.g. seeded fixture, post-rotation retag, post-incident rebuild). Bootstrap
+// NEVER uses this — it always sends EnsureAevatarOAuthClientProvisionedCommand
+// instead so the actor mediates the DCR call.
 message ProvisionAevatarOAuthClientCommand {
   string client_id = 1;
   int64 client_id_issued_at_unix = 2;
   string nyxid_authority = 3;
   // Optional diagnostic scope for manually provisioned clients. Bootstrap
-  // never uses this command path; an empty value means unknown.
+  // never uses this command path; an empty value means unknown. The
+  // operator-rebuild path must set this to AevatarOAuthClientScopes
+  // .AuthorizationScope so the next bootstrap does not detect drift and
+  // re-DCR the freshly-pinned client.
   string oauth_scope = 4;
+  // Optional redirect URI. The operator-rebuild path (POST /api/oauth/
+  // aevatar-client/rebuild) must set this to the resolver output so the next
+  // bootstrap does not detect redirect drift and re-DCR the freshly-pinned
+  // client. Tests / fixture seeds may leave it empty when they don't care
+  // about drift detection on a subsequent bootstrap pass.
+  string redirect_uri = 5;
 }
 
 // Issued by ops to force a fresh HMAC key rotation. Old tokens signed with

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -316,6 +316,38 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleProvision_PreservesRedirectUriAndScope_WhenCommandFieldsEmpty()
+    {
+        // PR #570 Codex P1: legacy / pre-redirect_uri callers (manual operator
+        // scripts, fixtures using only ClientId + NyxidAuthority) must NOT
+        // clobber previously-persisted redirect_uri / oauth_scope with empty
+        // strings — that would let the next bootstrap pass observe an empty
+        // redirect_uri, detect drift, and re-DCR the freshly-pinned client.
+        // Empty cmd field = "field not supplied", not "set to empty".
+        await _agent.HandleProvision(new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "client-x",
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        });
+
+        await _agent.HandleProvision(new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "client-y",
+            NyxidAuthority = "https://nyxid.test",
+        });
+
+        _agent.State.ClientId.Should().Be("client-y");
+        _agent.State.RedirectUri.Should().Be(
+            "https://aevatar.test/api/oauth/nyxid-callback",
+            "empty cmd.RedirectUri must preserve existing state, not clear it");
+        _agent.State.OauthScope.Should().Be(
+            AevatarOAuthClientScopes.AuthorizationScope,
+            "empty cmd.OauthScope must preserve existing state, not clear it");
+    }
+
+    [Fact]
     public async Task HandleProvision_RewritesEvent_WhenRedirectUriChanges()
     {
         // The same-snapshot check covers redirect_uri so an operator can

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -271,6 +271,80 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleProvision_PersistsRedirectUriAndScope_FromCommand()
+    {
+        // Pin issue #549 operator-rebuild path: when ops calls
+        // POST /api/oauth/aevatar-client/rebuild after a wedge, the actor
+        // must persist redirect_uri and oauth_scope so the next bootstrap
+        // pass observes no drift and does not re-DCR away the pinned
+        // client_id.
+        await _agent.HandleProvision(new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "operator-rebuilt-client",
+            ClientIdIssuedAtUnix = 1700000000,
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        });
+
+        _agent.State.ClientId.Should().Be("operator-rebuilt-client");
+        _agent.State.RedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+    }
+
+    [Fact]
+    public async Task HandleProvision_IsNoOp_WhenSnapshotMatches()
+    {
+        // Same-snapshot idempotency: client_id + authority + redirect_uri +
+        // oauth_scope all unchanged → no Provisioned event written. Only
+        // HMAC-seed event on first call (subsequent call is a full no-op).
+        var cmd = new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "client-x",
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        };
+
+        await _agent.HandleProvision(cmd);
+        var versionAfterFirst = _agent.EventSourcing!.CurrentVersion;
+
+        await _agent.HandleProvision(cmd);
+
+        _agent.EventSourcing!.CurrentVersion.Should().Be(versionAfterFirst,
+            "matching snapshot must not append additional events");
+    }
+
+    [Fact]
+    public async Task HandleProvision_RewritesEvent_WhenRedirectUriChanges()
+    {
+        // The same-snapshot check covers redirect_uri so an operator can
+        // heal a wedged actor that has the right client_id but stale
+        // redirect_uri without changing client_id. Pre-fix the check was
+        // (client_id, authority) only and this case silently no-op'd —
+        // leaving redirect_uri empty meant the next bootstrap detected
+        // drift and re-DCR'd the pinned client_id away.
+        await _agent.HandleProvision(new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "client-x",
+            NyxidAuthority = "https://nyxid.test",
+        });
+        _agent.State.RedirectUri.Should().BeEmpty();
+
+        await _agent.HandleProvision(new ProvisionAevatarOAuthClientCommand
+        {
+            ClientId = "client-x",
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        });
+
+        _agent.State.ClientId.Should().Be("client-x");
+        _agent.State.RedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+    }
+
+    [Fact]
     public async Task HandleObserveBrokerCapability_IsIdempotent()
     {
         await _agent.HandleProvision(new ProvisionAevatarOAuthClientCommand

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildEndpointTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildEndpointTests.cs
@@ -24,9 +24,9 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 /// without DB access. The endpoint must (a) refuse fail-secure when no
 /// admin token is configured, (b) reject without a matching token, (c)
 /// validate body fields, (d) dispatch ProvisionAevatarOAuthClientCommand
-/// with redirect_uri + oauth_scope so the next bootstrap pass observes
-/// no drift, and (e) wait for the readmodel to reflect the pin before
-/// declaring success.
+/// with the canonical redirect_uri + oauth_scope (operator cannot override
+/// — see PR #570 review), and (e) wait for the readmodel to reflect the
+/// pin before declaring success.
 /// </summary>
 public sealed class IdentityOAuthClientRebuildEndpointTests
 {
@@ -90,8 +90,6 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
             adminTokenHeader: AdminToken,
             body: new IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest(
                 client_id: null,
-                redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
-                oauth_scope: AevatarOAuthClientScopes.AuthorizationScope,
                 client_id_issued_at_unix: null),
             provider: provider,
             actorRuntime: runtime);
@@ -101,26 +99,31 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
     }
 
     [Fact]
-    public async Task Returns400_WhenOauthScopeMissingCanonicalScopes()
+    public async Task Returns400_WhenIssuedAtUnixOutOfRange()
     {
+        // Pin codex P1: AevatarOAuthClientProjectionProvider.GetAsync
+        // calls DateTimeOffset.FromUnixTimeSeconds on the persisted value
+        // and throws ArgumentOutOfRangeException for values like
+        // long.MaxValue. The endpoint must surface the bad input as 400
+        // here so the read path does not crash on the next status poll.
         var (provider, runtime) = NewProviderReflectingDispatch();
         var result = await InvokeRebuildAsync(
             adminTokenConfigured: AdminToken,
             adminTokenHeader: AdminToken,
             body: new IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest(
                 client_id: OperatorClientId,
-                redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
-                oauth_scope: "openid",
-                client_id_issued_at_unix: null),
+                client_id_issued_at_unix: long.MaxValue),
             provider: provider,
             actorRuntime: runtime);
 
         var doc = await ReadJsonAsync(result);
-        doc.RootElement.GetProperty("error").GetString().Should().Be("oauth_scope_invalid");
+        doc.RootElement.GetProperty("error").GetString().Should().Be("client_id_issued_at_unix_invalid");
+        runtime.Captured.Should().BeEmpty(
+            "rejected request must not dispatch the actor command");
     }
 
     [Fact]
-    public async Task DispatchesProvisionCommand_WithOperatorSnapshot()
+    public async Task DispatchesProvisionCommand_WithCanonicalSnapshot()
     {
         var (provider, runtime) = NewProviderReflectingDispatch();
         var result = await InvokeRebuildAsync(
@@ -128,8 +131,6 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
             adminTokenHeader: AdminToken,
             body: new IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest(
                 client_id: OperatorClientId,
-                redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
-                oauth_scope: AevatarOAuthClientScopes.AuthorizationScope,
                 client_id_issued_at_unix: 1700000000),
             provider: provider,
             actorRuntime: runtime);
@@ -140,7 +141,10 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
         var cmd = envelope.Payload.Unpack<ProvisionAevatarOAuthClientCommand>();
         cmd.ClientId.Should().Be(OperatorClientId);
         cmd.ClientIdIssuedAtUnix.Should().Be(1700000000);
-        cmd.RedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        // Endpoint always uses the resolver / canonical scope — operator
+        // cannot override, otherwise the next bootstrap pass would observe
+        // drift and re-DCR the pinned client (PR #570 review consensus).
+        cmd.RedirectUri.Should().Be(NyxIdRedirectUriResolver.Resolve());
         cmd.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
         cmd.NyxidAuthority.Should().NotBeNullOrWhiteSpace();
 
@@ -154,7 +158,7 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
     {
         // Provider always returns the OLD snapshot — readmodel never
         // catches up. Endpoint must report rebuild_pending_propagation
-        // instead of waiting forever. Production budget is 30s; the test
+        // instead of waiting forever. Production budget is 15s; the test
         // tightens it via the CoreAsync seam so the assertion runs in
         // sub-second wall time.
         var provider = Substitute.For<IAevatarOAuthClientProvider>();
@@ -177,6 +181,11 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
         var text = await new StreamReader(ctx.Response.Body, Encoding.UTF8).ReadToEndAsync();
         var doc = JsonDocument.Parse(text);
         doc.RootElement.GetProperty("status").GetString().Should().Be("rebuild_pending_propagation");
+        // Pin mimo P1: even the timeout path must have dispatched the
+        // command — otherwise a regression that drops the dispatch could
+        // pass with a stale provider and never trigger this assertion.
+        runtime.Captured.Should().HaveCount(1,
+            "timeout path must still have dispatched the provision command before the wait loop began");
     }
 
     // ─── Test plumbing ───
@@ -184,8 +193,6 @@ public sealed class IdentityOAuthClientRebuildEndpointTests
     private static IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest SampleBody() =>
         new(
             client_id: OperatorClientId,
-            redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
-            oauth_scope: AevatarOAuthClientScopes.AuthorizationScope,
             client_id_issued_at_unix: 1700000000);
 
     private static AevatarOAuthClientSnapshot SuccessSnapshotFor(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildEndpointTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthClientRebuildEndpointTests.cs
@@ -1,0 +1,351 @@
+using System.Text;
+using System.Text.Json;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Endpoints;
+using FluentAssertions;
+using Google.Protobuf;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+/// <summary>
+/// Behaviour tests for <see cref="IdentityOAuthEndpoints.HandleAevatarOAuthClientRebuildAsync"/>.
+/// Pins issue #549 operator-rebuild path: ops calls this endpoint with a
+/// freshly-created (NyxID admin) client_id to heal a wedged cluster
+/// without DB access. The endpoint must (a) refuse fail-secure when no
+/// admin token is configured, (b) reject without a matching token, (c)
+/// validate body fields, (d) dispatch ProvisionAevatarOAuthClientCommand
+/// with redirect_uri + oauth_scope so the next bootstrap pass observes
+/// no drift, and (e) wait for the readmodel to reflect the pin before
+/// declaring success.
+/// </summary>
+public sealed class IdentityOAuthClientRebuildEndpointTests
+{
+    private const string AdminToken = "test-admin-token-very-secret";
+    private const string OperatorClientId = "17cecaad-214b-4521-9dba-d435462e4095";
+
+    [Fact]
+    public async Task Returns503_WhenAdminTokenNotConfigured()
+    {
+        var (provider, runtime) = NewProviderReflectingDispatch();
+        var result = await InvokeRebuildAsync(
+            adminTokenConfigured: string.Empty,
+            adminTokenHeader: AdminToken,
+            body: SampleBody(),
+            provider: provider,
+            actorRuntime: runtime);
+
+        var doc = await ReadJsonAsync(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("rebuild_not_configured");
+    }
+
+    [Fact]
+    public async Task Returns401_WhenAdminTokenHeaderMissing()
+    {
+        var (provider, runtime) = NewProviderReflectingDispatch();
+        var result = await InvokeRebuildAsync(
+            adminTokenConfigured: AdminToken,
+            adminTokenHeader: null,
+            body: SampleBody(),
+            provider: provider,
+            actorRuntime: runtime);
+
+        // Results.Unauthorized() renders to status 401.
+        var ctx = NewHttpContext();
+        await result.ExecuteAsync(ctx);
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task Returns401_WhenAdminTokenHeaderMismatch()
+    {
+        var (provider, runtime) = NewProviderReflectingDispatch();
+        var result = await InvokeRebuildAsync(
+            adminTokenConfigured: AdminToken,
+            adminTokenHeader: "wrong-token",
+            body: SampleBody(),
+            provider: provider,
+            actorRuntime: runtime);
+
+        var ctx = NewHttpContext();
+        await result.ExecuteAsync(ctx);
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task Returns400_WhenClientIdMissing()
+    {
+        var (provider, runtime) = NewProviderReflectingDispatch();
+        var result = await InvokeRebuildAsync(
+            adminTokenConfigured: AdminToken,
+            adminTokenHeader: AdminToken,
+            body: new IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest(
+                client_id: null,
+                redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
+                oauth_scope: AevatarOAuthClientScopes.AuthorizationScope,
+                client_id_issued_at_unix: null),
+            provider: provider,
+            actorRuntime: runtime);
+
+        var doc = await ReadJsonAsync(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("client_id_required");
+    }
+
+    [Fact]
+    public async Task Returns400_WhenOauthScopeMissingCanonicalScopes()
+    {
+        var (provider, runtime) = NewProviderReflectingDispatch();
+        var result = await InvokeRebuildAsync(
+            adminTokenConfigured: AdminToken,
+            adminTokenHeader: AdminToken,
+            body: new IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest(
+                client_id: OperatorClientId,
+                redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
+                oauth_scope: "openid",
+                client_id_issued_at_unix: null),
+            provider: provider,
+            actorRuntime: runtime);
+
+        var doc = await ReadJsonAsync(result);
+        doc.RootElement.GetProperty("error").GetString().Should().Be("oauth_scope_invalid");
+    }
+
+    [Fact]
+    public async Task DispatchesProvisionCommand_WithOperatorSnapshot()
+    {
+        var (provider, runtime) = NewProviderReflectingDispatch();
+        var result = await InvokeRebuildAsync(
+            adminTokenConfigured: AdminToken,
+            adminTokenHeader: AdminToken,
+            body: new IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest(
+                client_id: OperatorClientId,
+                redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
+                oauth_scope: AevatarOAuthClientScopes.AuthorizationScope,
+                client_id_issued_at_unix: 1700000000),
+            provider: provider,
+            actorRuntime: runtime);
+
+        runtime.Captured.Should().HaveCount(1);
+        var envelope = runtime.Captured[0];
+        envelope.Route.Direct.TargetActorId.Should().Be(AevatarOAuthClientGAgent.WellKnownId);
+        var cmd = envelope.Payload.Unpack<ProvisionAevatarOAuthClientCommand>();
+        cmd.ClientId.Should().Be(OperatorClientId);
+        cmd.ClientIdIssuedAtUnix.Should().Be(1700000000);
+        cmd.RedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        cmd.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+        cmd.NyxidAuthority.Should().NotBeNullOrWhiteSpace();
+
+        var doc = await ReadJsonAsync(result);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("rebuilt");
+        doc.RootElement.GetProperty("client_id").GetString().Should().Be(OperatorClientId);
+    }
+
+    [Fact]
+    public async Task Returns202_WhenReadmodelDoesNotReflectRebuildBeforeTimeout()
+    {
+        // Provider always returns the OLD snapshot — readmodel never
+        // catches up. Endpoint must report rebuild_pending_propagation
+        // instead of waiting forever. Production budget is 30s; the test
+        // tightens it via the CoreAsync seam so the assertion runs in
+        // sub-second wall time.
+        var provider = Substitute.For<IAevatarOAuthClientProvider>();
+        provider.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(StaleSnapshot()));
+        var runtime = new RecordingActorRuntime();
+        var result = await InvokeRebuildCoreAsync(
+            adminTokenConfigured: AdminToken,
+            adminTokenHeader: AdminToken,
+            body: SampleBody(),
+            provider: provider,
+            actorRuntime: runtime,
+            observationTimeout: TimeSpan.FromMilliseconds(150),
+            observationPollDelay: TimeSpan.FromMilliseconds(20));
+
+        var ctx = NewHttpContext();
+        await result.ExecuteAsync(ctx);
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        ctx.Response.Body.Position = 0;
+        var text = await new StreamReader(ctx.Response.Body, Encoding.UTF8).ReadToEndAsync();
+        var doc = JsonDocument.Parse(text);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("rebuild_pending_propagation");
+    }
+
+    // ─── Test plumbing ───
+
+    private static IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest SampleBody() =>
+        new(
+            client_id: OperatorClientId,
+            redirect_uri: "https://aevatar.test/api/oauth/nyxid-callback",
+            oauth_scope: AevatarOAuthClientScopes.AuthorizationScope,
+            client_id_issued_at_unix: 1700000000);
+
+    private static AevatarOAuthClientSnapshot SuccessSnapshotFor(
+        string clientId,
+        string redirectUri,
+        string oauthScope) =>
+        new(
+            ClientId: clientId,
+            ClientIdIssuedAt: DateTimeOffset.FromUnixTimeSeconds(1700000000),
+            HmacKid: AevatarOAuthClientGAgent.InitialHmacKid,
+            HmacKey: new byte[32],
+            HmacKeyRotatedAt: DateTimeOffset.UtcNow,
+            NyxIdAuthority: NyxIdAuthorityResolver.Resolve(),
+            BrokerCapabilityObserved: true,
+            BrokerCapabilityObservedAt: DateTimeOffset.UtcNow,
+            PreviousHmacKid: null,
+            PreviousHmacKey: null,
+            PreviousHmacDemotedAt: null,
+            RedirectUri: redirectUri,
+            OauthScope: oauthScope);
+
+    private static AevatarOAuthClientSnapshot StaleSnapshot() =>
+        new(
+            ClientId: "stale-old-client",
+            ClientIdIssuedAt: DateTimeOffset.FromUnixTimeSeconds(1600000000),
+            HmacKid: AevatarOAuthClientGAgent.InitialHmacKid,
+            HmacKey: new byte[32],
+            HmacKeyRotatedAt: DateTimeOffset.UtcNow,
+            NyxIdAuthority: NyxIdAuthorityResolver.Resolve(),
+            BrokerCapabilityObserved: false,
+            BrokerCapabilityObservedAt: null,
+            PreviousHmacKid: null,
+            PreviousHmacKey: null,
+            PreviousHmacDemotedAt: null,
+            RedirectUri: "https://stale.example.com/callback",
+            OauthScope: "openid");
+
+    private static (IAevatarOAuthClientProvider Provider, RecordingActorRuntime Runtime) NewProviderReflectingDispatch()
+    {
+        var runtime = new RecordingActorRuntime();
+        var provider = Substitute.For<IAevatarOAuthClientProvider>();
+        provider.GetAsync(Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (runtime.Captured.Count == 0)
+                    return Task.FromResult(StaleSnapshot());
+                var cmd = runtime.Captured[^1].Payload.Unpack<ProvisionAevatarOAuthClientCommand>();
+                return Task.FromResult(SuccessSnapshotFor(cmd.ClientId, cmd.RedirectUri, cmd.OauthScope));
+            });
+        return (provider, runtime);
+    }
+
+    private static AevatarOAuthClientProjectionPort NewProjectionPort()
+    {
+        var activationService = Substitute.For<IProjectionScopeActivationService<AevatarOAuthClientMaterializationRuntimeLease>>();
+        activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<AevatarOAuthClientMaterializationRuntimeLease?>(
+                new AevatarOAuthClientMaterializationRuntimeLease(
+                    new AevatarOAuthClientMaterializationContext
+                    {
+                        RootActorId = AevatarOAuthClientGAgent.WellKnownId,
+                        ProjectionKind = AevatarOAuthClientProjectionPort.ProjectionKind,
+                    }))!);
+        return new AevatarOAuthClientProjectionPort(activationService);
+    }
+
+    /// <summary>
+    /// Wraps NSubstitute-built IActorRuntime so test assertions can read the
+    /// captured envelope without re-querying NSubstitute call queues.
+    /// </summary>
+    private sealed class RecordingActorRuntime
+    {
+        public List<EventEnvelope> Captured { get; } = new();
+        public IActorRuntime Runtime { get; }
+
+        public RecordingActorRuntime()
+        {
+            var actor = Substitute.For<IActor>();
+            actor.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    Captured.Add(callInfo.Arg<EventEnvelope>());
+                    return Task.CompletedTask;
+                });
+            Runtime = Substitute.For<IActorRuntime>();
+            Runtime.CreateAsync<AevatarOAuthClientGAgent>(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<IActor>(actor));
+        }
+    }
+
+    private static Task<IResult> InvokeRebuildAsync(
+        string adminTokenConfigured,
+        string? adminTokenHeader,
+        IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest body,
+        IAevatarOAuthClientProvider provider,
+        RecordingActorRuntime actorRuntime,
+        CancellationToken ct = default) =>
+        InvokeRebuildCoreAsync(
+            adminTokenConfigured,
+            adminTokenHeader,
+            body,
+            provider,
+            actorRuntime,
+            // Default budget is generous: happy-path tests exit on the
+            // first provider poll; only the 202 test cares about timeout.
+            observationTimeout: TimeSpan.FromSeconds(2),
+            observationPollDelay: TimeSpan.FromMilliseconds(20),
+            ct);
+
+    private static async Task<IResult> InvokeRebuildCoreAsync(
+        string adminTokenConfigured,
+        string? adminTokenHeader,
+        IdentityOAuthEndpoints.RebuildAevatarOAuthClientRequest body,
+        IAevatarOAuthClientProvider provider,
+        RecordingActorRuntime actorRuntime,
+        TimeSpan observationTimeout,
+        TimeSpan observationPollDelay,
+        CancellationToken ct = default)
+    {
+        var http = NewHttpContext();
+        if (adminTokenHeader is not null)
+            http.Request.Headers[AevatarOAuthAdminOptions.RebuildTokenHeader] = adminTokenHeader;
+
+        var options = Options.Create(new AevatarOAuthAdminOptions { RebuildToken = adminTokenConfigured });
+        var projectionPort = NewProjectionPort();
+
+        return await IdentityOAuthEndpoints.HandleAevatarOAuthClientRebuildCoreAsync(
+            http: http,
+            body: body,
+            adminOptions: options,
+            provider: provider,
+            projectionPort: projectionPort,
+            actorRuntime: actorRuntime.Runtime,
+            loggerFactory: NullLoggerFactory.Instance,
+            observationTimeout: observationTimeout,
+            observationPollDelay: observationPollDelay,
+            ct: ct);
+    }
+
+    private static async Task<JsonDocument> ReadJsonAsync(IResult result)
+    {
+        var context = NewHttpContext();
+        await result.ExecuteAsync(context);
+        context.Response.Body.Position = 0;
+        var text = await new StreamReader(context.Response.Body, Encoding.UTF8).ReadToEndAsync();
+        return JsonDocument.Parse(text);
+    }
+
+    private static HttpContext NewHttpContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var provider = services.BuildServiceProvider();
+        return new DefaultHttpContext
+        {
+            RequestServices = provider,
+            Response =
+            {
+                Body = new MemoryStream(),
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Issue #549 — production wedge that leaves \`AevatarOAuthClientGAgent\`
pinned to a broken \`client_id\` after K8s rolling deploys. The OCC
absorber landed in commit \`9326204d\` keeps the cluster from deadlocking
on every restart, but it can't replace the wedged snapshot itself. This
PR adds the operator-grade unblock that points \`aevatar\` at a freshly-
created NyxID client without DB access.

- \`POST /api/oauth/aevatar-client/rebuild\` accepts a JSON body
  \`{ client_id, redirect_uri?, oauth_scope?, client_id_issued_at_unix? }\`
  with an \`X-Aevatar-Admin-Token\` header (constant-time compared
  against \`ChannelIdentity:Admin:RebuildToken\`). Empty config →
  fail-secure 503. Wrong/missing token → 401. Bad body → 400.
  Happy path: dispatches \`ProvisionAevatarOAuthClientCommand\`,
  waits ≤30s for the readmodel to reflect the pin, returns 200; if
  the readmodel hasn't caught up, returns 202 \`rebuild_pending_propagation\`.
- \`ProvisionAevatarOAuthClientCommand\` proto gains a \`redirect_uri\`
  field (#5). The handler now writes it to \`AevatarOAuthClientProvisionedEvent\`
  and treats \`(client_id, authority, redirect_uri, oauth_scope)\` as
  the same-snapshot key. Pre-fix the check was \`(client_id, authority)\`
  only, so a partial heal silently no-op'd and let the next bootstrap
  pass detect drift and re-DCR away the operator's pinned id.
- \`AevatarOAuthAdminOptions\` binds \`ChannelIdentity:Admin\`. Production
  sets \`ChannelIdentity__Admin__RebuildToken\` via env; tests/dev
  clusters leave it unset and the endpoint stays disabled.

Other layers from issue #549 (distributed-lock bootstrap, sync grain
RPC dispatch, \`ProjectionScopeGAgentBase\` OCC absorber, multi-silo
CI test) are intentionally out of scope and tracked as follow-ups —
the OCC absorber already keeps the cluster live; this PR closes the
loop on the ops handoff that turns the new \`17cecaad-…\` NyxID client
into the cluster's authoritative snapshot.

## Test plan
- [x] \`dotnet build agents/Aevatar.GAgents.Channel.Identity/Aevatar.GAgents.Channel.Identity.csproj\` — clean.
- [x] \`dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests --filter "Identity"\` — 27/27 identity tests pass (3 new HandleProvision unit tests + 6 new endpoint tests + existing suites).
- [x] \`dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests\` — 869/869 pass.
- [x] \`bash tools/ci/test_stability_guards.sh\` — passes (no polling waits added beyond the operator-grade observation loop).
- [ ] Production rollout: set \`ChannelIdentity__Admin__RebuildToken\`, then \`curl -H "X-Aevatar-Admin-Token: …" -d '{"client_id":"17cecaad-214b-4521-9dba-d435462e4095"}' POST /api/oauth/aevatar-client/rebuild\`. Verify \`/api/oauth/aevatar-client/status\` reflects the new id with no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)