### PR TITLE
Wrap up issue #513 follow-ups: /whoami no-auth, override matrix, callback hint

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Endpoints/IdentityOAuthEndpoints.cs
@@ -159,7 +159,7 @@ public static class IdentityOAuthEndpoints
             // orphan. Best-effort revoke at NyxID before responding so the
             // orphan does not accumulate at NyxID with no local reference.
             await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
-            return Results.Ok(new { status = "already_bound", detail = "已绑定 NyxID 账号,可以回到 Lark 继续对话" });
+            return RenderBoundSuccessHtml(displayName: null, alreadyBound: true);
         }
 
         var actor = await TryActivateActorAsync(actorRuntime, actorId, logger, ct).ConfigureAwait(false);
@@ -252,7 +252,7 @@ public static class IdentityOAuthEndpoints
                     resolvedAfterTimeout.Value,
                     exchange.BindingId);
                 await TryRevokeOrphanBindingAsync(brokerCallback, exchange.BindingId, logger, ct).ConfigureAwait(false);
-                return Results.Ok(new { status = "already_bound", detail = "已绑定 NyxID 账号,可以回到 Lark 继续对话" });
+                return RenderBoundSuccessHtml(displayName: null, alreadyBound: true);
             }
 
             logger.LogWarning(
@@ -271,13 +271,7 @@ public static class IdentityOAuthEndpoints
             "Bound external identity {Platform}:{Tenant}:{User} -> binding_id={BindingId}",
             subject.Platform, subject.Tenant, subject.ExternalUserId, exchange.BindingId);
 
-        return Results.Ok(new
-        {
-            status = "bound",
-            detail = displayName is null
-                ? "已绑定 NyxID 账号,可以回到 Lark 继续对话"
-                : $"已绑定 NyxID 账号({displayName}),可以回到 Lark 继续对话",
-        });
+        return RenderBoundSuccessHtml(displayName, alreadyBound: false);
     }
 
     // ─── Status endpoint ───
@@ -485,5 +479,61 @@ public static class IdentityOAuthEndpoints
             case 3: padded += "="; break;
         }
         return Convert.FromBase64String(padded);
+    }
+
+    /// <summary>
+    /// Render the user-facing success page returned in the OAuth-callback
+    /// response. Issue #513 phase 1 asked for a "callback success → please pick
+    /// a model" prompt. The full version is a card update pushed back into
+    /// Lark, which requires capturing the /init card's adapter-owned message
+    /// id and passing it through the OAuth state token — substantial new
+    /// design surface left as a follow-up. This page is the browser-side
+    /// substitute the user sees immediately after the OAuth redirect, and it
+    /// names the next-step commands (<c>/model</c>, <c>/whoami</c>) explicitly
+    /// so the user is not left guessing what to type back in Lark.
+    /// </summary>
+    /// <remarks>
+    /// Display name comes from the id_token "name" / sub claim; HTML-encoded
+    /// before interpolation so a malicious id_token cannot inject markup.
+    /// Other error paths in the callback intentionally keep returning JSON for
+    /// ops/programmatic consumers.
+    /// </remarks>
+    internal static IResult RenderBoundSuccessHtml(string? displayName, bool alreadyBound)
+    {
+        var badge = alreadyBound ? "已绑定" : "绑定成功";
+        var heading = alreadyBound ? "NyxID 账号已绑定" : "已绑定 NyxID 账号";
+        var displayLine = string.IsNullOrWhiteSpace(displayName)
+            ? string.Empty
+            : $"<p>账号:{System.Net.WebUtility.HtmlEncode(displayName)}</p>";
+        var body = alreadyBound
+            ? "<p>当前账号已经完成绑定,无需重复操作。可以关闭此页,回到 Lark 继续对话。</p>"
+            : "<p>可以关闭此页,回到 Lark 继续对话。</p>";
+
+        var html = $@"<!DOCTYPE html>
+<html lang=""zh-CN"">
+<head>
+<meta charset=""UTF-8"">
+<meta name=""viewport"" content=""width=device-width, initial-scale=1"">
+<title>NyxID 绑定 — {badge}</title>
+<style>
+body {{ font-family: -apple-system, ""Segoe UI"", ""PingFang SC"", ""Microsoft YaHei"", sans-serif; max-width: 480px; margin: 60px auto; padding: 0 20px; color: #1d1d1f; line-height: 1.6; }}
+.badge {{ display: inline-block; padding: 4px 10px; background: #d1f5d3; color: #146c2e; border-radius: 999px; font-size: 13px; font-weight: 500; }}
+h1 {{ font-size: 22px; margin: 16px 0 8px; }}
+.hint {{ background: #f5f5f7; padding: 16px 20px; border-radius: 8px; margin-top: 24px; }}
+.hint code {{ background: #fff; padding: 2px 6px; border-radius: 4px; font-family: ui-monospace, ""SFMono-Regular"", Menlo, monospace; }}
+</style>
+</head>
+<body>
+<span class=""badge"">{badge}</span>
+<h1>{heading}</h1>
+{displayLine}
+{body}
+<div class=""hint"">
+<strong>下一步</strong><br>
+回到 Lark 后,发送 <code>/model</code> 选择想用的模型,或 <code>/whoami</code> 查看当前绑定状态。
+</div>
+</body>
+</html>";
+        return Results.Content(html, "text/html; charset=utf-8");
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Slash/WhoamiChannelSlashCommandHandler.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Slash/WhoamiChannelSlashCommandHandler.cs
@@ -4,15 +4,17 @@ using Aevatar.GAgents.Channel.Abstractions.Slash;
 namespace Aevatar.GAgents.Channel.Identity.Slash;
 
 /// <summary>
-/// /whoami — show the inbound sender their current binding state. Always
-/// requires a binding; the runner short-circuits unbound senders to the
-/// /init prompt before invoking the handler.
+/// /whoami — show the inbound sender their current binding state. Issue #513
+/// Phase 6 specifies <c>/init</c>, <c>/unbind</c>, and <c>/whoami</c> do NOT
+/// require a binding so an unbound sender can introspect their own state
+/// without being bounced through the binding gate. Bound senders see masked
+/// binding info; unbound senders see "未绑定" with a /init hint.
 /// </summary>
 public sealed class WhoamiChannelSlashCommandHandler : IChannelSlashCommandHandler
 {
     public string Name => "whoami";
 
-    public bool RequiresBinding => true;
+    public bool RequiresBinding => false;
 
     public ChannelSlashCommandUsage Usage => new(
         Name,
@@ -28,13 +30,21 @@ public sealed class WhoamiChannelSlashCommandHandler : IChannelSlashCommandHandl
             ? context.SenderId
             : context.SenderName;
 
-        var lines = new[]
-        {
-            $"已绑定 NyxID 账号。",
-            $"- 平台账号:{senderName}",
-            $"- Binding ID:{Mask(bindingId)}",
-            $"- 平台:{context.Subject.Platform}",
-        };
+        var lines = string.IsNullOrEmpty(bindingId)
+            ? new[]
+            {
+                "未绑定 NyxID 账号。",
+                $"- 平台账号:{senderName}",
+                $"- 平台:{context.Subject.Platform}",
+                "发送 /init 完成绑定。",
+            }
+            : new[]
+            {
+                "已绑定 NyxID 账号。",
+                $"- 平台账号:{senderName}",
+                $"- Binding ID:{Mask(bindingId)}",
+                $"- 平台:{context.Subject.Platform}",
+            };
 
         var reply = new MessageContent
         {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -355,6 +355,109 @@ public sealed class ConversationReplyGeneratorTests
         ownerMetadata.Should().NotContainKey(LLMRequestMetadataKeys.SenderNyxIdAccessToken);
     }
 
+    // ─── Issue #513 phase 3 — explicit 3 binding × 3 owner-prefs override matrix ───
+    //
+    // The four [Fact] tests above pin specific scenarios (owner-only,
+    // sender-overrides-model, sender-store-throws, route-failure-retry). This
+    // [Theory] adds the explicit 3×3 matrix the issue calls out: the binding
+    // axis (unbound / bound-with-empty-prefs / bound-with-model-only) is
+    // crossed with the owner-prefs axis (none / partial=model-only / full).
+    // Sender prefs in the bound-set row deliberately set ONLY DefaultModel so
+    // we exercise the "sender supplies a subset, owner fills the rest" path
+    // without crossing the route-applied + no-sender-token branch (which
+    // silently swaps in the owner snapshot — orthogonal to the matrix and
+    // already covered by UsesOwnerPrefsImmediatelyWhenSenderRouteHasNoToken).
+    public const string MatrixUnbound = "unbound";
+    public const string MatrixBoundEmpty = "bound_empty_prefs";
+    public const string MatrixBoundModelOnly = "bound_model_only";
+    public const string MatrixOwnerNone = "owner_none";
+    public const string MatrixOwnerPartial = "owner_partial_model_only";
+    public const string MatrixOwnerFull = "owner_full";
+
+    [Theory]
+    [InlineData(MatrixUnbound, MatrixOwnerNone, null, null, null)]
+    [InlineData(MatrixUnbound, MatrixOwnerPartial, "owner-model", null, null)]
+    [InlineData(MatrixUnbound, MatrixOwnerFull, "owner-model", "/api/v1/proxy/s/owner", "9")]
+    [InlineData(MatrixBoundEmpty, MatrixOwnerNone, null, null, null)]
+    [InlineData(MatrixBoundEmpty, MatrixOwnerPartial, "owner-model", null, null)]
+    [InlineData(MatrixBoundEmpty, MatrixOwnerFull, "owner-model", "/api/v1/proxy/s/owner", "9")]
+    [InlineData(MatrixBoundModelOnly, MatrixOwnerNone, "sender-model", null, null)]
+    [InlineData(MatrixBoundModelOnly, MatrixOwnerPartial, "sender-model", null, null)]
+    [InlineData(MatrixBoundModelOnly, MatrixOwnerFull, "sender-model", "/api/v1/proxy/s/owner", "9")]
+    public async Task GenerateReplyAsync_OverrideMatrix_BindingTimesOwnerPrefs(
+        string bindingState,
+        string ownerState,
+        string? expectedModel,
+        string? expectedRoute,
+        string? expectedRounds)
+    {
+        var providerFactory = new RecordingProviderFactory();
+        var prefsStore = new ScopedStubPreferencesStore();
+
+        switch (bindingState)
+        {
+            case MatrixBoundEmpty:
+                // Lookup returns the default empty record (no entry in
+                // ByBinding), so SetIfFilled writes nothing.
+                break;
+            case MatrixBoundModelOnly:
+                prefsStore.ByBinding["bnd_sender"] = new NyxIdUserLlmPreferences(
+                    DefaultModel: "sender-model",
+                    PreferredRoute: string.Empty,
+                    MaxToolRounds: 0);
+                break;
+        }
+
+        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (bindingState != MatrixUnbound)
+            metadata[LLMRequestMetadataKeys.SenderBindingId] = "bnd_sender";
+
+        switch (ownerState)
+        {
+            case MatrixOwnerPartial:
+                metadata[LLMRequestMetadataKeys.ModelOverride] = "owner-model";
+                break;
+            case MatrixOwnerFull:
+                metadata[LLMRequestMetadataKeys.ModelOverride] = "owner-model";
+                metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = "/api/v1/proxy/s/owner";
+                metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride] = "9";
+                break;
+        }
+
+        var generator = new NyxIdConversationReplyGenerator(providerFactory, preferencesStore: prefsStore);
+        await generator.GenerateReplyAsync(
+            new ChatActivity
+            {
+                Id = $"msg-{bindingState}-{ownerState}",
+                Conversation = new ConversationReference { CanonicalKey = "lark:dm:user-1" },
+                Content = new MessageContent { Text = "hello" },
+            },
+            metadata,
+            streamingSink: null,
+            CancellationToken.None);
+
+        var request = providerFactory.Requests.Should().ContainSingle().Subject;
+        var effective = request.Metadata!;
+
+        AssertKey(effective, LLMRequestMetadataKeys.ModelOverride, expectedModel);
+        AssertKey(effective, LLMRequestMetadataKeys.NyxIdRoutePreference, expectedRoute);
+        AssertKey(effective, LLMRequestMetadataKeys.MaxToolRoundsOverride, expectedRounds);
+
+        if (bindingState == MatrixUnbound)
+            prefsStore.Lookups.Should().BeEmpty(
+                "no binding-id in metadata → generator must not consult the prefs store");
+        else
+            prefsStore.Lookups.Should().ContainSingle().Which.Should().Be("bnd_sender");
+    }
+
+    private static void AssertKey(IReadOnlyDictionary<string, string> metadata, string key, string? expected)
+    {
+        if (expected is null)
+            metadata.Should().NotContainKey(key);
+        else
+            metadata.Should().ContainKey(key).WhoseValue.Should().Be(expected);
+    }
+
     private sealed class ScopedStubPreferencesStore : INyxIdUserLlmPreferencesStore
     {
         public Dictionary<string, NyxIdUserLlmPreferences> ByBinding { get; } = new(StringComparer.Ordinal);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthCallbackEndpointTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityOAuthCallbackEndpointTests.cs
@@ -58,8 +58,9 @@ public sealed class IdentityOAuthCallbackEndpointTests
         var (result, _) = await InvokeCallbackAsync(broker, queryPort, readiness);
 
         await broker.Received(1).RevokeBindingByIdAsync(incoming, Arg.Any<CancellationToken>());
-        await ReadJsonAsync(result).ContinueWith(t =>
-            t.Result.RootElement.GetProperty("status").GetString().Should().Be("already_bound"));
+        var html = await ReadTextAsync(result);
+        html.Should().Contain("已绑定");
+        html.Should().Contain("/whoami");
     }
 
     [Fact]
@@ -108,8 +109,37 @@ public sealed class IdentityOAuthCallbackEndpointTests
 
         await broker.DidNotReceive().RevokeBindingByIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await queryPort.Received(1).ResolveAsync(Arg.Any<ExternalSubjectRef>(), Arg.Any<CancellationToken>());
-        var doc = await ReadJsonAsync(result);
-        doc.RootElement.GetProperty("status").GetString().Should().Be("bound");
+        var html = await ReadTextAsync(result);
+        // Issue #513 phase 1 substitute: the success page must name the
+        // next-step slash commands so the user knows what to type back in
+        // Lark after the OAuth round-trip.
+        html.Should().Contain("绑定成功");
+        html.Should().Contain("/model");
+        html.Should().Contain("/whoami");
+    }
+
+    [Fact]
+    public async Task HappyPath_RendersHtml_ContentTypeIsTextHtml()
+    {
+        const string incoming = "bnd_incoming";
+        var subject = SampleSubject();
+        var broker = NewBroker(subject, incoming);
+        var queryPort = Substitute.For<IExternalIdentityBindingQueryPort>();
+        queryPort.ResolveAsync(Arg.Any<ExternalSubjectRef>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<BindingId?>(null));
+        var readiness = Substitute.For<IProjectionReadinessPort>();
+        readiness.WaitForBindingStateAsync(
+                Arg.Any<ExternalSubjectRef>(),
+                incoming,
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var (result, _) = await InvokeCallbackAsync(broker, queryPort, readiness);
+        var (text, contentType) = await ReadTextWithContentTypeAsync(result);
+
+        contentType.Should().StartWith("text/html");
+        text.Should().Contain("<!DOCTYPE html>");
     }
 
     // ─── Test plumbing ───
@@ -190,11 +220,23 @@ public sealed class IdentityOAuthCallbackEndpointTests
 
     private static async Task<JsonDocument> ReadJsonAsync(IResult result)
     {
+        var (text, _) = await ReadTextWithContentTypeAsync(result);
+        return JsonDocument.Parse(text);
+    }
+
+    private static async Task<string> ReadTextAsync(IResult result)
+    {
+        var (text, _) = await ReadTextWithContentTypeAsync(result);
+        return text;
+    }
+
+    private static async Task<(string Text, string? ContentType)> ReadTextWithContentTypeAsync(IResult result)
+    {
         var context = NewHttpContext();
         await result.ExecuteAsync(context);
         context.Response.Body.Position = 0;
         var text = await new StreamReader(context.Response.Body, Encoding.UTF8).ReadToEndAsync();
-        return JsonDocument.Parse(text);
+        return (text, context.Response.ContentType);
     }
 
     private static HttpContext NewHttpContext()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/SlashCommandHandlerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/SlashCommandHandlerTests.cs
@@ -83,31 +83,63 @@ public sealed class SlashCommandHandlerTests
     }
 
     [Fact]
-    public async Task Whoami_RequiresBinding_AndReturnsMaskedBindingId()
+    public async Task Whoami_BoundSender_ReturnsMaskedBindingId()
     {
         var handler = new WhoamiChannelSlashCommandHandler();
-        handler.RequiresBinding.Should().BeTrue();
 
-        var ctx = Context(bindingValue: "bnd_1234567890abcdef");
-        ctx = new ChannelSlashCommandContext
+        var ctx = new ChannelSlashCommandContext
         {
             CommandName = "whoami",
-            ArgumentText = ctx.ArgumentText,
-            Subject = ctx.Subject,
-            BindingIdValue = ctx.BindingIdValue,
-            RegistrationId = ctx.RegistrationId,
-            RegistrationScopeId = ctx.RegistrationScopeId,
-            SenderId = ctx.SenderId,
-            SenderName = ctx.SenderName,
-            IsPrivateChat = ctx.IsPrivateChat,
+            ArgumentText = string.Empty,
+            Subject = Subject(),
+            BindingIdValue = "bnd_1234567890abcdef",
+            RegistrationId = "reg-1",
+            RegistrationScopeId = "scope-1",
+            SenderId = "ou_user_y",
+            SenderName = "Eric",
+            IsPrivateChat = true,
         };
 
         var reply = await handler.HandleAsync(ctx, default);
 
         reply.Should().NotBeNull();
-        reply!.Text.Should().Contain("Eric");
+        reply!.Text.Should().Contain("已绑定");
+        reply.Text.Should().Contain("Eric");
         reply.Text.Should().Contain("bnd_…cdef");
         reply.Text.Should().NotContain("1234567890abcdef");
+    }
+
+    [Fact]
+    public async Task Whoami_DoesNotRequireBinding_AndReturnsUnboundHintForUnboundSender()
+    {
+        // Issue #513 phase 6: /whoami must reach its handler regardless of
+        // binding state so the user can introspect "am I bound?" without the
+        // turn runner short-circuiting them to the /init prompt instead.
+        var handler = new WhoamiChannelSlashCommandHandler();
+        handler.RequiresBinding.Should().BeFalse();
+
+        var ctx = new ChannelSlashCommandContext
+        {
+            CommandName = "whoami",
+            ArgumentText = string.Empty,
+            Subject = Subject(),
+            BindingIdValue = null,
+            RegistrationId = "reg-1",
+            RegistrationScopeId = "scope-1",
+            SenderId = "ou_user_y",
+            SenderName = "Eric",
+            IsPrivateChat = true,
+        };
+
+        var reply = await handler.HandleAsync(ctx, default);
+
+        reply.Should().NotBeNull();
+        reply!.Text.Should().Contain("未绑定");
+        reply.Text.Should().Contain("/init");
+        reply.Text.Should().Contain("Eric");
+        // Must not invent a binding-id placeholder — masked output is only
+        // for actual bindings.
+        reply.Text.Should().NotContain("Binding ID");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Three small loose ends from issue #513 (per-user NyxID binding product experience). PR #521 + #557 already shipped the bulk; this clears the remaining gaps surfaced when re-reading the spec against `feature/lark-bot`.

### 1. Phase 6 — `/whoami` no longer requires binding

The issue explicitly carves `/init`, `/unbind`, `/whoami` out of the auth requirement so unbound users can introspect their own state. Previously `WhoamiChannelSlashCommandHandler.RequiresBinding` was `true`, so the turn runner short-circuited unbound senders to the binding-gate `/init` prompt instead of running the handler.

- Switch `RequiresBinding=false`.
- In `HandleAsync`, branch on `BindingIdValue`: bound → masked binding info (unchanged); unbound → `未绑定 ... 发送 /init 完成绑定` with no fake binding-id placeholder.

### 2. Phase 3 — explicit 3 binding × 3 owner-prefs matrix test

`ConversationReplyGeneratorTests` already covered sender-overrides-model, sender-store-throws, route-failure-retry, and no-sender-token cases. The issue's `单测覆盖三种 binding 状态 × 三种 prefs 状态矩阵` was not pinned as an explicit matrix.

Added a `[Theory]` (`GenerateReplyAsync_OverrideMatrix_BindingTimesOwnerPrefs`) with 9 cells:

|             | Owner None | Owner Partial (model) | Owner Full (model+route+rounds) |
|-------------|-----------|------------------------|----------------------------------|
| Unbound     | (∅,∅,∅)   | (O-M,∅,∅)              | (O-M,O-R,9)                      |
| BoundEmpty  | (∅,∅,∅)   | (O-M,∅,∅)              | (O-M,O-R,9)                      |
| BoundModelOnly | (S-M,∅,∅) | (S-M,∅,∅)            | (S-M,O-R,9)                      |

Sender-bound row deliberately sets only `DefaultModel` so the matrix doesn't cross the route-applied + no-sender-token "silent fallback to owner snapshot" branch (orthogonal, already covered by `UsesOwnerPrefsImmediatelyWhenSenderRouteHasNoToken`).

### 3. Phase 1 — OAuth callback HTML success page with `/model` hint

> ⚠️ **Scoped down**: the issue says `callback 成功后的卡片更新："绑定成功，请选择模型"`. The full version is a Lark **card update** pushed back into the chat, which requires capturing the `/init` card's adapter-owned message-id and threading it through the OAuth state token (`StateTokenPayload` proto change + new `IChannelOutboundPort.ContinueConversationAsync` plumbing). That's substantial new design surface and out of scope for a wrap-up PR. **Left as a follow-up.**

The browser-side substitute: the OAuth callback response was JSON. After this PR the success / already-bound paths return a small inline-styled HTML page (`Results.Content(html, "text/html")`) that names the next-step commands explicitly:

> 回到 Lark 后,发送 `/model` 选择想用的模型,或 `/whoami` 查看当前绑定状态。

- Display name from `id_token.name` is HTML-encoded.
- Error paths (`code_missing`, `state_malformed`, `actor_activation_failed`, `token_exchange_failed`, `binding_pending_propagation`, `client_not_provisioned`, `broker_capability_disabled`) keep returning JSON for ops / programmatic consumers.
- `binding_pending_propagation` left as JSON; if we want HTML for that retry-friendly user-facing case too, that's a separate small change.

## Validation

- [x] `dotnet build test/Aevatar.GAgents.ChannelRuntime.Tests/...` clean (84 warnings, 0 errors — all pre-existing CS0612/CA1502)
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/...` — **868/868 passing** (10 new tests: 9 matrix cells + new HTML content-type test + reworked existing /whoami test + new unbound-/whoami test; 2 existing OAuth-callback tests updated to read text instead of JSON)
- [x] `tools/ci/test_stability_guards.sh` passes
- [x] `tools/ci/channel_mega_interface_guard.sh` passes
- [ ] Smoke test on staging: `/whoami` from an unbound Lark sender → see `未绑定 ... /init` hint instead of binding card; OAuth round-trip → see HTML success page in browser with `/model` and `/whoami` named.

## Out of scope (follow-ups)

- **Phase 1 in-chat card update** (binding pending → authorizing → bound). Needs `StateTokenPayload` to carry `registration_id` so the OAuth callback can resolve the originating channel adapter and call `IChannelOutboundPort.UpdateAsync` / `ContinueConversationAsync` against the original `/init` message-id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)