### PR TITLE
Prevent team-level invoke semantics

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.test.tsx
@@ -16,7 +16,6 @@ jest.mock('@/shared/api/runtimeRunsApi', () => ({
 jest.mock('@/shared/api/scopeRuntimeApi', () => ({
   scopeRuntimeApi: {
     getMemberEndpointContract: jest.fn(),
-    getServiceEndpointContract: jest.fn(),
   },
 }));
 
@@ -63,38 +62,13 @@ describe('StudioMemberInvokePanel', () => {
       supportsSse: false,
       supportsWebSocket: false,
     });
-    (scopeRuntimeApi.getServiceEndpointContract as jest.Mock).mockImplementation(
-      (_scopeId: string, serviceId: string, endpointId: string) =>
-        Promise.resolve({
-          defaultSmokeInputMode: 'typed-payload',
-          defaultSmokePrompt: null,
-          deploymentStatus: 'Active',
-          endpointId,
-          fetchExample: null,
-          curlExample: null,
-          invokePath: `/api/scopes/scope-1/services/${serviceId}/invoke/${endpointId}`,
-          method: 'POST',
-          requestContentType: 'application/json',
-          requestTypeUrl: 'type.googleapis.com/example.ContractSubmit',
-          responseContentType: 'application/json',
-          responseTypeUrl: 'type.googleapis.com/example.ContractSubmitResult',
-          revisionId: 'contract-rev',
-          sampleRequestJson: '{"message":"hello"}',
-          scopeId: 'scope-1',
-          serviceId,
-          smokeTestSupported: true,
-          streamFrameFormat: null,
-          supportsAguiFrames: false,
-          supportsSse: false,
-          supportsWebSocket: false,
-        }),
-    );
     (parseBackendSSEStream as jest.Mock).mockImplementation(async function* () {});
   });
 
   it('renders the invoke workbench skeleton with a compact contract and a persistent console', async () => {
     render(
       React.createElement(StudioMemberInvokePanel, {
+        memberId: 'default',
         memberRevision: {
           allocationWeight: 100,
           artifactHash: 'hash-2',

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokePanel.tsx
@@ -321,7 +321,9 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
     trimOptional(selectedService?.displayName) ||
     trimOptional(selectedService?.serviceId) ||
     '当前成员';
-  const canInvoke = Boolean(scopeId && selectedService && selectedEndpoint);
+  const canInvoke = Boolean(
+    scopeId && normalizedMemberId && selectedService && selectedEndpoint,
+  );
   const visibleRequestHistory = useMemo(() => {
     const currentServiceId =
       trimOptional(selectedService?.serviceId) || trimOptional(initialServiceId);
@@ -363,11 +365,11 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   const currentRawOutput = currentRunViewModel.rawOutput;
   const currentContractStatusLabel = getContractStatusLabel({
     hasEndpoint: Boolean(selectedEndpoint),
-    hasMember: Boolean(selectedService),
+    hasMember: Boolean(normalizedMemberId),
   });
   const currentContractStatus = getContractStatus({
     hasEndpoint: Boolean(selectedEndpoint),
-    hasMember: Boolean(selectedService),
+    hasMember: Boolean(normalizedMemberId),
   });
   const consoleMinHeight = screens.xl || screens.lg ? 280 : 220;
   const runElapsedLabel = formatElapsedTime(
@@ -463,7 +465,13 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   useEffect(() => {
     const endpointId = trimOptional(selectedEndpoint?.endpointId);
     const serviceId = trimOptional(selectedService?.serviceId);
-    if (!scopeId || !endpointId || !serviceId || selectedService?.kind === 'nyxid-chat') {
+    if (
+      !scopeId ||
+      !normalizedMemberId ||
+      !endpointId ||
+      !serviceId ||
+      selectedService?.kind === 'nyxid-chat'
+    ) {
       setEndpointContract(null);
       setEndpointContractError('');
       return;
@@ -473,13 +481,11 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
     setEndpointContract(null);
     setEndpointContractError('');
 
-    const request = normalizedMemberId
-      ? scopeRuntimeApi.getMemberEndpointContract(
-          scopeId,
-          normalizedMemberId,
-          endpointId,
-        )
-      : scopeRuntimeApi.getServiceEndpointContract(scopeId, serviceId, endpointId);
+    const request = scopeRuntimeApi.getMemberEndpointContract(
+      scopeId,
+      normalizedMemberId,
+      endpointId,
+    );
 
     request
       .then((contract) => {
@@ -631,7 +637,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   }, []);
 
   const handleInvoke = useCallback(async () => {
-    if (!scopeId || !selectedService || !selectedEndpoint) {
+    if (!scopeId || !normalizedMemberId || !selectedService || !selectedEndpoint) {
       return;
     }
 
@@ -722,7 +728,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
           },
           controller.signal,
           {
-            memberId: normalizedMemberId || undefined,
+            memberId: normalizedMemberId,
             serviceId: selectedService.serviceId,
           },
         );
@@ -897,7 +903,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
           prompt: trimmedPrompt,
         },
         {
-          memberId: normalizedMemberId || undefined,
+          memberId: normalizedMemberId,
           serviceId: selectedService.serviceId,
         },
       );
@@ -1012,6 +1018,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   }, [
     appendRequestHistory,
     ensureNyxIdChatBound,
+    normalizedMemberId,
     payloadBase64,
     payloadTypeUrl,
     prompt,
@@ -1021,7 +1028,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
   ]);
 
   const handleOpenRuns = useCallback(() => {
-    if (!scopeId || !selectedEndpoint) {
+    if (!scopeId || !normalizedMemberId || !selectedEndpoint) {
       return;
     }
 
@@ -1072,6 +1079,7 @@ const StudioMemberInvokePanel: React.FC<StudioMemberInvokePanelProps> = ({
     invokeResult.endpointId,
     invokeResult.events,
     invokeResult.runId,
+    normalizedMemberId,
     payloadBase64,
     payloadTypeUrl,
     prompt,

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioMemberInvokeSetupPanels.tsx
@@ -460,6 +460,10 @@ export const StudioMemberInvokeComposerPanel: React.FC<
         )}
         {formError ? (
           <Typography.Text type="danger">{formError}</Typography.Text>
+        ) : !canInvoke ? (
+          <Typography.Text style={helperTextStyle} type="secondary">
+            Invoke requires a selected backend Team member and a published member endpoint.
+          </Typography.Text>
         ) : isChatEndpoint ? (
           <Typography.Text style={helperTextStyle} type="secondary">
             这是当前成员的对话输入区。开始对话后，结果会直接显示在下方工作台。

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -341,6 +341,7 @@ describe('StudioMemberBindPanel', () => {
           scopeSource: 'nyxid',
         },
         buildWorkflowYamls,
+        memberId: 'default',
         scopeId: 'scope-1',
         preferredServiceId: 'default',
         onContinueToInvoke: handleContinueToInvoke,
@@ -456,6 +457,64 @@ describe('StudioMemberBindPanel', () => {
     fireEvent.click(continueButton);
 
     expect(handleContinueToInvoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps published Invoke unavailable until a backend member is selected', async () => {
+    const handleContinueToInvoke = jest.fn();
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        scopeId: 'scope-1',
+        preferredServiceId: 'default',
+        onContinueToInvoke: handleContinueToInvoke,
+        services: [
+          {
+            serviceKey: 'scope-1:default:workspace-demo',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'default',
+            displayName: 'workspace-demo',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'dep-2',
+            primaryActorId: 'actor-default',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'chat',
+                displayName: 'Chat',
+                kind: 'chat',
+                requestTypeUrl: '',
+                responseTypeUrl: '',
+                description: 'Chat with the published workflow.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-03-26T08:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    expect(await screen.findByText('Select a Team member before using Invoke.')).toBeTruthy();
+    expect(screen.queryByTestId('studio-bind-contract-card')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Send smoke test' })).toBeDisabled();
+    const continueButton = screen.getByRole('button', { name: 'Continue to Invoke' });
+    expect(continueButton).toBeDisabled();
+
+    fireEvent.click(continueButton);
+
+    expect(handleContinueToInvoke).not.toHaveBeenCalled();
+    expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
+    expect(runtimeRunsApi.invokeEndpoint).not.toHaveBeenCalled();
   });
 
   it('does not block current draft smoke tests on published endpoint auth state', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -492,6 +492,9 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
   const publishedSmokeRequiresAuth =
     !runsCurrentWorkflowDraft &&
     Boolean(bindContract?.authEnabled && !bindContract.authAuthenticated);
+  const canUsePublishedMemberInvoke = Boolean(
+    normalizedMemberId && selectedService && selectedEndpoint && bindContract,
+  );
 
   useEffect(() => {
     const nextDefaultInput = createDefaultBindSampleInput(bindContract);
@@ -541,7 +544,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
         return;
       }
 
-      if (!selectedService || !selectedEndpoint) {
+      if (!selectedService || !selectedEndpoint || !normalizedMemberId || !bindContract) {
         return;
       }
 
@@ -554,7 +557,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
           },
           new AbortController().signal,
           {
-            memberId: normalizedMemberId || undefined,
+            memberId: normalizedMemberId,
             serviceId: selectedService.serviceId,
           },
         );
@@ -585,7 +588,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
           prompt: smokeInput.trim() || createDefaultBindSampleInput(bindContract),
         },
         {
-          memberId: normalizedMemberId || undefined,
+          memberId: normalizedMemberId,
           serviceId: selectedService.serviceId,
         },
       );
@@ -614,6 +617,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
   }, [
     bindContract,
     buildWorkflowYamls,
+    normalizedMemberId,
     scopeId,
     selectedEndpoint,
     selectedService,
@@ -921,6 +925,14 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 type="warning"
               />
             ) : null}
+            {!normalizedMemberId && selectedService && selectedEndpoint ? (
+              <Alert
+                showIcon
+                message="Select a Team member before using Invoke."
+                description="Bind can inspect the published service, but Studio only reveals invoke URLs and live requests after the route resolves to a backend member."
+                type="info"
+              />
+            ) : null}
           </div>
         </AevatarPanel>
 
@@ -971,7 +983,11 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 <Alert
                   showIcon
                   message="Select an endpoint to reveal the invoke contract."
-                  description="The contract URL, revision badge, snippets, and smoke test are generated from the selected service endpoint."
+                  description={
+                    normalizedMemberId
+                      ? 'The contract URL, revision badge, snippets, and smoke test are generated from the selected member endpoint.'
+                      : 'Invoke is member-scoped. Select or create a backend member before Studio reveals the invoke contract.'
+                  }
                   type="info"
                 />
               )}
@@ -1052,8 +1068,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                   loading={smokeTestResult.status === 'running'}
                   type="primary"
                   disabled={
-                    (!runsCurrentWorkflowDraft &&
-                      (!selectedService || !selectedEndpoint)) ||
+                    (!runsCurrentWorkflowDraft && !canUsePublishedMemberInvoke) ||
                     publishedSmokeRequiresAuth
                   }
                   onClick={() => void handleRunSmokeTest()}
@@ -1063,9 +1078,9 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 <Button
                   block
                   icon={<LinkOutlined />}
-                  disabled={!selectedService || !selectedEndpoint}
+                  disabled={!canUsePublishedMemberInvoke}
                   onClick={() => {
-                    if (!selectedService || !selectedEndpoint) {
+                    if (!canUsePublishedMemberInvoke || !selectedService || !selectedEndpoint) {
                       return;
                     }
 

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/bindContract.test.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/bindContract.test.ts
@@ -5,16 +5,16 @@ import {
 } from './bindContract';
 
 describe('bindContract', () => {
-  it('builds the streaming invoke path for chat endpoints', () => {
+  it('does not build an invoke path without a member identity', () => {
     expect(
       buildStudioBindInvokePath('scope-1', 'chat', undefined, 'default', {
         endpointId: 'chat',
         kind: 'chat',
       }),
-    ).toBe('/api/scopes/scope-1/services/default/invoke/chat:stream');
+    ).toBeNull();
   });
 
-  it('prefers the member invoke path when the current member id is known', () => {
+  it('builds the member invoke path when the current member id is known', () => {
     expect(
       buildStudioBindInvokePath('scope-1', 'chat', 'joker', 'default', {
         endpointId: 'chat',
@@ -41,6 +41,7 @@ describe('bindContract', () => {
         responseTypeUrl: '',
         description: 'Chat with the member.',
       },
+      memberId: 'joker',
       origin: 'https://console.example.test',
       revision: {
         revisionId: 'rev-2',
@@ -91,9 +92,9 @@ describe('bindContract', () => {
       authLabel: 'Authenticated',
       deploymentStatus: 'Active',
       endpointDisplayName: 'Chat',
-      invokePath: '/api/scopes/scope-1/services/default/invoke/chat:stream',
+      invokePath: '/api/scopes/scope-1/members/joker/invoke/chat:stream',
       invokeUrl:
-        'https://console.example.test/api/scopes/scope-1/services/default/invoke/chat:stream',
+        'https://console.example.test/api/scopes/scope-1/members/joker/invoke/chat:stream',
       revisionId: 'rev-2',
       scopeLabel: 'scope-1',
       scopeSource: 'nyxid',
@@ -110,13 +111,52 @@ describe('bindContract', () => {
       buildStudioBindInvokeUrl(
         'scope-1',
         'chat',
-        undefined,
+        'joker',
         'default',
         { endpointId: 'chat', kind: 'chat' },
         'https://console.example.test',
       ),
     ).toBe(
-      'https://console.example.test/api/scopes/scope-1/services/default/invoke/chat:stream',
+      'https://console.example.test/api/scopes/scope-1/members/joker/invoke/chat:stream',
     );
+  });
+
+  it('does not build a bind contract when no backend member identity is known', () => {
+    expect(
+      buildStudioBindContract({
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        endpoint: {
+          endpointId: 'chat',
+          displayName: 'Chat',
+          kind: 'chat',
+          requestTypeUrl: '',
+          responseTypeUrl: '',
+          description: 'Chat with the member.',
+        },
+        origin: 'https://console.example.test',
+        scopeId: 'scope-1',
+        service: {
+          serviceKey: 'scope-1:default:workspace-demo',
+          tenantId: 'scope-1',
+          appId: 'default',
+          namespace: 'default',
+          serviceId: 'default',
+          displayName: 'workspace-demo',
+          defaultServingRevisionId: 'rev-2',
+          activeServingRevisionId: 'rev-2',
+          deploymentId: 'dep-2',
+          primaryActorId: 'actor-default',
+          deploymentStatus: 'Active',
+          endpoints: [],
+          policyIds: [],
+          updatedAt: '2026-03-26T08:00:00Z',
+        },
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/bindContract.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/bindContract.ts
@@ -110,37 +110,24 @@ export function buildStudioBindInvokePath(
   memberId?: string,
   serviceId?: string,
   endpoint?: Pick<ServiceEndpointSnapshot, 'endpointId' | 'kind'> | null,
-): string {
+): string | null {
   const encodedScopeId = encodeSegment(scopeId);
   const encodedEndpointId = encodeSegment(endpointId);
   const normalizedMemberId = trimOptional(memberId);
-  const normalizedServiceId = trimOptional(serviceId);
+
+  if (!normalizedMemberId) {
+    return null;
+  }
 
   if (isChatServiceEndpoint(endpoint)) {
-    if (normalizedMemberId) {
-      return `/api/scopes/${encodedScopeId}/members/${encodeSegment(
-        normalizedMemberId,
-      )}/invoke/chat:stream`;
-    }
-
-    return normalizedServiceId
-      ? `/api/scopes/${encodedScopeId}/services/${encodeSegment(
-          normalizedServiceId,
-        )}/invoke/chat:stream`
-      : `/api/scopes/${encodedScopeId}/invoke/chat:stream`;
-  }
-
-  if (normalizedMemberId) {
     return `/api/scopes/${encodedScopeId}/members/${encodeSegment(
       normalizedMemberId,
-    )}/invoke/${encodedEndpointId}`;
+    )}/invoke/chat:stream`;
   }
 
-  return normalizedServiceId
-    ? `/api/scopes/${encodedScopeId}/services/${encodeSegment(
-        normalizedServiceId,
-      )}/invoke/${encodedEndpointId}`
-    : `/api/scopes/${encodedScopeId}/invoke/${encodedEndpointId}`;
+  return `/api/scopes/${encodedScopeId}/members/${encodeSegment(
+    normalizedMemberId,
+  )}/invoke/${encodedEndpointId}`;
 }
 
 export function buildStudioBindInvokeUrl(
@@ -150,7 +137,7 @@ export function buildStudioBindInvokeUrl(
   serviceId?: string,
   endpoint?: Pick<ServiceEndpointSnapshot, 'endpointId' | 'kind'> | null,
   origin?: string,
-): string {
+): string | null {
   const path = buildStudioBindInvokePath(
     scopeId,
     endpointId,
@@ -158,6 +145,10 @@ export function buildStudioBindInvokeUrl(
     serviceId,
     endpoint,
   );
+  if (!path) {
+    return null;
+  }
+
   const resolvedOrigin = resolveOrigin(origin);
   return resolvedOrigin ? `${resolvedOrigin}${path}` : path;
 }
@@ -169,21 +160,30 @@ export function buildStudioBindContract(
     return null;
   }
 
+  const normalizedMemberId = trimOptional(input.memberId);
+  if (!normalizedMemberId) {
+    return null;
+  }
+
   const invokePath = buildStudioBindInvokePath(
     input.scopeId,
     input.endpoint.endpointId,
-    trimOptional(input.memberId) || undefined,
+    normalizedMemberId,
     input.service.serviceId,
     input.endpoint,
   );
   const invokeUrl = buildStudioBindInvokeUrl(
     input.scopeId,
     input.endpoint.endpointId,
-    trimOptional(input.memberId) || undefined,
+    normalizedMemberId,
     input.service.serviceId,
     input.endpoint,
     input.origin,
   );
+  if (!invokePath || !invokeUrl) {
+    return null;
+  }
+
   const isChatEndpoint = isChatServiceEndpoint(input.endpoint);
   const authDescriptor = buildAuthDescriptor(input.authSession);
   const revisionId =

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -2089,6 +2089,18 @@ jest.mock("./components/bind/StudioMemberBindPanel", () => ({
         `workflow-yamls:${props.buildWorkflowYamls ? "present" : "none"}`
       ),
       React.createElement(
+        "div",
+        { key: "member" },
+        `member:${props.memberId || "no-member"}`
+      ),
+      !props.memberId
+        ? React.createElement(
+            "div",
+            { key: "member-warning" },
+            "Select a Team member before using Invoke."
+          )
+        : null,
+      React.createElement(
         "button",
         {
           key: "select-endpoint",
@@ -2115,7 +2127,11 @@ jest.mock("./components/bind/StudioMemberBindPanel", () => ({
         {
           key: "continue",
           type: "button",
-          onClick: () => props.onContinueToInvoke?.("default", "support-chat"),
+          disabled: !props.memberId,
+          onClick: () =>
+            props.memberId
+              ? props.onContinueToInvoke?.("default", "support-chat")
+              : undefined,
         },
         "Continue to Invoke"
       ),
@@ -3176,6 +3192,21 @@ describe("StudioPage", () => {
       scopeResolved: true,
       workflowStorageMode: "scope",
     });
+    mockStudioMembers = [
+      ...mockStudioMembers,
+      {
+        memberId: "joker",
+        scopeId: "scope-1",
+        displayName: "joker",
+        description: "Joker workflow member",
+        implementationKind: "workflow",
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "joker",
+        lastBoundRevisionId: "rev-joker",
+        createdAt: "2026-04-27T08:00:00Z",
+        updatedAt: "2026-04-27T08:05:00Z",
+      },
+    ];
     mockWorkflowFile = {
       ...mockWorkflowFile,
       name: "scope-demo",
@@ -3859,19 +3890,40 @@ describe("StudioPage", () => {
   });
 
   it("carries the selected bind contract into invoke after continuing from build", async () => {
-    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+    renderStudioPage("/studio?scopeId=scope-1&memberId=workspace-demo&focus=workflow%3Aworkflow-1&tab=studio");
 
     expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
     expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Continue to Invoke" })).not.toBeDisabled();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Continue to Invoke" }));
 
     expect(await screen.findByTestId("studio-invoke-surface")).toBeTruthy();
     expect(screen.getByText("service:default")).toBeTruthy();
     expect(screen.getByText("services:default")).toBeTruthy();
     expect(screen.getByText("endpoint:support-chat")).toBeTruthy();
+  });
+
+  it("does not continue from Bind to Invoke without backend member identity", async () => {
+    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+
+    expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
+    expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
+    expect(screen.getByText("Select a Team member before using Invoke.")).toBeTruthy();
+
+    const continueButton = screen.getByRole("button", { name: "Continue to Invoke" });
+    expect(continueButton).toBeDisabled();
+    fireEvent.click(continueButton);
+
+    expect(screen.queryByTestId("studio-invoke-surface")).toBeNull();
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get("step")).not.toBe("invoke");
   });
 
   it("pins Invoke to the selected member instead of exposing every runtime service", async () => {
@@ -3940,7 +3992,7 @@ describe("StudioPage", () => {
     expect(screen.getByText("service:script-alpha")).toBeTruthy();
     expect(screen.getByText("services:none")).toBeTruthy();
     expect(screen.getByText("endpoint:no-endpoint")).toBeTruthy();
-    expect(screen.getByText(/empty:script-alpha 还不能直接调用。/)).toBeTruthy();
+    expect(screen.getByText(/empty:当前选择还不能直接调用。/)).toBeTruthy();
   });
 
   it("surfaces the current workflow as a bind candidate before any published service exists", async () => {
@@ -3967,7 +4019,7 @@ describe("StudioPage", () => {
       ]);
     (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
 
-    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+    renderStudioPage("/studio?scopeId=scope-1&memberId=workspace-demo&focus=workflow%3Aworkflow-1&tab=studio");
 
     expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
 
@@ -3975,7 +4027,8 @@ describe("StudioPage", () => {
 
     expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
     await waitFor(() => {
-      expect(screen.getByText("candidate:workspace-demo")).toBeTruthy();
+      expect(screen.getByText("service:default")).toBeTruthy();
+      expect(screen.getByText("candidate:none")).toBeTruthy();
     });
 
     await act(async () => {
@@ -4094,7 +4147,7 @@ describe("StudioPage", () => {
     await waitFor(() => {
       expect(screen.getByText("service:default")).toBeTruthy();
       const searchParams = new URLSearchParams(window.location.search);
-      expect(searchParams.get("member")).toBe("workflow:workflow-1");
+      expect(searchParams.get("member")).toBe("member:workspace-demo");
       expect(searchParams.get("focus")).toBeNull();
       expect(searchParams.get("step")).toBe("bind");
     });
@@ -4107,7 +4160,7 @@ describe("StudioPage", () => {
       expect(screen.getByText("service:default")).toBeTruthy();
       expect(screen.queryByText("service:no-service")).toBeNull();
       const searchParams = new URLSearchParams(window.location.search);
-      expect(searchParams.get("member")).toBe("workflow:workflow-1");
+      expect(searchParams.get("member")).toBe("member:workspace-demo");
     });
   });
 
@@ -4123,6 +4176,21 @@ describe("StudioPage", () => {
         name: "draft1",
       },
     };
+    mockStudioMembers = [
+      ...mockStudioMembers,
+      {
+        memberId: "joker",
+        scopeId: "scope-1",
+        displayName: "joker",
+        description: "Joker workflow member",
+        implementationKind: "workflow",
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "joker",
+        lastBoundRevisionId: "rev-joker",
+        createdAt: "2026-04-27T08:00:00Z",
+        updatedAt: "2026-04-27T08:05:00Z",
+      },
+    ];
     (studioApi.listWorkflows as jest.Mock).mockResolvedValueOnce([
       {
         workflowId: "workflow-1",
@@ -4279,6 +4347,21 @@ describe("StudioPage", () => {
         name: "draft1",
       },
     };
+    mockStudioMembers = [
+      ...mockStudioMembers,
+      {
+        memberId: "joker",
+        scopeId: "scope-1",
+        displayName: "joker",
+        description: "Joker workflow member",
+        implementationKind: "workflow",
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "joker",
+        lastBoundRevisionId: "rev-joker",
+        createdAt: "2026-04-27T08:00:00Z",
+        updatedAt: "2026-04-27T08:05:00Z",
+      },
+    ];
     (studioApi.listWorkflows as jest.Mock).mockResolvedValueOnce([
       {
         workflowId: "workflow-1",
@@ -5753,7 +5836,10 @@ describe("StudioPage", () => {
     renderStudioPage("/studio?scopeId=scope-1&teamId=t-alpha&memberId=workspace-demo&focus=workflow%3Aworkflow-1&tab=studio");
 
     fireEvent.click(await screen.findByRole("button", { name: "Bind" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Continue to Invoke" }));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Continue to Invoke" })).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Invoke" }));
 
     expect(await screen.findByTestId("studio-invoke-surface")).toBeTruthy();
     await waitFor(() => {
@@ -5904,13 +5990,16 @@ describe("StudioPage", () => {
   });
 
   it("walks the lifecycle flow from build to bind to invoke to observe", async () => {
-    renderStudioPage("/studio?scopeId=scope-1&focus=workflow%3Aworkflow-1&tab=studio");
+    renderStudioPage("/studio?scopeId=scope-1&memberId=workspace-demo&focus=workflow%3Aworkflow-1&tab=studio");
 
     expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
     expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Continue to Invoke" })).not.toBeDisabled();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Continue to Invoke" }));
     expect(await screen.findByTestId("studio-invoke-surface")).toBeTruthy();
 

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -1048,6 +1048,11 @@ function readMemberIdFromMemberKey(memberKey: string): string {
   return trimOptional(normalizedMemberKey.slice('member:'.length));
 }
 
+function buildBackendMemberKey(memberId: string): `member:${string}` | '' {
+  const normalizedMemberId = trimOptional(memberId);
+  return normalizedMemberId ? `member:${normalizedMemberId}` : '';
+}
+
 function readScriptIdFromMemberKey(memberKey: string): string {
   const normalizedMemberKey = trimOptional(memberKey);
   if (!normalizedMemberKey.startsWith('script:')) {
@@ -3922,14 +3927,30 @@ const StudioPage: React.FC = () => {
             ? `member:${resolvedBoundMemberId}`
             : `member:${boundServiceId}`;
         })();
-      setRecentlyBoundMemberKey(boundMemberKey);
-      setRecentlyBoundServiceId(boundServiceId);
       const selectedService = (servicesResult.data ?? []).find(
         (service) => service.serviceId === boundServiceId,
       );
       const defaultEndpointId = resolveStudioServiceDefaultEndpointId(
         selectedService,
       );
+      const routeMemberSummary = resolveStudioMemberSummaryFromMemberKey(
+        trimOptional(routeState.memberKey) ||
+          buildBackendMemberKey(routeState.memberId),
+        publishedScopeMembers,
+        studioScopeMembers,
+      );
+      const resolvedBoundMemberId =
+        resolvedBuildMemberId ||
+        resolvePublishedMemberIdFromServiceId(
+          boundServiceId,
+          publishedScopeMembers,
+          studioScopeMembers,
+        ) ||
+        trimOptional(routeMemberSummary?.memberId);
+      const routedBoundMemberKey =
+        buildBackendMemberKey(resolvedBoundMemberId) || boundMemberKey;
+      setRecentlyBoundMemberKey(routedBoundMemberKey);
+      setRecentlyBoundServiceId(boundServiceId);
 
       bindingSelectionRef.current = {
         serviceId: boundServiceId,
@@ -3944,7 +3965,7 @@ const StudioPage: React.FC = () => {
         buildStudioRoute({
           scopeId: resolvedStudioScopeId || undefined,
           teamId: routeState.teamId || undefined,
-          memberKey: boundMemberKey,
+          memberKey: routedBoundMemberKey,
           step: 'bind',
         }),
       );
@@ -5387,8 +5408,14 @@ const StudioPage: React.FC = () => {
   );
   const handleUseBindingEndpoint = useCallback(
     (serviceId: string, endpointId: string) => {
+      const routeMemberSummary = resolveStudioMemberSummaryFromMemberKey(
+        trimOptional(routeState.memberKey) ||
+          buildBackendMemberKey(routeState.memberId),
+        publishedScopeMembers,
+        studioScopeMembers,
+      );
       const resolvedMemberId =
-        trimOptional(routeState.memberId) ||
+        trimOptional(routeMemberSummary?.memberId) ||
         resolvePublishedMemberIdFromServiceId(
           serviceId,
           publishedScopeMembers,
@@ -5402,17 +5429,18 @@ const StudioPage: React.FC = () => {
         serviceId,
         endpointId,
       };
+      if (!resolvedMemberId) {
+        void message.warning(
+          'Invoke needs a backend Team member identity. Select or create a member before continuing.',
+        );
+        return;
+      }
+
       history.replace(
         buildStudioRoute({
           scopeId: resolvedStudioScopeId || undefined,
           teamId: routeState.teamId || undefined,
-          memberKey:
-            trimOptional(routeState.memberKey) ||
-            (resolvedMemberId
-              ? `member:${resolvedMemberId}`
-              : '') ||
-            activeBuildFocusKey ||
-            (serviceId ? `member:${serviceId}` : undefined),
+          memberKey: buildBackendMemberKey(resolvedMemberId) || undefined,
           step: 'invoke',
           tab: 'invoke',
         }),
@@ -5420,7 +5448,6 @@ const StudioPage: React.FC = () => {
       applyStudioTarget('invoke');
     },
     [
-      activeBuildFocusKey,
       applyStudioTarget,
       history,
       publishedScopeMembers,
@@ -6489,15 +6516,12 @@ const StudioPage: React.FC = () => {
       : bindTargetDefaultEndpointId
     : '';
   const hasInvokeTargetMemberSelection =
-    Boolean(trimOptional(routeState.memberId)) ||
-    Boolean(currentSelectedMemberServiceId) ||
-    Boolean(currentInvokeSelectionServiceId) ||
-    Boolean(currentBindingSelectionServiceId);
+    Boolean(workbenchStudioMemberId);
   const invokeTargetServiceId =
     currentInvokeSelectionServiceId ||
     currentBindingSelectionServiceId ||
-    trimOptional(routeState.memberId) ||
-    currentSelectedMemberServiceId;
+    currentSelectedMemberServiceId ||
+    trimOptional(routeState.memberId);
   const invokeTargetService = useMemo(
     () => {
       if (!invokeTargetServiceId) {
@@ -7299,6 +7323,7 @@ const StudioPage: React.FC = () => {
     );
   const selectedMemberCanInvoke =
     selectedMemberCanBind &&
+    Boolean(workbenchStudioMemberId) &&
     Boolean(invokeTargetServiceId) &&
     Boolean(invokeTargetDefaultEndpointId);
   const lifecycleSteps = useMemo<readonly StudioLifecycleStep[]>(

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -822,7 +822,7 @@ describe("TeamDetailPage", () => {
     expect(screen.getByText("Runtime deltas")).toBeTruthy();
     expect(await screen.findByText("Step deltas")).toBeTruthy();
     expect(await screen.findByText("Handoff deltas")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "本次对话" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "本次成员对话" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "服务映射" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "高级编辑" })).toBeTruthy();
     expect(studioApi.getTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
@@ -1381,7 +1381,7 @@ describe("TeamDetailPage", () => {
     await screen.findByRole("button", { name: "服务映射" });
     fireEvent.click(screen.getByRole("button", { name: "事件流" }));
     await screen.findAllByText(/risk_review/);
-    fireEvent.click(screen.getAllByRole("button", { name: "本次对话" })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: "本次成员对话" })[0]);
 
     await waitFor(() => {
       expect(window.location.pathname).toBe("/runtime/runs");

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -3544,7 +3544,7 @@ const TeamDetailPage: React.FC = () => {
     runtimeServiceId,
     scopeId,
   ]);
-  const conversationActionLabel = lens.playback.currentRunId ? "本次对话" : "运行记录";
+  const conversationActionLabel = lens.playback.currentRunId ? "本次成员对话" : "成员运行记录";
   const serviceMappingActionLabel = "服务映射";
   const teamBuilderActionLabel = "高级编辑";
   const editTeamActionLabel = "Edit Team";

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -204,6 +204,15 @@ describe("TeamsHomePage", () => {
     expect(params.get("intent")).toBe("create-member");
   });
 
+  it("labels team card runtime shortcuts as member-scoped", async () => {
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    fireEvent.click(await screen.findByRole("button", { name: "更多" }));
+
+    expect(await screen.findByText("查看默认成员运行")).toBeTruthy();
+    expect(screen.queryByText("查看运行")).toBeNull();
+  });
+
   it("routes Create Team to the real create-team page", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -515,7 +515,7 @@ function buildMemberRosterPreview(input: {
     input.member.lifecycleStage === "bind_ready"
   ) {
     attention = "no-bound-service";
-    attentionDetail = "当前成员已经准备好绑定，但还没有稳定的可调用入口。";
+    attentionDetail = "当前成员已经准备好绑定，但还没有稳定的成员调用入口。";
   }
 
   const detailHref = serviceId
@@ -541,7 +541,7 @@ function buildMemberRosterPreview(input: {
   if (runtimeHref) {
     moreActions.push({
       key: "runtime",
-      label: "查看运行",
+      label: "查看成员运行",
       onClick: () => history.push(runtimeHref),
     });
   }
@@ -663,7 +663,7 @@ function buildTeamRosterPreview(input: {
   if (runtimeHref) {
     moreActions.push({
       key: "runtime",
-      label: "查看运行",
+      label: "查看默认成员运行",
       onClick: () => history.push(runtimeHref),
     });
   }
@@ -1429,7 +1429,7 @@ const TeamsHomePage: React.FC = () => {
                     打开 Studio
                   </Button>
                 }
-                description={`其中 ${membersPendingBindingCount} 个成员还没有完成独立绑定，或还没有形成稳定的可调用入口。`}
+                description={`其中 ${membersPendingBindingCount} 个成员还没有完成独立绑定，或还没有形成稳定的成员调用入口。`}
                 showIcon
                 title="还有成员待整理"
                 type="info"


### PR DESCRIPTION
## Problem

Team should not be treated as an invoke target. Issue #588 tracks the product/semantic mismatch where Studio could still fall back to team/service/scope-level invoke behavior instead of requiring a backend Team member.

## Solution

- Require backend `memberId` for bind contract, invoke, and run lookup paths.
- Normalize Studio member routing to `member:<backendMemberId>` instead of treating workflow/service identifiers as invoke identities.
- Block smoke test and "Continue to Invoke" until a member-scoped contract with endpoint data is available.
- Update Team list/detail wording so Team remains the authority/roster surface and invocation is explicitly member-scoped.
- Remove tests that encoded service/scope-level invoke fallbacks and add coverage for member-only routing.

Closes #588

## Impact

This is frontend-only under `apps/aevatar-console-web`. No backend or CLI frontend changes are included.

## Validation

- `npm --prefix apps/aevatar-console-web run jest -- --selectProjects jsdom --runTestsByPath src/pages/studio/components/bind/bindContract.test.ts src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx src/pages/studio/components/StudioMemberInvokePanel.test.tsx src/pages/studio/index.test.tsx src/pages/teams/home.test.tsx src/pages/teams/detail.test.tsx --runInBand --silent`
- `npm --prefix apps/aevatar-console-web run tsc`
- `git diff --check`
- Chrome manual QA on `http://127.0.0.1:5173` for Team list/detail and Studio Bind/Invoke member routing.
