### PR TITLE
Fix script member authority flow

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -1070,6 +1070,44 @@ jest.mock("@/shared/studio/api", () => ({
       },
       expectedActorId: `scope-script:${input.scopeId}:${input.scriptId}:dep-1`,
     })),
+    bindMemberScript: jest.fn(async (input: {
+      scopeId: string;
+      memberId: string;
+      displayName?: string;
+      scriptId: string;
+      scriptRevision: string;
+    }) => {
+      const existingMember = mockStudioMembers.find(
+        (member) => member.memberId === input.memberId
+      );
+      const serviceId = existingMember?.publishedServiceId || `member-${input.memberId}`;
+      mockStudioMembers = mockStudioMembers.map((member) =>
+        member.memberId === input.memberId
+          ? {
+              ...member,
+              lifecycleStage: "bind_ready",
+              publishedServiceId: serviceId,
+              lastBoundRevisionId: "rev-script-binding",
+              updatedAt: "2026-04-27T08:15:00Z",
+            }
+          : member
+      );
+
+      return {
+        scopeId: input.scopeId,
+        serviceId,
+        displayName: input.displayName || input.scriptId,
+        targetKind: "script",
+        targetName: input.scriptId,
+        revisionId: "rev-script-binding",
+        script: {
+          scriptId: input.scriptId,
+          scriptRevision: input.scriptRevision,
+          definitionActorId: "definition-1",
+        },
+        expectedActorId: `scope-script:${input.scopeId}:${serviceId}:dep-1`,
+      };
+    }),
     bindMemberWorkflow: jest.fn(async (input: {
       scopeId: string;
       memberId: string;
@@ -3594,7 +3632,7 @@ describe("StudioPage", () => {
     expect(studioApi.saveWorkflow).not.toHaveBeenCalled();
   });
 
-  it("creates a named Script draft from the create-member modal before bind", async () => {
+  it("creates a named Script member authority and opens its draft before bind", async () => {
     (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
       ...defaultStudioAppContext,
       scopeId: "scope-1",
@@ -3640,8 +3678,10 @@ describe("StudioPage", () => {
     expect(
       window.localStorage.getItem("aevatar:studio:script-drafts:v1"),
     ).toContain("refund-handler");
-    expect(studioApi.createMember).not.toHaveBeenCalledWith(
+    expect(studioApi.createMember).toHaveBeenCalledWith(
       expect.objectContaining({
+        scopeId: "scope-1",
+        displayName: "Refund Handler",
         implementationKind: "script",
       }),
     );
@@ -3649,6 +3689,7 @@ describe("StudioPage", () => {
       const searchParams = new URLSearchParams(window.location.search);
       expect(searchParams.get("tab")).toBe("scripts");
       expect(searchParams.get("step")).toBe("build");
+      expect(searchParams.get("member")).toBe("member:refund-handler");
       expect(searchParams.get("focus")).toBe("script:refund-handler");
     });
   });
@@ -3990,9 +4031,10 @@ describe("StudioPage", () => {
 
     expect(await screen.findByTestId("studio-invoke-surface")).toBeTruthy();
     expect(screen.getByText("service:script-alpha")).toBeTruthy();
+    expect(screen.getByText("member:script-alpha")).toBeTruthy();
     expect(screen.getByText("services:none")).toBeTruthy();
     expect(screen.getByText("endpoint:no-endpoint")).toBeTruthy();
-    expect(screen.getByText(/empty:当前选择还不能直接调用。/)).toBeTruthy();
+    expect(screen.getByText(/empty:script-alpha 还不能直接调用。/)).toBeTruthy();
   });
 
   it("surfaces the current workflow as a bind candidate before any published service exists", async () => {
@@ -5633,7 +5675,7 @@ describe("StudioPage", () => {
     expect(screen.queryByTestId("studio-workflow-build-panel")).toBeNull();
   });
 
-  it("binds a catalog-applied Script build candidate through the script binding API", async () => {
+  it("binds a catalog-applied Script member through the member binding API", async () => {
     (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
       ...defaultStudioAppContext,
       features: {
@@ -5643,6 +5685,21 @@ describe("StudioPage", () => {
       scopeId: "scope-1",
       scopeResolved: true,
     });
+    mockStudioMembers = [
+      ...mockStudioMembers,
+      {
+        memberId: "script-member",
+        scopeId: "scope-1",
+        displayName: "script-alpha",
+        description: "Script member",
+        implementationKind: "script",
+        lifecycleStage: "created",
+        publishedServiceId: "member-script-member",
+        lastBoundRevisionId: null,
+        createdAt: "2026-04-27T08:00:00Z",
+        updatedAt: "2026-04-27T08:05:00Z",
+      },
+    ];
     (scriptsApi.listScripts as jest.Mock).mockResolvedValue([
       {
         available: true,
@@ -5664,57 +5721,74 @@ describe("StudioPage", () => {
         },
       },
     ]);
-    mockScopeRuntimeApi.listServices.mockResolvedValue([
-      {
-        serviceId: "script-alpha",
-        displayName: "script-alpha",
-        deploymentStatus: "Active",
-        primaryActorId: "actor-script-alpha",
-        endpoints: [
-          {
-            endpointId: "script-command",
-            displayName: "Script command",
-            kind: "command",
-            description: "Invoke the script command.",
-            requestTypeUrl: "type.googleapis.com/example.ScriptCommand",
-            responseTypeUrl: "type.googleapis.com/example.ScriptResult",
-          },
-        ],
-      },
-    ]);
+    mockScopeRuntimeApi.listServices
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        {
+          serviceId: "member-script-member",
+          displayName: "script-alpha",
+          deploymentStatus: "Active",
+          primaryActorId: "actor-script-alpha",
+          endpoints: [
+            {
+              endpointId: "script-command",
+              displayName: "Script command",
+              kind: "command",
+              description: "Invoke the script command.",
+              requestTypeUrl: "type.googleapis.com/example.ScriptCommand",
+              responseTypeUrl: "type.googleapis.com/example.ScriptResult",
+            },
+          ],
+        },
+      ]);
     (studioApi.getScopeBinding as jest.Mock).mockResolvedValueOnce(null);
     mockScopeRuntimeApi.getServiceRevisions.mockImplementation(
       async (_scopeId: string, serviceId: string) =>
-        mockBuildServiceRevisionCatalog({
+        mockBuildScriptServiceRevisionCatalog({
           serviceId,
           displayName: "script-alpha",
+          scriptId: "script-alpha",
           revisionId: "rev-script-binding",
         })
     );
 
     renderStudioPage(
-      "/studio?scopeId=scope-1&member=script%3Ascript-alpha&step=bind&tab=bindings"
+      "/studio?scopeId=scope-1&member=member%3Ascript-member&focus=script%3Ascript-alpha&tab=scripts"
     );
+
+    expect(await screen.findByTestId("studio-script-build-panel")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Continue to Bind" }));
 
     expect(await screen.findByTestId("studio-bind-surface")).toBeTruthy();
     await waitFor(() => {
       expect(screen.getByText("candidate:script-alpha")).toBeTruthy();
-      expect(screen.getByText("service:no-service")).toBeTruthy();
+      expect(screen.getByText("service:member-script-member")).toBeTruthy();
+      expect(screen.getByText("member:script-member")).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Bind current member" }));
 
     await waitFor(() => {
-      expect(studioApi.bindScopeScript).toHaveBeenCalledWith(
+      expect(studioApi.bindMemberScript).toHaveBeenCalledWith(
         expect.objectContaining({
           scopeId: "scope-1",
+          memberId: "script-member",
           displayName: "script-alpha",
-          serviceId: "script-alpha",
           scriptId: "script-alpha",
           scriptRevision: "rev-1",
         })
       );
     });
+    expect(studioApi.bindScopeScript).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByText("services:member-script-member")).toBeTruthy();
+      expect(screen.getByText("candidate:none")).toBeTruthy();
+    });
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get("member")).toBe("member:script-member");
+    expect(searchParams.get("focus")).toBe("script:script-alpha");
+    expect(searchParams.get("step")).toBe("bind");
+    expect(searchParams.get("tab")).toBe("bindings");
   });
 
   it("loads discovered GAgent types and the published service revision catalog", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -109,6 +109,7 @@ import type { ServiceCatalogSnapshot } from '@/shared/models/services';
 import type {
   StudioExecutionDetail,
   StudioExecutionSummary,
+  StudioMemberRoster,
   StudioMemberBindingRevision,
   StudioMemberSummary,
   StudioValidationFinding,
@@ -964,6 +965,41 @@ function buildInventoryScriptName(
   }
 
   return `script-${Date.now()}`;
+}
+
+function upsertStudioMemberRosterMember(
+  roster: StudioMemberRoster | undefined,
+  scopeId: string,
+  member: StudioMemberSummary,
+): StudioMemberRoster {
+  const normalizedMemberId = trimOptional(member.memberId);
+  const normalizedScopeId =
+    trimOptional(roster?.scopeId) ||
+    trimOptional(member.scopeId) ||
+    trimOptional(scopeId);
+  const currentMembers = roster?.members ?? [];
+  let matched = false;
+  const members = currentMembers.map((currentMember) => {
+    if (
+      normalizedMemberId &&
+      trimOptional(currentMember.memberId) === normalizedMemberId
+    ) {
+      matched = true;
+      return member;
+    }
+
+    return currentMember;
+  });
+
+  if (!matched) {
+    members.push(member);
+  }
+
+  return {
+    scopeId: normalizedScopeId,
+    members,
+    nextPageToken: roster?.nextPageToken ?? null,
+  };
 }
 
 function readStoredScriptDrafts(): Record<string, StudioPendingScriptDraft> {
@@ -1919,12 +1955,16 @@ function buildStudioFocusKey(input: {
   routeMemberKey?: string;
   routeMemberId?: string;
 }): string {
+  const routeMemberKey = parseStudioRouteMember(input.routeMemberKey).key;
+  if (routeMemberKey.startsWith('member:')) {
+    return routeMemberKey;
+  }
+
   const activeBuildFocusKey = trimOptional(input.activeBuildFocusKey);
   if (activeBuildFocusKey) {
     return activeBuildFocusKey;
   }
 
-  const routeMemberKey = parseStudioRouteMember(input.routeMemberKey).key;
   if (routeMemberKey) {
     return routeMemberKey;
   }
@@ -3796,8 +3836,77 @@ const StudioPage: React.FC = () => {
     isBindSurface,
   ]);
   const buildPendingMemberSummary = useMemo(() => {
-    if (buildPendingBindCandidate?.kind !== 'workflow') {
+    if (!buildPendingBindCandidate) {
       return null;
+    }
+
+    const routeMemberId = trimOptional(routeState.memberId);
+    if (routeMemberId) {
+      const routeMember = studioScopeMembers.find(
+        (member) => trimOptional(member.memberId) === routeMemberId,
+      );
+      if (
+        routeMember &&
+        normalizeStudioMemberBindingImplementationKind(
+          routeMember.implementationKind,
+        ) === buildPendingBindCandidate.kind
+      ) {
+        return routeMember;
+      }
+    }
+
+    if (buildPendingBindCandidate.kind === 'script') {
+      const scriptId = trimOptional(buildPendingBindCandidate.scriptId);
+      const normalizedCandidateName = normalizeComparableText(
+        buildPendingBindCandidate.displayName || scriptId,
+      );
+
+      const publishedMatch = publishedScopeMembers.find(
+        ({ matchedScript, memberSummary, service }) => {
+          if (
+            scriptId &&
+            trimOptional(matchedScript?.script?.scriptId) === scriptId
+          ) {
+            return true;
+          }
+
+          if (
+            scriptId &&
+            trimOptional(service.serviceId) === scriptId
+          ) {
+            return true;
+          }
+
+          const memberDisplayName = trimOptional(memberSummary?.displayName);
+          return (
+            Boolean(memberDisplayName) &&
+            normalizeComparableText(memberDisplayName) === normalizedCandidateName
+          );
+        },
+      )?.memberSummary;
+      if (publishedMatch) {
+        return publishedMatch;
+      }
+
+      const rosterMatches = studioScopeMembers.filter((member) => {
+        if (
+          normalizeStudioMemberBindingImplementationKind(
+            member.implementationKind,
+          ) !== 'script'
+        ) {
+          return false;
+        }
+
+        const displayName = normalizeComparableText(member.displayName);
+        const publishedServiceId = trimOptional(member.publishedServiceId);
+        const memberId = trimOptional(member.memberId);
+        return (
+          Boolean(displayName && displayName === normalizedCandidateName) ||
+          Boolean(scriptId && publishedServiceId === scriptId) ||
+          Boolean(scriptId && memberId === scriptId)
+        );
+      });
+      return rosterMatches.length === 1 ? rosterMatches[0] : null;
     }
 
     const candidateWorkflowId = trimOptional(
@@ -3845,6 +3954,7 @@ const StudioPage: React.FC = () => {
     activeWorkflowFile?.workflowId,
     buildPendingBindCandidate,
     publishedScopeMembers,
+    routeState.memberId,
     selectedWorkflowId,
     studioScopeMembers,
   ]);
@@ -3853,7 +3963,10 @@ const StudioPage: React.FC = () => {
       throw new Error('Resolve the current scope before binding this member.');
     }
 
-    const resolvedBuildMemberId = trimOptional(buildPendingMemberSummary?.memberId);
+    const resolvedBuildMemberId =
+      trimOptional(buildPendingMemberSummary?.memberId) ||
+      readMemberIdFromMemberKey(routeState.memberKey) ||
+      trimOptional(routeState.memberId);
     const result =
       buildPendingBindCandidate.kind === 'workflow'
         ? resolvedBuildMemberId
@@ -3868,13 +3981,21 @@ const StudioPage: React.FC = () => {
               displayName: buildPendingBindCandidate.displayName,
               workflowYamls: await buildWorkflowYamlBundle(),
             })
-        : await studioApi.bindScopeScript({
-            scopeId: resolvedStudioScopeId,
-            displayName: buildPendingBindCandidate.displayName,
-            serviceId: buildPendingBindCandidate.scriptId,
-            scriptId: buildPendingBindCandidate.scriptId,
-            scriptRevision: buildPendingBindCandidate.scriptRevision,
-          });
+        : resolvedBuildMemberId
+          ? await studioApi.bindMemberScript({
+              scopeId: resolvedStudioScopeId,
+              memberId: resolvedBuildMemberId,
+              displayName: buildPendingBindCandidate.displayName,
+              scriptId: buildPendingBindCandidate.scriptId,
+              scriptRevision: buildPendingBindCandidate.scriptRevision,
+            })
+          : await studioApi.bindScopeScript({
+              scopeId: resolvedStudioScopeId,
+              displayName: buildPendingBindCandidate.displayName,
+              serviceId: buildPendingBindCandidate.scriptId,
+              scriptId: buildPendingBindCandidate.scriptId,
+              scriptRevision: buildPendingBindCandidate.scriptRevision,
+            });
     await queryClient.invalidateQueries({
       queryKey: ['studio-scope-members', resolvedStudioScopeId],
     });
@@ -3966,7 +4087,12 @@ const StudioPage: React.FC = () => {
           scopeId: resolvedStudioScopeId || undefined,
           teamId: routeState.teamId || undefined,
           memberKey: routedBoundMemberKey,
+          focus:
+            buildPendingBindCandidate.kind === 'script'
+              ? `script:${buildPendingBindCandidate.scriptId}`
+              : undefined,
           step: 'bind',
+          tab: 'bindings',
         }),
       );
     }
@@ -4309,6 +4435,41 @@ const StudioPage: React.FC = () => {
           return;
         }
 
+        let createdScriptMember: StudioMemberSummary | null = null;
+        if (resolvedStudioScopeId) {
+          setInventoryBusyKey('create');
+          setInventoryBusyAction('create');
+          try {
+            createdScriptMember = await studioApi.createMember({
+              scopeId: resolvedStudioScopeId,
+              displayName: scriptDisplayName,
+              implementationKind: 'script',
+              ...(createMemberTeamId ? { teamId: createMemberTeamId } : {}),
+            });
+            queryClient.setQueryData<StudioMemberRoster>(
+              ['studio-scope-members', resolvedStudioScopeId],
+              (current) =>
+                upsertStudioMemberRosterMember(
+                  current,
+                  resolvedStudioScopeId,
+                  createdScriptMember as StudioMemberSummary,
+                ),
+            );
+            void queryClient.invalidateQueries({
+              queryKey: ['studio-scope-members', resolvedStudioScopeId],
+            });
+          } catch (memberError) {
+            setInventoryBusyKey('');
+            setInventoryBusyAction('');
+            void message.error(
+              memberError instanceof Error
+                ? `Studio could not register the Script member authority: ${memberError.message}`
+                : 'Studio could not register the Script member authority.',
+            );
+            return;
+          }
+        }
+
         const nextDraft = {
           scriptId,
           displayName: scriptDisplayName,
@@ -4323,6 +4484,9 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: createMemberTeamId || undefined,
+            memberKey: createdScriptMember?.memberId
+              ? `member:${createdScriptMember.memberId}`
+              : undefined,
             focus: `script:${scriptId}`,
             step: 'build',
             tab: 'scripts',
@@ -4330,7 +4494,13 @@ const StudioPage: React.FC = () => {
         );
         setBuildSurface('scripts');
         setStudioSurface('build');
-        void message.success(`Created Script draft ${scriptId}.`);
+        setInventoryBusyKey('');
+        setInventoryBusyAction('');
+        void message.success(
+          createdScriptMember
+            ? `Created Script member ${createdScriptMember.displayName} and opened its draft.`
+            : `Created Script draft ${scriptId}.`,
+        );
         return;
       }
 
@@ -5778,7 +5948,7 @@ const StudioPage: React.FC = () => {
 
     const tab: StudioTab | undefined =
       studioSurface === 'bind'
-        ? undefined
+        ? 'bindings'
         : studioSurface === 'invoke'
           ? 'invoke'
           : studioSurface === 'observe'
@@ -5809,11 +5979,16 @@ const StudioPage: React.FC = () => {
       studioSurface === 'build'
         ? trimOptional(persistableBuildMemberKey) || undefined
         : trimOptional(lifecycleSurfaceMemberKey) || undefined;
+    const persistedLifecycleFocus =
+      studioSurface === 'bind' && routeBuildFocus.kind === 'script'
+        ? (`script:${routeBuildFocus.value}` as const)
+        : undefined;
     const persistedFocus =
-      persistBuildFocusRoute &&
+      persistedLifecycleFocus ||
+      (persistBuildFocusRoute &&
       trimOptional(activeBuildFocusKey) !== trimOptional(persistedMemberKey)
         ? activeBuildFocusKey || undefined
-        : undefined;
+        : undefined);
 
     history.replace(buildStudioRoute({
       scopeId: resolvedStudioScopeId || undefined,
@@ -5878,8 +6053,17 @@ const StudioPage: React.FC = () => {
     [publishedScopeMembers, studioScopeMembers, workbenchMemberKey],
   );
   const workbenchStudioMemberId = useMemo(
-    () => trimOptional(workbenchStudioMemberSummary?.memberId),
-    [workbenchStudioMemberSummary?.memberId],
+    () =>
+      trimOptional(workbenchStudioMemberSummary?.memberId) ||
+      readMemberIdFromMemberKey(workbenchMemberKey) ||
+      readMemberIdFromMemberKey(routeState.memberKey) ||
+      trimOptional(routeState.memberId),
+    [
+      routeState.memberId,
+      routeState.memberKey,
+      workbenchMemberKey,
+      workbenchStudioMemberSummary?.memberId,
+    ],
   );
   const workbenchStudioMemberDetailQuery = useQuery({
     queryKey: ['studio-scope-member', resolvedStudioScopeId, workbenchStudioMemberId],
@@ -6453,18 +6637,34 @@ const StudioPage: React.FC = () => {
   const bindSelectedMemberServiceId =
     currentSelectedMemberServiceId ||
     (isBindSurface ? recentBindSelectedMemberServiceId : '');
+  const bindPublishedService = useMemo(
+    () =>
+      bindSelectedMemberServiceId
+        ? publishedScopeServices.find(
+            (service) => service.serviceId === bindSelectedMemberServiceId,
+          ) ?? null
+        : null,
+    [bindSelectedMemberServiceId, publishedScopeServices],
+  );
+  const bindPendingCandidate =
+    buildPendingBindCandidate &&
+    !bindPublishedService &&
+    (workbenchMemberKey.startsWith('workflow:') ||
+      workbenchMemberKey.startsWith('script:') ||
+      (workbenchMemberKey.startsWith('member:') &&
+        normalizeStudioMemberBindingImplementationKind(
+          workbenchStudioMember?.implementationKind,
+        ) === buildPendingBindCandidate.kind))
+      ? buildPendingBindCandidate
+      : null;
   const bindTargetService = useMemo(
     () => {
-      if (!bindSelectedMemberServiceId) {
+      if (!bindSelectedMemberServiceId || bindPendingCandidate) {
         return null;
       }
 
-      const matchedPublishedService =
-        publishedScopeServices.find(
-          (service) => service.serviceId === bindSelectedMemberServiceId,
-        ) ?? null;
-      if (matchedPublishedService) {
-        return matchedPublishedService;
+      if (bindPublishedService) {
+        return bindPublishedService;
       }
 
       return {
@@ -6487,9 +6687,10 @@ const StudioPage: React.FC = () => {
       };
     },
     [
+      bindPendingCandidate,
+      bindPublishedService,
       bindSelectedMemberServiceId,
       currentMemberLabel,
-      publishedScopeServices,
       resolvedStudioScopeId,
     ],
   );
@@ -6501,14 +6702,6 @@ const StudioPage: React.FC = () => {
     () => resolveStudioServiceDefaultEndpointId(bindTargetService),
     [bindTargetService],
   );
-  const bindPendingCandidate =
-    bindSelectedMemberServiceId ||
-    !(
-      workbenchMemberKey.startsWith('workflow:') ||
-      workbenchMemberKey.startsWith('script:')
-    )
-      ? null
-      : buildPendingBindCandidate;
   const bindInitialEndpointId = bindSelectedMemberServiceId
     ? currentBindingSelectionServiceId === bindSelectedMemberServiceId &&
       currentBindingSelectionEndpointId
@@ -7965,11 +8158,17 @@ const StudioPage: React.FC = () => {
         }
       }}
       onContinueToBind={() => {
+        const scriptFocusId =
+          trimOptional(selectedScriptId) ||
+          (routeBuildFocus.kind === 'script' ? routeBuildFocus.value : '') ||
+          (routeSelectedMember.kind === 'script' ? routeSelectedMember.value : '') ||
+          trimOptional(scriptBuildState?.scriptId);
         history.push(
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: routeState.teamId || undefined,
-            memberKey: selectedScriptId ? `script:${selectedScriptId}` : undefined,
+            memberKey: routeSelectedMemberKey || undefined,
+            focus: scriptFocusId ? `script:${scriptFocusId}` : undefined,
             step: 'bind',
             tab: 'bindings',
           }),


### PR DESCRIPTION
## Problem
Script member creation in Studio opened a local script draft without first creating the backend Team member authority. That let later Bind/Invoke routing fall back to script or scope identity instead of the member identity required by #588 semantics.

Closes #628.

## Solution
- Create a backend script Team member before opening the new script draft.
- Preserve `member=member:<memberId>` as the authority route key and use `focus=script:<scriptId>` only for editor focus.
- Bind script candidates through `bindMemberScript` whenever a backend member id is present, with no team/scope/service fallback for member-scoped Invoke semantics.
- Keep the pending Script bind candidate visible while service catalog projection catches up.

## Validation
- `npm --prefix apps/aevatar-console-web test -- --runTestsByPath src/pages/studio/index.test.tsx src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx src/pages/studio/components/bind/bindContract.test.ts`
- `npm --prefix apps/aevatar-console-web run tsc`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check -- apps/aevatar-console-web/src/pages/studio/index.tsx apps/aevatar-console-web/src/pages/studio/index.test.tsx`

## Manual QA
Chrome local Studio flow successfully created a script member with `member=member:<memberId>` and `focus=script:<scriptId>`, reached the member-scoped Bind action, and avoided `member:no-member`. The backend bind call returned HTTP 500 in the local environment, so this PR stops at the frontend routing/API-contract fix without backend changes.