### PR TITLE
[codex] Refactor LLM reply continuation into agent runs

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -30,8 +30,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 {
     // Orleans Reminders (the durable scheduler backing ScheduleSelfDurableTimeoutAsync)
     // round dueTime up to the local reminder service tick (typically ~1 minute), so
-    // sub-minute schedules are unreliable. The inbox dispatch happens inline via
-    // IChannelLlmReplyInbox; the durable timer is reserved for retry/rehydration.
+    // sub-minute schedules are unreliable. The run dispatch happens inline via
+    // IChannelLlmReplyRunDispatcher; the durable timer is reserved for retry/rehydration.
     private static readonly TimeSpan DeferredLlmDispatchRetryDelay = TimeSpan.FromSeconds(60);
     // Pending LLM reply requests older than this are considered stale on rehydration:
     // the user gave up, the relay reply_token (~30 min TTL) is likely already expired,
@@ -122,16 +122,16 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         if (result.LlmReplyRequest is not null)
         {
-            // The transient inbox copy keeps reply_token + expiry so the LLM worker can
+            // The transient run command copy keeps reply_token + expiry so the run actor can
             // echo them back inside LlmReplyReadyEvent; the persisted state copy must
             // not carry the credential into the event store / projection / read model.
-            var inboxCopy = result.LlmReplyRequest.Clone();
-            inboxCopy.TargetActorId = Id;
-            var persistedCopy = inboxCopy.Clone();
+            var runCopy = result.LlmReplyRequest.Clone();
+            runCopy.TargetActorId = Id;
+            var persistedCopy = runCopy.Clone();
             persistedCopy.ReplyToken = string.Empty;
             persistedCopy.ReplyTokenExpiresAtUnixMs = 0;
             await PersistDomainEventAsync(persistedCopy);
-            await DispatchPendingLlmReplyAsync(inboxCopy, CancellationToken.None);
+            await DispatchPendingLlmReplyAsync(runCopy, CancellationToken.None);
             Logger.LogInformation(
                 "Accepted inbound activity for deferred LLM reply: activity={ActivityId} conversation={Key}",
                 activity.Id,
@@ -298,7 +298,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             CausationId = string.Empty,
             Kind = FailureKind.PermanentAdapterError,
             ErrorCode = reason,
-            ErrorSummary = "Deferred LLM reply request was dropped by the inbox pre-LLM gate.",
+            ErrorSummary = "Deferred LLM reply request was dropped by the run actor pre-LLM gate.",
             NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
             FailedAtUnixMs = evt.DroppedAtUnixMs > 0
                 ? evt.DroppedAtUnixMs
@@ -308,7 +308,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         RemoveNyxRelayReplyToken(evt.CorrelationId, pending.Activity);
 
         Logger.LogInformation(
-            "Retired pending LLM reply after inbox drop: correlation={CorrelationId} reason={Reason}",
+            "Retired pending LLM reply after run drop: correlation={CorrelationId} reason={Reason}",
             evt.CorrelationId,
             reason);
     }
@@ -344,11 +344,11 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private async Task DispatchPendingLlmReplyAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
-        var inbox = Services.GetService<IChannelLlmReplyInbox>();
-        if (inbox is null)
+        var dispatcher = Services.GetService<IChannelLlmReplyRunDispatcher>();
+        if (dispatcher is null)
         {
             Logger.LogWarning(
-                "Channel LLM reply inbox not registered; scheduling durable retry: correlation={CorrelationId}",
+                "Channel LLM reply run dispatcher not registered; scheduling durable retry: correlation={CorrelationId}",
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
             return;
@@ -357,24 +357,24 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         // Retry and rehydration paths read `request` from State.PendingLlmReplyRequests,
         // which always carries an empty ReplyToken (the inbound handler strips it before
         // persist). If the actor is still alive and the in-memory dict still has the
-        // token for this correlation, re-enrich the inbox copy so the subscriber's relay
-        // credential gate does not mistake a legitimate retry for a dead request.
+        // token for this correlation, re-enrich the run command copy so AgentRunGAgent's
+        // relay credential gate does not mistake a legitimate retry for a dead request.
         var enriched = EnrichWithRuntimeReplyTokenIfNeeded(request);
 
         try
         {
-            await inbox.EnqueueAsync(enriched.Clone(), ct);
+            await dispatcher.DispatchAsync(enriched.Clone(), ct);
             Logger.LogInformation(
-                "Enqueued LLM reply request to inbox: correlation={CorrelationId} conversation={Key} replyTokenSource={Source}",
+                "Dispatched LLM reply run request: correlation={CorrelationId} conversation={Key} replyTokenSource={Source}",
                 enriched.CorrelationId,
                 enriched.Activity?.Conversation?.CanonicalKey,
-                DescribeEnqueuedReplyTokenSource(request, enriched));
+                DescribeDispatchedReplyTokenSource(request, enriched));
         }
         catch (Exception ex)
         {
             Logger.LogError(
                 ex,
-                "Failed to enqueue LLM reply request; scheduling durable retry: correlation={CorrelationId}",
+                "Failed to dispatch LLM reply run request; scheduling durable retry: correlation={CorrelationId}",
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
         }
@@ -405,7 +405,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         return enriched;
     }
 
-    private static string DescribeEnqueuedReplyTokenSource(
+    private static string DescribeDispatchedReplyTokenSource(
         NeedsLlmReplyEvent original,
         NeedsLlmReplyEvent enriched)
     {
@@ -1170,9 +1170,9 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
     {
         var activity = pendingActivity ?? evt.Activity;
 
-        // Inbox-echoed credential is the authoritative source — it survives actor
+        // Run-echoed credential is the authoritative source: it survives actor
         // deactivation between inbound capture and LLM reply ready, which the in-memory
-        // dict cannot. Fall back to the dict only when the inbox didn't carry a token
+        // dict cannot. Fall back to the dict only when the run event didn't carry a token
         // (legacy in-flight messages from before this change deployed).
         var inlineToken = NormalizeOptional(evt.ReplyToken);
         if (inlineToken is not null)
@@ -1199,7 +1199,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         if (runtimeContext.NyxRelayReplyToken is null)
             return "none";
         if (!string.IsNullOrWhiteSpace(evt.ReplyToken))
-            return "inbox-echo";
+            return "run-echo";
         return "actor-runtime-dict";
     }
 

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyInbox.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyInbox.cs
@@ -1,6 +1,0 @@
-namespace Aevatar.GAgents.Channel.Runtime;
-
-public interface IChannelLlmReplyInbox
-{
-    Task EnqueueAsync(NeedsLlmReplyEvent request, CancellationToken ct);
-}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyRunDispatcher.cs
@@ -1,0 +1,10 @@
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Stateless port used by <see cref="ConversationGAgent"/> to hand one deferred
+/// LLM reply run to its run-scoped continuation owner.
+/// </summary>
+public interface IChannelLlmReplyRunDispatcher
+{
+    Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/IStreamingReplySink.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/IStreamingReplySink.cs
@@ -2,13 +2,13 @@ namespace Aevatar.GAgents.Channel.Runtime;
 
 /// <summary>
 /// Receives per-delta streaming updates from <see cref="IConversationReplyGenerator"/> so the reply
-/// inbox can fan the accumulated text to the conversation actor as it is being generated. The
+/// run actor can fan the accumulated text to the conversation actor as it is being generated. The
 /// actor is the sole holder of the relay reply token, so only it is allowed to drive the relay
 /// placeholder send and subsequent edit calls; this sink therefore fans out signals (chunk events)
 /// and never touches the outbound port directly.
 /// </summary>
 /// <remarks>
-/// Implementations are per-turn and owned by the inbox runtime. A null sink signals that streaming
+/// Implementations are per-turn and owned by the run actor. A null sink signals that streaming
 /// is disabled for the turn (for example, the feature flag is off, the activity is not a relay
 /// turn, or an earlier failure invalidated the turn); generators must tolerate a null sink by
 /// simply accumulating the final text without calling any sink method.

--- a/agents/Aevatar.GAgents.Channel.Runtime/TurnStreamingReplySink.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/TurnStreamingReplySink.cs
@@ -32,7 +32,7 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// <item><see cref="FinalizeAsync"/> bypasses the throttle so the actor sees the complete text
 /// once the stream ends; if a dispatch is in flight, the final text reflushes after it and
 /// <see cref="FinalizeAsync"/> awaits the dispatch loop's drain signal before returning so the
-/// caller (the inbox runtime) does not race the ready event past the final chunk.</item>
+/// caller (the run actor) does not race the ready event past the final chunk.</item>
 /// </list>
 /// </para>
 /// <para>
@@ -68,7 +68,7 @@ public sealed class TurnStreamingReplySink : IStreamingReplySink, IDisposable
     private bool _dispatchInProgress;
     private bool _disposed;
     // Signaled by the dispatch loop when it fully drains. FinalizeAsync awaits this when a
-    // dispatch is already in flight so the caller does not race the inbox runtime's
+    // dispatch is already in flight so the caller does not race AgentRunGAgent's
     // LlmReplyReadyEvent past the final chunk dispatch (the ConversationGAgent
     // processed-command guard would otherwise drop the late chunk).
     private TaskCompletionSource<bool>? _drainTcs;
@@ -116,7 +116,7 @@ public sealed class TurnStreamingReplySink : IStreamingReplySink, IDisposable
     /// Applies the final accumulated text, bypassing the throttle so the actor can drive the final
     /// edit once the stream ends. If a dispatch is already in flight, the final text is stashed and
     /// this call awaits the dispatch loop's drain signal so the final chunk is on the wire before
-    /// the caller proceeds (the inbox runtime sends LlmReplyReadyEvent immediately after).
+    /// the caller proceeds (AgentRunGAgent sends LlmReplyReadyEvent immediately after).
     /// </summary>
     public Task FinalizeAsync(string finalText, CancellationToken ct) =>
         FlushAsync(finalText, isFinal: true, ct);
@@ -188,7 +188,7 @@ public sealed class TurnStreamingReplySink : IStreamingReplySink, IDisposable
                 if (isFinal)
                 {
                     // Block FinalizeAsync until the dispatch loop drains the stashed final text.
-                    // Without this wait, ChannelLlmReplyInboxRuntime sends LlmReplyReadyEvent
+                    // Without this wait, AgentRunGAgent sends LlmReplyReadyEvent
                     // first and ConversationGAgent's processed-command guard drops the late
                     // final chunk.
                     _drainTcs ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -30,10 +30,10 @@ message NeedsLlmReplyEvent {
   aevatar.gagents.channel.abstractions.ChatActivity activity = 4;
   map<string, string> metadata = 5;
   int64 requested_at_unix_ms = 6;
-  // Transient inbox-only credential. The actor MUST clear `reply_token` and
+  // Transient run-command-only credential. The actor MUST clear `reply_token` and
   // `reply_token_expires_at_unix_ms` (set them to the empty default) on the
-  // copy passed to PersistDomainEventAsync; only the inbox-bound copy may
-  // carry them so the LLM worker can echo the credential back without the
+  // copy passed to PersistDomainEventAsync; only the run-bound copy may
+  // carry them so AgentRunGAgent can echo the credential back without the
   // actor's in-memory dict surviving deactivation. Never persist to event
   // store, projection, or read model.
   string reply_token = 7;
@@ -70,16 +70,16 @@ message LlmReplyReadyEvent {
   string error_code = 7;
   string error_summary = 8;
   int64 ready_at_unix_ms = 9;
-  // Transient inbox-echoed credential carried back from the LLM worker so the
+  // Transient run-echoed credential carried back from AgentRunGAgent so the
   // actor's outbound relay reply does not depend on its in-memory token dict
   // surviving deactivation. The actor consumes these fields directly and never
-  // persists them. The inbox subscriber copies the values from the inbound
+  // persists them. AgentRunGAgent copies the values from the inbound
   // NeedsLlmReplyEvent verbatim.
   string reply_token = 10;
   int64 reply_token_expires_at_unix_ms = 11;
 }
 
-// Per-delta streaming signal dispatched from the LLM inbox runtime to the conversation actor while
+// Per-delta streaming signal dispatched from AgentRunGAgent to the conversation actor while
 // the reply is still being generated. The actor owns the outbound reply credential and the
 // placeholder message identifier for the turn, so it must be the one issuing the relay placeholder
 // send and subsequent edit calls. This message carries only the cumulative accumulated text for
@@ -154,7 +154,7 @@ message NyxRelayReplyTokenCleanupRequestedEvent {
   int64 requested_at_unix_ms = 2;
 }
 
-// Sent by ChannelLlmReplyInboxRuntime when its pre-LLM gates (stale age,
+// Sent by AgentRunGAgent when its pre-LLM gates (stale age,
 // missing relay credential, malformed payload) refuse to process a deferred
 // LLM reply. The actor consumes this to retire the matching pending entry
 // from State.PendingLlmReplyRequests via a NotRetryable

--- a/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
+++ b/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
@@ -36,9 +36,20 @@
     <ProjectReference Include="..\..\src\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="protos\*.proto"
+              GrpcServices="None"
+              ProtoRoot="protos"
+              AdditionalImportDirs="..\Aevatar.GAgents.Channel.Runtime\protos;..\Aevatar.GAgents.Channel.Abstractions\protos" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
@@ -1,0 +1,65 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+/// <summary>
+/// Thin Channel.Runtime port implementation that creates the run actor and
+/// dispatches the start command. It holds no run state.
+/// </summary>
+public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
+{
+    private readonly IActorRuntime _actorRuntime;
+    private readonly IActorDispatchPort _actorDispatchPort;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<AgentRunDispatcher> _logger;
+
+    public AgentRunDispatcher(
+        IActorRuntime actorRuntime,
+        IActorDispatchPort actorDispatchPort,
+        ILogger<AgentRunDispatcher> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (string.IsNullOrWhiteSpace(request.CorrelationId))
+            throw new InvalidOperationException("Deferred LLM reply request requires correlation_id for AgentRunGAgent dispatch.");
+
+        var runId = request.CorrelationId.Trim();
+        var actorId = AgentRunGAgent.BuildActorId(runId);
+        var actor = await _actorRuntime.GetAsync(actorId)
+                    ?? await _actorRuntime.CreateAsync<AgentRunGAgent>(actorId, ct);
+
+        var command = new AgentRunStartRequested
+        {
+            Request = request.Clone(),
+        };
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
+            Payload = Any.Pack(command),
+            Route = EnvelopeRouteSemantics.CreateDirect("channel-llm-reply-run-dispatcher", actor.Id),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = runId,
+            },
+        };
+
+        await _actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
+        _logger.LogInformation(
+            "Dispatched deferred LLM reply run: runId={RunId} actorId={ActorId} target={TargetActorId}",
+            runId,
+            actor.Id,
+            request.TargetActorId);
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
@@ -12,18 +12,18 @@ namespace Aevatar.GAgents.NyxidChat;
 public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
 {
     private readonly IActorRuntime _actorRuntime;
-    private readonly IActorDispatchPort _actorDispatchPort;
+    private readonly IStreamProvider _streamProvider;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<AgentRunDispatcher> _logger;
 
     public AgentRunDispatcher(
         IActorRuntime actorRuntime,
-        IActorDispatchPort actorDispatchPort,
+        IStreamProvider streamProvider,
         ILogger<AgentRunDispatcher> logger,
         TimeProvider? timeProvider = null)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
-        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _streamProvider = streamProvider ?? throw new ArgumentNullException(nameof(streamProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
@@ -55,9 +55,9 @@ public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
             },
         };
 
-        await _actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
+        await _streamProvider.GetStream(actor.Id).ProduceAsync(envelope, ct);
         _logger.LogInformation(
-            "Dispatched deferred LLM reply run: runId={RunId} actorId={ActorId} target={TargetActorId}",
+            "Accepted deferred LLM reply run for actor inbox: runId={RunId} actorId={ActorId} target={TargetActorId}",
             runId,
             actor.Id,
             request.TargetActorId);

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -1,25 +1,39 @@
-using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
-using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Channel.NyxIdRelay;
-using Aevatar.GAgents.NyxidChat;
+using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.Studio.Application.Studio.Abstractions;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
 
-public sealed class ChannelLlmReplyInboxRuntime :
-    IHostedService,
-    IAsyncDisposable,
-    IChannelLlmReplyInbox
+/// <summary>
+/// Run-scoped continuation owner for one deferred channel LLM reply.
+/// </summary>
+public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 {
-    internal const string InboxStreamId = "channel-runtime:llm-reply:inbox";
+    public const string ActorIdPrefix = "channel-agent-run:";
 
-    private readonly IStreamProvider _streamProvider;
+    internal const long MaxRunRequestAgeMs = 5 * 60 * 1000;
+
+    /// <summary>
+    /// Hard upper bound on a single LLM reply turn. Mirrors
+    /// <c>NyxIdRelayOptions.ResponseTimeoutSeconds</c> (default 300s).
+    /// A configured value of <c>0</c> or negative is treated as "disable the cap".
+    /// </summary>
+    internal const int FallbackTimeoutSecondsDefault = 300;
+
+    /// <summary>
+    /// Standalone budget for metadata enrichment (scope resolve + UserConfig lookup).
+    /// </summary>
+    internal static readonly TimeSpan MetadataBuildBudget = TimeSpan.FromSeconds(15);
+
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IConversationReplyGenerator _replyGenerator;
@@ -28,26 +42,21 @@ public sealed class ChannelLlmReplyInboxRuntime :
     private readonly INyxIdRelayScopeResolver? _scopeResolver;
     private readonly IUserConfigQueryPort? _userConfigQueryPort;
     private readonly TimeProvider _timeProvider;
-    private readonly ILogger<ChannelLlmReplyInboxRuntime> _logger;
-    private IAsyncDisposable? _subscription;
+    private readonly ILogger<AgentRunGAgent> _logger;
 
-    public ChannelLlmReplyInboxRuntime(
-        IStreamProvider streamProvider,
+    public AgentRunGAgent(
         IActorRuntime actorRuntime,
+        IActorDispatchPort actorDispatchPort,
         IConversationReplyGenerator replyGenerator,
         IInteractiveReplyCollector? interactiveReplyCollector,
         Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
-        ILogger<ChannelLlmReplyInboxRuntime> logger,
+        ILogger<AgentRunGAgent> logger,
         INyxIdRelayScopeResolver? scopeResolver = null,
         IUserConfigQueryPort? userConfigQueryPort = null,
-        TimeProvider? timeProvider = null,
-        IActorDispatchPort? actorDispatchPort = null)
+        TimeProvider? timeProvider = null)
     {
-        _streamProvider = streamProvider ?? throw new ArgumentNullException(nameof(streamProvider));
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
-        _actorDispatchPort = actorDispatchPort
-            ?? actorRuntime as IActorDispatchPort
-            ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
         _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
         _interactiveReplyCollector = interactiveReplyCollector;
         _relayOptions = relayOptions;
@@ -57,109 +66,106 @@ public sealed class ChannelLlmReplyInboxRuntime :
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task StartAsync(CancellationToken ct)
+    public static string BuildActorId(string correlationId)
     {
-        if (_subscription is not null)
+        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+        return ActorIdPrefix + correlationId.Trim();
+    }
+
+    protected override AgentRunGAgentState TransitionState(AgentRunGAgentState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<AgentRunStartedEvent>(ApplyStarted)
+            .On<AgentRunReplyProducedEvent>(ApplyReplyProduced)
+            .On<AgentRunDroppedEvent>(ApplyDropped)
+            .On<AgentRunFailedEvent>(ApplyFailed)
+            .OrCurrent();
+
+    [EventHandler]
+    public async Task HandleStartAsync(AgentRunStartRequested command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (command.Request is null)
+        {
+            _logger.LogWarning("Dropping malformed agent run start command without request: runActor={RunActorId}", Id);
             return;
+        }
 
-        _subscription = await _streamProvider
-            .GetStream(InboxStreamId)
-            .SubscribeAsync<NeedsLlmReplyEvent>(ProcessAsync, ct);
+        var request = command.Request.Clone();
+        var runId = NormalizeOptional(request.CorrelationId) ?? Id;
+        var startedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
-        _logger.LogInformation("Started channel LLM reply inbox on {StreamId}", InboxStreamId);
-    }
-
-    public async Task StopAsync(CancellationToken ct)
-    {
-        if (_subscription is null)
+        if (State.Status is AgentRunStatus.ReplyProduced or AgentRunStatus.Dropped or AgentRunStatus.Failed)
+        {
+            _logger.LogInformation(
+                "Ignoring duplicate terminal agent run start: runId={RunId} status={Status}",
+                runId,
+                State.Status);
             return;
+        }
 
-        await _subscription.DisposeAsync();
-        _subscription = null;
-        _logger.LogInformation("Stopped channel LLM reply inbox on {StreamId}", InboxStreamId);
+        if (string.IsNullOrWhiteSpace(State.RunId))
+        {
+            await PersistDomainEventAsync(new AgentRunStartedEvent
+            {
+                RunId = runId,
+                CorrelationId = request.CorrelationId,
+                TargetActorId = request.TargetActorId,
+                StartedAtUnixMs = startedAtUnixMs,
+            });
+        }
+
+        await ProcessAsync(request, runId);
     }
 
-    public Task EnqueueAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+    private async Task ProcessAsync(NeedsLlmReplyEvent request, string runId)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        return _streamProvider.GetStream(InboxStreamId).ProduceAsync(request, ct);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await StopAsync(CancellationToken.None);
-    }
-
-    internal const long MaxInboxRequestAgeMs = 5 * 60 * 1000;
-
-    /// <summary>
-    /// Hard upper bound on a single LLM reply turn. Mirrors
-    /// <c>NyxIdRelayOptions.ResponseTimeoutSeconds</c> (default 300s) — long enough for the
-    /// aevatar Lark bot's multi-step flows (skill search + remote tool + summarize) to land
-    /// without truncation, short enough that a true hang does not pin the inbox task forever.
-    /// A configured value of <c>0</c> or negative is treated as "disable the cap" — pass
-    /// through with no timeout, mirroring HttpClient/Polly conventions where 0 means
-    /// "no limit". The default of 300s applies when the option is unset.
-    /// </summary>
-    internal const int FallbackTimeoutSecondsDefault = 300;
-
-    /// <summary>
-    /// Standalone budget for metadata enrichment (scope resolve + UserConfig lookup).
-    /// We split this out from the LLM run budget so that slow infra around metadata
-    /// can't silently steal the LLM's response window — and so a metadata timeout
-    /// surfaces as a distinct error code rather than a misleading "llm_reply_timeout".
-    /// </summary>
-    internal static readonly TimeSpan MetadataBuildBudget = TimeSpan.FromSeconds(15);
-
-    internal async Task ProcessAsync(NeedsLlmReplyEvent request)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
         _logger.LogInformation(
-            "Processing LLM reply request: correlation={CorrelationId} target={TargetActorId}",
+            "Processing agent run LLM reply request: runId={RunId} correlation={CorrelationId} target={TargetActorId}",
+            runId,
             request.CorrelationId,
             request.TargetActorId);
 
         if (request.Activity is null || string.IsNullOrWhiteSpace(request.TargetActorId))
         {
             _logger.LogWarning(
-                "Dropping malformed deferred LLM reply request: correlation={CorrelationId}, target={TargetActorId}",
+                "Dropping malformed deferred LLM reply request: runId={RunId}, correlation={CorrelationId}, target={TargetActorId}",
+                runId,
                 request.CorrelationId,
                 request.TargetActorId);
-            await NotifyActorOfDropAsync(request, "malformed_deferred_llm_reply_request");
+            await DropAsync(request, runId, "malformed_deferred_llm_reply_request");
             return;
         }
 
         // Stale gate: NyxID relay reply tokens have a ~30 min TTL and the user access
         // token used for the LLM call expires inside ~15 min. A request that has been
-        // sitting in the stream for hours can't lead to a successful reply, so drop it
-        // here instead of spending an LLM round just to fail at the outbound stage.
-        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        if (request.RequestedAtUnixMs > 0 && nowMs - request.RequestedAtUnixMs > MaxInboxRequestAgeMs)
+        // delayed past the run window cannot lead to a successful reply.
+        var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        if (request.RequestedAtUnixMs > 0 && nowMs - request.RequestedAtUnixMs > MaxRunRequestAgeMs)
         {
             _logger.LogInformation(
-                "Dropping stale LLM reply request: correlation={CorrelationId} ageMs={AgeMs}",
+                "Dropping stale LLM reply request: runId={RunId} correlation={CorrelationId} ageMs={AgeMs}",
+                runId,
                 request.CorrelationId,
                 nowMs - request.RequestedAtUnixMs);
-            await NotifyActorOfDropAsync(request, "stale_inbox_request_dropped");
+            await DropAsync(request, runId, "stale_agent_run_request_dropped");
             return;
         }
 
         // Relay credential gate: relay turns require a fresh reply_token to send the
-        // outbound. A relay request with no inbox-carried token (e.g., rehydrated from
-        // persisted state after a pod restart that lost the original capture) cannot
-        // be delivered, so skip the LLM call entirely.
+        // outbound. A relay request with no command-carried token cannot be delivered,
+        // so skip the LLM call entirely.
         if (IsRelayRequest(request) && string.IsNullOrWhiteSpace(request.ReplyToken))
         {
             _logger.LogWarning(
-                "Dropping relay LLM reply request without inbox-carried reply_token: correlation={CorrelationId}",
+                "Dropping relay LLM reply request without command-carried reply_token: runId={RunId} correlation={CorrelationId}",
+                runId,
                 request.CorrelationId);
-            await NotifyActorOfDropAsync(request, "missing_relay_reply_token");
+            await DropAsync(request, runId, "missing_relay_reply_token");
             return;
         }
 
-        var actor = await _actorRuntime.GetAsync(request.TargetActorId)
-                    ?? await _actorRuntime.CreateAsync<ConversationGAgent>(request.TargetActorId, CancellationToken.None);
+        await EnsureTargetActorAsync(request.TargetActorId);
 
         string replyText;
         MessageContent? outboundIntent = null;
@@ -168,9 +174,6 @@ public sealed class ChannelLlmReplyInboxRuntime :
         var errorSummary = string.Empty;
         using TurnStreamingReplySink? streamingSink = TryBuildStreamingSink(request, request.TargetActorId);
 
-        // Metadata enrichment runs on its own short budget so a slow scope/UserConfig lookup
-        // can't silently shrink the LLM run's window. The LLM CTS only starts ticking after
-        // metadata is in hand, and a metadata timeout surfaces as a distinct error code.
         IReadOnlyDictionary<string, string> effectiveMetadata;
         using (var metadataCts = new CancellationTokenSource(MetadataBuildBudget))
         {
@@ -182,14 +185,15 @@ public sealed class ChannelLlmReplyInboxRuntime :
             {
                 _logger.LogWarning(
                     ex,
-                    "Deferred LLM reply metadata build timed out after {TimeoutSeconds}s: correlation={CorrelationId}",
+                    "Deferred LLM reply metadata build timed out after {TimeoutSeconds}s: runId={RunId} correlation={CorrelationId}",
                     (int)MetadataBuildBudget.TotalSeconds,
+                    runId,
                     request.CorrelationId);
                 replyText = "Sorry, I couldn't load your model preferences in time. Please try again.";
                 terminalState = LlmReplyTerminalState.Failed;
                 errorCode = "llm_reply_metadata_timeout";
                 errorSummary = $"Metadata enrichment exceeded {(int)MetadataBuildBudget.TotalSeconds}s budget.";
-                await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+                await FailAndDispatchReadyAsync(request, runId, replyText, outboundIntent, terminalState, errorCode, errorSummary);
                 return;
             }
         }
@@ -239,12 +243,13 @@ public sealed class ChannelLlmReplyInboxRuntime :
             terminalState = LlmReplyTerminalState.Failed;
             errorCode = "llm_reply_timeout";
             errorSummary = $"LLM reply generation exceeded {(int)fallbackTimeout.TotalSeconds}s budget.";
-            replyText = "Sorry, this took too long to process — the model or one of its tools didn't " +
+            replyText = "Sorry, this took too long to process - the model or one of its tools didn't " +
                         "respond in time. Please try again, or rephrase the request.";
             _logger.LogWarning(
                 ex,
-                "Deferred LLM reply timed out after {TimeoutSeconds}s: correlation={CorrelationId}",
+                "Deferred LLM reply timed out after {TimeoutSeconds}s: runId={RunId} correlation={CorrelationId}",
                 (int)fallbackTimeout.TotalSeconds,
+                runId,
                 request.CorrelationId);
         }
         catch (Exception ex)
@@ -255,11 +260,69 @@ public sealed class ChannelLlmReplyInboxRuntime :
             replyText = NyxIdRelayErrorClassifier.Classify(ex.Message);
             _logger.LogWarning(
                 ex,
-                "Deferred LLM reply generation failed: correlation={CorrelationId}",
+                "Deferred LLM reply generation failed: runId={RunId} correlation={CorrelationId}",
+                runId,
                 request.CorrelationId);
         }
 
+        if (terminalState == LlmReplyTerminalState.Failed)
+        {
+            await FailAndDispatchReadyAsync(
+                request,
+                runId,
+                replyText,
+                outboundIntent,
+                terminalState,
+                errorCode,
+                errorSummary);
+            return;
+        }
+
+        await PersistDomainEventAsync(new AgentRunReplyProducedEvent
+        {
+            RunId = runId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            TerminalState = terminalState,
+            ProducedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        });
         await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+    }
+
+    private async Task FailAndDispatchReadyAsync(
+        NeedsLlmReplyEvent request,
+        string runId,
+        string replyText,
+        MessageContent? outboundIntent,
+        LlmReplyTerminalState terminalState,
+        string errorCode,
+        string errorSummary)
+    {
+        await PersistDomainEventAsync(new AgentRunFailedEvent
+        {
+            RunId = runId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            ErrorCode = errorCode,
+            ErrorSummary = errorSummary,
+            FailedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        });
+
+        await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+    }
+
+    private async Task DropAsync(NeedsLlmReplyEvent request, string runId, string reason)
+    {
+        await PersistDomainEventAsync(new AgentRunDroppedEvent
+        {
+            RunId = runId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            Reason = reason,
+            DroppedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        });
+
+        await NotifyActorOfDropAsync(request, reason);
     }
 
     private async Task DispatchReadyEventAsync(
@@ -270,31 +333,27 @@ public sealed class ChannelLlmReplyInboxRuntime :
         string errorCode,
         string errorSummary)
     {
+        if (string.IsNullOrWhiteSpace(request.TargetActorId))
+            return;
+
         var ready = new LlmReplyReadyEvent
         {
             CorrelationId = request.CorrelationId,
             RegistrationId = request.RegistrationId,
-            SourceActorId = InboxStreamId,
+            SourceActorId = Id,
             Activity = request.Activity!.Clone(),
             Outbound = outboundIntent?.Clone() ?? new MessageContent { Text = replyText },
             TerminalState = terminalState,
             ErrorCode = errorCode,
             ErrorSummary = errorSummary,
             ReadyAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-            // Echo the inbox-only relay credential straight back so ConversationGAgent's
+            // Echo the command-only relay credential straight back so ConversationGAgent's
             // outbound reply does not depend on its in-memory token dict still having the
             // entry. The actor consumes these fields and never persists them.
             ReplyToken = request.ReplyToken ?? string.Empty,
             ReplyTokenExpiresAtUnixMs = request.ReplyTokenExpiresAtUnixMs,
         };
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-            Payload = Any.Pack(ready),
-            Route = EnvelopeRouteSemantics.CreateDirect(InboxStreamId, request.TargetActorId),
-        };
-
+        var envelope = CreateEnvelope(request.TargetActorId, ready, request.CorrelationId);
         await _actorDispatchPort.DispatchAsync(request.TargetActorId, envelope, CancellationToken.None);
     }
 
@@ -317,9 +376,6 @@ public sealed class ChannelLlmReplyInboxRuntime :
         var throttle = TimeSpan.FromMilliseconds(Math.Max(0, cardMode
             ? _relayOptions.StreamingCardKitFlushIntervalMs
             : _relayOptions.StreamingFlushIntervalMs));
-        // CardKit element-content updates have no per-card edit cap, so the interim cap that
-        // protects the legacy edit-message path is irrelevant. Pass int.MaxValue so the sink's
-        // throttle is the only frame-rate gate.
         var maxInterimChunks = cardMode
             ? int.MaxValue
             : Math.Max(0, _relayOptions.StreamingMaxInterimChunks);
@@ -342,21 +398,8 @@ public sealed class ChannelLlmReplyInboxRuntime :
     {
         var metadata = new Dictionary<string, string>(request.Metadata, StringComparer.Ordinal);
 
-        // Apply the bot owner's pre-configured LLM route + model. The relay callback
-        // identifies the bot by api_key_id (in activity.Bot.Value); we resolve that to
-        // the owner's Aevatar scope id and load the same UserConfig the owner uses
-        // when chatting through nyxid-chat themselves, then pin ModelOverride /
-        // NyxIdRoutePreference / MaxToolRoundsOverride from that configuration.
         await ApplyBotOwnerLlmConfigAsync(request, metadata, ct);
 
-        // The inbound callback's X-NyxID-User-Token is the bot owner's NyxID session
-        // JWT (freshly issued by NyxID for each callback). It is the bot owner's own
-        // credential for LLM calls — the same thing that would authorize them in
-        // nyxid-chat. The short TTL (~15 min) is mitigated by the direct-enqueue
-        // dispatch (#380), the inbox-echoed token flow (#383), and the stale pending
-        // request GC, so the token is still valid when the LLM call actually fires
-        // for any non-stale request. If the downstream provider rejects it, the
-        // classifier surfaces a real user-facing error via NyxIdRelayErrorClassifier.
         var userAccessToken = request.Activity?.TransportExtras?.NyxUserAccessToken?.Trim();
         if (!string.IsNullOrWhiteSpace(userAccessToken))
         {
@@ -388,7 +431,8 @@ public sealed class ChannelLlmReplyInboxRuntime :
         {
             _logger.LogWarning(
                 ex,
-                "Failed to resolve bot owner scope id for LLM config: correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                "Failed to resolve bot owner scope id for LLM config: runId={RunId} correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                Id,
                 request.CorrelationId,
                 apiKeyId);
             return;
@@ -397,7 +441,8 @@ public sealed class ChannelLlmReplyInboxRuntime :
         if (string.IsNullOrWhiteSpace(scopeId))
         {
             _logger.LogDebug(
-                "No bot owner scope id resolved for LLM config: correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                "No bot owner scope id resolved for LLM config: runId={RunId} correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                Id,
                 request.CorrelationId,
                 apiKeyId);
             return;
@@ -415,7 +460,8 @@ public sealed class ChannelLlmReplyInboxRuntime :
                     config.MaxToolRounds.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
             _logger.LogInformation(
-                "Applied bot owner LLM config: correlation={CorrelationId} scopeId={ScopeId} model={Model} route={Route}",
+                "Applied bot owner LLM config: runId={RunId} correlation={CorrelationId} scopeId={ScopeId} model={Model} route={Route}",
+                Id,
                 request.CorrelationId,
                 scopeId,
                 string.IsNullOrWhiteSpace(config.DefaultModel) ? "<server-default>" : config.DefaultModel,
@@ -425,22 +471,13 @@ public sealed class ChannelLlmReplyInboxRuntime :
         {
             _logger.LogWarning(
                 ex,
-                "Failed to load bot owner LLM config: correlation={CorrelationId} scopeId={ScopeId}",
+                "Failed to load bot owner LLM config: runId={RunId} correlation={CorrelationId} scopeId={ScopeId}",
+                Id,
                 request.CorrelationId,
                 scopeId);
         }
     }
 
-    /// <summary>
-    /// Resolve the LLM-run cap from <c>NyxIdRelayOptions.ResponseTimeoutSeconds</c>.
-    /// Conventions:
-    ///   * unset / null  → <see cref="FallbackTimeoutSecondsDefault"/> (300s)
-    ///   * &gt; 0        → use that exact value
-    ///   * 0 or negative → <see cref="TimeSpan.Zero"/> meaning "no timeout"; the caller
-    ///     constructs an unbounded <see cref="CancellationTokenSource"/>. Use this only
-    ///     in environments that have an external watchdog — without it, a hung tool
-    ///     keeps the inbox task alive indefinitely.
-    /// </summary>
     private TimeSpan ResolveFallbackTimeout()
     {
         if (_relayOptions is null)
@@ -475,32 +512,23 @@ public sealed class ChannelLlmReplyInboxRuntime :
         {
             _logger.LogWarning(
                 ex,
-                "Failed to resolve actor for inbox drop notification: correlation={CorrelationId} target={TargetActorId}",
+                "Failed to resolve actor for run drop notification: runId={RunId} correlation={CorrelationId} target={TargetActorId}",
+                Id,
                 request.CorrelationId,
                 request.TargetActorId);
             return;
         }
 
         if (actor is null)
-        {
-            // No active actor means there is nothing pending to clean up; the request
-            // either was never persisted or the actor's state was already retired.
             return;
-        }
 
         var dropped = new DeferredLlmReplyDroppedEvent
         {
             CorrelationId = request.CorrelationId,
             Reason = reason,
-            DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            DroppedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
         };
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(dropped),
-            Route = EnvelopeRouteSemantics.CreateDirect(InboxStreamId, request.TargetActorId),
-        };
+        var envelope = CreateEnvelope(request.TargetActorId, dropped, request.CorrelationId);
 
         try
         {
@@ -510,10 +538,21 @@ public sealed class ChannelLlmReplyInboxRuntime :
         {
             _logger.LogWarning(
                 ex,
-                "Failed to deliver inbox drop notification: correlation={CorrelationId} reason={Reason}",
+                "Failed to deliver run drop notification: runId={RunId} correlation={CorrelationId} reason={Reason}",
+                Id,
                 request.CorrelationId,
                 reason);
         }
+    }
+
+    private async Task EnsureTargetActorAsync(string targetActorId)
+    {
+        if (string.IsNullOrWhiteSpace(targetActorId))
+            return;
+
+        var actor = await _actorRuntime.GetAsync(targetActorId);
+        if (actor is null)
+            await _actorRuntime.CreateAsync<ConversationGAgent>(targetActorId, CancellationToken.None);
     }
 
     private bool ShouldCaptureInteractiveReply(ChatActivity? activity)
@@ -530,18 +569,79 @@ public sealed class ChannelLlmReplyInboxRuntime :
             CorrelationId.Length: > 0,
         };
     }
-}
 
-public sealed class ChannelLlmReplyInboxHostedService : IHostedService
-{
-    private readonly ChannelLlmReplyInboxRuntime _runtime;
+    private EventEnvelope CreateEnvelope<TPayload>(
+        string targetActorId,
+        TPayload payload,
+        string correlationId)
+        where TPayload : IMessage =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateDirect(Id, targetActorId),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = correlationId ?? string.Empty,
+            },
+        };
 
-    public ChannelLlmReplyInboxHostedService(ChannelLlmReplyInboxRuntime runtime)
+    private static AgentRunGAgentState ApplyStarted(AgentRunGAgentState current, AgentRunStartedEvent evt)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        var next = current.Clone();
+        next.RunId = evt.RunId;
+        next.CorrelationId = evt.CorrelationId;
+        next.TargetActorId = evt.TargetActorId;
+        next.Status = AgentRunStatus.Started;
+        next.StartedAtUnixMs = evt.StartedAtUnixMs;
+        return next;
     }
 
-    public Task StartAsync(CancellationToken ct) => _runtime.StartAsync(ct);
+    private static AgentRunGAgentState ApplyReplyProduced(
+        AgentRunGAgentState current,
+        AgentRunReplyProducedEvent evt)
+    {
+        var next = current.Clone();
+        next.RunId = string.IsNullOrWhiteSpace(next.RunId) ? evt.RunId : next.RunId;
+        next.CorrelationId = string.IsNullOrWhiteSpace(next.CorrelationId) ? evt.CorrelationId : next.CorrelationId;
+        next.TargetActorId = string.IsNullOrWhiteSpace(next.TargetActorId) ? evt.TargetActorId : next.TargetActorId;
+        next.Status = AgentRunStatus.ReplyProduced;
+        next.CompletedAtUnixMs = evt.ProducedAtUnixMs;
+        next.ErrorCode = evt.ErrorCode;
+        next.ErrorSummary = evt.ErrorSummary;
+        return next;
+    }
 
-    public Task StopAsync(CancellationToken ct) => _runtime.StopAsync(ct);
+    private static AgentRunGAgentState ApplyDropped(AgentRunGAgentState current, AgentRunDroppedEvent evt)
+    {
+        var next = current.Clone();
+        next.RunId = string.IsNullOrWhiteSpace(next.RunId) ? evt.RunId : next.RunId;
+        next.CorrelationId = string.IsNullOrWhiteSpace(next.CorrelationId) ? evt.CorrelationId : next.CorrelationId;
+        next.TargetActorId = string.IsNullOrWhiteSpace(next.TargetActorId) ? evt.TargetActorId : next.TargetActorId;
+        next.Status = AgentRunStatus.Dropped;
+        next.CompletedAtUnixMs = evt.DroppedAtUnixMs;
+        next.ErrorCode = evt.Reason;
+        next.ErrorSummary = string.Empty;
+        return next;
+    }
+
+    private static AgentRunGAgentState ApplyFailed(AgentRunGAgentState current, AgentRunFailedEvent evt)
+    {
+        var next = current.Clone();
+        next.RunId = string.IsNullOrWhiteSpace(next.RunId) ? evt.RunId : next.RunId;
+        next.CorrelationId = string.IsNullOrWhiteSpace(next.CorrelationId) ? evt.CorrelationId : next.CorrelationId;
+        next.TargetActorId = string.IsNullOrWhiteSpace(next.TargetActorId) ? evt.TargetActorId : next.TargetActorId;
+        next.Status = AgentRunStatus.Failed;
+        next.CompletedAtUnixMs = evt.FailedAtUnixMs;
+        next.ErrorCode = evt.ErrorCode;
+        next.ErrorSummary = evt.ErrorSummary;
+        return next;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -37,6 +37,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
     internal static readonly TimeSpan TerminalCleanupDelay = TimeSpan.FromMinutes(5);
     private const string TerminalCleanupCallbackPrefix = "agent-run-terminal-cleanup";
+    internal static readonly TimeSpan OutputDispatchRetryDelay = TimeSpan.FromSeconds(5);
+    private const string OutputDispatchRetryCallbackPrefix = "agent-run-output-dispatch-retry";
 
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
@@ -126,13 +128,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         }
         catch (AgentRunOutputDispatchException ex)
         {
-            // The run has not entered a terminal state yet. Leaving it Started lets the
-            // durable dispatcher retry the start command and re-emit the ready/drop signal.
-            _logger.LogWarning(
-                ex,
-                "Agent run output notification was not accepted; run remains retryable: runId={RunId} correlation={CorrelationId}",
-                runId,
-                request.CorrelationId);
+            if (!await TryHandleOutputDispatchFailureAsync(request, runId, ex))
+                throw;
         }
         catch (Exception ex)
         {
@@ -414,11 +411,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             }
             catch (AgentRunOutputDispatchException dispatchEx)
             {
-                _logger.LogWarning(
-                    dispatchEx,
-                    "Unhandled run failure notification was not accepted; run remains retryable: runId={RunId} correlation={CorrelationId}",
-                    runId,
-                    request.CorrelationId);
+                if (!await TryHandleOutputDispatchFailureAsync(request, runId, dispatchEx))
+                    throw;
                 return;
             }
         }
@@ -629,6 +623,56 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         }
     }
 
+    private async Task<bool> TryHandleOutputDispatchFailureAsync(
+        NeedsLlmReplyEvent request,
+        string runId,
+        AgentRunOutputDispatchException ex)
+    {
+        _logger.LogWarning(
+            ex,
+            "Agent run output notification was not accepted; run remains retryable: runId={RunId} correlation={CorrelationId}",
+            runId,
+            request.CorrelationId);
+
+        if (await TryScheduleStartRetryAsync(request, runId))
+            return true;
+
+        _logger.LogWarning(
+            ex,
+            "Agent run output retry could not be scheduled; propagating to runtime retry: runId={RunId} correlation={CorrelationId}",
+            runId,
+            request.CorrelationId);
+        return false;
+    }
+
+    private async Task<bool> TryScheduleStartRetryAsync(NeedsLlmReplyEvent request, string runId)
+    {
+        if (Services.GetService<IActorRuntimeCallbackScheduler>() is null)
+            return false;
+
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildOutputDispatchRetryCallbackId(runId),
+                OutputDispatchRetryDelay,
+                new AgentRunStartRequested
+                {
+                    Request = request.Clone(),
+                },
+                ct: CancellationToken.None);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to schedule agent run output retry: runId={RunId} actorId={ActorId}",
+                runId,
+                Id);
+            return false;
+        }
+    }
+
     private async Task ScheduleTerminalCleanupAsync(string runId)
     {
         if (Services.GetService<IActorRuntimeCallbackScheduler>() is null)
@@ -664,6 +708,16 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             .Take(96)
             .ToArray();
         return $"{TerminalCleanupCallbackPrefix}:{new string(chars)}";
+    }
+
+    private static string BuildOutputDispatchRetryCallbackId(string runId)
+    {
+        var normalized = NormalizeOptional(runId) ?? "unknown";
+        var chars = normalized
+            .Select(static ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '_')
+            .Take(96)
+            .ToArray();
+        return $"{OutputDispatchRetryCallbackPrefix}:{new string(chars)}";
     }
 
     private async Task EnsureTargetActorAsync(string targetActorId)

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -1,6 +1,7 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
@@ -8,7 +9,7 @@ using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
@@ -33,6 +34,9 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
     /// Standalone budget for metadata enrichment (scope resolve + UserConfig lookup).
     /// </summary>
     internal static readonly TimeSpan MetadataBuildBudget = TimeSpan.FromSeconds(15);
+
+    internal static readonly TimeSpan TerminalCleanupDelay = TimeSpan.FromMinutes(5);
+    private const string TerminalCleanupCallbackPrefix = "agent-run-terminal-cleanup";
 
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
@@ -101,6 +105,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
                 "Ignoring duplicate terminal agent run start: runId={RunId} status={Status}",
                 runId,
                 State.Status);
+            await ScheduleTerminalCleanupAsync(NormalizeOptional(State.RunId) ?? runId);
             return;
         }
 
@@ -115,7 +120,40 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             });
         }
 
-        await ProcessAsync(request, runId);
+        try
+        {
+            await ProcessAsync(request, runId);
+        }
+        catch (AgentRunOutputDispatchException ex)
+        {
+            // The run has not entered a terminal state yet. Leaving it Started lets the
+            // durable dispatcher retry the start command and re-emit the ready/drop signal.
+            _logger.LogWarning(
+                ex,
+                "Agent run output notification was not accepted; run remains retryable: runId={RunId} correlation={CorrelationId}",
+                runId,
+                request.CorrelationId);
+        }
+        catch (Exception ex)
+        {
+            await FailAfterUnexpectedExceptionAsync(request, runId, ex);
+        }
+    }
+
+    [EventHandler]
+    public async Task HandleCleanupAsync(AgentRunCleanupRequested command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (State.Status is not (AgentRunStatus.ReplyProduced or AgentRunStatus.Dropped or AgentRunStatus.Failed))
+            return;
+        if (!string.IsNullOrWhiteSpace(command.RunId) &&
+            !string.IsNullOrWhiteSpace(State.RunId) &&
+            !string.Equals(command.RunId, State.RunId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await _actorRuntime.DestroyAsync(Id, CancellationToken.None);
     }
 
     private async Task ProcessAsync(NeedsLlmReplyEvent request, string runId)
@@ -278,15 +316,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             return;
         }
 
-        await PersistDomainEventAsync(new AgentRunReplyProducedEvent
-        {
-            RunId = runId,
-            CorrelationId = request.CorrelationId,
-            TargetActorId = request.TargetActorId,
-            TerminalState = terminalState,
-            ProducedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-        });
         await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+        await PersistReplyProducedAsync(request, runId, terminalState, errorCode, errorSummary);
     }
 
     private async Task FailAndDispatchReadyAsync(
@@ -295,6 +326,54 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         string replyText,
         MessageContent? outboundIntent,
         LlmReplyTerminalState terminalState,
+        string errorCode,
+        string errorSummary)
+    {
+        await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+        await PersistFailedAsync(request, runId, errorCode, errorSummary);
+    }
+
+    private async Task DropAsync(NeedsLlmReplyEvent request, string runId, string reason)
+    {
+        if (CanNotifyDrop(request))
+            await DispatchDropNotificationAsync(request, reason);
+
+        await PersistDomainEventAsync(new AgentRunDroppedEvent
+        {
+            RunId = runId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            Reason = reason,
+            DroppedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        });
+
+        await ScheduleTerminalCleanupAsync(runId);
+    }
+
+    private async Task PersistReplyProducedAsync(
+        NeedsLlmReplyEvent request,
+        string runId,
+        LlmReplyTerminalState terminalState,
+        string errorCode,
+        string errorSummary)
+    {
+        await PersistDomainEventAsync(new AgentRunReplyProducedEvent
+        {
+            RunId = runId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            TerminalState = terminalState,
+            ErrorCode = errorCode,
+            ErrorSummary = errorSummary,
+            ProducedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        });
+
+        await ScheduleTerminalCleanupAsync(runId);
+    }
+
+    private async Task PersistFailedAsync(
+        NeedsLlmReplyEvent request,
+        string runId,
         string errorCode,
         string errorSummary)
     {
@@ -308,21 +387,43 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             FailedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
         });
 
-        await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+        await ScheduleTerminalCleanupAsync(runId);
     }
 
-    private async Task DropAsync(NeedsLlmReplyEvent request, string runId, string reason)
+    private async Task FailAfterUnexpectedExceptionAsync(NeedsLlmReplyEvent request, string runId, Exception ex)
     {
-        await PersistDomainEventAsync(new AgentRunDroppedEvent
-        {
-            RunId = runId,
-            CorrelationId = request.CorrelationId,
-            TargetActorId = request.TargetActorId,
-            Reason = reason,
-            DroppedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-        });
+        const string errorCode = "agent_run_unhandled_exception";
+        var errorSummary = ex.Message;
+        _logger.LogError(
+            ex,
+            "Agent run failed with unhandled exception: runId={RunId} correlation={CorrelationId}",
+            runId,
+            request.CorrelationId);
 
-        await NotifyActorOfDropAsync(request, reason);
+        if (request.Activity is not null && !string.IsNullOrWhiteSpace(request.TargetActorId))
+        {
+            try
+            {
+                await DispatchReadyEventAsync(
+                    request,
+                    "Sorry, I couldn't complete this reply. Please try again.",
+                    null,
+                    LlmReplyTerminalState.Failed,
+                    errorCode,
+                    errorSummary);
+            }
+            catch (AgentRunOutputDispatchException dispatchEx)
+            {
+                _logger.LogWarning(
+                    dispatchEx,
+                    "Unhandled run failure notification was not accepted; run remains retryable: runId={RunId} correlation={CorrelationId}",
+                    runId,
+                    request.CorrelationId);
+                return;
+            }
+        }
+
+        await PersistFailedAsync(request, runId, errorCode, errorSummary);
     }
 
     private async Task DispatchReadyEventAsync(
@@ -353,8 +454,16 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             ReplyToken = request.ReplyToken ?? string.Empty,
             ReplyTokenExpiresAtUnixMs = request.ReplyTokenExpiresAtUnixMs,
         };
-        var envelope = CreateEnvelope(request.TargetActorId, ready, request.CorrelationId);
-        await _actorDispatchPort.DispatchAsync(request.TargetActorId, envelope, CancellationToken.None);
+        try
+        {
+            await SendToAsync(request.TargetActorId, ready, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            throw new AgentRunOutputDispatchException(
+                $"Failed to send LLM reply ready event to conversation actor '{request.TargetActorId}'.",
+                ex);
+        }
     }
 
     private TurnStreamingReplySink? TryBuildStreamingSink(NeedsLlmReplyEvent request, string targetActorId)
@@ -495,54 +604,66 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             CorrelationId.Length: > 0,
         };
 
-    private async Task NotifyActorOfDropAsync(NeedsLlmReplyEvent request, string reason)
+    private static bool CanNotifyDrop(NeedsLlmReplyEvent request) =>
+        !string.IsNullOrWhiteSpace(request.TargetActorId) &&
+        !string.IsNullOrWhiteSpace(request.CorrelationId);
+
+    private async Task DispatchDropNotificationAsync(NeedsLlmReplyEvent request, string reason)
     {
-        if (string.IsNullOrWhiteSpace(request.TargetActorId) ||
-            string.IsNullOrWhiteSpace(request.CorrelationId))
-        {
-            return;
-        }
-
-        IActor? actor;
-        try
-        {
-            actor = await _actorRuntime.GetAsync(request.TargetActorId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to resolve actor for run drop notification: runId={RunId} correlation={CorrelationId} target={TargetActorId}",
-                Id,
-                request.CorrelationId,
-                request.TargetActorId);
-            return;
-        }
-
-        if (actor is null)
-            return;
-
         var dropped = new DeferredLlmReplyDroppedEvent
         {
             CorrelationId = request.CorrelationId,
             Reason = reason,
             DroppedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
         };
-        var envelope = CreateEnvelope(request.TargetActorId, dropped, request.CorrelationId);
 
         try
         {
-            await _actorDispatchPort.DispatchAsync(request.TargetActorId, envelope, CancellationToken.None);
+            await SendToAsync(request.TargetActorId, dropped, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            throw new AgentRunOutputDispatchException(
+                $"Failed to send deferred LLM reply drop event to conversation actor '{request.TargetActorId}' (reason '{reason}').",
+                ex);
+        }
+    }
+
+    private async Task ScheduleTerminalCleanupAsync(string runId)
+    {
+        if (Services.GetService<IActorRuntimeCallbackScheduler>() is null)
+            return;
+
+        try
+        {
+            await ScheduleSelfDurableTimeoutAsync(
+                BuildCleanupCallbackId(runId),
+                TerminalCleanupDelay,
+                new AgentRunCleanupRequested
+                {
+                    RunId = runId,
+                    RequestedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+                },
+                ct: CancellationToken.None);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(
                 ex,
-                "Failed to deliver run drop notification: runId={RunId} correlation={CorrelationId} reason={Reason}",
-                Id,
-                request.CorrelationId,
-                reason);
+                "Failed to schedule terminal agent run cleanup: runId={RunId} actorId={ActorId}",
+                runId,
+                Id);
         }
+    }
+
+    private static string BuildCleanupCallbackId(string runId)
+    {
+        var normalized = NormalizeOptional(runId) ?? "unknown";
+        var chars = normalized
+            .Select(static ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '_')
+            .Take(96)
+            .ToArray();
+        return $"{TerminalCleanupCallbackPrefix}:{new string(chars)}";
     }
 
     private async Task EnsureTargetActorAsync(string targetActorId)
@@ -569,23 +690,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             CorrelationId.Length: > 0,
         };
     }
-
-    private EventEnvelope CreateEnvelope<TPayload>(
-        string targetActorId,
-        TPayload payload,
-        string correlationId)
-        where TPayload : IMessage =>
-        new()
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-            Payload = Any.Pack(payload),
-            Route = EnvelopeRouteSemantics.CreateDirect(Id, targetActorId),
-            Propagation = new EnvelopePropagation
-            {
-                CorrelationId = correlationId ?? string.Empty,
-            },
-        };
 
     private static AgentRunGAgentState ApplyStarted(AgentRunGAgentState current, AgentRunStartedEvent evt)
     {
@@ -644,4 +748,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         var trimmed = value?.Trim();
         return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
+
+    private sealed class AgentRunOutputDispatchException(string message, Exception innerException)
+        : Exception(message, innerException);
 }

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -119,7 +119,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
 
         // Normal LLM messages do not force /init. If the sender is bound we
         // carry that binding forward so the reply generator can try the
-        // sender's own NyxID LLM prefs first; otherwise the inbox/generator
+        // sender's own NyxID LLM prefs first; otherwise the run actor/generator
         // will use the bot owner's ambient LLM config.
         var senderBinding = await TryResolveSenderBindingAsync(inbound, registration, ct).ConfigureAwait(false);
 
@@ -1509,9 +1509,9 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 
-        // Carry the relay reply credential through the inbox as transient inbox-only
+        // Carry the relay reply credential through the run command as transient command-only
         // fields. ConversationGAgent strips these before persisting NeedsLlmReplyEvent;
-        // ChannelLlmReplyInboxRuntime echoes them into the LlmReplyReadyEvent so the
+        // AgentRunGAgent echoes them into the LlmReplyReadyEvent so the
         // outbound reply does not depend on the actor's in-memory token dict surviving
         // deactivation.
         if (runtimeContext.NyxRelayReplyToken is { } token &&

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -10,7 +10,6 @@ using Aevatar.GAgents.NyxidChat.Slash;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
@@ -21,6 +20,7 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
         RuntimeHelpers.RunClassConstructor(typeof(NyxIdChatGAgent).TypeHandle);
+        RuntimeHelpers.RunClassConstructor(typeof(AgentRunGAgent).TypeHandle);
 
         services.AddHttpClient();
         services.TryAddSingleton(provider => BindRelayOptions(configuration));
@@ -36,10 +36,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NyxIdRelayTransport>();
         services.TryAddSingleton<NyxIdRelayAuthValidator>();
 
-        // ─── Channel LLM reply inbox runtime + hosted service ───
-        services.TryAddSingleton<ChannelLlmReplyInboxRuntime>();
-        services.TryAddSingleton<IChannelLlmReplyInbox>(sp => sp.GetRequiredService<ChannelLlmReplyInboxRuntime>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ChannelLlmReplyInboxHostedService>());
+        // ─── Channel LLM reply run dispatch ───
+        services.TryAddSingleton<IChannelLlmReplyRunDispatcher, AgentRunDispatcher>();
 
         // ─── Conversation turn-runner override + reply generator ───
         services.Replace(ServiceDescriptor.Singleton<IConversationTurnRunner, ChannelConversationTurnRunner>());

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -32,6 +32,11 @@ message AgentRunStartRequested {
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 1;
 }
 
+message AgentRunCleanupRequested {
+  string run_id = 1;
+  int64 requested_at_unix_ms = 2;
+}
+
 message AgentRunStartedEvent {
   string run_id = 1;
   string correlation_id = 2;

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package aevatar.gagents.nyxid_chat;
+
+option csharp_namespace = "Aevatar.GAgents.NyxidChat";
+
+import "conversation_events.proto";
+
+enum AgentRunStatus {
+  AGENT_RUN_STATUS_UNSPECIFIED = 0;
+  AGENT_RUN_STATUS_STARTED = 1;
+  AGENT_RUN_STATUS_REPLY_PRODUCED = 2;
+  AGENT_RUN_STATUS_DROPPED = 3;
+  AGENT_RUN_STATUS_FAILED = 4;
+}
+
+message AgentRunGAgentState {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  AgentRunStatus status = 4;
+  int64 started_at_unix_ms = 5;
+  int64 completed_at_unix_ms = 6;
+  string error_code = 7;
+  string error_summary = 8;
+}
+
+// Transient command for the run actor. The nested NeedsLlmReplyEvent may carry
+// a short-lived relay reply_token; AgentRunGAgent must never persist that
+// credential into AgentRunGAgentState or any AgentRun*Event.
+message AgentRunStartRequested {
+  aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 1;
+}
+
+message AgentRunStartedEvent {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  int64 started_at_unix_ms = 4;
+}
+
+message AgentRunReplyProducedEvent {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  aevatar.gagents.channel.runtime.LlmReplyTerminalState terminal_state = 4;
+  string error_code = 5;
+  string error_summary = 6;
+  int64 produced_at_unix_ms = 7;
+}
+
+message AgentRunDroppedEvent {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  string reason = 4;
+  int64 dropped_at_unix_ms = 5;
+}
+
+message AgentRunFailedEvent {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  string error_code = 4;
+  string error_summary = 5;
+  int64 failed_at_unix_ms = 6;
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -751,7 +751,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             metadata["scope_id"] = State.ScopeId;
 
         // Pin the bot owner's pre-configured model + NyxID route + tool-round cap onto the
-        // outbound LLM metadata, the same pattern ChannelLlmReplyInboxRuntime applies for
+        // outbound LLM metadata, the same pattern AgentRunGAgent applies for
         // nyxid-chat. Without this, scheduled runs fall through to NyxIdLLMProvider's
         // compile-time defaults (`gpt-5.4` against `/api/v1/llm/gateway/v1/`), which the
         // gateway routes to the OpenAI provider — failing for bot owners who pre-configured

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayOptions.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayOptions.cs
@@ -9,9 +9,9 @@ public class NyxIdRelayOptions
     /// Hard upper bound on a single LLM reply turn (LLM thinking + tool rounds + final
     /// streaming dispatch). 300s gives margin for multi-step tool chains common in the
     /// aevatar Lark bot flow — search a skill, hit a remote endpoint, summarize the result —
-    /// without letting a genuine hang pin the inbox task forever. Set to <c>0</c> or
+    /// without letting a genuine hang pin the run actor turn forever. Set to <c>0</c> or
     /// negative on a deployment that has its own watchdog and prefers no in-process cap;
-    /// see <c>ChannelLlmReplyInboxRuntime.ResolveFallbackTimeout</c>.
+    /// see <c>AgentRunGAgent.ResolveFallbackTimeout</c>.
     /// </summary>
     public int ResponseTimeoutSeconds { get; set; } = 300;
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSshExecTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSshExecTool.cs
@@ -112,7 +112,7 @@ public sealed class NyxIdSshExecTool : IAgentTool
         // `timeout_secs + a few seconds` (the server-side timer kicks in and returns
         // `timed_out: true`). In practice we have observed the call hang well past 60s
         // (NyxID SSH gateway / NodeAgent stuck on a stale session). Without a hard cap,
-        // the LLM run sits on a single tool call long enough to blow the inbox runtime's
+        // the LLM run sits on a single tool call long enough to blow the run actor's
         // turn budget and the user gets the generic "took too long" fallback instead of
         // a usable error from this tool. Cap at `timeout_secs + 15s` so NyxID has a
         // generous margin to return its own timeout response, then fail this tool with

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -433,13 +433,13 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleInboundActivityAsync_WhenInboxIsRegistered_DispatchesDirectlyWithoutWaitingForReminder()
+    public async Task HandleInboundActivityAsync_WhenRunDispatcherIsRegistered_DispatchesDirectlyWithoutWaitingForReminder()
     {
         // Regression: previously the inbound LlmReplyRequest path scheduled a 100ms durable
-        // Reminder before EnqueueAsync, which Orleans rounded up to ~1 minute and effectively
-        // dropped the dispatch in production. The inbound path must call inbox.EnqueueAsync
+        // Reminder before DispatchAsync, which Orleans rounded up to ~1 minute and effectively
+        // dropped the dispatch in production. The inbound path must call dispatcher.DispatchAsync
         // inline so the LLM worker picks it up immediately.
-        var inbox = new RecordingInbox();
+        var dispatcher = new RecordingRunDispatcher();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -452,20 +452,20 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = 42,
                 }),
         };
-        var (agent, _) = CreateAgent(runner, "conv-direct-dispatch", inbox);
+        var (agent, _) = CreateAgent(runner, "conv-direct-dispatch", dispatcher);
 
         await agent.HandleInboundActivityAsync(CreateActivity("act-direct", "conv:slack:C1"));
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].CorrelationId.ShouldBe("act-direct");
-        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
+        dispatcher.Dispatched.Count.ShouldBe(1);
+        dispatcher.Dispatched[0].CorrelationId.ShouldBe("act-direct");
+        dispatcher.Dispatched[0].TargetActorId.ShouldBe(agent.Id);
     }
 
     [Fact]
     public async Task HandleNyxRelayInboundActivityAsync_NeverPersistsReplyTokenIntoEventStore()
     {
         // Issue #366 §4 invariant: relay reply_token must stay actor-owned runtime state.
-        // The transient inbox envelope NyxRelayInboundActivity carries the token across the
+        // The transient run command NyxRelayInboundActivity carries the token across the
         // dispatch boundary, but the actor must not write it into any persisted event payload.
         const string sentinelReplyToken = "sentinel-reply-token-9f3c5b2e-must-not-persist";
         var runner = new RecordingTurnRunner
@@ -556,7 +556,7 @@ public sealed class ConversationGAgentDedupTests
         // requests are tracked by message_id, while reply tokens are keyed by the
         // callback correlation_id carried in OutboundDelivery.
         const string sentinelReplyToken = "sentinel-retry-token-7c10";
-        var inbox = new RecordingInbox();
+        var dispatcher = new RecordingRunDispatcher();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -569,7 +569,7 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner", inbox);
+        var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner", dispatcher);
 
         var inboundActivity = CreateActivity("nyx-msg-1", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -586,10 +586,10 @@ public sealed class ConversationGAgentDedupTests
             CorrelationId = "legacy-callback-jti-1",
         });
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
-        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
-        inbox.Enqueued.Clear();
+        dispatcher.Dispatched.Count.ShouldBe(1);
+        dispatcher.Dispatched[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        dispatcher.Dispatched[0].TargetActorId.ShouldBe(agent.Id);
+        dispatcher.Dispatched.Clear();
 
         await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
         {
@@ -597,10 +597,10 @@ public sealed class ConversationGAgentDedupTests
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].CorrelationId.ShouldBe("nyx-msg-1");
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
-        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
+        dispatcher.Dispatched.Count.ShouldBe(1);
+        dispatcher.Dispatched[0].CorrelationId.ShouldBe("nyx-msg-1");
+        dispatcher.Dispatched[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        dispatcher.Dispatched[0].TargetActorId.ShouldBe(agent.Id);
     }
 
     [Fact]
@@ -653,13 +653,13 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleInboundActivityAsync_StripsReplyTokenFromPersistedNeedsLlmReplyEvent_ButKeepsItOnInboxCopy()
+    public async Task HandleInboundActivityAsync_StripsReplyTokenFromPersistedNeedsLlmReplyEvent_ButKeepsItOnRunCommandCopy()
     {
         // Strip-on-persist invariant: NeedsLlmReplyEvent must keep reply_token on the
-        // copy enqueued to inbox so the LLM worker can echo it back, but the persisted
+        // copy dispatched to the run actor so the LLM worker can echo it back, but the persisted
         // copy that lands in event store must omit it.
         const string sentinelReplyToken = "sentinel-strip-on-persist-1f8b3";
-        var inbox = new RecordingInbox();
+        var dispatcher = new RecordingRunDispatcher();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -674,7 +674,7 @@ public sealed class ConversationGAgentDedupTests
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, store) = CreateAgent(runner, "conv-strip-token", inbox);
+        var (agent, store) = CreateAgent(runner, "conv-strip-token", dispatcher);
 
         var inboundActivity = CreateActivity("act-strip", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -684,8 +684,8 @@ public sealed class ConversationGAgentDedupTests
         };
         await agent.HandleInboundActivityAsync(inboundActivity);
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        dispatcher.Dispatched.Count.ShouldBe(1);
+        dispatcher.Dispatched[0].ReplyToken.ShouldBe(sentinelReplyToken);
 
         var events = await store.GetEventsAsync(agent.Id);
         events.ShouldNotBeEmpty();
@@ -703,12 +703,12 @@ public sealed class ConversationGAgentDedupTests
     {
         // Regression for Codex review: the persisted NeedsLlmReplyEvent in
         // State.PendingLlmReplyRequests always has an empty ReplyToken (strip-on-persist).
-        // On the retry / durable-reminder path we walk that state, so the inbox must see
+        // On the retry / durable-reminder path we walk that state, so the run dispatcher must see
         // the token re-enriched from the actor's in-memory dict while the activation is
-        // still alive. Without enrichment the inbox subscriber's relay gate would drop
+        // still alive. Without enrichment the run actor's relay gate would drop
         // the retry and permanently lose the reply.
         const string sentinelReplyToken = "sentinel-retry-enrich-b3d7a";
-        var inbox = new RecordingInbox();
+        var dispatcher = new RecordingRunDispatcher();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -723,7 +723,7 @@ public sealed class ConversationGAgentDedupTests
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, _) = CreateAgent(runner, "conv-retry-enrich", inbox);
+        var (agent, _) = CreateAgent(runner, "conv-retry-enrich", dispatcher);
 
         var inboundActivity = CreateActivity("act-retry", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -739,29 +739,29 @@ public sealed class ConversationGAgentDedupTests
             CorrelationId = "corr-retry",
         };
 
-        // Inbound capture populates the actor runtime dict and enqueues with ReplyToken set directly.
+        // Inbound capture populates the actor runtime dict and dispatches with ReplyToken set directly.
         await agent.HandleNyxRelayInboundActivityAsync(relayInbound);
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        dispatcher.Dispatched.Count.ShouldBe(1);
+        dispatcher.Dispatched[0].ReplyToken.ShouldBe(sentinelReplyToken);
 
         // Simulate the durable-reminder retry firing: pendingRequest is read from state
         // where ReplyToken was stripped. DispatchPendingLlmReplyAsync must re-enrich
-        // from the actor dict so the inbox still receives the token.
+        // from the actor dict so the run dispatcher still receives the token.
         await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
         {
             CorrelationId = "corr-retry",
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
 
-        inbox.Enqueued.Count.ShouldBe(2);
-        inbox.Enqueued[1].ReplyToken.ShouldBe(sentinelReplyToken);
+        dispatcher.Dispatched.Count.ShouldBe(2);
+        dispatcher.Dispatched[1].ReplyToken.ShouldBe(sentinelReplyToken);
     }
 
     [Fact]
-    public async Task HandleLlmReplyReadyAsync_PrefersInboxEchoedReplyToken_OverActorRuntimeDict()
+    public async Task HandleLlmReplyReadyAsync_PrefersRunEchoedReplyToken_OverActorRuntimeDict()
     {
         // After a pod restart the in-memory _nyxRelayReplyTokens dict is empty, so the
-        // outbound reply must be able to consume the inbox-echoed reply_token from
+        // outbound reply must be able to consume the run-echoed reply_token from
         // LlmReplyReadyEvent directly. Capture the token observed by the runner to confirm.
         ConversationTurnRuntimeContext? observedContext = null;
         var runner = new RecordingTurnRunner
@@ -777,45 +777,45 @@ public sealed class ConversationGAgentDedupTests
                 }),
         };
         runner.LlmReplyContextObserver = ctx => observedContext = ctx;
-        var (agent, _) = CreateAgent(runner, "conv-inbox-echo");
+        var (agent, _) = CreateAgent(runner, "conv-run-echo");
 
-        var activity = CreateActivity("act-inbox-echo", "conv:slack:C1");
+        var activity = CreateActivity("act-run-echo", "conv:slack:C1");
         activity.OutboundDelivery = new OutboundDeliveryContext
         {
             ReplyMessageId = "relay-msg-echo",
-            CorrelationId = "corr-inbox-echo",
+            CorrelationId = "corr-run-echo",
         };
 
         await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
         {
-            CorrelationId = "nyx-msg-inbox-echo",
+            CorrelationId = "nyx-msg-run-echo",
             RegistrationId = "reg-1",
             SourceActorId = "llm-worker-1",
             Activity = activity.Clone(),
             Outbound = new MessageContent { Text = "reply-from-llm" },
             TerminalState = LlmReplyTerminalState.Completed,
             ReadyAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            ReplyToken = "inbox-echoed-token",
+            ReplyToken = "run-echoed-token",
             ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
         });
 
         observedContext.ShouldNotBeNull();
         observedContext!.NyxRelayReplyToken.ShouldNotBeNull();
-        observedContext.NyxRelayReplyToken!.ReplyToken.ShouldBe("inbox-echoed-token");
-        observedContext.NyxRelayReplyToken.CorrelationId.ShouldBe("corr-inbox-echo");
+        observedContext.NyxRelayReplyToken!.ReplyToken.ShouldBe("run-echoed-token");
+        observedContext.NyxRelayReplyToken.CorrelationId.ShouldBe("corr-run-echo");
         observedContext.NyxRelayReplyToken.ReplyMessageId.ShouldBe("relay-msg-echo");
     }
 
     [Fact]
     public async Task HandleDeferredLlmReplyDroppedAsync_RetiresPendingRequestWithNotRetryableFailure()
     {
-        // Inbox-side gates (stale-age, missing relay credential, malformed payload) need
+        // Run actor gates (stale-age, missing relay credential, malformed payload) need
         // a way to tell the actor "stop tracking this pending request" so it doesn't
         // silently accumulate in State.PendingLlmReplyRequests until the next
         // rehydration. The actor's drop handler emits a NotRetryable
         // ConversationContinueFailedEvent which routes through the existing state
         // matcher to remove the pending entry.
-        var inbox = new RecordingInbox();
+        var dispatcher = new RecordingRunDispatcher();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -830,7 +830,7 @@ public sealed class ConversationGAgentDedupTests
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, store) = CreateAgent(runner, "conv-drop-clears", inbox);
+        var (agent, store) = CreateAgent(runner, "conv-drop-clears", dispatcher);
 
         var inboundActivity = CreateActivity("act-drop", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -844,7 +844,7 @@ public sealed class ConversationGAgentDedupTests
         await agent.HandleDeferredLlmReplyDroppedAsync(new DeferredLlmReplyDroppedEvent
         {
             CorrelationId = "corr-drop",
-            Reason = "stale_inbox_request_dropped",
+            Reason = "stale_agent_run_request_dropped",
             DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
 
@@ -853,7 +853,7 @@ public sealed class ConversationGAgentDedupTests
         var lastEvent = events[^1];
         lastEvent.EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
         var failed = ConversationContinueFailedEvent.Parser.ParseFrom(lastEvent.EventData.Value);
-        failed.ErrorCode.ShouldBe("stale_inbox_request_dropped");
+        failed.ErrorCode.ShouldBe("stale_agent_run_request_dropped");
         failed.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable);
     }
 
@@ -866,7 +866,7 @@ public sealed class ConversationGAgentDedupTests
         await agent.HandleDeferredLlmReplyDroppedAsync(new DeferredLlmReplyDroppedEvent
         {
             CorrelationId = "corr-not-pending",
-            Reason = "stale_inbox_request_dropped",
+            Reason = "stale_agent_run_request_dropped",
             DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
 
@@ -984,7 +984,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-stream-sc",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-stream-sc", "relay-msg-1"),
             Outbound = new MessageContent { Text = "final text" },
             TerminalState = LlmReplyTerminalState.Completed,
@@ -1026,7 +1026,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-stream-fb",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-stream-fb", "relay-msg-1"),
             Outbound = new MessageContent { Text = "final text" },
             TerminalState = LlmReplyTerminalState.Completed,
@@ -1112,7 +1112,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-stream-final-retry",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-stream-final-retry", "relay-msg-1"),
             Outbound = new MessageContent { Text = "hello world final" },
             TerminalState = LlmReplyTerminalState.Completed,
@@ -1161,7 +1161,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-stream-final-degraded",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-stream-final-degraded", "relay-msg-1"),
             Outbound = new MessageContent { Text = "hello partial more final" },
             TerminalState = LlmReplyTerminalState.Completed,
@@ -1216,9 +1216,9 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-stream-failed",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-stream-failed", "relay-msg-1"),
-            // Inbox runtime classifies the LLM exception into a user-facing
+            // Run actor classifies the LLM exception into a user-facing
             // message and stuffs it into Outbound.Text on the Failed event.
             Outbound = new MessageContent { Text = "Sorry, the upstream model is rate limited (HTTP 429). Please try again in a moment." },
             TerminalState = LlmReplyTerminalState.Failed,
@@ -1271,7 +1271,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-stream-failed-deny",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-stream-failed-deny", "relay-msg-1"),
             Outbound = new MessageContent { Text = "Sorry, the LLM call failed." },
             TerminalState = LlmReplyTerminalState.Failed,
@@ -1336,7 +1336,7 @@ public sealed class ConversationGAgentDedupTests
     private static (ConversationGAgent agent, IEventStore store) CreateAgent(
         RecordingTurnRunner runner,
         string agentId,
-        IChannelLlmReplyInbox? inbox = null,
+        IChannelLlmReplyRunDispatcher? dispatcher = null,
         IConversationCardTurnRunner? cardRunner = null)
     {
         var store = new InMemoryEventStore();
@@ -1347,8 +1347,8 @@ public sealed class ConversationGAgentDedupTests
         services.AddSingleton<IConversationTurnRunner>(runner);
         if (cardRunner is not null)
             services.AddSingleton(cardRunner);
-        if (inbox is not null)
-            services.AddSingleton(inbox);
+        if (dispatcher is not null)
+            services.AddSingleton(dispatcher);
         services.AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
 
         var sp = services.BuildServiceProvider();
@@ -1513,13 +1513,13 @@ public sealed class ConversationGAgentDedupTests
         }
     }
 
-    private sealed class RecordingInbox : IChannelLlmReplyInbox
+    private sealed class RecordingRunDispatcher : IChannelLlmReplyRunDispatcher
     {
-        public List<NeedsLlmReplyEvent> Enqueued { get; } = [];
+        public List<NeedsLlmReplyEvent> Dispatched { get; } = [];
 
-        public Task EnqueueAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+        public Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
         {
-            Enqueued.Add(request.Clone());
+            Dispatched.Add(request.Clone());
             return Task.CompletedTask;
         }
     }
@@ -1743,7 +1743,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-card-finalize",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-card-finalize", "relay-msg-1"),
             Outbound = new MessageContent { Text = "complete answer" },
             TerminalState = LlmReplyTerminalState.Completed,
@@ -1788,7 +1788,7 @@ public sealed class ConversationGAgentDedupTests
         {
             CorrelationId = "act-card-fb-final",
             RegistrationId = "reg-1",
-            SourceActorId = "llm-inbox",
+            SourceActorId = "agent-run",
             Activity = CreateRelayActivity("act-card-fb-final", "relay-msg-1"),
             Outbound = new MessageContent { Text = "complete answer" },
             TerminalState = LlmReplyTerminalState.Completed,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -4,9 +4,11 @@ using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -14,10 +16,38 @@ using Xunit;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
-public sealed class ChannelLlmReplyInboxRuntimeTests
+public sealed class AgentRunGAgentTests
 {
     [Fact]
-    public async Task ProcessAsync_RelayTurnCapturesInteractiveIntentIntoReadyEvent()
+    public async Task DispatchAsync_ShouldCreateRunActorAndDispatchStartCommand()
+    {
+        var actorRuntime = new DispatchingActorRuntime();
+        var dispatcher = new AgentRunDispatcher(
+            actorRuntime,
+            actorRuntime,
+            NullLogger<AgentRunDispatcher>.Instance);
+
+        await dispatcher.DispatchAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-dispatch",
+            TargetActorId = "conversation-actor",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-dispatch",
+        }, CancellationToken.None);
+
+        actorRuntime.Dispatches.Should().ContainSingle();
+        var (actorId, envelope) = actorRuntime.Dispatches.Single();
+        actorId.Should().Be(AgentRunGAgent.BuildActorId("corr-dispatch"));
+        envelope.Propagation.CorrelationId.Should().Be("corr-dispatch");
+        var command = envelope.Payload.Unpack<AgentRunStartRequested>();
+        command.Request.CorrelationId.Should().Be("corr-dispatch");
+        command.Request.TargetActorId.Should().Be("conversation-actor");
+        command.Request.ReplyToken.Should().Be("relay-token-dispatch");
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_RelayTurnCapturesInteractiveIntentIntoReadyEvent()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() =>
@@ -41,15 +71,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-1",
             TargetActorId = "actor-1",
@@ -67,7 +95,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_NonRelayTurnDoesNotEnableInteractiveScope()
+    public async Task HandleStartAsync_NonRelayTurnDoesNotEnableInteractiveScope()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => collector.Capture(new MessageContent { Text = "ignored" }))
@@ -80,15 +108,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-2",
             TargetActorId = "actor-1",
@@ -108,7 +134,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldEmitFailedReply_WhenGeneratorThrows()
+    public async Task HandleStartAsync_ShouldEmitFailedReply_WhenGeneratorThrows()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new ThrowingReplyGenerator(new InvalidOperationException("boom"));
@@ -118,15 +144,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-throw",
             TargetActorId = "actor-1",
@@ -144,10 +168,10 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldEmitTimeoutFallbackReply_WhenGeneratorHangsPastBudget()
+    public async Task HandleStartAsync_ShouldEmitTimeoutFallbackReply_WhenGeneratorHangsPastBudget()
     {
         // Without a cancellation budget on the LLM run, a tool that hangs (broken sandbox,
-        // unreachable proxy upstream, slow remote SSH) would pin the inbox task indefinitely
+        // unreachable proxy upstream, slow remote SSH) would pin the run actor turn indefinitely
         // and Lark would stay on the loading reaction forever. The runtime caps each turn at
         // the relay ResponseTimeoutSeconds and folds the cancellation into a user-visible
         // fallback reply with errorCode=llm_reply_timeout.
@@ -159,8 +183,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
@@ -168,10 +191,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             {
                 InteractiveRepliesEnabled = true,
                 ResponseTimeoutSeconds = 1,
-            },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-timeout",
             TargetActorId = "actor-1",
@@ -190,7 +212,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldEmitFailedReply_WhenGeneratorReturnsEmpty()
+    public async Task HandleStartAsync_ShouldEmitFailedReply_WhenGeneratorReturnsEmpty()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false)
@@ -203,15 +225,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-empty",
             TargetActorId = "actor-1",
@@ -228,7 +248,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldEchoReplyTokenIntoLlmReplyReadyEvent()
+    public async Task HandleStartAsync_ShouldEchoReplyTokenIntoLlmReplyReadyEvent()
     {
         var actor = Substitute.For<IActor>();
         actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
@@ -236,16 +256,14 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             new RecordingReplyGenerator(() => false) { ReplyText = "ok" },
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
         var expiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds();
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-echo",
             TargetActorId = "actor-1",
@@ -262,7 +280,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldDropRelayRequest_WhenInboxCarriesNoReplyToken()
+    public async Task HandleStartAsync_ShouldDropRelayRequest_WhenRunCommandCarriesNoReplyToken()
     {
         var actor = Substitute.For<IActor>();
         actor.Id.Returns("actor-1");
@@ -271,17 +289,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        // Relay activity but no inbox-carried ReplyToken — simulates a request rehydrated
+        // Relay activity but no command-carried ReplyToken — simulates a request rehydrated
         // from persisted state after a pod restart, where the original token capture is gone.
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-no-token",
             TargetActorId = "actor-1",
@@ -297,7 +313,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldDropRequest_WhenOlderThanMaxAge()
+    public async Task HandleStartAsync_ShouldDropRequest_WhenOlderThanMaxAge()
     {
         var actor = Substitute.For<IActor>();
         actor.Id.Returns("actor-1");
@@ -306,18 +322,16 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
         var requestedAtUnixMs = DateTimeOffset.UtcNow
-            .AddMilliseconds(-(ChannelLlmReplyInboxRuntime.MaxInboxRequestAgeMs + 60_000))
+            .AddMilliseconds(-(AgentRunGAgent.MaxRunRequestAgeMs + 60_000))
             .ToUnixTimeMilliseconds();
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-stale",
             TargetActorId = "actor-1",
@@ -331,22 +345,20 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         handled.Should().NotBeNull();
         var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
         dropped.CorrelationId.Should().Be("corr-stale");
-        dropped.Reason.Should().Be("stale_inbox_request_dropped");
+        dropped.Reason.Should().Be("stale_agent_run_request_dropped");
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldDropSilently_WhenTargetActorIdMissing()
+    public async Task HandleStartAsync_ShouldDropSilently_WhenTargetActorIdMissing()
     {
         var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             new RecordingReplyGenerator(() => false),
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-missing",
             TargetActorId = string.Empty,
@@ -358,7 +370,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldNotifyActor_WhenActivityMissing()
+    public async Task HandleStartAsync_ShouldNotifyActor_WhenActivityMissing()
     {
         // Malformed payload (no Activity) should still tell the actor to retire its
         // pending entry — the actor decides whether to clean up. Otherwise the entry
@@ -369,15 +381,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled = call.Arg<EventEnvelope>());
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             new RecordingReplyGenerator(() => false),
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-no-activity",
             TargetActorId = "actor-1",
@@ -391,7 +401,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_StreamingEnabled_DispatchesChunkEventAndReadyEvent()
+    public async Task HandleStartAsync_StreamingEnabled_DispatchesChunkEventAndReadyEvent()
     {
         // Pin the legacy edit-message path explicitly: card-mode is now the default
         // (StreamingCardKitEnabled=true) and emits a structurally distinct
@@ -405,8 +415,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled.Add(call.Arg<EventEnvelope>()));
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
@@ -416,10 +425,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 StreamingRepliesEnabled = true,
                 StreamingFlushIntervalMs = 0,
                 StreamingCardKitEnabled = false,
-            },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-stream",
             TargetActorId = "actor-1",
@@ -438,12 +446,12 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_StreamingEnabledWithDefaultCardMode_DispatchesCardChunkEvent()
+    public async Task HandleStartAsync_StreamingEnabledWithDefaultCardMode_DispatchesCardChunkEvent()
     {
         // Pinning the new default: StreamingCardKitEnabled=true causes the sink to emit
         // the card-mode chunk type, exercising the CardKit lifecycle entrypoint without
         // needing a real ChannelCardConversationTurnRunner wired up (the actor is mocked,
-        // so we only verify the inbox dispatched the right proto type to the actor).
+        // so we only verify the run actor dispatched the right proto type to the actor).
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "card streamed reply" };
         var actor = Substitute.For<IActor>();
@@ -452,8 +460,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled.Add(call.Arg<EventEnvelope>()));
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
@@ -463,10 +470,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 StreamingRepliesEnabled = true,
                 StreamingCardKitFlushIntervalMs = 0,
                 // StreamingCardKitEnabled defaults to true.
-            },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-card-stream",
             TargetActorId = "actor-1",
@@ -485,7 +491,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_StreamingDisabledFlag_DispatchesOnlyReadyEvent()
+    public async Task HandleStartAsync_StreamingDisabledFlag_DispatchesOnlyReadyEvent()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "plain reply" };
@@ -495,15 +501,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled.Add(call.Arg<EventEnvelope>()));
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false, StreamingRepliesEnabled = false },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false, StreamingRepliesEnabled = false });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-legacy",
             TargetActorId = "actor-1",
@@ -518,7 +522,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_StreamingEnabledButNonRelay_DispatchesOnlyReadyEvent()
+    public async Task HandleStartAsync_StreamingEnabledButNonRelay_DispatchesOnlyReadyEvent()
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "plain reply" };
@@ -528,15 +532,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled.Add(call.Arg<EventEnvelope>()));
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             collector,
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false, StreamingRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false, StreamingRepliesEnabled = true });
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-nonrelay",
             TargetActorId = "actor-1",
@@ -554,7 +556,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldApplyBotOwnerLlmConfig_FromUserConfigQueryPort()
+    public async Task HandleStartAsync_ShouldApplyBotOwnerLlmConfig_FromUserConfigQueryPort()
     {
         // Bot owner's LLM model + route comes from UserConfig (the same store that backs
         // their nyxid-chat preferences), looked up by the scope id resolved from the
@@ -592,13 +594,11 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 GithubUsername: null,
                 MaxToolRounds: 11)));
 
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance,
             scopeResolver,
             userConfigQueryPort);
 
@@ -609,7 +609,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             NyxUserAccessToken = "bot-owner-session-jwt",
         };
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-bot-owner",
             TargetActorId = "actor-1",
@@ -631,12 +631,12 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     }
 
     [Fact]
-    public async Task ProcessAsync_ShouldThreadBotOwnerSessionTokenAsLlmBearer()
+    public async Task HandleStartAsync_ShouldThreadBotOwnerSessionTokenAsLlmBearer()
     {
         // The inbound X-NyxID-User-Token is the bot owner's own NyxID session JWT.
         // It is the credential that would authorize the owner's LLM calls in
         // nyxid-chat, so it is also the correct credential for the bot's relay
-        // LLM call. The stale-pending GC plus the direct-enqueue + inbox-echoed
+        // LLM call. The stale-pending GC plus the direct-enqueue + run-echoed
         // token flow keeps it fresh through the window where the LLM call actually
         // fires.
         var capturedMetadata = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -654,13 +654,11 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         actor.Id.Returns("actor-1");
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
 
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
+        var runtime = CreateRunAgent(
             actorRuntime,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
-            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
 
         var activity = BuildRelayActivity();
         activity.TransportExtras = new TransportExtras
@@ -668,7 +666,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             NyxUserAccessToken = "bot-owner-session-jwt",
         };
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-bearer",
             TargetActorId = "actor-1",
@@ -681,6 +679,51 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             .WhoseValue.Should().Be("bot-owner-session-jwt");
         capturedMetadata.Should().ContainKey(LLMRequestMetadataKeys.NyxIdOrgToken)
             .WhoseValue.Should().Be("bot-owner-session-jwt");
+    }
+
+    private static AgentRunGAgent CreateRunAgent(
+        IActorRuntime actorRuntime,
+        IConversationReplyGenerator replyGenerator,
+        IInteractiveReplyCollector? collector,
+        Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions relayOptions,
+        INyxIdRelayScopeResolver? scopeResolver = null,
+        IUserConfigQueryPort? userConfigQueryPort = null)
+    {
+        var dispatchPort = actorRuntime as IActorDispatchPort ?? Substitute.For<IActorDispatchPort>();
+        var agent = new AgentRunGAgent(
+            actorRuntime,
+            dispatchPort,
+            replyGenerator,
+            collector,
+            relayOptions,
+            NullLogger<AgentRunGAgent>.Instance,
+            scopeResolver,
+            userConfigQueryPort)
+        {
+            EventSourcing = new NoOpEventSourcing<AgentRunGAgentState>(),
+        };
+        SetId(agent, AgentRunGAgent.BuildActorId(Guid.NewGuid().ToString("N")));
+        return agent;
+    }
+
+    private static void SetId(object agent, string id)
+    {
+        var current = agent.GetType();
+        while (current is not null)
+        {
+            var setIdMethod = current.GetMethod(
+                "SetId",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            if (setIdMethod is not null)
+            {
+                setIdMethod.Invoke(agent, [id]);
+                return;
+            }
+
+            current = current.BaseType;
+        }
+
+        throw new InvalidOperationException("Unable to set agent id via reflection.");
     }
 
     private static ChatActivity BuildRelayActivity() =>
@@ -711,6 +754,8 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             static pair => pair.Id,
             static pair => pair.Actor,
             StringComparer.Ordinal);
+
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
 
         public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
             where TAgent : IAgent
@@ -747,10 +792,47 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
 
         public async Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
         {
+            Dispatches.Add((actorId, envelope));
             if (!_actors.TryGetValue(actorId, out var actor))
                 throw new InvalidOperationException($"Actor {actorId} not found.");
             await actor.HandleEventAsync(envelope, ct);
         }
+    }
+
+    private sealed class NoOpEventSourcing<TState> : IEventSourcingBehavior<TState>
+        where TState : class, IMessage<TState>, new()
+    {
+        private readonly List<IMessage> _pending = [];
+
+        public long CurrentVersion { get; private set; }
+
+        public void RaiseEvent<TEvent>(TEvent evt) where TEvent : IMessage
+        {
+            _pending.Add(evt);
+        }
+
+        public Task<EventStoreCommitResult> ConfirmEventsAsync(CancellationToken ct = default)
+        {
+            CurrentVersion += _pending.Count;
+            _pending.Clear();
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                LatestVersion = CurrentVersion,
+            });
+        }
+
+        public Task PersistSnapshotAsync(TState currentState, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task<TState?> ReplayAsync(string agentId, CancellationToken ct = default) =>
+            Task.FromResult<TState?>(null);
+
+        public void DiscardPendingEvents()
+        {
+            _pending.Clear();
+        }
+
+        public TState TransitionState(TState current, IMessage evt) => current;
     }
 
     private sealed class RecordingReplyGenerator(Func<bool> captureAction) : IConversationReplyGenerator
@@ -806,4 +888,13 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             return await pendingReply.Task;
         }
     }
+}
+
+internal static class AgentRunGAgentTestExtensions
+{
+    public static Task HandleStartAsync(this AgentRunGAgent agent, NeedsLlmReplyEvent request) =>
+        agent.HandleStartAsync(new AgentRunStartRequested
+        {
+            Request = request,
+        });
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -5,6 +5,7 @@ using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
@@ -22,9 +23,10 @@ public sealed class AgentRunGAgentTests
     public async Task DispatchAsync_ShouldCreateRunActorAndDispatchStartCommand()
     {
         var actorRuntime = new DispatchingActorRuntime();
+        var streamProvider = new RecordingStreamProvider();
         var dispatcher = new AgentRunDispatcher(
             actorRuntime,
-            actorRuntime,
+            streamProvider,
             NullLogger<AgentRunDispatcher>.Instance);
 
         await dispatcher.DispatchAsync(new NeedsLlmReplyEvent
@@ -36,14 +38,124 @@ public sealed class AgentRunGAgentTests
             ReplyToken = "relay-token-dispatch",
         }, CancellationToken.None);
 
-        actorRuntime.Dispatches.Should().ContainSingle();
-        var (actorId, envelope) = actorRuntime.Dispatches.Single();
+        streamProvider.Produced.Should().ContainSingle();
+        var (actorId, envelope) = streamProvider.Produced.Single();
         actorId.Should().Be(AgentRunGAgent.BuildActorId("corr-dispatch"));
         envelope.Propagation.CorrelationId.Should().Be("corr-dispatch");
         var command = envelope.Payload.Unpack<AgentRunStartRequested>();
         command.Request.CorrelationId.Should().Be("corr-dispatch");
         command.Request.TargetActorId.Should().Be("conversation-actor");
         command.Request.ReplyToken.Should().Be("relay-token-dispatch");
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_ShouldIgnoreDuplicateStart_AfterReadyAcceptedAndTerminalPersisted()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "ok" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-duplicate",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-duplicate",
+        };
+
+        await runtime.HandleStartAsync(request);
+        await runtime.HandleStartAsync(request.Clone());
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
+        replyGenerator.CallCount.Should().Be(1);
+        handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
+    }
+
+    [Fact]
+    public async Task HandleCleanupAsync_ShouldDestroyTerminalRunActor()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            new RecordingReplyGenerator(() => false) { ReplyText = "ok" },
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            });
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-cleanup",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-cleanup",
+        });
+
+        await runtime.HandleCleanupAsync(new AgentRunCleanupRequested
+        {
+            RunId = "corr-cleanup",
+        });
+
+        actorRuntime.DestroyedIds.Should().Contain(runtime.Id);
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_ShouldRetryReadySignal_WhenFirstOutputDispatchIsNotAccepted()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var publisher = new DispatchingEventPublisher(actorRuntime)
+        {
+            FailNextSend = true,
+        };
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "ok" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            eventPublisher: publisher);
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-retry-ready",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-retry-ready",
+        };
+
+        await runtime.HandleStartAsync(request);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.Started);
+        handled.Should().BeEmpty();
+
+        await runtime.HandleStartAsync(request.Clone());
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
+        replyGenerator.CallCount.Should().Be(2);
+        handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
     }
 
     [Fact]
@@ -687,7 +799,8 @@ public sealed class AgentRunGAgentTests
         IInteractiveReplyCollector? collector,
         Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions relayOptions,
         INyxIdRelayScopeResolver? scopeResolver = null,
-        IUserConfigQueryPort? userConfigQueryPort = null)
+        IUserConfigQueryPort? userConfigQueryPort = null,
+        IEventPublisher? eventPublisher = null)
     {
         var dispatchPort = actorRuntime as IActorDispatchPort ?? Substitute.For<IActorDispatchPort>();
         var agent = new AgentRunGAgent(
@@ -698,12 +811,32 @@ public sealed class AgentRunGAgentTests
             relayOptions,
             NullLogger<AgentRunGAgent>.Instance,
             scopeResolver,
-            userConfigQueryPort)
-        {
-            EventSourcing = new NoOpEventSourcing<AgentRunGAgentState>(),
-        };
+            userConfigQueryPort);
         SetId(agent, AgentRunGAgent.BuildActorId(Guid.NewGuid().ToString("N")));
+        agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
+            InvokeAgentTransition(agent, current, evt));
+        agent.EventPublisher = eventPublisher ?? new DispatchingEventPublisher(actorRuntime);
         return agent;
+    }
+
+    private static AgentRunGAgentState InvokeAgentTransition(
+        AgentRunGAgent agent,
+        AgentRunGAgentState current,
+        IMessage evt)
+    {
+        var currentType = agent.GetType();
+        while (currentType is not null)
+        {
+            var transitionMethod = currentType.GetMethod(
+                "TransitionState",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            if (transitionMethod is not null)
+                return (AgentRunGAgentState)transitionMethod.Invoke(agent, [current, evt])!;
+
+            currentType = currentType.BaseType;
+        }
+
+        throw new InvalidOperationException("Unable to invoke AgentRunGAgent transition via reflection.");
     }
 
     private static void SetId(object agent, string id)
@@ -757,6 +890,8 @@ public sealed class AgentRunGAgentTests
 
         public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
 
+        public List<string> DestroyedIds { get; } = [];
+
         public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
             where TAgent : IAgent
         {
@@ -775,6 +910,7 @@ public sealed class AgentRunGAgentTests
 
         public Task DestroyAsync(string id, CancellationToken ct = default)
         {
+            DestroyedIds.Add(id);
             _actors.Remove(id);
             return Task.CompletedTask;
         }
@@ -799,7 +935,8 @@ public sealed class AgentRunGAgentTests
         }
     }
 
-    private sealed class NoOpEventSourcing<TState> : IEventSourcingBehavior<TState>
+    private sealed class StateTransitionEventSourcing<TState>(Func<TState, IMessage, TState> transition)
+        : IEventSourcingBehavior<TState>
         where TState : class, IMessage<TState>, new()
     {
         private readonly List<IMessage> _pending = [];
@@ -832,12 +969,110 @@ public sealed class AgentRunGAgentTests
             _pending.Clear();
         }
 
-        public TState TransitionState(TState current, IMessage evt) => current;
+        public TState TransitionState(TState current, IMessage evt) => transition(current, evt);
+    }
+
+    private sealed class DispatchingEventPublisher(IActorRuntime actorRuntime) : IEventPublisher
+    {
+        public bool FailNextSend { get; set; }
+
+        public List<(string TargetActorId, IMessage Event)> Sent { get; } = [];
+
+        public Task PublishAsync<T>(
+            T e,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken c = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where T : IMessage => Task.CompletedTask;
+
+        public async Task SendToAsync<T>(
+            string targetActorId,
+            T e,
+            CancellationToken c = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where T : IMessage
+        {
+            if (FailNextSend)
+            {
+                FailNextSend = false;
+                throw new InvalidOperationException("send not accepted");
+            }
+
+            Sent.Add((targetActorId, e));
+            var actor = await actorRuntime.GetAsync(targetActorId)
+                        ?? throw new InvalidOperationException($"Actor {targetActorId} not found.");
+            await actor.HandleEventAsync(new EventEnvelope
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                Payload = Any.Pack(e),
+                Route = EnvelopeRouteSemantics.CreateDirect("agent-run-test-publisher", targetActorId),
+                Propagation = new EnvelopePropagation
+                {
+                    CorrelationId = sourceEnvelope?.Propagation?.CorrelationId ?? string.Empty,
+                },
+            }, c);
+        }
+    }
+
+    private sealed class RecordingStreamProvider : IStreamProvider
+    {
+        private readonly Dictionary<string, RecordingStream> _streams = new(StringComparer.Ordinal);
+
+        public List<(string StreamId, EventEnvelope Envelope)> Produced =>
+            _streams.Values.SelectMany(stream => stream.Produced.Select(envelope => (stream.StreamId, envelope))).ToList();
+
+        public IStream GetStream(string actorId)
+        {
+            if (!_streams.TryGetValue(actorId, out var stream))
+            {
+                stream = new RecordingStream(actorId);
+                _streams[actorId] = stream;
+            }
+
+            return stream;
+        }
+    }
+
+    private sealed class RecordingStream(string streamId) : IStream
+    {
+        public string StreamId { get; } = streamId;
+
+        public List<EventEnvelope> Produced { get; } = [];
+
+        public Task ProduceAsync<T>(T message, CancellationToken ct = default) where T : IMessage
+        {
+            if (message is EventEnvelope envelope)
+                Produced.Add(envelope.Clone());
+            return Task.CompletedTask;
+        }
+
+        public Task<IAsyncDisposable> SubscribeAsync<T>(Func<T, Task> handler, CancellationToken ct = default)
+            where T : IMessage, new() =>
+            Task.FromResult<IAsyncDisposable>(new NoopAsyncDisposable());
+
+        public Task UpsertRelayAsync(StreamForwardingBinding binding, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task RemoveRelayAsync(string targetStreamId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task<IReadOnlyList<StreamForwardingBinding>> ListRelaysAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<StreamForwardingBinding>>([]);
+    }
+
+    private sealed class NoopAsyncDisposable : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class RecordingReplyGenerator(Func<bool> captureAction) : IConversationReplyGenerator
     {
         public string ReplyText { get; init; } = string.Empty;
+
+        public int CallCount { get; private set; }
 
         public bool CaptureSucceeded { get; private set; }
 
@@ -849,6 +1084,7 @@ public sealed class AgentRunGAgentTests
             IStreamingReplySink? streamingSink,
             CancellationToken ct)
         {
+            CallCount++;
             CaptureSucceeded = captureAction();
             MetadataObserver?.Invoke(metadata);
             if (streamingSink is not null && !string.IsNullOrEmpty(ReplyText))

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -5,12 +5,14 @@ using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
@@ -81,6 +83,41 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleStartAsync_ShouldScheduleTerminalCleanupAfterReplyProduced()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var scheduler = new RecordingCallbackScheduler();
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            new RecordingReplyGenerator(() => false) { ReplyText = "ok" },
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            });
+        AttachScheduler(runtime, scheduler);
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-cleanup-schedule",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-cleanup-schedule",
+        });
+
+        var cleanup = scheduler.Timeouts.Should().ContainSingle(
+            timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunCleanupRequested.Descriptor)).Subject;
+        cleanup.ActorId.Should().Be(runtime.Id);
+        cleanup.DueTime.Should().Be(AgentRunGAgent.TerminalCleanupDelay);
+        var cleanupCommand = cleanup.TriggerEnvelope.Payload.Unpack<AgentRunCleanupRequested>();
+        cleanupCommand.RunId.Should().Be("corr-cleanup-schedule");
+    }
+
+    [Fact]
     public async Task HandleCleanupAsync_ShouldDestroyTerminalRunActor()
     {
         var actor = Substitute.For<IActor>();
@@ -104,7 +141,6 @@ public sealed class AgentRunGAgentTests
             Activity = BuildRelayActivity(),
             ReplyToken = "relay-token-cleanup",
         });
-
         await runtime.HandleCleanupAsync(new AgentRunCleanupRequested
         {
             RunId = "corr-cleanup",
@@ -114,7 +150,7 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
-    public async Task HandleStartAsync_ShouldRetryReadySignal_WhenFirstOutputDispatchIsNotAccepted()
+    public async Task HandleStartAsync_ShouldScheduleRetry_WhenReadySignalIsNotAccepted()
     {
         var actor = Substitute.For<IActor>();
         actor.Id.Returns("actor-1");
@@ -122,6 +158,7 @@ public sealed class AgentRunGAgentTests
         actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
             .Do(call => handled.Add(call.Arg<EventEnvelope>()));
         var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var scheduler = new RecordingCallbackScheduler();
         var publisher = new DispatchingEventPublisher(actorRuntime)
         {
             FailNextSend = true,
@@ -137,6 +174,7 @@ public sealed class AgentRunGAgentTests
                 StreamingRepliesEnabled = false,
             },
             eventPublisher: publisher);
+        AttachScheduler(runtime, scheduler);
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-retry-ready",
@@ -151,11 +189,106 @@ public sealed class AgentRunGAgentTests
         runtime.State.Status.Should().Be(AgentRunStatus.Started);
         handled.Should().BeEmpty();
 
-        await runtime.HandleStartAsync(request.Clone());
+        var retry = scheduler.Timeouts.Should().ContainSingle(
+            timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunStartRequested.Descriptor)).Subject;
+        retry.ActorId.Should().Be(runtime.Id);
+        retry.DueTime.Should().Be(AgentRunGAgent.OutputDispatchRetryDelay);
+        var retryCommand = retry.TriggerEnvelope.Payload.Unpack<AgentRunStartRequested>();
+
+        await runtime.HandleStartAsync(retryCommand);
 
         runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
         replyGenerator.CallCount.Should().Be(2);
         handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_ShouldScheduleRetry_WhenDropSignalIsNotAccepted()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var scheduler = new RecordingCallbackScheduler();
+        var publisher = new DispatchingEventPublisher(actorRuntime)
+        {
+            FailNextSend = true,
+        };
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            eventPublisher: publisher);
+        AttachScheduler(runtime, scheduler);
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-retry-drop",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+        };
+
+        await runtime.HandleStartAsync(request);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.Started);
+        handled.Should().BeEmpty();
+        replyGenerator.CallCount.Should().Be(0);
+
+        var retryCommand = scheduler.Timeouts.Should().ContainSingle(
+                timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunStartRequested.Descriptor))
+            .Subject.TriggerEnvelope.Payload.Unpack<AgentRunStartRequested>();
+
+        await runtime.HandleStartAsync(retryCommand);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.Dropped);
+        replyGenerator.CallCount.Should().Be(0);
+        handled.Should().ContainSingle(e => e.Payload.Is(DeferredLlmReplyDroppedEvent.Descriptor));
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_ShouldPersistFailed_WhenUnexpectedExceptionFollowsStartedEvent()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        EventEnvelope? handled = null;
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled = call.Arg<EventEnvelope>());
+        var actorRuntime = new FailingOnceGetActorRuntime(("actor-1", actor));
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            });
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-unexpected",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-unexpected",
+        });
+
+        runtime.State.Status.Should().Be(AgentRunStatus.Failed);
+        runtime.State.ErrorCode.Should().Be("agent_run_unhandled_exception");
+        replyGenerator.CallCount.Should().Be(0);
+        handled.Should().NotBeNull();
+        var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
+        ready.TerminalState.Should().Be(LlmReplyTerminalState.Failed);
+        ready.ErrorCode.Should().Be("agent_run_unhandled_exception");
     }
 
     [Fact]
@@ -819,6 +952,13 @@ public sealed class AgentRunGAgentTests
         return agent;
     }
 
+    private static void AttachScheduler(AgentRunGAgent agent, RecordingCallbackScheduler scheduler)
+    {
+        agent.Services = new ServiceCollection()
+            .AddSingleton<IActorRuntimeCallbackScheduler>(scheduler)
+            .BuildServiceProvider();
+    }
+
     private static AgentRunGAgentState InvokeAgentTransition(
         AgentRunGAgent agent,
         AgentRunGAgentState current,
@@ -935,6 +1075,41 @@ public sealed class AgentRunGAgentTests
         }
     }
 
+    private sealed class FailingOnceGetActorRuntime(params (string Id, IActor Actor)[] actors) : IActorRuntime
+    {
+        private readonly DispatchingActorRuntime _inner = new(actors);
+        private bool _failNextGet = true;
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            _inner.CreateAsync<TAgent>(id, ct);
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
+            _inner.CreateAsync(agentType, id, ct);
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) =>
+            _inner.DestroyAsync(id, ct);
+
+        public Task<IActor?> GetAsync(string id)
+        {
+            if (_failNextGet)
+            {
+                _failNextGet = false;
+                throw new InvalidOperationException("actor runtime lookup failed");
+            }
+
+            return _inner.GetAsync(id);
+        }
+
+        public Task<bool> ExistsAsync(string id) => _inner.ExistsAsync(id);
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            _inner.LinkAsync(parentId, childId, ct);
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            _inner.UnlinkAsync(childId, ct);
+    }
+
     private sealed class StateTransitionEventSourcing<TState>(Func<TState, IMessage, TState> transition)
         : IEventSourcingBehavior<TState>
         where TState : class, IMessage<TState>, new()
@@ -970,6 +1145,53 @@ public sealed class AgentRunGAgentTests
         }
 
         public TState TransitionState(TState current, IMessage evt) => transition(current, evt);
+    }
+
+    private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+
+        public List<RuntimeCallbackTimerRequest> Timers { get; } = [];
+
+        public List<RuntimeCallbackLease> Cancelled { get; } = [];
+
+        public List<string> PurgedActorIds { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            Timeouts.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default)
+        {
+            Timers.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timers.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            Cancelled.Add(lease);
+            return Task.CompletedTask;
+        }
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default)
+        {
+            PurgedActorIds.Add(actorId);
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class DispatchingEventPublisher(IActorRuntime actorRuntime) : IEventPublisher

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -802,7 +802,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     {
         // Regression for the "/daily failed: Provider 'openai' not connected" report:
         // skill runners must honor the bot owner's pre-configured model + NyxID route + tool
-        // cap — same shape ChannelLlmReplyInboxRuntime applies for nyxid-chat. Without it,
+        // cap — same shape AgentRunGAgent applies for nyxid-chat. Without it,
         // every scheduled run falls through to NyxIdLLMProvider's compile-time `gpt-5.4` +
         // gateway default, which the gateway routes to OpenAI and 400s for bot owners who
         // wired a custom NyxID service like `chrono-llm` at `/api/v1/proxy/s/chrono-llm`.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/TurnStreamingReplySinkTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/TurnStreamingReplySinkTests.cs
@@ -191,7 +191,7 @@ public sealed class TurnStreamingReplySinkTests
     public async Task FinalizeAsync_DispatchInFlight_WaitsForFinalChunkOnWire()
     {
         // Regression for the race where FinalizeAsync would return as soon as the final text
-        // was stashed (while a prior dispatch was still in flight), letting the inbox runtime
+        // was stashed (while a prior dispatch was still in flight), letting the run actor
         // send LlmReplyReadyEvent past the late final chunk and triggering the
         // ConversationGAgent processed-command guard to drop it.
         var firstDispatchGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
## Summary
- Implements issue #596 Phase A by replacing the channel LLM reply hosted inbox singleton with run-scoped `AgentRunGAgent` continuation actors.
- Adds `IChannelLlmReplyRunDispatcher` and the NyxidChat dispatcher that creates/gets `AgentRunGAgent` by `correlationId` and dispatches typed `AgentRunStartRequested` commands.
- Moves the existing LLM reply gates, metadata enrichment, fallback timeout, streaming sink, reply generation, ready/drop dispatch, and relay token echo into the run actor while keeping reply tokens out of persisted run state/events.
- Updates `ConversationGAgent` and tests to use the run dispatcher path and retires the old inbox interface/hosted service path.

## Validation
- `dotnet build test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`

Refs #596