### PR TITLE
Ingress v1 Phase 1 — ChatRoutePolicyGAgent + Document + Projector

### DIFF
--- a/aevatar.slnx
+++ b/aevatar.slnx
@@ -23,6 +23,7 @@
     <Project Path="agents\Aevatar.GAgents.Household\Aevatar.GAgents.Household.csproj" />
     <Project Path="agents/Aevatar.GAgents.StudioMember/Aevatar.GAgents.StudioMember.csproj" />
     <Project Path="agents/Aevatar.GAgents.StudioTeam/Aevatar.GAgents.StudioTeam.csproj" />
+    <Project Path="agents/Aevatar.GAgents.ChatRouting/Aevatar.GAgents.ChatRouting.csproj" />
   </Folder>
   <Folder Name="/demos/">
     <Project Path="demos\Aevatar.Demos.Cli\Aevatar.Demos.Cli.csproj" />
@@ -157,6 +158,7 @@
   <Folder Name="/test/">
     <Project Path="test/Aevatar.Interop.A2A.Tests/Aevatar.Interop.A2A.Tests.csproj" />
     <Project Path="test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj" />
+    <Project Path="test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Core.Tests\Aevatar.AI.Core.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Tests\Aevatar.AI.Tests.csproj" />
     <Project Path="test\Aevatar.AI.ToolProviders.Ornn.Tests\Aevatar.AI.ToolProviders.Ornn.Tests.csproj" />

--- a/agents/Aevatar.GAgents.ChatRouting/Aevatar.GAgents.ChatRouting.csproj
+++ b/agents/Aevatar.GAgents.ChatRouting/Aevatar.GAgents.ChatRouting.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Aevatar.GAgents.ChatRouting</AssemblyName>
+    <RootNamespace>Aevatar.GAgents.ChatRouting</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core\Aevatar.CQRS.Projection.Core.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Runtime.Abstractions\Aevatar.CQRS.Projection.Runtime.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Stores.Abstractions\Aevatar.CQRS.Projection.Stores.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Providers.InMemory\Aevatar.CQRS.Projection.Providers.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+  <ItemGroup>
+    <!--
+      chat_route_policy_readmodel.proto imports chat_route_policy.proto from
+      Aevatar.ChatRouting.Abstractions. The imported proto is resolved for
+      protoc via AdditionalImportDirs (not listed as a compiled Protobuf item)
+      so its C# types are NOT regenerated here — they come from the
+      Aevatar.ChatRouting.Abstractions assembly via ProjectReference. This
+      keeps a single authoritative copy of the wire types.
+    -->
+    <Protobuf Include="chat_route_policy_readmodel.proto"
+              ProtoRoot="."
+              AdditionalImportDirs="..\..\src\Aevatar.ChatRouting.Abstractions"
+              GrpcServices="None" />
+  </ItemGroup>
+</Project>

--- a/agents/Aevatar.GAgents.ChatRouting/Aevatar.GAgents.ChatRouting.csproj
+++ b/agents/Aevatar.GAgents.ChatRouting/Aevatar.GAgents.ChatRouting.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\src\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core\Aevatar.CQRS.Projection.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Runtime\Aevatar.CQRS.Projection.Runtime.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Runtime.Abstractions\Aevatar.CQRS.Projection.Runtime.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Stores.Abstractions\Aevatar.CQRS.Projection.Stores.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Providers.InMemory\Aevatar.CQRS.Projection.Providers.InMemory.csproj" />

--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCurrentStateDocument.Partial.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCurrentStateDocument.Partial.cs
@@ -1,0 +1,21 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+/// <summary>
+/// Hand-written half of the proto-generated <see cref="ChatRoutePolicyCurrentStateDocument"/>:
+/// adapts the readmodel envelope fields to the <see cref="IProjectionReadModel{T}"/>
+/// contract that the projection document stores require.
+/// </summary>
+public sealed partial class ChatRoutePolicyCurrentStateDocument
+    : IProjectionReadModel<ChatRoutePolicyCurrentStateDocument>
+{
+    string IProjectionReadModel.ActorId => ActorId;
+
+    long IProjectionReadModel.StateVersion => StateVersion;
+
+    string IProjectionReadModel.LastEventId => LastEventId;
+
+    DateTimeOffset IProjectionReadModel.UpdatedAt
+        => UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue;
+}

--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCurrentStateProjector.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCurrentStateProjector.cs
@@ -1,0 +1,73 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+/// <summary>
+/// Materializes <see cref="ChatRoutePolicyState"/> committed events into
+/// <see cref="ChatRoutePolicyCurrentStateDocument"/> in the projection document
+/// store. Each committed state is an authoritative full snapshot, so the
+/// projector overwrite-writes the whole document — it never reads the previous
+/// document to derive the next (CLAUDE.md 覆盖复制优先).
+///
+/// <c>state_version</c> / <c>last_event_id</c> come from the committed
+/// <see cref="StateEvent"/> (the authoritative version watermark); the business
+/// fields mirror <see cref="ChatRoutePolicyState"/> 1:1.
+/// </summary>
+public sealed class ChatRoutePolicyCurrentStateProjector
+    : ICurrentStateProjectionMaterializer<ChatRoutePolicyMaterializationContext>
+{
+    private readonly IProjectionWriteDispatcher<ChatRoutePolicyCurrentStateDocument> _writeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    public ChatRoutePolicyCurrentStateProjector(
+        IProjectionWriteDispatcher<ChatRoutePolicyCurrentStateDocument> writeDispatcher,
+        IProjectionClock clock)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async ValueTask ProjectAsync(
+        ChatRoutePolicyMaterializationContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!CommittedStateEventEnvelope.TryUnpackState<ChatRoutePolicyState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out var state) ||
+            stateEvent?.EventData == null ||
+            state == null)
+        {
+            return;
+        }
+
+        var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
+
+        var document = new ChatRoutePolicyCurrentStateDocument
+        {
+            Id = context.RootActorId,
+            ActorId = context.RootActorId,
+            StateVersion = stateEvent.Version,
+            LastEventId = stateEvent.EventId ?? string.Empty,
+            UpdatedAt = Timestamp.FromDateTimeOffset(updatedAt),
+            PolicyId = state.PolicyId,
+            OwnerScope = state.OwnerScope?.Clone(),
+            DefaultTarget = state.DefaultTarget?.Clone(),
+            PolicyVersion = state.Version,
+            PolicyUpdatedAt = state.UpdatedAt?.Clone(),
+        };
+        document.Rules.AddRange(state.Rules.Select(rule => rule.Clone()));
+
+        await _writeDispatcher.UpsertAsync(document, ct);
+    }
+}

--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyGAgent.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyGAgent.cs
@@ -1,0 +1,130 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+/// <summary>
+/// Per-scope, long-lived config aggregate that owns the authoritative chat
+/// route policy (issue #672 / ADR-0024). It is the single source of truth for
+/// <see cref="ChatRoutePolicyState"/>; the <c>ChatRoutePolicyCurrentStateDocument</c>
+/// readmodel is a query-side replica projected from its committed
+/// <see cref="ChatRoutePolicyUpdated"/> events.
+///
+/// This actor only handles config commands — it never participates in turn
+/// dispatch and never answers queries (queries read the readmodel, per
+/// CLAUDE.md 读写分离).
+///
+/// Actor ID convention: <c>chat-route-policy:{scopeId}</c> (per-scope).
+/// </summary>
+public sealed class ChatRoutePolicyGAgent : GAgentBase<ChatRoutePolicyState>, IProjectedActor
+{
+    public static string ProjectionKind => "chat-route-policy";
+
+    /// <summary>
+    /// Creates or replaces the policy for this scope. <c>default_target</c> is
+    /// required so the resolver always has a fallback when no rule matches.
+    /// Rules are persisted pre-ordered by priority so the resolver can evaluate
+    /// them in stored order.
+    /// </summary>
+    [EventHandler]
+    public async Task HandleUpsertAsync(UpsertChatRoutePolicyRequested command)
+    {
+        if (command.DefaultTarget is null ||
+            command.DefaultTarget.ActionCase == ChatRouteAction.ActionOneofCase.None)
+        {
+            throw new InvalidOperationException(
+                "UpsertChatRoutePolicyRequested.default_target is required: a chat route policy must " +
+                "declare a default ChatRouteAction (e.g. ForwardToModel) so the resolver always has a " +
+                "fallback when no rule matches. Set default_target to a non-empty ChatRouteAction.");
+        }
+
+        var nextState = new ChatRoutePolicyState
+        {
+            PolicyId = string.IsNullOrEmpty(State.PolicyId) ? Id : State.PolicyId,
+            OwnerScope = command.OwnerScope?.Clone(),
+            DefaultTarget = command.DefaultTarget.Clone(),
+            Version = State.Version + 1,
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+        nextState.Rules.AddRange(OrderRulesByPriority(command.Rules));
+
+        await PersistDomainEventAsync(new ChatRoutePolicyUpdated { State = nextState });
+    }
+
+    /// <summary>
+    /// Removes a single rule by id. Rejects an empty id, an uninitialized
+    /// policy, and an unknown rule id with an actionable error rather than
+    /// silently no-op'ing.
+    /// </summary>
+    [EventHandler]
+    public async Task HandleRemoveRuleAsync(RemoveChatRouteRuleRequested command)
+    {
+        if (string.IsNullOrWhiteSpace(command.RuleId))
+        {
+            throw new InvalidOperationException(
+                "RemoveChatRouteRuleRequested.rule_id is required.");
+        }
+
+        if (!IsInitialized())
+        {
+            throw new InvalidOperationException(
+                $"chat route policy '{Id}' is not initialized; upsert a policy before removing rules.");
+        }
+
+        var retained = State.Rules
+            .Where(rule => !string.Equals(rule.RuleId, command.RuleId, StringComparison.Ordinal))
+            .Select(rule => rule.Clone())
+            .ToList();
+        if (retained.Count == State.Rules.Count)
+        {
+            throw new InvalidOperationException(
+                $"chat route rule '{command.RuleId}' not found in policy '{State.PolicyId}'.");
+        }
+
+        var nextState = new ChatRoutePolicyState
+        {
+            PolicyId = State.PolicyId,
+            OwnerScope = State.OwnerScope?.Clone(),
+            DefaultTarget = State.DefaultTarget.Clone(),
+            Version = State.Version + 1,
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+        nextState.Rules.AddRange(retained);
+
+        await PersistDomainEventAsync(new ChatRoutePolicyUpdated { State = nextState });
+    }
+
+    protected override ChatRoutePolicyState TransitionState(
+        ChatRoutePolicyState current, IMessage evt) =>
+        StateTransitionMatcher
+            .Match(current, evt)
+            .On<ChatRoutePolicyUpdated>(ApplyPolicyUpdated)
+            .OrCurrent();
+
+    // ChatRoutePolicyUpdated carries the full next state, so applying it is a
+    // straight replacement — the actor never derives state field-by-field.
+    private static ChatRoutePolicyState ApplyPolicyUpdated(
+        ChatRoutePolicyState current, ChatRoutePolicyUpdated evt)
+        => evt.State.Clone();
+
+    // A policy "exists" once a valid default_target has been upserted.
+    private bool IsInitialized() =>
+        State.DefaultTarget is not null &&
+        State.DefaultTarget.ActionCase != ChatRouteAction.ActionOneofCase.None;
+
+    // Higher priority first; ties broken by rule_id lexical order — matches the
+    // ChatRouteRule proto contract. Persisting rules pre-ordered means the
+    // resolver evaluates them in stored order without re-sorting.
+    private static IEnumerable<ChatRouteRule> OrderRulesByPriority(
+        IEnumerable<ChatRouteRule> rules) =>
+        rules
+            .Where(rule => rule is not null)
+            .Select(rule => rule.Clone())
+            .OrderByDescending(rule => rule.Priority)
+            .ThenBy(rule => rule.RuleId, StringComparer.Ordinal);
+}

--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyMaterializationContext.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyMaterializationContext.cs
@@ -1,0 +1,15 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+/// <summary>
+/// Materialization context for the ChatRoutePolicy projection scope. Carries
+/// the authority actor id and projection kind into
+/// <see cref="ChatRoutePolicyCurrentStateProjector"/>.
+/// </summary>
+public sealed class ChatRoutePolicyMaterializationContext : IProjectionMaterializationContext
+{
+    public required string RootActorId { get; init; }
+
+    public required string ProjectionKind { get; init; }
+}

--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyMaterializationRuntimeLease.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyMaterializationRuntimeLease.cs
@@ -1,0 +1,17 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+public sealed class ChatRoutePolicyMaterializationRuntimeLease
+    : ProjectionRuntimeLeaseBase,
+      IProjectionContextRuntimeLease<ChatRoutePolicyMaterializationContext>
+{
+    public ChatRoutePolicyMaterializationRuntimeLease(ChatRoutePolicyMaterializationContext context)
+        : base(context.RootActorId)
+    {
+        Context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public ChatRoutePolicyMaterializationContext Context { get; }
+}

--- a/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
@@ -1,0 +1,32 @@
+using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+/// <summary>
+/// DI registration entry point for the ChatRouting agent package
+/// (ingress layer v1 — issue #692, Phase 1).
+/// </summary>
+public static class ChatRoutingServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the <see cref="ChatRoutePolicyCurrentStateDocument"/> projection
+    /// document store (reader + writer). Without this registration the projector's
+    /// <c>UpsertAsync</c> has no backing store and the readmodel silently never
+    /// materializes.
+    ///
+    /// Phase 1 wires the InMemory store unconditionally; the Elasticsearch-vs-InMemory
+    /// selection (mirroring <c>AddScheduledAgents</c>) lands when an ingress entry
+    /// actually consumes the readmodel.
+    /// </summary>
+    public static IServiceCollection AddChatRoutingAgents(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddInMemoryDocumentProjectionStore<ChatRoutePolicyCurrentStateDocument, string>(
+            static document => document.ActorId,
+            static key => key);
+
+        return services;
+    }
+}

--- a/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
@@ -1,5 +1,10 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.DependencyInjection;
+using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
+using Aevatar.CQRS.Projection.Runtime.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aevatar.GAgents.ChatRouting;
 
@@ -10,10 +15,18 @@ namespace Aevatar.GAgents.ChatRouting;
 public static class ChatRoutingServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers the <see cref="ChatRoutePolicyCurrentStateDocument"/> projection
-    /// document store (reader + writer). Without this registration the projector's
-    /// <c>UpsertAsync</c> has no backing store and the readmodel silently never
-    /// materializes.
+    /// Wires the ChatRoutePolicy projection pipeline so that committed
+    /// <c>ChatRoutePolicyUpdated</c> events from <see cref="ChatRoutePolicyGAgent"/>
+    /// flow through the materialization runtime into <see cref="ChatRoutePolicyCurrentStateProjector"/>
+    /// and land in <see cref="ChatRoutePolicyCurrentStateDocument"/>:
+    /// <list type="bullet">
+    ///   <item>materialization runtime + scope + per-scope lease,</item>
+    ///   <item>the current-state projector as an <see cref="Aevatar.CQRS.Projection.Core.Abstractions.ICurrentStateProjectionMaterializer{TContext}"/> contributor,</item>
+    ///   <item>the InMemory document projection store (reader + writer).</item>
+    /// </list>
+    /// Without the runtime and materializer registrations the projector would
+    /// have a backing store but no subscribed materialization, so the readmodel
+    /// would silently never populate (the projection-store-registration pitfall).
     ///
     /// Phase 1 wires the InMemory store unconditionally; the Elasticsearch-vs-InMemory
     /// selection (mirroring <c>AddScheduledAgents</c>) lands when an ingress entry
@@ -22,6 +35,26 @@ public static class ChatRoutingServiceCollectionExtensions
     public static IServiceCollection AddChatRoutingAgents(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // Shared projection plumbing used by the projector (write dispatcher +
+        // clock). Both registrations are TryAdd so they're safe alongside other
+        // agents that already wire them.
+        services.AddProjectionReadModelRuntime();
+        services.TryAddSingleton<IProjectionClock, SystemProjectionClock>();
+
+        services.AddProjectionMaterializationRuntimeCore<
+            ChatRoutePolicyMaterializationContext,
+            ChatRoutePolicyMaterializationRuntimeLease,
+            ProjectionMaterializationScopeGAgent<ChatRoutePolicyMaterializationContext>>(
+            static scopeKey => new ChatRoutePolicyMaterializationContext
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+            },
+            static context => new ChatRoutePolicyMaterializationRuntimeLease(context));
+        services.AddCurrentStateProjectionMaterializer<
+            ChatRoutePolicyMaterializationContext,
+            ChatRoutePolicyCurrentStateProjector>();
 
         services.AddInMemoryDocumentProjectionStore<ChatRoutePolicyCurrentStateDocument, string>(
             static document => document.ActorId,

--- a/agents/Aevatar.GAgents.ChatRouting/chat_route_policy_readmodel.proto
+++ b/agents/Aevatar.GAgents.ChatRouting/chat_route_policy_readmodel.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package aevatar.chat_routing.v1;
+
+option csharp_namespace = "Aevatar.GAgents.ChatRouting";
+
+import "google/protobuf/timestamp.proto";
+import "chat_route_policy.proto";
+
+// ─── ChatRoutePolicy current-state readmodel ───
+//
+// Query-side replica of ChatRoutePolicyState, materialized from the
+// ChatRoutePolicyGAgent's committed ChatRoutePolicyUpdated events by
+// ChatRoutePolicyCurrentStateProjector (CLAUDE.md 一权威状态 → 多 readmodel).
+//
+// Business fields mirror ChatRoutePolicyState field-for-field with the
+// strongly-typed sub-messages from chat_route_policy.proto — no
+// google.protobuf.Any state_root bag — so query ports read typed fields
+// directly without unpacking the authority's internal layout.
+//
+// The two version/timestamp pairs are deliberately distinct:
+//   - state_version / updated_at  → projection-envelope facts (the committed
+//     StateEvent.Version the document was materialized from, and when the
+//     projector wrote it).
+//   - policy_version / policy_updated_at → the authority's own monotonic
+//     ChatRoutePolicyState.version and updated_at, mirrored verbatim.
+message ChatRoutePolicyCurrentStateDocument {
+  string id = 1;
+  string actor_id = 2;
+  int64 state_version = 3;
+  string last_event_id = 4;
+  google.protobuf.Timestamp updated_at = 5;
+
+  // Business fields (projected 1:1 from ChatRoutePolicyState).
+  string policy_id = 10;
+  ChatRouteCallerScope owner_scope = 11;
+  ChatRouteAction default_target = 12;
+  repeated ChatRouteRule rules = 13;
+  int64 policy_version = 14;
+  google.protobuf.Timestamp policy_updated_at = 15;
+}

--- a/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
+++ b/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\agents\platforms\Aevatar.GAgents.Platform.Telegram\Aevatar.GAgents.Platform.Telegram.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Authoring.Lark\Aevatar.GAgents.Authoring.Lark.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Scheduled\Aevatar.GAgents.Scheduled.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.ChatRouting\Aevatar.GAgents.ChatRouting.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Device\Aevatar.GAgents.Device.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.AgentCatalog\Aevatar.AI.ToolProviders.AgentCatalog.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Channel\Aevatar.AI.ToolProviders.Channel.csproj" />

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -17,6 +17,7 @@ using Aevatar.GAgents.Channel.Identity.DependencyInjection;
 using Aevatar.GAgents.Channel.Identity.Endpoints;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.ChatRouting;
 using Aevatar.GAgents.ChatbotClassifier;
 using Aevatar.GAgents.Device;
 using Aevatar.GAgents.NyxidChat;
@@ -90,6 +91,11 @@ public static class MainnetHostBuilderExtensions
         builder.Services.AddChannelIdentityProjectionStores(builder.Configuration);
         builder.Services.AddDeviceRegistration(builder.Configuration);
         builder.Services.AddScheduledAgents(builder.Configuration);
+        // Ingress layer v1 (issue #692, Phase 1): registers the ChatRoutePolicy
+        // current-state readmodel document store. The policy actor + projector
+        // ship in this phase; ingress entries start consulting the readmodel in
+        // a later phase.
+        builder.Services.AddChatRoutingAgents();
         builder.Services.TryAddSingleton<IResponsesCallerScopeResolver, NyxIdResponsesCallerScopeResolver>();
         builder.Services.TryAddSingleton<IResponsesModelsAggregator, NyxIdResponsesModelsAggregator>();
         builder.Services.TryAddSingleton<IResponsesRouteResolver, CachingResponsesRouteResolver>();

--- a/test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Aevatar.GAgents.ChatRouting.Tests</AssemblyName>
+    <RootNamespace>Aevatar.GAgents.ChatRouting.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.ChatRouting\Aevatar.GAgents.ChatRouting.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Runtime.Abstractions\Aevatar.CQRS.Projection.Runtime.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Stores.Abstractions\Aevatar.CQRS.Projection.Stores.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCurrentStateProjectorTests.cs
@@ -1,0 +1,192 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.ChatRouting.Tests;
+
+/// <summary>
+/// Locks in the projector contract: committed <see cref="ChatRoutePolicyState"/>
+/// events are overwrite-materialized into <see cref="ChatRoutePolicyCurrentStateDocument"/>
+/// with every business field mirrored, re-projecting the same version is
+/// idempotent, and non-committed envelopes produce no write.
+/// </summary>
+public sealed class ChatRoutePolicyCurrentStateProjectorTests
+{
+    private const string RootActorId = "chat-route-policy:scope-1";
+
+    [Fact]
+    public async Task ProjectAsync_OverwriteWritesDocument_FromCommittedState()
+    {
+        var dispatcher = new RecordingWriteDispatcher<ChatRoutePolicyCurrentStateDocument>();
+        var projector = new ChatRoutePolicyCurrentStateProjector(
+            dispatcher, new FixedProjectionClock(DateTimeOffset.Parse("2026-05-19T00:00:00Z")));
+
+        await projector.ProjectAsync(
+            NewContext(),
+            WrapCommitted(SampleState(version: 7), version: 7, eventId: "evt-7"));
+
+        dispatcher.Upserts.Should().ContainSingle();
+        var document = dispatcher.Upserts[0];
+
+        // Projection-envelope facts come from the committed StateEvent.
+        document.Id.Should().Be(RootActorId);
+        document.ActorId.Should().Be(RootActorId);
+        document.StateVersion.Should().Be(7);
+        document.LastEventId.Should().Be("evt-7");
+
+        // Business fields mirror ChatRoutePolicyState 1:1, strongly typed.
+        document.PolicyId.Should().Be(RootActorId);
+        document.PolicyVersion.Should().Be(7);
+        document.OwnerScope.RegistrationScopeId.Should().Be("scope-1");
+        document.DefaultTarget.ForwardToModel.ModelName.Should().Be("chrono-llm/gpt-5.5");
+        document.Rules.Select(rule => rule.RuleId).Should().Equal("alpha", "beta");
+        document.PolicyUpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_SameVersionTwice_ProducesIdenticalDocument()
+    {
+        var dispatcher = new RecordingWriteDispatcher<ChatRoutePolicyCurrentStateDocument>();
+        var projector = new ChatRoutePolicyCurrentStateProjector(
+            dispatcher, new FixedProjectionClock(DateTimeOffset.Parse("2026-05-19T00:00:00Z")));
+        var envelope = WrapCommitted(SampleState(version: 3), version: 3, eventId: "evt-3");
+
+        await projector.ProjectAsync(NewContext(), envelope);
+        await projector.ProjectAsync(NewContext(), envelope);
+
+        dispatcher.Upserts.Should().HaveCount(2);
+        dispatcher.Upserts[0].Should().Be(
+            dispatcher.Upserts[1],
+            "re-projecting the same committed version is a deterministic, idempotent overwrite");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_NoOp_WhenEnvelopeIsNotCommittedStateEvent()
+    {
+        var dispatcher = new RecordingWriteDispatcher<ChatRoutePolicyCurrentStateDocument>();
+        var projector = new ChatRoutePolicyCurrentStateProjector(
+            dispatcher, new FixedProjectionClock(DateTimeOffset.UtcNow));
+
+        // A bare domain event without the CommittedStateEventPublished wrapper
+        // must not produce a write — the projector is downstream of committed
+        // events only.
+        var envelope = new EventEnvelope
+        {
+            Id = "raw",
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new ChatRoutePolicyUpdated { State = SampleState(version: 1) }),
+        };
+
+        await projector.ProjectAsync(NewContext(), envelope);
+
+        dispatcher.Upserts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_RejectsNullArguments()
+    {
+        var projector = new ChatRoutePolicyCurrentStateProjector(
+            new RecordingWriteDispatcher<ChatRoutePolicyCurrentStateDocument>(),
+            new FixedProjectionClock(DateTimeOffset.UtcNow));
+
+        await FluentActions
+            .Awaiting(() => projector.ProjectAsync(null!, new EventEnvelope()).AsTask())
+            .Should().ThrowAsync<ArgumentNullException>();
+        await FluentActions
+            .Awaiting(() => projector.ProjectAsync(NewContext(), null!).AsTask())
+            .Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_RejectsNullDependencies()
+    {
+        var dispatcher = new RecordingWriteDispatcher<ChatRoutePolicyCurrentStateDocument>();
+        var clock = new FixedProjectionClock(DateTimeOffset.UtcNow);
+
+        FluentActions
+            .Invoking(() => new ChatRoutePolicyCurrentStateProjector(null!, clock))
+            .Should().Throw<ArgumentNullException>();
+        FluentActions
+            .Invoking(() => new ChatRoutePolicyCurrentStateProjector(dispatcher, null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    private static ChatRoutePolicyMaterializationContext NewContext() => new()
+    {
+        RootActorId = RootActorId,
+        ProjectionKind = ChatRoutePolicyGAgent.ProjectionKind,
+    };
+
+    private static ChatRoutePolicyState SampleState(long version)
+    {
+        var state = new ChatRoutePolicyState
+        {
+            PolicyId = RootActorId,
+            OwnerScope = new ChatRouteCallerScope { RegistrationScopeId = "scope-1" },
+            DefaultTarget = ForwardToModelAction("chrono-llm/gpt-5.5"),
+            Version = version,
+            UpdatedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+        };
+        state.Rules.Add(new ChatRouteRule
+        {
+            RuleId = "alpha", Priority = 10, Action = ForwardToModelAction("model-a"),
+        });
+        state.Rules.Add(new ChatRouteRule
+        {
+            RuleId = "beta", Priority = 5, Action = ForwardToModelAction("model-b"),
+        });
+        return state;
+    }
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) =>
+        new() { ForwardToModel = new ForwardToModel { ModelName = modelName } };
+
+    private static EventEnvelope WrapCommitted(ChatRoutePolicyState state, long version, string eventId)
+    {
+        return new EventEnvelope
+        {
+            Id = eventId,
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = version,
+                    EventData = Any.Pack(new ChatRoutePolicyUpdated { State = state }),
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+    }
+
+    private sealed class RecordingWriteDispatcher<TReadModel> : IProjectionWriteDispatcher<TReadModel>
+        where TReadModel : class, IProjectionReadModel
+    {
+        public List<TReadModel> Upserts { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Upserts.Add(readModel);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+    }
+
+    private sealed class FixedProjectionClock(DateTimeOffset utcNow) : IProjectionClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+    }
+}

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyGAgentTests.cs
@@ -1,0 +1,237 @@
+using System.Reflection;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChatRouting.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ChatRoutePolicyGAgent"/>. The agent is exercised
+/// in-process (no Orleans): the actor id is reflection-set, an in-memory event
+/// store backs event sourcing, and command handlers are invoked directly.
+/// </summary>
+public sealed class ChatRoutePolicyGAgentTests : IAsyncLifetime
+{
+    private const string ActorId = "chat-route-policy:scope-1";
+
+    private ChatRoutePolicyGAgent _agent = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IEventStore, InMemoryEventStore>();
+        services.AddSingleton<EventSourcingRuntimeOptions>();
+        services.AddTransient(
+            typeof(IEventSourcingBehaviorFactory<>),
+            typeof(DefaultEventSourcingBehaviorFactory<>));
+        _serviceProvider = services.BuildServiceProvider();
+
+        _agent = new ChatRoutePolicyGAgent
+        {
+            Services = _serviceProvider,
+            EventSourcingBehaviorFactory =
+                _serviceProvider.GetRequiredService<IEventSourcingBehaviorFactory<ChatRoutePolicyState>>(),
+        };
+        // GAgentBase.Id has a private setter and SetId is internal to
+        // Aevatar.Foundation.Core; the test assembly is not a friend, so the
+        // per-scope actor id is reflection-set.
+        typeof(GAgentBase).GetProperty(nameof(GAgentBase.Id))!.SetValue(_agent, ActorId);
+
+        await _agent.ActivateAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _serviceProvider.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task HandleUpsertAsync_CreatesPolicy_WithDefaultTargetAndRules()
+    {
+        await _agent.HandleUpsertAsync(new UpsertChatRoutePolicyRequested
+        {
+            OwnerScope = new ChatRouteCallerScope { RegistrationScopeId = "scope-1" },
+            DefaultTarget = ForwardToModelAction("chrono-llm/gpt-5.5"),
+            Rules = { Rule("daily", priority: 10) },
+        });
+
+        _agent.State.PolicyId.Should().Be(ActorId);
+        _agent.State.Version.Should().Be(1);
+        _agent.State.DefaultTarget.ForwardToModel.ModelName.Should().Be("chrono-llm/gpt-5.5");
+        _agent.State.OwnerScope.RegistrationScopeId.Should().Be("scope-1");
+        _agent.State.Rules.Should().ContainSingle().Which.RuleId.Should().Be("daily");
+        _agent.State.UpdatedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task HandleRemoveRuleAsync_RemovesNamedRule()
+    {
+        await _agent.HandleUpsertAsync(new UpsertChatRoutePolicyRequested
+        {
+            DefaultTarget = ForwardToModelAction("chrono-llm/gpt-5.5"),
+            Rules = { Rule("keep", priority: 10), Rule("drop", priority: 5) },
+        });
+
+        await _agent.HandleRemoveRuleAsync(new RemoveChatRouteRuleRequested { RuleId = "drop" });
+
+        _agent.State.Version.Should().Be(2, "the second committed command bumps the monotonic version");
+        _agent.State.Rules.Select(rule => rule.RuleId).Should().Equal("keep");
+    }
+
+    [Fact]
+    public async Task HandleUpsertAsync_MissingDefaultTarget_RejectsCommand()
+    {
+        var act = () => _agent.HandleUpsertAsync(new UpsertChatRoutePolicyRequested
+        {
+            OwnerScope = new ChatRouteCallerScope { RegistrationScopeId = "scope-1" },
+            // default_target intentionally unset.
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*default_target is required*");
+        _agent.State.Version.Should().Be(0, "a rejected command persists no event");
+    }
+
+    [Fact]
+    public async Task HandleUpsertAsync_PersistsRulesInPriorityOrder()
+    {
+        await _agent.HandleUpsertAsync(new UpsertChatRoutePolicyRequested
+        {
+            DefaultTarget = ForwardToModelAction("chrono-llm/gpt-5.5"),
+            Rules =
+            {
+                Rule("low", priority: 1),
+                Rule("high", priority: 100),
+                Rule("mid-b", priority: 50),
+                Rule("mid-a", priority: 50),
+            },
+        });
+
+        _agent.State.Rules.Select(rule => rule.RuleId)
+            .Should().Equal(
+                ["high", "mid-a", "mid-b", "low"],
+                "rules persist highest-priority-first, ties broken by rule_id lexical order");
+    }
+
+    [Fact]
+    public async Task HandleRemoveRuleAsync_UnknownRule_RejectsCommand()
+    {
+        await _agent.HandleUpsertAsync(new UpsertChatRoutePolicyRequested
+        {
+            DefaultTarget = ForwardToModelAction("chrono-llm/gpt-5.5"),
+            Rules = { Rule("keep", priority: 10) },
+        });
+
+        var act = () => _agent.HandleRemoveRuleAsync(new RemoveChatRouteRuleRequested { RuleId = "ghost" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*rule 'ghost' not found*");
+        _agent.State.Version.Should().Be(1, "a rejected command persists no event");
+        _agent.State.Rules.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ChatRoutePolicyGAgent_HandlesOnlyConfigCommands()
+    {
+        // Guard: the policy actor is config-only — it must never grow a query
+        // handler or a turn-message handler (CLAUDE.md 读写分离; config actor
+        // 不接 turn dispatch). Every [EventHandler] takes a known command type.
+        var handlerParameterTypes = typeof(ChatRoutePolicyGAgent)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(method => method.GetCustomAttributes(typeof(EventHandlerAttribute), inherit: false).Length > 0)
+            .Select(method => method.GetParameters().Single().ParameterType)
+            .ToList();
+
+        handlerParameterTypes.Should().BeEquivalentTo(
+            [typeof(UpsertChatRoutePolicyRequested), typeof(RemoveChatRouteRuleRequested)]);
+    }
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) =>
+        new() { ForwardToModel = new ForwardToModel { ModelName = modelName } };
+
+    private static ChatRouteRule Rule(string ruleId, int priority) =>
+        new()
+        {
+            RuleId = ruleId,
+            Priority = priority,
+            Action = ForwardToModelAction("chrono-llm/gpt-5.5"),
+        };
+
+    /// <summary>Minimal in-process <see cref="IEventStore"/> for unit tests.</summary>
+    private sealed class InMemoryEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+            {
+                stream = [];
+                _events[agentId] = stream;
+            }
+
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            if (currentVersion != expectedVersion)
+            {
+                throw new InvalidOperationException(
+                    $"Optimistic concurrency conflict: expected {expectedVersion}, actual {currentVersion}");
+            }
+
+            var appended = events.Select(stateEvent => stateEvent.Clone()).ToList();
+            stream.AddRange(appended);
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = stream[^1].Version,
+                CommittedEvents = { appended.Select(stateEvent => stateEvent.Clone()) },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult<IReadOnlyList<StateEvent>>([]);
+
+            IReadOnlyList<StateEvent> result = fromVersion.HasValue
+                ? stream.Where(stateEvent => stateEvent.Version > fromVersion.Value)
+                    .Select(stateEvent => stateEvent.Clone()).ToList()
+                : stream.Select(stateEvent => stateEvent.Clone()).ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream) || stream.Count == 0)
+                return Task.FromResult(0L);
+            return Task.FromResult(stream[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (toVersion <= 0 || !_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var before = stream.Count;
+            stream.RemoveAll(stateEvent => stateEvent.Version <= toVersion);
+            return Task.FromResult((long)(before - stream.Count));
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,26 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChatRouting.Tests;
+
+/// <summary>
+/// Guards the ChatRoutePolicy projection store registration. A missing
+/// document store registration makes the readmodel silently never materialize,
+/// so this is asserted explicitly rather than left to integration coverage.
+/// </summary>
+public sealed class ChatRoutingServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddChatRoutingAgents_RegistersChatRoutePolicyDocumentStore()
+    {
+        using var provider = new ServiceCollection()
+            .AddChatRoutingAgents()
+            .BuildServiceProvider();
+
+        provider.GetService<IProjectionDocumentReader<ChatRoutePolicyCurrentStateDocument, string>>()
+            .Should().NotBeNull("the readmodel cannot be queried without its document reader");
+        provider.GetService<IProjectionDocumentWriter<ChatRoutePolicyCurrentStateDocument>>()
+            .Should().NotBeNull("the projector cannot upsert without its document writer");
+    }
+}

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutingServiceCollectionExtensionsTests.cs
@@ -1,3 +1,5 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -5,9 +7,12 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Aevatar.GAgents.ChatRouting.Tests;
 
 /// <summary>
-/// Guards the ChatRoutePolicy projection store registration. A missing
-/// document store registration makes the readmodel silently never materialize,
-/// so this is asserted explicitly rather than left to integration coverage.
+/// Guards the ChatRoutePolicy projection wiring. The earlier Phase 1 cut only
+/// registered the document store, which left the projector with nowhere to
+/// subscribe — committed <c>ChatRoutePolicyUpdated</c> events landed in event
+/// storage but never materialized into <see cref="ChatRoutePolicyCurrentStateDocument"/>.
+/// These assertions lock in the full materialization-runtime + materializer +
+/// document-store triple so the readmodel actually populates.
 /// </summary>
 public sealed class ChatRoutingServiceCollectionExtensionsTests
 {
@@ -22,5 +27,43 @@ public sealed class ChatRoutingServiceCollectionExtensionsTests
             .Should().NotBeNull("the readmodel cannot be queried without its document reader");
         provider.GetService<IProjectionDocumentWriter<ChatRoutePolicyCurrentStateDocument>>()
             .Should().NotBeNull("the projector cannot upsert without its document writer");
+    }
+
+    [Fact]
+    public void AddChatRoutingAgents_RegistersMaterializationRuntimeAndProjector()
+    {
+        using var provider = new ServiceCollection()
+            .AddChatRoutingAgents()
+            .BuildServiceProvider();
+
+        provider.GetService<Func<ProjectionRuntimeScopeKey, ChatRoutePolicyMaterializationContext>>()
+            .Should().NotBeNull("the materialization runtime needs a scope-key → context factory");
+        provider.GetService<ChatRoutePolicyCurrentStateProjector>()
+            .Should().NotBeNull("the current-state projector must be resolvable as a concrete singleton");
+        provider.GetService<ICurrentStateProjectionMaterializer<ChatRoutePolicyMaterializationContext>>()
+            .Should().NotBeNull(
+                "without the materializer subscription, committed ChatRoutePolicyUpdated events would " +
+                "land in event storage but never reach ChatRoutePolicyCurrentStateDocument");
+    }
+
+    [Fact]
+    public void AddChatRoutingAgents_ContextFactory_MirrorsScopeKey()
+    {
+        using var provider = new ServiceCollection()
+            .AddChatRoutingAgents()
+            .BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<
+            Func<ProjectionRuntimeScopeKey, ChatRoutePolicyMaterializationContext>>();
+
+        var key = new ProjectionRuntimeScopeKey(
+            "chat-route-policy:scope-1",
+            ChatRoutePolicyGAgent.ProjectionKind,
+            ProjectionRuntimeMode.DurableMaterialization);
+
+        var context = factory(key);
+
+        context.RootActorId.Should().Be("chat-route-policy:scope-1");
+        context.ProjectionKind.Should().Be(ChatRoutePolicyGAgent.ProjectionKind);
     }
 }


### PR DESCRIPTION
## 问题与方案

实现 issue #692（Ingress v1 · Phase 1），落在 #672 / ADR-0024 的「config actor + boundary resolver」设计之上。Phase 0（`feature/router` 已有）只引入了 `Aevatar.ChatRouting.Abstractions` 的 wire proto + ADR；本 PR 落地配置 actor、readmodel、projector。

新增 `agents/Aevatar.GAgents.ChatRouting` 包：

- **`ChatRoutePolicyGAgent`** — per-scope 长期 config aggregate（`GAgentBase<ChatRoutePolicyState>`, `IProjectedActor`）。处理 `UpsertChatRoutePolicyRequested` / `RemoveChatRouteRuleRequested`，产出 committed `ChatRoutePolicyUpdated`。Upsert 校验 `default_target` 必填（缺失抛出可操作错误），rule 按 priority 降序持久化（同 priority 按 `rule_id` 字典序）。config-only — 无 query handler、不接 turn dispatch。
- **`ChatRoutePolicyCurrentStateDocument`** — query 侧 readmodel，字段 1:1 强类型镜像 `ChatRoutePolicyState`（无 `Any` state_root bag）。`chat_route_policy_readmodel.proto` 通过 Grpc.Tools `AdditionalImportDirs` import `chat_route_policy.proto`，wire 类型单一来源仍在 `Aevatar.ChatRouting.Abstractions`。
- **`ChatRoutePolicyCurrentStateProjector`** — 消费 committed `ChatRoutePolicyState` → 覆盖写 readmodel；`state_version` / `last_event_id` 取自 committed `StateEvent`（不本地造版本号）。
- **`AddChatRoutingAgents`** — 注册 InMemory document projection store，接入 Mainnet host bootstrap。

## ⚠️ 与 issue 描述的偏差：Reset 命令

issue #692 列了 3 个命令含 `ResetChatRoutePolicyRequested`，但 issue 成文后 **PR #699 的 review 已把 Reset 从 `chat_route_policy.proto` 删除** —— 理由：`default_target` 在 actor 存在时必填，Reset「清空 default_target」会落下非法持久态。本 PR 以**当前 proto 为准**：2 个命令，无 Reset（与用户确认一致，按 #699 fix 的处理方式实现）。需要重置策略的调用方按 #699 的指引用 `UpsertChatRoutePolicyRequested`（空 rules + 目标 default_target）原子替换。

## 影响路径

- 新增 leaf 包 `agents/Aevatar.GAgents.ChatRouting`，仅被 Mainnet host 引用。
- `MainnetHostBuilderExtensions` 在 `AddScheduledAgents` 后新增 `AddChatRoutingAgents()`。
- `aevatar.slnx` 新增 2 个 project 条目（agent + test）。
- 不改动任何既有 actor / endpoint / projection 链路；ingress 入口接入留待后续 phase。

## 验证命令与结果

- `dotnet build aevatar.slnx` — **0 errors**（84 个 pre-existing CA 警告）。
- `dotnet test test/Aevatar.GAgents.ChatRouting.Tests` — **12/12 pass**：
  - GAgent：upsert / remove-rule happy path、`default_target` 缺失拒绝、rule priority 排序、未知 rule 拒绝、config-only handler 守卫。
  - Projector：committed-state 覆盖写、同 version 幂等、非 committed 信封 no-op、null 参数 / null 依赖守卫。
  - DI：`AddChatRoutingAgents` 注册 document store reader + writer。
- `tools/ci/projection_state_version_guard.sh` / `projection_route_mapping_guard.sh` / `projection_state_mirror_current_state_guard.sh` — pass。
- `tools/ci/architecture_guards.sh` — proto buf lint、projection 系列、`studio_projection_readmodel_registration` 等全部 pass。唯一中断在 `playground_asset_drift_guard`，因本机 `tools/Aevatar.Tools.Cli/Frontend` 未装 `node_modules`（`tsc` not found）——环境问题，且该 guard 按变更范围只对 CLI/Demo-Web 静态资源触发，与本 PR 文件集无关。
- 预存在失败核对：`solution_split_test_guards` 中 `WorkflowHostingExtensionsCoverageTests.AddAevatarPlatform_ShouldRegisterWorkflowScriptingAiAndMakerBundles` 失败、`solution_split_guards` 的 `NETSDK1004` restore 报错，均已在 stash 掉本 PR 改动后于干净 `feature/router` 复现 —— 与本 PR 无关。

## 文档

实现严格遵循已合入的 [ADR-0024](docs/adr/0024-chat-route-policy.md)（Phase 0），无新增架构决策，无需新增 / 修改 `docs/`。

Closes #692. Tracks milestone "Ingress layer v1"; part of #672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)