### PR TITLE
Add Team update and archive UI

### DIFF
--- a/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
@@ -15,8 +15,12 @@ export type TeamTabOption = {
 
 type TeamActionRailProps = {
   readonly conversationActionLabel: string;
+  readonly editTeamDisabled?: boolean;
+  readonly editTeamLabel: string;
+  readonly editTeamHint?: string;
   readonly onOpenConversation: () => void;
   readonly onOpenServiceMapping: () => void;
+  readonly onOpenTeamEditor: () => void;
   readonly onOpenTeamBuilder: () => void;
   readonly serviceMappingDisabled?: boolean;
   readonly serviceMappingHint?: string;
@@ -61,8 +65,12 @@ export const TeamDetailEmptyState: React.FC = () => (
 
 export const TeamActionRail: React.FC<TeamActionRailProps> = ({
   conversationActionLabel,
+  editTeamDisabled = false,
+  editTeamLabel,
+  editTeamHint,
   onOpenConversation,
   onOpenServiceMapping,
+  onOpenTeamEditor,
   onOpenTeamBuilder,
   serviceMappingDisabled = false,
   serviceMappingHint,
@@ -78,6 +86,14 @@ export const TeamActionRail: React.FC<TeamActionRailProps> = ({
       type="primary"
     >
       {serviceMappingActionLabel}
+    </Button>
+    <Button
+      disabled={editTeamDisabled}
+      onClick={onOpenTeamEditor}
+      style={topActionButtonStyle}
+      title={editTeamDisabled ? editTeamHint : undefined}
+    >
+      {editTeamLabel}
     </Button>
     <Button onClick={onOpenConversation} style={topActionButtonStyle}>
       {conversationActionLabel}

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1,4 +1,5 @@
-import { act, cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { message } from "antd";
 import React from "react";
 import { scopesApi } from "@/shared/api/scopesApi";
 import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
@@ -16,6 +17,21 @@ jest.mock("@/shared/graphs/GraphCanvas", () => ({
     return React.createElement("div", null, "Graph canvas");
   },
 }));
+
+jest.mock("antd", () => {
+  const actual = jest.requireActual("antd");
+  return {
+    ...actual,
+    message: {
+      ...actual.message,
+      success: jest.fn(),
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+      destroy: jest.fn(),
+    },
+  };
+});
 
 function mockCreateRunsCatalog() {
   return {
@@ -640,6 +656,15 @@ jest.mock("@/shared/studio/api", () => ({
     })),
     listMembers: jest.fn(async () => mockCreateMembersCatalog()),
     getTeam: jest.fn(async () => mockCreateTeamSummary()),
+    updateTeam: jest.fn(async () => ({
+      ...mockCreateTeamSummary(),
+      displayName: "Alpha Ops Team",
+      description: "",
+    })),
+    archiveTeam: jest.fn(async () => ({
+      ...mockCreateTeamSummary(),
+      lifecycleStage: "archived",
+    })),
     listTeamMembers: jest.fn(async () => mockCreateTeamMembersCatalog()),
     parseYaml: jest.fn(async () => ({
       document: {
@@ -691,6 +716,17 @@ describe("TeamDetailPage", () => {
     (studioApi.getTeam as jest.Mock).mockImplementation(
       async () => mockCreateTeamSummary(),
     );
+    (studioApi.updateTeam as jest.Mock).mockReset();
+    (studioApi.updateTeam as jest.Mock).mockImplementation(async () => ({
+      ...mockCreateTeamSummary(),
+      displayName: "Alpha Ops Team",
+      description: "",
+    }));
+    (studioApi.archiveTeam as jest.Mock).mockReset();
+    (studioApi.archiveTeam as jest.Mock).mockImplementation(async () => ({
+      ...mockCreateTeamSummary(),
+      lifecycleStage: "archived",
+    }));
     (studioApi.listTeamMembers as jest.Mock).mockReset();
     (studioApi.listTeamMembers as jest.Mock).mockImplementation(
       async () => mockCreateTeamMembersCatalog(),
@@ -1051,6 +1087,126 @@ describe("TeamDetailPage", () => {
     await waitFor(() => {
       expect(studioApi.getTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
     });
+  });
+
+  it("updates the real Team summary from the detail header", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("heading", {
+      level: 1,
+      name: "Alpha Support Team",
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Edit Team" }));
+
+    const nameInput = await screen.findByLabelText("Edit team name");
+    expect(nameInput).toHaveValue("Alpha Support Team");
+    fireEvent.change(nameInput, {
+      target: { value: " Alpha Ops Team " },
+    });
+    fireEvent.change(screen.getByLabelText("Edit team description"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Team" }));
+
+    await waitFor(() => {
+      expect(studioApi.updateTeam).toHaveBeenCalledWith({
+        scopeId: "scope-1",
+        teamId: "t-alpha",
+        displayName: "Alpha Ops Team",
+        description: null,
+      });
+    });
+    expect(message.success).toHaveBeenCalledWith("Team updated.");
+    await waitFor(() => {
+      expect(studioApi.getTeam).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not submit an empty Team name", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("heading", {
+      level: 1,
+      name: "Alpha Support Team",
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Edit Team" }));
+    fireEvent.change(await screen.findByLabelText("Edit team name"), {
+      target: { value: "   " },
+    });
+
+    expect(screen.getByRole("button", { name: "Save Team" })).toBeDisabled();
+    expect(studioApi.updateTeam).not.toHaveBeenCalled();
+  });
+
+  it("archives the Team without making archived Teams read-only", async () => {
+    (studioApi.getTeam as jest.Mock)
+      .mockResolvedValueOnce(mockCreateTeamSummary())
+      .mockResolvedValue({
+        ...mockCreateTeamSummary(),
+        lifecycleStage: "archived",
+      });
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha&tab=advanced",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("Active roster entry")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Archive Team" }));
+    expect(await screen.findByText("Archive this Team?")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This marks the Team as archived and de-emphasizes it in the active roster. You can still edit its configuration and view its history.",
+      ),
+    ).toBeTruthy();
+    fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Archive this Team?" })).getByRole(
+        "button",
+        { name: "Archive Team" },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(studioApi.archiveTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
+    });
+    expect(message.success).toHaveBeenCalledWith("Team archived.");
+    expect(await screen.findByText("Archived but still maintainable")).toBeTruthy();
+    expect(screen.getByText("维护这支团队配置")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Edit Team" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Archive Team" })).toBeNull();
+  });
+
+  it("keeps archived Teams maintainable on first load", async () => {
+    (studioApi.getTeam as jest.Mock).mockResolvedValueOnce({
+      ...mockCreateTeamSummary(),
+      lifecycleStage: "archived",
+    });
+    window.history.replaceState(
+      {},
+      "",
+      "/teams/scope-1?scopeId=scope-1&teamId=t-alpha&tab=advanced",
+    );
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    expect(await screen.findByText("Archived but still maintainable")).toBeTruthy();
+    expect(screen.getByText("维护这支团队配置")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Edit Team" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Archive Team" })).toBeNull();
   });
 
   it("keeps the runtime overview when Team summary fails", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -8,15 +8,14 @@ import {
   DeploymentUnitOutlined,
 } from "@ant-design/icons";
 import type { Edge, Node } from "@xyflow/react";
-import { Button, Space, Tooltip, Typography, theme } from "antd";
-import { useQuery } from "@tanstack/react-query";
+import { Input, Modal, Space, Typography, message, theme } from "antd";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import React from "react";
 import { scopesApi } from "@/shared/api/scopesApi";
 import {
   formatCompactDateTime,
   formatTimeOnly,
 } from "@/shared/datetime/dateTime";
-import GraphCanvas from "@/shared/graphs/GraphCanvas";
 import { buildActorGraphElements } from "@/shared/graphs/buildGraphElements";
 import {
   getLocationSnapshot,
@@ -52,11 +51,8 @@ import {
   formatStudioTeamLifecycleStage,
   type StudioWorkflowDocument,
 } from "@/shared/studio/models";
-import {
-  AevatarInspectorEmpty,
-  AevatarPanel,
-} from "@/shared/ui/aevatarPageShells";
 import { AevatarCompactText } from "@/shared/ui/compactText";
+import { describeError } from "@/shared/ui/errorText";
 import {
   TeamActionRail,
   TeamDetailEmptyState,
@@ -65,9 +61,7 @@ import {
 } from "./components/TeamDetailChrome";
 import {
   DetailPill,
-  FactLine,
   factValueFontFamily,
-  SignalCard,
 } from "./components/TeamDetailPrimitives";
 import TeamAdvancedTab from "./tabs/TeamAdvancedTab";
 import TeamAssetsTab, { teamAssetIcons } from "./tabs/TeamAssetsTab";
@@ -444,7 +438,10 @@ function buildDepthMap(
   const queue = [normalizedRootId];
 
   while (queue.length > 0) {
-    const current = queue.shift()!;
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
     const nextDepth = (depths.get(current) ?? 0) + 1;
     for (const next of adjacency.get(current) ?? []) {
       if (depths.has(next)) {
@@ -651,6 +648,13 @@ function resolveStatusPillStyle(
   value: string | null | undefined,
 ): React.CSSProperties {
   const normalized = normalizeStatus(value);
+
+  if (normalized === "archived") {
+    return {
+      background: token.colorFillQuaternary,
+      color: token.colorTextSecondary,
+    };
+  }
 
   if (
     [
@@ -1079,6 +1083,7 @@ const TopologyNodeCard: React.FC<{
 };
 
 const TeamDetailPage: React.FC = () => {
+  const queryClient = useQueryClient();
   const locationSnapshot = React.useSyncExternalStore(
     subscribeToLocationChanges,
     getLocationSnapshot,
@@ -1107,6 +1112,12 @@ const TeamDetailPage: React.FC = () => {
   const [selectedActorId, setSelectedActorId] = React.useState("");
   const [selectedConnectorKey, setSelectedConnectorKey] = React.useState("");
   const [selectedTopologyNodeId, setSelectedTopologyNodeId] = React.useState("");
+  const [teamEditorOpen, setTeamEditorOpen] = React.useState(false);
+  const [teamArchiveOpen, setTeamArchiveOpen] = React.useState(false);
+  const [teamEditorName, setTeamEditorName] = React.useState("");
+  const [teamEditorDescription, setTeamEditorDescription] = React.useState("");
+  const [teamEditorSaving, setTeamEditorSaving] = React.useState(false);
+  const [teamArchiving, setTeamArchiving] = React.useState(false);
   const { token } = theme.useToken();
 
   React.useEffect(() => {
@@ -1131,7 +1142,6 @@ const TeamDetailPage: React.FC = () => {
   const {
     actorGraphQuery,
     actorsQuery,
-    baselineRunAuditQuery,
     currentRunAuditQuery,
     lens,
     runsQuery,
@@ -1174,6 +1184,24 @@ const TeamDetailPage: React.FC = () => {
     queryKey: ["teams", "team-summary", scopeId, selectedTeamId],
     retry: false,
   });
+
+  React.useEffect(() => {
+    if (!teamEditorOpen || !teamSummaryQuery.data) {
+      return;
+    }
+
+    setTeamEditorName(teamSummaryQuery.data.displayName);
+    setTeamEditorDescription(teamSummaryQuery.data.description);
+  }, [teamEditorOpen, teamSummaryQuery.data]);
+
+  const refreshTeamAuthority = React.useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ["teams", "team-summary", scopeId, selectedTeamId],
+      }),
+      queryClient.invalidateQueries({ queryKey: ["teams", "roster", scopeId] }),
+    ]);
+  }, [queryClient, scopeId, selectedTeamId]);
 
   const fallbackWorkflowSummary = React.useMemo(() => {
     if (lens.activeRevision?.implementationKind !== "workflow") {
@@ -1787,7 +1815,6 @@ const TeamDetailPage: React.FC = () => {
     "--";
   const currentStateVersion =
     lens.currentRun?.stateVersion != null ? String(lens.currentRun.stateVersion) : "--";
-  const currentLastEventId = trimText(lens.currentRun?.lastEventId) || "--";
   const currentEndpointCount = lens.currentService?.endpoints.length ?? 0;
   const currentPolicyCount = lens.currentService?.policyIds.length ?? 0;
   const enabledConnectorCount = integrations.items.filter((item) => item.enabled).length;
@@ -3424,6 +3451,106 @@ const TeamDetailPage: React.FC = () => {
   const conversationActionLabel = lens.playback.currentRunId ? "本次对话" : "运行记录";
   const serviceMappingActionLabel = "服务映射";
   const teamBuilderActionLabel = "高级编辑";
+  const editTeamActionLabel = "Edit Team";
+  const canEditSelectedTeam = Boolean(teamSummaryQuery.data && selectedTeamId);
+  const editTeamHint = selectedTeamId
+    ? "Team summary 读取完成后才能编辑。"
+    : "当前路由还没有选中真实 Team。";
+  const openTeamEditor = React.useCallback(() => {
+    if (!teamSummaryQuery.data) {
+      return;
+    }
+
+    setTeamEditorName(teamSummaryQuery.data.displayName);
+    setTeamEditorDescription(teamSummaryQuery.data.description);
+    setTeamEditorOpen(true);
+  }, [teamSummaryQuery.data]);
+  const closeTeamEditor = React.useCallback(() => {
+    if (teamEditorSaving) {
+      return;
+    }
+
+    setTeamEditorOpen(false);
+  }, [teamEditorSaving]);
+  const saveTeamEditor = React.useCallback(async () => {
+    if (!teamSummaryQuery.data || teamEditorSaving) {
+      return;
+    }
+
+    const displayName = teamEditorName.trim();
+    if (!displayName) {
+      void message.error("Team name is required.");
+      return;
+    }
+
+    setTeamEditorSaving(true);
+    try {
+      await studioApi.updateTeam({
+        scopeId,
+        teamId: selectedTeamId,
+        displayName,
+        description: teamEditorDescription.trim() || null,
+      });
+      void message.success("Team updated.");
+      setTeamEditorOpen(false);
+      await refreshTeamAuthority();
+    } catch (error) {
+      void message.error(describeError(error, "Team update failed."));
+    } finally {
+      setTeamEditorSaving(false);
+    }
+  }, [
+    refreshTeamAuthority,
+    scopeId,
+    selectedTeamId,
+    teamEditorDescription,
+    teamEditorName,
+    teamEditorSaving,
+    teamSummaryQuery.data,
+  ]);
+  const isTeamArchived = normalizeStatus(teamSummaryQuery.data?.lifecycleStage) === "archived";
+  const archiveTeamActionLabel = teamSummaryQuery.data && !isTeamArchived ? "Archive Team" : "";
+  const archiveTeamHint = selectedTeamId
+    ? "Team summary 读取完成后才能归档。"
+    : "当前路由还没有选中真实 Team。";
+  const openTeamArchive = React.useCallback(() => {
+    if (!teamSummaryQuery.data || isTeamArchived) {
+      return;
+    }
+
+    setTeamArchiveOpen(true);
+  }, [isTeamArchived, teamSummaryQuery.data]);
+  const closeTeamArchive = React.useCallback(() => {
+    if (teamArchiving) {
+      return;
+    }
+
+    setTeamArchiveOpen(false);
+  }, [teamArchiving]);
+  const confirmTeamArchive = React.useCallback(async () => {
+    if (!teamSummaryQuery.data || isTeamArchived || teamArchiving) {
+      return;
+    }
+
+    setTeamArchiving(true);
+    try {
+      await studioApi.archiveTeam(scopeId, selectedTeamId);
+      void message.success("Team archived.");
+      setTeamArchiveOpen(false);
+      await refreshTeamAuthority();
+    } catch (error) {
+      void message.error(describeError(error, "Team archive failed."));
+    } finally {
+      setTeamArchiving(false);
+    }
+  }, [
+    isTeamArchived,
+    refreshTeamAuthority,
+    scopeId,
+    selectedTeamId,
+    teamArchiving,
+    teamSummaryQuery.data,
+  ]);
   const topologyFocusActorId =
     trimText(effectiveActorId) ||
     trimText(lens.graph.focusActorId) ||
@@ -3731,9 +3858,29 @@ const TeamDetailPage: React.FC = () => {
   };
 
   const renderAdvancedTab = () => {
+    const lifecycleLabel = teamSummaryQuery.data
+      ? teamLifecycleLabel
+      : selectedTeamId
+        ? "加载中"
+        : "未绑定 Team";
+    const lifecycleDescription = teamSummaryQuery.data
+      ? isTeamArchived
+        ? "This Team is archived and de-emphasized in the active roster. You can still edit its identity, configuration, members, and history."
+        : "This Team is active in the roster. Archive only de-emphasizes it; it does not lock future maintenance."
+      : selectedTeamId
+        ? "Team summary 读取完成后才能修改 lifecycle。"
+        : "当前路由还没有选中真实 Team。";
+    const adjustmentTitle = isTeamArchived ? "维护这支团队配置" : "继续调整这支团队";
+    const adjustmentLead = isTeamArchived
+      ? "这支 Team 已归档，但配置仍可维护；先确认这次要调整的是流程、服务映射，还是连接器引用。"
+      : "先确认这次要调整的是流程、服务映射，还是连接器引用。";
+
     return (
       <TeamAdvancedTab
         adjustmentBadgeStyle={resolveTonePillStyle(token, "neutral")}
+        archiveTeamActionLabel={archiveTeamActionLabel}
+        archiveTeamDisabled={!teamSummaryQuery.data || teamArchiving}
+        archiveTeamHint={archiveTeamHint}
         configurationAdjustmentRows={configurationAdjustmentRows}
         configurationDetailRows={configurationDetailRows}
         conversationActionLabel={conversationActionLabel}
@@ -3741,6 +3888,7 @@ const TeamDetailPage: React.FC = () => {
         currentDeploymentFriendly={currentDeploymentFriendly}
         currentServiceFriendly={currentServiceFriendly}
         currentVersionFriendly={currentVersionFriendly}
+        onArchiveTeam={openTeamArchive}
         onOpenConversation={handleOpenConversation}
         onOpenServiceMapping={handleOpenServiceMapping}
         onOpenTeamBuilder={() => history.push(teamBuilderRoute)}
@@ -3750,7 +3898,23 @@ const TeamDetailPage: React.FC = () => {
         secondaryActionButtonStyle={resolveActionButtonStyle(token)}
         serviceMappingActionLabel={serviceMappingActionLabel}
         summaryCards={advancedSummaryCards}
+        teamAdjustmentLead={adjustmentLead}
+        teamAdjustmentTitle={adjustmentTitle}
         teamBuilderActionLabel={teamBuilderActionLabel}
+        teamLifecycleBadgeStyle={
+          teamSummaryQuery.data
+            ? resolveStatusPillStyle(token, teamLifecycleStatus)
+            : resolveTonePillStyle(token, "neutral")
+        }
+        teamLifecycleDescription={lifecycleDescription}
+        teamLifecycleLabel={lifecycleLabel}
+        teamLifecycleTitle={
+          teamSummaryQuery.data
+            ? isTeamArchived
+              ? "Archived but still maintainable"
+              : "Active roster entry"
+            : "Team authority lifecycle"
+        }
         teamImpactSummary={advancedTeamImpactSummary}
       />
     );
@@ -3790,8 +3954,12 @@ const TeamDetailPage: React.FC = () => {
       actionRail={
         <TeamActionRail
           conversationActionLabel={conversationActionLabel}
+          editTeamDisabled={!canEditSelectedTeam}
+          editTeamHint={editTeamHint}
+          editTeamLabel={editTeamActionLabel}
           onOpenConversation={handleOpenConversation}
           onOpenServiceMapping={handleOpenServiceMapping}
+          onOpenTeamEditor={openTeamEditor}
           onOpenTeamBuilder={() => history.push(teamBuilderRoute)}
           serviceMappingDisabled={!canOpenPlatformTopology}
           serviceMappingHint={platformTopologyHint || undefined}
@@ -3823,6 +3991,55 @@ const TeamDetailPage: React.FC = () => {
       teamsListHref={teamsListHref}
     >
       {tabContent}
+      <Modal
+        confirmLoading={teamEditorSaving}
+        okButtonProps={{ disabled: !teamEditorName.trim() }}
+        okText="Save Team"
+        onCancel={closeTeamEditor}
+        onOk={() => void saveTeamEditor()}
+        open={teamEditorOpen}
+        title="Edit Team"
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Typography.Text strong>Team name</Typography.Text>
+            <Input
+              aria-label="Edit team name"
+              disabled={teamEditorSaving}
+              onChange={(event) => setTeamEditorName(event.target.value)}
+              value={teamEditorName}
+            />
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Typography.Text strong>Description</Typography.Text>
+            <Input.TextArea
+              aria-label="Edit team description"
+              autoSize={{ minRows: 3, maxRows: 5 }}
+              disabled={teamEditorSaving}
+              onChange={(event) => setTeamEditorDescription(event.target.value)}
+              value={teamEditorDescription}
+            />
+          </div>
+          <Typography.Text type="secondary">
+            This updates the Team authority summary. Archived Teams can still be
+            edited and maintained.
+          </Typography.Text>
+        </div>
+      </Modal>
+      <Modal
+        confirmLoading={teamArchiving}
+        okText="Archive Team"
+        okButtonProps={{ danger: true }}
+        onCancel={closeTeamArchive}
+        onOk={() => void confirmTeamArchive()}
+        open={teamArchiveOpen}
+        title="Archive this Team?"
+      >
+        <Typography.Text>
+          This marks the Team as archived and de-emphasizes it in the active
+          roster. You can still edit its configuration and view its history.
+        </Typography.Text>
+      </Modal>
     </TeamDetailShell>
   );
 };

--- a/apps/aevatar-console-web/src/pages/teams/new.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.test.tsx
@@ -121,6 +121,61 @@ describe('TeamCreatePage', () => {
     expect(message.success).toHaveBeenCalledWith('已创建 Team。');
   });
 
+  it('ignores legacy scopeId=new links and creates under the authenticated scope', async () => {
+    window.history.replaceState({}, '', '/teams/new?scopeId=new&teamName=test');
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        enabled: false,
+        scopeId: 'scope-a',
+        scopeSource: 'nyxid',
+      }),
+    } as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({
+        ...teamResponse,
+        displayName: 'test',
+        description: 'test',
+      }),
+    } as Response);
+
+    renderWithQueryClient(React.createElement(TeamCreatePage));
+
+    expect(await screen.findByLabelText('Team name')).toHaveValue('test');
+    await waitFor(() => {
+      expect(new URLSearchParams(window.location.search).get('scopeId')).toBe(
+        'scope-a',
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText('Team description'), {
+      target: { value: 'test' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create Team' })[0]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/scopes/scope-a/teams',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            displayName: 'test',
+            description: 'test',
+          }),
+        }),
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/scopes/new/teams',
+      expect.anything(),
+    );
+  });
+
   it('opens Studio with only scope context from the secondary action', async () => {
     renderWithQueryClient(React.createElement(TeamCreatePage));
 

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAdvancedTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAdvancedTab.tsx
@@ -30,6 +30,9 @@ type AdvancedAdjustmentRow = {
 
 type TeamAdvancedTabProps = {
   readonly adjustmentBadgeStyle: React.CSSProperties;
+  readonly archiveTeamActionLabel: string;
+  readonly archiveTeamDisabled?: boolean;
+  readonly archiveTeamHint?: string;
   readonly configurationAdjustmentRows: readonly AdvancedAdjustmentRow[];
   readonly configurationDetailRows: readonly AdvancedDetailRow[];
   readonly conversationActionLabel: string;
@@ -37,6 +40,7 @@ type TeamAdvancedTabProps = {
   readonly currentDeploymentFriendly: string;
   readonly currentServiceFriendly: string;
   readonly currentVersionFriendly: string;
+  readonly onArchiveTeam: () => void;
   readonly onOpenConversation: () => void;
   readonly onOpenServiceMapping: () => void;
   readonly onOpenTeamBuilder: () => void;
@@ -46,12 +50,21 @@ type TeamAdvancedTabProps = {
   readonly secondaryActionButtonStyle: React.CSSProperties;
   readonly serviceMappingActionLabel: string;
   readonly summaryCards: readonly AdvancedSummaryCard[];
+  readonly teamAdjustmentLead: string;
+  readonly teamAdjustmentTitle: string;
   readonly teamBuilderActionLabel: string;
+  readonly teamLifecycleBadgeStyle: React.CSSProperties;
+  readonly teamLifecycleDescription: string;
+  readonly teamLifecycleLabel: string;
+  readonly teamLifecycleTitle: string;
   readonly teamImpactSummary: string;
 };
 
 const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
   adjustmentBadgeStyle,
+  archiveTeamActionLabel,
+  archiveTeamDisabled = false,
+  archiveTeamHint,
   configurationAdjustmentRows,
   configurationDetailRows,
   conversationActionLabel,
@@ -59,6 +72,7 @@ const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
   currentDeploymentFriendly,
   currentServiceFriendly,
   currentVersionFriendly,
+  onArchiveTeam,
   onOpenConversation,
   onOpenServiceMapping,
   onOpenTeamBuilder,
@@ -68,7 +82,13 @@ const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
   secondaryActionButtonStyle,
   serviceMappingActionLabel,
   summaryCards,
+  teamAdjustmentLead,
+  teamAdjustmentTitle,
   teamBuilderActionLabel,
+  teamLifecycleBadgeStyle,
+  teamLifecycleDescription,
+  teamLifecycleLabel,
+  teamLifecycleTitle,
   teamImpactSummary,
 }) => {
   const { token } = theme.useToken();
@@ -94,6 +114,36 @@ const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
               value={card.value}
             />
           ))}
+        </div>
+      </AevatarPanel>
+      <AevatarPanel
+        title="Team lifecycle"
+        extra={
+          <DetailPill
+            compact
+            style={teamLifecycleBadgeStyle}
+            text={teamLifecycleLabel}
+          />
+        }
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <Typography.Text strong>{teamLifecycleTitle}</Typography.Text>
+            <FactLine rows={3} secondary text={teamLifecycleDescription} />
+          </div>
+          {archiveTeamActionLabel ? (
+            <Space wrap>
+              <Button
+                danger
+                disabled={archiveTeamDisabled}
+                onClick={onArchiveTeam}
+                style={secondaryActionButtonStyle}
+                title={archiveTeamDisabled ? archiveTeamHint : undefined}
+              >
+                {archiveTeamActionLabel}
+              </Button>
+            </Space>
+          ) : null}
         </div>
       </AevatarPanel>
       <div
@@ -138,12 +188,10 @@ const TeamAdvancedTab: React.FC<TeamAdvancedTabProps> = ({
             ))}
           </div>
         </AevatarPanel>
-        <AevatarPanel title="继续调整这支团队">
+        <AevatarPanel title={teamAdjustmentTitle}>
           <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              <Typography.Text strong>
-                先确认这次要调整的是流程、服务映射，还是连接器引用。
-              </Typography.Text>
+              <Typography.Text strong>{teamAdjustmentLead}</Typography.Text>
               <Typography.Text type="secondary">
                 当前会影响 {currentServiceFriendly}、{currentVersionFriendly}，以及
                 {teamImpactSummary}。

--- a/apps/aevatar-console-web/src/shared/navigation/scopeRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/scopeRoutes.test.ts
@@ -12,6 +12,21 @@ describe("scopeRoutes", () => {
     });
   });
 
+  it("does not treat the create route segment as a real scope", () => {
+    expect(readScopeQueryDraft("", "/teams/new")).toEqual({
+      scopeId: "",
+    });
+    expect(readScopeQueryDraft("?scopeId=new", "/teams/new")).toEqual({
+      scopeId: "",
+    });
+  });
+
+  it("keeps an explicit real scope on the team create route", () => {
+    expect(readScopeQueryDraft("?scopeId=scope-alpha", "/teams/new")).toEqual({
+      scopeId: "scope-alpha",
+    });
+  });
+
   it("keeps the team pathname when building the overview href from a team detail route", () => {
     expect(
       buildScopeOverviewHref(

--- a/apps/aevatar-console-web/src/shared/navigation/scopeRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/scopeRoutes.ts
@@ -10,16 +10,22 @@ function trimOptional(value: string | null | undefined): string {
   return value?.trim() ?? "";
 }
 
+function isTeamCreatePath(pathname: string): boolean {
+  const normalizedPathname = pathname.split(/[?#]/)[0]?.replace(/\/+$/, "") ?? "";
+  return normalizedPathname === "/teams/new";
+}
+
 function readTeamScopeId(pathname: string): string {
   const match = pathname.match(/^\/teams\/([^/?#]+)/);
   if (!match) {
     return "";
   }
 
+  const rawScopeId = match[1] ?? "";
   try {
-    return decodeURIComponent(match[1] ?? "").trim();
+    return decodeURIComponent(rawScopeId).trim();
   } catch {
-    return (match[1] ?? "").trim();
+    return rawScopeId.trim();
   }
 }
 
@@ -34,10 +40,17 @@ export function readScopeQueryDraft(
   pathname = typeof window === "undefined" ? "" : window.location.pathname,
 ): ScopeQueryDraft {
   const params = new URLSearchParams(search);
+  const isCreatePath = isTeamCreatePath(pathname);
   const queryScopeId = readString(params.get("scopeId"));
-  if (queryScopeId) {
+  if (queryScopeId && !(isCreatePath && queryScopeId === "new")) {
     return {
       scopeId: queryScopeId,
+    };
+  }
+
+  if (isCreatePath) {
+    return {
+      scopeId: "",
     };
   }
 


### PR DESCRIPTION
## Problem
Team detail had real roster and summary data, but the frontend still lacked the maintenance path for updating Team identity and moving inactive Teams out of the active roster emphasis. A legacy create URL could also preserve `scopeId=new`, causing the Team create API to call `/api/scopes/new/teams` and fail scope access validation.

Closes #577

## Solution
- Add an `Edit Team` action on Team detail that calls the real Team update API.
- Add a Team lifecycle panel on the Advanced tab that archives a Team through the real archive API.
- Keep archived Teams editable and maintainable instead of making the detail view read-only.
- Refresh Team summary and roster queries after update/archive actions.
- Normalize `/teams/new?scopeId=new` so Team creation uses the authenticated scope instead of the route segment.

## Impact Paths
- `apps/aevatar-console-web/src/pages/teams/detail.tsx`
- `apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx`
- `apps/aevatar-console-web/src/pages/teams/tabs/TeamAdvancedTab.tsx`
- `apps/aevatar-console-web/src/pages/teams/new.test.tsx`
- `apps/aevatar-console-web/src/shared/navigation/scopeRoutes.ts`

## Verification
- `npm --prefix apps/aevatar-console-web run tsc`
- `npm --prefix apps/aevatar-console-web run jest -- --selectProjects jsdom --runTestsByPath src/pages/teams/detail.test.tsx src/pages/teams/new.test.tsx src/shared/navigation/scopeRoutes.test.ts --runInBand`
- `npm --prefix apps/aevatar-console-web run biome:lint -- src/shared/navigation/scopeRoutes.ts src/shared/navigation/scopeRoutes.test.ts src/pages/teams/new.test.tsx`
- `npm --prefix apps/aevatar-console-web run build`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`
