### PR TITLE
Refine workspace copy

### DIFF
--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.test.tsx
@@ -338,7 +338,7 @@ describe('ScriptsWorkbenchPage', () => {
       expect(mockedScriptsApi.observeSaveScript).toHaveBeenCalledTimes(2);
     });
     expect(
-      await screen.findByText('Saved script-1 into current scope scope-1.'),
+      await screen.findByText('Saved script-1 into workspace scope-1.'),
     ).toBeTruthy();
   });
 
@@ -622,7 +622,7 @@ public sealed class DraftBehavior : ScriptBehavior<AppScriptReadModel, AppScript
     const headerScope = within(header as HTMLElement);
     expect(headerScope.getByText('not saved')).toBeTruthy();
     expect(headerScope.getByText('嵌入式 Host')).toBeTruthy();
-    expect(headerScope.getByText('Scope 1626c177…b0d6')).toBeTruthy();
+    expect(headerScope.getByText('Workspace 1626c177…b0d6')).toBeTruthy();
     expect(headerScope.getByRole('button', { name: 'New draft' })).toBeTruthy();
     expect(headerScope.getByRole('button', { name: 'Save' })).toBeTruthy();
     expect(
@@ -760,7 +760,7 @@ public sealed class DraftBehavior : ScriptBehavior<AppScriptReadModel, AppScript
     ).toBeTruthy();
     expect(
       screen.getByText(
-        /Updated scope scope-1 to serve script script-1 on revision rev-1\./,
+        /Updated workspace scope-1 to serve script script-1 on revision rev-1\./,
       ),
     ).toBeTruthy();
 

--- a/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/ScriptsWorkbenchPage.tsx
@@ -1279,7 +1279,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       onSelectScriptId?.(detail.script?.scriptId || '');
       setNotice({
         type: 'info',
-        message: `Loaded ${detail.script?.scriptId || 'scope script'} into the active draft list.`,
+        message: `Loaded ${detail.script?.scriptId || 'workspace script'} into the active draft list.`,
       });
     },
     [drafts, onSelectScriptId],
@@ -1594,7 +1594,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     }
 
     if (!scopeBacked) {
-      throw new Error('Save is only available after Studio resolves the current scope.');
+      throw new Error('Save is only available after Studio resolves the current workspace.');
     }
 
     const persistedSource = serializePersistedSource(selectedDraft.package);
@@ -1655,7 +1655,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       scopeId: accepted.acceptedScript.scopeId,
       scriptId: accepted.acceptedScript.scriptId,
       status: 'pending',
-      message: `Save request for ${accepted.acceptedScript.scriptId} is still waiting to appear in the scope catalog.`,
+      message: `Save request for ${accepted.acceptedScript.scriptId} is still waiting to appear in the workspace catalog.`,
       currentScript: null,
       isTerminal: false,
     };
@@ -1694,7 +1694,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       const accepted = await saveCurrentDraftToScope();
       setNotice({
         type: 'info',
-        message: `Save accepted for ${accepted.acceptedScript.scriptId}. Waiting for the scope catalog to catch up.`,
+        message: `Save accepted for ${accepted.acceptedScript.scriptId}. Waiting for the workspace catalog to catch up.`,
       });
       const observation = await observeAcceptedSave(accepted);
       await refreshScopeScripts();
@@ -1731,7 +1731,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       setNotice({
         type: observation.status === 'applied' ? 'success' : 'warning',
         message: observation.status === 'applied'
-          ? `Saved ${accepted.acceptedScript.scriptId} into current scope ${accepted.acceptedScript.scopeId}.`
+          ? `Saved ${accepted.acceptedScript.scriptId} into workspace ${accepted.acceptedScript.scopeId}.`
           : observation.message,
       });
     } catch (error) {
@@ -1767,7 +1767,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     if (!scriptRevision) {
       setNotice({
         type: 'warning',
-        message: 'Save the current script into the scope before binding it.',
+        message: 'Save the current script into the workspace before binding it.',
       });
       return;
     }
@@ -1789,7 +1789,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       openWorkspaceSection('activity');
       setNotice({
         type: 'success',
-        message: `Updated scope ${result.scopeId} to serve script ${result.targetName} on revision ${result.revisionId}.`,
+        message: `Updated workspace ${result.scopeId} to serve script ${result.targetName} on revision ${result.revisionId}.`,
         description:
           'Review the active binding, revision rollout, and saved script assets from the team views.',
         actions: [
@@ -1845,7 +1845,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     if (!resolvedScopeId) {
       setNotice({
         type: 'warning',
-        message: 'Test Run requires the current scope.',
+        message: 'Test Run requires the current workspace.',
       });
       return;
     }
@@ -1919,7 +1919,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     if (!scopeBacked) {
       setNotice({
         type: 'warning',
-        message: 'Promotion is only available after Studio resolves the current scope.',
+        message: 'Promotion is only available after Studio resolves the current workspace.',
       });
       return;
     }
@@ -1929,7 +1929,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
     if (!baseRevision) {
       setNotice({
         type: 'warning',
-        message: 'Save the script into the current scope before proposing a promotion.',
+        message: 'Save the script into the workspace before proposing a promotion.',
       });
       return;
     }
@@ -2423,10 +2423,10 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
       'Clean';
   const headerRevisionLabel = selectedDraft?.revision || 'not saved';
   const headerScopeLabel = scopeBacked
-    ? `Scope ${compactHeaderValue(resolvedScopeId)}`
+    ? `Workspace ${compactHeaderValue(resolvedScopeId)}`
     : 'Local draft';
   const headerScopeTooltip = scopeBacked
-    ? `Scope ${resolvedScopeId || '-'}`
+    ? `Workspace ID ${resolvedScopeId || '-'}`
     : 'Local draft';
   const moreActions: NonNullable<MenuProps['items']> = [
     {
@@ -2627,7 +2627,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
                 </span>
               ) : null}
               <Tooltip
-                title="Create a fresh local draft without changing the current scope catalog"
+                title="Create a fresh local draft without changing the workspace catalog"
                 placement="bottom"
               >
                 <span className="console-scripts-tooltip-anchor">
@@ -2643,7 +2643,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
                 </span>
               </Tooltip>
               <Tooltip
-                title={scopeBacked ? 'Save the active draft into the current scope catalog' : 'Requires the current scope'}
+                title={scopeBacked ? 'Save the active draft into the workspace catalog' : 'Requires the current workspace'}
                 placement="bottom"
               >
                 <span className="console-scripts-tooltip-anchor">
@@ -2662,8 +2662,8 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
               <Tooltip
                 title={
                   canBindScope
-                    ? 'Bind the saved script to the default service for this scope.'
-                    : 'Save the current script into the scope before binding it.'
+                    ? 'Bind the saved script to the default service for this workspace.'
+                    : 'Save the current script into the workspace before binding it.'
                 }
                 placement="bottom"
               >
@@ -3187,7 +3187,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
           <div className="console-scripts-detail-copy">
             Test Run executes the current draft directly through
             <code style={{ marginInline: 4 }}>/api/scopes/{'{scopeId}'}/scripts/draft-run</code>
-            without rebinding the scope default service.
+            without rebinding the workspace default service.
           </div>
           <textarea
             aria-label="Script test run input"
@@ -3239,7 +3239,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
 
         <ScriptsStudioModal
           open={bindModalOpen}
-          eyebrow="Scope"
+          eyebrow="Workspace"
           title="Bind saved script"
           onClose={() => setBindModalOpen(false)}
           actions={
@@ -3263,7 +3263,7 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
           }
         >
           <div className="console-scripts-detail-copy">
-            Bind the saved scope script to the default service for this scope.
+            Bind the saved workspace script to the default service for this workspace.
             Existing workflow authoring stays available alongside this flow.
           </div>
           <div style={{ marginTop: 16 }}>
@@ -3310,9 +3310,9 @@ const ScriptsWorkbenchPage: React.FC<ScriptsWorkbenchPageProps> = ({
           width={560}
         >
           <div className="console-scripts-detail-copy" style={{ marginTop: 0 }}>
-            The current script changes have not been saved to Scope yet. Your
+            The current script changes have not been saved to the workspace yet. Your
             local draft will still be kept in this browser, but these changes
-            will not be visible in Scope until you save them.
+            will not be visible in the workspace until you save them.
           </div>
         </ScriptsStudioModal>
 

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptInspectorPanel.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptInspectorPanel.test.tsx
@@ -72,7 +72,7 @@ describe('ScriptInspectorPanel', () => {
 
     expect(screen.getByText('script-1')).toBeTruthy();
     expect(screen.getByText('rev-2')).toBeTruthy();
-    expect(screen.getByText('当前团队 · scope-1')).toBeTruthy();
+    expect(screen.getByText('工作空间 ID · scope-1')).toBeTruthy();
     expect(screen.getByText('type.googleapis.com/example.Command')).toBeTruthy();
     expect(screen.getByText('嵌入式 Host')).toBeTruthy();
     expect(screen.getByText('校验, 保存, 发布, 测试运行, AI 辅助')).toBeTruthy();

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptInspectorPanel.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptInspectorPanel.tsx
@@ -60,7 +60,7 @@ const ScriptInspectorPanel: React.FC<ScriptInspectorPanelProps> = ({
   ];
   const unavailableActions = [
     ...(!scopeBacked
-      ? ['保存（需要当前团队）', '发布（需要当前团队）']
+      ? ['保存（需要当前工作空间）', '发布（需要当前工作空间）']
       : []),
     ...(!isEmbeddedMode
       ? ['测试运行（需要嵌入式 Host）', 'AI 辅助（需要嵌入式 Host）']
@@ -115,7 +115,7 @@ const ScriptInspectorPanel: React.FC<ScriptInspectorPanelProps> = ({
               <div className="console-scripts-field-label">存储位置</div>
               <div className="console-scripts-field-value">
                 {scopeBacked
-                  ? `当前团队 · ${appContext.scopeId}`
+                  ? `工作空间 ID · ${appContext.scopeId}`
                   : '仅本地草稿'}
               </div>
             </div>

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptResultsPanel.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptResultsPanel.test.tsx
@@ -201,7 +201,7 @@ describe('ScriptResultsPanel', () => {
       />,
     );
 
-    expect(screen.getByText('Scope: scope-1')).toBeTruthy();
+    expect(screen.getByText('Workspace ID: scope-1')).toBeTruthy();
     expect(screen.getByText('Catalog: catalog-1')).toBeTruthy();
     expect(screen.getByText('Previous: rev-0')).toBeTruthy();
     expect(screen.getByText('History: rev-0 -> rev-1')).toBeTruthy();

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptResultsPanel.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptResultsPanel.tsx
@@ -151,8 +151,8 @@ function renderResultDetail(props: ScriptResultsPanelProps): React.JSX.Element {
     if (!scopeDetail?.script) {
       return (
         <ScriptsStudioEmptyState
-          title="还没有保存到当前团队"
-          copy="先把当前草稿保存到团队里，这里才会显示已保存版本的目录状态。"
+          title="还没有保存到当前工作空间"
+          copy="先把当前草稿保存到工作空间里，这里才会显示已保存版本的目录状态。"
         />
       );
     }
@@ -163,7 +163,7 @@ function renderResultDetail(props: ScriptResultsPanelProps): React.JSX.Element {
           <div className="console-scripts-detail-card">
             <div className="console-scripts-section-label">Catalog</div>
             <div className="console-scripts-detail-copy">
-              <div>Scope: {scopeDetail.scopeId}</div>
+              <div>Workspace ID: {scopeDetail.scopeId}</div>
               <div>Revision: {scopeDetail.script.activeRevision}</div>
               <div>Updated: {formatScriptDateTime(scopeDetail.script.updatedAt)}</div>
             </div>
@@ -374,8 +374,8 @@ const ScriptResultsPanel: React.FC<ScriptResultsPanelProps> = (props) => {
     ? props.selectedSnapshotView.output || props.selectedSnapshotView.status || '运行结果已就绪'
     : '开始一次测试运行后，这里会显示运行时快照。';
   const saveSummary = props.scopeDetail?.script
-    ? `当前团队 ${props.scopeDetail.scopeId} 正在指向 ${props.scopeDetail.script.activeRevision}。`
-    : '当前草稿还没有保存到团队目录。';
+    ? `当前工作空间 ${props.scopeDetail.scopeId} 正在指向 ${props.scopeDetail.script.activeRevision}。`
+    : '当前草稿还没有保存到工作空间目录。';
   const promotionSummary = props.selectedDecision
     ? props.selectedDecision.failureReason ||
       `Candidate ${props.selectedDecision.candidateRevision || '-'}`

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsResourceRail.test.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsResourceRail.test.tsx
@@ -131,7 +131,7 @@ describe('ScriptsResourceRail', () => {
       target: { value: 'runtime' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'script-1' }));
-    fireEvent.click(screen.getByRole('button', { name: /Refresh scope catalog/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Refresh workspace catalog/ }));
     fireEvent.click(screen.getByRole('button', { name: 'scope-script' }));
     fireEvent.click(screen.getByRole('button', { name: /Runtimes \(1\)/ }));
     fireEvent.click(screen.getByRole('button', { name: /Refresh runtimes/ }));

--- a/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsResourceRail.tsx
+++ b/apps/aevatar-console-web/src/modules/studio/scripts/components/ScriptsResourceRail.tsx
@@ -73,7 +73,7 @@ const ScriptsResourceRail: React.FC<ScriptsResourceRailProps> = ({
         <input
           type="search"
           className="console-scripts-search-input"
-          placeholder="Search drafts or the current scope catalog"
+          placeholder="Search drafts or the workspace catalog"
           value={search}
           onChange={(event) => onSearchChange(event.target.value)}
         />
@@ -122,16 +122,16 @@ const ScriptsResourceRail: React.FC<ScriptsResourceRailProps> = ({
       </ScriptsStudioSection>
 
       <ScriptsStudioSection
-        eyebrow="Scope Catalog"
-        title={`Current Scope Catalog (${scopeScripts.length})`}
+        eyebrow="Workspace Catalog"
+        title={`Workspace Catalog (${scopeScripts.length})`}
         actions={
           scopeBacked ? (
             <button
               type="button"
               onClick={onRefreshScopeScripts}
               className="console-scripts-icon-button"
-              title="Refresh scope catalog"
-              aria-label="Refresh scope catalog"
+              title="Refresh workspace catalog"
+              aria-label="Refresh workspace catalog"
               disabled={scopeScriptsLoading}
             >
               <SyncOutlined spin={scopeScriptsLoading} />
@@ -142,20 +142,20 @@ const ScriptsResourceRail: React.FC<ScriptsResourceRailProps> = ({
         <div className="console-scripts-run-list">
           {!scopeBacked ? (
             <ScriptsStudioEmptyState
-              title="Scope save unavailable"
-              copy="Studio has not resolved a current scope yet, so only local drafts are available."
+              title="Workspace save unavailable"
+              copy="Studio has not resolved a current workspace yet, so only local drafts are available."
             />
           ) : scopeScripts.length === 0 ? (
             <ScriptsStudioEmptyState
               title={
                 scopeScriptsLoading
-                  ? 'Loading scope catalog'
-                  : 'No scope catalog entries matched'
+                  ? 'Loading workspace catalog'
+                  : 'No workspace catalog entries matched'
               }
               copy={
                 scopeScriptsLoading
-                  ? 'Pulling the current scope catalog now.'
-                  : 'Try a different search or save the active draft to the current scope.'
+                  ? 'Pulling the current workspace catalog now.'
+                  : 'Try a different search or save the active draft to the workspace.'
               }
             />
           ) : (
@@ -237,7 +237,7 @@ const ScriptsResourceRail: React.FC<ScriptsResourceRailProps> = ({
           {proposalDecisions.length === 0 ? (
             <ScriptsStudioEmptyState
               title="No proposal decisions yet"
-              copy="Promotion decisions will appear here after the scope catalog points at them."
+              copy="Promotion decisions will appear here after the workspace catalog points at them."
             />
           ) : (
             proposalDecisions.map((decision) => (

--- a/apps/aevatar-console-web/src/pages/chat/chatAdvancedConsole.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatAdvancedConsole.tsx
@@ -97,17 +97,17 @@ const monoFontFamily =
 
 const queryTargets: { description: string; id: QueryTarget; label: string }[] = [
   {
-    description: "Current default binding for this scope.",
+    description: "Current default binding for this workspace.",
     id: "binding",
-    label: "Scope Binding",
+    label: "Workspace Binding",
   },
   {
-    description: "All published services currently visible to this scope.",
+    description: "All published services currently visible to this workspace.",
     id: "services",
     label: "Services",
   },
   {
-    description: "Workflow assets currently deployed into this scope.",
+    description: "Workflow assets currently deployed into this workspace.",
     id: "workflows",
     label: "Workflows",
   },
@@ -489,7 +489,7 @@ export function ChatAdvancedConsole({
   const consoleFlowGroups = useMemo(
     () => [
       {
-        description: "Inspect the current scope and understand runtime state.",
+        description: "Inspect the current workspace and understand runtime state.",
         flows: consoleFlows.filter((flow) => flow.group === "understand"),
         id: "understand",
         label: "Understand",
@@ -1153,15 +1153,15 @@ export function ChatAdvancedConsole({
     <AevatarContextDrawer
       onClose={onClose}
       open={open}
-      subtitle="Inspect scope state, invoke endpoints, or hit raw API paths without leaving chat."
+      subtitle="Inspect workspace state, invoke endpoints, or hit raw API paths without leaving chat."
       title="Advanced Console"
       width={960}
     >
       {!scopeId ? (
         <Alert
-          description="Open a scoped chat first so the console has a project context."
+          description="Open a workspace chat first so the console has a project context."
           showIcon
-          title="No scope is currently active."
+          title="No workspace is currently active."
           type="warning"
         />
       ) : (
@@ -1185,7 +1185,7 @@ export function ChatAdvancedConsole({
               }}
             >
               Suggested path: start with <strong>Query</strong> to orient the
-              scope, move to <strong>Execute</strong> when you are ready to act,
+              workspace, move to <strong>Execute</strong> when you are ready to act,
               then use <strong>Timeline</strong> if the run needs evidence or
               operator input. Keep <strong>Raw API</strong> for protocol-level
               debugging.
@@ -1337,7 +1337,7 @@ export function ChatAdvancedConsole({
           {activeTab === "query" ? (
             <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
               <div style={drawerSectionStyle}>
-                <Typography.Text strong>Query Scope State</Typography.Text>
+                <Typography.Text strong>Query Workspace State</Typography.Text>
                 <div
                   style={{
                     display: "grid",
@@ -1423,7 +1423,7 @@ export function ChatAdvancedConsole({
                       ? "Loading..."
                       : `Query ${
                           queryTargets.find((target) => target.id === queryTarget)
-                            ?.label || "Scope"
+                            ?.label || "Workspace"
                         }`}
                   </button>
                 </div>

--- a/apps/aevatar-console-web/src/pages/chat/chatOnboardingGuide.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatOnboardingGuide.tsx
@@ -89,7 +89,7 @@ function getStepDescription(
       return "NyxID Chat can use this provider immediately. You can switch back to the assistant or start over.";
     case "select_provider":
     default:
-      return "Pick the provider you want NyxID Chat to use by default for this scope.";
+      return "Pick the provider you want NyxID Chat to use by default for this workspace.";
   }
 }
 

--- a/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/chatPresentation.tsx
@@ -1529,7 +1529,7 @@ export function ChatToolsMenu({
     {
       actionLabel: advancedOpen ? "Hide panel" : "Open panel",
       description:
-        "Inspect scope state, launch endpoints, and review runtime evidence.",
+        "Inspect workspace state, launch endpoints, and review runtime evidence.",
       label: "Advanced Console",
       onClick: onToggleAdvanced,
       open: advancedOpen,
@@ -2537,7 +2537,7 @@ export function ChatMetaStrip({
     modelLabel ? { label: "Model", value: modelLabel } : null,
   ].filter(Boolean) as Array<{ label: string; value: string }>;
   const detailItems = [
-    scopeId ? { label: "Scope", value: scopeId } : null,
+    scopeId ? { label: "Workspace ID", value: scopeId } : null,
     runId ? { label: "Run", value: runId } : null,
     actorId ? { label: "Actor", value: actorId } : null,
     commandId ? { label: "Command", value: commandId } : null,

--- a/apps/aevatar-console-web/src/pages/chat/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/chat/index.test.tsx
@@ -1136,7 +1136,7 @@ describe("ChatPage", () => {
     });
   });
 
-  it("opens the advanced console and queries the current scope binding", async () => {
+  it("opens the advanced console and queries the current workspace binding", async () => {
     renderWithQueryClient(React.createElement(ChatPage));
 
     const serviceSelector = await screen.findByLabelText("Chat service");
@@ -1148,7 +1148,7 @@ describe("ChatPage", () => {
     expect(await screen.findByText("Advanced Console")).toBeTruthy();
 
     fireEvent.click(
-      await screen.findByRole("button", { name: "Query Scope Binding" })
+      await screen.findByRole("button", { name: "Query Workspace Binding" })
     );
 
     expect(

--- a/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.test.tsx
@@ -491,7 +491,7 @@ describe("GAgentsPage", () => {
 
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: "I understand this changes the scope's published default service.",
+        name: "I understand this changes the workspace's published default service.",
       })
     );
     fireEvent.click(screen.getByRole("button", { name: "Publish binding" }));
@@ -602,7 +602,7 @@ describe("GAgentsPage", () => {
       ).toHaveBeenCalledWith("scope-a", "rev-2");
     });
     expect(
-      await screen.findByText("Scope scope-a is now serving revision rev-2.")
+      await screen.findByText("Workspace scope-a is now serving revision rev-2.")
     ).toBeTruthy();
 
     const retireButton = screen

--- a/apps/aevatar-console-web/src/pages/gagents/index.tsx
+++ b/apps/aevatar-console-web/src/pages/gagents/index.tsx
@@ -630,7 +630,7 @@ const GAgentsPage: React.FC = () => {
     }
 
     if (!bindingQuery.data?.available || !currentBindingRevision) {
-      return 'This will create the first published default service for the current scope.';
+      return 'This will create the first published default service for the current workspace.';
     }
 
     if (currentBindingMatchesSelectedType) {
@@ -825,7 +825,7 @@ const GAgentsPage: React.FC = () => {
     if (!normalizedScopeId) {
       setRegistryNotice({
         type: 'error',
-        message: 'Scope is required before removing a saved actor.',
+        message: 'Workspace is required before removing a saved actor.',
       });
       return;
     }
@@ -986,7 +986,7 @@ const GAgentsPage: React.FC = () => {
       setBindingNotice({
         type: 'error',
         message:
-          'Resolve the current scope before publishing a GAgent binding.',
+          'Resolve the current workspace before publishing a GAgent binding.',
       });
       return;
     }
@@ -1091,7 +1091,7 @@ const GAgentsPage: React.FC = () => {
       setIsRevisionDrawerOpen(true);
       setBindingNotice({
         type: 'success',
-        message: `Scope ${result.scopeId} is now serving revision ${result.revisionId}.`,
+        message: `Workspace ${result.scopeId} is now serving revision ${result.revisionId}.`,
       });
     } catch (error) {
       setBindingNotice({
@@ -1144,7 +1144,7 @@ const GAgentsPage: React.FC = () => {
     if (!normalizedScopeId || !normalizedActorTypeName || !normalizedPrompt) {
       setRunState((current) => ({
         ...current,
-        error: 'Scope, GAgent type, and prompt are required before running.',
+        error: 'Workspace, GAgent type, and prompt are required before running.',
         status: 'error',
       }));
       return;
@@ -1320,17 +1320,17 @@ const GAgentsPage: React.FC = () => {
   const rail = (
     <div style={cliRailShellStyle}>
       <div style={cliRailSectionStyle}>
-        <div style={cliCardLabelStyle}>Scope Context</div>
+        <div style={cliCardLabelStyle}>Workspace Context</div>
         <Input
-          aria-label="Scope ID"
+          aria-label="Workspace ID"
           onChange={(event) => setScopeId(event.target.value)}
-          placeholder="Scope ID"
+          placeholder="Workspace ID"
           value={scopeId}
         />
         <Typography.Text type="secondary">
           {resolvedScope?.scopeId
-            ? `NyxID resolved scope: ${resolvedScope.scopeId}`
-            : 'No scope was resolved from the current session.'}
+            ? `NyxID resolved workspace: ${resolvedScope.scopeId}`
+            : 'No workspace was resolved from the current session.'}
         </Typography.Text>
         {bindingQuery.data?.available ? (
           <div
@@ -1704,8 +1704,8 @@ const GAgentsPage: React.FC = () => {
     <WorkbenchCard
       description={
         selectedType
-          ? `Reusable actor ids saved for ${selectedType.typeName} in this scope.`
-          : 'Reusable actor ids saved for this scope.'
+          ? `Reusable actor ids saved for ${selectedType.typeName} in this workspace.`
+          : 'Reusable actor ids saved for this workspace.'
       }
       eyebrow="Actor Registry"
       extra={
@@ -1742,7 +1742,7 @@ const GAgentsPage: React.FC = () => {
             description={
               gAgentActorsQuery.isLoading
                 ? 'Loading actor registry.'
-                : 'No saved actors were found for this scope.'
+                : 'No saved actors were found for this workspace.'
             }
             image={Empty.PRESENTED_IMAGE_SIMPLE}
           />
@@ -1871,8 +1871,8 @@ const GAgentsPage: React.FC = () => {
 
   const currentBindingPanel = (
     <WorkbenchCard
-      description="Current default service for this scope."
-      eyebrow="Current Scope Binding"
+      description="Current default service for this workspace."
+      eyebrow="Current Workspace Binding"
       extra={
         <Space size={[8, 8]} wrap>
           <Button
@@ -2000,7 +2000,7 @@ const GAgentsPage: React.FC = () => {
 
   const publishBindingPanel = (
     <WorkbenchCard
-      description="Publish the selected GAgent type as this scope's default service."
+      description="Publish the selected GAgent type as this workspace's default service."
       eyebrow="Publish Binding"
       extra={
         <Button
@@ -2327,7 +2327,7 @@ const GAgentsPage: React.FC = () => {
               checked={publishAcknowledged}
               onChange={(event) => setPublishAcknowledged(event.target.checked)}
             >
-              I understand this changes the scope's published default service.
+              I understand this changes the workspace's published default service.
             </Checkbox>
 
             <Space size={[8, 8]} wrap>
@@ -2722,7 +2722,7 @@ const GAgentsPage: React.FC = () => {
       layoutMode="document"
       extra={
         <Space size={[8, 8]} wrap>
-          <Typography.Text type="secondary">Scope</Typography.Text>
+          <Typography.Text type="secondary">Workspace ID</Typography.Text>
           <Typography.Text style={{ maxWidth: 320 }} strong>
             {normalizedScopeId || resolvedScope?.scopeId || 'Not resolved'}
           </Typography.Text>

--- a/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.test.tsx
@@ -117,7 +117,7 @@ describe("RunsLaunchRail", () => {
     );
 
     expect(screen.getByLabelText("Chat route (optional)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Scope ID")).toBeInTheDocument();
+    expect(screen.getByLabelText("Workspace ID")).toBeInTheDocument();
     expect(screen.queryByLabelText("Endpoint")).toBeNull();
     expect(screen.queryByText("Requests go through /api/scopes/{scopeId}/invoke/chat:stream")).toBeNull();
 

--- a/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/components/RunsLaunchRail.tsx
@@ -162,7 +162,7 @@ function renderRouteMiniCard(
       <div style={embeddedPanelStyle}>
         <Space wrap size={[6, 6]}>
           <Tag color="geekblue">Command invoke</Tag>
-          <Tag>Scope binding</Tag>
+          <Tag>Workspace binding</Tag>
         </Space>
         <Typography.Text strong style={{ display: "block", marginTop: 10 }}>
           {activeEndpointId}
@@ -593,7 +593,7 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
                         extra={
                           draftMode
                             ? "Draft runs execute the bundled Studio draft."
-                            : "Selecting a route targets the published scope service with the same id. Leave it empty to use the scope default binding; binding override wins when provided."
+                            : "Selecting a route targets the published workspace service with the same id. Leave it empty to use the workspace default binding; binding override wins when provided."
                         }
                         disabled={draftMode}
                         options={routeOptions}
@@ -625,12 +625,12 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
                     )}
                     <ProFormText
                       name="scopeId"
-                      label="Scope ID"
-                      placeholder="NyxID user / scope id"
+                      label="Workspace ID"
+                      placeholder="NyxID user / workspace id"
                       rules={[
                         {
                           required: true,
-                          message: "Scope ID is required.",
+                          message: "Workspace ID is required.",
                         },
                       ]}
                     />
@@ -653,7 +653,7 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
                                   <ProFormText
                                     name="serviceOverrideId"
                                     label="Binding override (optional)"
-                                    placeholder="Leave empty to use the scope default binding."
+                                    placeholder="Leave empty to use the workspace default binding."
                                   />
                                 ) : null}
                                 {isChatEndpoint ? (
@@ -703,7 +703,7 @@ const RunsLaunchRail: React.FC<RunsLaunchRailProps> = ({
                           <ProFormText
                             name="serviceOverrideId"
                             label="Binding override (optional)"
-                            placeholder="Leave empty to use the scope default binding."
+                            placeholder="Leave empty to use the workspace default binding."
                           />
                         ) : null}
                         {isChatEndpoint ? (

--- a/apps/aevatar-console-web/src/pages/runs/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.test.tsx
@@ -246,7 +246,7 @@ jest.mock("./components/RunsLaunchRail", () => {
           })
         : null,
       React.createElement("input", {
-        "aria-label": "Scope ID",
+        "aria-label": "Workspace ID",
         onChange: (event: any) =>
           setValues((current: Record<string, unknown>) => ({
             ...current,

--- a/apps/aevatar-console-web/src/pages/runs/index.tsx
+++ b/apps/aevatar-console-web/src/pages/runs/index.tsx
@@ -811,7 +811,7 @@ const RunsPage: React.FC = () => {
           requestedRun.payloadBase64?.trim() ?? "";
 
         if (!normalizedScopeId) {
-          throw new Error("Scope ID is required.");
+          throw new Error("Workspace ID is required.");
         }
         if (normalizedEndpointKind === "command" && !normalizedEndpointId) {
           throw new Error("Endpoint ID is required for command invokes.");
@@ -896,7 +896,7 @@ const RunsPage: React.FC = () => {
                 messageApi.warning(
                   `Selected service '${extractMissingServiceId(
                     event.message ?? ""
-                  )}' is no longer available. Retrying with the scope default binding.`
+                  )}' is no longer available. Retrying with the workspace default binding.`
                 );
                 await runAttempt(
                   {
@@ -987,7 +987,7 @@ const RunsPage: React.FC = () => {
             messageApi.warning(
               `Selected service '${extractMissingServiceId(
                 text
-              )}' is no longer available. Retrying with the scope default binding.`
+              )}' is no longer available. Retrying with the workspace default binding.`
             );
             await runAttempt(
               {
@@ -1074,7 +1074,7 @@ const RunsPage: React.FC = () => {
       const scopeId = resolveRunScopeId();
       const serviceOverrideId = resolveRunServiceOverrideId();
       if (!scopeId) {
-        throw new Error("Scope ID is required to resume a run.");
+        throw new Error("Workspace ID is required to resume a run.");
       }
 
       return runtimeRunsApi.resume(scopeId, request, {
@@ -1085,7 +1085,7 @@ const RunsPage: React.FC = () => {
       const scopeId = resolveRunScopeId();
       const serviceOverrideId = resolveRunServiceOverrideId();
       if (!scopeId) {
-        throw new Error("Scope ID is required to signal a run.");
+        throw new Error("Workspace ID is required to signal a run.");
       }
 
       return runtimeRunsApi.signal(scopeId, request, {
@@ -1325,7 +1325,7 @@ const RunsPage: React.FC = () => {
 
       return {
         routeName: endpointName,
-        groupLabel: endpointInvocationDraftPayload ? "Scope" : "Scope binding",
+        groupLabel: endpointInvocationDraftPayload ? "Workspace" : "Workspace binding",
         sourceLabel: endpointInvocationDraftPayload
           ? "Invocation draft"
           : payloadTypeUrl

--- a/apps/aevatar-console-web/src/pages/scopes/components/ScopeQueryCard.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/components/ScopeQueryCard.tsx
@@ -24,7 +24,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
   onLoad,
   onReset,
   resetDisabled,
-  loadLabel = 'Load scope',
+  loadLabel = 'Load workspace',
   resolvedScopeId,
   resolvedScopeSource,
   onUseResolvedScope,
@@ -81,7 +81,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
       >
         <Input
           allowClear
-          placeholder="输入团队 scopeId"
+          placeholder="输入工作空间 ID"
           style={{ flex: '1 1 240px', minWidth: 0, width: '100%' }}
           value={draft.scopeId}
           onChange={(event) =>
@@ -111,7 +111,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
         {normalizedResolvedScopeId ? (
           <>
             <Typography.Text style={helperLabelStyle}>
-              已解析团队
+              已解析工作空间
             </Typography.Text>
             <Typography.Paragraph
               copyable={{ text: normalizedResolvedScopeId }}
@@ -130,23 +130,23 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
                   wordBreak: 'break-word',
                 }}
               >
-                当前会话已通过 {normalizedResolvedScopeSource} 解析出这个团队
+                当前会话已通过 {normalizedResolvedScopeSource} 解析出这个工作空间
               </Typography.Text>
             ) : null}
             {loadIsNoOp ? (
               <Typography.Text style={helperCopyStyle}>
-                当前已加载这个团队，所以“{loadLabel}”不会再触发变化。
+                当前已加载这个工作空间，所以“{loadLabel}”不会再触发变化。
               </Typography.Text>
             ) : null}
             {resetIsNoOp ? (
               <Typography.Text style={helperCopyStyle}>
-                当前已经回到会话解析出的团队，所以“重置”不会再触发变化。
+                当前已经回到会话解析出的工作空间，所以“重置”不会再触发变化。
               </Typography.Text>
             ) : null}
             {canUseResolvedScope ? (
               <div>
                 <Button size="small" onClick={onUseResolvedScope}>
-                  使用会话团队
+                  使用会话工作空间
                 </Button>
               </div>
             ) : null}
@@ -162,7 +162,7 @@ const ScopeQueryCard: React.FC<ScopeQueryCardProps> = ({
               wordBreak: 'break-word',
             }}
           >
-            当前会话里没有自动解析出团队。请手动输入一个 scopeId。
+            当前会话里没有自动解析出工作空间。请手动输入一个工作空间 ID。
           </Typography.Text>
         )}
       </div>

--- a/apps/aevatar-console-web/src/pages/scopes/components/ScopeServiceRuntimeWorkbench.tsx
+++ b/apps/aevatar-console-web/src/pages/scopes/components/ScopeServiceRuntimeWorkbench.tsx
@@ -572,7 +572,7 @@ const ScopeServiceRuntimeWorkbench: React.FC<ScopeServiceRuntimeWorkbenchProps> 
     </div>
   ) : (
     <Empty
-      description="No scope-specific bindings are published for this service yet."
+      description="No workspace bindings are published for this service yet."
       image={Empty.PRESENTED_IMAGE_SIMPLE}
     />
   );
@@ -759,7 +759,7 @@ const ScopeServiceRuntimeWorkbench: React.FC<ScopeServiceRuntimeWorkbenchProps> 
 
           <AevatarPanel
             title="Endpoint Surface"
-            titleHelp="Operators can switch endpoints from here without losing the current scope and service context."
+            titleHelp="Operators can switch endpoints from here without losing the current workspace and service context."
           >
             <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
               {selectedService.endpoints.length > 0 ? (
@@ -848,7 +848,7 @@ const ScopeServiceRuntimeWorkbench: React.FC<ScopeServiceRuntimeWorkbenchProps> 
               </Button>
             }
             title="Dependency Surface"
-            titleHelp="Scope-specific bindings describe which services, connectors, or secrets this published service is allowed to depend on inside the project."
+            titleHelp="Workspace bindings describe which services, connectors, or secrets this published service is allowed to depend on inside the project."
           >
             {bindingsQuery.error ? (
               <Alert

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -1061,7 +1061,7 @@ export const StudioWorkflowBuildPanel: React.FC<StudioWorkflowBuildPanelProps> =
     }
 
     if (!scopeId) {
-      const visibleMessage = 'Resolve the current scope before running the workflow draft.';
+      const visibleMessage = 'Resolve the current workspace before running the workflow draft.';
       setWorkflowRunError(visibleMessage);
       void message.error(visibleMessage);
       return;
@@ -2409,7 +2409,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
 
   const handleSave = React.useCallback(async () => {
     if (!scopeId || !activeScript?.script?.scriptId) {
-      setSaveNotice('Resolve the current scope and select a script before saving.');
+      setSaveNotice('Resolve the current workspace and select a script before saving.');
       return;
     }
 
@@ -2512,7 +2512,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
 
   const handlePromoteEvolution = React.useCallback(async () => {
     if (!scopeId || !activeScript?.script?.scriptId) {
-      setPromotionNotice('Resolve the current scope and script before proposing evolution.');
+      setPromotionNotice('Resolve the current workspace and script before proposing evolution.');
       return;
     }
 
@@ -2551,7 +2551,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
 
   const handleRun = React.useCallback(async () => {
     if (!scopeId || !activeScript?.script?.scriptId) {
-      setRunOutput('Resolve the current scope and select a script before running.');
+      setRunOutput('Resolve the current workspace and select a script before running.');
       return;
     }
 
@@ -2591,7 +2591,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
     return (
       <div data-testid="studio-script-build-panel" style={buildSurfaceCardStyle}>
         <Typography.Text type="secondary">
-          Loading scope scripts...
+          Loading workspace scripts...
         </Typography.Text>
       </div>
     );
@@ -2967,7 +2967,7 @@ export const StudioScriptBuildPanel: React.FC<StudioScriptBuildPanelProps> = ({
             </div>
           ) : (
             <Empty
-              description="Create a Script draft or select a saved scope script to start editing."
+              description="Create a Script draft or select a saved workspace script to start editing."
             >
               <Button
                 className={AEVATAR_INTERACTIVE_BUTTON_CLASS}
@@ -3240,7 +3240,7 @@ export const StudioGAgentBuildPanel: React.FC<StudioGAgentBuildPanelProps> = ({
     if (!scopeId || !selectedTypeName.trim() || !runPrompt.trim()) {
       setRunState({
         ...IDLE_DRAFT_RUN_STATE,
-        error: 'Scope, GAgent type, and prompt are required before running.',
+        error: 'Workspace, GAgent type, and prompt are required before running.',
         status: 'error',
       });
       return;

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioFilesDetailPane.tsx
@@ -766,7 +766,7 @@ async function syncWorkspaceDirectories(
       )
     ) {
       throw new Error(
-        'Workflow directories are managed by the current scope and cannot be edited here.',
+        'Workflow directories are managed by the current workspace and cannot be edited here.',
       );
     }
 
@@ -2392,8 +2392,8 @@ const StudioFilesDetailPane: React.FC<Props> = ({
             <Alert
               type="info"
               showIcon
-              message="Resolve a project scope to browse chat histories."
-              description="Chat histories are loaded from the active scope once the Studio host resolves a scope context."
+              message="Resolve a workspace to browse chat histories."
+              description="Chat histories are loaded from the active workspace once the Studio host resolves a workspace context."
             />
           </div>
         </div>
@@ -2585,8 +2585,8 @@ const StudioFilesDetailPane: React.FC<Props> = ({
             <Alert
               type="info"
               showIcon
-              message="Resolve a project scope to browse scripts."
-              description="Script files are loaded from the active scope once Studio resolves a scope context."
+              message="Resolve a workspace to browse scripts."
+              description="Script files are loaded from the active workspace once Studio resolves a workspace context."
             />
           </div>
         </div>

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioShell.test.tsx
@@ -21,7 +21,7 @@ describe('StudioShell', () => {
       key: 'script:risk-review',
       label: 'risk-review',
       description: 'definition-1',
-      meta: 'rev-2 · Scope script',
+      meta: 'rev-2 · Workspace script',
       kind: 'script',
       tone: 'draft',
     },

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -736,7 +736,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
     return (
       <Alert
         showIcon
-        message="Resolve a team scope before binding this member."
+        message="Resolve a workspace before binding this member."
         type="info"
       />
     );
@@ -749,7 +749,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
           <Alert
             showIcon
             message="Loading current member contracts..."
-            description="Studio is checking whether this member already has a callable published contract in the current scope."
+            description="Studio is checking whether this member already has a callable published contract in the current workspace."
             type="info"
           />
         </div>
@@ -788,7 +788,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                   </Typography.Text>
                 </div>
                 <div style={valueCardStyle}>
-                  <Typography.Text type="secondary">Scope</Typography.Text>
+                  <Typography.Text type="secondary">Workspace ID</Typography.Text>
                   <Typography.Text strong style={{ wordBreak: 'break-word' }}>
                     {scopeId}
                   </Typography.Text>
@@ -823,7 +823,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
       <div data-testid="studio-bind-surface" style={rootStyle}>
         <Alert
           showIcon
-          message="No published contract is available for this member in the current scope yet."
+          message="No published contract is available for this member in the current workspace yet."
           description="Bind a workflow, script, or gagent revision first so Studio can reveal the invoke contract."
           type="warning"
         />
@@ -1224,14 +1224,14 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                 children: bindContract ? (
                   <div style={parameterGridStyle}>
                     <div style={valueCardStyle}>
-                      <Typography.Text type="secondary">Scope</Typography.Text>
+                      <Typography.Text type="secondary">Workspace ID</Typography.Text>
                       <Typography.Text strong style={{ wordBreak: 'break-word' }}>
                         {bindContract.scopeLabel}
                       </Typography.Text>
                       <Typography.Text type="secondary">
                         {bindContract.scopeSource
                           ? `Resolved from ${bindContract.scopeSource}.`
-                          : 'Bound to the current Studio scope.'}
+                          : 'Bound to the current Studio workspace.'}
                       </Typography.Text>
                     </div>
                     <div style={valueCardStyle}>
@@ -1319,7 +1319,7 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                   </div>
                 ) : (
                   <Empty
-                    description="This service does not depend on any extra connectors, secrets, or service bindings in the current scope."
+                    description="This service does not depend on any extra connectors, secrets, or service bindings in the current workspace."
                     image={Empty.PRESENTED_IMAGE_SIMPLE}
                   />
                 ),

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/bindContract.ts
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/bindContract.ts
@@ -86,7 +86,7 @@ function buildAuthDescriptor(authSession?: StudioAuthSession | null): Pick<
     return {
       authAuthenticated: false,
       authEnabled: true,
-      authHint: 'Studio is not authenticated for this scope yet.',
+      authHint: 'Studio is not authenticated for this workspace yet.',
       authLabel: 'Sign-in required',
     };
   }

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -3960,7 +3960,7 @@ const StudioPage: React.FC = () => {
   ]);
   const handleBindPendingCandidate = useCallback(async () => {
     if (!buildPendingBindCandidate || !resolvedStudioScopeId) {
-      throw new Error('Resolve the current scope before binding this member.');
+      throw new Error('Resolve the current workspace before binding this member.');
     }
 
     const resolvedBuildMemberId =
@@ -4431,7 +4431,7 @@ const StudioPage: React.FC = () => {
         }
 
         if (availableScopeScriptIds.has(scriptId)) {
-          void message.warning('A scope script with the same id already exists.');
+          void message.warning('A workspace script with the same id already exists.');
           return;
         }
 
@@ -4572,7 +4572,7 @@ const StudioPage: React.FC = () => {
       if (!resolvedStudioScopeId) {
         setCreateMemberTeamId('');
         void message.success(
-          `Created workflow draft for member ${workflowName}. Connect a scope to register the backend member authority.`,
+          `Created workflow draft for member ${workflowName}. Connect a workspace to register the backend member authority.`,
         );
         return;
       }
@@ -4991,7 +4991,7 @@ const StudioPage: React.FC = () => {
     if (!scopeId) {
       setRunNotice({
         type: 'error',
-        message: 'Resolve the current scope before starting a draft run.',
+        message: 'Resolve the current workspace before starting a draft run.',
       });
       return;
     }
@@ -7112,7 +7112,7 @@ const StudioPage: React.FC = () => {
               openScopeScript(scriptId);
             } else {
               void message.warning(
-                `Could not find a scope script for ${memberImplementationName || 'this member'}.`,
+                `Could not find a workspace script for ${memberImplementationName || 'this member'}.`,
               );
             }
             return;
@@ -7433,12 +7433,12 @@ const StudioPage: React.FC = () => {
           primary: 'Script implementation',
           secondary:
             trimOptional(scriptDetail.script?.definitionActorId) ||
-            'Scope-backed script behavior',
-        }) || 'Scope-backed script behavior',
+            'Workspace script behavior',
+        }) || 'Workspace script behavior',
         kind: 'member',
         meta: formatStudioAssetMeta({
           primary: scriptDetail.script?.activeRevision || '',
-          secondary: 'Scope script',
+          secondary: 'Workspace script',
         }),
         tone:
           currentFocusMemberKey === `script:${scriptId}` ? 'live' : 'idle',
@@ -8470,7 +8470,7 @@ const StudioPage: React.FC = () => {
                       <div style={inventoryCreateHintStyle}>
                         Script id: {createScriptId || 'enter-a-script-name'}
                         {createScriptIdAlreadyExists
-                          ? ' · already exists in this scope'
+                          ? ' · already exists in this workspace'
                           : ' · saved after Validate and Save script'}
                       </div>
                     ) : null}

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -158,7 +158,7 @@ describe("TeamsHomePage", () => {
     expect(await screen.findByRole("button", { name: "查看团队" })).toBeTruthy();
     expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
     expect(screen.getByText("我的 AI 团队")).toBeTruthy();
-    expect(screen.getByText("当前 Scope")).toBeTruthy();
+    expect(screen.getByText("当前工作空间")).toBeTruthy();
     expect(screen.getByText("真实 Team")).toBeTruthy();
     expect(screen.getByText("Team roster")).toBeTruthy();
     expect(screen.getByText("运行正常")).toBeTruthy();
@@ -280,10 +280,10 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByText("当前登录态校验失败，已回退到本地 Scope")).toBeTruthy();
+    expect(await screen.findByText("当前登录态校验失败，已回退到本地工作空间")).toBeTruthy();
     expect(
       screen.getByText(
-        "登录状态暂时不可用，请刷新后重试。 当前已回退到本地会话里的 Scope scope-a。",
+        "登录状态暂时不可用，请刷新后重试。 当前已回退到本地会话里的工作空间 ID scope-a。",
       ),
     ).toBeTruthy();
 
@@ -402,7 +402,7 @@ describe("TeamsHomePage", () => {
 
     expect(
       await screen.findByText(
-        "当前 Scope 下还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。",
+        "当前工作空间还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。",
       ),
     ).toBeTruthy();
     expect(scopeRuntimeApi.listMemberRuns).not.toHaveBeenCalled();

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -1180,12 +1180,12 @@ const TeamsHomePage: React.FC = () => {
   ).length;
   const emptyRosterHint =
     scopeId.length > 0
-      ? "当前 Scope 下还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。"
-      : "先导入一个 Scope，首页才能渲染出这组 Team roster。";
+      ? "当前工作空间还没有创建任何 Team。创建 Team 后，这里会按后端 roster 展示真实团队。"
+      : "先选择一个工作空间，首页才能渲染出这组 Team roster。";
   const partialIssues = [
     servicesQuery.isError ? "服务目录暂时不可见。" : null,
-    membersQuery.isError ? "当前 Scope 的成员清单暂时不可见。" : null,
-    teamsQuery.isError ? "当前 Scope 的 Team roster 暂时不可见。" : null,
+    membersQuery.isError ? "当前工作空间的成员清单暂时不可见。" : null,
+    teamsQuery.isError ? "当前工作空间的 Team roster 暂时不可见。" : null,
     ...memberRunQueries.map((query) =>
       query.isError ? "部分成员运行信号暂时不可见。" : null,
     ),
@@ -1256,8 +1256,8 @@ const TeamsHomePage: React.FC = () => {
                 </Button>
               ) : null
             }
-            title="Scope 上下文"
-            titleHelp="这一步只负责锁定你当前要查看的 Scope，不把它抢成首页主角。"
+            title="工作空间上下文"
+            titleHelp="这一步只负责锁定你当前要查看的工作空间。"
           >
             <ScopeQueryCard
               activeScopeId={scopeId}
@@ -1323,7 +1323,7 @@ const TeamsHomePage: React.FC = () => {
                 minWidth: 0,
               }}
             >
-              <Typography.Text type="secondary">当前 Scope</Typography.Text>
+              <Typography.Text type="secondary">当前工作空间</Typography.Text>
               <Typography.Text
                 strong
                 style={{
@@ -1334,19 +1334,19 @@ const TeamsHomePage: React.FC = () => {
                 {scopeId}
               </Typography.Text>
               <Typography.Text type="secondary">
-                首页按这个 Scope 读取后端 Team roster；成员绑定与运行状态只作为 Team 卡片的辅助信号。
+                首页按这个工作空间读取后端 Team roster；成员绑定与运行状态只作为 Team 卡片的辅助信号。
               </Typography.Text>
             </div>
           </div>
         ) : null}
 
-	{!scopeId ? (
-	  <Alert
-	    showIcon
-	    title="先导入一个 Scope，首页才能渲染出这组 Team roster。"
-	    type="info"
-	  />
-	) : null}
+        {!scopeId ? (
+          <Alert
+            showIcon
+            title="先选择一个工作空间，首页才能渲染出这组 Team roster。"
+            type="info"
+          />
+        ) : null}
 
         {partialIssues.length > 0 ? (
           <Alert
@@ -1361,13 +1361,13 @@ const TeamsHomePage: React.FC = () => {
           <Alert
             description={
               resolvedScope?.scopeId
-                ? `${authSessionIssue} 当前已回退到本地会话里的 Scope ${resolvedScope.scopeId}。`
+                ? `${authSessionIssue} 当前已回退到本地会话里的工作空间 ID ${resolvedScope.scopeId}。`
                 : authSessionIssue
             }
             showIcon
             title={
               resolvedScope?.scopeId
-                ? "当前登录态校验失败，已回退到本地 Scope"
+                ? "当前登录态校验失败，已回退到本地工作空间"
                 : "当前登录态校验失败"
             }
             type="warning"
@@ -1437,11 +1437,11 @@ const TeamsHomePage: React.FC = () => {
             ) : null}
 
             {teamsQuery.isLoading ? (
-              <AevatarInspectorEmpty description="正在读取当前 Scope 的 Team roster。" />
+              <AevatarInspectorEmpty description="正在读取当前工作空间的 Team roster。" />
             ) : teamsQuery.isError ? (
               <Alert
                 showIcon
-                title="当前 Scope 的 Team roster 暂时无法加载。"
+                title="当前工作空间的 Team roster 暂时无法加载。"
                 type="error"
               />
             ) : teamPreviews.length > 0 ? (
@@ -1471,7 +1471,7 @@ const TeamsHomePage: React.FC = () => {
                       Team roster
                     </Typography.Title>
                     <Typography.Text type="secondary">
-                      当前 Scope 下已经登记的真实 Team；成员绑定和运行状态只作为辅助信号。
+                      当前工作空间下已经登记的真实 Team；成员绑定和运行状态只作为辅助信号。
                     </Typography.Text>
                   </div>
                   {visibleTeamCount > 1 ? (

--- a/apps/aevatar-console-web/src/pages/teams/new.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.test.tsx
@@ -56,7 +56,7 @@ describe('TeamCreatePage', () => {
     expect(screen.getByRole('heading', { level: 2, name: 'Create Team' })).toBeTruthy();
     expect(screen.getByText('数据源')).toBeTruthy();
     expect(screen.getByText('StudioTeam')).toBeTruthy();
-    expect(screen.getByText('Scope context')).toBeTruthy();
+    expect(screen.getByText('工作空间上下文')).toBeTruthy();
     expect(screen.getByText('Team authority')).toBeTruthy();
     expect(screen.getByRole('heading', { level: 3, name: 'Create real Team roster entry' })).toBeTruthy();
     expect(screen.getByLabelText('Team name')).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/teams/new.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/new.tsx
@@ -291,16 +291,16 @@ const TeamCreatePage: React.FC = () => {
         }}
       >
         <ConsoleMetricCard label="数据源" tone="green" value="StudioTeam" />
-        <ConsoleMetricCard label="Scope" value={scopeId || '待选择'} />
+        <ConsoleMetricCard label="工作空间" value={scopeId || '待选择'} />
         <ConsoleMetricCard label="创建后" value="Team detail" />
         <ConsoleMetricCard label="成员归属" value="后续分配" />
       </div>
 
-      <AevatarPanel layoutMode="document" padding={20} title="Scope context">
+      <AevatarPanel layoutMode="document" padding={20} title="工作空间上下文">
         <ScopeQueryCard
           activeScopeId={scopeId}
           draft={draft}
-          loadLabel="使用这个 Scope"
+          loadLabel="使用这个工作空间"
           onChange={setDraft}
           onLoad={() => {
             const nextDraft = normalizeScopeDraft(draft);
@@ -368,7 +368,7 @@ const TeamCreatePage: React.FC = () => {
                 gap: 8,
               }}
             >
-              {['真实 Team API', 'Scope 内归属', '成员后续分配', '运行态只作辅助'].map((item) => (
+              {['真实 Team API', '工作空间内归属', '成员后续分配', '运行态只作辅助'].map((item) => (
                 <span key={item} style={stageChipStyle}>
                   {item}
                 </span>

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamAssetsTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamAssetsTab.tsx
@@ -70,7 +70,7 @@ const TeamAssetsTab: React.FC<TeamAssetsTabProps> = ({
         title="当前 Team 资产"
         extra={
           <Typography.Text style={{ fontSize: 12 }} type="secondary">
-            scope workflows · scope scripts · Studio deep-link
+            workspace workflows · workspace scripts · Studio deep-link
           </Typography.Text>
         }
       >

--- a/apps/aevatar-console-web/src/pages/teams/workflowOperationalUnits.ts
+++ b/apps/aevatar-console-web/src/pages/teams/workflowOperationalUnits.ts
@@ -327,7 +327,7 @@ function deriveAttention(input: {
     return {
       attention: "no-bound-service",
       attentionDetail:
-        "This workflow advertises a service key, but no matching bound service is visible in the current scope.",
+        "This workflow advertises a service key, but no matching bound service is visible in the current workspace.",
       attentionLabel: "No bound service",
       isDraftOnly: false,
     };


### PR DESCRIPTION
## Summary

- Refine Console and Studio user-facing copy so `Scope` is presented as a workspace in operator-facing surfaces.
- Align script catalog, team home, run launch, GAgent, chat console, and Studio helper text with the Team-first / workspace IA language.
- Update related frontend tests to match the revised copy.

## Why

The Harness / Console IA discussion is converging on Team-first product language where `Scope` remains an underlying partition/context concept, while users see a workspace-level framing. This PR removes remaining user-facing `Scope` wording from the affected Console and Studio surfaces and fixes the script draft message that still referred to a team catalog when it actually means the workspace catalog.

## Related

- Relates to #568
- Relates to #567

## Validation

- `npm --prefix apps/aevatar-console-web test -- --runInBand`
  - 103 test suites passed
  - 602 tests passed
- `git diff --check`
