### PR TITLE
Fix tractable findings from PR #678 multi-model review

### DIFF
--- a/.claude/skills/codex-refactor-loop/prompts/remote-ci-fix.md
+++ b/.claude/skills/codex-refactor-loop/prompts/remote-ci-fix.md
@@ -5,7 +5,7 @@ PR: `{{pr_number}}`，失败 check: `{{check_name}}`，run url: `{{run_url}}`。
 
 ## 必读
 
-1. `/Users/auric/aevatar/CLAUDE.md`
+1. `$REPO_ROOT/CLAUDE.md`
 2. 失败日志：`{{failure_log_path}}` —— 完整 stderr/stdout 的最后 200-1000 行
 3. 最近 commits（可能引入失败的）：通过 `git log --oneline -10 origin/{{base_branch}}..HEAD` 查看
 4. 失败 check 对应的本地 job 脚本（如有，位于 `.github/workflows/`）
@@ -39,7 +39,7 @@ PR: `{{pr_number}}`，失败 check: `{{check_name}}`，run url: `{{run_url}}`。
    - `git add -A && git status`
    - **不 commit**（controller 处理）
 
-6. 摘要写入 `/Users/auric/aevatar/.refactor-loop/runs/remote-ci-fix-{{check_name}}-{{sha_short}}.md`：
+6. 摘要写入 `$REPO_ROOT/.refactor-loop/runs/remote-ci-fix-{{check_name}}-{{sha_short}}.md`：
    - 根因分析
    - 改动文件列表
    - 本地复现/验证命令
@@ -49,7 +49,7 @@ PR: `{{pr_number}}`，失败 check: `{{check_name}}`，run url: `{{run_url}}`。
 
 ## 红线
 
-- worktree 外**唯一可写**：`/Users/auric/aevatar/.refactor-loop/runs/remote-ci-fix-{{check_name}}-{{sha_short}}.md`
+- worktree 外**唯一可写**：`$REPO_ROOT/.refactor-loop/runs/remote-ci-fix-{{check_name}}-{{sha_short}}.md`
 - 禁止 commit/push/checkout/install
 - 禁止 disable 测试或加 `[Skip]` 让 CI 绿
 - 禁止改 worktree 外的其它 cluster 工作

--- a/.claude/skills/codex-refactor-loop/prompts/test-add.md
+++ b/.claude/skills/codex-refactor-loop/prompts/test-add.md
@@ -4,9 +4,9 @@ worktree: `{{worktree_path}}`，分支 `{{branch}}`。
 
 ## 必读
 
-1. `/Users/auric/aevatar/CLAUDE.md` 全部强制条款（含 "Codex CLI 调用规范"、"测试与质量门禁"）。
-2. `/Users/auric/aevatar/.refactor-loop/runs/audit-iter-N.md` 中 `{{cluster_id}}` 一节
-3. `/Users/auric/aevatar/.refactor-loop/runs/implement-{{cluster_id}}.md`
+1. `$REPO_ROOT/CLAUDE.md` 全部强制条款（含 "Codex CLI 调用规范"、"测试与质量门禁"）。
+2. `$REPO_ROOT/.refactor-loop/runs/audit-iter-N.md` 中 `{{cluster_id}}` 一节
+3. `$REPO_ROOT/.refactor-loop/runs/implement-{{cluster_id}}.md`
 4. **未覆盖行报告**：以下文件:行号 是 codecov 标记为 patch miss/partial 的位置：
 
 ```
@@ -56,7 +56,7 @@ worktree: `{{worktree_path}}`，分支 `{{branch}}`。
    dotnet test {{primary_test_project_csproj}} --nologo --collect:"XPlat Code Coverage" \
      --settings <coverlet.runsettings if exists> 2>&1 | tail -5
    ```
-7. 跑 `bash /Users/auric/aevatar/tools/ci/test_stability_guards.sh` —— 必须通过（禁 `Task.Delay` 等）。
+7. 跑 `bash $REPO_ROOT/tools/ci/test_stability_guards.sh` —— 必须通过（禁 `Task.Delay` 等）。
 8. `git add -A && git status`。
 9. **不 commit**。
 10. 摘要写入 `$REPO_ROOT/.refactor-loop/runs/test-add-{{cluster_id}}.md`：

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,11 @@
     <!-- Refactor (iter13/cluster-023):
          Old: 1.15.0 triggered NU1902 vulnerable-package warnings on production hosts
          (GHSA-g94r-2vxg-569j, GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933).
-         New: bump to same-line patch 1.15.3 (no API change) to clear advisories. -->
+         New: the security-critical core/exporter packages are individually pinned to
+         1.15.3 in the ItemGroup below (see the OpenTelemetry comment there). This
+         variable stays at 1.15.1 — the highest patch shared by the packages that have
+         no 1.15.3 release (Instrumentation.Runtime, Exporter.Prometheus.AspNetCore);
+         it is NOT the advisory-clearing version. -->
     <OpenTelemetryVersion>1.15.1</OpenTelemetryVersion>
     <!-- MassTransit (pinned to v8.x; do not upgrade to v9 without explicit architecture decision) -->
     <MassTransitVersion>8.5.7</MassTransitVersion>

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Aevatar.CQRS.Projection.Core.DependencyInjection;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Core.Streaming;
 using Aevatar.CQRS.Projection.Runtime.DependencyInjection;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.AI.ToolProviders.Lark;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions.Slash;
@@ -108,15 +109,31 @@ public static class ServiceCollectionExtensions
             },
             static context => new NyxIdChatSessionRuntimeLease(context));
         services.TryAddSingleton<IProjectionClock, SystemProjectionClock>();
-        services.TryAddSingleton<IProjectionSessionEventCodec<AGUIEvent>, NyxIdChatSessionEventCodec>();
-        services.TryAddSingleton<IProjectionSessionEventHub<AGUIEvent>, ProjectionSessionEventHub<AGUIEvent>>();
-        services.TryAddSingleton<INyxIdChatSessionProjectionPort, NyxIdChatSessionProjectionPort>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<
-            IProjectionProjector<NyxIdChatSessionProjectionContext>,
-            NyxIdChatSessionEventProjector>());
+        // Fix (pr678-review): NyxId chat, GAgent draft-run and script-service AGUI all
+        //   project AGUIEvent. Registering IProjectionSessionEventCodec<AGUIEvent> /
+        //   IProjectionSessionEventHub<AGUIEvent> as one shared service let TryAddSingleton
+        //   silently drop whichever module registered second — a pipeline could then run on
+        //   the wrong codec/channel. Each pipeline now builds its own channel-scoped hub.
+        services.TryAddSingleton<INyxIdChatSessionProjectionPort>(static sp =>
+            new NyxIdChatSessionProjectionPort(
+                sp.GetRequiredService<IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease>>(),
+                sp.GetRequiredService<IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease>>(),
+                CreateNyxIdChatSessionEventHub(sp)));
+        services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<IProjectionProjector<NyxIdChatSessionProjectionContext>, NyxIdChatSessionEventProjector>(
+                static sp => new NyxIdChatSessionEventProjector(CreateNyxIdChatSessionEventHub(sp))));
 
         return services;
     }
+
+    // Fix (pr678-review): builds a NyxId-chat-scoped event hub so its session streams
+    //   are codec/channel-isolated from the draft-run and script-service AGUI pipelines.
+    //   The hub holds no mutable state, so a per-consumer instance is safe.
+    private static ProjectionSessionEventHub<AGUIEvent> CreateNyxIdChatSessionEventHub(IServiceProvider sp) =>
+        new(
+            sp.GetRequiredService<IStreamProvider>(),
+            new NyxIdChatSessionEventCodec(),
+            sp.GetService<ILogger<ProjectionSessionEventHub<AGUIEvent>>>());
 
     private static NyxIdRelayOptions BindRelayOptions(IConfiguration? configuration)
     {

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -82,6 +82,13 @@ public sealed class UserAgentCatalogProjector
             }
 
             var existing = await _documentReader.GetAsync(key, ct);
+            // Fix (pr678-review): per-source monotonic guard. The document merges two
+            //   authoritative sources (catalog + runner), so it cannot carry one
+            //   authoritative version. Skip a catalog commit already materialized here —
+            //   without this, a stale/replayed catalog event would roll CatalogSourceVersion
+            //   back and re-write older membership fields over newer ones.
+            if (existing is not null && stateEvent.Version <= existing.CatalogSourceVersion)
+                continue;
             var document = MaterializeCatalogEntry(entry, stateEvent, updatedAt, existing);
             if (!string.Equals(document.Id, key, StringComparison.Ordinal))
             {
@@ -105,6 +112,10 @@ public sealed class UserAgentCatalogProjector
 
         var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
         var existing = await _documentReader.GetAsync(agentId, ct);
+        // Fix (pr678-review): per-source monotonic guard — skip a runner commit already
+        //   materialized into this document (see ProjectCatalogMembershipAsync).
+        if (existing is not null && stateEvent.Version <= existing.RunnerSourceVersion)
+            return;
         await _writeDispatcher.UpsertAsync(
             MaterializeRunnerExecution(agentId, state, stateEvent, updatedAt, existing),
             ct);
@@ -230,6 +241,11 @@ public sealed class UserAgentCatalogProjector
             : SkillRunnerDefaults.StatusRunning;
     }
 
+    // Fix (pr678-review): StateVersion merges two authoritative source versions. With the
+    //   per-source monotonic guards above, every accepted event strictly advances exactly
+    //   one source, so the sum is strictly monotonic per document and is a valid overwrite
+    //   watermark. CatalogSourceVersion / RunnerSourceVersion remain the honest per-source
+    //   versions; a fully vector-typed StateVersion would need a proto schema change.
     private static long ResolveMergedStateVersion(UserAgentCatalogDocument document) =>
         Math.Max(0, document.CatalogSourceVersion) + Math.Max(0, document.RunnerSourceVersion);
 

--- a/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
+++ b/src/Aevatar.AI.Core/Tools/StreamingToolExecutor.cs
@@ -36,6 +36,10 @@ public sealed class StreamingToolExecutor : IDisposable
     private readonly Channel<ToolExecutionResult> _readyResults = Channel.CreateUnbounded<ToolExecutionResult>(
         new UnboundedChannelOptions { SingleReader = false, SingleWriter = true });
     private readonly CancellationTokenSource _discardCts = new();
+    // Fix (pr678-review): the coordinator loop was started fire-and-forget (`_ = RunCoordinatorAsync()`),
+    //   so a fault inside it was unobserved and silently stopped all tool processing — callers blocked
+    //   in GetRemainingResultsAsync would then hang forever. Keep the task so faults stay observable.
+    private readonly Task _coordinatorTask;
 
     public StreamingToolExecutor(
         ToolManager tools,
@@ -47,7 +51,7 @@ public sealed class StreamingToolExecutor : IDisposable
         _hooks = hooks;
         _toolMiddlewares = toolMiddlewares ?? [];
         _requestMetadata = requestMetadata;
-        _ = RunCoordinatorAsync();
+        _coordinatorTask = RunCoordinatorAsync();
     }
 
     /// <summary>
@@ -115,6 +119,13 @@ public sealed class StreamingToolExecutor : IDisposable
     {
         Discard();
         _signals.Writer.TryComplete();
+        // Observe a faulted coordinator task so its exception is not re-raised
+        // unobserved on the finalizer thread after the executor is disposed.
+        _coordinatorTask.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
         _discardCts.Dispose();
     }
 
@@ -284,7 +295,19 @@ public sealed class StreamingToolExecutor : IDisposable
         var completion = new TaskCompletionSource<ExecutorStateSnapshot>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         await _signals.Writer.WriteAsync(new StateRequestSignal(completion), ct);
-        return await completion.Task.WaitAsync(ct);
+
+        // Fix (pr678-review): if the coordinator loop has faulted or stopped, completion.Task
+        //   would never be set and this await would hang until ct fires. Race the request
+        //   against the coordinator task so a fault surfaces to the caller instead.
+        var finished = await Task.WhenAny(completion.Task, _coordinatorTask).WaitAsync(ct);
+        if (finished == _coordinatorTask)
+        {
+            await _coordinatorTask; // observe / rethrow the coordinator fault, if any
+            throw new InvalidOperationException(
+                "StreamingToolExecutor coordinator stopped before the state request was served.");
+        }
+
+        return await completion.Task;
     }
 
     private void PostSignal(CoordinatorSignal signal) => _signals.Writer.TryWrite(signal);

--- a/src/platform/Aevatar.GAgentService.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using Aevatar.GAgentService.Projection.ReadModels;
 using Aevatar.Presentation.AGUI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgentService.Projection.DependencyInjection;
 
@@ -138,10 +139,22 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IGAgentRunTerminalProjectionPort, GAgentRunTerminalProjectionPort>();
         services.TryAddSingleton<ILlmSessionCurrentStateProjectionPort, LlmSessionCurrentStateProjectionPort>();
         services.TryAddSingleton<IResponsesAgentToolStateCurrentStateProjectionPort, ResponsesAgentToolStateCurrentStateProjectionPort>();
-        services.TryAddSingleton<IProjectionSessionEventCodec<AGUIEvent>, GAgentDraftRunSessionEventCodec>();
-        services.TryAddSingleton<IProjectionSessionEventHub<AGUIEvent>, ProjectionSessionEventHub<AGUIEvent>>();
-        services.TryAddSingleton<IGAgentDraftRunProjectionPort, GAgentDraftRunProjectionPort>();
-        services.TryAddSingleton<IScriptServiceAguiProjectionPort, ScriptServiceAguiProjectionPort>();
+        // Fix (pr678-review): see Aevatar.GAgents.NyxidChat ServiceCollectionExtensions.
+        //   AGUIEvent is projected by three pipelines (draft-run, script-service, NyxId chat);
+        //   a single shared IProjectionSessionEventHub<AGUIEvent> made TryAddSingleton silently
+        //   drop all codecs but the first. Each pipeline now builds its own channel-scoped hub.
+        services.TryAddSingleton<IGAgentDraftRunProjectionPort>(static sp =>
+            new GAgentDraftRunProjectionPort(
+                sp.GetRequiredService<ServiceProjectionOptions>(),
+                sp.GetRequiredService<IProjectionScopeActivationService<GAgentDraftRunRuntimeLease>>(),
+                sp.GetRequiredService<IProjectionScopeReleaseService<GAgentDraftRunRuntimeLease>>(),
+                CreateAguiSessionEventHub(sp, new GAgentDraftRunSessionEventCodec())));
+        services.TryAddSingleton<IScriptServiceAguiProjectionPort>(static sp =>
+            new ScriptServiceAguiProjectionPort(
+                sp.GetRequiredService<ServiceProjectionOptions>(),
+                sp.GetRequiredService<IProjectionScopeActivationService<ScriptServiceAguiRuntimeLease>>(),
+                sp.GetRequiredService<IProjectionScopeReleaseService<ScriptServiceAguiRuntimeLease>>(),
+                CreateAguiSessionEventHub(sp, new ScriptServiceAguiSessionEventCodec())));
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceCatalogReadModel>, ServiceCatalogReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceDeploymentCatalogReadModel>, ServiceDeploymentCatalogReadModelMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<ServiceServingSetReadModel>, ServiceServingSetReadModelMetadataProvider>();
@@ -197,15 +210,27 @@ public static class ServiceCollectionExtensions
         services.AddCurrentStateProjectionMaterializer<
             ResponsesAgentToolStateCurrentStateProjectionContext,
             ResponsesAgentToolStateCurrentStateProjector>();
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<
-            IProjectionProjector<GAgentDraftRunProjectionContext>,
-            GAgentDraftRunSessionEventProjector>());
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<
-            IProjectionProjector<ScriptServiceAguiProjectionContext>,
-            ScriptServiceAguiSessionEventProjector>());
+        services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<IProjectionProjector<GAgentDraftRunProjectionContext>, GAgentDraftRunSessionEventProjector>(
+                static sp => new GAgentDraftRunSessionEventProjector(
+                    CreateAguiSessionEventHub(sp, new GAgentDraftRunSessionEventCodec()))));
+        services.TryAddEnumerable(ServiceDescriptor
+            .Singleton<IProjectionProjector<ScriptServiceAguiProjectionContext>, ScriptServiceAguiSessionEventProjector>(
+                static sp => new ScriptServiceAguiSessionEventProjector(
+                    CreateAguiSessionEventHub(sp, new ScriptServiceAguiSessionEventCodec()))));
 
         return services;
     }
+
+    // Fix (pr678-review): builds a channel-scoped AGUIEvent hub for one projection
+    //   pipeline. The hub holds no mutable state, so a per-consumer instance is safe.
+    private static ProjectionSessionEventHub<AGUIEvent> CreateAguiSessionEventHub(
+        IServiceProvider sp,
+        IProjectionSessionEventCodec<AGUIEvent> codec) =>
+        new(
+            sp.GetRequiredService<IStreamProvider>(),
+            codec,
+            sp.GetService<ILogger<ProjectionSessionEventHub<AGUIEvent>>>());
 
     private static IServiceCollection AddServiceProjectionRuntime<TContext, TScopeAgent>(
         this IServiceCollection services,

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiSessionEventCodec.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiSessionEventCodec.cs
@@ -1,0 +1,46 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Presentation.AGUI;
+using Google.Protobuf;
+
+namespace Aevatar.GAgentService.Projection.Orchestration;
+
+// Fix (pr678-review): script-service AGUI projection had no codec of its own and
+//   silently rode on GAgentDraftRunSessionEventCodec through a shared
+//   IProjectionSessionEventCodec<AGUIEvent> registration. It now owns a distinct
+//   channel so its session streams are isolated from the draft-run pipeline.
+public sealed class ScriptServiceAguiSessionEventCodec : IProjectionSessionEventCodec<AGUIEvent>
+{
+    public string Channel => "script-service-agui-session";
+
+    public string GetEventType(AGUIEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        return evt.EventCase == AGUIEvent.EventOneofCase.None
+            ? AGUIEvent.Descriptor.FullName
+            : evt.EventCase.ToString();
+    }
+
+    public ByteString Serialize(AGUIEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        return evt.ToByteString();
+    }
+
+    public AGUIEvent? Deserialize(string eventType, ByteString payload)
+    {
+        if (string.IsNullOrWhiteSpace(eventType) || payload == null || payload.IsEmpty)
+            return null;
+
+        try
+        {
+            var decoded = AGUIEvent.Parser.ParseFrom(payload);
+            return string.Equals(GetEventType(decoded), eventType, StringComparison.Ordinal)
+                ? decoded
+                : null;
+        }
+        catch (InvalidProtocolBufferException)
+        {
+            return null;
+        }
+    }
+}

--- a/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingToolExecutorTests.cs
@@ -385,6 +385,32 @@ public class StreamingToolExecutorTests
         results[0].Result.Should().Contain("not found");
     }
 
+    [Fact]
+    public async Task CoordinatorFault_ShouldSurfaceToCaller_NotHang()
+    {
+        // Fix (pr678-review): the coordinator loop was started fire-and-forget, so a fault
+        // inside it left GetRemainingResultsAsync awaiting a completion that was never set.
+        // A tool whose IsReadOnly getter throws forces the coordinator loop to fault; the
+        // caller must observe that fault instead of hanging forever.
+        var tools = new ToolManager();
+        tools.Register(new FaultingTool("boom"));
+
+        using var executor = new StreamingToolExecutor(tools);
+        executor.AddTool(new ToolCall { Id = "tc-1", Name = "boom", ArgumentsJson = "{}" });
+
+        // Safety net: with the fix the fault surfaces in milliseconds; without it this
+        // await would hang indefinitely, so the linked timeout bounds a regression.
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        var drain = async () =>
+        {
+            await foreach (var _ in executor.GetRemainingResultsAsync(timeout.Token)) { }
+        };
+
+        (await drain.Should().ThrowAsync<InvalidOperationException>())
+            .Which.Message.Should().Contain("injected coordinator fault");
+    }
+
     // ─── Test helpers ───
 
     private sealed class ConcurrencyTrackingTool : IAgentTool
@@ -418,6 +444,17 @@ public class StreamingToolExecutorTests
         public string ParametersSchema => "{}";
         public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
             Task.FromResult(execute(argumentsJson));
+    }
+
+    private sealed class FaultingTool(string name) : IAgentTool
+    {
+        public string Name => name;
+        public string Description => "faulting";
+        public string ParametersSchema => "{}";
+        // Read by the coordinator's HandleToolDiscovered — throwing here faults the loop.
+        public bool IsReadOnly => throw new InvalidOperationException("injected coordinator fault");
+        public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+            Task.FromResult("unreachable");
     }
 
     private sealed class DelegateToolCallMiddleware(

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -2,11 +2,18 @@ using System.Runtime.CompilerServices;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Runtime.Streaming;
 using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Projection.Configuration;
+using Aevatar.GAgentService.Projection.DependencyInjection;
 using Aevatar.GAgentService.Projection.Orchestration;
+using Aevatar.GAgentService.Projection.Projectors;
 using Aevatar.Presentation.AGUI;
 using FluentAssertions;
+using Google.Protobuf;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.GAgentService.Tests.Projection;
 
@@ -16,6 +23,77 @@ namespace Aevatar.GAgentService.Tests.Projection;
 public sealed class ScriptServiceAguiProjectionPortTests
 {
     private const string ScriptServiceAguiProjectionKind = "script-service-agui-session";
+
+    [Fact]
+    public void SessionEventCodec_ShouldSerializeDeserializeAndValidateEventType()
+    {
+        var codec = new ScriptServiceAguiSessionEventCodec();
+        var evt = new AGUIEvent
+        {
+            RunFinished = new RunFinishedEvent
+            {
+                ThreadId = "script-actor-1",
+                RunId = "run-1",
+            },
+        };
+
+        codec.Channel.Should().Be(ScriptServiceAguiProjectionKind);
+        codec.GetEventType(evt).Should().Be(AGUIEvent.EventOneofCase.RunFinished.ToString());
+
+        var payload = codec.Serialize(evt);
+        codec.Deserialize(codec.GetEventType(evt), payload).Should().BeEquivalentTo(evt);
+        codec.Deserialize("DifferentType", payload).Should().BeNull();
+        codec.Deserialize("", payload).Should().BeNull();
+        codec.Deserialize(codec.GetEventType(evt), null!).Should().BeNull();
+        codec.Deserialize(codec.GetEventType(evt), ByteString.Empty).Should().BeNull();
+        codec.Deserialize(codec.GetEventType(evt), ByteString.CopyFromUtf8("not-a-proto")).Should().BeNull();
+        codec.GetEventType(new AGUIEvent()).Should().Be(AGUIEvent.Descriptor.FullName);
+
+        var getEventTypeWithNull = () => codec.GetEventType(null!);
+        getEventTypeWithNull.Should().Throw<ArgumentNullException>();
+        var serializeWithNull = () => codec.Serialize(null!);
+        serializeWithNull.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddGAgentServiceProjection_ShouldResolveChannelScopedAguiPortsAndProjectors()
+    {
+        var services = new ServiceCollection();
+
+        services.AddGAgentServiceProjection();
+        services.AddSingleton<IStreamProvider, InMemoryStreamProvider>();
+        services.AddSingleton<IProjectionScopeActivationService<GAgentDraftRunRuntimeLease>>(
+            new StaticActivationService<GAgentDraftRunRuntimeLease>(new GAgentDraftRunRuntimeLease(new GAgentDraftRunProjectionContext
+            {
+                RootActorId = "draft-actor-1",
+                ProjectionKind = "service-draft-run-session",
+                SessionId = "draft-run-1",
+            })));
+        services.AddSingleton<IProjectionScopeReleaseService<GAgentDraftRunRuntimeLease>, StaticReleaseService<GAgentDraftRunRuntimeLease>>();
+        services.AddSingleton<IProjectionScopeActivationService<ScriptServiceAguiRuntimeLease>>(
+            new StaticActivationService<ScriptServiceAguiRuntimeLease>(new ScriptServiceAguiRuntimeLease(new ScriptServiceAguiProjectionContext
+            {
+                RootActorId = "script-actor-1",
+                ProjectionKind = ScriptServiceAguiProjectionKind,
+                SessionId = "run-1",
+            })));
+        services.AddSingleton<IProjectionScopeReleaseService<ScriptServiceAguiRuntimeLease>, StaticReleaseService<ScriptServiceAguiRuntimeLease>>();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IGAgentDraftRunProjectionPort>()
+            .Should().BeOfType<GAgentDraftRunProjectionPort>();
+        provider.GetRequiredService<IScriptServiceAguiProjectionPort>()
+            .Should().BeOfType<ScriptServiceAguiProjectionPort>();
+        provider.GetServices<IProjectionProjector<GAgentDraftRunProjectionContext>>()
+            .Should().ContainSingle(x => x is GAgentDraftRunSessionEventProjector);
+        provider.GetServices<IProjectionProjector<ScriptServiceAguiProjectionContext>>()
+            .Should().ContainSingle(x => x is ScriptServiceAguiSessionEventProjector);
+        provider.GetServices<IProjectionSessionEventCodec<AGUIEvent>>()
+            .Should().BeEmpty("AGUIEvent codecs are channel-scoped inside each pipeline factory");
+        provider.GetServices<IProjectionSessionEventHub<AGUIEvent>>()
+            .Should().BeEmpty("AGUIEvent hubs are channel-scoped inside each pipeline factory");
+    }
 
     [Fact]
     public async Task EnsureAttachDetachRelease_ShouldUseSessionProjectionLease()
@@ -192,6 +270,28 @@ public sealed class ScriptServiceAguiProjectionPortTests
         {
             onDispose();
             return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class StaticActivationService<TLease>(TLease lease) : IProjectionScopeActivationService<TLease>
+        where TLease : class, IProjectionRuntimeLease
+    {
+        public Task<TLease> EnsureAsync(ProjectionScopeStartRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(lease);
+        }
+    }
+
+    private sealed class StaticReleaseService<TLease> : IProjectionScopeReleaseService<TLease>
+        where TLease : class, IProjectionRuntimeLease
+    {
+        public Task ReleaseIfIdleAsync(TLease lease, CancellationToken ct = default)
+        {
+            _ = lease;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceConfigurationProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceConfigurationProjectionInfrastructureTests.cs
@@ -78,10 +78,12 @@ public sealed class ServiceConfigurationProjectionInfrastructureTests
             x.ImplementationType == typeof(ServiceConfigurationQueryReader));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionMaterializer<ServiceConfigurationProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceConfigurationProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceConfigurationProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceConfigurationProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceConfigurationProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceConfigurationProjector)));
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -321,13 +321,16 @@ public sealed class ServiceProjectionInfrastructureTests
             x.ImplementationType == typeof(GAgentRunTerminalProjectionPort));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceCatalogProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceCatalogProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceCatalogProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceRevisionCatalogProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceRevisionCatalogProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceRevisionCatalogProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(ICurrentStateProjectionMaterializer<GAgentRunTerminalProjectionContext>) &&
-            x.ImplementationType == typeof(GAgentRunTerminalProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(GAgentRunTerminalProjector)));
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectionInfrastructureTests.cs
@@ -139,19 +139,24 @@ public sealed class ServiceServingProjectionInfrastructureTests
             x.ImplementationType == typeof(ServiceTrafficViewProjectionPort));
         services.Should().Contain(x =>
             x.ServiceType == typeof(ICurrentStateProjectionMaterializer<ServiceServingSetProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceServingSetProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceServingSetProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(ICurrentStateProjectionMaterializer<ServiceTrafficViewProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceTrafficViewProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceTrafficViewProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceDeploymentCatalogProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceDeploymentCatalogProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceDeploymentCatalogProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceRolloutProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceRolloutProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceRolloutProjector)));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceRolloutProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceRolloutCommandObservationProjector));
+            x.ImplementationType != null &&
+            x.ImplementationType.GenericTypeArguments.Contains(typeof(ServiceRolloutCommandObservationProjector)));
     }
 
     [Fact]

--- a/tools/ci/orleans_garnet_persistence_smoke.sh
+++ b/tools/ci/orleans_garnet_persistence_smoke.sh
@@ -15,10 +15,15 @@ GARNET_CONTAINER_NAME="aevatar-garnet"
 GARNET_READY_LOG="Ready to accept connections"
 GARNET_WAIT_ATTEMPTS="${GARNET_WAIT_ATTEMPTS:-60}"
 GARNET_WAIT_INTERVAL_SECONDS="${GARNET_WAIT_INTERVAL_SECONDS:-2}"
+GARNET_COMPOSE_UP_ATTEMPTS="${GARNET_COMPOSE_UP_ATTEMPTS:-3}"
+GARNET_COMPOSE_UP_RETRY_SECONDS="${GARNET_COMPOSE_UP_RETRY_SECONDS:-10}"
+GARNET_STARTED_BY_SCRIPT=0
 
 cleanup() {
-  docker compose stop garnet >/dev/null 2>&1 || true
-  docker compose rm -f garnet >/dev/null 2>&1 || true
+  if [[ "${GARNET_STARTED_BY_SCRIPT}" == "1" ]]; then
+    docker compose stop garnet >/dev/null 2>&1 || true
+    docker compose rm -f garnet >/dev/null 2>&1 || true
+  fi
   release_distributed_smoke_lock
 }
 trap cleanup EXIT INT TERM
@@ -53,10 +58,30 @@ wait_garnet() {
   return 1
 }
 
+start_garnet_with_retry() {
+  local attempt
+
+  for ((attempt = 1; attempt <= GARNET_COMPOSE_UP_ATTEMPTS; attempt++)); do
+    if docker compose up -d garnet; then
+      GARNET_STARTED_BY_SCRIPT=1
+      return 0
+    fi
+
+    if (( attempt == GARNET_COMPOSE_UP_ATTEMPTS )); then
+      echo "Failed to start Garnet after ${GARNET_COMPOSE_UP_ATTEMPTS} attempts."
+      return 1
+    fi
+
+    echo "Garnet compose startup failed; retrying in ${GARNET_COMPOSE_UP_RETRY_SECONDS}s... (attempt ${attempt}/${GARNET_COMPOSE_UP_ATTEMPTS})"
+    docker compose rm -f garnet >/dev/null 2>&1 || true
+    sleep "${GARNET_COMPOSE_UP_RETRY_SECONDS}"
+  done
+}
+
 echo "Starting Garnet..."
 acquire_distributed_smoke_lock "${LOCK_OWNER}"
 ensure_local_tcp_ports_free "${LOCK_OWNER}" "${GARNET_PORT}"
-docker compose up -d garnet
+start_garnet_with_retry
 wait_garnet
 
 echo "Running Orleans + Garnet persistence integration test..."


### PR DESCRIPTION
## Context

PR #678 (*Refactor iter1: clean 3 architectural violations + add codex-refactor-loop skill*)
was merged into `dev` (merge commit `601d92b2`) before a post-merge review completed.
This follow-up PR carries that review as its body and fixes every tractable finding.

The review ran 6 models over the #678 diff via `/opencode-pr-review`.
**deepseek-v4-pro · glm-5.1 · mimo-v2.5-pro · codex** produced parseable reviews;
**kimi** timed out and **gemini** OOM'd — both excluded. 23 raw clusters were
consolidated into ~18 distinct findings; each is dispositioned below.

| Finding | Sev | Models | Disposition |
|---|---|---|---|
| M1 hardcoded dev paths in skill prompts | major | glm-5.1 | ✅ fixed |
| M4 `IProjectionSessionEventCodec<AGUIEvent>` DI collision | major | codex | ✅ fixed |
| M5 projector synthesizes `StateVersion` | major | codex | ✅ fixed |
| M6 fire-and-forget tool coordinator | major | v4-pro + mimo | ✅ fixed |
| m1 misleading OpenTelemetry comment | minor | glm-5.1 + mimo | ✅ fixed |
| M3 HouseholdEntityToolSource DI param | major | glm-5.1 | ✔️ verified OK |
| M2 reasoning collects only `DeltaContent` | major | v4-pro | 📝 correct as-is |
| M7 hook-rewrite-to-destructive continues | major | codex | 📝 pre-existing |
| M8 2-min timeout now covers dispatch | major | v4-pro | 📝 correct as-is |
| M9 unauthenticated actor-query endpoints | major | codex + v4-pro | 🚫 PR-acknowledged |
| 8 minor findings | minor | various | 📝 see below |

---

## ✅ Fixed

### M4 — `IProjectionSessionEventCodec<AGUIEvent>` DI collision · major (codex) — **PR-introduced**
`GAgentService.Projection` registered `GAgentDraftRunSessionEventCodec` and NyxidChat
registered `NyxIdChatSessionEventCodec` — both as `IProjectionSessionEventCodec<AGUIEvent>`
via `TryAddSingleton`, so the second registration was a **silent no-op** and a pipeline
could run on the wrong codec/channel. Script-service AGUI had no codec at all and rode
on the draft-run one. **Fix:** each pipeline (NyxId chat, draft-run, script-service)
now builds its own channel-scoped `ProjectionSessionEventHub<AGUIEvent>` via a factory
registration; adds a dedicated `ScriptServiceAguiSessionEventCodec`. The hub holds no
mutable state, so a per-consumer instance is safe.

### M5 — `UserAgentCatalogProjector` synthesizes `StateVersion` · major (codex)
The projector merges two authoritative sources (catalog + runner) and set
`StateVersion = CatalogSourceVersion + RunnerSourceVersion`. It had **no per-source
staleness guard**, so a stale/replayed event for one source would roll that source's
version back and re-write older fields. **Fix:** added per-source monotonic guards —
a catalog/runner commit not newer than the document's stored version for that source
is skipped. With the guards every accepted event strictly advances one source, so the
sum is strictly monotonic per document and a valid overwrite watermark. The honest
per-source versions are retained; a fully vector-typed `StateVersion` would need a
proto schema change (noted for a dedicated change).

### M6 — `StreamingToolExecutor` coordinator started fire-and-forget · major (v4-pro + mimo, consensus)
`_ = RunCoordinatorAsync()` — a fault in the loop was unobserved, the loop silently
died, and `GetRemainingResultsAsync` hung forever. **Fix:** the coordinator task is
retained; `RequestStateAsync` races the request against it so faults surface to the
caller; `Dispose` observes a faulted task. Regression test
`CoordinatorFault_ShouldSurfaceToCaller_NotHang` added.

### M1 — hardcoded `/Users/auric/aevatar/` paths in codex-refactor-loop prompts · major (glm-5.1)
`remote-ci-fix.md` / `test-add.md` → `$REPO_ROOT/`, matching `audit.md` / `implement.md` / `verify.md`.

### m1 — misleading OpenTelemetry version comment · minor (glm-5.1 + mimo)
`Directory.Packages.props` comment claimed the variable holds `1.15.3`; it holds `1.15.1`.
Comment corrected — security-critical packages are individually pinned to `1.15.3`.

## ✔️ Verified — no fix needed

- **M3** (glm-5.1): `HouseholdEntityToolSource` is registered by-type, so DI auto-supplies
  the new `IActorDispatchPort` ctor param; tests construct it directly. No change needed.

## 📝 Reviewed — current code is correct (no change, with reasons)

- **M2** (v4-pro): `HouseholdEntity` reasoning aggregates `chunk.DeltaContent`. For a normal
  model this reconstructs exactly the assistant answer the old `ChatAsync` returned; the
  decision text (`NO_ACTION`) is content, not reasoning. Folding in `DeltaReasoningContent`
  would pollute the decision with chain-of-thought — a regression. Correct as-is.
- **M7** (codex): `StreamingToolExecutor:326` hook-rewrite-to-destructive "records error +
  continues" — this is **pre-existing** behavior (the old code set `_hasErrored` and
  continued too); the refactor only changed the mechanism. Not a #678 regression.
- **M8** (v4-pro): `ScopeServiceEndpoints` 2-min linked timeout now covers `RunRuntimeAsync`.
  Dispatch is accepted-only (fast); the timeout also usefully bounds a stuck mailbox.
  v4-pro's suggested split would leave dispatch unbounded — current code is acceptable.

## 📝 Minor findings — reviewed

- `NyxIdChatStreamingRunner:48` finally-block OCE — the exception falls through to the
  outer cancellation handler; behavior is correct.
- `ScopeBindingCommandApplicationService` "hardcoded `PropagationStage`" (mimo) — the named
  fields (`AcceptanceStage` / `PropagationStage`) **do not exist** in the code; inaccurate finding.
- `StreamingToolExecutor:155` `GetCompletedResults` race — reviewer notes it self-resolves.
- `StreamingToolExecutor:198` `Dispose` race — mitigated by the M6 fix (`RequestStateAsync`
  now throws instead of hanging).
- `ConnectedServiceSpecCache` dual constructor — **deliberate & documented** (`// Fix
  (remote-ci...)`: DI `ValidateService` ctor-ambiguity workaround). Left intact by design.
- `NyxIdSpecCatalog` singleton disposal — already guarded (`Interlocked`, OCE catches,
  `finally` cleanup); the fire-and-forget cleanup is acceptable for a shutdown singleton.
- `UserAgentCatalogProjector` runner-id fallback — the runner branch only runs after a
  successful `TryUnpackState<SkillRunnerState>`; the `PublisherActorId` fallback is sound.
- `architecture_guards.sh` `tools/` scan — currently passes; the concern is hypothetical.

## 🚫 Out of scope — already acknowledged by PR #678

- **M9** (codex + v4-pro): `ChatQueryEndpoints` exposes 6 unauthenticated `/actors/{actorId}`
  endpoints. PR #678's own *"Out-of-scope (security follow-up needed)"* section already
  flags this for a `/cso` / threat-model pass; the real fix is a caller-scope contract.

## Test plan

- [x] `dotnet build` — affected projects build
- [x] `Aevatar.GAgents.ChannelRuntime.Tests` — 820/820 pass (M5)
- [x] `Aevatar.AI.Tests` — 556/556 pass (M4 NyxId chat, M6)
- [x] `Aevatar.GAgentService.Tests` — M4/M5 add **0** new failures
- [x] `tools/ci/architecture_guards.sh` — all guards pass
- [x] `tools/ci/test_stability_guards.sh` — passes
- [x] Remote CI green on `dev` base

> ℹ️ **Also fixed — 3 pre-existing stale tests** (`b4ef987c`): `ServiceProjectionInfrastructureTests`,
> `ServiceServingProjectionInfrastructureTests` and `ServiceConfigurationProjectionInfrastructureTests`
> asserted `ImplementationType` against the bare projector type, but `AddProjectionArtifactMaterializer` /
> `AddCurrentStateProjectionMaterializer` wrap materializers in the `Observed*` observability decorator.
> These were red on `dev` independently of #678; the assertions now verify the projector via
> `ImplementationType.GenericTypeArguments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)