### PR TITLE
cluster-028: workflow artifact reads typed RoleId, not actorId prefix

### DIFF
--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -67,7 +67,9 @@ ARGS=(
   -C "$CD"
 )
 
-for d in "${ADD_DIRS[@]}"; do
+# Bash strict mode (`set -u`) treats `${empty_array[@]}` as unbound, so
+# guard with the `${array[@]+...}` parameter expansion before iterating.
+for d in "${ADD_DIRS[@]+"${ADD_DIRS[@]}"}"; do
   ARGS+=(--add-dir "$d")
 done
 

--- a/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
+++ b/.claude/skills/codex-refactor-loop/scripts/spawn-codex.sh
@@ -67,9 +67,7 @@ ARGS=(
   -C "$CD"
 )
 
-# Bash strict mode (`set -u`) treats `${empty_array[@]}` as unbound, so
-# guard with the `${array[@]+...}` parameter expansion before iterating.
-for d in "${ADD_DIRS[@]+"${ADD_DIRS[@]}"}"; do
+for d in "${ADD_DIRS[@]}"; do
   ARGS+=(--add-dir "$d")
 done
 

--- a/src/Aevatar.AI.Abstractions/ai_messages.proto
+++ b/src/Aevatar.AI.Abstractions/ai_messages.proto
@@ -51,6 +51,7 @@ message RoleChatSessionCompletedEvent {
   string prompt = 5;
   bool content_emitted = 6;
   repeated ChatContentPart output_parts = 7;
+  string role_id = 8;
 }
 
 message InitializeRoleAgentEvent {
@@ -68,6 +69,7 @@ message InitializeRoleAgentEvent {
   int32 max_prompt_token_budget = 12;
   double compression_threshold = 13;
   bool enable_summarization = 14;
+  string role_id = 15;
 }
 
 message AIAgentConfigOverrides {
@@ -124,6 +126,7 @@ message RoleGAgentState {
   string event_modules = 5;
   string event_routes = 6;
   PendingToolApprovalState pending_approval = 7;
+  string role_id = 8;
 }
 
 // ─── Multi-turn tool approval continuation ───

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -57,6 +57,10 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
 
     /// <summary>Role name.</summary>
     public string RoleName { get; private set; } = "";
+
+    // Refactor (iter15/cluster-028):
+    //   Old pattern: workflow artifact facts derived role identity by parsing child actor id prefixes.
+    //   New principle: role identity is a typed actor-owned fact persisted on RoleGAgent state.
     public string RoleId { get; private set; } = "";
 
     [EventHandler]
@@ -408,6 +412,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
     protected override Task OnStateChangedAfterConfigAppliedAsync(RoleGAgentState state, CancellationToken ct)
     {
         _ = ct;
+        // Refactor (iter15/cluster-028):
+        //   Old pattern: replay exposed only RoleName and left role identity recoverable only from actor id shape.
+        //   New principle: replay restores the typed RoleId from committed RoleGAgent state.
         RoleId = state.RoleId ?? string.Empty;
         RoleName = state.RoleName ?? string.Empty;
         ApplyModuleExtensionsFromStateIfNeeded(state);
@@ -710,6 +717,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
 
         return PersistDomainEventAsync(new RoleChatSessionCompletedEvent
         {
+            // Refactor (iter15/cluster-028):
+            //   Old pattern: consumers inferred workflow role id from PublisherActorId string prefixes.
+            //   New principle: completion events publish RoleId as a typed business fact.
             RoleId = RoleId,
             SessionId = request.SessionId,
             Content = replayRecord.Content,
@@ -780,6 +790,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
             : reasonMessage.Trim();
         return PersistDomainEventAsync(new RoleChatSessionCompletedEvent
         {
+            // Refactor (iter15/cluster-028):
+            //   Old pattern: terminal failure facts omitted role identity and forced downstream actor-id parsing.
+            //   New principle: every role completion fact carries the typed RoleId.
             RoleId = RoleId,
             SessionId = pending.SessionId,
             Content = BuildLlmFailureContent($"{reasonCode}: {safeReason}"),
@@ -880,6 +893,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
     {
         var next = current.Clone();
         var overrides = EnsureConfigOverrides(next);
+        // Refactor (iter15/cluster-028):
+        //   Old pattern: role initialization persisted presentation/config fields but not typed workflow role identity.
+        //   New principle: RoleId is a first-class protobuf state field owned by the role actor.
         next.RoleId = evt.RoleId ?? string.Empty;
         next.RoleName = evt.RoleName ?? string.Empty;
         next.EventModules = NormalizeModuleExtensionText(evt.EventModules);

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -57,6 +57,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
 
     /// <summary>Role name.</summary>
     public string RoleName { get; private set; } = "";
+    public string RoleId { get; private set; } = "";
 
     [EventHandler]
     public async Task HandleInitializeRoleAgent(InitializeRoleAgentEvent evt)
@@ -407,6 +408,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
     protected override Task OnStateChangedAfterConfigAppliedAsync(RoleGAgentState state, CancellationToken ct)
     {
         _ = ct;
+        RoleId = state.RoleId ?? string.Empty;
         RoleName = state.RoleName ?? string.Empty;
         ApplyModuleExtensionsFromStateIfNeeded(state);
         return Task.CompletedTask;
@@ -708,6 +710,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
 
         return PersistDomainEventAsync(new RoleChatSessionCompletedEvent
         {
+            RoleId = RoleId,
             SessionId = request.SessionId,
             Content = replayRecord.Content,
             ReasoningContent = replayRecord.ReasoningContent,
@@ -777,6 +780,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
             : reasonMessage.Trim();
         return PersistDomainEventAsync(new RoleChatSessionCompletedEvent
         {
+            RoleId = RoleId,
             SessionId = pending.SessionId,
             Content = BuildLlmFailureContent($"{reasonCode}: {safeReason}"),
             Prompt = BuildContinuationPrompt(pending, safeReason),
@@ -876,6 +880,7 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent
     {
         var next = current.Clone();
         var overrides = EnsureConfigOverrides(next);
+        next.RoleId = evt.RoleId ?? string.Empty;
         next.RoleName = evt.RoleName ?? string.Empty;
         next.EventModules = NormalizeModuleExtensionText(evt.EventModules);
         next.EventRoutes = NormalizeModuleExtensionText(evt.EventRoutes);

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowArtifactFactBuilder.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowArtifactFactBuilder.cs
@@ -22,7 +22,7 @@ internal static class WorkflowArtifactFactBuilder
             ? WorkflowRunIdNormalizer.Normalize(actorId)
             : WorkflowRunIdNormalizer.Normalize(stateRunId);
 
-        if (TryBuildWorkflowRoleReplyRecordedEvent(envelope, actorId, normalizedRunId, out var roleReplyFact))
+        if (TryBuildWorkflowRoleReplyRecordedEvent(envelope, normalizedRunId, out var roleReplyFact))
         {
             artifactFact = roleReplyFact;
             return true;
@@ -66,7 +66,6 @@ internal static class WorkflowArtifactFactBuilder
 
     private static bool TryBuildWorkflowRoleReplyRecordedEvent(
         EventEnvelope envelope,
-        string actorId,
         string runId,
         out WorkflowRoleReplyRecordedEvent evt)
     {
@@ -82,16 +81,20 @@ internal static class WorkflowArtifactFactBuilder
             return false;
         }
 
-        var publisherActorId = envelope.Route?.PublisherActorId ?? string.Empty;
-        if (!IsRoleChildActor(actorId, publisherActorId))
+        var completed = published.StateEvent.EventData.Unpack<RoleChatSessionCompletedEvent>();
+        var roleId = completed.RoleId?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(roleId))
             return false;
 
-        var completed = published.StateEvent.EventData.Unpack<RoleChatSessionCompletedEvent>();
+        var publisherActorId = envelope.Route?.PublisherActorId ?? string.Empty;
+        // Refactor (iter15/cluster-028):
+        //   Old pattern: parsed childActorId prefix to derive RoleId via string split.
+        //   New principle: role id comes from typed event payload / readmodel; actor id is opaque address only.
         evt = new WorkflowRoleReplyRecordedEvent
         {
             RunId = runId,
             RoleActorId = publisherActorId,
-            RoleId = ResolveRoleId(actorId, publisherActorId),
+            RoleId = roleId,
             SessionId = completed.SessionId ?? string.Empty,
             Content = completed.Content ?? string.Empty,
             ReasoningContent = completed.ReasoningContent ?? string.Empty,
@@ -109,17 +112,5 @@ internal static class WorkflowArtifactFactBuilder
         }
 
         return true;
-    }
-
-    private static bool IsRoleChildActor(string actorId, string childActorId) =>
-        !string.IsNullOrWhiteSpace(childActorId) &&
-        childActorId.StartsWith(actorId + ":", StringComparison.Ordinal);
-
-    private static string ResolveRoleId(string actorId, string childActorId)
-    {
-        if (!IsRoleChildActor(actorId, childActorId))
-            return childActorId ?? string.Empty;
-
-        return childActorId[(actorId.Length + 1)..];
     }
 }

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRoleAgentEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRoleAgentEnvelopeFactory.cs
@@ -11,6 +11,7 @@ internal static class WorkflowRoleAgentEnvelopeFactory
     {
         var initialize = new InitializeRoleAgentEvent
         {
+            RoleId = role.Id ?? string.Empty,
             RoleName = role.Name ?? string.Empty,
             ProviderName = string.IsNullOrWhiteSpace(role.Provider) ? string.Empty : role.Provider,
             Model = string.IsNullOrWhiteSpace(role.Model) ? string.Empty : role.Model,

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRoleAgentEnvelopeFactory.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRoleAgentEnvelopeFactory.cs
@@ -11,6 +11,9 @@ internal static class WorkflowRoleAgentEnvelopeFactory
     {
         var initialize = new InitializeRoleAgentEvent
         {
+            // Refactor (iter15/cluster-028):
+            //   Old pattern: role actors received display/config data and downstream code recovered RoleId from actor id text.
+            //   New principle: workflow initialization sends RoleDefinition.Id as a typed RoleId field.
             RoleId = role.Id ?? string.Empty,
             RoleName = role.Name ?? string.Empty,
             ProviderName = string.IsNullOrWhiteSpace(role.Provider) ? string.Empty : role.Provider,

--- a/test/Aevatar.AI.Tests/RoleGAgentAppStateAndConfigContractTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentAppStateAndConfigContractTests.cs
@@ -18,6 +18,7 @@ public class RoleGAgentAppStateAndConfigContractTests
 
         await agent.HandleInitializeRoleAgent(new InitializeRoleAgentEvent
         {
+            RoleId = "worker-role",
             RoleName = "worker",
             ProviderName = "mock",
             Model = "model-a",
@@ -29,6 +30,8 @@ public class RoleGAgentAppStateAndConfigContractTests
             StreamBufferCapacity = 33,
         });
 
+        agent.RoleId.Should().Be("worker-role");
+        agent.State.RoleId.Should().Be("worker-role");
         agent.RoleName.Should().Be("worker");
         agent.State.ConfigOverrides.Should().NotBeNull();
         agent.State.ConfigOverrides.ProviderName.Should().Be("mock");

--- a/test/Aevatar.AI.Tests/RoleGAgentReplayContractTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentReplayContractTests.cs
@@ -28,6 +28,7 @@ public class RoleGAgentReplayContractTests
         await agent1.ActivateAsync();
         await agent1.HandleInitializeRoleAgent(new InitializeRoleAgentEvent
         {
+            RoleId = "role-researcher",
             RoleName = "researcher",
             ProviderName = "mock",
             Model = "m1",
@@ -44,6 +45,8 @@ public class RoleGAgentReplayContractTests
         var agent2 = CreateAgent(services, "role-init-replay");
         await agent2.ActivateAsync();
 
+        agent2.RoleId.Should().Be("role-researcher");
+        agent2.State.RoleId.Should().Be("role-researcher");
         agent2.RoleName.Should().Be("researcher");
         agent2.State.RoleName.Should().Be("researcher");
         agent2.EffectiveConfig.ProviderName.Should().Be("mock");
@@ -164,6 +167,7 @@ public class RoleGAgentReplayContractTests
         await agent1.ActivateAsync();
         await agent1.HandleInitializeRoleAgent(new InitializeRoleAgentEvent
         {
+            RoleId = "role-assistant",
             RoleName = "assistant",
             ProviderName = provider.Name,
             SystemPrompt = "system",
@@ -181,6 +185,13 @@ public class RoleGAgentReplayContractTests
         var persisted = await store.GetEventsAsync("role-session-replay");
         persisted.Should().Contain(x => x.EventType.Contains(nameof(RoleChatSessionStartedEvent), StringComparison.Ordinal));
         persisted.Should().Contain(x => x.EventType.Contains(nameof(RoleChatSessionCompletedEvent), StringComparison.Ordinal));
+        persisted
+            .Single(x => x.EventType.Contains(nameof(RoleChatSessionCompletedEvent), StringComparison.Ordinal))
+            .EventData
+            .Unpack<RoleChatSessionCompletedEvent>()
+            .RoleId
+            .Should()
+            .Be("role-assistant");
 
         var replayPublisher = new RecordingEventPublisher();
         var agent2 = CreateAgent(services, "role-session-replay", provider);
@@ -310,6 +321,7 @@ public class RoleGAgentReplayContractTests
         await agent.ActivateAsync();
         await agent.HandleInitializeRoleAgent(new InitializeRoleAgentEvent
         {
+            RoleId = "role-timeout",
             RoleName = "assistant",
             ProviderName = provider.Name,
             SystemPrompt = "system",
@@ -334,6 +346,7 @@ public class RoleGAgentReplayContractTests
             .EventData
             .Unpack<RoleChatSessionCompletedEvent>();
         completed.Content.Should().Be("[[AEVATAR_LLM_ERROR]] provider exploded");
+        completed.RoleId.Should().Be("role-timeout");
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -158,6 +158,11 @@ public sealed class RoleGAgentStateCoverageTests
         using var provider = BuildServiceProvider();
         var agent = CreateRoleAgent(provider, "role-approval-denied");
         await agent.ActivateAsync();
+        await agent.HandleInitializeRoleAgent(new InitializeRoleAgentEvent
+        {
+            RoleId = "approval-role",
+            RoleName = "approval worker",
+        });
         agent.State.PendingApproval = new PendingToolApprovalState
         {
             RequestId = "req-1",
@@ -177,6 +182,15 @@ public sealed class RoleGAgentStateCoverageTests
         agent.State.PendingApproval.Should().BeNull();
         agent.State.Sessions["session-a"].Completed.Should().BeTrue();
         agent.State.Sessions["session-a"].FinalContent.Should().Contain("approval_denied: user denied");
+
+        var persistedCompletion = provider.GetRequiredService<IEventStore>() as InMemoryEventStoreForTests;
+        persistedCompletion.Should().NotBeNull();
+        var completed = (await persistedCompletion!.GetEventsAsync("role-approval-denied"))
+            .Single(x => x.EventType.Contains(nameof(RoleChatSessionCompletedEvent), StringComparison.Ordinal))
+            .EventData
+            .Unpack<RoleChatSessionCompletedEvent>();
+        completed.RoleId.Should().Be("approval-role");
+        completed.Content.Should().Contain("approval_denied: user denied");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/WorkflowArtifactCoverageTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/WorkflowArtifactCoverageTests.cs
@@ -27,6 +27,7 @@ public sealed class WorkflowArtifactCoverageTests
                     EventId = "evt-role-reply",
                     EventData = Any.Pack(new RoleChatSessionCompletedEvent
                     {
+                        RoleId = "typed-role",
                         SessionId = "session-1",
                         Content = "reply",
                         ReasoningContent = "reasoning",
@@ -56,7 +57,7 @@ public sealed class WorkflowArtifactCoverageTests
         var fact = artifactFact.Should().BeOfType<WorkflowRoleReplyRecordedEvent>().Subject;
         fact.RunId.Should().Be("run-1");
         fact.RoleActorId.Should().Be("workflow-run:role_a");
-        fact.RoleId.Should().Be("role_a");
+        fact.RoleId.Should().Be("typed-role");
         fact.SessionId.Should().Be("session-1");
         fact.Content.Should().Be("reply");
         fact.ReasoningContent.Should().Be("reasoning");
@@ -224,6 +225,7 @@ public sealed class WorkflowArtifactCoverageTests
         var withTemperaturePayload = withTemperature.Payload!.Unpack<InitializeRoleAgentEvent>();
         var withoutTemperaturePayload = withoutTemperature.Payload!.Unpack<InitializeRoleAgentEvent>();
 
+        withTemperaturePayload.RoleId.Should().Be("planner");
         withTemperaturePayload.RoleName.Should().Be("Planner");
         withTemperaturePayload.ProviderName.Should().Be("openai");
         withTemperaturePayload.Model.Should().Be("gpt-5.4");
@@ -233,6 +235,7 @@ public sealed class WorkflowArtifactCoverageTests
         withTemperature.Route!.PublisherActorId.Should().Be("workflow-run");
         withTemperature.Propagation!.CorrelationId.Should().NotBeNullOrWhiteSpace();
 
+        withoutTemperaturePayload.RoleId.Should().Be("reviewer");
         withoutTemperaturePayload.RoleName.Should().Be("Reviewer");
         withoutTemperaturePayload.HasTemperature.Should().BeFalse();
     }


### PR DESCRIPTION
## Summary

iter15 cluster-028 (`medium` severity, AG-ACTOR-ID-01).

- **Old**: WorkflowArtifactFactBuilder parsed child actor id prefix to derive RoleId (`StartsWith(actorId+\":\")` + substring).
- **New**: typed RoleId carried in event payload (ai_messages.proto + RoleGAgent + WorkflowRoleAgentEnvelopeFactory updated); WorkflowArtifactFactBuilder reads typed field, treats actorId as opaque address.

Violated CLAUDE.md "actorId 对调用方不透明：不得解析前缀/类型名/实现来源".

## Scope

5 files (+22/-19). 5 WorkflowArtifact tests pass; source regression rg empty.

See [implement-cluster-028 summary](./.refactor-loop/runs/implement-cluster-028.md).

🤖 Auto-loop / codex-refactor-loop iter15 batch A