### PR TITLE
docs: update frontend design guidelines

### DIFF
--- a/docs/canon/frontend-design.md
+++ b/docs/canon/frontend-design.md
@@ -2,26 +2,224 @@
 title: "Aevatar 前端设计基线"
 status: active
 owner: potter
+last_updated: 2026-05-11
 ---
 
 # Aevatar 前端设计基线
 
 本文档定义 Aevatar 仓库内前端实现的默认设计口径。凡是页面、组件、控制台、playground、样式系统、视觉 polish 或前端重构任务，默认以本文为准。
 
+本文尤其约束 `apps/aevatar-console-web`：Console Web 不是普通后台管理系统，而是用户理解、运行、调试和治理 AI Team 的工作台。前端设计必须同时表达产品语义、架构语义和视觉系统，不能只停留在样式美化。
+
 ## 1. 适用范围
 
 当前仓库内的主要前端工作面包括：
 
+- `apps/aevatar-console-web`：控制台 Web 应用，是本文档的首要约束对象。
 - `tools/Aevatar.Tools.Cli/Frontend`：CLI playground React/Vite 源码。
 - `tools/Aevatar.Tools.Cli/wwwroot`：CLI host 分发的静态产物。
 - `demos/Aevatar.Demos.Workflow.Web/wwwroot`：Demo Web 静态 playground。
-- `apps/aevatar-console-web`：控制台 Web 应用。
 
 如果未来新增前端宿主，也默认继承本文档；只有该宿主存在更高优先级的局部设计文档时，才允许局部覆盖。
 
-## 2. 默认设计立场
+## 2. Console Web 产品定位
 
-### 2.1 先定方向，再写界面
+Console Web 的产品主语是 `AI Team Workbench`，不是系统对象浏览器。
+
+用户进入 Console Web 后，页面应优先回答：
+
+- 当前 Team 是谁、在做什么、是否健康。
+- 最近一次 run、message、tool call、human input 或 workflow signal 处在哪个阶段。
+- 当前能力如何构建、绑定、调用、观察。
+- 出问题时该看哪个事实源、哪个 readmodel、哪条 observation。
+- 需要治理时如何下钻到 service、deployment、policy、binding 与 endpoint。
+
+默认信息架构应保持两层心智：
+
+- `Teams` 层负责运行、协作、介入和理解。
+- `Platform` 层负责服务治理、发布、绑定、流量、策略和排障。
+
+V1 页面不得为了视觉完整性伪造后端不存在的事实源。已有稳定 API 或 readmodel 的对象，例如 member roster、team roster、run summary，必须读取真实契约；没有稳定契约的全局 team catalog、跨 team health、组织级 analytics 或运营 KPI，只能展示当前上下文、最近记录、可验证的 readmodel 或明确标注为本地临时状态。
+
+## 3. Console Web 页面模型
+
+Console Web 新增或重构页面时，优先落到以下页面模型之一。
+
+### 3.1 Team Workbench
+
+Team 页面负责 team-first 运行视角。
+
+标准结构：
+
+- 顶部 `Team Context Header`：team/scope、状态摘要、最近 run、待处理事项、关键操作。
+- 主区域 `Activity / Topology / Intervention / Bindings`：活动流、拓扑、人工介入、连接与策略。
+- 右侧或下方 `Observation Panel`：timeline、trace、summary、raw。
+
+Team 页面不得把 workflow、script、GAgent、service 作为无上下文的一级卡片墙。它们应被解释为当前 Team 的成员实现、能力入口、运行记录或治理对象。
+
+### 3.2 Member Workbench
+
+Studio 的直接编辑对象是 Team 中的某个 `Member`，不是抽象工具集合。
+
+标准结构：
+
+- 顶部 `Context Bar`：scope、team、member、implementation kind、revision、binding、health。
+- 左侧 `Member Rail`：team members、binding 状态、health、last run、revision。
+- 中间四阶段工作区：`Build -> Bind -> Invoke -> Observe`。
+
+任何保存、发布、绑定、调用、测试、观察动作都必须让用户知道当前主语是哪个 member。
+
+### 3.3 Service Workbench
+
+Service / Invoke 页面负责一次真实请求的运行闭环。
+
+标准结构：
+
+- 顶部 `Service Header`：service、endpoint、scope、revision、状态、主要动作。
+- 阶段提示：`Contract / Invoke / Observe / Govern`，用于表达当前 service 的契约、调用、观察与治理位置。
+- 左侧 `Playground`：prompt、actorId、headers、实际 request preview、run/stop/replay。
+- 左下 `Request History`：最近请求、状态、耗时、结果摘要。
+- 右侧 `AGUI Events`：timeline、trace、tabs、bubbles、raw、run summary、response。
+
+request preview 必须等于实际发送 payload。若 endpoint 不支持当前 workbench 的 streaming invoke，不得伪装成可执行，应给出原因和跳转入口。
+
+Service Workbench 不拥有 implementation build 语义。需要编辑 workflow、script 或 GAgent 实现时，必须跳转到 Member Workbench；service 页面只负责已发布能力的契约、调用、观察和治理。
+
+### 3.4 Platform Governance
+
+Platform 页面负责 service-centric 治理。
+
+它可以更密集、更工具化，但仍要保持：
+
+- 当前对象身份清晰。
+- 版本、部署、流量、policy、binding 的关系清晰。
+- 异步动作有 loading、错误反馈和防重复提交。
+- 表格、筛选、详情抽屉和诊断面板之间有稳定导航关系。
+
+### 3.5 页面职责表
+
+| 页面模型 | 主要路由 | 主语 | 子视图 / 对象 |
+|---|---|---|---|
+| `Team Workbench` | `/teams`、`/teams/:scopeId`、`/teams/:scopeId/:teamId` | Team | activity、topology、intervention、members、team-scoped bindings |
+| `Member Workbench` | `/studio` | Member | build、bind、invoke、observe、implementation、revision |
+| `Service Workbench` | `/services`、service invoke 入口 | Service | contract、invoke、request history、AGUI events、run summary |
+| `Platform Governance` | `/governance`、`/governance/*`、`/deployments` | Platform object | deployment、traffic、policy、binding、endpoint catalog |
+| `Run Diagnostics` | `/runs` 或工作台内嵌 run view | Run | timeline、trace、audit、response、errors、human input |
+
+`Run / Binding / Policy` 不是默认一级页面模型；它们是 Team、Member、Service 或 Platform 工作台中的子视图或治理对象。只有当用户任务明确是跨对象诊断或治理时，才允许作为独立入口出现。
+
+## 4. 架构语义 UI 规则
+
+前端必须把 Aevatar 的 CQRS / Observation / ReadModel 语义显式呈现为 UI 状态。
+
+### 4.1 状态不得混用
+
+以下状态必须分开建模，禁止合并成一个 `success` 或 `completed`：
+
+| UI 状态 | 来源 | 含义 |
+|---|---|---|
+| `LocalDraft` | 本地 UI | 用户还在编辑，未发 command。 |
+| `Accepted` | Command receipt | 后端已受理 command，并返回稳定 `commandId`。 |
+| `Running` | Observation | actor 已开始推进，或 workflow/run 进入执行中。 |
+| `Streaming` | Observation | AGUI / SSE / WebSocket 正在推送 token、tool call、step event。 |
+| `Paused` | Observation / ReadModel | 等待 human input、approval 或 signal。 |
+| `Observed` | ReadModel | 查询结果已经物化到某个 `stateVersion` 或刷新戳。 |
+| `Completed` | 公开业务状态 | 公开 contract 明确表示 run/message/service action 已完成。 |
+| `StillProcessing` | 本地 UI + 超时策略 | 暂无新 observation，但不能证明失败。 |
+| `Failed` | 公开错误状态 | API、observation 或 readmodel 明确返回失败。 |
+
+HTTP 200、`accepted` receipt 或 `POST` 成功只能进入 `Accepted` 或 `Running`，不能直接把业务结果标成 `Completed`。
+
+`Streaming` 是 `Running` 的子状态或表现形式，不要求与 `Running` 互斥。LLM token streaming、tool call streaming 与普通 step 推进可以同时存在；UI 可以用主状态表达 `Running`，用子状态、badge 或 progress rail 表达 `Streaming`。
+
+### 4.2 Query 只读 ReadModel
+
+页面加载最近消息、run summary、team activity、service detail、binding 列表等稳定查询时，默认只能读取已物化的 readmodel 或正式 query DTO。
+
+前端不得设计或调用以下路径作为正常查询体验：
+
+- actor 内部 state 读取。
+- event store replay 后即时返回。
+- query 方法内触发 projection refresh。
+- 根据 actor runtime 结构临时拼装事实。
+
+如果 readmodel 暂时为空或落后，UI 应显示 empty、stale、still processing、refresh available 或 observed version，而不是触发 query-time priming。
+
+### 4.3 Observation 是运行过程，不是查询替代品
+
+AGUI、SSE、WebSocket 与 timeline 事件用于呈现运行过程。它们可以更新当前屏幕的临时体验，但稳定页面恢复、刷新、分享和历史回看仍应回到 readmodel/query。
+
+Observation 面板默认优先展示用户可理解的信息：
+
+1. `Run Summary`
+2. `Response`
+3. `Timeline`
+4. `Trace / Tool Calls`
+5. `Raw`
+
+Raw event 是高级调试视图，不能成为普通用户理解运行结果的唯一入口。
+
+### 4.4 前端稳定依赖
+
+前端可以稳定依赖：
+
+- 公开 DTO 字段。
+- 公开业务状态枚举。
+- `commandId`、`correlationId` 等追踪标识。
+- `readmodel.stateVersion`、`refreshedAt` 或等价新鲜度字段。
+- API 明确声明的 `messageRole`、`messageKind`、`sourceType`、`eventKind`。
+
+前端不得稳定依赖：
+
+- `actorId` 字符串前缀或格式。
+- C# 类名、namespace、GAgent 实现类型名。
+- `EventEnvelope` 内部 route、runtime、stream provider 字段。
+- 后端日志文案或异常字符串。
+- 临时本地缓存中的事实状态。
+
+本节部分架构边界已有 CI 门禁覆盖，例如 actorId 字符串解析、projection lifecycle 边界等会在 `tools/ci/architecture_guards.sh` 及其子脚本中被检查。文档结构与 frontmatter 由 `tools/docs/lint.sh` 覆盖。若新增或恢复专门的前端静态边界门禁，必须同步在本节写明覆盖范围和触发命令。
+
+### 4.5 命名与文案规范
+
+Console Web 面向用户的文案默认使用产品语义，而不是后端实现语义。
+
+推荐用语：
+
+- `Team`：用户正在运营和观察的协作边界。
+- `Member`：Team 内可构建、绑定、调用和观察的能力单元。
+- `Service`：已发布、可治理、可调用的能力入口。
+- `Run`：一次真实执行或调用。
+- `Binding`：成员或服务和运行契约、凭据、endpoint 的连接关系。
+- `Policy`：治理规则、审批要求、流量或访问约束。
+
+仅在调试、高级设置、Raw、Trace 或开发者文档中暴露：
+
+- `actorId`
+- `EventEnvelope`
+- `readmodel`
+- `stateVersion`
+- C# 类型名、namespace、GAgent 实现类型名
+
+普通用户路径应把这些术语翻译为可理解的产品语言。例如 `readmodel.stateVersion` 可以显示为“已观察到版本 42”，`actorId` 可以显示为“运行实体地址”，并放在可复制的高级详情里。
+
+### 4.6 状态展示标准
+
+空态、加载态、错误态、stale 态和 paused 态必须解释当前事实源和下一步动作，不能只显示一个空容器或 spinner。
+
+| 状态 | 必须说明 | 推荐动作 |
+|---|---|---|
+| `Empty` | 当前查询的对象、是否有权限、是否确实没有数据 | 创建、连接、返回 Team、刷新 |
+| `Loading` | 正在读取 query/readmodel，还是正在等待 observation | 保持上下文，不清空已有稳定结果 |
+| `Stale` | 当前 readmodel 的刷新戳或版本，为什么可能落后 | 继续观察、手动刷新、查看最近 run |
+| `StillProcessing` | command 已受理但暂无新 observation | 继续等待、打开 run diagnostics、刷新 readmodel |
+| `Paused` | 等待 human input、approval 还是 signal | 输入、批准、拒绝、发送 signal、查看上下文 |
+| `Failed` | 失败来源是 API、observation、readmodel 还是本地校验 | 重试、复制错误、打开 trace、联系治理入口 |
+
+状态展示不得删除用户已经看到的稳定事实。新的 observation 到达前，页面可以显示“仍在处理”，但不应把已有 readmodel 结果清空成未知。
+
+## 5. 视觉设计立场
+
+### 5.1 先定方向，再写界面
 
 前端实现前，必须先回答三个问题：
 
@@ -29,107 +227,190 @@ owner: potter
 2. 这个工作面最重要的交互是什么？
 3. 这一屏最让人记住的视觉特征是什么？
 
-允许的风格可以很大胆，也可以很克制，但必须单一、明确、连续。  
-可选方向例如：editorial、industrial、warm technical、brutalist、refined minimal、retro-futurist。  
-禁止把多种弱风格混合成“看起来像模板站”的中间态。
+允许的风格可以很大胆，也可以很克制，但必须单一、明确、连续。可选方向例如：editorial、industrial、warm technical、brutalist、refined minimal、retro-futurist。禁止把多种弱风格混合成“看起来像模板站”的中间态。
 
-### 2.2 连续性优先于炫技
+### 5.2 连续性优先于炫技
 
 在已有产品表面上工作时，优先保持：
 
-- 信息架构不变
-- 核心导航不变
-- 主要操作流程不变
-- 领域术语不变
+- 信息架构不变。
+- 核心导航不变。
+- 主要操作流程不变。
+- 领域术语不变。
 
 设计提升应主要体现在层次、比例、排版、状态、密度控制、质感和动效，而不是随意重排用户已经形成肌肉记忆的结构。
 
-## 3. 明确禁止项
+### 5.3 明确禁止项
 
 以下模式在仓库内默认视为低质量实现，应避免作为默认方案：
 
-- 以 `Inter`、`Arial`、`Roboto`、宽泛 `system-ui` 作为首选字体栈
-- 紫白渐变默认主题
-- 千篇一律的 SaaS 卡片墙和统计卡堆叠
-- 没有层次变化的浅灰边框 + 白底面板拼接
-- 为了“看起来现代”而堆砌玻璃态、发光和悬浮阴影
-- 缺少主题 token、完全依赖散落硬编码颜色和 spacing
-- 只追求截图好看，不考虑真实内容密度、滚动状态和空/错/载入态
+- 以 `Inter`、`Arial`、`Roboto`、宽泛 `system-ui` 作为首选字体栈。
+- 紫白渐变默认主题。
+- 千篇一律的 SaaS 卡片墙和统计卡堆叠。
+- 没有层次变化的浅灰边框 + 白底面板拼接。
+- 为了“看起来现代”而堆砌玻璃态、发光和悬浮阴影。
+- 缺少主题 token、完全依赖散落硬编码颜色和 spacing。
+- 只追求截图好看，不考虑真实内容密度、滚动状态和空/错/载入态。
 
 如确有历史兼容或局部延续需求，必须说明为什么不能收敛到更有辨识度的方案。
 
-## 4. 设计系统要求
+## 6. 设计系统要求
 
-### 4.1 Token 优先
+### 6.1 Token 优先
 
 颜色、字体、字号、间距、圆角、阴影、边框、动效时长与 easing，优先收敛为：
 
-- CSS variables
-- theme tokens
-- 可复用样式原语
+- CSS variables。
+- theme tokens。
+- 可复用样式原语。
+
+Console Web 的共享 token 和布局原语优先维护在：
+
+- `apps/aevatar-console-web/src/shared/ui/aevatarWorkbench.ts`
+- `apps/aevatar-console-web/src/shared/ui/proComponents.ts`
+- `apps/aevatar-console-web/src/shared/ui/interactionStandards.ts`
+- `apps/aevatar-console-web/src/global.less`
 
 禁止在多个页面中长期复制相近但不相等的硬编码值。
 
-### 4.2 字体策略
+### 6.2 字体策略
 
-- 优先选择有性格的 display font 搭配克制的正文字体。
-- 如果工作面受现有框架或设计系统限制，允许局部保守，但仍应提升字重、字阶、行高和密度控制。
-- 控制台类产品要优先保证可读性，再追求风格化。
+Console Web 默认使用 `AlibabaSans` 作为产品字体。新增 Console 页面不得回退到 `Inter`、`Arial`、`Roboto` 或裸 `system-ui` 作为主字体。
 
-### 4.3 版式与层次
+CLI Playground 当前若存在历史字体栈，应视为局部历史实现，不得反向扩散到 Console Web。后续 redesign 时应逐步收敛到与 Aevatar 产品气质一致的字体与字号系统。
+
+控制台类产品要优先保证可读性，再追求风格化。display font 只能用于真正的标题、品牌信号或空态表达，不能牺牲表格、编辑器、timeline、trace 和表单的扫描效率。
+
+### 6.3 版式与层次
 
 - 优先通过留白、对齐、尺寸级差、色块关系建立层次，不靠额外说明文字补层次。
 - 允许不对称布局、强调区、分层背景、局部高对比，但必须服务于任务流。
 - 面板、侧栏、工作区和检查区要有清晰主次，避免全部元素同权重。
+- 工具型页面要优先稳定尺寸、滚动区域和响应式约束，避免 hover、loading、长文本导致布局跳动。
+- 不使用卡片套卡片。页面分区用全宽 band、工作台分栏或 unframed layout；卡片只用于列表项、模态、详情块和明确的 framed tool。
 
-### 4.4 动效
+### 6.4 动效
 
 - 动效必须有职责：进入、聚焦、反馈、切换、状态确认。
 - 允许少量高质量的 page-load 或 panel transition。
 - 禁止到处堆 hover 特效和无意义的微动效。
+- 运行态动画要表达真实状态，例如 streaming、loading、paused、failed，不得制造虚假的实时感。
 
-## 5. 按工作面执行的规则
+## 7. 组件交互标准
 
-## 5.1 CLI Playground
+Console Web 交互组件默认继承 [组件交互标准](../design/2026-04-23-component-interaction-standard.md)。
+
+所有按钮、chip、pressable card、tab、toolbar action 和异步入口默认必须满足：
+
+- `default / hover / active / disabled / loading` 状态完整。
+- hover 有清晰反馈，active 有按压反馈。
+- disabled 不可点击，`aria-disabled` 与键盘行为一致。
+- 异步动作 loading 期间不可重复触发。
+- 异步失败必须有用户可见反馈，优先 `message.error(...)`，必要时补局部 `Alert`。
+- keyboard focus 必须可见。
+- 状态切换使用统一 transition。
+
+新增组件优先复用：
+
+- `AEVATAR_INTERACTIVE_BUTTON_CLASS`
+- `AEVATAR_INTERACTIVE_CHIP_CLASS`
+- `AEVATAR_PRESSABLE_CARD_CLASS`
+
+不要回到裸 `<button>`、无 pending lock、无错误提示、只靠灰色表示 disabled 的实现方式。
+
+## 8. 按工作面执行的规则
+
+### 8.1 Console Web
+
+`apps/aevatar-console-web` 运行在既有 Ant Design Pro shell 内，但页面心智应是 Aevatar workbench，而不是默认 Ant Design 管理后台。
+
+要求：
+
+- 默认在现有 shell 内做 refinement，除非用户明确要求大改，否则不推翻全局布局和导航组织。
+- 页面优先表达 `Team / Member / Service / Platform` 的当前主语。
+- `Run / Binding / Policy` 应作为上述工作台内的子视图或治理对象呈现；只有跨对象诊断、审计或治理任务明确存在时，才作为独立入口出现。
+- 高频工作流优先采用 workbench 结构，而不是散装 card grid。
+- AGUI、timeline、trace、request history、readmodel freshness 是一等体验，不是 debug 附件。
+- 表单、表格、编辑器、图谱、运行面板必须在真实内容密度下可读。
+- 任何展示的状态、payload、metric、health、version 都必须能追溯到公开 API、readmodel 或本地 UI 状态。
+
+### 8.2 CLI Playground
 
 `tools/Aevatar.Tools.Cli/Frontend` 是 playground 的权威源码。
 
 要求：
 
-- 优先从共享 token、排版和 panel 原语入手，不做一次性“补丁式美化”
-- 修改后必须同步生成 `tools/Aevatar.Tools.Cli/wwwroot`
-- 必须确保 `demos/Aevatar.Demos.Workflow.Web/wwwroot` 与 CLI playground 产物保持一致
+- 优先从共享 token、排版和 panel 原语入手，不做一次性“补丁式美化”。
+- 修改后必须同步生成 `tools/Aevatar.Tools.Cli/wwwroot`。
+- 必须确保 `demos/Aevatar.Demos.Workflow.Web/wwwroot` 与 CLI playground 产物保持一致。
+- Playground 可以更实验性，但 request、streaming、history 和 observation 语义必须与 Console Web 保持一致。
 
-## 5.2 Console Web
-
-`apps/aevatar-console-web` 运行在既有控制台壳之上。
-
-要求：
-
-- 默认在现有 Ant Design Pro shell 内做 refinement
-- 除非用户明确要求大改，否则不推翻全局布局和导航组织
-- 强调页面层级、阅读节奏、表单/面板状态和高频操作可见性
-
-## 5.3 Demo Web
+### 8.3 Demo Web
 
 `demos/Aevatar.Demos.Workflow.Web/wwwroot` 主要承担演示和体验验证职责。
 
 要求：
 
-- 与 CLI playground 保持资产和核心样式一致
-- 若存在 Demo 特有按钮或壳层差异，必须限制在 demo 边界内，不反向污染主源码结构
+- 与 CLI playground 保持资产和核心样式一致。
+- 若存在 Demo 特有按钮或壳层差异，必须限制在 demo 边界内，不反向污染主源码结构。
+- Demo 可以简化治理能力，但不能简化到误导用户理解 command、observation、readmodel 的状态边界。
 
-## 6. 质量门槛
+## 9. 质量门槛
 
 前端实现默认要满足以下要求：
 
-- 桌面端与移动端都能正常加载和操作
-- 键盘导航可达
-- 真实内容密度下仍然可读
-- 空态、加载态、错误态至少具备基本视觉处理
-- 不为了风格牺牲表单、编辑器、图形工作区等核心交互的可用性
+- 桌面端与移动端都能正常加载和操作。
+- 键盘导航可达。
+- 真实内容密度下仍然可读。
+- 空态、加载态、错误态、stale 态、paused 态至少具备基本视觉处理。
+- 文本不溢出、不遮挡、不因为按钮标签、长 ID、长 service 名称破坏布局。
+- 不为了风格牺牲表单、编辑器、图形工作区、timeline、trace 等核心交互的可用性。
+- 不把调试视图作为普通用户理解运行结果的唯一入口。
 
-## 7. 验证要求
+## 10. 响应式优先级
+
+Console Web 是密集工具，不是 landing page。桌面端是完整构建和治理的主工作面，移动端必须保证关键运行与介入动作可完成。
+
+移动端最低要求：
+
+- 可以查看 Team / Service / Run 的当前状态和最近活动。
+- 可以读取 response、timeline 摘要、错误原因和 paused 原因。
+- 可以完成 human input、approval、signal、stop、retry 等运行介入动作。
+- 可以复制 endpoint、commandId、runId、错误信息和关键 trace 链接。
+- 可以从 Team 跳到 Studio / Service / Run 的正确上下文。
+
+允许桌面优先的能力：
+
+- 复杂 workflow / graph 编辑。
+- 多栏 trace 对比。
+- 大型表格批量治理。
+- 长 JSON / Raw payload 编辑。
+
+这类桌面优先能力在移动端必须给出诚实降级，不得显示看似可编辑但实际不可用的半成品 UI。
+
+## 11. PR 设计自查清单
+
+Console Web 相关 PR 在提交前至少自查：
+
+1. 页面主语是否明确是 `Team / Member / Service / Platform / Run` 之一。
+2. 是否伪造了后端不存在的 team catalog、analytics、health、roster 或 run 事实。
+3. `POST` 成功、`accepted` receipt、observation、readmodel observed、completed 是否被分开显示。
+4. query 是否只读正式 readmodel / query DTO，没有 query-time replay 或 projection refresh。
+5. UI 是否解析了 `actorId` 前缀、C# 类名、`EventEnvelope` 内部字段或日志文案。
+6. request preview 是否等于实际发送 payload。
+7. Raw / Trace 是否只是高级入口，而不是普通用户理解结果的唯一入口。
+8. loading、empty、stale、paused、failed 是否都有原因和下一步动作。
+9. 异步按钮是否有 loading、防重复点击、错误反馈和 keyboard focus。
+10. 移动端是否至少能查看状态、复制关键标识、处理人工介入和打开诊断。
+
+## 12. 验证要求
+
+修改 `apps/aevatar-console-web` 后，至少执行与改动相称的前端构建校验，例如：
+
+```bash
+npm --prefix apps/aevatar-console-web run tsc
+npm --prefix apps/aevatar-console-web run build
+```
 
 修改 `tools/Aevatar.Tools.Cli/Frontend` 后，至少执行：
 
@@ -139,11 +420,9 @@ pnpm -C tools/Aevatar.Tools.Cli/Frontend exec vite build --outDir tools/Aevatar.
 bash tools/ci/playground_asset_drift_guard.sh
 ```
 
-修改 `apps/aevatar-console-web` 后，至少执行与改动相称的前端构建校验，例如：
+如果任务只涉及文档或规则更新，不需要运行前端构建；至少执行：
 
 ```bash
-npm --prefix apps/aevatar-console-web run tsc
-npm --prefix apps/aevatar-console-web run build
+bash tools/docs/lint.sh
+git diff --check
 ```
-
-如果任务只涉及文档或规则更新，至少执行文档 lint，确保权威文档结构合法。

--- a/docs/discussions/2026-05-11-frontend-architecture-discussion.md
+++ b/docs/discussions/2026-05-11-frontend-architecture-discussion.md
@@ -1,0 +1,581 @@
+---
+title: "Console Web 前端设计讨论"
+status: draft
+owner: potter
+last_updated: 2026-05-11
+---
+
+# Console Web 前端设计讨论
+
+## 1. 结论
+
+当前 [前端设计基线](../canon/frontend-design.md) 的方向是合理的，而且比普通 UI 规范更接近 Aevatar 真正需要的东西：它没有只讨论颜色、字体和卡片，而是把 `Team / Member / Service / Run / Governance` 这些产品主语和 `Command / Observation / ReadModel` 这些架构语义放进了前端规则里。
+
+这很关键。Aevatar Console Web 不能只是一个后台管理系统。它应该帮助用户理解和运营一个 AI Team。
+
+但这份规范还需要通过一个团队讨论稿继续补强。原因是：规范回答的是“以后前端应该遵守什么规则”，团队还需要回答“我们为什么这样做、先做哪几页、用哪些后端事实源、怎么判断做对了”。
+
+本讨论稿的建议是：
+
+1. 把 Console Web 明确定位成 `AI Team Workbench`，而不是对象浏览器。
+2. 让前端围绕用户任务组织页面，而不是围绕后端对象平铺页面。
+3. 把 `Command 已受理`、`Observation 正在推进`、`ReadModel 已物化` 做成用户能看懂的状态。
+4. 把 Team、Member、Service、Run 的职责切开，避免一个页面同时扮演编辑器、调试器、治理台和审计台。
+5. 先做少数关键闭环：Team 状态理解、Member 构建调用、Service 调用观察、Run 诊断。
+
+## 2. 设计原则：从用户工作流出发，不从后端对象出发
+
+后端有 Team、Member、Service、Workflow、Script、Run、Governance 这些概念。但用户打开 Console Web 的时候，脑子里想的不是这些词。
+
+用户进来只有三种情况：
+
+### 情况 A："我要做一个 AI 能力"
+
+他需要的是：选一个 Team → 选一个 Member → 写/改实现 → 绑定 → 发一次 → 看结果。
+
+这是一条**线性工作流**，不是五个独立页面。
+
+### 情况 B："出事了，我要看看怎么了"
+
+他需要的是：看到哪个 Team/Run 有问题 → 看失败在哪一步 → 看能不能介入 → 复制信息给同事。
+
+这是一条**诊断工作流**，起点是异常信号，不是导航菜单。
+
+### 情况 C："我要管一个已上线的能力"
+
+他需要的是：看 Service 状态 → 看版本/流量/策略 → 改绑定或策略 → 确认生效。
+
+这是一条**治理工作流**，核心是"当前状态是什么"和"我改了之后生效了吗"。
+
+### 核心原则
+
+**让每条工作流在一个屏幕内走完，而不是让用户在五个页面之间跳转。**
+
+具体来说：
+
+1. **第一屏不应该是"列表"，应该是"当前上下文 + 待办"。** 用户打开 Console Web，第一屏应该回答：我在哪个 Team？有没有正在运行的、等待我介入的、刚失败的？我上次做到哪一步了？列表本身就是状态面板，不是"名称 + 描述"的目录。
+
+2. **核心页面不是"对象详情页"，而是"工作台"。** Workbench 的核心是"我正在做的事"，不是"这个对象的属性"。Team Workbench 的主区域应该是当前运行状态和待处理事项，Topology 是下钻能力，不是首页主视觉。
+
+3. **"Service" 不应该是独立的列表页，而是 Member 发布后的自然延伸。** 用户从 Team → Member → Build → Bind → 发布 → 进入 Service Workbench。Platform Owner 需要的全局 Service 视图是平台治理的一部分，不是产品主体验。
+
+4. **"Runs" 不应该是独立页面，应该是每个工作台的一部分。** Run Diagnostics 是一个共享视图，可以从任何工作台打开。高级 Operator 需要的全局 Run 视图是高级诊断入口，不是主体验。
+
+5. **后端的 Team / Member / Service / Run / Governance 是事实模型，不是页面模型。** 前端应该把事实模型翻译成用户的工作流，而不是把事实模型平铺成列表页。
+
+以上三种情况覆盖了 Builder、Operator、Platform Owner 三类主要用户。第四类用户 Frontend / Backend Contributor 的需求（知道哪些事实源可用、哪些状态来自哪里、PR 应该跑什么校验）由规范文档本身服务，不需要独立的工作流入口。
+
+### 翻译到具体页面
+
+| 用户场景 | 当前做法 | 理想做法 |
+|---|---|---|
+| "我要做一个 AI 能力" | 跳 Teams → Team Detail → Members → Studio → 执行 → 回到 Runs 看结果 | Team Workbench 内完成：选 Member → Build → Bind → Invoke → Observe，不离开当前页面 |
+| "出事了" | 跳到 Runs 页 → 找到 run → 看 timeline → 看错误 | Team 首页有异常信号入口，点击直接进入 Run Diagnostics，诊断完成后可跳回 Member 修改 |
+| "我要管一个已上线的能力" | 跳 Services → 详情 → Deployments → Governance | Service Workbench 内完成：看 contract → 看 serving/traffic → 改 policy/binding → 确认生效 |
+| "我要看整个平台" | Platform 分组下有 5 个独立入口 | Platform Governance 作为高级入口保留，但主体验从 Teams 开始 |
+
+## 3. 产品视角 Review
+
+### 3.1 当前规范合理的地方
+
+当前 `docs/canon/frontend-design.md` 最有价值的部分不是视觉规则，而是产品语义规则。
+
+它明确了：
+
+1. Console Web 的主语是 `AI Team Workbench`。
+2. 页面模型应收敛到 `Team Workbench / Member Workbench / Service Workbench / Platform Governance / Run Diagnostics`。
+3. 前端不能把 `HTTP 200`、`accepted receipt`、`running`、`observed`、`completed` 混成一个成功态。
+4. Query 只读 readmodel，Observation 只表达运行过程，Raw event 只是高级调试视图。
+5. 前端不能依赖 `actorId` 前缀、C# 类型名、`EventEnvelope` 内部字段或日志文案。
+6. 视觉规范要求 token、交互状态、响应式、空态、stale 态和 paused 态，这些都服务真实使用，而不是只服务截图。
+
+这是正确方向。
+
+### 3.2 还需要补强的地方
+
+当前规范仍然偏“规则”。团队讨论时还需要补齐以下内容：
+
+| 缺口 | 为什么重要 | 建议补充 |
+|---|---|---|
+| 用户角色不够明确 | Builder、Operator、Platform Owner 的任务不同 | 明确每类用户进入 Console 后最常做的 3 件事 |
+| 页面优先级不够明确 | 全部页面都重要，就等于没有优先级 | 给 Team、Member、Service、Run 排 P0/P1/P2 |
+| 数据契约矩阵不足 | 前端容易为了视觉完整性拼假数据 | 每个页面列出必须读取的 API、readmodel、observation |
+| 成功指标不足 | 团队很难判断设计是否变好 | 为每个工作台定义可验证的体验指标 |
+| 组件策略不足 | Observation、状态条、诊断面板会重复造轮子 | 定义共享组件和禁止重复实现的范围 |
+| 权限和降级状态不足 | 企业控制台最常见的问题不是空态，而是无权限、过期、延迟、部分失败 | 补充权限、stale、partial、unsupported endpoint 的 UI 规则 |
+
+## 4. 用户与核心任务
+
+前端设计应该从用户任务出发，不从后端对象出发。
+
+### 4.1 Builder
+
+Builder 想完成的是：
+
+1. 创建或选择一个 Team。
+2. 找到某个 Member。
+3. 修改 workflow、script 或 GAgent 实现。
+4. 绑定并发布。
+5. 立刻发一次真实 invoke。
+6. 看结果、看 timeline、看失败原因。
+
+Builder 不应该被迫理解 `serviceId`、`actorId`、`EventEnvelope` 或投影内部字段。
+
+### 4.2 Operator
+
+Operator 想完成的是：
+
+1. 看当前 Team 是否还在运行。
+2. 看最近 run 是否失败、暂停或等待人工介入。
+3. 处理 human input、approval、signal、stop、retry。
+4. 打开 run diagnostics 找到失败步骤。
+5. 复制 runId、commandId、错误信息或 trace 链接给工程同学。
+
+Operator 最怕的是页面显示“成功”，但实际只是 command accepted。这个会直接误导操作。
+
+### 4.3 Platform Owner
+
+Platform Owner 想完成的是：
+
+1. 看 Service 的 contract、revision、deployment、serving、traffic。
+2. 管理 binding、policy、endpoint exposure。
+3. 确认某次发布有没有进入正确 serving set。
+4. 从 Service 下钻到一次具体 run。
+
+Platform Owner 需要密集、稳定、可筛选的信息，不需要营销式大卡片。
+
+### 4.4 Frontend / Backend Contributor
+
+贡献者想完成的是：
+
+1. 知道一个页面允许读取哪些事实源。
+2. 知道哪些状态必须从 API、readmodel、observation 或本地 UI 推导。
+3. 知道不能为了体验绕过 readmodel 或解析 actorId。
+4. 知道 PR 提交前应该跑哪些校验。
+
+这类用户需要的是规则和边界。规范文档应该服务他们。
+
+## 5. 前端应该怎么服务用户
+
+### 5.1 把架构复杂度翻译成用户语言
+
+Aevatar 的后端架构很强，但用户不应该被迫直接消费架构术语。
+
+前端应该这样翻译：
+
+| 架构事实 | 用户语言 |
+|---|---|
+| Command accepted | 请求已受理 |
+| Observation streaming | 正在运行，收到实时进展 |
+| ReadModel observed | 已观察到最新可查询状态 |
+| stateVersion | 已观察到版本 |
+| actorId | 运行实体地址 |
+| EventEnvelope raw payload | 原始事件，仅用于调试 |
+| Projection lag | 数据可能稍有延迟 |
+
+这个翻译层是前端的核心价值。否则 Console Web 只是把后端对象倒出来。
+
+### 5.2 把一次工作闭环放在一个屏幕里
+
+用户最常见的闭环不是“浏览一个列表”，而是：
+
+1. 选择上下文。
+2. 发起动作。
+3. 观察过程。
+4. 判断结果。
+5. 失败时诊断。
+6. 需要时治理或修改。
+
+所以高频页面应该是 workbench，而不是 CRUD 列表。
+
+### 5.3 不伪装强一致
+
+如果后端只返回 accepted，页面就只能显示 accepted。
+
+如果 readmodel 可能落后，页面就应该显示 `refreshedAt`、`stateVersion` 或“仍在处理”。
+
+如果 observation 断开，页面不能假装 run 完成。应该显示“实时连接已断开，最后收到事件时间为 X，可刷新 readmodel 或打开 Run Diagnostics”。
+
+这个诚实性会让产品看起来更复杂一点，但它会减少误判。对开发者工具来说，这是好事。
+
+### 5.4 让 Raw 成为最后一层
+
+普通用户的观察顺序应该是：
+
+1. Summary
+2. Response
+3. Timeline
+4. Trace / Tool Calls
+5. Raw
+
+Raw event 很重要，但不能成为默认解释路径。否则用户会觉得产品只做了一半。
+
+## 6. 页面 Review 与建议
+
+### 6.1 Teams
+
+`/teams` 和 Team Detail 应该是 Console Web 的第一主屏。
+
+当前合理点：
+
+1. 路由已经把 `/overview` 和 `/` 重定向到 `/teams`。
+2. Team 已经是主导航入口。
+3. Team Detail 已经有 detail route，适合承接 workbench。
+
+需要优化：
+
+1. Team 列表页不应只像对象目录，应展示每个 Team 的可验证状态摘要。
+2. Team Detail 不应只是 tab 管理页，应升级成运行工作台。
+3. Team 页面应内置最近 run、activity、paused/intervention、members、bindings 的关系。
+4. 不要展示没有契约支持的全局健康、组织级 KPI 或跨 team analytics。
+
+建议 P0：
+
+1. Team Header 固定显示 `Team / Scope / Member count / Last observed / Pending action`。
+2. Activity 区域复用 Run/Observation 摘要。
+3. Paused run 必须有一等入口，例如 human input、approval、signal。
+4. Topology 和 Bindings 是下钻，不是首页主视觉。
+
+### 6.2 Studio / Member Workbench
+
+Studio 的正确主语是 `Member`，不是 workflow、script、GAgent 的资产集合。
+
+当前合理点：
+
+1. ADR-0016 已经锁定 `scope -> member -> implementation -> published service -> endpoint -> run`。
+2. `docs/2026-04-27-member-first-studio-apis.md` 已经给出 member-first route。
+3. `docs/design/2026-04-20-studio-member-workbench-prd.md` 已经把 Studio 定义成 `Build -> Bind -> Invoke -> Observe`。
+
+需要优化：
+
+1. `/studio` 目前是隐藏页面，这会让高频 Builder 工作流不够可发现。
+2. Studio 和 Members 页的关系需要产品决策：是合并，还是保持 Members 为 roster，Studio 为 selected member workbench。
+3. URL 和 UI 必须明确当前 `scopeId / teamId / memberId`，不能让用户不知道自己在改谁。
+
+建议 P0：
+
+1. 从 Team Detail 的 member roster 进入 Studio，并携带 `scopeId/teamId/memberId`。
+2. Studio 左 rail 永远是当前 Team 的 members，不是资产类型导航。
+3. Build、Bind、Invoke、Observe 的每一步都显示当前 member 和 published service contract。
+4. 普通用户不输入 `serviceId`，只看到只读 contract metadata。
+
+### 6.3 Services / Service Workbench
+
+Service 页面应该从列表升级为 Service Workbench。
+
+当前合理点：
+
+1. 后端已经有 service catalog、revision、deployment、rollout、serving、traffic、binding、policy 等 readmodel。
+2. `/services`、`/deployments`、`/governance` 已经存在，说明平台层能力是成熟方向。
+
+需要优化：
+
+1. Service 生命周期被拆在多个页面，用户很难理解一个 service 的完整状态。
+2. Invoke 能力分散在 Chat、Scope Invoke、Runs 等页面，Service 下缺少一次真实请求闭环。
+3. Governance 的 policy/binding/endpoint 和 Service 的关系需要更直接。
+
+建议 P1：
+
+1. `/services/:serviceId` 做成 Service Workbench。
+2. 顶部显示 `Contract / Invoke / Observe / Govern`。
+3. Invoke 面板必须有 actual request preview，且 preview 等于真实发送 payload。
+4. Deployments 和 Governance 可以保留独立入口，但应能从 Service Workbench 下钻或回跳。
+
+### 6.4 Runs / Run Diagnostics
+
+Run Diagnostics 是跨页面诊断工具，不应只被理解为 Event Stream。
+
+当前合理点：
+
+1. `/runtime/runs` 已经是较完整的 observation 入口。
+2. 后端存在 timeline、audit、insight report 等能力。
+
+需要优化：
+
+1. Runs 页应该成为所有工作台的诊断落点。
+2. Team、Member、Service 页打开某个 run 时，应进入同一套诊断视图。
+3. Run 状态必须区分 accepted、running、streaming、paused、observed、completed、failed。
+
+建议 P0：
+
+1. 抽取共享 `Observation Panel`。
+2. 抽取共享 `Run Status Rail`。
+3. 每个 run detail 支持复制 `runId / commandId / correlationId / error / trace link`。
+4. Paused 状态必须显示等待什么，以及用户能做什么。
+
+### 6.5 Governance / Deployments
+
+Governance 和 Deployments 是 Platform Owner 的工作台，不是 Team 的主体验。
+
+当前合理点：
+
+1. 这些页面继续作为独立入口是合理的。
+2. 它们信息密度可以更高，更接近传统控制台。
+
+需要优化：
+
+1. 需要从 Service Workbench 建立上下文跳转。
+2. Policy、Binding、Endpoint、Traffic 的关系要可解释。
+3. 异步动作必须有 loading、防重复提交、失败原因和回滚解释。
+
+建议 P1：
+
+1. Governance 页保留平台全局视角。
+2. Service Workbench 内嵌该 Service 的 governance summary。
+3. 用户从全局 Governance 点进具体对象后，应能回到对应 Service。
+
+## 7. 导航建议
+
+当前导航结构大体可用，但需要围绕任务重新解释。
+
+建议的一级导航：
+
+| 入口 | 定位 | 说明 |
+|---|---|---|
+| `Teams` | 运行与协作入口 | 默认首页 |
+| `Studio` | Member Workbench | 可作为一级入口，但必须要求选择 Team/Member |
+| `Services` | 已发布能力入口 | 从列表进入 Service Workbench |
+| `Runs` | 诊断入口 | 可以保留在 Platform 或提升为一级，取决于用户是否高频排障 |
+| `Governance` | 平台治理 | policy、binding、endpoint |
+| `Deployments` | 发布与流量 | 可以保留，也可以并入 Services 的平台分组 |
+| `Settings` | 用户配置 | 不变 |
+
+不建议把所有隐藏页面都提升为一级入口。`Workflows / Scripts / GAgents / Connectors` 更适合作为 Member、Service 或 Governance 内的子对象。
+
+真正要讨论的是 `Studio` 和 `Runs`：
+
+1. 如果目标用户主要是 Builder，`Studio` 应提升为一级入口。
+2. 如果目标用户主要是 Operator，`Runs` 或 `Operations` 应更可见。
+3. 如果目标是统一团队体验，入口仍应从 `Teams` 开始，Studio 和 Runs 作为上下文动作。
+
+## 8. 数据契约矩阵
+
+每个页面都应该声明自己的事实源。没有事实源，就不要展示假状态。
+
+| 页面 | 可展示事实 | 来源 |
+|---|---|---|
+| Team List | team identity、lifecycle、member count | Team readmodel |
+| Team Detail | roster、activity、bindings、recent run summary | Team readmodel、member readmodel、run readmodel |
+| Studio | selected member、implementation、binding、published service、member runs | member-first APIs、script/workflow readmodel、run readmodel |
+| Service Workbench | contract、revision、deployment、traffic、policy、invoke result | service readmodels、invoke observation、run readmodel |
+| Run Diagnostics | timeline、trace、summary、response、audit、errors | observation、run insight report、audit readmodel |
+| Governance | policies、bindings、endpoints | governance/service configuration readmodels |
+| Deployments | deployment、rollout、serving set、traffic | service deployment readmodels |
+
+每个组件也应该知道自己的数据层级：
+
+| UI 元素 | 数据层级 |
+|---|---|
+| form draft | Local UI |
+| submit receipt | Command receipt |
+| live token / step event | Observation |
+| final summary after refresh | ReadModel |
+| raw payload | Debug only |
+
+## 9. 前端实现建议
+
+### 9.1 共享组件
+
+建议优先抽取这些共享组件：
+
+1. `WorkbenchContextHeader`
+2. `ObservationPanel`
+3. `RunStatusRail`
+4. `ReadModelFreshnessBadge`
+5. `CommandReceiptBanner`
+6. `PausedInterventionPanel`
+7. `ActualRequestPreview`
+8. `TraceCopyMenu`
+
+这些组件不要绑定某个页面。它们应该服务 Team、Member、Service、Run 四类工作台。
+
+### 9.2 状态模型
+
+前端应把状态统一成四层：
+
+1. `localDraft`
+2. `commandReceipt`
+3. `observation`
+4. `readModel`
+
+页面展示时再映射为：
+
+1. `LocalDraft`
+2. `Accepted`
+3. `Running`
+4. `Streaming`
+5. `Paused`
+6. `Observed`
+7. `Completed`
+8. `StillProcessing`
+9. `Failed`
+
+不要让每个页面各自发明一套状态名。
+
+### 9.3 React Query 约束
+
+建议统一 query key 形态：
+
+1. `["team", scopeId, teamId]`
+2. `["team", scopeId, teamId, "members"]`
+3. `["member", scopeId, teamId, memberId]`
+4. `["service", serviceId]`
+5. `["service", serviceId, "runs"]`
+6. `["run", runId]`
+
+SSE/WebSocket 到达后，可以更新当前屏幕的临时 observation state，但页面恢复、刷新、分享和历史回看应回到 readmodel/query。
+
+### 9.4 视觉系统
+
+当前规范中关于 token、AlibabaSans、禁止模板化 SaaS 卡片墙的方向可以保留。
+
+但落地时要注意：
+
+1. Console Web 是工具，不是 landing page。
+2. Team 和 Service 的首屏要高密度可扫描。
+3. 视觉记忆点应该来自工作台结构、状态轨、timeline 和运行反馈，不是装饰性渐变。
+4. 移动端至少要能看状态、处理暂停、复制诊断信息。
+
+## 10. 后端配合建议
+
+这些不是要求后端为了前端临时造假，而是把已有架构能力用更清晰的 DTO 暴露出来。
+
+建议优先补齐：
+
+1. Team scoped recent activity query。
+2. Team/member scoped run summary query。
+3. 每个 readmodel 返回 `stateVersion` 或 `refreshedAt`。
+4. Run summary 中明确 `status / pausedReason / nextActions / lastObservationAt`。
+5. Service detail 聚合 DTO，至少聚合 catalog、latest revision、serving、traffic、policy summary。
+6. Endpoint capability DTO，明确某 endpoint 是否支持 streaming invoke。
+
+不建议：
+
+1. 让前端 query-time replay event store。
+2. 让前端解析 actorId 字符串。
+3. 用后端日志文案当 UI 状态。
+4. 为了做 dashboard 指标先加没有权威事实源的伪字段。
+
+## 11. 需求优先级
+
+### P0：先让核心闭环诚实可用
+
+1. Team Detail 显示真实 roster、recent runs、paused/intervention、bindings。
+2. Studio 固化 Member Workbench，入口从 Team Member 进入。
+3. Run Diagnostics 统一状态与 observation 展示。
+4. 前端状态模型区分 command、observation、readmodel。
+5. 文档和 PR checklist 明确禁止假事实源。
+
+### P1：把 Service Workbench 做成闭环
+
+1. Service detail 聚合 contract、invoke、observe、govern。
+2. Invoke 支持 actual request preview。
+3. Request history 只展示真实请求记录或明确标注本地 session。
+4. Governance、Deployments 与 Service 建立上下文互跳。
+
+### P2：提升规模化运营体验
+
+1. Team scoped activity inbox。
+2. 跨 run 比较。
+3. 更完整的 platform topology。
+4. 组织级 analytics，前提是后端有明确权威事实源。
+
+## 12. 成功指标
+
+团队可以用这些问题判断设计是否变好：
+
+1. 新用户能否在 3 分钟内理解当前 Team 正在发生什么。
+2. Builder 能否从 Team member 进入 Studio，并完成一次 build、bind、invoke、observe。
+3. Operator 能否在不看 Raw event 的情况下判断一次 run 失败在哪里。
+4. Platform Owner 能否从 Service 看清 revision、deployment、traffic、policy 的关系。
+5. 页面刷新后，用户是否仍能通过 readmodel 恢复稳定状态。
+6. 前端 PR 是否能明确说明每个状态来自 API、readmodel、observation 还是 local UI。
+
+## 13. 团队讨论议题
+
+建议会议只讨论这些决策，不要散开：
+
+1. 是否认同"从用户工作流出发，不从后端对象出发"作为 Console Web 的设计原则？如果认同，§2 的三种用户场景是否完整？
+2. `Studio` 是否提升为一级导航，还是保持从 Team 上下文进入？
+3. `Runs` 是否作为一级诊断入口，还是保留在 Platform 分组？
+4. Team Detail 第一版是否要从 tab 管理页改成 workbench 分栏？
+5. Service detail 是否升级为 Service Workbench，Deployments/Governance 是否保持独立入口？
+6. `ObservationPanel` 是否作为前端共享基础设施优先抽取？
+7. readmodel freshness 是否要求所有关键页面统一展示？
+8. 哪些指标明确不做，直到后端有权威事实源？
+
+## 14. 附录：当前导航快照
+
+当前 `apps/aevatar-console-web/config/routes.ts` 中，主要侧边栏入口是：
+
+```text
+Teams          -> /teams
+Platform
+  Services     -> /services
+  Governance   -> /governance
+  Deployments  -> /deployments
+  Topology     -> /runtime/explorer
+  Event Stream -> /runtime/runs
+Settings       -> /settings
+```
+
+以下页面目前隐藏在侧边栏外：
+
+1. `/studio`
+2. `/runtime/workflows`
+3. `/runtime/primitives`
+4. `/chat`
+5. `/runtime/mission-control`
+6. `/runtime/gagents`
+7. `/scopes/invoke`
+8. `/scopes/overview`
+9. `/scopes/assets`
+
+这些隐藏页面不一定都应该提升。更合理的方式是把它们归位到 Team、Member、Service 或 Platform 的上下文里。
+
+## 15. 附录：当前 ReadModel 与页面对照
+
+### Studio / Team / Member
+
+| ReadModel | 前端消费 | 说明 |
+|---|---|---|
+| `StudioTeamCurrentStateDocument` | Team pages | Team 列表和详情 |
+| `StudioMemberCurrentStateDocument` | Members / Studio | Member 列表和当前 member |
+| `UserConfigCurrentStateDocument` | Settings | 用户配置 |
+| `ConnectorCatalogCurrentStateDocument` | Connectors / Governance | 连接器目录 |
+| `RoleCatalogCurrentStateDocument` | 待定 | 角色目录 |
+| `ChatConversationCurrentStateDocument` | Chat | 对话状态 |
+| `ChatHistoryIndexCurrentStateDocument` | Chat | 对话历史 |
+| `GAgentRegistryCurrentStateDocument` | Members / Studio | GAgent 注册表 |
+
+### Workflow / Run
+
+| ReadModel | 前端消费 | 说明 |
+|---|---|---|
+| `WorkflowRunInsightReportDocument` | Runs | 完整执行报告 |
+| `WorkflowExecutionCurrentStateDocument` | Runs | 执行当前状态 |
+| `WorkflowRunTimelineDocument` | Runs | 执行时间线 |
+| `WorkflowRunGraphArtifactDocument` | Topology Explorer | 图拓扑 |
+| `WorkflowActorBindingDocument` | Team Detail bindings | Actor 绑定 |
+
+### Service
+
+| ReadModel | 前端消费 | 说明 |
+|---|---|---|
+| `ServiceCatalogReadModel` | Services | Service 目录 |
+| `ServiceRevisionCatalogReadModel` | Services detail | Revision 列表 |
+| `ServiceDeploymentCatalogReadModel` | Deployments | 部署目录 |
+| `ServiceRolloutReadModel` | Deployments | Rollout 状态 |
+| `ServiceServingSetReadModel` | Deployments | Serving 目标 |
+| `ServiceTrafficViewReadModel` | Deployments | 流量分布 |
+| `ServiceRunCurrentStateReadModel` | Runs / Service | Run 状态 |
+| `ServiceConfigurationReadModel` | Governance | 治理配置 |
+
+### Scripting
+
+| ReadModel | 前端消费 | 说明 |
+|---|---|---|
+| `ScriptReadModelDocument` | Studio | 脚本状态 |
+| `ScriptCatalogEntryDocument` | Studio | 脚本目录 |
+| `ScriptEvolutionReadModel` | Studio | 演化提案 |
+| `ScriptDefinitionSnapshotDocument` | 待定 | 定义快照 |


### PR DESCRIPTION
## Summary

- expand `docs/canon/frontend-design.md` into a Console Web design baseline that covers product positioning, page models, CQRS/Observation/ReadModel UI semantics, frontend dependency boundaries, state display standards, responsive priorities, and validation requirements
- add `docs/discussions/2026-05-11-frontend-architecture-discussion.md` as a PM-oriented team discussion doc for Console Web frontend design, navigation, page responsibilities, data contracts, shared components, priorities, and success metrics

## Why

The Console Web design guidance needs to describe more than visual style. Aevatar's frontend has to help users understand and operate AI Teams without leaking backend internals or faking consistency. This PR aligns frontend guidance with Team / Member / Service / Run / Governance workflows and makes the frontend contract around commands, observations, and read models explicit.

## Impact

- Documentation-only change
- Gives frontend contributors a clearer design baseline for Console Web, CLI playground, and demo surfaces
- Gives product/frontend/backend contributors a concrete discussion artifact for deciding navigation, workbench boundaries, shared observation components, and data-source ownership

## Validation

- `bash tools/docs/lint.sh`
- `git diff --check`
- `git diff --cached --check`
