### PR TITLE
Address ChannelRuntime callback review comments

### DIFF
--- a/docs/adr/0011-lark-nyx-relay-webhook.md
+++ b/docs/adr/0011-lark-nyx-relay-webhook.md
@@ -78,7 +78,7 @@ The required order is:
 2. Build and validate `channel-relay/reply`
 3. Switch the Lark console callback URL to Nyx
 4. Remove the direct Aevatar Lark callback path from the supported runtime contract
-5. Historical transition note: the retired direct endpoint could temporarily return `410 Gone`; the current runtime deletes the direct endpoint entirely.
+5. Return `410 Gone` for `POST /api/channels/lark/callback/{registrationId}` or delete that endpoint entirely
 
 ## Consequences
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -21,14 +21,14 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public sealed class ChannelCallbackEndpointsTests
 {
     [Fact]
-    public void MapChannelCallbackEndpoints_ShouldRequireAuthorization_ForDiagnosticErrors()
+    public async Task MapChannelCallbackEndpoints_ShouldRequireAuthorization_ForDiagnosticErrors()
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
             EnvironmentName = "Development",
         });
 
-        var app = builder.Build();
+        await using var app = builder.Build();
         var routeBuilder = (IEndpointRouteBuilder)app;
         app.MapChannelCallbackEndpoints();
 
@@ -41,14 +41,14 @@ public sealed class ChannelCallbackEndpointsTests
     }
 
     [Fact]
-    public void MapChannelCallbackEndpoints_ShouldNotRegisterRetiredDirectPlatformCallback()
+    public async Task MapChannelCallbackEndpoints_ShouldNotRegisterRetiredDirectPlatformCallback()
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
             EnvironmentName = "Development",
         });
 
-        var app = builder.Build();
+        await using var app = builder.Build();
         var routeBuilder = (IEndpointRouteBuilder)app;
         app.MapChannelCallbackEndpoints();
 


### PR DESCRIPTION
## Summary

- Revert the ADR-0011 edit from PR #673 so the already-superseded ADR remains immutable.
- Dispose the `WebApplication` instances in the ChannelCallback route mapping tests with `await using`.

Follow-up for review comments on #673.

## Validation

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo`
- `bash tools/ci/test_stability_guards.sh`
- `git diff --check`