### PR TITLE
Remove retired ChannelRuntime direct callback endpoint

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
@@ -35,7 +35,7 @@ For Lark, follow this guidance:
 
 1. Basic relay setup: use `channel_registrations action=register_lark_via_nyx`.
    If the user has a Lark verification token or the backend requires it, pass `verification_token=<token>` through the tool call.
-   The Lark developer console callback URL must point to the Nyx webhook URL returned by that tool, not to an Aevatar `/api/channels/lark/callback/...` URL.
+   The Lark developer console callback URL must point to the Nyx webhook URL returned by that tool.
    This stage is for inbound relay wiring and basic relay replies.
 
 2. Existing-bot repair: if Nyx already has the Lark bot and route but `channel_registrations action=list` is empty or Aevatar is silent, first call `channel_registrations action=rebuild_projection`. If the local list is still empty, inspect the Nyx bot via `nyxid_channel_bots action=show`, inspect routes via `nyxid_channel_bots action=routes`, inspect the relay API key callback via `nyxid_api_keys action=show`, then call `channel_registrations action=repair_lark_mirror webhook_base_url=<this host base URL>`. Aevatar no longer preserves relay signing credential references for this path; relay callbacks must use NyxID callback JWT.

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.Channel.NyxIdRelay;
@@ -19,11 +18,6 @@ public static class ChannelCallbackEndpoints
     public static IEndpointRouteBuilder MapChannelCallbackEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/channels").WithTags("ChannelRuntime");
-
-        // Platform callback — receives webhooks directly from platforms. These are invoked by
-        // external services (Lark, Telegram, …) without our JWT, so they must remain anonymous
-        // even after the host applies an authenticated-by-default fallback policy.
-        group.MapPost("/{platform}/callback/{registrationId}", HandleCallbackAsync).AllowAnonymous();
 
         // Registration CRUD — requires authentication
         group.MapPost("/registrations", HandleRegisterAsync).RequireAuthorization();
@@ -37,31 +31,6 @@ public static class ChannelCallbackEndpoints
         group.MapGet("/diagnostics/errors", HandleGetDiagnosticErrorsAsync).RequireAuthorization();
 
         return app;
-    }
-
-    /// <summary>
-    /// Receives a platform webhook callback directly.
-    /// 1. Handles verification challenges (returns immediately).
-    /// 2. Parses inbound message.
-    /// 3. Returns 200 OK immediately (platforms have short timeouts).
-    /// 4. Fires background task: dispatch to actor, collect response, send reply via Nyx provider.
-    /// </summary>
-    private static Task<IResult> HandleCallbackAsync(
-        HttpContext http,
-        string platform,
-        string registrationId)
-    {
-        var diagnostics = http.RequestServices.GetService<IChannelRuntimeDiagnostics>();
-        RecordDiagnostic(diagnostics, "Callback:retired", platform, registrationId, "direct_callback_retired");
-        return Task.FromResult<IResult>(Results.Json(
-            new
-            {
-                error = "Direct platform callbacks are retired. ChannelRuntime now accepts only Nyx relay ingress for supported platforms.",
-                registration_id = registrationId,
-                platform,
-                supported_ingress = "/api/webhooks/nyxid-relay",
-            },
-            statusCode: StatusCodes.Status410Gone));
     }
 
     // ─── Registration CRUD ───
@@ -537,16 +506,6 @@ public static class ChannelCallbackEndpoints
                 detail = entry.Detail,
             }),
         }));
-    }
-
-    private static void RecordDiagnostic(
-        IChannelRuntimeDiagnostics? diagnostics,
-        string stage,
-        string platform,
-        string registrationId,
-        string? detail = null)
-    {
-        diagnostics?.Record(stage, platform, registrationId, detail);
     }
 
     private static int ResolveProvisioningFailureStatusCode(string? error)

--- a/docs/adr/0011-lark-nyx-relay-webhook.md
+++ b/docs/adr/0011-lark-nyx-relay-webhook.md
@@ -78,7 +78,7 @@ The required order is:
 2. Build and validate `channel-relay/reply`
 3. Switch the Lark console callback URL to Nyx
 4. Remove the direct Aevatar Lark callback path from the supported runtime contract
-5. Return `410 Gone` for `POST /api/channels/lark/callback/{registrationId}` or delete that endpoint entirely
+5. Historical transition note: the retired direct endpoint could temporarily return `410 Gone`; the current runtime deletes the direct endpoint entirely.
 
 ## Consequences
 

--- a/docs/operations/2026-04-22-lark-nyx-cutover-runbook.md
+++ b/docs/operations/2026-04-22-lark-nyx-cutover-runbook.md
@@ -13,7 +13,7 @@ This runbook reflects the post-`#308` production contract.
 
 ## Goal
 
-Cut production Lark webhook ingress over to `Lark -> NyxID -> Aevatar` and retire the direct Aevatar Lark callback with `410 Gone`.
+Cut production Lark webhook ingress over to `Lark -> NyxID -> Aevatar` and remove the direct Aevatar Lark callback from the supported runtime surface.
 
 ## Preconditions
 
@@ -51,7 +51,7 @@ Operationally:
 5. Observe:
    - Nyx -> Aevatar relay callback success
    - Aevatar -> Nyx `channel-relay/reply` success
-   - `POST /api/channels/lark/callback/{registrationId}` returns `410 Gone`
+   - no direct Aevatar Lark callback route is registered
 
 ## Backfill Notes
 
@@ -62,8 +62,8 @@ Operationally:
 - New Lark provisioning goes through Nyx only.
 - `POST /api/channels/registrations` no longer accepts direct Lark registrations.
 - `channel_registrations action=register` no longer accepts `platform=lark`.
-- `POST /api/channels/lark/callback/{registrationId}` returns `410 Gone`.
-- direct platform callback/test-reply flows are retired from ChannelRuntime.
+- the direct Aevatar Lark callback path is no longer exposed.
+- direct platform callback flows are retired from ChannelRuntime.
 - `update_token` is retired; ChannelRuntime does not store or refresh channel credentials.
 - ChannelRuntime registration queries return only non-secret routing/identity/status handles.
 - ChannelRuntime no longer requires `ICredentialProvider` / `SecretsStoreCredentialProvider` composition for channel registration or reply delivery.

--- a/docs/operations/2026-04-27-telegram-nyx-cutover-runbook.md
+++ b/docs/operations/2026-04-27-telegram-nyx-cutover-runbook.md
@@ -125,7 +125,7 @@ because Aevatar never persisted the bot token.
 ## Expected Runtime Behavior
 
 - Inbound Telegram updates arrive at Aevatar through `POST /api/webhooks/nyxid-relay`
-  carrying `payload.platform == "telegram"`. There is no separate `/api/channels/telegram/callback/...` path on Aevatar.
+  carrying `payload.platform == "telegram"`. There is no separate direct Telegram callback path on Aevatar.
 - `ConversationReference.Scope` for Telegram traffic is derived by
   `NyxIdRelayConversationTypeMap`:
   `private` -> `DirectMessage`, `group` / `supergroup` -> `Group`,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -41,6 +41,30 @@ public sealed class ChannelCallbackEndpointsTests
     }
 
     [Fact]
+    public void MapChannelCallbackEndpoints_ShouldNotRegisterRetiredDirectPlatformCallback()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = "Development",
+        });
+
+        var app = builder.Build();
+        var routeBuilder = (IEndpointRouteBuilder)app;
+        app.MapChannelCallbackEndpoints();
+
+        var routePatterns = routeBuilder.DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(route => route.RoutePattern.RawText)
+            .ToArray();
+
+        routePatterns.Any(pattern => pattern?.Contains("/callback/", StringComparison.Ordinal) == true)
+            .Should().BeFalse();
+        routePatterns.Should().Contain("/api/channels/registrations");
+        routePatterns.Should().Contain("/api/channels/diagnostics/errors");
+    }
+
+    [Fact]
     public async Task HandleRegisterAsync_RejectsUnsupportedPlatform()
     {
         var provisioningService = Substitute.For<INyxChannelBotProvisioningService>();


### PR DESCRIPTION
## Summary

- Remove the retired direct platform callback route from `ChannelCallbackEndpoints`.
- Drop the `direct_callback_retired` diagnostic path that only existed for that route.
- Add route coverage proving ChannelRuntime no longer registers callback-style `/api/channels/.../callback/...` routes.
- Update runtime guidance and cutover docs to point only at NyxID relay ingress.

Fixes #671.

## Validation

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo --filter "FullyQualifiedName~NyxIdChatGAgentTests|FullyQualifiedName~NyxIdChatEndpointsCoverageTests"`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`