### PR TITLE
Fix #599: per-conversation LLM reply executor (drop silo-wide inbox)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -30,8 +30,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 {
     // Orleans Reminders (the durable scheduler backing ScheduleSelfDurableTimeoutAsync)
     // round dueTime up to the local reminder service tick (typically ~1 minute), so
-    // sub-minute schedules are unreliable. The inbox dispatch happens inline via
-    // IChannelLlmReplyInbox; the durable timer is reserved for retry/rehydration.
+    // sub-minute schedules are unreliable. Per-turn LLM dispatch happens inline via
+    // IConversationLlmReplyExecutor; the durable timer is reserved for retry/rehydration.
     private static readonly TimeSpan DeferredLlmDispatchRetryDelay = TimeSpan.FromSeconds(60);
     // Pending LLM reply requests older than this are considered stale on rehydration:
     // the user gave up, the relay reply_token (~30 min TTL) is likely already expired,
@@ -344,11 +344,11 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private async Task DispatchPendingLlmReplyAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
-        var inbox = Services.GetService<IChannelLlmReplyInbox>();
-        if (inbox is null)
+        var executor = Services.GetService<IConversationLlmReplyExecutor>();
+        if (executor is null)
         {
             Logger.LogWarning(
-                "Channel LLM reply inbox not registered; scheduling durable retry: correlation={CorrelationId}",
+                "Conversation LLM reply executor not registered; scheduling durable retry: correlation={CorrelationId}",
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
             return;
@@ -357,15 +357,15 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         // Retry and rehydration paths read `request` from State.PendingLlmReplyRequests,
         // which always carries an empty ReplyToken (the inbound handler strips it before
         // persist). If the actor is still alive and the in-memory dict still has the
-        // token for this correlation, re-enrich the inbox copy so the subscriber's relay
+        // token for this correlation, re-enrich the executor copy so the executor's relay
         // credential gate does not mistake a legitimate retry for a dead request.
         var enriched = EnrichWithRuntimeReplyTokenIfNeeded(request);
 
         try
         {
-            await inbox.EnqueueAsync(enriched.Clone(), ct);
+            await executor.StartAsync(enriched.Clone(), ct);
             Logger.LogInformation(
-                "Enqueued LLM reply request to inbox: correlation={CorrelationId} conversation={Key} replyTokenSource={Source}",
+                "Started LLM reply work: correlation={CorrelationId} conversation={Key} replyTokenSource={Source}",
                 enriched.CorrelationId,
                 enriched.Activity?.Conversation?.CanonicalKey,
                 DescribeEnqueuedReplyTokenSource(request, enriched));
@@ -374,7 +374,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         {
             Logger.LogError(
                 ex,
-                "Failed to enqueue LLM reply request; scheduling durable retry: correlation={CorrelationId}",
+                "Failed to start LLM reply work; scheduling durable retry: correlation={CorrelationId}",
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
         }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -344,6 +344,16 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private async Task DispatchPendingLlmReplyAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
+        // Per-conversation parallelism is allowed: if the same conversation has multiple
+        // pending requests (e.g. the user sent two messages within the prior reply window),
+        // each calls executor.StartAsync independently and their LLM work runs concurrently.
+        // The previous host-level FIFO subscriber happened to serialize per-conversation as
+        // a side effect of the silo-wide bottleneck this PR removes — but per-user replies
+        // already require an explicit ack and Lark renders the typing indicator per-message,
+        // so out-of-order arrivals are uncommon and tolerable. If product feedback shows
+        // frequent reordering, the actor can grow an in-flight gate (block subsequent
+        // StartAsync until the current correlation's LlmReplyReadyEvent arrives) without
+        // breaking cross-conversation parallelism.
         var executor = Services.GetService<IConversationLlmReplyExecutor>();
         if (executor is null)
         {

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -311,6 +311,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             "Retired pending LLM reply after inbox drop: correlation={CorrelationId} reason={Reason}",
             evt.CorrelationId,
             reason);
+        await DispatchHeadOfLlmReplyQueueIfChangedAsync(evt.CorrelationId);
     }
 
     [EventHandler]
@@ -344,16 +345,30 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private async Task DispatchPendingLlmReplyAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
-        // Per-conversation parallelism is allowed: if the same conversation has multiple
-        // pending requests (e.g. the user sent two messages within the prior reply window),
-        // each calls executor.StartAsync independently and their LLM work runs concurrently.
-        // The previous host-level FIFO subscriber happened to serialize per-conversation as
-        // a side effect of the silo-wide bottleneck this PR removes — but per-user replies
-        // already require an explicit ack and Lark renders the typing indicator per-message,
-        // so out-of-order arrivals are uncommon and tolerable. If product feedback shows
-        // frequent reordering, the actor can grow an in-flight gate (block subsequent
-        // StartAsync until the current correlation's LlmReplyReadyEvent arrives) without
-        // breaking cross-conversation parallelism.
+        // Per-conversation FIFO gate: at most one LLM reply per ConversationGAgent is
+        // dispatched to an executor at a time. The head of State.PendingLlmReplyRequests is
+        // the in-flight slot; everything behind it waits. When the head retires (success,
+        // terminal failure, or executor crash drop), the corresponding terminal handler
+        // calls DispatchHeadOfLlmReplyQueueIfChangedAsync to start the new head. Cross-
+        // conversation parallelism (the headline win of #599's fix) is unaffected because
+        // each ConversationGAgent owns its own queue.
+        var head = State.PendingLlmReplyRequests.FirstOrDefault();
+        if (head is null)
+        {
+            // The pending entry was already retired (e.g. a duplicate terminal event raced
+            // ahead of this dispatch). Nothing to do.
+            return;
+        }
+        if (!string.Equals(head.CorrelationId, request.CorrelationId, StringComparison.Ordinal))
+        {
+            Logger.LogInformation(
+                "Per-conversation FIFO gate: deferring LLM reply behind in-flight head: head={Head} pending={Pending} conversation={Key}",
+                head.CorrelationId,
+                request.CorrelationId,
+                State.Conversation?.CanonicalKey);
+            return;
+        }
+
         var executor = Services.GetService<IConversationLlmReplyExecutor>();
         if (executor is null)
         {
@@ -388,6 +403,25 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
         }
+    }
+
+    private async Task DispatchHeadOfLlmReplyQueueIfChangedAsync(string completedCorrelationId)
+    {
+        var head = State.PendingLlmReplyRequests.FirstOrDefault();
+        if (head is null)
+            return;
+        if (string.Equals(head.CorrelationId, completedCorrelationId, StringComparison.Ordinal))
+        {
+            // Head still alive (e.g. transient failure scheduled a durable retry); the
+            // retry trigger will redispatch when its delay elapses.
+            return;
+        }
+        Logger.LogInformation(
+            "Per-conversation FIFO gate advancing: completed={Completed} nextHead={NextHead} conversation={Key}",
+            completedCorrelationId,
+            head.CorrelationId,
+            State.Conversation?.CanonicalKey);
+        await DispatchPendingLlmReplyAsync(head.Clone(), CancellationToken.None);
     }
 
     private NeedsLlmReplyEvent EnrichWithRuntimeReplyTokenIfNeeded(NeedsLlmReplyEvent request)
@@ -459,6 +493,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             var streamingActivity = referenceActivity ?? evt.Activity;
             if (streamingActivity is not null)
                 _ = ResolveRunner().OnReplyDeliveredAsync(streamingActivity, CancellationToken.None);
+            await DispatchHeadOfLlmReplyQueueIfChangedAsync(evt.CorrelationId);
             return;
         }
 
@@ -489,6 +524,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 evt.CorrelationId,
                 result.SentActivityId,
                 completed.Conversation?.CanonicalKey);
+            await DispatchHeadOfLlmReplyQueueIfChangedAsync(evt.CorrelationId);
             return;
         }
 
@@ -529,6 +565,9 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             evt.CorrelationId,
             result.ErrorCode,
             result.FailureKind);
+        // Advance the per-conversation FIFO gate. Retryable failures don't move the head
+        // (the helper will no-op); terminal failures do.
+        await DispatchHeadOfLlmReplyQueueIfChangedAsync(evt.CorrelationId);
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyInbox.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyInbox.cs
@@ -1,6 +1,0 @@
-namespace Aevatar.GAgents.Channel.Runtime;
-
-public interface IChannelLlmReplyInbox
-{
-    Task EnqueueAsync(NeedsLlmReplyEvent request, CancellationToken ct);
-}

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationLlmReplyExecutor.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationLlmReplyExecutor.cs
@@ -1,0 +1,30 @@
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Per-conversation LLM reply driver. Replaces the host-level inbox stream subscriber with a seam
+/// that <see cref="ConversationGAgent"/> calls directly, so each conversation actor owns its own
+/// LLM reply work and different conversations run in parallel rather than serializing on a single
+/// silo-wide subscription.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The actor must persist the request into <c>State.PendingLlmReplyRequests</c> before invoking
+/// this seam: the executor runs the LLM call on a background task and only signals completion via
+/// dispatch, so durability is provided by actor state, not by the executor.
+/// </para>
+/// <para>
+/// Implementations MUST eventually deliver one terminal signal to <see cref="NeedsLlmReplyEvent.TargetActorId"/>:
+/// either an <see cref="LlmReplyReadyEvent"/> (success or classified failure) or a
+/// <see cref="DeferredLlmReplyDroppedEvent"/> (request rejected by a pre-LLM gate). Without a
+/// terminal signal, the actor's pending entry would leak.
+/// </para>
+/// <para>
+/// <see cref="StartAsync"/> returns once the work has been kicked off — not when the LLM call
+/// completes. The actor turn must not block on the LLM call (60-300s) or it would re-introduce the
+/// per-actor serial bottleneck this seam exists to remove.
+/// </para>
+/// </remarks>
+public interface IConversationLlmReplyExecutor
+{
+    Task StartAsync(NeedsLlmReplyEvent request, CancellationToken ct);
+}

--- a/agents/Aevatar.GAgents.Channel.Runtime/IStreamingReplySink.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/IStreamingReplySink.cs
@@ -1,16 +1,16 @@
 namespace Aevatar.GAgents.Channel.Runtime;
 
 /// <summary>
-/// Receives per-delta streaming updates from <see cref="IConversationReplyGenerator"/> so the reply
-/// inbox can fan the accumulated text to the conversation actor as it is being generated. The
-/// actor is the sole holder of the relay reply token, so only it is allowed to drive the relay
+/// Receives per-delta streaming updates from <see cref="IConversationReplyGenerator"/> so the LLM
+/// reply executor can fan the accumulated text to the conversation actor as it is being generated.
+/// The actor is the sole holder of the relay reply token, so only it is allowed to drive the relay
 /// placeholder send and subsequent edit calls; this sink therefore fans out signals (chunk events)
 /// and never touches the outbound port directly.
 /// </summary>
 /// <remarks>
-/// Implementations are per-turn and owned by the inbox runtime. A null sink signals that streaming
-/// is disabled for the turn (for example, the feature flag is off, the activity is not a relay
-/// turn, or an earlier failure invalidated the turn); generators must tolerate a null sink by
+/// Implementations are per-turn and owned by the LLM reply executor. A null sink signals that
+/// streaming is disabled for the turn (for example, the feature flag is off, the activity is not a
+/// relay turn, or an earlier failure invalidated the turn); generators must tolerate a null sink by
 /// simply accumulating the final text without calling any sink method.
 /// </remarks>
 public interface IStreamingReplySink

--- a/agents/Aevatar.GAgents.Channel.Runtime/TurnStreamingReplySink.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/TurnStreamingReplySink.cs
@@ -32,7 +32,7 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// <item><see cref="FinalizeAsync"/> bypasses the throttle so the actor sees the complete text
 /// once the stream ends; if a dispatch is in flight, the final text reflushes after it and
 /// <see cref="FinalizeAsync"/> awaits the dispatch loop's drain signal before returning so the
-/// caller (the inbox runtime) does not race the ready event past the final chunk.</item>
+/// caller (the LLM reply executor) does not race the ready event past the final chunk.</item>
 /// </list>
 /// </para>
 /// <para>
@@ -68,7 +68,7 @@ public sealed class TurnStreamingReplySink : IStreamingReplySink, IDisposable
     private bool _dispatchInProgress;
     private bool _disposed;
     // Signaled by the dispatch loop when it fully drains. FinalizeAsync awaits this when a
-    // dispatch is already in flight so the caller does not race the inbox runtime's
+    // dispatch is already in flight so the caller does not race the LLM reply executor's
     // LlmReplyReadyEvent past the final chunk dispatch (the ConversationGAgent
     // processed-command guard would otherwise drop the late chunk).
     private TaskCompletionSource<bool>? _drainTcs;
@@ -116,7 +116,7 @@ public sealed class TurnStreamingReplySink : IStreamingReplySink, IDisposable
     /// Applies the final accumulated text, bypassing the throttle so the actor can drive the final
     /// edit once the stream ends. If a dispatch is already in flight, the final text is stashed and
     /// this call awaits the dispatch loop's drain signal so the final chunk is on the wire before
-    /// the caller proceeds (the inbox runtime sends LlmReplyReadyEvent immediately after).
+    /// the caller proceeds (the LLM reply executor sends LlmReplyReadyEvent immediately after).
     /// </summary>
     public Task FinalizeAsync(string finalText, CancellationToken ct) =>
         FlushAsync(finalText, isFinal: true, ct);
@@ -188,7 +188,7 @@ public sealed class TurnStreamingReplySink : IStreamingReplySink, IDisposable
                 if (isFinal)
                 {
                     // Block FinalizeAsync until the dispatch loop drains the stashed final text.
-                    // Without this wait, ChannelLlmReplyInboxRuntime sends LlmReplyReadyEvent
+                    // Without this wait, ConversationLlmReplyExecutor sends LlmReplyReadyEvent
                     // first and ConversationGAgent's processed-command guard drops the late
                     // final chunk.
                     _drainTcs ??= new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -79,7 +79,7 @@ message LlmReplyReadyEvent {
   int64 reply_token_expires_at_unix_ms = 11;
 }
 
-// Per-delta streaming signal dispatched from the LLM inbox runtime to the conversation actor while
+// Per-delta streaming signal dispatched from the LLM reply executor to the conversation actor while
 // the reply is still being generated. The actor owns the outbound reply credential and the
 // placeholder message identifier for the turn, so it must be the one issuing the relay placeholder
 // send and subsequent edit calls. This message carries only the cumulative accumulated text for
@@ -154,7 +154,7 @@ message NyxRelayReplyTokenCleanupRequestedEvent {
   int64 requested_at_unix_ms = 2;
 }
 
-// Sent by ChannelLlmReplyInboxRuntime when its pre-LLM gates (stale age,
+// Sent by ConversationLlmReplyExecutor when its pre-LLM gates (stale age,
 // missing relay credential, malformed payload) refuse to process a deferred
 // LLM reply. The actor consumes this to retire the matching pending entry
 // from State.PendingLlmReplyRequests via a NotRetryable

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1509,9 +1509,9 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         };
 
-        // Carry the relay reply credential through the inbox as transient inbox-only
+        // Carry the relay reply credential through to the executor as transient inbox-only
         // fields. ConversationGAgent strips these before persisting NeedsLlmReplyEvent;
-        // ChannelLlmReplyInboxRuntime echoes them into the LlmReplyReadyEvent so the
+        // ConversationLlmReplyExecutor echoes them into the LlmReplyReadyEvent so the
         // outbound reply does not depend on the actor's in-memory token dict surviving
         // deactivation.
         if (runtimeContext.NyxRelayReplyToken is { } token &&

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationLlmReplyExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationLlmReplyExecutor.cs
@@ -1,26 +1,39 @@
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Channel.NyxIdRelay;
-using Aevatar.GAgents.NyxidChat;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
 
-public sealed class ChannelLlmReplyInboxRuntime :
-    IHostedService,
-    IAsyncDisposable,
-    IChannelLlmReplyInbox
+/// <summary>
+/// Drives one LLM reply turn end-to-end on behalf of <see cref="ConversationGAgent"/>:
+/// pre-LLM gates (stale age, missing relay token, malformed payload), bot-owner config
+/// enrichment, the LLM call itself, streaming-sink wiring, and dispatch of the terminal
+/// signal back to the originating actor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Replaces the silo-wide <c>ChannelLlmReplyInboxRuntime</c> stream subscriber. The actor
+/// invokes <see cref="StartAsync"/> from inside its turn; the executor schedules the LLM
+/// work on a background task so the 60-300s call cannot pin the actor turn, then
+/// dispatches an <c>LlmReplyReadyEvent</c> (or <c>DeferredLlmReplyDroppedEvent</c>) back
+/// to <c>request.TargetActorId</c> via <see cref="IActorDispatchPort"/>.
+/// </para>
+/// <para>
+/// The background task only does external I/O and finishes by signalling the actor; it
+/// never reads or writes actor state directly. All actor-state mutations happen inside
+/// the actor's handler when the dispatched event arrives, preserving the actor's
+/// single-threaded execution invariant.
+/// </para>
+/// </remarks>
+public sealed class ConversationLlmReplyExecutor : IConversationLlmReplyExecutor
 {
-    internal const string InboxStreamId = "channel-runtime:llm-reply:inbox";
+    internal const string PublisherActorId = "channel-runtime.llm-reply-executor";
 
-    private readonly IStreamProvider _streamProvider;
-    private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IConversationReplyGenerator _replyGenerator;
     private readonly IInteractiveReplyCollector? _interactiveReplyCollector;
@@ -28,26 +41,19 @@ public sealed class ChannelLlmReplyInboxRuntime :
     private readonly INyxIdRelayScopeResolver? _scopeResolver;
     private readonly IUserConfigQueryPort? _userConfigQueryPort;
     private readonly TimeProvider _timeProvider;
-    private readonly ILogger<ChannelLlmReplyInboxRuntime> _logger;
-    private IAsyncDisposable? _subscription;
+    private readonly ILogger<ConversationLlmReplyExecutor> _logger;
 
-    public ChannelLlmReplyInboxRuntime(
-        IStreamProvider streamProvider,
-        IActorRuntime actorRuntime,
+    public ConversationLlmReplyExecutor(
+        IActorDispatchPort actorDispatchPort,
         IConversationReplyGenerator replyGenerator,
         IInteractiveReplyCollector? interactiveReplyCollector,
         Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
-        ILogger<ChannelLlmReplyInboxRuntime> logger,
+        ILogger<ConversationLlmReplyExecutor> logger,
         INyxIdRelayScopeResolver? scopeResolver = null,
         IUserConfigQueryPort? userConfigQueryPort = null,
-        TimeProvider? timeProvider = null,
-        IActorDispatchPort? actorDispatchPort = null)
+        TimeProvider? timeProvider = null)
     {
-        _streamProvider = streamProvider ?? throw new ArgumentNullException(nameof(streamProvider));
-        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
-        _actorDispatchPort = actorDispatchPort
-            ?? actorRuntime as IActorDispatchPort
-            ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
         _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
         _interactiveReplyCollector = interactiveReplyCollector;
         _relayOptions = relayOptions;
@@ -57,46 +63,19 @@ public sealed class ChannelLlmReplyInboxRuntime :
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task StartAsync(CancellationToken ct)
-    {
-        if (_subscription is not null)
-            return;
-
-        _subscription = await _streamProvider
-            .GetStream(InboxStreamId)
-            .SubscribeAsync<NeedsLlmReplyEvent>(ProcessAsync, ct);
-
-        _logger.LogInformation("Started channel LLM reply inbox on {StreamId}", InboxStreamId);
-    }
-
-    public async Task StopAsync(CancellationToken ct)
-    {
-        if (_subscription is null)
-            return;
-
-        await _subscription.DisposeAsync();
-        _subscription = null;
-        _logger.LogInformation("Stopped channel LLM reply inbox on {StreamId}", InboxStreamId);
-    }
-
-    public Task EnqueueAsync(NeedsLlmReplyEvent request, CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        return _streamProvider.GetStream(InboxStreamId).ProduceAsync(request, ct);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await StopAsync(CancellationToken.None);
-    }
-
-    internal const long MaxInboxRequestAgeMs = 5 * 60 * 1000;
+    /// <summary>
+    /// Pending LLM reply requests older than this are considered stale and dropped before
+    /// the LLM call: NyxID relay reply tokens have a ~30 min TTL and the user access token
+    /// used for the LLM call expires inside ~15 min, so a request that has been waiting for
+    /// hours cannot lead to a successful reply.
+    /// </summary>
+    internal const long MaxRequestAgeMs = 5 * 60 * 1000;
 
     /// <summary>
     /// Hard upper bound on a single LLM reply turn. Mirrors
-    /// <c>NyxIdRelayOptions.ResponseTimeoutSeconds</c> (default 300s) — long enough for the
+    /// <see cref="Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions.ResponseTimeoutSeconds"/> (default 300s) — long enough for the
     /// aevatar Lark bot's multi-step flows (skill search + remote tool + summarize) to land
-    /// without truncation, short enough that a true hang does not pin the inbox task forever.
+    /// without truncation, short enough that a true hang does not pin the turn forever.
     /// A configured value of <c>0</c> or negative is treated as "disable the cap" — pass
     /// through with no timeout, mirroring HttpClient/Polly conventions where 0 means
     /// "no limit". The default of 300s applies when the option is unset.
@@ -110,6 +89,42 @@ public sealed class ChannelLlmReplyInboxRuntime :
     /// surfaces as a distinct error code rather than a misleading "llm_reply_timeout".
     /// </summary>
     internal static readonly TimeSpan MetadataBuildBudget = TimeSpan.FromSeconds(15);
+
+    public Task StartAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        // Snapshot the request: the caller may mutate the original (e.g. the actor
+        // re-enriches with a fresh reply token on retry) and we are about to hand off
+        // ownership to a background task.
+        var snapshot = request.Clone();
+
+        // Use Task.Run so the LLM work runs on the thread pool, not on the caller's
+        // synchronization context (which, for an actor turn, must not be blocked or the
+        // very bottleneck this seam removes is reintroduced inside one actor). The
+        // background task only does external I/O and finishes by dispatching back to
+        // the actor — it never reads or writes actor state.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await ProcessAsync(snapshot).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // ProcessAsync handles its own errors and dispatches a terminal signal;
+                // an exception bubbling out here means dispatch itself or some outer
+                // step failed unexpectedly. Log and swallow so the unobserved exception
+                // does not crash the host.
+                _logger.LogError(
+                    ex,
+                    "Conversation LLM reply executor crashed before dispatching terminal signal: correlation={CorrelationId} target={TargetActorId}",
+                    snapshot.CorrelationId,
+                    snapshot.TargetActorId);
+            }
+        }, CancellationToken.None);
+
+        return Task.CompletedTask;
+    }
 
     internal async Task ProcessAsync(NeedsLlmReplyEvent request)
     {
@@ -130,12 +145,8 @@ public sealed class ChannelLlmReplyInboxRuntime :
             return;
         }
 
-        // Stale gate: NyxID relay reply tokens have a ~30 min TTL and the user access
-        // token used for the LLM call expires inside ~15 min. A request that has been
-        // sitting in the stream for hours can't lead to a successful reply, so drop it
-        // here instead of spending an LLM round just to fail at the outbound stage.
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        if (request.RequestedAtUnixMs > 0 && nowMs - request.RequestedAtUnixMs > MaxInboxRequestAgeMs)
+        if (request.RequestedAtUnixMs > 0 && nowMs - request.RequestedAtUnixMs > MaxRequestAgeMs)
         {
             _logger.LogInformation(
                 "Dropping stale LLM reply request: correlation={CorrelationId} ageMs={AgeMs}",
@@ -152,14 +163,11 @@ public sealed class ChannelLlmReplyInboxRuntime :
         if (IsRelayRequest(request) && string.IsNullOrWhiteSpace(request.ReplyToken))
         {
             _logger.LogWarning(
-                "Dropping relay LLM reply request without inbox-carried reply_token: correlation={CorrelationId}",
+                "Dropping relay LLM reply request without reply_token: correlation={CorrelationId}",
                 request.CorrelationId);
             await NotifyActorOfDropAsync(request, "missing_relay_reply_token");
             return;
         }
-
-        var actor = await _actorRuntime.GetAsync(request.TargetActorId)
-                    ?? await _actorRuntime.CreateAsync<ConversationGAgent>(request.TargetActorId, CancellationToken.None);
 
         string replyText;
         MessageContent? outboundIntent = null;
@@ -274,7 +282,7 @@ public sealed class ChannelLlmReplyInboxRuntime :
         {
             CorrelationId = request.CorrelationId,
             RegistrationId = request.RegistrationId,
-            SourceActorId = InboxStreamId,
+            SourceActorId = PublisherActorId,
             Activity = request.Activity!.Clone(),
             Outbound = outboundIntent?.Clone() ?? new MessageContent { Text = replyText },
             TerminalState = terminalState,
@@ -292,7 +300,7 @@ public sealed class ChannelLlmReplyInboxRuntime :
             Id = Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
             Payload = Any.Pack(ready),
-            Route = EnvelopeRouteSemantics.CreateDirect(InboxStreamId, request.TargetActorId),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, request.TargetActorId),
         };
 
         await _actorDispatchPort.DispatchAsync(request.TargetActorId, envelope, CancellationToken.None);
@@ -432,14 +440,14 @@ public sealed class ChannelLlmReplyInboxRuntime :
     }
 
     /// <summary>
-    /// Resolve the LLM-run cap from <c>NyxIdRelayOptions.ResponseTimeoutSeconds</c>.
+    /// Resolve the LLM-run cap from <see cref="Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions.ResponseTimeoutSeconds"/>.
     /// Conventions:
     ///   * unset / null  → <see cref="FallbackTimeoutSecondsDefault"/> (300s)
     ///   * &gt; 0        → use that exact value
     ///   * 0 or negative → <see cref="TimeSpan.Zero"/> meaning "no timeout"; the caller
     ///     constructs an unbounded <see cref="CancellationTokenSource"/>. Use this only
     ///     in environments that have an external watchdog — without it, a hung tool
-    ///     keeps the inbox task alive indefinitely.
+    ///     keeps the executor task alive indefinitely.
     /// </summary>
     private TimeSpan ResolveFallbackTimeout()
     {
@@ -466,28 +474,6 @@ public sealed class ChannelLlmReplyInboxRuntime :
             return;
         }
 
-        IActor? actor;
-        try
-        {
-            actor = await _actorRuntime.GetAsync(request.TargetActorId);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to resolve actor for inbox drop notification: correlation={CorrelationId} target={TargetActorId}",
-                request.CorrelationId,
-                request.TargetActorId);
-            return;
-        }
-
-        if (actor is null)
-        {
-            // No active actor means there is nothing pending to clean up; the request
-            // either was never persisted or the actor's state was already retired.
-            return;
-        }
-
         var dropped = new DeferredLlmReplyDroppedEvent
         {
             CorrelationId = request.CorrelationId,
@@ -499,7 +485,7 @@ public sealed class ChannelLlmReplyInboxRuntime :
             Id = Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             Payload = Any.Pack(dropped),
-            Route = EnvelopeRouteSemantics.CreateDirect(InboxStreamId, request.TargetActorId),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, request.TargetActorId),
         };
 
         try
@@ -530,18 +516,4 @@ public sealed class ChannelLlmReplyInboxRuntime :
             CorrelationId.Length: > 0,
         };
     }
-}
-
-public sealed class ChannelLlmReplyInboxHostedService : IHostedService
-{
-    private readonly ChannelLlmReplyInboxRuntime _runtime;
-
-    public ChannelLlmReplyInboxHostedService(ChannelLlmReplyInboxRuntime runtime)
-    {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
-    }
-
-    public Task StartAsync(CancellationToken ct) => _runtime.StartAsync(ct);
-
-    public Task StopAsync(CancellationToken ct) => _runtime.StopAsync(ct);
 }

--- a/agents/Aevatar.GAgents.NyxidChat/ConversationLlmReplyExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ConversationLlmReplyExecutor.cs
@@ -93,6 +93,11 @@ public sealed class ConversationLlmReplyExecutor : IConversationLlmReplyExecutor
     public Task StartAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
+        // Honor the caller's token: a turn cancelled before scheduling shouldn't burn an
+        // LLM round. If the token is already signaled, throw before cloning so the actor
+        // sees the cancellation directly instead of via a swallowed background error.
+        ct.ThrowIfCancellationRequested();
+
         // Snapshot the request: the caller may mutate the original (e.g. the actor
         // re-enriches with a fresh reply token on retry) and we are about to hand off
         // ownership to a background task.
@@ -102,7 +107,10 @@ public sealed class ConversationLlmReplyExecutor : IConversationLlmReplyExecutor
         // synchronization context (which, for an actor turn, must not be blocked or the
         // very bottleneck this seam removes is reintroduced inside one actor). The
         // background task only does external I/O and finishes by dispatching back to
-        // the actor — it never reads or writes actor state.
+        // the actor — it never reads or writes actor state. Passing `ct` means a
+        // cancellation between StartAsync and the scheduler picking up the work skips
+        // the LLM round entirely; once the task is already running, internal cancellation
+        // tokens (metadata budget, fallback timeout) take over.
         _ = Task.Run(async () =>
         {
             try
@@ -113,15 +121,30 @@ public sealed class ConversationLlmReplyExecutor : IConversationLlmReplyExecutor
             {
                 // ProcessAsync handles its own errors and dispatches a terminal signal;
                 // an exception bubbling out here means dispatch itself or some outer
-                // step failed unexpectedly. Log and swallow so the unobserved exception
-                // does not crash the host.
+                // step failed unexpectedly. The IConversationLlmReplyExecutor contract
+                // requires a terminal signal so the actor can retire its pending entry —
+                // without it, State.PendingLlmReplyRequests leaks until the 5-minute
+                // stale-age gate kicks in on the next activation. Send the drop notice
+                // directly; the stale gate becomes a fallback if even the drop dispatch
+                // fails.
                 _logger.LogError(
                     ex,
                     "Conversation LLM reply executor crashed before dispatching terminal signal: correlation={CorrelationId} target={TargetActorId}",
                     snapshot.CorrelationId,
                     snapshot.TargetActorId);
+                try
+                {
+                    await NotifyActorOfDropAsync(snapshot, "executor_crash").ConfigureAwait(false);
+                }
+                catch (Exception notifyEx)
+                {
+                    _logger.LogError(
+                        notifyEx,
+                        "Failed to notify actor of executor crash; pending entry will retire via 5-min stale-age gate: correlation={CorrelationId}",
+                        snapshot.CorrelationId);
+                }
             }
-        }, CancellationToken.None);
+        }, ct);
 
         return Task.CompletedTask;
     }

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -10,7 +10,6 @@ using Aevatar.GAgents.NyxidChat.Slash;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
@@ -36,10 +35,12 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<NyxIdRelayTransport>();
         services.TryAddSingleton<NyxIdRelayAuthValidator>();
 
-        // ─── Channel LLM reply inbox runtime + hosted service ───
-        services.TryAddSingleton<ChannelLlmReplyInboxRuntime>();
-        services.TryAddSingleton<IChannelLlmReplyInbox>(sp => sp.GetRequiredService<ChannelLlmReplyInboxRuntime>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, ChannelLlmReplyInboxHostedService>());
+        // ─── Per-conversation LLM reply executor ───
+        // Each ConversationGAgent owns its own LLM reply work via this executor; replaces the
+        // silo-wide stream subscriber that bottlenecked all conversations on a single FIFO.
+        services.TryAddSingleton<ConversationLlmReplyExecutor>();
+        services.TryAddSingleton<IConversationLlmReplyExecutor>(sp =>
+            sp.GetRequiredService<ConversationLlmReplyExecutor>());
 
         // ─── Conversation turn-runner override + reply generator ───
         services.Replace(ServiceDescriptor.Singleton<IConversationTurnRunner, ChannelConversationTurnRunner>());

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -751,7 +751,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             metadata["scope_id"] = State.ScopeId;
 
         // Pin the bot owner's pre-configured model + NyxID route + tool-round cap onto the
-        // outbound LLM metadata, the same pattern ChannelLlmReplyInboxRuntime applies for
+        // outbound LLM metadata, the same pattern ConversationLlmReplyExecutor applies for
         // nyxid-chat. Without this, scheduled runs fall through to NyxIdLLMProvider's
         // compile-time defaults (`gpt-5.4` against `/api/v1/llm/gateway/v1/`), which the
         // gateway routes to the OpenAI provider — failing for bot owners who pre-configured

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayOptions.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayOptions.cs
@@ -9,9 +9,9 @@ public class NyxIdRelayOptions
     /// Hard upper bound on a single LLM reply turn (LLM thinking + tool rounds + final
     /// streaming dispatch). 300s gives margin for multi-step tool chains common in the
     /// aevatar Lark bot flow — search a skill, hit a remote endpoint, summarize the result —
-    /// without letting a genuine hang pin the inbox task forever. Set to <c>0</c> or
+    /// without letting a genuine hang pin the executor task forever. Set to <c>0</c> or
     /// negative on a deployment that has its own watchdog and prefers no in-process cap;
-    /// see <c>ChannelLlmReplyInboxRuntime.ResolveFallbackTimeout</c>.
+    /// see <c>ConversationLlmReplyExecutor.ResolveFallbackTimeout</c>.
     /// </summary>
     public int ResponseTimeoutSeconds { get; set; } = 300;
 

--- a/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSshExecTool.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/Tools/NyxIdSshExecTool.cs
@@ -112,7 +112,7 @@ public sealed class NyxIdSshExecTool : IAgentTool
         // `timeout_secs + a few seconds` (the server-side timer kicks in and returns
         // `timed_out: true`). In practice we have observed the call hang well past 60s
         // (NyxID SSH gateway / NodeAgent stuck on a stale session). Without a hard cap,
-        // the LLM run sits on a single tool call long enough to blow the inbox runtime's
+        // the LLM run sits on a single tool call long enough to blow the executor's
         // turn budget and the user gets the generic "took too long" fallback instead of
         // a usable error from this tool. Cap at `timeout_secs + 15s` so NyxID has a
         // generous margin to return its own timeout response, then fail this tool with

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -433,13 +433,13 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleInboundActivityAsync_WhenInboxIsRegistered_DispatchesDirectlyWithoutWaitingForReminder()
+    public async Task HandleInboundActivityAsync_WhenExecutorIsRegistered_DispatchesDirectlyWithoutWaitingForReminder()
     {
         // Regression: previously the inbound LlmReplyRequest path scheduled a 100ms durable
-        // Reminder before EnqueueAsync, which Orleans rounded up to ~1 minute and effectively
-        // dropped the dispatch in production. The inbound path must call inbox.EnqueueAsync
+        // Reminder before dispatch, which Orleans rounded up to ~1 minute and effectively
+        // dropped the dispatch in production. The inbound path must call executor.StartAsync
         // inline so the LLM worker picks it up immediately.
-        var inbox = new RecordingInbox();
+        var executor = new RecordingExecutor();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -452,13 +452,13 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = 42,
                 }),
         };
-        var (agent, _) = CreateAgent(runner, "conv-direct-dispatch", inbox);
+        var (agent, _) = CreateAgent(runner, "conv-direct-dispatch", executor);
 
         await agent.HandleInboundActivityAsync(CreateActivity("act-direct", "conv:slack:C1"));
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].CorrelationId.ShouldBe("act-direct");
-        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].CorrelationId.ShouldBe("act-direct");
+        executor.Started[0].TargetActorId.ShouldBe(agent.Id);
     }
 
     [Fact]
@@ -556,7 +556,7 @@ public sealed class ConversationGAgentDedupTests
         // requests are tracked by message_id, while reply tokens are keyed by the
         // callback correlation_id carried in OutboundDelivery.
         const string sentinelReplyToken = "sentinel-retry-token-7c10";
-        var inbox = new RecordingInbox();
+        var executor = new RecordingExecutor();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -569,7 +569,7 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner", inbox);
+        var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner", executor);
 
         var inboundActivity = CreateActivity("nyx-msg-1", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -586,10 +586,10 @@ public sealed class ConversationGAgentDedupTests
             CorrelationId = "legacy-callback-jti-1",
         });
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
-        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
-        inbox.Enqueued.Clear();
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        executor.Started[0].TargetActorId.ShouldBe(agent.Id);
+        executor.Started.Clear();
 
         await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
         {
@@ -597,10 +597,10 @@ public sealed class ConversationGAgentDedupTests
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].CorrelationId.ShouldBe("nyx-msg-1");
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
-        inbox.Enqueued[0].TargetActorId.ShouldBe(agent.Id);
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].CorrelationId.ShouldBe("nyx-msg-1");
+        executor.Started[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        executor.Started[0].TargetActorId.ShouldBe(agent.Id);
     }
 
     [Fact]
@@ -653,13 +653,13 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleInboundActivityAsync_StripsReplyTokenFromPersistedNeedsLlmReplyEvent_ButKeepsItOnInboxCopy()
+    public async Task HandleInboundActivityAsync_StripsReplyTokenFromPersistedNeedsLlmReplyEvent_ButKeepsItOnExecutorCopy()
     {
         // Strip-on-persist invariant: NeedsLlmReplyEvent must keep reply_token on the
-        // copy enqueued to inbox so the LLM worker can echo it back, but the persisted
+        // copy passed to the executor so the LLM worker can echo it back, but the persisted
         // copy that lands in event store must omit it.
         const string sentinelReplyToken = "sentinel-strip-on-persist-1f8b3";
-        var inbox = new RecordingInbox();
+        var executor = new RecordingExecutor();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -674,7 +674,7 @@ public sealed class ConversationGAgentDedupTests
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, store) = CreateAgent(runner, "conv-strip-token", inbox);
+        var (agent, store) = CreateAgent(runner, "conv-strip-token", executor);
 
         var inboundActivity = CreateActivity("act-strip", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -684,8 +684,8 @@ public sealed class ConversationGAgentDedupTests
         };
         await agent.HandleInboundActivityAsync(inboundActivity);
 
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].ReplyToken.ShouldBe(sentinelReplyToken);
 
         var events = await store.GetEventsAsync(agent.Id);
         events.ShouldNotBeEmpty();
@@ -703,12 +703,12 @@ public sealed class ConversationGAgentDedupTests
     {
         // Regression for Codex review: the persisted NeedsLlmReplyEvent in
         // State.PendingLlmReplyRequests always has an empty ReplyToken (strip-on-persist).
-        // On the retry / durable-reminder path we walk that state, so the inbox must see
+        // On the retry / durable-reminder path we walk that state, so the executor must see
         // the token re-enriched from the actor's in-memory dict while the activation is
-        // still alive. Without enrichment the inbox subscriber's relay gate would drop
+        // still alive. Without enrichment the executor's relay gate would drop
         // the retry and permanently lose the reply.
         const string sentinelReplyToken = "sentinel-retry-enrich-b3d7a";
-        var inbox = new RecordingInbox();
+        var executor = new RecordingExecutor();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -723,7 +723,7 @@ public sealed class ConversationGAgentDedupTests
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, _) = CreateAgent(runner, "conv-retry-enrich", inbox);
+        var (agent, _) = CreateAgent(runner, "conv-retry-enrich", executor);
 
         var inboundActivity = CreateActivity("act-retry", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -739,22 +739,22 @@ public sealed class ConversationGAgentDedupTests
             CorrelationId = "corr-retry",
         };
 
-        // Inbound capture populates the actor runtime dict and enqueues with ReplyToken set directly.
+        // Inbound capture populates the actor runtime dict and starts the executor with ReplyToken set directly.
         await agent.HandleNyxRelayInboundActivityAsync(relayInbound);
-        inbox.Enqueued.Count.ShouldBe(1);
-        inbox.Enqueued[0].ReplyToken.ShouldBe(sentinelReplyToken);
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].ReplyToken.ShouldBe(sentinelReplyToken);
 
         // Simulate the durable-reminder retry firing: pendingRequest is read from state
         // where ReplyToken was stripped. DispatchPendingLlmReplyAsync must re-enrich
-        // from the actor dict so the inbox still receives the token.
+        // from the actor dict so the executor still receives the token.
         await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
         {
             CorrelationId = "corr-retry",
             RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
 
-        inbox.Enqueued.Count.ShouldBe(2);
-        inbox.Enqueued[1].ReplyToken.ShouldBe(sentinelReplyToken);
+        executor.Started.Count.ShouldBe(2);
+        executor.Started[1].ReplyToken.ShouldBe(sentinelReplyToken);
     }
 
     [Fact]
@@ -809,13 +809,13 @@ public sealed class ConversationGAgentDedupTests
     [Fact]
     public async Task HandleDeferredLlmReplyDroppedAsync_RetiresPendingRequestWithNotRetryableFailure()
     {
-        // Inbox-side gates (stale-age, missing relay credential, malformed payload) need
+        // Executor-side gates (stale-age, missing relay credential, malformed payload) need
         // a way to tell the actor "stop tracking this pending request" so it doesn't
         // silently accumulate in State.PendingLlmReplyRequests until the next
         // rehydration. The actor's drop handler emits a NotRetryable
         // ConversationContinueFailedEvent which routes through the existing state
         // matcher to remove the pending entry.
-        var inbox = new RecordingInbox();
+        var executor = new RecordingExecutor();
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
@@ -830,7 +830,7 @@ public sealed class ConversationGAgentDedupTests
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
                 }),
         };
-        var (agent, store) = CreateAgent(runner, "conv-drop-clears", inbox);
+        var (agent, store) = CreateAgent(runner, "conv-drop-clears", executor);
 
         var inboundActivity = CreateActivity("act-drop", "conv:slack:C1");
         inboundActivity.OutboundDelivery = new OutboundDeliveryContext
@@ -1336,7 +1336,7 @@ public sealed class ConversationGAgentDedupTests
     private static (ConversationGAgent agent, IEventStore store) CreateAgent(
         RecordingTurnRunner runner,
         string agentId,
-        IChannelLlmReplyInbox? inbox = null,
+        IConversationLlmReplyExecutor? executor = null,
         IConversationCardTurnRunner? cardRunner = null)
     {
         var store = new InMemoryEventStore();
@@ -1347,8 +1347,8 @@ public sealed class ConversationGAgentDedupTests
         services.AddSingleton<IConversationTurnRunner>(runner);
         if (cardRunner is not null)
             services.AddSingleton(cardRunner);
-        if (inbox is not null)
-            services.AddSingleton(inbox);
+        if (executor is not null)
+            services.AddSingleton(executor);
         services.AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
 
         var sp = services.BuildServiceProvider();
@@ -1513,13 +1513,13 @@ public sealed class ConversationGAgentDedupTests
         }
     }
 
-    private sealed class RecordingInbox : IChannelLlmReplyInbox
+    private sealed class RecordingExecutor : IConversationLlmReplyExecutor
     {
-        public List<NeedsLlmReplyEvent> Enqueued { get; } = [];
+        public List<NeedsLlmReplyEvent> Started { get; } = [];
 
-        public Task EnqueueAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+        public Task StartAsync(NeedsLlmReplyEvent request, CancellationToken ct)
         {
-            Enqueued.Add(request.Clone());
+            Started.Add(request.Clone());
             return Task.CompletedTask;
         }
     }

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -462,6 +462,102 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleInboundActivityAsync_WhenLlmReplyAlreadyInFlight_DefersSecondRequestUntilReadyEvent()
+    {
+        // Per-conversation FIFO gate: a second inbound activity arriving while the first
+        // request is still being processed by the executor must NOT spawn a parallel
+        // executor.StartAsync — the head-of-queue is the in-flight slot, the rest wait.
+        // When the head's terminal LlmReplyReadyEvent arrives, the queue advances and the
+        // next pending request is dispatched.
+        var executor = new RecordingExecutor();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = 42,
+                }),
+            LlmReplyResultFactory = reply => ConversationTurnResult.Sent(
+                "sent:" + reply.CorrelationId,
+                new MessageContent { Text = "ack" },
+                "bot",
+                new OutboundDeliveryContext()),
+        };
+        var (agent, _) = CreateAgent(runner, "conv-fifo-gate-ready", executor);
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-1", "conv:slack:C1"));
+        await agent.HandleInboundActivityAsync(CreateActivity("act-2", "conv:slack:C1"));
+
+        // Only the head dispatched; act-2 is parked behind it.
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].CorrelationId.ShouldBe("act-1");
+        agent.State.PendingLlmReplyRequests.Select(r => r.CorrelationId)
+            .ShouldBe(new[] { "act-1", "act-2" });
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-1",
+            RegistrationId = "reg-1",
+            SourceActorId = "llm-worker-1",
+            Activity = CreateActivity("act-1", "conv:slack:C1"),
+            Outbound = new MessageContent { Text = "reply-1" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        // act-1 retired → act-2 becomes head and dispatches automatically.
+        executor.Started.Count.ShouldBe(2);
+        executor.Started[1].CorrelationId.ShouldBe("act-2");
+        agent.State.PendingLlmReplyRequests.Select(r => r.CorrelationId)
+            .ShouldBe(new[] { "act-2" });
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_WhenInFlightRequestDropped_DispatchesNextPendingRequest()
+    {
+        // Per-conversation FIFO gate: a DeferredLlmReplyDroppedEvent for the head must
+        // also advance the queue, not just LlmReplyReadyEvent. Otherwise a head that fails
+        // its pre-LLM gate (or crashes inside the executor) would block all subsequent
+        // requests for that conversation.
+        var executor = new RecordingExecutor();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = 42,
+                }),
+        };
+        var (agent, _) = CreateAgent(runner, "conv-fifo-gate-drop", executor);
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-a", "conv:slack:C1"));
+        await agent.HandleInboundActivityAsync(CreateActivity("act-b", "conv:slack:C1"));
+
+        executor.Started.Count.ShouldBe(1);
+        executor.Started[0].CorrelationId.ShouldBe("act-a");
+
+        await agent.HandleDeferredLlmReplyDroppedAsync(new DeferredLlmReplyDroppedEvent
+        {
+            CorrelationId = "act-a",
+            Reason = "executor_crash",
+            DroppedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        executor.Started.Count.ShouldBe(2);
+        executor.Started[1].CorrelationId.ShouldBe("act-b");
+        agent.State.PendingLlmReplyRequests.Select(r => r.CorrelationId)
+            .ShouldBe(new[] { "act-b" });
+    }
+
+    [Fact]
     public async Task HandleNyxRelayInboundActivityAsync_NeverPersistsReplyTokenIntoEventStore()
     {
         // Issue #366 §4 invariant: relay reply_token must stay actor-owned runtime state.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationLlmReplyExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationLlmReplyExecutorTests.cs
@@ -607,6 +607,192 @@ public sealed class ConversationLlmReplyExecutorTests
             .WhoseValue.Should().Be("bot-owner-session-jwt");
     }
 
+    [Fact]
+    public async Task StartAsync_ReturnsImmediately_WhileLlmCallStillRunning()
+    {
+        // Non-blocking guarantee: the actor turn must not wait on the 60-300s LLM call.
+        // StartAsync schedules the work on the thread pool and returns; verify by gating
+        // the reply generator on a TCS that we never signal during the assertion.
+        var releaseGenerator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var generatorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var replyGenerator = new GatedReplyGenerator(generatorEntered, releaseGenerator);
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
+
+        var startTask = executor.StartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-nonblocking",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-1",
+        }, CancellationToken.None);
+
+        // StartAsync must complete without waiting for the generator to finish.
+        await startTask.WaitAsync(TimeSpan.FromSeconds(2));
+        startTask.IsCompletedSuccessfully.Should().BeTrue();
+
+        // Confirm the background task actually started the generator (so we know we're
+        // testing "non-blocking despite work in progress" rather than "no work happened").
+        await generatorEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        dispatchPort.Dispatched.Should().BeEmpty(
+            "the executor must not dispatch a terminal signal until the generator returns");
+
+        // Drain: release the generator and let the background task finalize.
+        releaseGenerator.SetResult();
+    }
+
+    [Fact]
+    public async Task StartAsync_ClonesRequest_SoCallerMutationsDoNotAffectInFlightWork()
+    {
+        // Snapshot guarantee: StartAsync must not pin the caller's NeedsLlmReplyEvent —
+        // the actor often clones+mutates pending requests on retry/rehydration. The
+        // background task should observe the values at the moment of StartAsync.
+        var observedActivities = new List<ChatActivity>();
+        var releaseGenerator = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var generatorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var replyGenerator = new GatedReplyGenerator(generatorEntered, releaseGenerator)
+        {
+            ReplyText = "ok",
+            ActivityObserver = activity => observedActivities.Add(activity.Clone()),
+        };
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
+
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-snapshot",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-1",
+        };
+        await executor.StartAsync(request, CancellationToken.None);
+
+        await generatorEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Mutate the original AFTER StartAsync — the in-flight task must observe the
+        // pre-mutation activity.
+        request.Activity!.Content = new MessageContent { Text = "MUTATED-AFTER-START" };
+        request.ReplyToken = "MUTATED-TOKEN";
+
+        releaseGenerator.SetResult();
+
+        // Wait for terminal dispatch to confirm the work finished.
+        await WaitForDispatchAsync(dispatchPort, count: 1, TimeSpan.FromSeconds(5));
+
+        observedActivities.Should().ContainSingle();
+        observedActivities[0].Content.Text.Should().Be("hello",
+            "the generator must observe the cloned activity, not post-StartAsync mutations");
+    }
+
+    [Fact]
+    public async Task StartAsync_DispatchesExecutorCrashDrop_WhenBackgroundTaskThrowsAfterGates()
+    {
+        // Contract: the executor MUST eventually deliver a terminal signal so the actor
+        // can retire its pending entry. If something past the pre-LLM gates throws
+        // (here: the dispatch of the ready event itself fails), the outer catch must
+        // send DeferredLlmReplyDroppedEvent with reason executor_crash.
+        //
+        // Streaming is disabled here so the only dispatch is the ready event — that way
+        // the first ThrowOnceDispatchPort attempt is unambiguously the ready dispatch
+        // (with streaming on, the streaming sink dispatches first and the sink swallows
+        // its own dispatch errors, masking the failure path under test).
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "ok" };
+        var dispatchPort = new ThrowOnceDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
+
+        await executor.StartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-crash",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-crash",
+        }, CancellationToken.None);
+
+        // First dispatch (LlmReplyReadyEvent) throws; the outer catch sends a second
+        // dispatch (DeferredLlmReplyDroppedEvent) so the actor isn't left with a leaked
+        // pending entry.
+        await WaitForDispatchAsync(dispatchPort, count: 2, TimeSpan.FromSeconds(5));
+
+        dispatchPort.Attempts[0].Payload.Is(LlmReplyReadyEvent.Descriptor).Should().BeTrue();
+        var dropped = dispatchPort.Attempts[1].Payload.Unpack<DeferredLlmReplyDroppedEvent>();
+        dropped.CorrelationId.Should().Be("corr-crash");
+        dropped.Reason.Should().Be("executor_crash");
+    }
+
+    [Fact]
+    public async Task StartAsync_ThrowsImmediately_WhenCallerTokenAlreadyCancelled()
+    {
+        // A turn that's already cancelled before reaching the executor shouldn't burn
+        // an LLM round; throw directly so the actor sees the cancellation and skips
+        // dispatch instead of swallowing it inside a background task.
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
+            new RecordingReplyGenerator(() => false) { ReplyText = "should not run" },
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await executor.StartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-cancelled",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-1",
+        }, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        dispatchPort.Dispatched.Should().BeEmpty();
+    }
+
+    private static async Task WaitForDispatchAsync(
+        RecordingDispatchPort port,
+        int count,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (port.Dispatched.Count < count && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(20);
+        port.Dispatched.Count.Should().BeGreaterThanOrEqualTo(count);
+    }
+
+    private static async Task WaitForDispatchAsync(
+        ThrowOnceDispatchPort port,
+        int count,
+        TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (port.Attempts.Count < count && DateTimeOffset.UtcNow < deadline)
+            await Task.Delay(20);
+        port.Attempts.Count.Should().BeGreaterThanOrEqualTo(count);
+    }
+
     private static ChatActivity BuildRelayActivity() =>
         new()
         {
@@ -640,6 +826,24 @@ public sealed class ConversationLlmReplyExecutorTests
         }
     }
 
+    /// <summary>
+    /// Throws on the first dispatch and accepts the rest. Lets the executor-crash test
+    /// confirm that the outer catch sends a follow-up DeferredLlmReplyDroppedEvent after
+    /// the first envelope (the ready signal) fails to land.
+    /// </summary>
+    private sealed class ThrowOnceDispatchPort : IActorDispatchPort
+    {
+        public List<EventEnvelope> Attempts { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Attempts.Add(envelope);
+            if (Attempts.Count == 1)
+                throw new InvalidOperationException("dispatch failure simulation");
+            return Task.CompletedTask;
+        }
+    }
+
     private sealed class RecordingReplyGenerator(Func<bool> captureAction) : IConversationReplyGenerator
     {
         public string ReplyText { get; init; } = string.Empty;
@@ -669,6 +873,34 @@ public sealed class ConversationLlmReplyExecutorTests
             IReadOnlyDictionary<string, string> metadata,
             IStreamingReplySink? streamingSink,
             CancellationToken ct) => Task.FromException<string?>(exception);
+    }
+
+    /// <summary>
+    /// Generator that signals when invoked (<paramref name="entered"/>) and waits for an
+    /// external release (<paramref name="release"/>) before returning. Used to assert
+    /// non-blocking semantics (StartAsync returns while the generator is still running)
+    /// and snapshot semantics (the generator observes the cloned activity, not later
+    /// caller mutations).
+    /// </summary>
+    private sealed class GatedReplyGenerator(
+        TaskCompletionSource entered,
+        TaskCompletionSource release) : IConversationReplyGenerator
+    {
+        public string ReplyText { get; init; } = string.Empty;
+
+        public Action<ChatActivity>? ActivityObserver { get; init; }
+
+        public async Task<string?> GenerateReplyAsync(
+            ChatActivity activity,
+            IReadOnlyDictionary<string, string> metadata,
+            IStreamingReplySink? streamingSink,
+            CancellationToken ct)
+        {
+            ActivityObserver?.Invoke(activity);
+            entered.TrySetResult();
+            await release.Task.WaitAsync(ct);
+            return ReplyText;
+        }
     }
 
     /// <summary>Generator that never completes on its own; only ends when the executor cancels it.</summary>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationLlmReplyExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationLlmReplyExecutorTests.cs
@@ -4,7 +4,6 @@ using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
@@ -14,7 +13,7 @@ using Xunit;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
-public sealed class ChannelLlmReplyInboxRuntimeTests
+public sealed class ConversationLlmReplyExecutorTests
 {
     [Fact]
     public async Task ProcessAsync_RelayTurnCapturesInteractiveIntentIntoReadyEvent()
@@ -35,21 +34,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             });
             return collector.Capture(intent);
         });
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-1",
             TargetActorId = "actor-1",
@@ -59,6 +52,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeTrue();
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
         ready.Outbound.Text.Should().Be("Choose one");
@@ -74,21 +68,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         {
             ReplyText = "plain reply",
         };
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-2",
             TargetActorId = "actor-1",
@@ -101,6 +89,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeFalse();
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
         ready.Outbound.Text.Should().Be("plain reply");
@@ -112,21 +101,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new ThrowingReplyGenerator(new InvalidOperationException("boom"));
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-throw",
             TargetActorId = "actor-1",
@@ -135,6 +118,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             ReplyToken = "relay-token-throw",
         });
 
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
         ready.TerminalState.Should().Be(LlmReplyTerminalState.Failed);
@@ -147,21 +131,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     public async Task ProcessAsync_ShouldEmitTimeoutFallbackReply_WhenGeneratorHangsPastBudget()
     {
         // Without a cancellation budget on the LLM run, a tool that hangs (broken sandbox,
-        // unreachable proxy upstream, slow remote SSH) would pin the inbox task indefinitely
-        // and Lark would stay on the loading reaction forever. The runtime caps each turn at
+        // unreachable proxy upstream, slow remote SSH) would pin the executor task indefinitely
+        // and Lark would stay on the loading reaction forever. The executor caps each turn at
         // the relay ResponseTimeoutSeconds and folds the cancellation into a user-visible
         // fallback reply with errorCode=llm_reply_timeout.
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new HangingReplyGenerator();
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
@@ -169,9 +147,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 InteractiveRepliesEnabled = true,
                 ResponseTimeoutSeconds = 1,
             },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-timeout",
             TargetActorId = "actor-1",
@@ -181,6 +159,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.WasCancelled.Should().BeTrue();
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
         ready.TerminalState.Should().Be(LlmReplyTerminalState.Failed);
@@ -197,21 +176,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         {
             ReplyText = "   ",
         };
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-empty",
             TargetActorId = "actor-1",
@@ -220,6 +193,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             ReplyToken = "relay-token-empty",
         });
 
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
         ready.TerminalState.Should().Be(LlmReplyTerminalState.Failed);
@@ -230,22 +204,16 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     [Fact]
     public async Task ProcessAsync_ShouldEchoReplyTokenIntoLlmReplyReadyEvent()
     {
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             new RecordingReplyGenerator(() => false) { ReplyText = "ok" },
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
         var expiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds();
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-echo",
             TargetActorId = "actor-1",
@@ -255,6 +223,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             ReplyTokenExpiresAtUnixMs = expiresAtUnixMs,
         });
 
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
         ready.ReplyToken.Should().Be("relay-token-echo");
@@ -264,24 +233,18 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     [Fact]
     public async Task ProcessAsync_ShouldDropRelayRequest_WhenInboxCarriesNoReplyToken()
     {
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("actor-1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var dispatchPort = new RecordingDispatchPort();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
         // Relay activity but no inbox-carried ReplyToken — simulates a request rehydrated
         // from persisted state after a pod restart, where the original token capture is gone.
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-no-token",
             TargetActorId = "actor-1",
@@ -290,6 +253,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeFalse();
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
         dropped.CorrelationId.Should().Be("corr-no-token");
@@ -299,25 +263,19 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     [Fact]
     public async Task ProcessAsync_ShouldDropRequest_WhenOlderThanMaxAge()
     {
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("actor-1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var dispatchPort = new RecordingDispatchPort();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "should not run" };
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
         var requestedAtUnixMs = DateTimeOffset.UtcNow
-            .AddMilliseconds(-(ChannelLlmReplyInboxRuntime.MaxInboxRequestAgeMs + 60_000))
+            .AddMilliseconds(-(ConversationLlmReplyExecutor.MaxRequestAgeMs + 60_000))
             .ToUnixTimeMilliseconds();
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-stale",
             TargetActorId = "actor-1",
@@ -328,6 +286,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeFalse();
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
         dropped.CorrelationId.Should().Be("corr-stale");
@@ -337,16 +296,18 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     [Fact]
     public async Task ProcessAsync_ShouldDropSilently_WhenTargetActorIdMissing()
     {
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        // A malformed payload with an empty TargetActorId has nowhere to send the drop
+        // notification — there is no actor to retire a pending entry on. The executor
+        // must short-circuit cleanly without attempting to dispatch.
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             new RecordingReplyGenerator(() => false),
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-missing",
             TargetActorId = string.Empty,
@@ -354,7 +315,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             Activity = BuildRelayActivity(),
         });
 
-        await actorRuntime.DidNotReceiveWithAnyArgs().GetAsync(Arg.Any<string>());
+        dispatchPort.Dispatched.Should().BeEmpty();
     }
 
     [Fact]
@@ -363,27 +324,22 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         // Malformed payload (no Activity) should still tell the actor to retire its
         // pending entry — the actor decides whether to clean up. Otherwise the entry
         // accumulates silently in State.PendingLlmReplyRequests until rehydration.
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("actor-1");
-        EventEnvelope? handled = null;
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled = call.Arg<EventEnvelope>());
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             new RecordingReplyGenerator(() => false),
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-no-activity",
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
         });
 
+        var handled = dispatchPort.Last;
         handled.Should().NotBeNull();
         var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
         dropped.CorrelationId.Should().Be("corr-no-activity");
@@ -399,15 +355,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         // text-edit chunk shape, so opt out of card mode here.
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "streamed reply" };
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        var handled = new List<EventEnvelope>();
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
@@ -417,9 +367,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 StreamingFlushIntervalMs = 0,
                 StreamingCardKitEnabled = false,
             },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-stream",
             TargetActorId = "actor-1",
@@ -429,9 +379,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
         });
 
-        handled.Any(e => e.Payload.Is(LlmReplyStreamChunkEvent.Descriptor)).Should().BeTrue();
-        handled.Any(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor)).Should().BeTrue();
-        var chunk = handled.First(e => e.Payload.Is(LlmReplyStreamChunkEvent.Descriptor))
+        dispatchPort.Dispatched.Any(e => e.Payload.Is(LlmReplyStreamChunkEvent.Descriptor)).Should().BeTrue();
+        dispatchPort.Dispatched.Any(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor)).Should().BeTrue();
+        var chunk = dispatchPort.Dispatched.First(e => e.Payload.Is(LlmReplyStreamChunkEvent.Descriptor))
             .Payload.Unpack<LlmReplyStreamChunkEvent>();
         chunk.AccumulatedText.Should().Be("streamed reply");
         chunk.CorrelationId.Should().Be("corr-stream");
@@ -443,18 +393,12 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
         // Pinning the new default: StreamingCardKitEnabled=true causes the sink to emit
         // the card-mode chunk type, exercising the CardKit lifecycle entrypoint without
         // needing a real ChannelCardConversationTurnRunner wired up (the actor is mocked,
-        // so we only verify the inbox dispatched the right proto type to the actor).
+        // so we only verify the executor dispatched the right proto type to the actor).
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "card streamed reply" };
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_2");
-        var handled = new List<EventEnvelope>();
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
@@ -464,9 +408,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 StreamingCardKitFlushIntervalMs = 0,
                 // StreamingCardKitEnabled defaults to true.
             },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-card-stream",
             TargetActorId = "actor-1",
@@ -476,9 +420,9 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
         });
 
-        handled.Any(e => e.Payload.Is(LlmReplyCardStreamChunkEvent.Descriptor)).Should().BeTrue();
-        handled.Any(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor)).Should().BeTrue();
-        var chunk = handled.First(e => e.Payload.Is(LlmReplyCardStreamChunkEvent.Descriptor))
+        dispatchPort.Dispatched.Any(e => e.Payload.Is(LlmReplyCardStreamChunkEvent.Descriptor)).Should().BeTrue();
+        dispatchPort.Dispatched.Any(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor)).Should().BeTrue();
+        var chunk = dispatchPort.Dispatched.First(e => e.Payload.Is(LlmReplyCardStreamChunkEvent.Descriptor))
             .Payload.Unpack<LlmReplyCardStreamChunkEvent>();
         chunk.AccumulatedText.Should().Be("card streamed reply");
         chunk.CorrelationId.Should().Be("corr-card-stream");
@@ -489,21 +433,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "plain reply" };
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:group:oc_group_chat_1");
-        var handled = new List<EventEnvelope>();
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false, StreamingRepliesEnabled = false },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-legacy",
             TargetActorId = "actor-1",
@@ -513,8 +451,8 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
         });
 
-        handled.Should().ContainSingle();
-        handled[0].Payload.Is(LlmReplyReadyEvent.Descriptor).Should().BeTrue();
+        dispatchPort.Dispatched.Should().ContainSingle();
+        dispatchPort.Dispatched[0].Payload.Is(LlmReplyReadyEvent.Descriptor).Should().BeTrue();
     }
 
     [Fact]
@@ -522,21 +460,15 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
     {
         var collector = new AsyncLocalInteractiveReplyCollector();
         var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "plain reply" };
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("channel-conversation:lark:dm:user");
-        var handled = new List<EventEnvelope>();
-        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
-            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var dispatchPort = new RecordingDispatchPort();
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             collector,
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = false, StreamingRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-nonrelay",
             TargetActorId = "actor-1",
@@ -549,8 +481,8 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             },
         });
 
-        handled.Should().ContainSingle();
-        handled[0].Payload.Is(LlmReplyReadyEvent.Descriptor).Should().BeTrue();
+        dispatchPort.Dispatched.Should().ContainSingle();
+        dispatchPort.Dispatched[0].Payload.Is(LlmReplyReadyEvent.Descriptor).Should().BeTrue();
     }
 
     [Fact]
@@ -572,10 +504,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                     capturedMetadata[pair.Key] = pair.Value;
             },
         };
-
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("actor-1");
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var dispatchPort = new RecordingDispatchPort();
 
         var scopeResolver = Substitute.For<INyxIdRelayScopeResolver>();
         scopeResolver.ResolveScopeIdByApiKeyAsync("api-key-bot", Arg.Any<CancellationToken>())
@@ -592,13 +521,12 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                 GithubUsername: null,
                 MaxToolRounds: 11)));
 
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance,
+            NullLogger<ConversationLlmReplyExecutor>.Instance,
             scopeResolver,
             userConfigQueryPort);
 
@@ -609,7 +537,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             NyxUserAccessToken = "bot-owner-session-jwt",
         };
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-bot-owner",
             TargetActorId = "actor-1",
@@ -649,18 +577,14 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
                     capturedMetadata[pair.Key] = pair.Value;
             },
         };
+        var dispatchPort = new RecordingDispatchPort();
 
-        var actor = Substitute.For<IActor>();
-        actor.Id.Returns("actor-1");
-        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
-
-        var runtime = new ChannelLlmReplyInboxRuntime(
-            Substitute.For<IStreamProvider>(),
-            actorRuntime,
+        var executor = new ConversationLlmReplyExecutor(
+            dispatchPort,
             replyGenerator,
             new AsyncLocalInteractiveReplyCollector(),
             new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true },
-            NullLogger<ChannelLlmReplyInboxRuntime>.Instance);
+            NullLogger<ConversationLlmReplyExecutor>.Instance);
 
         var activity = BuildRelayActivity();
         activity.TransportExtras = new TransportExtras
@@ -668,7 +592,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             NyxUserAccessToken = "bot-owner-session-jwt",
         };
 
-        await runtime.ProcessAsync(new NeedsLlmReplyEvent
+        await executor.ProcessAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-bearer",
             TargetActorId = "actor-1",
@@ -703,53 +627,16 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             },
         };
 
-    private sealed class DispatchingActorRuntime(params (string Id, IActor Actor)[] actors) :
-        IActorRuntime,
-        IActorDispatchPort
+    private sealed class RecordingDispatchPort : IActorDispatchPort
     {
-        private readonly Dictionary<string, IActor> _actors = actors.ToDictionary(
-            static pair => pair.Id,
-            static pair => pair.Actor,
-            StringComparer.Ordinal);
+        public List<EventEnvelope> Dispatched { get; } = [];
 
-        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
-            where TAgent : IAgent
+        public EventEnvelope? Last => Dispatched.Count == 0 ? null : Dispatched[^1];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
         {
-            var actorId = id ?? Guid.NewGuid().ToString("N");
-            if (_actors.TryGetValue(actorId, out var existing))
-                return Task.FromResult(existing);
-
-            var actor = Substitute.For<IActor>();
-            actor.Id.Returns(actorId);
-            _actors[actorId] = actor;
-            return Task.FromResult(actor);
-        }
-
-        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
-            CreateAsync<ConversationGAgent>(id, ct);
-
-        public Task DestroyAsync(string id, CancellationToken ct = default)
-        {
-            _actors.Remove(id);
+            Dispatched.Add(envelope);
             return Task.CompletedTask;
-        }
-
-        public Task<IActor?> GetAsync(string id) =>
-            Task.FromResult(_actors.TryGetValue(id, out var actor) ? actor : null);
-
-        public Task<bool> ExistsAsync(string id) => Task.FromResult(_actors.ContainsKey(id));
-
-        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
-            Task.CompletedTask;
-
-        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
-            Task.CompletedTask;
-
-        public async Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
-        {
-            if (!_actors.TryGetValue(actorId, out var actor))
-                throw new InvalidOperationException($"Actor {actorId} not found.");
-            await actor.HandleEventAsync(envelope, ct);
         }
     }
 
@@ -784,7 +671,7 @@ public sealed class ChannelLlmReplyInboxRuntimeTests
             CancellationToken ct) => Task.FromException<string?>(exception);
     }
 
-    /// <summary>Generator that never completes on its own; only ends when the runtime cancels it.</summary>
+    /// <summary>Generator that never completes on its own; only ends when the executor cancels it.</summary>
     private sealed class HangingReplyGenerator : IConversationReplyGenerator
     {
         public bool WasCancelled { get; private set; }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -802,7 +802,7 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     {
         // Regression for the "/daily failed: Provider 'openai' not connected" report:
         // skill runners must honor the bot owner's pre-configured model + NyxID route + tool
-        // cap — same shape ChannelLlmReplyInboxRuntime applies for nyxid-chat. Without it,
+        // cap — same shape ConversationLlmReplyExecutor applies for nyxid-chat. Without it,
         // every scheduled run falls through to NyxIdLLMProvider's compile-time `gpt-5.4` +
         // gateway default, which the gateway routes to OpenAI and 400s for bot owners who
         // wired a custom NyxID service like `chrono-llm` at `/api/v1/proxy/s/chrono-llm`.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/TurnStreamingReplySinkTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/TurnStreamingReplySinkTests.cs
@@ -191,8 +191,8 @@ public sealed class TurnStreamingReplySinkTests
     public async Task FinalizeAsync_DispatchInFlight_WaitsForFinalChunkOnWire()
     {
         // Regression for the race where FinalizeAsync would return as soon as the final text
-        // was stashed (while a prior dispatch was still in flight), letting the inbox runtime
-        // send LlmReplyReadyEvent past the late final chunk and triggering the
+        // was stashed (while a prior dispatch was still in flight), letting the LLM reply
+        // executor send LlmReplyReadyEvent past the late final chunk and triggering the
         // ConversationGAgent processed-command guard to drop it.
         var firstDispatchGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var envelopes = new List<EventEnvelope>();

--- a/tools/ci/test_polling_allowlist.txt
+++ b/tools/ci/test_polling_allowlist.txt
@@ -18,5 +18,5 @@ test/Aevatar.Tools.Cli.Tests/ChronoStorageChatHistoryStoreTests.cs
 test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
 # Fake voice transport uses Task.Delay(Infinite, ct) to keep receive loop alive until relay teardown cancels it
 test/Aevatar.Foundation.VoicePresence.Tests/VoiceTransportRelayTests.cs
-# HangingReplyGenerator test double uses Task.Delay(Infinite, ct) to verify runtime cancels reply generation on timeout
-test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelLlmReplyInboxRuntimeTests.cs
+# HangingReplyGenerator test double uses Task.Delay(Infinite, ct) to verify the executor cancels reply generation on timeout
+test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationLlmReplyExecutorTests.cs


### PR DESCRIPTION
## Summary

Moves LLM reply work from a silo-wide hosted-service stream subscriber into a per-conversation executor seam owned by `ConversationGAgent`. Different conversations (different Lark users) now run their LLM replies in parallel instead of strict FIFO serialization across the whole silo.

Closes #599.

## Root cause

`ChannelLlmReplyInboxRuntime` registered a single Orleans persistent-stream `SubscribeAsync` per silo (1 pod = 1 silo = 1 callback). Orleans serializes `SubscribeAsync` callbacks FIFO, and `ProcessAsync` synchronously awaited 60-300s LLM calls — so every Lark user's reply queued behind every other user's reply.

Production logs (60 min window 2026-05-08 08:28-09:28, pod `aevatar-console-backend-7b69b89cd6-x9d9t`): 6 LLM reply requests, 4 timeouts, 67% failure rate. Adjacent users' `Processing` timestamps showed strict back-to-back FIFO across distinct user IDs.

## Approach (Solution C)

- New `IConversationLlmReplyExecutor` seam in `Aevatar.GAgents.Channel.Runtime`. Single method: `Task StartAsync(NeedsLlmReplyEvent, CancellationToken)`.
- New `ConversationLlmReplyExecutor` implementation in `Aevatar.GAgents.NyxidChat`:
  - Pre-LLM gates (stale age, missing relay credential, malformed payload), bot-owner config enrichment, the LLM call itself, streaming-sink wiring, and dispatch of the terminal signal back to the originating actor — same logic the old `ProcessAsync` had.
  - `StartAsync` is non-blocking: it spawns a `Task.Run` for the LLM work and returns immediately. The actor turn does not wait on the 60-300s call.
  - The background task only does external I/O and finishes by dispatching `LlmReplyReadyEvent` (or `DeferredLlmReplyDroppedEvent`) to `request.TargetActorId` via `IActorDispatchPort`. It never reads or writes actor state — only signals — preserving the actor's single-threaded execution invariant per CLAUDE.md.
- `ConversationGAgent.DispatchPendingLlmReplyAsync` now calls `executor.StartAsync` instead of `inbox.EnqueueAsync`.
- Deleted `ChannelLlmReplyInboxRuntime`, `ChannelLlmReplyInboxHostedService`, and `IChannelLlmReplyInbox`.
- DI registration drops the silo-wide hosted service; replaced with a singleton `ConversationLlmReplyExecutor`.

Durability: the request is persisted in `State.PendingLlmReplyRequests` before the actor calls `StartAsync`, exactly as before. Pod restart mid-flight rehydrates the actor and re-kicks the executor on activation via the existing `SchedulePendingLlmReplyDispatchesAsync` path.

CLAUDE.md fit: "Actor 即业务实体 — 一个 actor = 一个业务实体（数据与方法同住）；禁止按技术功能（读/写/投影）拆分同一业务实体为多个 actor". The LLM reply is part of the conversation entity's behavior; the original host-level worker was the violation.

## Files

- `agents/Aevatar.GAgents.Channel.Runtime/Conversation/IConversationLlmReplyExecutor.cs` (new)
- `agents/Aevatar.GAgents.NyxidChat/ConversationLlmReplyExecutor.cs` (renamed from `ChannelLlmReplyInboxRuntime.cs`)
- `agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyInbox.cs` (deleted)
- `agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs` — `DispatchPendingLlmReplyAsync` rewired
- `agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs` — drop hosted service, register executor singleton
- `test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationLlmReplyExecutorTests.cs` (renamed from `ChannelLlmReplyInboxRuntimeTests.cs`, ported to executor-shape)
- `test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs` — `RecordingInbox` → `RecordingExecutor`
- Misc comment / proto-doc / allowlist renames

## Test plan

- [x] `dotnet build aevatar.slnx` — 0 errors
- [x] `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj` — 895/895 pass
- [x] `dotnet test test/Aevatar.GAgents.Channel.Protocol.Tests/Aevatar.GAgents.Channel.Protocol.Tests.csproj` — 133/133 pass
- [x] `dotnet test test/Aevatar.GAgents.Platform.Lark.Tests/Aevatar.GAgents.Platform.Lark.Tests.csproj` — 17/17 pass
- [x] `bash tools/ci/architecture_guards.sh` — pass
- [ ] **Production verification** (post-deploy): script 10 simultaneous Lark DMs to different users; expect their `Processing` timestamps to interleave (no longer strict FIFO) and failure rate < 5% in the same 60-min window.

## Out of scope

- `SkillRunnerGAgent` non-reentrant grain (mentioned in #599 as a secondary bottleneck) — separate fix.
- Cold-start `EventStoreOptimisticConcurrencyException` against `user-agent-catalog-read-model` — independent issue, low frequency (1/hr).