### PR TITLE
Connect console Teams to real roster API

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -755,6 +755,7 @@ jest.mock("@/shared/studio/api", () => ({
         implementationKind: "workflow" | "script" | "gagent";
         description?: string | null;
         memberId?: string | null;
+        teamId?: string | null;
       }) => {
         const nextMemberId =
           input.memberId?.trim() ||
@@ -768,6 +769,7 @@ jest.mock("@/shared/studio/api", () => ({
           lifecycleStage: "created",
           publishedServiceId: `member-${nextMemberId}`,
           lastBoundRevisionId: null,
+          teamId: input.teamId ?? null,
           createdAt: "2026-04-27T08:10:00Z",
           updatedAt: "2026-04-27T08:10:00Z",
         };
@@ -3462,6 +3464,28 @@ describe("StudioPage", () => {
       expect(message.success).toHaveBeenCalledWith(
         "Created member orders-draft and opened its workflow draft.",
       );
+    });
+  });
+
+  it("passes route Team context when creating a backend member", async () => {
+    renderStudioPage("/studio?scopeId=scope-1&teamId=t-alpha&tab=studio&intent=create-member");
+
+    const createDialog = await screen.findByRole("dialog", { name: "Create member" });
+    const nameInput = within(createDialog).getByLabelText("Member name");
+    fireEvent.change(nameInput, {
+      target: {
+        value: "team-worker",
+      },
+    });
+    fireEvent.click(within(createDialog).getByRole("button", { name: "Create member" }));
+
+    await waitFor(() => {
+      expect(studioApi.createMember).toHaveBeenCalledWith({
+        scopeId: "scope-1",
+        displayName: "team-worker",
+        implementationKind: "workflow",
+        teamId: "t-alpha",
+      });
     });
   });
 

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -155,6 +155,7 @@ import {
 
 type StudioRouteState = {
   scopeId: string;
+  teamId: string;
   memberKey: string;
   memberId: string;
   step: StudioStep;
@@ -1084,6 +1085,7 @@ function readStudioRouteState(search?: string): StudioRouteState {
   if (typeof window === 'undefined' && typeof search !== 'string') {
     return {
       scopeId: '',
+      teamId: '',
       memberKey: '',
       memberId: '',
       step: 'build',
@@ -1107,6 +1109,7 @@ function readStudioRouteState(search?: string): StudioRouteState {
   const routeMember = readStudioRouteMemberFromParams(params);
   return {
     scopeId: trimOptional(params.get('scopeId')),
+    teamId: trimOptional(params.get('teamId')),
     memberKey: routeMember.key,
     memberId: routeMember.memberId,
     step: parseStudioStep(params.get('step')),
@@ -2300,6 +2303,7 @@ const StudioPage: React.FC = () => {
   const [createMemberKind, setCreateMemberKind] = useState<BuildMode>('workflow');
   const [createMemberName, setCreateMemberName] = useState('');
   const [createMemberDirectoryId, setCreateMemberDirectoryId] = useState('');
+  const [createMemberTeamId, setCreateMemberTeamId] = useState('');
   const [runPrompt, setRunPrompt] = useState(() => readStudioRouteState().prompt);
   const [runPending, setRunPending] = useState(false);
   const [runNotice, setRunNotice] = useState<DraftRunNotice | null>(null);
@@ -4187,6 +4191,7 @@ const StudioPage: React.FC = () => {
       return;
     }
 
+    setCreateMemberTeamId(trimOptional(routeState.teamId));
     setCreateMemberName(suggestedCreateWorkflowName);
     setCreateMemberKind('workflow');
     setCreateMemberDirectoryId(
@@ -4197,6 +4202,7 @@ const StudioPage: React.FC = () => {
     confirmScriptsStudioLeave,
     inventoryDirectoryId,
     inventoryDirectoryOptions,
+    routeState.teamId,
     suggestedCreateWorkflowName,
   ]);
 
@@ -4205,6 +4211,7 @@ const StudioPage: React.FC = () => {
       return;
     }
 
+    setCreateMemberTeamId(trimOptional(routeState.teamId));
     setCreateMemberName(suggestedCreateScriptName);
     setCreateMemberKind('script');
     setCreateMemberDirectoryId(
@@ -4215,6 +4222,7 @@ const StudioPage: React.FC = () => {
     confirmScriptsStudioLeave,
     inventoryDirectoryId,
     inventoryDirectoryOptions,
+    routeState.teamId,
     suggestedCreateScriptName,
   ]);
 
@@ -4251,6 +4259,7 @@ const StudioPage: React.FC = () => {
     }
 
     setCreateMemberModalOpen(false);
+    setCreateMemberTeamId('');
   }, [inventoryBusyKey]);
 
   const handleCreateMember = useCallback(async (selectedCreateMemberKind: BuildMode) => {
@@ -4286,9 +4295,11 @@ const StudioPage: React.FC = () => {
         setSelectedScriptId(scriptId);
         setScriptBuildState(null);
         setCreateMemberModalOpen(false);
+        setCreateMemberTeamId('');
         history.push(
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
+            teamId: createMemberTeamId || undefined,
             focus: `script:${scriptId}`,
             step: 'build',
             tab: 'scripts',
@@ -4301,9 +4312,11 @@ const StudioPage: React.FC = () => {
       }
 
       setCreateMemberModalOpen(false);
+      setCreateMemberTeamId('');
       history.push(
         buildStudioRoute({
           scopeId: resolvedStudioScopeId || undefined,
+          teamId: createMemberTeamId || undefined,
           step: 'build',
           tab: 'gagents',
         }),
@@ -4364,6 +4377,7 @@ const StudioPage: React.FC = () => {
       setCreateMemberModalOpen(false);
 
       if (!resolvedStudioScopeId) {
+        setCreateMemberTeamId('');
         void message.success(
           `Created workflow draft for member ${workflowName}. Connect a scope to register the backend member authority.`,
         );
@@ -4375,6 +4389,7 @@ const StudioPage: React.FC = () => {
           scopeId: resolvedStudioScopeId,
           displayName: workflowName,
           implementationKind: 'workflow',
+          ...(createMemberTeamId ? { teamId: createMemberTeamId } : {}),
         });
         await queryClient.invalidateQueries({
           queryKey: ['studio-scope-members', resolvedStudioScopeId],
@@ -4389,6 +4404,7 @@ const StudioPage: React.FC = () => {
             : 'Workflow draft created, but Studio could not register the member authority.',
         );
       }
+      setCreateMemberTeamId('');
     } catch (error) {
       void message.error(
         error instanceof Error
@@ -4406,6 +4422,7 @@ const StudioPage: React.FC = () => {
     confirmScriptsStudioLeave,
     createMemberDirectoryId,
     createMemberName,
+    createMemberTeamId,
     history,
     inventoryDirectoryId,
     queryClient,
@@ -5767,6 +5784,7 @@ const StudioPage: React.FC = () => {
 
     history.replace(buildStudioRoute({
       scopeId: resolvedStudioScopeId || undefined,
+      teamId: routeState.teamId || undefined,
       memberKey: persistedMemberKey,
       step,
       focus: persistedFocus,
@@ -5791,6 +5809,7 @@ const StudioPage: React.FC = () => {
     routeBuildFocus.kind,
     routeBuildFocus.value,
     routeSelectedMemberKey,
+    routeState.teamId,
     runPrompt,
     selectedWorkflowId,
     selectedExecutionId,

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -165,6 +165,28 @@ function mockCreateMembersCatalog() {
   };
 }
 
+function mockCreateTeamMembersCatalog() {
+  return {
+    scopeId: "scope-1",
+    members: [
+      {
+        memberId: "member-team-alpha",
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        displayName: "Team Alpha Operator",
+        description: "真实 Team roster 成员",
+        implementationKind: "workflow",
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "alpha-service",
+        lastBoundRevisionId: "rev-alpha",
+        createdAt: "2026-04-09T08:00:00Z",
+        updatedAt: "2026-04-09T09:00:00Z",
+      },
+    ],
+    nextPageToken: null,
+  };
+}
+
 function mockCreateRunAudit(scopeId: string, runId: string) {
   return {
     summary: {
@@ -604,6 +626,7 @@ jest.mock("@/shared/studio/api", () => ({
       ],
     })),
     listMembers: jest.fn(async () => mockCreateMembersCatalog()),
+    listTeamMembers: jest.fn(async () => mockCreateTeamMembersCatalog()),
     parseYaml: jest.fn(async () => ({
       document: {
         name: "support-triage",
@@ -649,6 +672,10 @@ describe("TeamDetailPage", () => {
     (studioApi.listMembers as jest.Mock).mockReset();
     (studioApi.listMembers as jest.Mock).mockImplementation(
       async () => mockCreateMembersCatalog(),
+    );
+    (studioApi.listTeamMembers as jest.Mock).mockReset();
+    (studioApi.listTeamMembers as jest.Mock).mockImplementation(
+      async () => mockCreateTeamMembersCatalog(),
     );
   });
 
@@ -957,6 +984,26 @@ describe("TeamDetailPage", () => {
     expect(screen.getAllByText("serviceId").length).toBeGreaterThan(0);
     expect(screen.getAllByText("default").length).toBeGreaterThan(0);
     expect(screen.getByRole("button", { name: "打开 Services" })).toBeTruthy();
+  });
+
+  it("uses the real Team roster when teamId is selected", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha&tab=members",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("真实 Team roster")).toBeTruthy();
+    expect(await screen.findByText("Team Alpha Operator")).toBeTruthy();
+    expect(screen.getByText("真实 Team roster 成员")).toBeTruthy();
+    expect(screen.getByText("member-team-alpha")).toBeTruthy();
+    expect(screen.getByText("alph...vice")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(studioApi.listTeamMembers).toHaveBeenCalledWith("scope-1", "t-alpha");
+    });
   });
 
   it("shows a team-first event stream with member mapping", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -47,7 +47,10 @@ import {
   buildStudioWorkflowEditorRoute,
   buildStudioWorkflowWorkspaceRoute,
 } from "@/shared/studio/navigation";
-import type { StudioWorkflowDocument } from "@/shared/studio/models";
+import {
+  formatStudioMemberLifecycleStage,
+  type StudioWorkflowDocument,
+} from "@/shared/studio/models";
 import {
   AevatarInspectorEmpty,
   AevatarPanel,
@@ -1088,6 +1091,7 @@ const TeamDetailPage: React.FC = () => {
     return readTeamDetailRouteState(window.location.search, window.location.pathname);
   }, [locationSnapshot]);
   const scopeId = routeState.scopeId.trim();
+  const selectedTeamId = trimText(routeState.teamId);
   const teamsListHref = React.useMemo(
     () => buildScopeHref("/teams", { scopeId }),
     [scopeId],
@@ -1154,6 +1158,13 @@ const TeamDetailPage: React.FC = () => {
     enabled: scopeId.length > 0,
     queryFn: () => studioApi.getConnectorCatalog(),
     queryKey: ["teams", "connector-catalog"],
+    retry: false,
+  });
+
+  const teamMembersQuery = useQuery({
+    enabled: scopeId.length > 0 && selectedTeamId.length > 0,
+    queryFn: () => studioApi.listTeamMembers(scopeId, selectedTeamId),
+    queryKey: ["teams", "team-members", scopeId, selectedTeamId],
     retry: false,
   });
 
@@ -1380,6 +1391,7 @@ const TeamDetailPage: React.FC = () => {
       buildTeamDetailHref({
         memberId: canonicalMemberId,
         scopeId,
+        teamId: selectedTeamId || undefined,
         workflowId: trimText(routeState.workflowId) || undefined,
         serviceId: trimText(routeState.serviceId) || undefined,
         runId: trimText(routeState.runId) || undefined,
@@ -1393,6 +1405,7 @@ const TeamDetailPage: React.FC = () => {
     routeState.serviceId,
     routeState.tab,
     routeState.workflowId,
+    selectedTeamId,
     scopeId,
   ]);
   const currentPlatformService =
@@ -1430,11 +1443,13 @@ const TeamDetailPage: React.FC = () => {
     trimText(activeWorkflowSummary?.workflowId).length > 0
       ? buildStudioWorkflowEditorRoute({
           scopeId,
+          teamId: selectedTeamId || undefined,
           memberKey: selectedStudioMemberKey,
           workflowId: activeWorkflowSummary?.workflowId,
         })
       : buildStudioWorkflowWorkspaceRoute({
           scopeId,
+          teamId: selectedTeamId || undefined,
           memberKey: selectedStudioMemberKey,
         });
 
@@ -1623,6 +1638,20 @@ const TeamDetailPage: React.FC = () => {
         implementationKind: lens.activeRevision?.implementationKind,
       }),
     [lens.activeRevision?.implementationKind, lens.members, teamWorkflowDocumentsQuery.data],
+  );
+  const teamRosterRows = React.useMemo(
+    () =>
+      (teamMembersQuery.data?.members ?? []).map((member) => ({
+        description: trimText(member.description),
+        implementationKind: formatCompositionKind(member.implementationKind),
+        key: member.memberId,
+        lifecycleLabel: formatStudioMemberLifecycleStage(member.lifecycleStage),
+        lifecycleStyle: resolveStatusPillStyle(token, member.lifecycleStage),
+        memberId: member.memberId,
+        name: trimText(member.displayName) || member.memberId,
+        serviceId: trimText(member.publishedServiceId) || "--",
+      })),
+    [teamMembersQuery.data?.members, token],
   );
   const latestVisibleUpdate =
     lens.currentRun?.lastUpdatedAt ||
@@ -3212,6 +3241,7 @@ const TeamDetailPage: React.FC = () => {
         buildTeamDetailHref({
           memberId: currentMemberId || undefined,
           scopeId,
+          teamId: selectedTeamId || undefined,
           workflowId: activeWorkflowId || undefined,
           serviceId: runtimeServiceId,
           runId:
@@ -3230,6 +3260,7 @@ const TeamDetailPage: React.FC = () => {
       lens.playback.currentRunId,
       preferredRunId,
       runtimeServiceId,
+      selectedTeamId,
       scopeId,
     ],
   );
@@ -3244,6 +3275,7 @@ const TeamDetailPage: React.FC = () => {
         buildTeamDetailHref({
           memberId: currentMemberId || undefined,
           scopeId,
+          teamId: selectedTeamId || undefined,
           workflowId: activeWorkflowId || undefined,
           serviceId: runtimeServiceId,
           runId: normalizedRunId || undefined,
@@ -3251,7 +3283,14 @@ const TeamDetailPage: React.FC = () => {
         }),
       );
     },
-    [activeTab, activeWorkflowId, currentMemberId, runtimeServiceId, scopeId],
+    [
+      activeTab,
+      activeWorkflowId,
+      currentMemberId,
+      runtimeServiceId,
+      selectedTeamId,
+      scopeId,
+    ],
   );
 
   const handleOpenConversation = React.useCallback(() => {
@@ -3510,6 +3549,10 @@ const TeamDetailPage: React.FC = () => {
         onOpenRuntimeExplorer={handleOpenServiceMapping}
         onOpenServices={handleOpenServices}
         onSelectActor={setSelectedActorId}
+        rosterError={teamMembersQuery.isError}
+        rosterLoading={teamMembersQuery.isLoading}
+        rosterRows={teamRosterRows}
+        rosterTeamId={selectedTeamId}
       />
     );
   };
@@ -3551,6 +3594,7 @@ const TeamDetailPage: React.FC = () => {
           history.push(
             buildStudioScriptsWorkspaceRoute({
               scopeId,
+              teamId: selectedTeamId || undefined,
               memberKey: selectedStudioMemberKey,
             }),
           )
@@ -3560,6 +3604,7 @@ const TeamDetailPage: React.FC = () => {
           history.push(
             buildStudioWorkflowWorkspaceRoute({
               scopeId,
+              teamId: selectedTeamId || undefined,
               memberKey: selectedStudioMemberKey,
             }),
           )

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -19,9 +19,23 @@ jest.mock("@/shared/api/scopeRuntimeApi", () => ({
 jest.mock("@/shared/studio/api", () => ({
   studioApi: {
     getAuthSession: jest.fn(),
+    listTeams: jest.fn(),
     listMembers: jest.fn(),
   },
 }));
+
+const defaultTeams = [
+  {
+    teamId: "t-support",
+    scopeId: "scope-a",
+    displayName: "客服团队",
+    description: "负责处理用户问题",
+    lifecycleStage: "active",
+    memberCount: 1,
+    createdAt: "2026-05-01T09:00:00Z",
+    updatedAt: "2026-05-01T10:02:00Z",
+  },
+];
 
 const defaultMembers = [
   {
@@ -33,6 +47,7 @@ const defaultMembers = [
     lifecycleStage: "bind_ready",
     publishedServiceId: "service-alpha",
     lastBoundRevisionId: "rev-2",
+    teamId: "t-support",
     createdAt: "2026-04-13T09:00:00Z",
     updatedAt: "2026-04-13T10:02:00Z",
   },
@@ -126,30 +141,36 @@ describe("TeamsHomePage", () => {
       members: defaultMembers,
       nextPageToken: null,
     });
+    (studioApi.listTeams as jest.Mock).mockResolvedValue({
+      scopeId: "scope-a",
+      teams: defaultTeams,
+      nextPageToken: null,
+    });
     (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValue(defaultServices);
     (scopeRuntimeApi.listMemberRuns as jest.Mock).mockImplementation(
       async (_scopeId: string, memberId: string) => buildMemberRunCatalog(memberId),
     );
   });
 
-  it("renders the team homepage around member-specific runtime facts", async () => {
+  it("renders the team homepage around real Team roster with member runtime hints", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
     expect(await screen.findByRole("button", { name: "查看团队" })).toBeTruthy();
     expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
     expect(screen.getByText("我的 AI 团队")).toBeTruthy();
     expect(screen.getByText("当前 Scope")).toBeTruthy();
-    expect(screen.getAllByText("团队成员").length).toBeGreaterThan(0);
+    expect(screen.getByText("真实 Team")).toBeTruthy();
+    expect(screen.getByText("Team roster")).toBeTruthy();
     expect(screen.getByText("运行正常")).toBeTruthy();
     expect(screen.getByText("需要处理")).toBeTruthy();
     expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
-    expect(screen.getByText("客服团队")).toBeTruthy();
-    expect(screen.getByText("成员标识：member-alpha")).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
+    expect(screen.getByText("Team 标识：t-support")).toBeTruthy();
     expect(screen.getByText("客服运行时")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "切换到列表视图" })).toBeNull();
   });
 
-  it("opens Studio from the member card without falling back to service-shaped member routes", async () => {
+  it("opens Studio from the team card actions", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
     fireEvent.click(await screen.findByRole("button", { name: "更多" }));
@@ -161,26 +182,39 @@ describe("TeamsHomePage", () => {
 
     const params = new URLSearchParams(window.location.search);
     expect(params.get("scopeId")).toBe("scope-a");
-    expect(params.get("member")).toBe("member:member-alpha");
+    expect(params.get("teamId")).toBeNull();
     expect(params.get("tab")).toBe("studio");
   });
 
-  it("routes Create Team directly into Studio member creation", async () => {
+  it("opens Studio member creation with Team context from the team card actions", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "组建新团队" }));
+    fireEvent.click(await screen.findByRole("button", { name: "更多" }));
+    fireEvent.click(await screen.findByText("新增成员"));
 
-    expect(window.location.pathname).toBe("/studio");
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/studio");
+    });
+
     const params = new URLSearchParams(window.location.search);
     expect(params.get("scopeId")).toBe("scope-a");
+    expect(params.get("teamId")).toBe("t-support");
     expect(params.get("tab")).toBe("studio");
     expect(params.get("intent")).toBe("create-member");
   });
 
-  it("does not show the roster view toggle when only one member is visible", async () => {
+  it("routes Create Team to the real create-team page", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    await screen.findByText("客服团队");
+    fireEvent.click(await screen.findByRole("button", { name: "组建新团队" }));
+
+    expect(window.location.pathname).toBe("/teams/new");
+  });
+
+  it("does not show the roster view toggle when only one Team is visible", async () => {
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    await screen.findByRole("heading", { level: 3, name: "客服团队" });
     expect(screen.queryByRole("button", { name: "切换到列表视图" })).toBeNull();
     expect(screen.queryByRole("button", { name: "切换到卡片视图" })).toBeNull();
   });
@@ -192,7 +226,7 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByText("客服团队")).toBeTruthy();
+    expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.getByText("部分团队信号暂时不可见")).toBeTruthy();
     expect(
       screen.queryByText("No stub for /api/scopes/scope-a/members/member-alpha/runs"),
@@ -209,6 +243,7 @@ describe("TeamsHomePage", () => {
     });
 
     const params = new URLSearchParams(window.location.search);
+    expect(params.get("teamId")).toBe("t-support");
     expect(params.get("memberId")).toBe("member-alpha");
     expect(params.get("serviceId")).toBe("service-alpha");
     expect(params.get("runId")).toBe("run-latest");
@@ -247,7 +282,24 @@ describe("TeamsHomePage", () => {
     });
   });
 
-  it("renders one card per member instead of collapsing the homepage into a scope singleton", async () => {
+  it("renders one card per Team instead of using member cards as teams", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [
+        ...defaultTeams,
+        {
+          teamId: "t-joker",
+          scopeId: "scope-a",
+          displayName: "joker",
+          description: "讽刺评论 Team",
+          lifecycleStage: "active",
+          memberCount: 1,
+          createdAt: "2026-05-01T09:10:00Z",
+          updatedAt: "2026-05-01T10:10:00Z",
+        },
+      ],
+      nextPageToken: null,
+    });
     (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       members: [
@@ -261,6 +313,7 @@ describe("TeamsHomePage", () => {
           lifecycleStage: "bind_ready",
           publishedServiceId: "service-joker",
           lastBoundRevisionId: "rev-joker",
+          teamId: "t-joker",
           createdAt: "2026-04-13T09:10:00Z",
           updatedAt: "2026-04-13T10:10:00Z",
         },
@@ -291,11 +344,44 @@ describe("TeamsHomePage", () => {
 
     expect(await screen.findByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "joker" })).toBeTruthy();
-    expect(screen.getByText("成员标识：member-joker")).toBeTruthy();
+    expect(screen.getByText("Team 标识：t-joker")).toBeTruthy();
     expect(screen.getAllByRole("button", { name: "查看团队" })).toHaveLength(2);
   });
 
-  it("shows an empty member roster state without querying member runs", async () => {
+  it("shows unassigned members without promoting them into team cards", async () => {
+    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      members: [
+        {
+          memberId: "member-loose",
+          scopeId: "scope-a",
+          displayName: "未归队成员",
+          description: "还没有 Team",
+          implementationKind: "workflow",
+          lifecycleStage: "created",
+          publishedServiceId: "",
+          lastBoundRevisionId: null,
+          teamId: null,
+          createdAt: "2026-04-13T09:10:00Z",
+          updatedAt: "2026-04-13T10:10:00Z",
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByText("存在未归队成员")).toBeTruthy();
+    expect(screen.getByText("Team 标识：t-support")).toBeTruthy();
+    expect(screen.queryByRole("heading", { level: 3, name: "未归队成员" })).toBeNull();
+  });
+
+  it("shows an empty Team roster state without querying member runs", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [],
+      nextPageToken: null,
+    });
     (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       members: [],
@@ -306,13 +392,18 @@ describe("TeamsHomePage", () => {
 
     expect(
       await screen.findByText(
-        "当前 Scope 下还没有创建任何 member。进入 Studio 创建成员后，这里会按成员逐个展示。",
+        "当前 Scope 下还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。",
       ),
     ).toBeTruthy();
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();
   });
 
-  it("opens Studio from the empty member roster state", async () => {
+  it("opens the real create-team page from the empty Team roster state", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [],
+      nextPageToken: null,
+    });
     (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
       scopeId: "scope-a",
       members: [],
@@ -321,14 +412,8 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "打开 Studio" }));
+    fireEvent.click(await screen.findByRole("button", { name: "组建新团队" }));
 
-    await waitFor(() => {
-      expect(window.location.pathname).toBe("/studio");
-    });
-
-    const params = new URLSearchParams(window.location.search);
-    expect(params.get("scopeId")).toBe("scope-a");
-    expect(params.get("tab")).toBe("studio");
+    expect(window.location.pathname).toBe("/teams/new");
   });
 });

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -20,9 +20,7 @@ import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
 import { loadRestorableAuthSession } from "@/shared/auth/session";
 import { formatCompactDateTime } from "@/shared/datetime/dateTime";
 import { history } from "@/shared/navigation/history";
-import {
-  buildTeamDetailHref,
-} from "@/shared/navigation/teamRoutes";
+import { buildTeamDetailHref } from "@/shared/navigation/teamRoutes";
 import { buildRuntimeRunsHref } from "@/shared/navigation/runtimeRoutes";
 import { studioApi } from "@/shared/studio/api";
 import type { ScopeServiceRunSummary } from "@/shared/models/runtime/scopeServices";
@@ -30,11 +28,9 @@ import type { ServiceCatalogSnapshot } from "@/shared/models/services";
 import {
   formatStudioMemberLifecycleStage,
   type StudioMemberSummary,
+  type StudioTeamSummary,
 } from "@/shared/studio/models";
-import {
-  buildStudioRoute,
-  buildStudioWorkflowWorkspaceRoute,
-} from "@/shared/studio/navigation";
+import { buildStudioWorkflowWorkspaceRoute } from "@/shared/studio/navigation";
 import {
   AevatarInspectorEmpty,
   AevatarPageShell,
@@ -68,6 +64,21 @@ type MemberRosterPreview = {
   readonly primaryActionLabel: string;
   readonly serviceId: string;
   readonly serviceLabel: string;
+  readonly title: string;
+  readonly updatedAt: string | null;
+};
+
+type TeamRosterPreview = {
+  readonly attention: WorkflowOperationalAttention;
+  readonly attentionDetail: string;
+  readonly detailHref: string;
+  readonly latestRun: ScopeServiceRunSummary | null;
+  readonly memberPreviewLabel: string;
+  readonly moreActions: Array<{ key: string; label: string; onClick: () => void }>;
+  readonly primaryActionLabel: string;
+  readonly serviceLabel: string;
+  readonly team: StudioTeamSummary;
+  readonly teamId: string;
   readonly title: string;
   readonly updatedAt: string | null;
 };
@@ -366,6 +377,41 @@ function compareMembers(
   return right.memberId.localeCompare(left.memberId);
 }
 
+function compareTeams(
+  left: StudioTeamSummary,
+  right: StudioTeamSummary,
+): number {
+  const rightTime = parseTimestamp(right.updatedAt);
+  const leftTime = parseTimestamp(left.updatedAt);
+  if (rightTime !== leftTime) {
+    return rightTime - leftTime;
+  }
+
+  return right.teamId.localeCompare(left.teamId);
+}
+
+function groupMembersByTeamId(
+  members: readonly StudioMemberSummary[],
+): Map<string, StudioMemberSummary[]> {
+  const result = new Map<string, StudioMemberSummary[]>();
+  members.forEach((member) => {
+    const teamId = trimOptional(member.teamId);
+    if (!teamId) {
+      return;
+    }
+
+    const existing = result.get(teamId);
+    if (existing) {
+      existing.push(member);
+    } else {
+      result.set(teamId, [member]);
+    }
+  });
+
+  result.forEach((teamMembers) => teamMembers.sort(compareMembers));
+  return result;
+}
+
 function resolveMemberPreviewService(input: {
   readonly member: StudioMemberSummary;
   readonly services: readonly ServiceCatalogSnapshot[];
@@ -523,6 +569,143 @@ function buildMemberRosterPreview(input: {
   };
 }
 
+function buildTeamRosterPreview(input: {
+  readonly guardrailedMemberIds?: ReadonlySet<string>;
+  readonly members: readonly StudioMemberSummary[];
+  readonly runsByMemberId: Readonly<Record<string, readonly ScopeServiceRunSummary[]>>;
+  readonly runtimeAvailableByMemberId?: ReadonlySet<string>;
+  readonly scopeId: string;
+  readonly services: readonly ServiceCatalogSnapshot[];
+  readonly team: StudioTeamSummary;
+}): TeamRosterPreview {
+  const memberPreviews = input.members.map((member) =>
+    buildMemberRosterPreview({
+      guardrailedMemberIds: input.guardrailedMemberIds,
+      member,
+      runsByMemberId: input.runsByMemberId,
+      runtimeAvailableByMemberId: input.runtimeAvailableByMemberId,
+      scopeId: input.scopeId,
+      services: input.services,
+    }),
+  );
+  const sortedMembers = [...input.members].sort(compareMembers);
+  const latestRun =
+    memberPreviews
+      .map((preview) => preview.latestRun)
+      .filter((run): run is ScopeServiceRunSummary => Boolean(run))
+      .sort(compareRuns)[0] ?? null;
+  const statusRank: Record<WorkflowOperationalAttention, number> = {
+    failed: 0,
+    waiting: 1,
+    "runtime-unresolved": 2,
+    "no-bound-service": 3,
+    "no-recent-runs": 4,
+    draft: 5,
+    healthy: 6,
+  };
+  const mostImportantMemberPreview = memberPreviews
+    .slice()
+    .sort(
+      (left, right) =>
+        statusRank[left.attention] - statusRank[right.attention] ||
+        parseTimestamp(right.updatedAt) - parseTimestamp(left.updatedAt) ||
+        right.memberId.localeCompare(left.memberId),
+    )[0];
+  const memberCount =
+    input.team.memberCount > 0 ? input.team.memberCount : input.members.length;
+  const firstMemberLabel = pickMeaningfulLabel(
+    sortedMembers[0]?.displayName,
+    sortedMembers[0]?.memberId,
+  );
+  const memberPreviewLabel =
+    memberCount > 0
+      ? firstMemberLabel
+        ? memberCount > 1
+          ? `${firstMemberLabel} 等 ${memberCount} 个成员`
+          : firstMemberLabel
+        : `${memberCount} 个成员`
+      : "暂无成员";
+  const serviceLabels = memberPreviews
+    .map((preview) => preview.serviceLabel)
+    .filter((label) => label && label !== "未绑定");
+  const uniqueServiceLabels = Array.from(new Set(serviceLabels));
+  const primaryMemberPreview =
+    memberPreviews.find((preview) => preview.serviceId) ?? memberPreviews[0] ?? null;
+  const detailHref = buildTeamDetailHref({
+    memberId: primaryMemberPreview?.memberId || undefined,
+    runId: latestRun?.runId || undefined,
+    scopeId: input.scopeId,
+    serviceId: primaryMemberPreview?.serviceId || undefined,
+    teamId: input.team.teamId,
+  });
+  const studioHref = buildStudioWorkflowWorkspaceRoute({
+    scopeId: input.scopeId,
+  });
+  const runtimeHref =
+    primaryMemberPreview?.serviceId && primaryMemberPreview.serviceId.length > 0
+      ? buildRuntimeRunsHref({
+          actorId: latestRun?.actorId || undefined,
+          scopeId: input.scopeId,
+          serviceId: primaryMemberPreview.serviceId,
+        })
+      : "";
+  const moreActions: Array<{ key: string; label: string; onClick: () => void }> = [];
+  const createMemberHref = buildStudioWorkflowWorkspaceRoute({
+    scopeId: input.scopeId,
+    teamId: input.team.teamId,
+    intent: "create-member",
+  });
+  if (runtimeHref) {
+    moreActions.push({
+      key: "runtime",
+      label: "查看运行",
+      onClick: () => history.push(runtimeHref),
+    });
+  }
+  moreActions.push({
+    key: "add-member",
+    label: "新增成员",
+    onClick: () => history.push(createMemberHref),
+  });
+  moreActions.push({
+    key: "builder",
+    label: "进入 Studio",
+    onClick: () => history.push(studioHref),
+  });
+
+  let attention: WorkflowOperationalAttention =
+    mostImportantMemberPreview?.attention ?? "draft";
+  let attentionDetail = "这个 Team 已经存在后端事实，但还没有分配成员。";
+  if (input.team.lifecycleStage === "archived") {
+    attention = "draft";
+    attentionDetail = "这个 Team 已归档，列表中仅保留它的后端 roster 事实。";
+  } else if (mostImportantMemberPreview) {
+    attentionDetail = mostImportantMemberPreview.attentionDetail;
+  }
+
+  return {
+    attention,
+    attentionDetail,
+    detailHref,
+    latestRun,
+    memberPreviewLabel,
+    moreActions,
+    primaryActionLabel: "查看团队",
+    serviceLabel:
+      uniqueServiceLabels.length > 0
+        ? uniqueServiceLabels.slice(0, 2).join(" / ")
+        : "暂无绑定服务",
+    team: input.team,
+    teamId: input.team.teamId,
+    title: pickMeaningfulLabel(input.team.displayName, input.team.teamId) || "未命名 Team",
+    updatedAt:
+      latestRun?.lastUpdatedAt ||
+      mostImportantMemberPreview?.updatedAt ||
+      input.team.updatedAt ||
+      null,
+  };
+}
+
 const MoreActionsButton: React.FC<{
   readonly actions: Array<{ key: string; label: string; onClick: () => void }>;
 }> = ({ actions }) => (
@@ -554,8 +737,8 @@ const MoreActionsButton: React.FC<{
   </Dropdown>
 );
 
-const MemberRosterCard: React.FC<{
-  readonly preview: MemberRosterPreview;
+const TeamRosterCard: React.FC<{
+  readonly preview: TeamRosterPreview;
 }> = ({ preview }) => {
   const { token } = theme.useToken();
 
@@ -636,7 +819,7 @@ const MemberRosterCard: React.FC<{
           fontSize: 13,
         }}
       >
-        成员标识：{preview.entryLabel}
+        Team 标识：{preview.teamId}
       </Typography.Text>
 
       <div
@@ -659,6 +842,18 @@ const MemberRosterCard: React.FC<{
           label="最近更新"
           value={formatShortTime(preview.updatedAt)}
         />
+      </div>
+
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          display: "grid",
+          gap: 14,
+          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          paddingTop: 14,
+        }}
+      >
+        <TeamFact label="Team 成员" value={preview.memberPreviewLabel} />
         <TeamFact label="关联服务" value={preview.serviceLabel} />
       </div>
 
@@ -676,8 +871,8 @@ const MemberRosterCard: React.FC<{
   );
 };
 
-const MemberRosterRow: React.FC<{
-  readonly preview: MemberRosterPreview;
+const TeamRosterRow: React.FC<{
+  readonly preview: TeamRosterPreview;
 }> = ({ preview }) => {
   const { token } = theme.useToken();
 
@@ -698,9 +893,9 @@ const MemberRosterRow: React.FC<{
         borderRadius: 20,
         boxShadow: token.boxShadowTertiary,
         cursor: "pointer",
-        display: "grid",
-        gap: 16,
-        gridTemplateColumns: "minmax(0, 1.8fr) repeat(3, minmax(88px, 120px)) auto",
+    display: "grid",
+    gap: 16,
+    gridTemplateColumns: "minmax(0, 1.8fr) repeat(4, minmax(88px, 120px)) auto",
         minWidth: 0,
         padding: 16,
       }}
@@ -749,7 +944,7 @@ const MemberRosterRow: React.FC<{
             fontSize: 13,
           }}
         >
-          成员标识：{preview.entryLabel}
+          Team 标识：{preview.teamId}
         </Typography.Text>
       </div>
 
@@ -761,6 +956,7 @@ const MemberRosterRow: React.FC<{
         )}
       />
       <TeamFact label="更新" value={formatShortTime(preview.updatedAt)} />
+      <TeamFact label="成员" value={preview.memberPreviewLabel} />
       <TeamFact label="服务" value={preview.serviceLabel} />
 
       <Space wrap>
@@ -849,6 +1045,12 @@ const TeamsHomePage: React.FC = () => {
     queryFn: () => studioApi.listMembers(scopeId),
     retry: false,
   });
+  const teamsQuery = useQuery({
+    enabled: scopeId.length > 0,
+    queryKey: ["teams", "roster", scopeId],
+    queryFn: () => studioApi.listTeams(scopeId),
+    retry: false,
+  });
   const servicesQuery = useQuery({
     enabled: scopeId.length > 0,
     queryKey: ["teams", "services", scopeId],
@@ -862,6 +1064,18 @@ const TeamsHomePage: React.FC = () => {
   const studioMembers = React.useMemo(
     () => [...(membersQuery.data?.members ?? [])].sort(compareMembers),
     [membersQuery.data?.members],
+  );
+  const studioTeams = React.useMemo(
+    () => [...(teamsQuery.data?.teams ?? [])].sort(compareTeams),
+    [teamsQuery.data?.teams],
+  );
+  const membersByTeamId = React.useMemo(
+    () => groupMembersByTeamId(studioMembers),
+    [studioMembers],
+  );
+  const unassignedMembers = React.useMemo(
+    () => studioMembers.filter((member) => !trimOptional(member.teamId)),
+    [studioMembers],
   );
   const runtimeTrackableMembers = React.useMemo(
     () =>
@@ -916,25 +1130,27 @@ const TeamsHomePage: React.FC = () => {
       ) as Record<string, readonly any[]>,
     [memberRunQueries, runtimeSampleMembers],
   );
-  const memberPreviews = React.useMemo(
+  const teamPreviews = React.useMemo(
     () =>
-      studioMembers.map((member) =>
-        buildMemberRosterPreview({
+      studioTeams.map((team) =>
+        buildTeamRosterPreview({
           guardrailedMemberIds,
-          member,
+          members: membersByTeamId.get(team.teamId) ?? [],
           runsByMemberId,
           runtimeAvailableByMemberId,
           scopeId,
           services: servicesQuery.data ?? [],
+          team,
         }),
       ),
     [
       guardrailedMemberIds,
+      membersByTeamId,
       runsByMemberId,
       runtimeAvailableByMemberId,
       scopeId,
       servicesQuery.data,
-      studioMembers,
+      studioTeams,
     ],
   );
   const membersPendingBindingCount = React.useMemo(
@@ -946,24 +1162,25 @@ const TeamsHomePage: React.FC = () => {
       ).length,
     [studioMembers],
   );
-  const visibleTeamCount = memberPreviews.length;
+  const visibleTeamCount = teamPreviews.length;
   const resolvedRosterView =
     manualRosterView ??
     (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
   const useCompactRoster = resolvedRosterView === "list";
-  const healthyTeamCount = memberPreviews.filter(
+  const healthyTeamCount = teamPreviews.filter(
     (preview) => preview.attention === "healthy",
   ).length;
-  const attentionTeamCount = memberPreviews.filter(
+  const attentionTeamCount = teamPreviews.filter(
     (preview) => preview.attention !== "healthy",
   ).length;
   const emptyRosterHint =
     scopeId.length > 0
-      ? "当前 Scope 下还没有创建任何 member。进入 Studio 创建成员后，这里会按成员逐个展示。"
-      : "先导入一个 Scope，首页才能渲染出这组成员卡片。";
+      ? "当前 Scope 下还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。"
+      : "先导入一个 Scope，首页才能渲染出这组 Team roster。";
   const partialIssues = [
     servicesQuery.isError ? "服务目录暂时不可见。" : null,
     membersQuery.isError ? "当前 Scope 的成员清单暂时不可见。" : null,
+    teamsQuery.isError ? "当前 Scope 的 Team roster 暂时不可见。" : null,
     ...memberRunQueries.map((query) =>
       query.isError ? "部分成员运行信号暂时不可见。" : null,
     ),
@@ -1000,19 +1217,7 @@ const TeamsHomePage: React.FC = () => {
         <Space wrap>
           <Button
             icon={<PlusOutlined />}
-            onClick={() =>
-              history.push(
-                buildStudioRoute({
-                  scopeId:
-                    scopeId ||
-                    readScopeQueryDraft().scopeId ||
-                    resolvedScope?.scopeId ||
-                    localScopeId,
-                  tab: "studio",
-                  intent: "create-member",
-                }),
-              )
-            }
+            onClick={() => history.push("/teams/new")}
             style={{ borderRadius: 16, height: 40, paddingInline: 18 }}
             type="primary"
           >
@@ -1122,19 +1327,19 @@ const TeamsHomePage: React.FC = () => {
                 {scopeId}
               </Typography.Text>
               <Typography.Text type="secondary">
-                首页按这个 Scope 汇总成员本身的绑定与运行状态，Scope 只做上下文，不再直接当团队名展示。
+                首页按这个 Scope 读取后端 Team roster；成员绑定与运行状态只作为 Team 卡片的辅助信号。
               </Typography.Text>
             </div>
           </div>
         ) : null}
 
-        {!scopeId ? (
-          <Alert
-            showIcon
-            title="先导入一个 Scope，首页才能渲染出这组成员卡片。"
-            type="info"
-          />
-        ) : null}
+	{!scopeId ? (
+	  <Alert
+	    showIcon
+	    title="先导入一个 Scope，首页才能渲染出这组 Team roster。"
+	    type="info"
+	  />
+	) : null}
 
         {partialIssues.length > 0 ? (
           <Alert
@@ -1171,10 +1376,34 @@ const TeamsHomePage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
               }}
             >
-              <SummaryStatCard accent label="团队成员" value={visibleTeamCount} />
+              <SummaryStatCard accent label="真实 Team" value={visibleTeamCount} />
               <SummaryStatCard label="运行正常" value={healthyTeamCount} />
               <SummaryStatCard label="需要处理" value={attentionTeamCount} />
             </div>
+
+            {unassignedMembers.length > 0 ? (
+              <Alert
+                action={
+                  <Button
+                    onClick={() =>
+                      history.push(
+                        buildStudioWorkflowWorkspaceRoute({
+                          scopeId,
+                        }),
+                      )
+                    }
+                    size="small"
+                    type="primary"
+                  >
+                    打开 Studio
+                  </Button>
+                }
+                description={`还有 ${unassignedMembers.length} 个成员没有归属 Team。它们不会被当成 Team 展示，只作为待整理成员保留。`}
+                showIcon
+                title="存在未归队成员"
+                type="info"
+              />
+            ) : null}
 
             {membersPendingBindingCount > 0 ? (
               <Alert
@@ -1200,15 +1429,15 @@ const TeamsHomePage: React.FC = () => {
               />
             ) : null}
 
-            {membersQuery.isLoading ? (
-              <AevatarInspectorEmpty description="正在整理当前 Scope 的成员清单。" />
-            ) : membersQuery.isError ? (
+            {teamsQuery.isLoading ? (
+              <AevatarInspectorEmpty description="正在读取当前 Scope 的 Team roster。" />
+            ) : teamsQuery.isError ? (
               <Alert
                 showIcon
-                title="当前 Scope 的成员清单暂时无法加载。"
+                title="当前 Scope 的 Team roster 暂时无法加载。"
                 type="error"
               />
-            ) : memberPreviews.length > 0 ? (
+            ) : teamPreviews.length > 0 ? (
               <>
                 <div
                   style={{
@@ -1232,10 +1461,10 @@ const TeamsHomePage: React.FC = () => {
                         margin: 0,
                       }}
                     >
-                      团队成员
+                      Team roster
                     </Typography.Title>
                     <Typography.Text type="secondary">
-                      当前 Scope 下已经登记的成员，以及它们各自的绑定和运行状态。
+                      当前 Scope 下已经登记的真实 Team；成员绑定和运行状态只作为辅助信号。
                     </Typography.Text>
                   </div>
                   {visibleTeamCount > 1 ? (
@@ -1268,8 +1497,8 @@ const TeamsHomePage: React.FC = () => {
                       gap: 14,
                     }}
                   >
-                    {memberPreviews.map((preview) => (
-                      <MemberRosterRow key={preview.memberId} preview={preview} />
+                    {teamPreviews.map((preview) => (
+                      <TeamRosterRow key={preview.teamId} preview={preview} />
                     ))}
                   </div>
                 ) : (
@@ -1281,8 +1510,8 @@ const TeamsHomePage: React.FC = () => {
                       gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
                     }}
                   >
-                    {memberPreviews.map((preview) => (
-                      <MemberRosterCard key={preview.memberId} preview={preview} />
+                    {teamPreviews.map((preview) => (
+                      <TeamRosterCard key={preview.teamId} preview={preview} />
                     ))}
                   </div>
                 )}
@@ -1294,15 +1523,11 @@ const TeamsHomePage: React.FC = () => {
               >
                 <Button
                   onClick={() =>
-                    history.push(
-                      buildStudioWorkflowWorkspaceRoute({
-                        scopeId,
-                      }),
-                    )
+                    history.push("/teams/new")
                   }
                   type="primary"
                 >
-                  打开 Studio
+                  组建新团队
                 </Button>
               </Empty>
             )}

--- a/apps/aevatar-console-web/src/pages/teams/new.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.test.tsx
@@ -21,70 +21,124 @@ jest.mock('antd', () => {
 });
 
 describe('TeamCreatePage', () => {
+  const teamResponse = {
+    teamId: 't-alpha',
+    scopeId: 'scope-a',
+    displayName: '订单助手团队',
+    description: '处理订单异常',
+    lifecycleStage: 'active',
+    memberCount: 0,
+    createdAt: '2026-05-06T08:00:00Z',
+    updatedAt: '2026-05-06T08:00:00Z',
+  };
+  let fetchMock: jest.Mock;
+
   beforeEach(() => {
-    window.history.replaceState({}, '', '/teams/new');
+    window.history.replaceState({}, '', '/teams/new?scopeId=scope-a');
     jest.clearAllMocks();
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        enabled: false,
+        scopeId: 'scope-a',
+        scopeSource: 'nyxid',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
   });
 
-  it('renders the hidden compatibility page for saved draft recovery', async () => {
+  it('renders the real Team API create page with saved draft recovery kept secondary', async () => {
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
     expect(await screen.findByText('Aevatar / Teams')).toBeTruthy();
-    expect(screen.getByText('Saved Draft Recovery')).toBeTruthy();
-    expect(screen.getByText('用途')).toBeTruthy();
-    expect(screen.getByText('恢复对象')).toBeTruthy();
-    expect(screen.getByText('继续位置')).toBeTruthy();
-    expect(screen.getByText('新增后端事实')).toBeTruthy();
-    expect(screen.getByText('Continue initial member draft')).toBeTruthy();
-    expect(screen.getByRole('heading', { level: 3, name: 'Saved draft recovery' })).toBeTruthy();
-    expect(screen.getByLabelText('Legacy team label')).toBeTruthy();
-    expect(screen.getByLabelText('Initial member label')).toBeTruthy();
-    expect(
-      screen.getAllByRole('button', { name: 'Continue in Studio' }).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { level: 2, name: 'Create Team' })).toBeTruthy();
+    expect(screen.getByText('数据源')).toBeTruthy();
+    expect(screen.getByText('StudioTeam')).toBeTruthy();
+    expect(screen.getByText('Scope context')).toBeTruthy();
+    expect(screen.getByText('Team authority')).toBeTruthy();
+    expect(screen.getByRole('heading', { level: 3, name: 'Create real Team roster entry' })).toBeTruthy();
+    expect(screen.getByLabelText('Team name')).toBeTruthy();
+    expect(screen.getByLabelText('Team description')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Create Team' }).length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: 'View Behaviors' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Back to My Teams' })).toBeTruthy();
     expect(
       screen.getByText(
-        'This compatibility page preserves old Create Team links and saved draft recovery. New team creation now starts in Studio by creating the first member.',
+        'This page now creates a backend StudioTeam record. Members can be assigned later; the Teams homepage will use this roster entry as the primary team truth.',
       ),
     ).toBeTruthy();
-    expect(screen.queryByText('Team Builder Entry')).toBeNull();
-    expect(screen.queryByText('Start Building')).toBeNull();
-    expect(screen.queryByText('Open Studio')).toBeNull();
-    expect(
-      screen.queryByText(
-        '当前实现不会新增一套独立后端流程，而是复用现有 Studio 工作区先组建团队，再进入 Team Details 查看拓扑和事件流。',
-      ),
-    ).toBeNull();
-    expect(screen.queryByText('Next Steps')).toBeNull();
-    expect(screen.queryByText('Builder 模式')).toBeNull();
-    expect(screen.queryByText('默认入口')).toBeNull();
-    expect(screen.queryByText('后续页')).toBeNull();
-    expect(screen.queryByText('数据源')).toBeNull();
   });
 
-  it('opens Studio in member-first build mode without persisting create-team draft params', async () => {
+  it('creates a backend StudioTeam and routes to team focus', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        enabled: false,
+        scopeId: 'scope-a',
+        scopeSource: 'nyxid',
+      }),
+    } as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => teamResponse,
+    } as Response);
+
+    renderWithQueryClient(React.createElement(TeamCreatePage));
+
+    fireEvent.change(await screen.findByLabelText('Team name'), {
+      target: { value: '订单助手团队' },
+    });
+    fireEvent.change(screen.getByLabelText('Team description'), {
+      target: { value: '处理订单异常' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create Team' })[0]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/scopes/scope-a/teams',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            displayName: '订单助手团队',
+            description: '处理订单异常',
+          }),
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/teams/scope-a');
+    });
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('scopeId')).toBe('scope-a');
+    expect(params.get('teamId')).toBe('t-alpha');
+    expect(message.success).toHaveBeenCalledWith('已创建 Team。');
+  });
+
+  it('opens Studio with only scope context from the secondary action', async () => {
     renderWithQueryClient(React.createElement(TeamCreatePage));
 
     const openStudioButtons = await screen.findAllByRole('button', {
       name: 'Continue in Studio',
     });
 
-    expect(openStudioButtons[0]).toBeDisabled();
+    expect(openStudioButtons[0]).toBeEnabled();
 
-    fireEvent.change(screen.getByLabelText('Legacy team label'), {
+    fireEvent.change(screen.getByLabelText('Team name'), {
       target: { value: '订单助手团队' },
     });
-    fireEvent.change(screen.getByLabelText('Initial member label'), {
-      target: { value: '订单入口' },
-    });
 
-    expect(openStudioButtons[0]).toBeEnabled();
     fireEvent.click(openStudioButtons[0]);
 
     expect(window.location.pathname).toBe('/studio');
     const params = new URLSearchParams(window.location.search);
+    expect(params.get('scopeId')).toBe('scope-a');
     expect(params.get('tab')).toBe('studio');
     expect(params.get('focus')).toBeNull();
     expect(params.get('teamMode')).toBeNull();

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -1,13 +1,23 @@
-import { BuildOutlined, RocketOutlined } from '@ant-design/icons';
+import { BuildOutlined, RocketOutlined, TeamOutlined } from '@ant-design/icons';
 import { Button, Input, Space, Typography, message } from 'antd';
+import { useQuery } from '@tanstack/react-query';
 import React from 'react';
+import { loadRestorableAuthSession } from '@/shared/auth/session';
 import { history } from '@/shared/navigation/history';
-import { buildTeamCreateHref, buildTeamsHref } from '@/shared/navigation/teamRoutes';
+import { buildTeamsHref } from '@/shared/navigation/teamRoutes';
 import { studioApi } from '@/shared/studio/api';
 import { buildStudioRoute } from '@/shared/studio/navigation';
 import { AevatarPanel } from '@/shared/ui/aevatarPageShells';
 import ConsoleMetricCard from '@/shared/ui/ConsoleMetricCard';
 import ConsoleMenuPageShell from '@/shared/ui/ConsoleMenuPageShell';
+import ScopeQueryCard from '../scopes/components/ScopeQueryCard';
+import { resolveStudioScopeContext } from '../scopes/components/resolvedScope';
+import {
+  buildScopeHref,
+  normalizeScopeDraft,
+  readScopeQueryDraft,
+  type ScopeQueryDraft,
+} from '../scopes/components/scopeQuery';
 
 const primaryActionButtonStyle: React.CSSProperties = {
   background: '#6c5ce7',
@@ -39,6 +49,10 @@ const stageChipStyle: React.CSSProperties = {
   padding: '6px 12px',
 };
 
+function trimOptional(value: string | null | undefined): string {
+  return value?.trim() ?? '';
+}
+
 function readCreateTeamDraftFromLocation(): {
   readonly teamName: string;
   readonly entryName: string;
@@ -65,29 +79,103 @@ function readCreateTeamDraftFromLocation(): {
 
 const TeamCreatePage: React.FC = () => {
   const initialDraft = React.useMemo(readCreateTeamDraftFromLocation, []);
+  const [draft, setDraft] = React.useState<ScopeQueryDraft>(() =>
+    readScopeQueryDraft(),
+  );
+  const [activeDraft, setActiveDraft] = React.useState<ScopeQueryDraft>(() =>
+    readScopeQueryDraft(),
+  );
   const [teamName, setTeamName] = React.useState(initialDraft.teamName);
-  const [entryName, setEntryName] = React.useState(initialDraft.entryName);
+  const [teamDescription, setTeamDescription] = React.useState('');
+  const [entryName] = React.useState(initialDraft.entryName);
   const [teamDraftWorkflowId, setTeamDraftWorkflowId] = React.useState(
     initialDraft.teamDraftWorkflowId,
   );
   const [teamDraftWorkflowName, setTeamDraftWorkflowName] = React.useState(
     initialDraft.teamDraftWorkflowName,
   );
+  const [isCreatingTeam, setIsCreatingTeam] = React.useState(false);
   const [isDeletingDraft, setIsDeletingDraft] = React.useState(false);
-  const resolvedEntryName = entryName.trim() || teamName.trim();
+  const hasInitializedScopeFromResolvedSession = React.useRef(false);
+  const authSessionQuery = useQuery({
+    queryKey: ['scopes', 'auth-session'],
+    queryFn: () => studioApi.getAuthSession(),
+    retry: false,
+  });
+  const localScopeId = trimOptional(loadRestorableAuthSession()?.user.sub);
+  const locallyResolvedScope = React.useMemo(() => {
+    if (!localScopeId) {
+      return null;
+    }
+
+    return {
+      scopeId: localScopeId,
+      scopeSource: 'local-session',
+    };
+  }, [localScopeId]);
+  const resolvedScope = React.useMemo(
+    () => resolveStudioScopeContext(authSessionQuery.data) ?? locallyResolvedScope,
+    [authSessionQuery.data, locallyResolvedScope],
+  );
+  React.useEffect(() => {
+    if (!resolvedScope?.scopeId) {
+      return;
+    }
+    if (hasInitializedScopeFromResolvedSession.current) {
+      return;
+    }
+
+    hasInitializedScopeFromResolvedSession.current = true;
+    setDraft((currentDraft) =>
+      currentDraft.scopeId.trim()
+        ? currentDraft
+        : { scopeId: resolvedScope.scopeId },
+    );
+    setActiveDraft((currentDraft) =>
+      currentDraft.scopeId.trim()
+        ? currentDraft
+        : { scopeId: resolvedScope.scopeId },
+    );
+  }, [resolvedScope?.scopeId]);
+  const scopeId = activeDraft.scopeId.trim();
+  const legacyCreateParams = React.useMemo(
+    () => ({
+      entryName: initialDraft.entryName || undefined,
+      teamDraftWorkflowId: teamDraftWorkflowId.trim() || undefined,
+      teamDraftWorkflowName: teamDraftWorkflowName.trim() || undefined,
+      teamName: teamName.trim() || undefined,
+    }),
+    [
+      initialDraft.entryName,
+      teamDraftWorkflowId,
+      teamDraftWorkflowName,
+      teamName,
+    ],
+  );
+  React.useEffect(() => {
+    const nextPath = buildScopeHref(
+      '/teams/new',
+      activeDraft,
+      legacyCreateParams,
+    );
+    const currentPath =
+      typeof window === 'undefined'
+        ? ''
+        : `${window.location.pathname}${window.location.search}`;
+    if (nextPath !== currentPath) {
+      history.replace(nextPath);
+    }
+  }, [activeDraft, legacyCreateParams]);
   const resolvedDraftWorkflowId = teamDraftWorkflowId.trim();
   const resolvedDraftWorkflowName =
     teamDraftWorkflowName.trim() || resolvedDraftWorkflowId;
   const hasSavedDraft = Boolean(resolvedDraftWorkflowId);
-  const canOpenBuilder = Boolean(teamName.trim());
+  const canCreateTeam = Boolean(scopeId && teamName.trim());
+  const canOpenBuilder = Boolean(scopeId);
   const openBuilder = () =>
     history.push(
       buildStudioRoute({
-        teamMode: 'create',
-        teamName: teamName.trim() || undefined,
-        entryName: resolvedEntryName || undefined,
-        teamDraftWorkflowId: resolvedDraftWorkflowId || undefined,
-        teamDraftWorkflowName: resolvedDraftWorkflowName || undefined,
+        scopeId,
         focus: resolvedDraftWorkflowId
           ? `workflow:${resolvedDraftWorkflowId}`
           : undefined,
@@ -97,9 +185,44 @@ const TeamCreatePage: React.FC = () => {
   const openBehaviors = () =>
     history.push(
       buildStudioRoute({
+        scopeId,
         tab: 'workflows',
       }),
     );
+  const handleCreateTeam = async () => {
+    if (!canCreateTeam || isCreatingTeam) {
+      return;
+    }
+
+    setIsCreatingTeam(true);
+    try {
+      const team = await studioApi.createTeam({
+        scopeId,
+        displayName: teamName.trim(),
+        description: teamDescription.trim() || undefined,
+      });
+      void message.success('已创建 Team。');
+      history.push(
+        buildScopeHref(
+          `/teams/${encodeURIComponent(team.scopeId)}`,
+          {
+            scopeId: team.scopeId,
+          },
+          {
+            teamId: team.teamId,
+          },
+        ),
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error && error.message.trim()
+          ? error.message
+          : '创建 Team 失败。';
+      void message.error(errorMessage);
+    } finally {
+      setIsCreatingTeam(false);
+    }
+  };
   const handleDeleteDraft = async () => {
     if (!resolvedDraftWorkflowId || isDeletingDraft) {
       return;
@@ -111,10 +234,14 @@ const TeamCreatePage: React.FC = () => {
       setTeamDraftWorkflowId('');
       setTeamDraftWorkflowName('');
       history.replace(
-        buildTeamCreateHref({
-          teamName: teamName.trim() || undefined,
-          entryName: entryName.trim() || undefined,
-        }),
+        buildScopeHref(
+          '/teams/new',
+          { scopeId },
+          {
+            teamName: teamName.trim() || undefined,
+            entryName: entryName.trim() || undefined,
+          },
+        ),
       );
       void message.success('已删除当前团队草稿。');
     } catch (error) {
@@ -132,15 +259,25 @@ const TeamCreatePage: React.FC = () => {
     <ConsoleMenuPageShell
       breadcrumb="Aevatar / Teams"
       extra={
-        <Button
-          disabled={!canOpenBuilder}
-          onClick={openBuilder}
-          style={primaryActionButtonStyle}
-        >
-          Continue in Studio
-        </Button>
+        <Space wrap>
+          <Button
+            disabled={!canCreateTeam}
+            loading={isCreatingTeam}
+            onClick={() => void handleCreateTeam()}
+            style={primaryActionButtonStyle}
+          >
+            Create Team
+          </Button>
+          <Button
+            disabled={!canOpenBuilder}
+            onClick={openBuilder}
+            style={secondaryActionButtonStyle}
+          >
+            Continue in Studio
+          </Button>
+        </Space>
       }
-      title="Saved Draft Recovery"
+      title="Create Team"
     >
       <div
         style={{
@@ -150,16 +287,55 @@ const TeamCreatePage: React.FC = () => {
           marginBottom: 20,
         }}
       >
-        <ConsoleMetricCard label="用途" tone="purple" value="旧链接恢复" />
-        <ConsoleMetricCard label="恢复对象" value="初始 member 草稿" />
-        <ConsoleMetricCard label="继续位置" value="Studio" />
-        <ConsoleMetricCard label="新增后端事实" tone="green" value="0" />
+        <ConsoleMetricCard label="数据源" tone="green" value="StudioTeam" />
+        <ConsoleMetricCard label="Scope" value={scopeId || '待选择'} />
+        <ConsoleMetricCard label="创建后" value="Team detail" />
+        <ConsoleMetricCard label="成员归属" value="后续分配" />
       </div>
+
+      <AevatarPanel layoutMode="document" padding={20} title="Scope context">
+        <ScopeQueryCard
+          activeScopeId={scopeId}
+          draft={draft}
+          loadLabel="使用这个 Scope"
+          onChange={setDraft}
+          onLoad={() => {
+            const nextDraft = normalizeScopeDraft(draft);
+            setDraft(nextDraft);
+            setActiveDraft(nextDraft);
+          }}
+          onReset={() => {
+            const nextDraft = normalizeScopeDraft({
+              scopeId: resolvedScope?.scopeId ?? '',
+            });
+            setDraft(nextDraft);
+            setActiveDraft(nextDraft);
+          }}
+          onUseResolvedScope={() => {
+            if (!resolvedScope?.scopeId) {
+              return;
+            }
+
+            const nextDraft = normalizeScopeDraft({
+              scopeId: resolvedScope.scopeId,
+            });
+            setDraft(nextDraft);
+            setActiveDraft(nextDraft);
+          }}
+          resetDisabled={
+            normalizeScopeDraft(draft).scopeId ===
+              (resolvedScope?.scopeId?.trim() ?? '') &&
+            scopeId === (resolvedScope?.scopeId?.trim() ?? '')
+          }
+          resolvedScopeId={resolvedScope?.scopeId}
+          resolvedScopeSource={resolvedScope?.scopeSource}
+        />
+      </AevatarPanel>
 
       <AevatarPanel
         layoutMode="document"
         padding={20}
-        title="Continue initial member draft"
+        title="Team authority"
       >
         <div
           style={{
@@ -180,7 +356,7 @@ const TeamCreatePage: React.FC = () => {
                 margin: 0,
               }}
             >
-              Saved draft recovery
+              Create real Team roster entry
             </Typography.Title>
             <div
               style={{
@@ -189,7 +365,7 @@ const TeamCreatePage: React.FC = () => {
                 gap: 8,
               }}
             >
-              {['旧链接兼容', '草稿恢复', '显式进入 Studio', '不创建团队事实'].map((item) => (
+              {['真实 Team API', 'Scope 内归属', '成员后续分配', '运行态只作辅助'].map((item) => (
                 <span key={item} style={stageChipStyle}>
                   {item}
                 </span>
@@ -204,41 +380,50 @@ const TeamCreatePage: React.FC = () => {
               }}
             >
               <div style={{ display: 'grid', gap: 8 }}>
-                <Typography.Text strong>Legacy team label</Typography.Text>
+                <Typography.Text strong>Team name</Typography.Text>
                 <Input
-                  aria-label="Legacy team label"
+                  aria-label="Team name"
                   placeholder="例如：订单助手团队"
                   value={teamName}
                   onChange={(event) => setTeamName(event.target.value)}
                 />
               </div>
               <div style={{ display: 'grid', gap: 8 }}>
-                <Typography.Text strong>Initial member label</Typography.Text>
+                <Typography.Text strong>Description</Typography.Text>
                 <Input
-                  aria-label="Initial member label"
-                  placeholder="默认复用团队名称"
-                  value={entryName}
-                  onChange={(event) => setEntryName(event.target.value)}
+                  aria-label="Team description"
+                  placeholder="这个 Team 负责什么"
+                  value={teamDescription}
+                  onChange={(event) => setTeamDescription(event.target.value)}
                 />
               </div>
               <Typography.Text
                 type="secondary"
                 style={{ gridColumn: '1 / -1', lineHeight: 1.6 }}
               >
-                This compatibility page preserves old Create Team links and saved
-                draft recovery. New team creation now starts in Studio by creating
-                the first member.
+                This page now creates a backend StudioTeam record. Members can be
+                assigned later; the Teams homepage will use this roster entry as
+                the primary team truth.
                 {hasSavedDraft
-                  ? ' Continue in Studio to edit the linked initial member draft.'
+                  ? ' The old saved draft below remains available for Studio recovery.'
                   : ''}
               </Typography.Text>
             </div>
             <Space wrap size={[8, 8]}>
               <Button
+                icon={<TeamOutlined />}
+                disabled={!canCreateTeam}
+                loading={isCreatingTeam}
+                onClick={() => void handleCreateTeam()}
+                style={primaryActionButtonStyle}
+              >
+                Create Team
+              </Button>
+              <Button
                 icon={<BuildOutlined />}
                 disabled={!canOpenBuilder}
                 onClick={openBuilder}
-                style={primaryActionButtonStyle}
+                style={secondaryActionButtonStyle}
               >
                 Continue in Studio
               </Button>
@@ -272,8 +457,8 @@ const TeamCreatePage: React.FC = () => {
               }}
             >
               {teamName.trim()
-                ? `Legacy label: ${teamName.trim()}`
-                : 'Use this page only for old links or saved drafts'}
+                ? `Team label: ${teamName.trim()}`
+                : 'Create a Team before assigning members'}
             </Typography.Text>
           </div>
         </div>
@@ -318,6 +503,11 @@ const TeamCreatePage: React.FC = () => {
               Delete Draft removes the linked workflow draft. Legacy labels stay
               in the URL so old links remain understandable.
             </Typography.Text>
+            {entryName.trim() ? (
+              <Typography.Text type="secondary">
+                Legacy initial member label: {entryName.trim()}
+              </Typography.Text>
+            ) : null}
           </div>
         </AevatarPanel>
       ) : null}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -21,6 +21,17 @@ type MemberCompositionRow = {
   readonly summary: string;
 };
 
+type TeamRosterMemberRow = {
+  readonly description: string;
+  readonly implementationKind: string;
+  readonly key: string;
+  readonly lifecycleLabel: string;
+  readonly lifecycleStyle: React.CSSProperties;
+  readonly memberId: string;
+  readonly name: string;
+  readonly serviceId: string;
+};
+
 type MemberIdentityRow = {
   readonly actorId: string;
   readonly cardStyle: React.CSSProperties;
@@ -42,6 +53,10 @@ type TeamMembersTabProps = {
   readonly onOpenRuntimeExplorer: () => void;
   readonly onOpenServices: () => void;
   readonly onSelectActor: (actorId: string) => void;
+  readonly rosterError?: boolean;
+  readonly rosterLoading?: boolean;
+  readonly rosterRows?: readonly TeamRosterMemberRow[];
+  readonly rosterTeamId?: string;
 };
 
 const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
@@ -52,10 +67,14 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
   onOpenRuntimeExplorer,
   onOpenServices,
   onSelectActor,
+  rosterError = false,
+  rosterLoading = false,
+  rosterRows = [],
+  rosterTeamId = "",
 }) => {
   const { token } = theme.useToken();
   const showMembersOverviewEmpty =
-    compositionRows.length === 0 && identityRows.length === 0;
+    compositionRows.length === 0 && identityRows.length === 0 && rosterRows.length === 0;
   const actionButtonStyle: React.CSSProperties = {
     borderRadius: 14,
     height: 36,
@@ -103,6 +122,109 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <AevatarPanel
+        title="真实 Team roster"
+        extra={
+          <Typography.Text style={{ fontSize: 12 }} type="secondary">
+            teamId · memberId · implementation
+          </Typography.Text>
+        }
+      >
+        {rosterLoading ? (
+          <AevatarInspectorEmpty
+            compact
+            title="正在读取 Team roster"
+            description="正在从后端 Team API 读取这支团队的成员清单。"
+          />
+        ) : rosterError ? (
+          <AevatarInspectorEmpty
+            compact
+            title="Team roster 暂不可见"
+            description="当前无法读取后端 Team roster，下面只保留运行时观察到的身份信号。"
+          />
+        ) : rosterRows.length > 0 ? (
+          <div
+            style={{
+              border: "1px solid var(--ant-colorBorderSecondary)",
+              borderRadius: 18,
+              overflow: "hidden",
+            }}
+          >
+            <div style={{ overflowX: "auto" }}>
+              <div style={{ minWidth: 820 }}>
+                <div
+                  style={{
+                    background: "var(--ant-colorBgContainerDisabled)",
+                    borderBottom: "1px solid var(--ant-colorBorderSecondary)",
+                    color: "var(--ant-colorTextSecondary)",
+                    display: "grid",
+                    fontSize: 12,
+                    fontWeight: 600,
+                    gap: 16,
+                    gridTemplateColumns:
+                      "minmax(160px, 1.2fr) minmax(220px, 1.4fr) minmax(120px, 0.8fr) minmax(120px, 0.8fr)",
+                    padding: "12px 16px",
+                  }}
+                >
+                  <span>成员</span>
+                  <span>职责</span>
+                  <span>实现</span>
+                  <span>服务</span>
+                </div>
+                {rosterRows.map((row, index) => (
+                  <div
+                    key={row.key}
+                    style={{
+                      alignItems: "center",
+                      borderTop:
+                        index === 0 ? "none" : "1px solid var(--ant-colorBorderSecondary)",
+                      display: "grid",
+                      gap: 16,
+                      gridTemplateColumns:
+                        "minmax(160px, 1.2fr) minmax(220px, 1.4fr) minmax(120px, 0.8fr) minmax(120px, 0.8fr)",
+                      padding: "14px 16px",
+                    }}
+                  >
+                    <div style={{ display: "flex", flexDirection: "column", gap: 4, minWidth: 0 }}>
+                      <Typography.Text strong>{row.name}</Typography.Text>
+                      <Typography.Text
+                        style={{ fontFamily: factValueFontFamily, fontSize: 12 }}
+                        type="secondary"
+                      >
+                        {row.memberId}
+                      </Typography.Text>
+                    </div>
+                    <FactLine rows={2} text={row.description || `归属 Team ${rosterTeamId || "--"}`} />
+                    <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+                      <DetailPill compact style={row.lifecycleStyle} text={row.lifecycleLabel} />
+                      <Typography.Text style={{ fontFamily: factValueFontFamily, fontSize: 12 }}>
+                        {row.implementationKind}
+                      </Typography.Text>
+                    </div>
+                    <CompactFactValue
+                      color="var(--ant-color-text-secondary)"
+                      strong={false}
+                      value={row.serviceId}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : rosterTeamId ? (
+          <AevatarInspectorEmpty
+            compact
+            title="这支 Team 还没有成员"
+            description="Team 已经是后端事实，但当前 roster 为空。新增 member 后会出现在这里。"
+          />
+        ) : (
+          <AevatarInspectorEmpty
+            compact
+            title="尚未选中真实 Team"
+            description="当前路由还没有 teamId，所以只能展示运行时观察到的成员身份。"
+          />
+        )}
+      </AevatarPanel>
       <AevatarPanel
         title="参与者结构"
         extra={

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
@@ -11,13 +11,14 @@ describe("teamRoutes", () => {
       buildTeamDetailHref({
         memberId: " member-alpha ",
         scopeId: " scope-alpha ",
+        teamId: " t-alpha ",
         workflowId: "workflow-1",
         serviceId: "service-1",
         runId: "run-1",
         tab: "events",
       }),
     ).toBe(
-      "/teams/scope-alpha?memberId=member-alpha&workflowId=workflow-1&tab=events&serviceId=service-1&runId=run-1",
+      "/teams/scope-alpha?memberId=member-alpha&teamId=t-alpha&workflowId=workflow-1&tab=events&serviceId=service-1&runId=run-1",
     );
   });
 
@@ -46,7 +47,7 @@ describe("teamRoutes", () => {
   it("reads the team detail route state from path and query", () => {
     expect(
       readTeamDetailRouteState(
-        "?memberId=member-alpha&workflowId=wf-1&serviceId=service-1&runId=run-1&tab=members",
+        "?memberId=member-alpha&teamId=t-alpha&workflowId=wf-1&serviceId=service-1&runId=run-1&tab=members",
         "/teams/scope-alpha",
       ),
     ).toEqual({
@@ -55,6 +56,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-alpha",
       serviceId: "service-1",
       tab: "members",
+      teamId: "t-alpha",
       workflowId: "wf-1",
     });
   });
@@ -71,6 +73,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-alpha",
       serviceId: "",
       tab: "bindings",
+      teamId: "",
       workflowId: "wf-1",
     });
   });
@@ -87,6 +90,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-query",
       serviceId: "",
       tab: "overview",
+      teamId: "",
       workflowId: "wf-2",
     });
   });
@@ -103,6 +107,7 @@ describe("teamRoutes", () => {
       scopeId: "scope-query",
       serviceId: "",
       tab: "overview",
+      teamId: "",
       workflowId: "wf-2",
     });
   });

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
@@ -14,6 +14,7 @@ type TeamDetailRouteState = {
   readonly scopeId: string;
   readonly serviceId: string;
   readonly tab: TeamDetailTab;
+  readonly teamId: string;
   readonly workflowId: string;
 };
 
@@ -90,6 +91,7 @@ export function buildTeamCreateHref(options?: {
 export function buildTeamDetailHref(options: {
   memberId?: string;
   scopeId: string;
+  teamId?: string;
   tab?: TeamDetailTab;
   serviceId?: string;
   runId?: string;
@@ -102,6 +104,7 @@ export function buildTeamDetailHref(options: {
 
   return buildHref(`/teams/${encodeURIComponent(scopeId)}`, {
     memberId: options.memberId,
+    teamId: options.teamId,
     workflowId: options.workflowId,
     tab: options.tab,
     serviceId: options.serviceId,
@@ -127,6 +130,7 @@ export function readTeamDetailRouteState(
     scopeId: trimOptional(params.get('scopeId')) || scopeIdFromPath,
     serviceId: trimOptional(params.get('serviceId')),
     tab: parseTeamTab(params.get('tab'), defaultTab),
+    teamId: trimOptional(params.get('teamId')),
     workflowId: trimOptional(params.get('workflowId')),
   };
 }

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -1053,6 +1053,7 @@ describe('studioApi host-session requests', () => {
             lifecycleStage: 'bind_ready',
             publishedServiceId: 'member-joker',
             lastBoundRevisionId: 'rev-2',
+            teamId: 't-alpha',
             createdAt: '2026-04-27T08:00:00Z',
             updatedAt: '2026-04-27T08:05:00Z',
           },
@@ -1074,6 +1075,7 @@ describe('studioApi host-session requests', () => {
           lifecycleStage: 'bind_ready',
           publishedServiceId: 'member-joker',
           lastBoundRevisionId: 'rev-2',
+          teamId: 't-alpha',
           createdAt: '2026-04-27T08:00:00Z',
           updatedAt: '2026-04-27T08:05:00Z',
         },
@@ -1083,6 +1085,222 @@ describe('studioApi host-session requests', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/scopes/scope-1/members',
+      expect.objectContaining({
+        credentials: 'same-origin',
+      }),
+    );
+  });
+
+  it('lists studio teams from the team authority endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        scopeId: 'scope-1',
+        teams: [
+          {
+            teamId: 't-alpha',
+            scopeId: 'scope-1',
+            displayName: 'Alpha Team',
+            description: 'Owns support workflows',
+            lifecycleStage: 'active',
+            memberCount: 2,
+            createdAt: '2026-05-01T08:00:00Z',
+            updatedAt: '2026-05-01T08:05:00Z',
+          },
+        ],
+        nextPageToken: null,
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(studioApi.listTeams('scope-1')).resolves.toEqual({
+      scopeId: 'scope-1',
+      teams: [
+        {
+          teamId: 't-alpha',
+          scopeId: 'scope-1',
+          displayName: 'Alpha Team',
+          description: 'Owns support workflows',
+          lifecycleStage: 'active',
+          memberCount: 2,
+          createdAt: '2026-05-01T08:00:00Z',
+          updatedAt: '2026-05-01T08:05:00Z',
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/teams',
+      expect.objectContaining({
+        credentials: 'same-origin',
+      }),
+    );
+  });
+
+  it('creates, updates, archives, and lists members for studio teams', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const teamResponse = {
+      teamId: 't-alpha',
+      scopeId: 'scope-1',
+      displayName: 'Alpha Team',
+      description: 'Owns support workflows',
+      lifecycleStage: 'active',
+      memberCount: 1,
+      createdAt: '2026-05-01T08:00:00Z',
+      updatedAt: '2026-05-01T08:05:00Z',
+    };
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => teamResponse,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ...teamResponse,
+          displayName: 'Alpha Ops',
+          description: '',
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ...teamResponse,
+          lifecycleStage: 'archived',
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          scopeId: 'scope-1',
+          members: [
+            {
+              memberId: 'joker',
+              scopeId: 'scope-1',
+              displayName: 'joker',
+              description: 'Support workflow member',
+              implementationKind: 'workflow',
+              lifecycleStage: 'bind_ready',
+              publishedServiceId: 'member-joker',
+              lastBoundRevisionId: 'rev-2',
+              teamId: 't-alpha',
+              createdAt: '2026-04-27T08:00:00Z',
+              updatedAt: '2026-04-27T08:05:00Z',
+            },
+          ],
+          nextPageToken: null,
+        }),
+      } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(
+      studioApi.createTeam({
+        scopeId: 'scope-1',
+        displayName: 'Alpha Team',
+        description: 'Owns support workflows',
+        teamId: 't-alpha',
+      }),
+    ).resolves.toEqual(teamResponse);
+    await expect(
+      studioApi.updateTeam({
+        scopeId: 'scope-1',
+        teamId: 't-alpha',
+        displayName: 'Alpha Ops',
+        description: null,
+      }),
+    ).resolves.toEqual({
+      ...teamResponse,
+      displayName: 'Alpha Ops',
+      description: '',
+    });
+    await expect(studioApi.archiveTeam('scope-1', 't-alpha')).resolves.toEqual({
+      ...teamResponse,
+      lifecycleStage: 'archived',
+    });
+    await expect(studioApi.listTeamMembers('scope-1', 't-alpha')).resolves.toEqual({
+      scopeId: 'scope-1',
+      members: [
+        {
+          memberId: 'joker',
+          scopeId: 'scope-1',
+          displayName: 'joker',
+          description: 'Support workflow member',
+          implementationKind: 'workflow',
+          lifecycleStage: 'bind_ready',
+          publishedServiceId: 'member-joker',
+          lastBoundRevisionId: 'rev-2',
+          teamId: 't-alpha',
+          createdAt: '2026-04-27T08:00:00Z',
+          updatedAt: '2026-04-27T08:05:00Z',
+        },
+      ],
+      nextPageToken: null,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      '/api/scopes/scope-1/teams',
+      expect.objectContaining({
+        body: JSON.stringify({
+          displayName: 'Alpha Team',
+          description: 'Owns support workflows',
+          teamId: 't-alpha',
+        }),
+        credentials: 'same-origin',
+        method: 'POST',
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/scopes/scope-1/teams/t-alpha',
+      expect.objectContaining({
+        body: JSON.stringify({
+          displayName: 'Alpha Ops',
+          description: null,
+        }),
+        method: 'PATCH',
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      '/api/scopes/scope-1/teams/t-alpha/archive',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      '/api/scopes/scope-1/teams/t-alpha/members',
       expect.objectContaining({
         credentials: 'same-origin',
       }),
@@ -1143,6 +1361,7 @@ describe('studioApi host-session requests', () => {
         lifecycleStage: 'bind_ready',
         publishedServiceId: 'member-joker',
         lastBoundRevisionId: 'rev-2',
+        teamId: null,
         createdAt: '2026-04-27T08:00:00Z',
         updatedAt: '2026-04-27T08:05:00Z',
       },
@@ -1216,6 +1435,7 @@ describe('studioApi host-session requests', () => {
       lifecycleStage: 'created',
       publishedServiceId: 'member-orders-draft',
       lastBoundRevisionId: null,
+      teamId: null,
       createdAt: '2026-04-27T08:10:00Z',
       updatedAt: '2026-04-27T08:10:00Z',
     });

--- a/apps/aevatar-console-web/src/shared/studio/api.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.ts
@@ -38,6 +38,11 @@ import type {
   StudioSerializeYamlResult,
   StudioSettings,
   StudioStartExecutionInput,
+  StudioTeamCreateInput,
+  StudioTeamLifecycleStage,
+  StudioTeamRoster,
+  StudioTeamSummary,
+  StudioTeamUpdateInput,
   StudioUserConfig,
   StudioUserConfigModelsResponse,
   StudioWorkflowDraft,
@@ -50,6 +55,7 @@ import type {
 import {
   normalizeStudioMemberLifecycleStage,
   normalizeStudioScopeBindingImplementationKind,
+  normalizeStudioTeamLifecycleStage,
 } from "./models";
 import type { WorkflowCatalogItemDetail } from "@/shared/api/models";
 import { scopesApi } from "@/shared/api/scopesApi";
@@ -951,6 +957,15 @@ function readStudioMemberLifecycle(
   );
 }
 
+function readStudioTeamLifecycle(
+  record: Record<string, unknown>,
+  keys: string | string[]
+): StudioTeamLifecycleStage {
+  return normalizeStudioTeamLifecycleStage(
+    readNullableString(record, keys, "StudioTeamSummary.lifecycleStage")
+  );
+}
+
 function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
   const record = expectRecord(value, "StudioMemberSummary");
   return {
@@ -994,6 +1009,12 @@ function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
         ["lastBoundRevisionId", "LastBoundRevisionId"],
         "StudioMemberSummary.lastBoundRevisionId"
       ) ?? null,
+    teamId:
+      readNullableString(
+        record,
+        ["teamId", "TeamId"],
+        "StudioMemberSummary.teamId"
+      ) ?? null,
     createdAt: readString(
       record,
       ["createdAt", "CreatedAt"],
@@ -1004,6 +1025,74 @@ function decodeStudioMemberSummary(value: unknown): StudioMemberSummary {
       ["updatedAt", "UpdatedAt"],
       "StudioMemberSummary.updatedAt"
     ),
+  };
+}
+
+function decodeStudioTeamSummary(value: unknown): StudioTeamSummary {
+  const record = expectRecord(value, "StudioTeamSummary");
+  return {
+    teamId: readString(
+      record,
+      ["teamId", "TeamId"],
+      "StudioTeamSummary.teamId"
+    ),
+    scopeId: readString(
+      record,
+      ["scopeId", "ScopeId"],
+      "StudioTeamSummary.scopeId"
+    ),
+    displayName: readString(
+      record,
+      ["displayName", "DisplayName"],
+      "StudioTeamSummary.displayName"
+    ),
+    description:
+      readNullableString(
+        record,
+        ["description", "Description"],
+        "StudioTeamSummary.description"
+      ) ?? "",
+    lifecycleStage: readStudioTeamLifecycle(record, [
+      "lifecycleStage",
+      "LifecycleStage",
+    ]),
+    memberCount: readNumber(
+      record,
+      ["memberCount", "MemberCount"],
+      "StudioTeamSummary.memberCount"
+    ),
+    createdAt: readString(
+      record,
+      ["createdAt", "CreatedAt"],
+      "StudioTeamSummary.createdAt"
+    ),
+    updatedAt: readString(
+      record,
+      ["updatedAt", "UpdatedAt"],
+      "StudioTeamSummary.updatedAt"
+    ),
+  };
+}
+
+function decodeStudioTeamRoster(value: unknown): StudioTeamRoster {
+  const record = expectRecord(value, "StudioTeamRoster");
+  return {
+    scopeId: readString(
+      record,
+      ["scopeId", "ScopeId"],
+      "StudioTeamRoster.scopeId"
+    ),
+    teams: expectArray(
+      record.teams ?? record.Teams,
+      "StudioTeamRoster.teams",
+      decodeStudioTeamSummary
+    ),
+    nextPageToken:
+      readNullableString(
+        record,
+        ["nextPageToken", "NextPageToken"],
+        "StudioTeamRoster.nextPageToken"
+      ) ?? null,
   };
 }
 
@@ -1132,6 +1221,75 @@ export const studioApi = {
     return requestJson(withOptionalScopeId("/api/workspace/", scopeId));
   },
 
+  listTeams(scopeId: string): Promise<StudioTeamRoster> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams`,
+      decodeStudioTeamRoster
+    );
+  },
+
+  getTeam(scopeId: string, teamId: string): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams/${encodeURIComponent(teamId.trim())}`,
+      decodeStudioTeamSummary
+    );
+  },
+
+  createTeam(input: StudioTeamCreateInput): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/teams`,
+      decodeStudioTeamSummary,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(
+          compactObject({
+            displayName: input.displayName.trim(),
+            description: trimOptional(input.description),
+            teamId: trimOptional(input.teamId),
+          })
+        ),
+      }
+    );
+  },
+
+  updateTeam(input: StudioTeamUpdateInput): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/teams/${encodeURIComponent(input.teamId.trim())}`,
+      decodeStudioTeamSummary,
+      {
+        method: "PATCH",
+        headers: JSON_HEADERS,
+        body: JSON.stringify(
+          compactObject({
+            displayName:
+              input.displayName === null ? null : trimOptional(input.displayName),
+            description:
+              input.description === null ? null : trimOptional(input.description),
+          })
+        ),
+      }
+    );
+  },
+
+  archiveTeam(scopeId: string, teamId: string): Promise<StudioTeamSummary> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams/${encodeURIComponent(teamId.trim())}/archive`,
+      decodeStudioTeamSummary,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+      }
+    );
+  },
+
+  listTeamMembers(scopeId: string, teamId: string): Promise<StudioMemberRoster> {
+    return requestDecodedJson(
+      `/api/scopes/${encodeURIComponent(scopeId.trim())}/teams/${encodeURIComponent(teamId.trim())}/members`,
+      decodeStudioMemberRoster
+    );
+  },
+
   listMembers(scopeId: string): Promise<StudioMemberRoster> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(scopeId.trim())}/members`,
@@ -1152,6 +1310,7 @@ export const studioApi = {
     implementationKind: StudioMemberImplementationKind;
     description?: string | null;
     memberId?: string | null;
+    teamId?: string | null;
   }): Promise<StudioMemberSummary> {
     return requestDecodedJson(
       `/api/scopes/${encodeURIComponent(input.scopeId.trim())}/members`,
@@ -1165,6 +1324,7 @@ export const studioApi = {
             implementationKind: input.implementationKind,
             description: trimOptional(input.description),
             memberId: trimOptional(input.memberId),
+            teamId: trimOptional(input.teamId),
           })
         ),
       }

--- a/apps/aevatar-console-web/src/shared/studio/models.ts
+++ b/apps/aevatar-console-web/src/shared/studio/models.ts
@@ -440,6 +440,7 @@ export interface StudioMemberSummary {
   readonly lifecycleStage: StudioMemberLifecycleStage;
   readonly publishedServiceId: string;
   readonly lastBoundRevisionId: string | null;
+  readonly teamId?: string | null;
   readonly createdAt: string;
   readonly updatedAt: string;
 }
@@ -470,6 +471,65 @@ export interface StudioMemberRoster {
   readonly scopeId: string;
   readonly members: readonly StudioMemberSummary[];
   readonly nextPageToken?: string | null;
+}
+
+export type StudioTeamLifecycleStage = 'active' | 'archived' | 'unknown';
+
+export function normalizeStudioTeamLifecycleStage(
+  value: string | null | undefined,
+): StudioTeamLifecycleStage {
+  switch (String(value || '').trim().toLowerCase()) {
+    case 'active':
+      return 'active';
+    case 'archived':
+      return 'archived';
+    default:
+      return 'unknown';
+  }
+}
+
+export function formatStudioTeamLifecycleStage(
+  value: StudioTeamLifecycleStage | string | null | undefined,
+): string {
+  switch (normalizeStudioTeamLifecycleStage(value)) {
+    case 'active':
+      return 'Active';
+    case 'archived':
+      return 'Archived';
+    default:
+      return 'Unknown';
+  }
+}
+
+export interface StudioTeamSummary {
+  readonly teamId: string;
+  readonly scopeId: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly lifecycleStage: StudioTeamLifecycleStage;
+  readonly memberCount: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface StudioTeamRoster {
+  readonly scopeId: string;
+  readonly teams: readonly StudioTeamSummary[];
+  readonly nextPageToken?: string | null;
+}
+
+export interface StudioTeamCreateInput {
+  readonly scopeId: string;
+  readonly displayName: string;
+  readonly description?: string | null;
+  readonly teamId?: string | null;
+}
+
+export interface StudioTeamUpdateInput {
+  readonly scopeId: string;
+  readonly teamId: string;
+  readonly displayName?: string | null;
+  readonly description?: string | null;
 }
 
 export type StudioMemberBindingTargetKind = StudioScopeBindingTargetKind;

--- a/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
@@ -69,10 +69,12 @@ describe('buildStudioRoute', () => {
   it('supports the typed create-member Studio intent', () => {
     expect(
       buildStudioRoute({
+        scopeId: 'scope-1',
+        teamId: 't-alpha',
         tab: 'studio',
         intent: 'create-member',
       }),
-    ).toBe('/studio?tab=studio&intent=create-member');
+    ).toBe('/studio?scopeId=scope-1&teamId=t-alpha&tab=studio&intent=create-member');
   });
 
   it('drops invalid Studio intent values', () => {

--- a/apps/aevatar-console-web/src/shared/studio/navigation.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.ts
@@ -19,6 +19,7 @@ type StudioRouteOptions = {
   scopeId?: string;
   memberId?: string;
   memberKey?: StudioMemberKey | string;
+  teamId?: string;
   step?: StudioStep;
   focus?: StudioBuildFocus;
   tab?: StudioTab;
@@ -133,6 +134,9 @@ export function buildStudioRoute(options?: StudioRouteOptions): string {
   const params = new URLSearchParams();
   if (options?.scopeId?.trim()) {
     params.set('scopeId', options.scopeId.trim());
+  }
+  if (options?.teamId?.trim()) {
+    params.set('teamId', options.teamId.trim());
   }
   const memberKey = normalizeStudioMemberKey(
     options?.memberKey,


### PR DESCRIPTION
## Summary

Closes #572

- Add Console Web Studio Team API client/types for list/get/create/update/archive/list team members.
- Switch `/teams` to render real backend Team roster entries as the primary team cards, while keeping member/runtime signals as auxiliary health hints.
- Make `/teams/new` create a backend `StudioTeam` and route to the selected Team context after creation.
- Preserve `teamId` across Team detail and Studio routes so create-member requests attach new members to the selected Team.
- Add Team detail members roster rendering backed by `listTeamMembers`.

## Impact

This moves the frontend away from the earlier member-derived Team shortcut and aligns Console Web with the backend Team aggregate model: `scope -> team -> member`. Unassigned members remain visible as attention signals but are no longer promoted into Team cards.

## Validation

- `npm --prefix apps/aevatar-console-web run jest -- src/pages/teams/detail.test.tsx src/pages/teams/home.test.tsx src/pages/teams/new.test.tsx src/shared/studio/api.test.ts src/shared/navigation/teamRoutes.test.ts src/shared/studio/navigation.test.ts src/pages/studio/index.test.tsx --runInBand`
- `npm --prefix apps/aevatar-console-web run tsc`
- `npm --prefix apps/aevatar-console-web run build`
- `bash tools/ci/test_stability_guards.sh`

Notes: Jest emitted existing React `act(...)` warnings in Studio tests, and build emitted the existing Browserslist caniuse-lite freshness warning; neither blocked validation.
