### PR TITLE
Connect Team detail summary

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -187,6 +187,19 @@ function mockCreateTeamMembersCatalog() {
   };
 }
 
+function mockCreateTeamSummary() {
+  return {
+    teamId: "t-alpha",
+    scopeId: "scope-1",
+    displayName: "Alpha Support Team",
+    description: "Team authority summary",
+    lifecycleStage: "active",
+    memberCount: 3,
+    createdAt: "2026-05-01T08:00:00Z",
+    updatedAt: "2026-05-01T08:05:00Z",
+  };
+}
+
 function mockCreateRunAudit(scopeId: string, runId: string) {
   return {
     summary: {
@@ -626,6 +639,7 @@ jest.mock("@/shared/studio/api", () => ({
       ],
     })),
     listMembers: jest.fn(async () => mockCreateMembersCatalog()),
+    getTeam: jest.fn(async () => mockCreateTeamSummary()),
     listTeamMembers: jest.fn(async () => mockCreateTeamMembersCatalog()),
     parseYaml: jest.fn(async () => ({
       document: {
@@ -673,6 +687,10 @@ describe("TeamDetailPage", () => {
     (studioApi.listMembers as jest.Mock).mockImplementation(
       async () => mockCreateMembersCatalog(),
     );
+    (studioApi.getTeam as jest.Mock).mockReset();
+    (studioApi.getTeam as jest.Mock).mockImplementation(
+      async () => mockCreateTeamSummary(),
+    );
     (studioApi.listTeamMembers as jest.Mock).mockReset();
     (studioApi.listTeamMembers as jest.Mock).mockImplementation(
       async () => mockCreateTeamMembersCatalog(),
@@ -692,11 +710,13 @@ describe("TeamDetailPage", () => {
     expect(screen.getByText("scopeId")).toBeTruthy();
     expect(screen.getByText("scope-1")).toBeTruthy();
     const currentPostureHeading = screen.getByText("当前态势");
+    const teamAuthorityHeading = screen.getByText("Team authority");
     const trustHeading = screen.getByText("信任态势");
     const governanceHeading = screen.getByText("治理快照");
     const compareHeading = screen.getByText("Run Compare / Change Diff");
     expect(screen.getByText("团队构成")).toBeTruthy();
     expect(screen.getByText("运行摘要")).toBeTruthy();
+    expect(teamAuthorityHeading).toBeTruthy();
     expect(currentPostureHeading).toBeTruthy();
     expect(trustHeading).toBeTruthy();
     expect(
@@ -720,6 +740,7 @@ describe("TeamDetailPage", () => {
     expect(screen.getByRole("button", { name: "本次对话" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "服务映射" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "高级编辑" })).toBeTruthy();
+    expect(studioApi.getTeam).not.toHaveBeenCalled();
   });
 
   it("keeps compare honest when no successful baseline exists", async () => {
@@ -1006,6 +1027,58 @@ describe("TeamDetailPage", () => {
     });
   });
 
+  it("uses the real Team summary when teamId is selected", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 1,
+        name: "Alpha Support Team",
+      }),
+    ).toBeTruthy();
+    expect((await screen.findAllByText("Team authority summary")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("3 个成员").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("来自 Team authority 更新时间").length).toBeGreaterThan(0);
+    expect(screen.getByText("Team 更新时间")).toBeTruthy();
+    expect(screen.getByText("生命周期")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(studioApi.getTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
+    });
+  });
+
+  it("keeps the runtime overview when Team summary fails", async () => {
+    (studioApi.getTeam as jest.Mock).mockRejectedValueOnce(
+      new Error("Team summary failed"),
+    );
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect((await screen.findAllByText("Team summary 不可用")).length).toBeGreaterThan(0);
+    expect(screen.getByText("Team summary 暂不可用")).toBeTruthy();
+    expect(
+      screen.getByText("当前仍会显示运行时视图；Team authority summary 暂时无法读取。"),
+    ).toBeTruthy();
+    expect(await screen.findByText("当前态势")).toBeTruthy();
+    expect(await screen.findByText("信任态势")).toBeTruthy();
+    expect(screen.getByText("Support Escalation Triage")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(studioApi.getTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
+    });
+  });
+
   it("shows a team-first event stream with member mapping", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
@@ -1221,7 +1294,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     await screen.findByRole("button", { name: "服务映射" });
-    await screen.findByText("Support Escalation Triage");
+    await screen.findByRole("heading", {
+      level: 1,
+      name: "Support Escalation Triage",
+    });
     fireEvent.click(screen.getByRole("button", { name: "高级编辑" }));
 
     await waitFor(() => {
@@ -1278,7 +1354,12 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText("Support Escalation Triage")).toBeTruthy();
+    expect(
+      await screen.findByRole("heading", {
+        level: 1,
+        name: "Support Escalation Triage",
+      }),
+    ).toBeTruthy();
     expect(screen.queryByText("路由上下文已自动校正")).toBeNull();
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/shared/studio/navigation";
 import {
   formatStudioMemberLifecycleStage,
+  formatStudioTeamLifecycleStage,
   type StudioWorkflowDocument,
 } from "@/shared/studio/models";
 import {
@@ -1167,6 +1168,12 @@ const TeamDetailPage: React.FC = () => {
     queryKey: ["teams", "team-members", scopeId, selectedTeamId],
     retry: false,
   });
+  const teamSummaryQuery = useQuery({
+    enabled: scopeId.length > 0 && selectedTeamId.length > 0,
+    queryFn: () => studioApi.getTeam(scopeId, selectedTeamId),
+    queryKey: ["teams", "team-summary", scopeId, selectedTeamId],
+    retry: false,
+  });
 
   const fallbackWorkflowSummary = React.useMemo(() => {
     if (lens.activeRevision?.implementationKind !== "workflow") {
@@ -1610,24 +1617,53 @@ const TeamDetailPage: React.FC = () => {
     workflowId: activeWorkflowSummary?.workflowId,
     workflowName: activeWorkflowSummary?.workflowName,
     displayName:
+      trimText(teamSummaryQuery.data?.displayName) ||
       trimText(preferredMemberSummary?.displayName) ||
       activeWorkflowSummary?.displayName,
     lensTitle: lens.title,
   });
   const teamTitle = teamHeading.title;
-  const teamTitleMeta = teamHeading.metaScopeId ? (
-    <Space size={6} wrap>
-      <span style={{ textTransform: "none" }}>scopeId</span>
-      <AevatarCompactText
-        color="inherit"
-        head={8}
-        maxWidth={320}
-        monospace
-        tail={6}
-        value={teamHeading.metaScopeId}
-      />
-    </Space>
-  ) : null;
+  const teamLifecycleStatus = trimText(teamSummaryQuery.data?.lifecycleStage);
+  const teamLifecycleLabel = teamSummaryQuery.data
+    ? formatStudioTeamLifecycleStage(teamSummaryQuery.data.lifecycleStage)
+    : "";
+  const teamSummaryDescription = trimText(teamSummaryQuery.data?.description);
+  const teamMetaScopeId = teamHeading.metaScopeId || (selectedTeamId ? scopeId : "");
+  const teamTitleMeta =
+    selectedTeamId || teamMetaScopeId || teamSummaryQuery.data ? (
+      <Space size={[10, 6]} wrap>
+        {selectedTeamId ? (
+          <Space size={6} wrap>
+            <span style={{ textTransform: "none" }}>teamId</span>
+            <AevatarCompactText
+              color="inherit"
+              head={8}
+              maxWidth={320}
+              monospace
+              tail={6}
+              value={selectedTeamId}
+            />
+          </Space>
+        ) : null}
+        {teamMetaScopeId ? (
+          <Space size={6} wrap>
+            <span style={{ textTransform: "none" }}>scopeId</span>
+            <AevatarCompactText
+              color="inherit"
+              head={8}
+              maxWidth={320}
+              monospace
+              tail={6}
+              value={teamMetaScopeId}
+            />
+          </Space>
+        ) : null}
+        {teamSummaryQuery.data ? (
+          <span>{teamSummaryQuery.data.memberCount} 个成员</span>
+        ) : null}
+        {teamSummaryDescription ? <span>{teamSummaryDescription}</span> : null}
+      </Space>
+    ) : null;
   const activeWorkflowId =
     trimText(activeWorkflowSummary?.workflowId) || trimText(routeState.workflowId);
   const teamCompositionRows = React.useMemo(
@@ -1654,19 +1690,22 @@ const TeamDetailPage: React.FC = () => {
     [teamMembersQuery.data?.members, token],
   );
   const latestVisibleUpdate =
+    teamSummaryQuery.data?.updatedAt ||
     lens.currentRun?.lastUpdatedAt ||
     lens.currentRunAudit?.summary.lastUpdatedAt ||
     activeWorkflowSummary?.updatedAt ||
     "";
-  const latestVisibleUpdateNote = lens.currentRun?.lastUpdatedAt
-    ? trimText(lens.currentRun?.runId)
+  const latestVisibleUpdateNote = teamSummaryQuery.data?.updatedAt
+    ? "来自 Team authority 更新时间"
+    : lens.currentRun?.lastUpdatedAt
+      ? trimText(lens.currentRun?.runId)
       ? `来自 run ${compactId(lens.currentRun?.runId)}`
       : "来自最近可见运行"
-    : lens.currentRunAudit?.summary.lastUpdatedAt
-      ? "来自最近审计摘要"
-      : activeWorkflowSummary?.updatedAt
-        ? "来自 workflow 更新时间"
-        : "当前还没有可见更新时间";
+      : lens.currentRunAudit?.summary.lastUpdatedAt
+        ? "来自最近审计摘要"
+        : activeWorkflowSummary?.updatedAt
+          ? "来自 workflow 更新时间"
+          : "当前还没有可见更新时间";
   const activeRunId =
     lens.currentRun?.runId ||
     lens.playback.currentRunId ||
@@ -2906,6 +2945,76 @@ const TeamDetailPage: React.FC = () => {
         ? resolveTonePillStyle(token, "success")
         : resolveStatusPillStyle(token, row.badge),
   }));
+  const teamAuthorityStatusLabel = teamSummaryQuery.data
+    ? teamLifecycleLabel
+    : teamSummaryQuery.isError
+      ? "Team summary 不可用"
+      : selectedTeamId
+        ? "加载中"
+        : "未绑定 Team";
+  const teamAuthorityStatusStyle = teamSummaryQuery.data
+    ? resolveStatusPillStyle(token, teamLifecycleStatus)
+    : teamSummaryQuery.isError
+      ? resolveTonePillStyle(token, "warning")
+      : resolveTonePillStyle(token, "neutral");
+  const teamAuthorityTitle = teamSummaryQuery.data
+    ? teamTitle
+    : selectedTeamId
+      ? "Team summary 暂不可用"
+      : teamTitle;
+  const teamAuthorityDescription = teamSummaryQuery.data
+    ? teamSummaryDescription || "Team authority 当前没有描述。"
+    : selectedTeamId
+      ? "当前仍会显示运行时视图；Team authority summary 暂时无法读取。"
+      : "当前详情来自运行时上下文，还没有明确的 Team authority 绑定。";
+  const teamAuthorityRows = [
+    {
+      badge: teamLifecycleLabel || teamAuthorityStatusLabel,
+      badgeStyle: teamAuthorityStatusStyle,
+      key: "teamLifecycle",
+      label: "生命周期",
+      note: teamSummaryQuery.data
+        ? `teamId · ${compactId(teamSummaryQuery.data.teamId)}`
+        : selectedTeamId
+          ? `teamId · ${compactId(selectedTeamId)}`
+          : "当前路由没有 Team ID",
+      noteMonospace: false,
+      noteTooltip: teamSummaryQuery.data
+        ? `teamId · ${teamSummaryQuery.data.teamId}`
+        : selectedTeamId
+          ? `teamId · ${selectedTeamId}`
+          : "当前路由没有 Team ID",
+      value: teamAuthorityStatusLabel,
+    },
+    {
+      badge: teamSummaryQuery.data ? `${teamSummaryQuery.data.memberCount}` : "--",
+      badgeStyle: teamSummaryQuery.data
+        ? resolveTonePillStyle(token, "info")
+        : resolveTonePillStyle(token, "neutral"),
+      key: "teamMembers",
+      label: "成员规模",
+      note: teamSummaryQuery.data
+        ? "来自 Team authority memberCount"
+        : "成员数会在 Team summary 可用后显示",
+      noteMonospace: false,
+      value: teamSummaryQuery.data ? `${teamSummaryQuery.data.memberCount} 个成员` : "--",
+    },
+    {
+      badge: teamSummaryQuery.data?.updatedAt ? "已同步" : "--",
+      badgeStyle: teamSummaryQuery.data?.updatedAt
+        ? resolveTonePillStyle(token, "success")
+        : resolveTonePillStyle(token, "neutral"),
+      key: "teamUpdatedAt",
+      label: "Team 更新时间",
+      note: teamSummaryQuery.data?.updatedAt
+        ? "来自 Team authority updatedAt"
+        : "当前使用运行时更新时间作为降级参考",
+      noteMonospace: false,
+      value: teamSummaryQuery.data?.updatedAt
+        ? formatCompactTimestamp(teamSummaryQuery.data.updatedAt)
+        : "--",
+    },
+  ];
   const overviewGovernanceRows = [
     {
       badge: currentRevisionId !== "--" ? "serving" : "unknown",
@@ -3434,6 +3543,11 @@ const TeamDetailPage: React.FC = () => {
         latestVisibleUpdateNote={latestVisibleUpdateNote}
         partialSignals={overviewPartialSignals}
         runtimeSummaryRows={overviewRuntimeSummaryRows}
+        teamAuthorityDescription={teamAuthorityDescription}
+        teamAuthorityRows={teamAuthorityRows}
+        teamAuthorityStatusLabel={teamAuthorityStatusLabel}
+        teamAuthorityStatusStyle={teamAuthorityStatusStyle}
+        teamAuthorityTitle={teamAuthorityTitle}
       />
     );
   };
@@ -3691,7 +3805,12 @@ const TeamDetailPage: React.FC = () => {
       onOpenTeamsList={handleOpenTeamsList}
       onSelectTab={pushTeamTab}
       statusBadge={
-        currentHeaderStatusFriendly !== "--" ? (
+        teamSummaryQuery.data ? (
+          <DetailPill
+            style={resolveStatusPillStyle(token, teamLifecycleStatus)}
+            text={teamLifecycleLabel}
+          />
+        ) : currentHeaderStatusFriendly !== "--" ? (
           <DetailPill
             style={resolveStatusPillStyle(token, currentHeaderStatus)}
             text={currentHeaderStatusFriendly}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -73,6 +73,11 @@ type TeamOverviewTabProps = {
   readonly latestVisibleUpdateNote: string;
   readonly partialSignals: readonly string[];
   readonly runtimeSummaryRows: readonly OverviewRuntimeSummaryRow[];
+  readonly teamAuthorityDescription: string;
+  readonly teamAuthorityRows: readonly OverviewRuntimeSummaryRow[];
+  readonly teamAuthorityStatusLabel: string;
+  readonly teamAuthorityStatusStyle: React.CSSProperties;
+  readonly teamAuthorityTitle: string;
 };
 
 const surfaceStyle = (
@@ -128,11 +133,80 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
   latestVisibleUpdateNote,
   partialSignals,
   runtimeSummaryRows,
+  teamAuthorityDescription,
+  teamAuthorityRows,
+  teamAuthorityStatusLabel,
+  teamAuthorityStatusStyle,
+  teamAuthorityTitle,
 }) => {
   const { token } = theme.useToken();
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <section style={surfaceStyle(token)}>
+        <div
+          style={{
+            alignItems: "flex-start",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 12,
+            justifyContent: "space-between",
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <Space wrap size={8}>
+              <Typography.Text strong style={{ fontSize: 16 }}>
+                Team authority
+              </Typography.Text>
+              <DetailPill
+                style={teamAuthorityStatusStyle}
+                text={teamAuthorityStatusLabel}
+              />
+            </Space>
+            <Typography.Title level={3} style={{ margin: 0 }}>
+              {teamAuthorityTitle}
+            </Typography.Title>
+            <FactLine
+              monospace={false}
+              rows={2}
+              secondary
+              text={teamAuthorityDescription}
+            />
+          </div>
+        </div>
+        <div style={{ display: "grid", gap: 12 }}>
+          {teamAuthorityRows.map((row, index) => (
+            <div
+              key={row.key}
+              style={{
+                alignItems: "start",
+                borderTop:
+                  index === 0 ? "none" : `1px solid ${token.colorBorderSecondary}`,
+                display: "grid",
+                gap: 12,
+                gridTemplateColumns: "minmax(96px, 128px) minmax(0, 1fr) max-content",
+                paddingTop: index === 0 ? 0 : 12,
+              }}
+            >
+              <Typography.Text style={{ paddingTop: 2 }} type="secondary">
+                {row.label}
+              </Typography.Text>
+              <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+                <FactLine rows={2} text={String(row.value)} />
+                <FactLine
+                  monospace={row.noteMonospace ?? false}
+                  rows={3}
+                  secondary
+                  text={String(row.note)}
+                  tooltipText={row.noteTooltip}
+                />
+              </div>
+              <DetailPill compact style={row.badgeStyle} text={row.badge} />
+            </div>
+          ))}
+        </div>
+      </section>
+
       <section style={surfaceStyle(token)}>
         <div
           style={{

--- a/apps/aevatar-console-web/src/shared/studio/api.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/api.test.ts
@@ -1151,6 +1151,54 @@ describe('studioApi host-session requests', () => {
     );
   });
 
+  it('gets a studio team summary from the team authority endpoint', async () => {
+    persistAuthSession({
+      tokens: {
+        accessToken: 'access-token',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        expiresAt: Date.now() + 3_600_000,
+      },
+      user: {
+        sub: 'user-1',
+      },
+    });
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        teamId: 't-alpha',
+        scopeId: 'scope-1',
+        displayName: 'Alpha Team',
+        description: 'Owns support workflows',
+        lifecycleStage: 'active',
+        memberCount: 2,
+        createdAt: '2026-05-01T08:00:00Z',
+        updatedAt: '2026-05-01T08:05:00Z',
+      }),
+    } as Response);
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await expect(studioApi.getTeam('scope-1', 't-alpha')).resolves.toEqual({
+      teamId: 't-alpha',
+      scopeId: 'scope-1',
+      displayName: 'Alpha Team',
+      description: 'Owns support workflows',
+      lifecycleStage: 'active',
+      memberCount: 2,
+      createdAt: '2026-05-01T08:00:00Z',
+      updatedAt: '2026-05-01T08:05:00Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/scopes/scope-1/teams/t-alpha',
+      expect.objectContaining({
+        credentials: 'same-origin',
+      }),
+    );
+  });
+
   it('creates, updates, archives, and lists members for studio teams', async () => {
     persistAuthSession({
       tokens: {


### PR DESCRIPTION
## Summary

Closes #574

- Fetch the selected Team authority summary on Team Detail when the route has both `scopeId` and `teamId`.
- Prefer real Team summary fields in the detail header and Overview: display name, description, lifecycle stage, member count, and updated time.
- Add a Team authority Overview section while keeping runtime/member fallback visible when the summary is missing or fails.
- Cover the API client and Team Detail success/degraded/no-`teamId` behaviors with targeted tests.

## Impact Paths

- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/detail.test.tsx`
- `apps/aevatar-console-web/src/shared/studio/api.test.ts`

## Validation

- `npm --prefix apps/aevatar-console-web run jest -- src/pages/teams/detail.test.tsx src/shared/studio/api.test.ts --runInBand`
- `npm --prefix apps/aevatar-console-web run tsc`
- `bash tools/ci/test_stability_guards.sh`
- `npm --prefix apps/aevatar-console-web run build`

Notes: Jest emitted the existing watchman recrawl warning, and build emitted the existing Browserslist caniuse-lite freshness warning; neither blocked validation.
