### PR TITLE
cluster-024: ChatStreamAsync as the only AI executor

### DIFF
--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -67,8 +67,10 @@ ARGS=(
   -C "$CD"
 )
 
-# Bash strict mode (`set -u`) treats `${empty_array[@]}` as unbound, so
-# guard with the `${array[@]+...}` parameter expansion before iterating.
+# Refactor (iter15/cluster-024): this PR is dispatched through the
+# codex-refactor-loop wrapper, often without --add-dir. Bash strict mode
+# (`set -u`) treats `${empty_array[@]}` as unbound, so keep the wrapper
+# reliable for the cluster review/fix loop by guarding the expansion.
 for d in "${ADD_DIRS[@]+"${ADD_DIRS[@]}"}"; do
   ARGS+=(--add-dir "$d")
 done

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -67,11 +67,7 @@ ARGS=(
   -C "$CD"
 )
 
-# Refactor (iter15/cluster-024): this PR is dispatched through the
-# codex-refactor-loop wrapper, often without --add-dir. Bash strict mode
-# (`set -u`) treats `${empty_array[@]}` as unbound, so keep the wrapper
-# reliable for the cluster review/fix loop by guarding the expansion.
-for d in "${ADD_DIRS[@]+"${ADD_DIRS[@]}"}"; do
+for d in "${ADD_DIRS[@]}"; do
   ARGS+=(--add-dir "$d")
 done
 

--- a/agents/Aevatar.GAgents.ChatbotClassifier/ChatbotClassifierGAgent.cs
+++ b/agents/Aevatar.GAgents.ChatbotClassifier/ChatbotClassifierGAgent.cs
@@ -7,6 +7,7 @@ using Aevatar.AI.Core.Hooks;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Microsoft.Extensions.Logging;
+using System.Text;
 
 namespace Aevatar.GAgents.ChatbotClassifier;
 
@@ -16,7 +17,7 @@ namespace Aevatar.GAgents.ChatbotClassifier;
 /// classifies intent (FAQ / action / chitchat / unknown), generates a natural language
 /// reply, and extracts structured parameters for action intents.
 ///
-/// Uses non-streaming ChatAsync for reliable JSON output parsing.
+/// Uses authoritative ChatStreamAsync plus offline aggregation for reliable JSON output parsing.
 /// No tools — pure LLM classification with MaxToolRounds=0.
 /// </summary>
 public sealed class ChatbotClassifierGAgent : RoleGAgent
@@ -63,7 +64,17 @@ public sealed class ChatbotClassifierGAgent : RoleGAgent
         string? result;
         try
         {
-            result = await ChatAsync(request.Prompt, request.SessionId, metadata, CancellationToken.None);
+            // Refactor (iter15/cluster-024):
+            //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+            //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
+            var content = new StringBuilder();
+            await foreach (var chunk in ChatStreamAsync(request.Prompt, request.SessionId, metadata, CancellationToken.None))
+            {
+                if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                    content.Append(chunk.DeltaContent);
+            }
+
+            result = content.Length > 0 ? content.ToString() : null;
         }
         catch (Exception ex)
         {

--- a/agents/Aevatar.GAgents.ChatbotClassifier/ChatbotClassifierGAgent.cs
+++ b/agents/Aevatar.GAgents.ChatbotClassifier/ChatbotClassifierGAgent.cs
@@ -3,11 +3,11 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
+using Aevatar.AI.Core.Chat;
 using Aevatar.AI.Core.Hooks;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Microsoft.Extensions.Logging;
-using System.Text;
 
 namespace Aevatar.GAgents.ChatbotClassifier;
 
@@ -67,14 +67,9 @@ public sealed class ChatbotClassifierGAgent : RoleGAgent
             // Refactor (iter15/cluster-024):
             //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
             //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
-            var content = new StringBuilder();
-            await foreach (var chunk in ChatStreamAsync(request.Prompt, request.SessionId, metadata, CancellationToken.None))
-            {
-                if (!string.IsNullOrEmpty(chunk.DeltaContent))
-                    content.Append(chunk.DeltaContent);
-            }
-
-            result = content.Length > 0 ? content.ToString() : null;
+            result = await ChatStreamContentAggregator.AggregateContentAsync(
+                ChatStreamAsync(request.Prompt, request.SessionId, metadata, CancellationToken.None),
+                ct: CancellationToken.None);
         }
         catch (Exception ex)
         {

--- a/src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs
+++ b/src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs
@@ -15,7 +15,9 @@ public interface ILLMProvider
     LLMProviderCapabilities Capabilities => LLMProviderCapabilities.TextOnly;
 
     /// <summary>同步 Chat 调用。返回完整响应内容与 tool_calls。</summary>
-    // Provider boundary only — formal conversation entrypoints must call ChatStreamAsync.
+    // Refactor (iter15/cluster-024):
+    //   Old pattern: formal conversation entrypoints could call provider ChatAsync as a parallel executor.
+    //   New principle: provider ChatAsync is a boundary compatibility contract only; formal entrypoints call ChatStreamAsync.
     /// <param name="request">LLM 请求，包含消息、工具、模型参数等。</param>
     /// <param name="ct">取消令牌。</param>
     /// <returns>LLM 响应，包含文本内容、工具调用、Token 用量等。</returns>

--- a/src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs
+++ b/src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs
@@ -15,6 +15,7 @@ public interface ILLMProvider
     LLMProviderCapabilities Capabilities => LLMProviderCapabilities.TextOnly;
 
     /// <summary>同步 Chat 调用。返回完整响应内容与 tool_calls。</summary>
+    // Provider boundary only — formal conversation entrypoints must call ChatStreamAsync.
     /// <param name="request">LLM 请求，包含消息、工具、模型参数等。</param>
     /// <param name="ct">取消令牌。</param>
     /// <returns>LLM 响应，包含文本内容、工具调用、Token 用量等。</returns>

--- a/src/Aevatar.AI.Core/AIGAgentBase.cs
+++ b/src/Aevatar.AI.Core/AIGAgentBase.cs
@@ -199,6 +199,9 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
         return merged;
     }
 
+    // Refactor (iter15/cluster-024):
+    //   Old pattern: protected ChatAsync helpers let GAgents call the non-streaming executor as a formal conversation path.
+    //   New principle: GAgent subclasses use ChatStreamAsync; explicit offline aggregation is local to the caller that needs text.
     /// <summary>流式 Chat。</summary>
     protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(string userMessage, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.Core/AIGAgentBase.cs
+++ b/src/Aevatar.AI.Core/AIGAgentBase.cs
@@ -199,39 +199,6 @@ public abstract class AIGAgentBase<TState> : GAgentBase<TState, AIAgentConfig>
         return merged;
     }
 
-    // ─── Chat 快捷方法 ───
-
-    /// <summary>单轮 Chat（含 Tool Calling 循环）。</summary>
-    protected Task<string?> ChatAsync(string userMessage, CancellationToken ct = default)
-    {
-        EnsureRuntime();
-        return _chat!.ChatAsync(userMessage, EffectiveConfig.MaxToolRounds, ct);
-    }
-
-    /// <summary>单轮 Chat（含 Tool Calling 循环），显式传入稳定 request id 和 metadata。</summary>
-    protected Task<string?> ChatAsync(
-        string userMessage,
-        string? requestId,
-        IReadOnlyDictionary<string, string>? metadata = null,
-        CancellationToken ct = default)
-    {
-        EnsureRuntime();
-        var maxRounds = ResolveMaxToolRounds(metadata);
-        return _chat!.ChatAsync([ContentPart.TextPart(userMessage)], maxRounds, requestId, metadata, ct);
-    }
-
-    /// <summary>单轮 Chat（多模态内容），显式传入稳定 request id 和 metadata。</summary>
-    protected Task<string?> ChatAsync(
-        IReadOnlyList<ContentPart> userContent,
-        string? requestId,
-        IReadOnlyDictionary<string, string>? metadata = null,
-        CancellationToken ct = default)
-    {
-        EnsureRuntime();
-        var maxRounds = ResolveMaxToolRounds(metadata);
-        return _chat!.ChatAsync(userContent, maxRounds, requestId, metadata, ct);
-    }
-
     /// <summary>流式 Chat。</summary>
     protected IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(string userMessage, CancellationToken ct = default)
     {

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -70,7 +70,7 @@ public sealed class ChatRuntime
         _compressionConfig = compressionConfig ?? new ContextCompressionConfig();
     }
 
-    /// <summary>单轮 Chat（含 Tool Calling 循环），包裹 Agent Run Middleware。</summary>
+    /// <summary>单轮 Chat（含 Tool Calling 循环），显式离线聚合 adapter。</summary>
     public Task<string?> ChatAsync(string userMessage, int maxToolRounds = DefaultMaxToolRounds, CancellationToken ct = default) =>
         ChatAsync([ContentPart.TextPart(userMessage)], maxToolRounds, requestId: null, metadata: null, ct);
 
@@ -91,64 +91,17 @@ public sealed class ChatRuntime
         IReadOnlyDictionary<string, string>? metadata,
         CancellationToken ct = default)
     {
-        var normalizedUserContent = NormalizeUserContent(userContent);
-        var runContext = new AgentRunContext
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
+        var content = new StringBuilder();
+        await foreach (var chunk in ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, ct))
         {
-            UserMessage = DescribeUserContent(normalizedUserContent),
-            AgentId = _agentId,
-            AgentName = _agentName,
-            CancellationToken = ct,
-        };
-
-        try
-        {
-            await MiddlewarePipeline.RunAgentAsync(_agentMiddlewares, runContext, async () =>
-            {
-                if (runContext.Terminate) return;
-
-                _history.Add(ChatMessage.User(normalizedUserContent, runContext.UserMessage));
-                await RunCompressionIfNeededAsync(ct);
-                var baseRequest = ApplyRequestIdentity(_requestBuilder(), requestId, metadata);
-                var provider = _providerFactory();
-                runContext.Items["gen_ai.provider.name"] = provider.Name;
-                var messages = _history.BuildMessages(baseRequest.Messages.FirstOrDefault(m => m.Role == "system")?.Content);
-
-                var result = await _toolLoop.ExecuteAsync(provider, messages, baseRequest, maxToolRounds, ct);
-
-                _history.Clear();
-                foreach (var m in messages.Where(m => m.Role != "system"))
-                    _history.Add(m);
-
-                runContext.Result = result;
-            });
-
-            // ─── Hook: Stop（轮次正常完成） ───
-            if (_hooks != null)
-            {
-                var stopCtx = new AIGAgentExecutionHookContext { AgentId = _agentId };
-                stopCtx.Items["final_content"] = runContext.Result ?? "";
-                // Count tool-calling rounds by counting assistant messages that have tool calls
-                stopCtx.Items["total_rounds"] = _history.Messages
-                    .Count(m => m.Role == "assistant" && m.ToolCalls is { Count: > 0 });
-                await _hooks.RunStopAsync(stopCtx, ct);
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // ─── Hook: StopFailure（轮次因错误终止） ───
-            if (_hooks != null)
-            {
-                var failCtx = new AIGAgentExecutionHookContext { AgentId = _agentId };
-                failCtx.Items["error"] = ex;
-                failCtx.Items["error_message"] = ex.Message;
-                failCtx.Items["error_phase"] = "llm_or_tool_execution";
-                try { await _hooks.RunStopFailureAsync(failCtx, ct); }
-                catch { /* best-effort */ }
-            }
-            throw;
+            if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                content.Append(chunk.DeltaContent);
         }
 
-        return runContext.Result;
+        return content.Length > 0 ? content.ToString() : null;
     }
 
     /// <summary>流式 Chat，包裹 LLM Call Middleware。</summary>

--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -94,14 +94,9 @@ public sealed class ChatRuntime
         // Refactor (iter15/cluster-024):
         //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
         //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
-        var content = new StringBuilder();
-        await foreach (var chunk in ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, ct))
-        {
-            if (!string.IsNullOrEmpty(chunk.DeltaContent))
-                content.Append(chunk.DeltaContent);
-        }
-
-        return content.Length > 0 ? content.ToString() : null;
+        return await ChatStreamContentAggregator.AggregateContentAsync(
+            ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, ct),
+            ct: ct);
     }
 
     /// <summary>流式 Chat，包裹 LLM Call Middleware。</summary>

--- a/src/Aevatar.AI.Core/Chat/ChatStreamContentAggregator.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatStreamContentAggregator.cs
@@ -1,0 +1,66 @@
+using System.Text;
+using Aevatar.AI.Abstractions.LLMProviders;
+
+namespace Aevatar.AI.Core.Chat;
+
+/// <summary>Aggregates authoritative chat streams for explicit offline text adapters.</summary>
+public static class ChatStreamContentAggregator
+{
+    public static async Task<string?> AggregateContentAsync(
+        IAsyncEnumerable<LLMStreamChunk> stream,
+        bool emptyAsNull = true,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: offline callers duplicated StringBuilder loops after direct provider.ChatAsync removal.
+        //   New principle: ChatStreamAsync remains the only authoritative AI executor, with one narrow text aggregation adapter for offline consumers.
+        var content = new StringBuilder();
+        await foreach (var chunk in stream.WithCancellation(ct))
+        {
+            if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                content.Append(chunk.DeltaContent);
+        }
+
+        return content.Length > 0 || !emptyAsNull ? content.ToString() : null;
+    }
+
+    public static async Task<LLMResponse> AggregateResponseAsync(
+        ILLMProvider provider,
+        LLMRequest request,
+        CancellationToken ct = default)
+    {
+        var content = new StringBuilder();
+        var reasoningContent = new StringBuilder();
+        var toolCalls = new StreamingToolCallAccumulator();
+        TokenUsage? usage = null;
+        string? finishReason = null;
+
+        await foreach (var chunk in provider.ChatStreamAsync(request, ct).WithCancellation(ct))
+        {
+            if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                content.Append(chunk.DeltaContent);
+
+            if (!string.IsNullOrEmpty(chunk.DeltaReasoningContent))
+                reasoningContent.Append(chunk.DeltaReasoningContent);
+
+            if (chunk.DeltaToolCall != null)
+                toolCalls.TrackDelta(chunk.DeltaToolCall);
+
+            if (chunk.Usage != null)
+                usage = chunk.Usage;
+
+            if (chunk.FinishReason != null)
+                finishReason = chunk.FinishReason;
+        }
+
+        var finalToolCalls = toolCalls.BuildToolCalls();
+        return new LLMResponse
+        {
+            Content = content.Length > 0 ? content.ToString() : null,
+            ReasoningContent = reasoningContent.Length > 0 ? reasoningContent.ToString() : null,
+            ToolCalls = finalToolCalls.Count > 0 ? finalToolCalls : null,
+            Usage = usage,
+            FinishReason = finishReason,
+        };
+    }
+}

--- a/src/Aevatar.AI.Core/Chat/ChatStreamContentAggregator.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatStreamContentAggregator.cs
@@ -29,6 +29,9 @@ public static class ChatStreamContentAggregator
         LLMRequest request,
         CancellationToken ct = default)
     {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: ToolCallLoop treated provider.ChatAsync as a second authoritative LLM response path.
+        //   New principle: stream-derived LLMResponse aggregation preserves content, reasoning, tool calls, usage, and finish reason from provider.ChatStreamAsync.
         var content = new StringBuilder();
         var reasoningContent = new StringBuilder();
         var toolCalls = new StreamingToolCallAccumulator();

--- a/src/Aevatar.AI.Core/Chat/ContextCompressor.cs
+++ b/src/Aevatar.AI.Core/Chat/ContextCompressor.cs
@@ -256,14 +256,9 @@ public static class ContextCompressor
         // Refactor (iter15/cluster-024):
         //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
         //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
-        var summary = new StringBuilder();
-        await foreach (var chunk in provider.ChatStreamAsync(request, ct).WithCancellation(ct))
-        {
-            if (!string.IsNullOrEmpty(chunk.DeltaContent))
-                summary.Append(chunk.DeltaContent);
-        }
-
-        var summaryText = summary.ToString();
+        var summaryText = await ChatStreamContentAggregator.AggregateContentAsync(
+            provider.ChatStreamAsync(request, ct),
+            ct: ct);
         if (string.IsNullOrWhiteSpace(summaryText))
             return false;
 

--- a/src/Aevatar.AI.Core/Chat/ContextCompressor.cs
+++ b/src/Aevatar.AI.Core/Chat/ContextCompressor.cs
@@ -253,13 +253,23 @@ public static class ContextCompressor
             MaxTokens = 1024,
         };
 
-        var response = await provider.ChatAsync(request, ct);
-        if (string.IsNullOrWhiteSpace(response.Content))
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
+        var summary = new StringBuilder();
+        await foreach (var chunk in provider.ChatStreamAsync(request, ct).WithCancellation(ct))
+        {
+            if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                summary.Append(chunk.DeltaContent);
+        }
+
+        var summaryText = summary.ToString();
+        if (string.IsNullOrWhiteSpace(summaryText))
             return false;
 
         // Remove the block and insert summary
         messages.RemoveRange(startIndex, blockSize);
-        messages.Insert(startIndex, ChatMessage.System($"[Previous conversation summary]: {response.Content}"));
+        messages.Insert(startIndex, ChatMessage.System($"[Previous conversation summary]: {summaryText}"));
         return true;
     }
 

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -282,6 +282,9 @@ public sealed class ToolCallLoop
         LLMRequest request,
         CancellationToken ct)
     {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
         // ─── Hook: LLM Request Start ───
         var llmCtx = new AIGAgentExecutionHookContext { LLMRequest = request };
         if (_hooks != null) await _hooks.RunLLMRequestStartAsync(llmCtx, ct);
@@ -291,14 +294,14 @@ public sealed class ToolCallLoop
             Request = request,
             Provider = provider,
             CancellationToken = ct,
-            IsStreaming = false,
+            IsStreaming = true,
         };
         AnnotateRequestIdentity(llmCallContext);
 
         await MiddlewarePipeline.RunLLMCallAsync(_llmMiddlewares, llmCallContext, async () =>
         {
             if (llmCallContext.Terminate) return;
-            llmCallContext.Response = await provider.ChatAsync(llmCallContext.Request, ct);
+            llmCallContext.Response = await AggregateStreamResponseAsync(provider, llmCallContext.Request, ct);
         });
 
         var response = llmCallContext.Response
@@ -310,6 +313,46 @@ public sealed class ToolCallLoop
         if (_hooks != null) await _hooks.RunLLMRequestEndAsync(llmCtx, ct);
 
         return (response, llmCallContext.Terminate);
+    }
+
+    private static async Task<LLMResponse> AggregateStreamResponseAsync(
+        ILLMProvider provider,
+        LLMRequest request,
+        CancellationToken ct)
+    {
+        var content = new StringBuilder();
+        var reasoningContent = new StringBuilder();
+        var toolCalls = new StreamingToolCallAccumulator();
+        TokenUsage? usage = null;
+        string? finishReason = null;
+
+        await foreach (var chunk in provider.ChatStreamAsync(request, ct).WithCancellation(ct))
+        {
+            if (!string.IsNullOrEmpty(chunk.DeltaContent))
+                content.Append(chunk.DeltaContent);
+
+            if (!string.IsNullOrEmpty(chunk.DeltaReasoningContent))
+                reasoningContent.Append(chunk.DeltaReasoningContent);
+
+            if (chunk.DeltaToolCall != null)
+                toolCalls.TrackDelta(chunk.DeltaToolCall);
+
+            if (chunk.Usage != null)
+                usage = chunk.Usage;
+
+            if (chunk.FinishReason != null)
+                finishReason = chunk.FinishReason;
+        }
+
+        var finalToolCalls = toolCalls.BuildToolCalls();
+        return new LLMResponse
+        {
+            Content = content.Length > 0 ? content.ToString() : null,
+            ReasoningContent = reasoningContent.Length > 0 ? reasoningContent.ToString() : null,
+            ToolCalls = finalToolCalls.Count > 0 ? finalToolCalls : null,
+            Usage = usage,
+            FinishReason = finishReason,
+        };
     }
 
     internal static IReadOnlyDictionary<string, string>? BuildPerCallMetadata(

--- a/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
+++ b/src/Aevatar.AI.Core/Tools/ToolCallLoop.cs
@@ -301,7 +301,7 @@ public sealed class ToolCallLoop
         await MiddlewarePipeline.RunLLMCallAsync(_llmMiddlewares, llmCallContext, async () =>
         {
             if (llmCallContext.Terminate) return;
-            llmCallContext.Response = await AggregateStreamResponseAsync(provider, llmCallContext.Request, ct);
+            llmCallContext.Response = await ChatStreamContentAggregator.AggregateResponseAsync(provider, llmCallContext.Request, ct);
         });
 
         var response = llmCallContext.Response
@@ -313,46 +313,6 @@ public sealed class ToolCallLoop
         if (_hooks != null) await _hooks.RunLLMRequestEndAsync(llmCtx, ct);
 
         return (response, llmCallContext.Terminate);
-    }
-
-    private static async Task<LLMResponse> AggregateStreamResponseAsync(
-        ILLMProvider provider,
-        LLMRequest request,
-        CancellationToken ct)
-    {
-        var content = new StringBuilder();
-        var reasoningContent = new StringBuilder();
-        var toolCalls = new StreamingToolCallAccumulator();
-        TokenUsage? usage = null;
-        string? finishReason = null;
-
-        await foreach (var chunk in provider.ChatStreamAsync(request, ct).WithCancellation(ct))
-        {
-            if (!string.IsNullOrEmpty(chunk.DeltaContent))
-                content.Append(chunk.DeltaContent);
-
-            if (!string.IsNullOrEmpty(chunk.DeltaReasoningContent))
-                reasoningContent.Append(chunk.DeltaReasoningContent);
-
-            if (chunk.DeltaToolCall != null)
-                toolCalls.TrackDelta(chunk.DeltaToolCall);
-
-            if (chunk.Usage != null)
-                usage = chunk.Usage;
-
-            if (chunk.FinishReason != null)
-                finishReason = chunk.FinishReason;
-        }
-
-        var finalToolCalls = toolCalls.BuildToolCalls();
-        return new LLMResponse
-        {
-            Content = content.Length > 0 ? content.ToString() : null,
-            ReasoningContent = reasoningContent.Length > 0 ? reasoningContent.ToString() : null,
-            ToolCalls = finalToolCalls.Count > 0 ? finalToolCalls : null,
-            Usage = usage,
-            FinishReason = finishReason,
-        };
     }
 
     internal static IReadOnlyDictionary<string, string>? BuildPerCallMetadata(

--- a/src/Aevatar.Studio.Hosting/Endpoints/ScriptGenerateGAgent.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/ScriptGenerateGAgent.cs
@@ -31,12 +31,17 @@ internal sealed class ScriptGenerateGAgent : AIGAgentBase<Empty>
         return new AIAgentConfigStateOverrides();
     }
 
-    public Task<string?> GenerateAsync(
+    public async Task<string?> GenerateAsync(
         string prompt,
         string requestId,
         IReadOnlyDictionary<string, string>? metadata,
-        CancellationToken ct = default) =>
-        ChatAsync(prompt, requestId, metadata, ct);
+        CancellationToken ct = default)
+    {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
+        return await GenerateWithReasoningAsync(prompt, requestId, metadata, onReasoning: null, ct);
+    }
 
     public async Task<string?> GenerateWithReasoningAsync(
         string prompt,
@@ -45,6 +50,9 @@ internal sealed class ScriptGenerateGAgent : AIGAgentBase<Empty>
         Func<string, CancellationToken, Task>? onReasoning,
         CancellationToken ct = default)
     {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
         var content = new StringBuilder();
         await foreach (var chunk in ChatStreamAsync(prompt, requestId, metadata, ct))
         {

--- a/src/Aevatar.Studio.Hosting/Endpoints/ScriptGenerateGAgent.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/ScriptGenerateGAgent.cs
@@ -54,9 +54,6 @@ internal sealed class ScriptGenerateGAgent : AIGAgentBase<Empty>
         Func<string, CancellationToken, Task>? onReasoning,
         CancellationToken ct = default)
     {
-        // Refactor (iter15/cluster-024):
-        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
-        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
         var content = new StringBuilder();
         await foreach (var chunk in ChatStreamAsync(prompt, requestId, metadata, ct))
         {

--- a/src/Aevatar.Studio.Hosting/Endpoints/ScriptGenerateGAgent.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/ScriptGenerateGAgent.cs
@@ -2,6 +2,7 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.Core;
+using Aevatar.AI.Core.Chat;
 using Google.Protobuf.WellKnownTypes;
 using System.Text;
 
@@ -40,7 +41,10 @@ internal sealed class ScriptGenerateGAgent : AIGAgentBase<Empty>
         // Refactor (iter15/cluster-024):
         //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
         //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
-        return await GenerateWithReasoningAsync(prompt, requestId, metadata, onReasoning: null, ct);
+        return await ChatStreamContentAggregator.AggregateContentAsync(
+            ChatStreamAsync(prompt, requestId, metadata, ct),
+            emptyAsNull: false,
+            ct: ct);
     }
 
     public async Task<string?> GenerateWithReasoningAsync(

--- a/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateGAgent.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateGAgent.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Core;
+using Aevatar.AI.Core.Chat;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.AI.Abstractions.ToolProviders;
@@ -40,7 +41,10 @@ internal sealed class WorkflowGenerateGAgent : AIGAgentBase<Empty>
         // Refactor (iter15/cluster-024):
         //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
         //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
-        return await GenerateWithReasoningAsync(prompt, requestId, metadata, onReasoning: null, ct);
+        return await ChatStreamContentAggregator.AggregateContentAsync(
+            ChatStreamAsync(prompt, requestId, metadata, ct),
+            emptyAsNull: false,
+            ct: ct);
     }
 
     public async Task<string?> GenerateWithReasoningAsync(

--- a/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateGAgent.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateGAgent.cs
@@ -54,9 +54,6 @@ internal sealed class WorkflowGenerateGAgent : AIGAgentBase<Empty>
         Func<string, CancellationToken, Task>? onReasoning,
         CancellationToken ct = default)
     {
-        // Refactor (iter15/cluster-024):
-        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
-        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
         var content = new StringBuilder();
         await foreach (var chunk in ChatStreamAsync(prompt, requestId, metadata, ct))
         {

--- a/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateGAgent.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/WorkflowGenerateGAgent.cs
@@ -31,12 +31,17 @@ internal sealed class WorkflowGenerateGAgent : AIGAgentBase<Empty>
         return new AIAgentConfigStateOverrides();
     }
 
-    public Task<string?> GenerateAsync(
+    public async Task<string?> GenerateAsync(
         string prompt,
         string requestId,
         IReadOnlyDictionary<string, string>? metadata,
-        CancellationToken ct = default) =>
-        ChatAsync(prompt, requestId, metadata, ct);
+        CancellationToken ct = default)
+    {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
+        return await GenerateWithReasoningAsync(prompt, requestId, metadata, onReasoning: null, ct);
+    }
 
     public async Task<string?> GenerateWithReasoningAsync(
         string prompt,
@@ -45,6 +50,9 @@ internal sealed class WorkflowGenerateGAgent : AIGAgentBase<Empty>
         Func<string, CancellationToken, Task>? onReasoning,
         CancellationToken ct = default)
     {
+        // Refactor (iter15/cluster-024):
+        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
+        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
         var content = new StringBuilder();
         await foreach (var chunk in ChatStreamAsync(prompt, requestId, metadata, ct))
         {

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -387,11 +387,17 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
-    public void AiCoreSource_ShouldNotDirectlyCallProviderChatAsyncOutsideProviderBoundary()
+    public void UserFacingAiExecutorSurfaces_ShouldNotDirectlyCallProviderChatAsyncOutsideProviderBoundary()
     {
         var root = FindRepositoryRoot();
-        var aiCore = Path.Combine(root, "src", "Aevatar.AI.Core");
-        var offenders = Directory.EnumerateFiles(aiCore, "*.cs", SearchOption.AllDirectories)
+        var scannedRoots = new[]
+        {
+            Path.Combine(root, "src", "Aevatar.AI.Core"),
+            Path.Combine(root, "src", "Aevatar.Studio.Hosting"),
+            Path.Combine(root, "agents", "Aevatar.GAgents.ChatbotClassifier"),
+        };
+        var offenders = scannedRoots
+            .SelectMany(scanRoot => Directory.EnumerateFiles(scanRoot, "*.cs", SearchOption.AllDirectories))
             .SelectMany(file => File.ReadLines(file)
                 .Select((line, index) => new { file, line, index })
                 .Where(x => !x.line.TrimStart().StartsWith("//", StringComparison.Ordinal))

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -350,7 +350,7 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
-    public async Task ChatAsync_WhenAgentMiddlewareTerminates_ShouldReturnSyntheticResultWithoutCallingProvider()
+    public async Task ChatAsync_WhenAgentMiddlewareTerminates_ShouldAggregateStreamAdapterWithoutCallingProvider()
     {
         var provider = new StreamingProvider(["ignored"]);
         var runtime = CreateRuntime(
@@ -371,6 +371,36 @@ public sealed class ChatRuntimeStreamingBufferTests
         result.Should().Be("short-circuit");
         provider.ChatCallCount.Should().Be(0);
         provider.StreamCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ChatAsync_WhenProviderStreamsContent_ShouldAggregateWithoutCallingProviderChatAsync()
+    {
+        var provider = new StreamingProvider(["stream-", "answer"]);
+        var runtime = CreateRuntime(provider, streamBufferCapacity: 2);
+
+        var result = await runtime.ChatAsync("hello");
+
+        result.Should().Be("stream-answer");
+        provider.ChatCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void AiCoreSource_ShouldNotDirectlyCallProviderChatAsyncOutsideProviderBoundary()
+    {
+        var root = FindRepositoryRoot();
+        var aiCore = Path.Combine(root, "src", "Aevatar.AI.Core");
+        var offenders = Directory.EnumerateFiles(aiCore, "*.cs", SearchOption.AllDirectories)
+            .SelectMany(file => File.ReadLines(file)
+                .Select((line, index) => new { file, line, index })
+                .Where(x => !x.line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                .Where(x => x.line.Contains("provider.ChatAsync", StringComparison.Ordinal)
+                            || x.line.Contains("_provider.ChatAsync", StringComparison.Ordinal))
+                .Select(x => $"{Path.GetRelativePath(root, x.file)}:{x.index + 1}:{x.line.Trim()}"))
+            .ToArray();
+
+        offenders.Should().BeEmpty();
     }
 
     [Fact]
@@ -626,6 +656,20 @@ public sealed class ChatRuntimeStreamingBufferTests
 
             await next();
         }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (File.Exists(Path.Combine(current, "aevatar.slnx")))
+                return current;
+
+            current = Directory.GetParent(current)?.FullName;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
     }
 
     private sealed class DelegateAgentRunMiddleware(

--- a/test/Aevatar.AI.Tests/ChatbotClassifierGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/ChatbotClassifierGAgentTests.cs
@@ -28,7 +28,7 @@ public class ChatbotClassifierGAgentTests
     }
 
     [Fact]
-    public async Task HandleChatRequest_ShouldPublishClassifierResponseFromChatAsync()
+    public async Task HandleChatRequest_ShouldPublishClassifierResponseFromStreamAggregation()
     {
         const string responseJson =
             """{"intent":"faq","intent_type":"faq","reply":"Here is the answer.","context_summary":"faq","params":{}}""";
@@ -37,7 +37,7 @@ public class ChatbotClassifierGAgentTests
         var agent = CreateAgent(
             provider,
             "chatbot-classifier-success",
-            new StubChatProviderFactory((request, ct) =>
+            new StubStreamingProviderFactory((request, ct) =>
             {
                 request.Messages.Should().NotBeEmpty();
                 ct.ThrowIfCancellationRequested();
@@ -66,13 +66,13 @@ public class ChatbotClassifierGAgentTests
     }
 
     [Fact]
-    public async Task HandleChatRequest_ShouldEmitFallbackJsonWhenChatAsyncFails()
+    public async Task HandleChatRequest_ShouldEmitFallbackJsonWhenChatStreamAsyncFails()
     {
         using var provider = AgentCoverageTestSupport.BuildServiceProvider();
         var agent = CreateAgent(
             provider,
             "chatbot-classifier-failure",
-            new StubChatProviderFactory((_, _) => throw new InvalidOperationException("synthetic failure")));
+            new StubStreamingProviderFactory((_, _) => throw new InvalidOperationException("synthetic failure")));
         var publisher = new TestRecordingEventPublisher();
         agent.EventPublisher = publisher;
 
@@ -119,5 +119,45 @@ public class ChatbotClassifierGAgentTests
 
         AgentCoverageTestSupport.AssignActorId(agent, actorId);
         return agent;
+    }
+
+    private sealed class StubStreamingProviderFactory(
+        Func<LLMRequest, CancellationToken, Task<LLMResponse>> onChatStreamAsync)
+        : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "test-provider";
+
+        public ILLMProvider GetProvider(string name)
+        {
+            _ = name;
+            return this;
+        }
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            ct.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("Provider boundary ChatAsync should not be used by classifier.");
+        }
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            var response = await onChatStreamAsync(request, ct);
+            if (!string.IsNullOrEmpty(response.Content))
+                yield return new LLMStreamChunk { DeltaContent = response.Content };
+
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                Usage = response.Usage,
+                FinishReason = response.FinishReason,
+            };
+        }
     }
 }

--- a/test/Aevatar.AI.Tests/ContextCompressorTests.cs
+++ b/test/Aevatar.AI.Tests/ContextCompressorTests.cs
@@ -785,8 +785,24 @@ public class ContextCompressorTests
             [EnumeratorCancellation] CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            var response = _responses.Count > 0 ? _responses.Dequeue() : new LLMResponse();
+
+            if (!string.IsNullOrEmpty(response.Content))
+                yield return new LLMStreamChunk { DeltaContent = response.Content };
+
+            if (response.ToolCalls is { Count: > 0 })
+            {
+                foreach (var toolCall in response.ToolCalls)
+                    yield return new LLMStreamChunk { DeltaToolCall = toolCall };
+            }
+
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                Usage = response.Usage,
+                FinishReason = response.FinishReason,
+            };
             await Task.CompletedTask;
-            yield break;
         }
     }
 
@@ -822,8 +838,19 @@ public class ContextCompressorTests
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
         {
+            ct.ThrowIfCancellationRequested();
+            var response = handler(request);
+
+            if (!string.IsNullOrEmpty(response.Content))
+                yield return new LLMStreamChunk { DeltaContent = response.Content };
+
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                Usage = response.Usage,
+                FinishReason = response.FinishReason,
+            };
             await Task.CompletedTask;
-            yield break;
         }
     }
 

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -760,10 +760,29 @@ public class ToolCallLoopTests
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
         {
-            _ = request;
             ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            var response = _responses.Count > 0 ? _responses.Dequeue() : new LLMResponse();
+
+            if (!string.IsNullOrEmpty(response.ReasoningContent))
+                yield return new LLMStreamChunk { DeltaReasoningContent = response.ReasoningContent };
+
+            if (!string.IsNullOrEmpty(response.Content))
+                yield return new LLMStreamChunk { DeltaContent = response.Content };
+
+            if (response.ToolCalls is { Count: > 0 })
+            {
+                foreach (var toolCall in response.ToolCalls)
+                    yield return new LLMStreamChunk { DeltaToolCall = toolCall };
+            }
+
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                Usage = response.Usage,
+                FinishReason = response.FinishReason,
+            };
             await Task.CompletedTask;
-            yield break;
         }
     }
 

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -145,6 +145,46 @@ public class ToolCallLoopTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WhenLlmMiddlewareRuns_ShouldExposeStreamingContextAndAggregateProviderStream()
+    {
+        var provider = new QueueLLMProvider(
+        [
+            new LLMResponse
+            {
+                Content = "stream-answer",
+                ReasoningContent = "stream-reasoning",
+                FinishReason = "stop",
+            },
+        ], throwOnChatAsync: true);
+        bool? observedIsStreaming = null;
+        var middleware = new DelegateLlmCallMiddleware(async (context, next) =>
+        {
+            observedIsStreaming = context.IsStreaming;
+            await next();
+            context.Response.Should().NotBeNull();
+            context.Response!.Content.Should().Be("stream-answer");
+            context.Response.ReasoningContent.Should().Be("stream-reasoning");
+        });
+        var loop = new ToolCallLoop(
+            new ToolManager(),
+            hooks: null,
+            toolMiddlewares: [],
+            llmMiddlewares: [middleware]);
+        var messages = new List<ChatMessage> { ChatMessage.User("hello") };
+        var request = new LLMRequest { Messages = [], Tools = null };
+
+        var result = await loop.ExecuteAsync(provider, messages, request, maxRounds: 1, CancellationToken.None);
+
+        result.Should().Be("stream-answer");
+        observedIsStreaming.Should().BeTrue();
+        provider.Requests.Should().HaveCount(1);
+        messages.Should().ContainSingle(m =>
+            m.Role == "assistant" &&
+            m.Content == "stream-answer" &&
+            m.ReasoningContent == "stream-reasoning");
+    }
+
+    [Fact]
     public async Task ExecuteAsync_WhenHookMutatesToolCall_ShouldUseMutatedNameAndArguments()
     {
         var provider = new QueueLLMProvider(
@@ -740,10 +780,12 @@ public class ToolCallLoopTests
     private sealed class QueueLLMProvider : ILLMProvider
     {
         private readonly Queue<LLMResponse> _responses;
+        private readonly bool _throwOnChatAsync;
 
-        public QueueLLMProvider(IEnumerable<LLMResponse> responses)
+        public QueueLLMProvider(IEnumerable<LLMResponse> responses, bool throwOnChatAsync = false)
         {
             _responses = new Queue<LLMResponse>(responses);
+            _throwOnChatAsync = throwOnChatAsync;
         }
 
         public string Name => "queue";
@@ -752,6 +794,9 @@ public class ToolCallLoopTests
         public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
+            if (_throwOnChatAsync)
+                throw new InvalidOperationException("Provider boundary ChatAsync should not be used by ToolCallLoop.");
+
             Requests.Add(request);
             return Task.FromResult(_responses.Count > 0 ? _responses.Dequeue() : new LLMResponse());
         }

--- a/test/Aevatar.Studio.Tests/StudioGenerateGAgentStreamingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioGenerateGAgentStreamingTests.cs
@@ -1,0 +1,212 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Studio.Hosting.Endpoints;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioGenerateGAgentStreamingTests
+{
+    [Fact]
+    public async Task ScriptGenerateAsync_WhenProviderStreamsSplitContent_ShouldReturnConcatenatedContent()
+    {
+        using var services = BuildServiceProvider();
+        var provider = new SplitStreamingProviderFactory(["script ", "draft"]);
+        var agent = CreateAgent(new ScriptGenerateGAgent(provider), services, "script-generate-stream");
+
+        await agent.ActivateAsync();
+
+        var result = await agent.GenerateAsync("write script", "request-script", metadata: null);
+
+        result.Should().Be("script draft");
+        provider.ChatCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task WorkflowGenerateAsync_WhenProviderStreamsSplitContent_ShouldReturnConcatenatedContent()
+    {
+        using var services = BuildServiceProvider();
+        var provider = new SplitStreamingProviderFactory(["workflow ", "yaml"]);
+        var agent = CreateAgent(new WorkflowGenerateGAgent(provider), services, "workflow-generate-stream");
+
+        await agent.ActivateAsync();
+
+        var result = await agent.GenerateAsync("write workflow", "request-workflow", metadata: null);
+
+        result.Should().Be("workflow yaml");
+        provider.ChatCallCount.Should().Be(0);
+        provider.StreamCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_WhenProviderStreamHasNoContent_ShouldReturnEmptyString()
+    {
+        using var services = BuildServiceProvider();
+        var scriptProvider = new SplitStreamingProviderFactory([]);
+        var workflowProvider = new SplitStreamingProviderFactory([]);
+        var scriptAgent = CreateAgent(new ScriptGenerateGAgent(scriptProvider), services, "script-empty-stream");
+        var workflowAgent = CreateAgent(new WorkflowGenerateGAgent(workflowProvider), services, "workflow-empty-stream");
+
+        await scriptAgent.ActivateAsync();
+        await workflowAgent.ActivateAsync();
+
+        var scriptResult = await scriptAgent.GenerateAsync("empty script", "request-script-empty", metadata: null);
+        var workflowResult = await workflowAgent.GenerateAsync("empty workflow", "request-workflow-empty", metadata: null);
+
+        scriptResult.Should().BeEmpty();
+        workflowResult.Should().BeEmpty();
+        scriptProvider.ChatCallCount.Should().Be(0);
+        workflowProvider.ChatCallCount.Should().Be(0);
+        scriptProvider.StreamCallCount.Should().BeGreaterThan(0);
+        workflowProvider.StreamCallCount.Should().BeGreaterThan(0);
+    }
+
+    private static TAgent CreateAgent<TAgent>(TAgent agent, IServiceProvider services, string actorId)
+        where TAgent : AIGAgentBase<Empty>
+    {
+        agent.Services = services;
+        agent.EventSourcingBehaviorFactory = services.GetRequiredService<IEventSourcingBehaviorFactory<Empty>>();
+        AssignActorId(agent, actorId);
+        return agent;
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        return new ServiceCollection()
+            .AddSingleton<IEventStore, InMemoryEventStoreForStudioGenerateTests>()
+            .AddSingleton<EventSourcingRuntimeOptions>()
+            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
+            .BuildServiceProvider();
+    }
+
+    private static void AssignActorId(object agent, string actorId)
+    {
+        var setId = typeof(Aevatar.Foundation.Core.GAgentBase)
+            .GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        setId.Invoke(agent, [actorId]);
+    }
+
+    private sealed class SplitStreamingProviderFactory(IReadOnlyList<string> chunks)
+        : ILLMProviderFactory, ILLMProvider
+    {
+        public string Name => "studio-test-provider";
+
+        public int ChatCallCount { get; private set; }
+
+        public int StreamCallCount { get; private set; }
+
+        public ILLMProvider GetProvider(string name)
+        {
+            _ = name;
+            return this;
+        }
+
+        public ILLMProvider GetDefault() => this;
+
+        public IReadOnlyList<string> GetAvailableProviders() => [Name];
+
+        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            ChatCallCount++;
+            ct.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("Provider boundary ChatAsync should not be used by Studio generate GAgents.");
+        }
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            request.RequestId.Should().NotBeNullOrWhiteSpace();
+            StreamCallCount++;
+            foreach (var chunk in chunks)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return new LLMStreamChunk { DeltaContent = chunk };
+            }
+
+            yield return new LLMStreamChunk
+            {
+                IsLast = true,
+                FinishReason = "stop",
+            };
+
+            await Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryEventStoreForStudioGenerateTests : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+            {
+                stream = [];
+                _events[agentId] = stream;
+            }
+
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            if (currentVersion != expectedVersion)
+                throw new InvalidOperationException($"Optimistic concurrency conflict: expected {expectedVersion}, actual {currentVersion}");
+
+            var appended = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(appended);
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream.Count == 0 ? 0 : stream[^1].Version,
+                CommittedEvents = { appended.Select(x => x.Clone()) },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult<IReadOnlyList<StateEvent>>([]);
+
+            IReadOnlyList<StateEvent> result = fromVersion.HasValue
+                ? stream.Where(x => x.Version > fromVersion.Value).Select(x => x.Clone()).ToList()
+                : stream.Select(x => x.Clone()).ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(
+                _events.TryGetValue(agentId, out var stream) && stream.Count > 0
+                    ? stream[^1].Version
+                    : 0L);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (toVersion <= 0 || !_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var before = stream.Count;
+            stream.RemoveAll(x => x.Version <= toVersion);
+            return Task.FromResult((long)(before - stream.Count));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

iter15 cluster-024 (`high` severity, AG-AI-STREAM-01).

- **Old**: ChatRuntime/ToolCallLoop/AIGAgentBase/Classifier/Studio Generate/ContextCompressor kept non-streaming `ChatAsync` paths invoking `provider.ChatAsync` directly.
- **New**: `ChatStreamAsync` is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter; `ILLMProvider.ChatAsync` remains provider-boundary only with forbidding-comment for upper layers.

Violated AGENTS.md mandate "AI 对话主链必须流式化".

## Scope

12 files changed (+242/-111). Targeted ChatbotClassifier / ContextCompressor / ToolCallLoop tests pass. architecture_guards + test_stability_guards green.

See [implement-cluster-024 summary](./.refactor-loop/runs/implement-cluster-024.md) and [iter15 audit](./.refactor-loop/runs/audit-iter-15.md#cluster-024-ai-chatasync-authoritative-path).

## Stacked-PR

Part of iter15 batch A (with #PR-028 and #PR-029). All target the iter1-14 integration branch `refactor/2026-05-19_auto-refactor-trial` which has rollup PR #678 to dev.

🤖 Auto-loop produced by codex-refactor-loop skill