### PR TITLE
Issue #693: Ingress v1 Phase 2 — ChatRouteResolver lib + QueryPort + env fallback

### DIFF
--- a/aevatar.slnx
+++ b/aevatar.slnx
@@ -81,6 +81,7 @@
     <Project Path="src\Aevatar.Bootstrap.Extensions.AI\Aevatar.Bootstrap.Extensions.AI.csproj" />
     <Project Path="src\Aevatar.Bootstrap\Aevatar.Bootstrap.csproj" />
     <Project Path="src\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
+    <Project Path="src\Aevatar.ChatRouting.Core\Aevatar.ChatRouting.Core.csproj" />
     <Project Path="src\Aevatar.Configuration\Aevatar.Configuration.csproj" />
     <Project Path="src\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <Project Path="src\Aevatar.CQRS.Core\Aevatar.CQRS.Core.csproj" />
@@ -158,6 +159,7 @@
   <Folder Name="/test/">
     <Project Path="test/Aevatar.Interop.A2A.Tests/Aevatar.Interop.A2A.Tests.csproj" />
     <Project Path="test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj" />
+    <Project Path="test/Aevatar.ChatRouting.Core.Tests/Aevatar.ChatRouting.Core.Tests.csproj" />
     <Project Path="test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Core.Tests\Aevatar.AI.Core.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Tests\Aevatar.AI.Tests.csproj" />

--- a/src/Aevatar.ChatRouting.Core/Aevatar.ChatRouting.Core.csproj
+++ b/src/Aevatar.ChatRouting.Core/Aevatar.ChatRouting.Core.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>Aevatar.ChatRouting.Core</AssemblyName>
+        <RootNamespace>Aevatar.ChatRouting.Core</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Aevatar.ChatRouting.Abstractions\Aevatar.ChatRouting.Abstractions.csproj" />
+        <ProjectReference Include="..\Aevatar.CQRS.Projection.Stores.Abstractions\Aevatar.CQRS.Projection.Stores.Abstractions.csproj" />
+        <ProjectReference Include="..\..\agents\Aevatar.GAgents.ChatRouting\Aevatar.GAgents.ChatRouting.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Google.Protobuf" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+    </ItemGroup>
+
+</Project>

--- a/src/Aevatar.ChatRouting.Core/ChatRoutePolicyQueryPort.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRoutePolicyQueryPort.cs
@@ -1,0 +1,71 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.ChatRouting;
+
+namespace Aevatar.ChatRouting.Core;
+
+public sealed class ChatRoutePolicyQueryPort : IChatRoutePolicyQueryPort
+{
+    private readonly IProjectionDocumentReader<ChatRoutePolicyCurrentStateDocument, string> _documentReader;
+
+    public ChatRoutePolicyQueryPort(
+        IProjectionDocumentReader<ChatRoutePolicyCurrentStateDocument, string> documentReader)
+    {
+        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
+    }
+
+    // Implement (issue #693):
+    //   Behavior: read caller-scoped policy snapshots from the projection readmodel; missing rows return null.
+    //   Why this shape: query path stays readmodel-only and never touches event replay, actors, or projection priming.
+    public async Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+        OwnerScope callerScope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(callerScope);
+
+        var result = await _documentReader.QueryAsync(
+            new ProjectionDocumentQuery
+            {
+                Take = 1,
+                Filters = BuildCallerScopeFilters(callerScope),
+            },
+            ct);
+
+        var document = result.Items.FirstOrDefault();
+        if (document?.DefaultTarget is null ||
+            document.DefaultTarget.ActionCase == ChatRouteAction.ActionOneofCase.None)
+        {
+            return null;
+        }
+
+        return new ChatRoutePolicySnapshot(document.DefaultTarget, document.Rules);
+    }
+
+    private static IReadOnlyList<ProjectionDocumentFilter> BuildCallerScopeFilters(OwnerScope callerScope) =>
+    [
+        new ProjectionDocumentFilter
+        {
+            FieldPath = $"{nameof(ChatRoutePolicyCurrentStateDocument.OwnerScope)}.{nameof(ChatRouteCallerScope.NyxUserId)}",
+            Operator = ProjectionDocumentFilterOperator.Eq,
+            Value = ProjectionDocumentValue.FromString(callerScope.NyxUserId),
+        },
+        new ProjectionDocumentFilter
+        {
+            FieldPath = $"{nameof(ChatRoutePolicyCurrentStateDocument.OwnerScope)}.{nameof(ChatRouteCallerScope.Platform)}",
+            Operator = ProjectionDocumentFilterOperator.Eq,
+            Value = ProjectionDocumentValue.FromString(callerScope.Platform),
+        },
+        new ProjectionDocumentFilter
+        {
+            FieldPath = $"{nameof(ChatRoutePolicyCurrentStateDocument.OwnerScope)}.{nameof(ChatRouteCallerScope.RegistrationScopeId)}",
+            Operator = ProjectionDocumentFilterOperator.Eq,
+            Value = ProjectionDocumentValue.FromString(callerScope.RegistrationScopeId),
+        },
+        new ProjectionDocumentFilter
+        {
+            FieldPath = $"{nameof(ChatRoutePolicyCurrentStateDocument.OwnerScope)}.{nameof(ChatRouteCallerScope.SenderId)}",
+            Operator = ProjectionDocumentFilterOperator.Eq,
+            Value = ProjectionDocumentValue.FromString(callerScope.SenderId),
+        },
+    ];
+}

--- a/src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs
@@ -1,0 +1,105 @@
+using Aevatar.ChatRouting.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.ChatRouting.Core;
+
+/// <summary>
+/// Stateless boundary resolver for ingress chat routing decisions.
+/// </summary>
+public sealed class ChatRouteResolver
+{
+    private readonly IChatRouteFallbackProvider _fallbackProvider;
+
+    public ChatRouteResolver(IChatRouteFallbackProvider fallbackProvider)
+    {
+        _fallbackProvider = fallbackProvider ?? throw new ArgumentNullException(nameof(fallbackProvider));
+    }
+
+    // Implement (issue #693):
+    //   Behavior: resolve snapshot rules by priority, then default_target, then env/options fallback.
+    //   Why this shape: ingress entries need a deterministic library decision without actor hops or IO.
+    public ChatRouteDecision Resolve(ChatRoutePolicySnapshot? snapshot, ChatRouteInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (snapshot is null)
+        {
+            return _fallbackProvider.GetFallbackDecision();
+        }
+
+        foreach (var rule in snapshot.Rules
+                     .OrderByDescending(static rule => rule.Priority)
+                     .ThenBy(static rule => rule.RuleId, StringComparer.Ordinal))
+        {
+            if (!Matches(rule.Match, input))
+            {
+                continue;
+            }
+
+            return NewDecision(rule.Action, matchedRuleId: rule.RuleId, usedFallback: false);
+        }
+
+        return NewDecision(snapshot.DefaultTarget, matchedRuleId: string.Empty, usedFallback: false);
+    }
+
+    private static bool Matches(ChatRouteMatch? match, ChatRouteInput input)
+    {
+        if (match is null)
+        {
+            return true;
+        }
+
+        return MatchesEnum(match.SourceKind, ChatSourceKind.Unspecified, input.SourceKind)
+               && MatchesString(match.Channel, input.Channel)
+               && MatchesString(match.CommandName, input.CommandName)
+               && MatchesString(match.ContentHint, input.ContentHint)
+               && MatchesEnum(match.ToolMode, ToolMode.Unspecified, input.ToolMode);
+    }
+
+    private static bool MatchesString(string? expected, string actual) =>
+        string.IsNullOrEmpty(expected) || string.Equals(expected, actual, StringComparison.Ordinal);
+
+    private static bool MatchesEnum<TEnum>(TEnum expected, TEnum unspecified, TEnum actual)
+        where TEnum : struct, System.Enum =>
+        EqualityComparer<TEnum>.Default.Equals(expected, unspecified) ||
+        EqualityComparer<TEnum>.Default.Equals(expected, actual);
+
+    internal static ChatRouteDecision NewDecision(
+        ChatRouteAction action,
+        string matchedRuleId,
+        bool usedFallback) =>
+        new()
+        {
+            Action = action.Clone(),
+            MatchedRuleId = matchedRuleId,
+            UsedFallback = usedFallback,
+            ResolvedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+}
+
+/// <summary>
+/// Immutable resolver input copied from the committed policy readmodel.
+/// </summary>
+public sealed class ChatRoutePolicySnapshot
+{
+    public ChatRoutePolicySnapshot(ChatRouteAction defaultTarget, IEnumerable<ChatRouteRule>? rules)
+    {
+        ArgumentNullException.ThrowIfNull(defaultTarget);
+        if (defaultTarget.ActionCase == ChatRouteAction.ActionOneofCase.None)
+        {
+            throw new ArgumentException(
+                "Chat route policy snapshot requires a non-empty default target.",
+                nameof(defaultTarget));
+        }
+
+        DefaultTarget = defaultTarget.Clone();
+        Rules = (rules ?? [])
+            .Where(static rule => rule is not null)
+            .Select(static rule => rule.Clone())
+            .ToArray();
+    }
+
+    public ChatRouteAction DefaultTarget { get; }
+
+    public IReadOnlyList<ChatRouteRule> Rules { get; }
+}

--- a/src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRouteResolver.cs
@@ -36,11 +36,25 @@ public sealed class ChatRouteResolver
                 continue;
             }
 
+            // A projected rule whose action was omitted is not actionable —
+            // proto3 message fields can be null when not set, and the write
+            // side validates only default_target on upsert, so a stored rule
+            // can legitimately have no action. Skip it so resolution falls
+            // through to the next rule (and, if no rule has an action, to
+            // default_target) instead of NREing on action.Clone().
+            if (!HasAction(rule.Action))
+            {
+                continue;
+            }
+
             return NewDecision(rule.Action, matchedRuleId: rule.RuleId, usedFallback: false);
         }
 
         return NewDecision(snapshot.DefaultTarget, matchedRuleId: string.Empty, usedFallback: false);
     }
+
+    private static bool HasAction(ChatRouteAction? action) =>
+        action is not null && action.ActionCase != ChatRouteAction.ActionOneofCase.None;
 
     private static bool Matches(ChatRouteMatch? match, ChatRouteInput input)
     {

--- a/src/Aevatar.ChatRouting.Core/ChatRoutingOptions.cs
+++ b/src/Aevatar.ChatRouting.Core/ChatRoutingOptions.cs
@@ -1,0 +1,11 @@
+namespace Aevatar.ChatRouting.Core;
+
+public sealed class ChatRoutingOptions
+{
+    public ChatRoutingDefaultsOptions Defaults { get; init; } = new();
+}
+
+public sealed class ChatRoutingDefaultsOptions
+{
+    public string FallbackModel { get; init; } = string.Empty;
+}

--- a/src/Aevatar.ChatRouting.Core/EnvChatRouteFallbackProvider.cs
+++ b/src/Aevatar.ChatRouting.Core/EnvChatRouteFallbackProvider.cs
@@ -1,0 +1,36 @@
+using Aevatar.ChatRouting.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.ChatRouting.Core;
+
+public sealed class EnvChatRouteFallbackProvider : IChatRouteFallbackProvider
+{
+    public const string DefaultModelEnvironmentVariable = "AEVATAR_DEFAULT_LLM_MODEL";
+
+    private readonly IOptions<ChatRoutingOptions> _options;
+
+    public EnvChatRouteFallbackProvider(IOptions<ChatRoutingOptions> options)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    // Implement (issue #693):
+    //   Behavior: cold-start policy lookup falls back to env model, then configured default model.
+    //   Why this shape: fallback is configuration, not actor/readmodel state, and stays outside resolver matching.
+    public ChatRouteDecision GetFallbackDecision()
+    {
+        var modelName = Environment.GetEnvironmentVariable(DefaultModelEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(modelName))
+        {
+            modelName = _options.Value.Defaults.FallbackModel;
+        }
+
+        return ChatRouteResolver.NewDecision(
+            new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel { ModelName = modelName ?? string.Empty },
+            },
+            matchedRuleId: string.Empty,
+            usedFallback: true);
+    }
+}

--- a/src/Aevatar.ChatRouting.Core/IChatRouteFallbackProvider.cs
+++ b/src/Aevatar.ChatRouting.Core/IChatRouteFallbackProvider.cs
@@ -1,0 +1,8 @@
+using Aevatar.ChatRouting.Abstractions;
+
+namespace Aevatar.ChatRouting.Core;
+
+public interface IChatRouteFallbackProvider
+{
+    ChatRouteDecision GetFallbackDecision();
+}

--- a/src/Aevatar.ChatRouting.Core/IChatRoutePolicyQueryPort.cs
+++ b/src/Aevatar.ChatRouting.Core/IChatRoutePolicyQueryPort.cs
@@ -1,0 +1,8 @@
+namespace Aevatar.ChatRouting.Core;
+
+public interface IChatRoutePolicyQueryPort
+{
+    Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+        OwnerScope callerScope,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.ChatRouting.Core/OwnerScope.cs
+++ b/src/Aevatar.ChatRouting.Core/OwnerScope.cs
@@ -1,0 +1,37 @@
+namespace Aevatar.ChatRouting.Core;
+
+/// <summary>
+/// Caller ownership tuple used by chat routing read ports.
+/// </summary>
+public sealed class OwnerScope
+{
+    public const string NyxIdPlatform = "nyxid";
+
+    public string NyxUserId { get; init; } = string.Empty;
+
+    public string Platform { get; init; } = string.Empty;
+
+    public string RegistrationScopeId { get; init; } = string.Empty;
+
+    public string SenderId { get; init; } = string.Empty;
+
+    public static OwnerScope ForNyxIdNative(string nyxUserId) =>
+        new()
+        {
+            NyxUserId = nyxUserId ?? string.Empty,
+            Platform = NyxIdPlatform,
+        };
+
+    public static OwnerScope ForChannel(
+        string nyxUserId,
+        string platform,
+        string registrationScopeId,
+        string senderId) =>
+        new()
+        {
+            NyxUserId = nyxUserId ?? string.Empty,
+            Platform = (platform ?? string.Empty).Trim().ToLowerInvariant(),
+            RegistrationScopeId = registrationScopeId ?? string.Empty,
+            SenderId = senderId ?? string.Empty,
+        };
+}

--- a/src/Aevatar.ChatRouting.Core/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.ChatRouting.Core/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aevatar.ChatRouting.Core;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddChatRoutingCore(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddOptions<ChatRoutingOptions>();
+        services.TryAddSingleton<IChatRouteFallbackProvider, EnvChatRouteFallbackProvider>();
+        services.TryAddSingleton<ChatRouteResolver>();
+        services.TryAddSingleton<IChatRoutePolicyQueryPort, ChatRoutePolicyQueryPort>();
+
+        return services;
+    }
+}

--- a/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
+++ b/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Authoring.Lark\Aevatar.GAgents.Authoring.Lark.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Scheduled\Aevatar.GAgents.Scheduled.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.ChatRouting\Aevatar.GAgents.ChatRouting.csproj" />
+    <ProjectReference Include="..\Aevatar.ChatRouting.Core\Aevatar.ChatRouting.Core.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Device\Aevatar.GAgents.Device.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.AgentCatalog\Aevatar.AI.ToolProviders.AgentCatalog.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Channel\Aevatar.AI.ToolProviders.Channel.csproj" />

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Aevatar.AI.ToolProviders.Web;
 using Aevatar.Authentication.Hosting;
 using Aevatar.Authentication.Providers.NyxId;
 using Aevatar.Bootstrap.Hosting;
+using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.GAgents.Authoring.Lark;
@@ -96,6 +97,7 @@ public static class MainnetHostBuilderExtensions
         // ship in this phase; ingress entries start consulting the readmodel in
         // a later phase.
         builder.Services.AddChatRoutingAgents();
+        builder.Services.AddChatRoutingCore();
         builder.Services.TryAddSingleton<IResponsesCallerScopeResolver, NyxIdResponsesCallerScopeResolver>();
         builder.Services.TryAddSingleton<IResponsesModelsAggregator, NyxIdResponsesModelsAggregator>();
         builder.Services.TryAddSingleton<IResponsesRouteResolver, CachingResponsesRouteResolver>();

--- a/test/Aevatar.ChatRouting.Core.Tests/Aevatar.ChatRouting.Core.Tests.csproj
+++ b/test/Aevatar.ChatRouting.Core.Tests/Aevatar.ChatRouting.Core.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Aevatar.ChatRouting.Core.Tests</AssemblyName>
+    <RootNamespace>Aevatar.ChatRouting.Core.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.ChatRouting.Core\Aevatar.ChatRouting.Core.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Stores.Abstractions\Aevatar.CQRS.Projection.Stores.Abstractions.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.ChatRouting\Aevatar.GAgents.ChatRouting.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/test/Aevatar.ChatRouting.Core.Tests/ChatRoutePolicyQueryPortTests.cs
+++ b/test/Aevatar.ChatRouting.Core.Tests/ChatRoutePolicyQueryPortTests.cs
@@ -1,0 +1,139 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.ChatRouting;
+using FluentAssertions;
+
+namespace Aevatar.ChatRouting.Core.Tests;
+
+public sealed class ChatRoutePolicyQueryPortTests
+{
+    [Fact]
+    public async Task LookupForCallerAsync_MissingDocument_ReturnsNull()
+    {
+        var reader = new FakePolicyReader([]);
+        var port = new ChatRoutePolicyQueryPort(reader);
+
+        var snapshot = await port.LookupForCallerAsync(ChatRouteResolverTests.CallerScope());
+
+        snapshot.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task LookupForCallerAsync_FakeReadmodelThenResolver_EndToEndUsesPolicy()
+    {
+        var document = new ChatRoutePolicyCurrentStateDocument
+        {
+            Id = "chat-route-policy:bot-1",
+            ActorId = "chat-route-policy:bot-1",
+            OwnerScope = ToChatRouteCallerScope(ChatRouteResolverTests.CallerScope()),
+            DefaultTarget = ChatRouteResolverTests.ForwardToModelAction("default-model"),
+        };
+        document.Rules.Add(new ChatRouteRule
+        {
+            RuleId = "lark-daily",
+            Priority = 10,
+            Match = new ChatRouteMatch { Channel = "lark", CommandName = "/daily" },
+            Action = ChatRouteResolverTests.ForwardToModelAction("daily-model"),
+        });
+        var port = new ChatRoutePolicyQueryPort(new FakePolicyReader([document]));
+        var resolver = new ChatRouteResolver(new StaticFallbackProvider("fallback-model"));
+
+        var snapshot = await port.LookupForCallerAsync(ChatRouteResolverTests.CallerScope());
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput
+        {
+            Channel = "lark",
+            CommandName = "/daily",
+        });
+
+        snapshot.Should().NotBeNull();
+        decision.UsedFallback.Should().BeFalse();
+        decision.MatchedRuleId.Should().Be("lark-daily");
+        decision.Action.ForwardToModel.ModelName.Should().Be("daily-model");
+    }
+
+    [Fact]
+    public async Task LookupForCallerAsync_DifferentCaller_ReturnsNull()
+    {
+        var document = new ChatRoutePolicyCurrentStateDocument
+        {
+            OwnerScope = ToChatRouteCallerScope(OwnerScope.ForChannel("user-2", "lark", "bot-1", "sender-2")),
+            DefaultTarget = ChatRouteResolverTests.ForwardToModelAction("other-model"),
+        };
+        var port = new ChatRoutePolicyQueryPort(new FakePolicyReader([document]));
+
+        var snapshot = await port.LookupForCallerAsync(ChatRouteResolverTests.CallerScope());
+
+        snapshot.Should().BeNull();
+    }
+
+    private static ChatRouteCallerScope ToChatRouteCallerScope(OwnerScope scope) =>
+        new()
+        {
+            NyxUserId = scope.NyxUserId,
+            Platform = scope.Platform,
+            RegistrationScopeId = scope.RegistrationScopeId,
+            SenderId = scope.SenderId,
+        };
+
+    private sealed class StaticFallbackProvider : IChatRouteFallbackProvider
+    {
+        private readonly string _modelName;
+
+        public StaticFallbackProvider(string modelName)
+        {
+            _modelName = modelName;
+        }
+
+        public ChatRouteDecision GetFallbackDecision() =>
+            new()
+            {
+                Action = ChatRouteResolverTests.ForwardToModelAction(_modelName),
+                MatchedRuleId = string.Empty,
+                UsedFallback = true,
+            };
+    }
+
+    private sealed class FakePolicyReader : IProjectionDocumentReader<ChatRoutePolicyCurrentStateDocument, string>
+    {
+        private readonly IReadOnlyList<ChatRoutePolicyCurrentStateDocument> _documents;
+
+        public FakePolicyReader(IReadOnlyList<ChatRoutePolicyCurrentStateDocument> documents)
+        {
+            _documents = documents;
+        }
+
+        public Task<ChatRoutePolicyCurrentStateDocument?> GetAsync(string key, CancellationToken ct = default) =>
+            Task.FromResult<ChatRoutePolicyCurrentStateDocument?>(null);
+
+        public Task<ProjectionDocumentQueryResult<ChatRoutePolicyCurrentStateDocument>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var items = _documents
+                .Where(document => query.Filters.All(filter => Matches(document, filter)))
+                .Take(query.Take)
+                .ToArray();
+            return Task.FromResult(new ProjectionDocumentQueryResult<ChatRoutePolicyCurrentStateDocument>
+            {
+                Items = items,
+            });
+        }
+
+        private static bool Matches(ChatRoutePolicyCurrentStateDocument document, ProjectionDocumentFilter filter)
+        {
+            var expected = filter.Value.RawValue as string ?? string.Empty;
+            var actual = filter.FieldPath switch
+            {
+                "OwnerScope.NyxUserId" => document.OwnerScope?.NyxUserId ?? string.Empty,
+                "OwnerScope.Platform" => document.OwnerScope?.Platform ?? string.Empty,
+                "OwnerScope.RegistrationScopeId" => document.OwnerScope?.RegistrationScopeId ?? string.Empty,
+                "OwnerScope.SenderId" => document.OwnerScope?.SenderId ?? string.Empty,
+                _ => string.Empty,
+            };
+
+            return filter.Operator == ProjectionDocumentFilterOperator.Eq &&
+                   string.Equals(actual, expected, StringComparison.Ordinal);
+        }
+    }
+}

--- a/test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs
+++ b/test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs
@@ -125,6 +125,64 @@ public sealed class ChatRouteResolverTests
     }
 
     [Fact]
+    public void Resolve_MatchingRuleWithEmptyAction_FallsThroughToDefaultTarget()
+    {
+        var resolver = NewResolver();
+        var snapshot = new ChatRoutePolicySnapshot(
+            ForwardToModelAction("default-model"),
+            [
+                // A projected rule whose action was never set — proto3 leaves
+                // the message field null, and the write side only validates
+                // default_target on upsert, so this is reachable on the read
+                // side. Resolver must not NRE on action.Clone().
+                new ChatRouteRule
+                {
+                    RuleId = "broken",
+                    Priority = 10,
+                    Match = new ChatRouteMatch { Channel = "lark" },
+                    Action = null,
+                },
+            ]);
+
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput { Channel = "lark" });
+
+        decision.MatchedRuleId.Should().BeEmpty(
+            "an actionless matching rule must be skipped, not return a half-built decision");
+        decision.Action.ForwardToModel.ModelName.Should().Be("default-model");
+        decision.UsedFallback.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_HigherPriorityRuleEmpty_LowerPriorityRuleWithActionStillWins()
+    {
+        var resolver = NewResolver();
+        var snapshot = new ChatRoutePolicySnapshot(
+            ForwardToModelAction("default-model"),
+            [
+                new ChatRouteRule
+                {
+                    RuleId = "high-empty",
+                    Priority = 20,
+                    Match = new ChatRouteMatch { Channel = "lark" },
+                    Action = null,
+                },
+                new ChatRouteRule
+                {
+                    RuleId = "low-actioned",
+                    Priority = 5,
+                    Match = new ChatRouteMatch { Channel = "lark" },
+                    Action = ForwardToModelAction("low-model"),
+                },
+            ]);
+
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput { Channel = "lark" });
+
+        decision.MatchedRuleId.Should().Be("low-actioned",
+            "a higher-priority but actionless rule must not block a lower-priority actionable one");
+        decision.Action.ForwardToModel.ModelName.Should().Be("low-model");
+    }
+
+    [Fact]
     public void ResolverAssembly_HasNoOrleansRuntimeOrHttpClientInjectionSurface()
     {
         var disallowedReferences = typeof(ChatRouteResolver).Assembly.GetReferencedAssemblies()

--- a/test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs
+++ b/test/Aevatar.ChatRouting.Core.Tests/ChatRouteResolverTests.cs
@@ -1,0 +1,206 @@
+using Aevatar.ChatRouting.Abstractions;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Aevatar.ChatRouting.Core.Tests;
+
+public sealed class ChatRouteResolverTests
+{
+    [Fact]
+    public void Resolve_NullSnapshot_UsesFallbackDecision()
+    {
+        var fallback = Substitute.For<IChatRouteFallbackProvider>();
+        fallback.GetFallbackDecision().Returns(new ChatRouteDecision
+        {
+            Action = ForwardToModelAction("fallback-model"),
+            UsedFallback = true,
+        });
+        var resolver = new ChatRouteResolver(fallback);
+
+        var decision = resolver.Resolve(null, new ChatRouteInput());
+
+        decision.UsedFallback.Should().BeTrue();
+        decision.MatchedRuleId.Should().BeEmpty();
+        decision.Action.ForwardToModel.ModelName.Should().Be("fallback-model");
+    }
+
+    [Fact]
+    public void Resolve_RulesEmpty_ReturnsDefaultTarget()
+    {
+        var resolver = NewResolver();
+        var snapshot = new ChatRoutePolicySnapshot(ForwardToModelAction("default-model"), []);
+
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput());
+
+        decision.UsedFallback.Should().BeFalse();
+        decision.MatchedRuleId.Should().BeEmpty();
+        decision.Action.ForwardToModel.ModelName.Should().Be("default-model");
+    }
+
+    [Fact]
+    public void Resolve_SingleMatchingRule_ReturnsRuleActionAndMatchedRuleId()
+    {
+        var resolver = NewResolver();
+        var snapshot = new ChatRoutePolicySnapshot(
+            ForwardToModelAction("default-model"),
+            [
+                new ChatRouteRule
+                {
+                    RuleId = "daily",
+                    Priority = 10,
+                    Match = new ChatRouteMatch { CommandName = "/daily" },
+                    Action = ForwardToModelAction("daily-model"),
+                },
+            ]);
+
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput { CommandName = "/daily" });
+
+        decision.MatchedRuleId.Should().Be("daily");
+        decision.Action.ForwardToModel.ModelName.Should().Be("daily-model");
+    }
+
+    [Fact]
+    public void Resolve_MultipleMatchingRules_HighestPriorityWins()
+    {
+        var resolver = NewResolver();
+        var snapshot = new ChatRoutePolicySnapshot(
+            ForwardToModelAction("default-model"),
+            [
+                new ChatRouteRule
+                {
+                    RuleId = "low",
+                    Priority = 1,
+                    Match = new ChatRouteMatch { Channel = "lark" },
+                    Action = ForwardToModelAction("low-model"),
+                },
+                new ChatRouteRule
+                {
+                    RuleId = "high",
+                    Priority = 20,
+                    Match = new ChatRouteMatch { Channel = "lark" },
+                    Action = ForwardToModelAction("high-model"),
+                },
+            ]);
+
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput { Channel = "lark" });
+
+        decision.MatchedRuleId.Should().Be("high");
+        decision.Action.ForwardToModel.ModelName.Should().Be("high-model");
+    }
+
+    [Fact]
+    public void Resolve_VoiceSourceRule_ReturnsVoiceTargetModule()
+    {
+        var resolver = NewResolver();
+        var snapshot = new ChatRoutePolicySnapshot(
+            ForwardToModelAction("default-model"),
+            [
+                new ChatRouteRule
+                {
+                    RuleId = "voice-openai",
+                    Priority = 10,
+                    Match = new ChatRouteMatch { SourceKind = ChatSourceKind.Voice },
+                    Action = new ChatRouteAction
+                    {
+                        ForwardToGagent = new ForwardToGAgent
+                        {
+                            ActorId = "agent-voice",
+                            VoiceModuleName = "voice_presence_openai",
+                        },
+                    },
+                },
+            ]);
+
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput
+        {
+            SourceKind = ChatSourceKind.Voice,
+            Voice = new VoiceInput { VoiceModuleName = "voice_presence_openai" },
+        });
+
+        decision.MatchedRuleId.Should().Be("voice-openai");
+        decision.Action.ForwardToGagent.ActorId.Should().Be("agent-voice");
+        decision.Action.ForwardToGagent.VoiceModuleName.Should().Be("voice_presence_openai");
+    }
+
+    [Fact]
+    public void ResolverAssembly_HasNoOrleansRuntimeOrHttpClientInjectionSurface()
+    {
+        var disallowedReferences = typeof(ChatRouteResolver).Assembly.GetReferencedAssemblies()
+            .Select(static name => name.Name)
+            .Where(static name =>
+                name is not null &&
+                name.Contains("Orleans", StringComparison.OrdinalIgnoreCase));
+        disallowedReferences.Should().BeEmpty();
+
+        var disallowedConstructorTypes = typeof(ChatRouteResolver).GetConstructors()
+            .SelectMany(static ctor => ctor.GetParameters())
+            .Select(static parameter => parameter.ParameterType.FullName)
+            .Where(static name =>
+                name is not null &&
+                (name.Contains("HttpClient", StringComparison.Ordinal) ||
+                 name.Contains("IActorRuntime", StringComparison.Ordinal)));
+        disallowedConstructorTypes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnvFallback_EnvModelWinsOverOptions()
+    {
+        var previous = Environment.GetEnvironmentVariable(EnvChatRouteFallbackProvider.DefaultModelEnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(EnvChatRouteFallbackProvider.DefaultModelEnvironmentVariable, "env-model");
+            var provider = new EnvChatRouteFallbackProvider(Options.Create(new ChatRoutingOptions
+            {
+                Defaults = new ChatRoutingDefaultsOptions { FallbackModel = "option-model" },
+            }));
+
+            var decision = provider.GetFallbackDecision();
+
+            decision.UsedFallback.Should().BeTrue();
+            decision.MatchedRuleId.Should().BeEmpty();
+            decision.Action.ForwardToModel.ModelName.Should().Be("env-model");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvChatRouteFallbackProvider.DefaultModelEnvironmentVariable, previous);
+        }
+    }
+
+    [Fact]
+    public void AddChatRoutingCore_RegistersResolverFallbackAndQueryPort()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<
+            Aevatar.CQRS.Projection.Stores.Abstractions.IProjectionDocumentReader<
+                Aevatar.GAgents.ChatRouting.ChatRoutePolicyCurrentStateDocument,
+                string>>());
+
+        using var provider = services.AddChatRoutingCore().BuildServiceProvider();
+
+        provider.GetRequiredService<ChatRouteResolver>().Should().NotBeNull();
+        provider.GetRequiredService<IChatRouteFallbackProvider>().Should().BeOfType<EnvChatRouteFallbackProvider>();
+        provider.GetRequiredService<IChatRoutePolicyQueryPort>().Should().BeOfType<ChatRoutePolicyQueryPort>();
+    }
+
+    private static ChatRouteResolver NewResolver()
+    {
+        var fallback = Substitute.For<IChatRouteFallbackProvider>();
+        fallback.GetFallbackDecision().Returns(new ChatRouteDecision
+        {
+            Action = ForwardToModelAction("fallback-model"),
+            UsedFallback = true,
+        });
+        return new ChatRouteResolver(fallback);
+    }
+
+    internal static ChatRouteAction ForwardToModelAction(string modelName) =>
+        new() { ForwardToModel = new ForwardToModel { ModelName = modelName } };
+
+    internal static OwnerScope CallerScope() => OwnerScope.ForChannel(
+        "user-1",
+        "lark",
+        "bot-1",
+        "sender-1");
+}


### PR DESCRIPTION
## Issue
Closes #693 — Ingress v1 · Phase 2 — ChatRouteResolver lib + QueryPort + env fallback

## Implementation summary
See `.implement-loop/runs/implement-issue-693.md`.

Adds the stateless `Aevatar.ChatRouting.Core` library:
- `ChatRouteResolver` — pure function `Resolve(snapshot, input)`; priority-ordered rules, first match wins, records `matched_rule_id`; `snapshot==null` → fallback provider.
- `IChatRoutePolicyQueryPort` / `ChatRoutePolicyQueryPort` — reads `IProjectionDocumentReader<ChatRoutePolicyCurrentStateDocument>`, returns `null` when no readmodel exists (no query-time replay/priming).
- `IChatRouteFallbackProvider` / `EnvChatRouteFallbackProvider` — env `AEVATAR_DEFAULT_LLM_MODEL` → `ChatRoutingOptions.Defaults.FallbackModel`.
- `AddChatRoutingCore()` DI extension, wired into the Mainnet host composition root.
- 11 unit tests (resolver behavior, fallback, voice target, DI, no-Orleans/HttpClient surface, QueryPort→resolver flow).

## Stacked-PR position
- Base: `feat/2026-05-19_ingress-phase1-chat-route-policy` (Phase 1's branch — stacked PR)
- Head: `feat/2026-05-19_ingress-phase2-chat-route-resolver`
- Auto-loop iteration: codex-implement-loop / milestone 20 (Ingress v1)

## Notes
- Local gate: `dotnet build aevatar.slnx` passed, `test_stability_guards.sh` passed, `architecture_guards.sh` all guards passed **except** the pre-existing playground asset drift guard (`cli-app.js` vs `demo-app.js`) — unrelated to this PR, which touches zero frontend assets.
- `OwnerScope` is a Core-local caller tuple (not `Aevatar.GAgents.Scheduled.OwnerScope`) to keep `ChatRouting.Core` free of Orleans/Scheduled transitive deps.

🤖 Generated by codex-implement-loop. Reviewer is a Claude subagent (see PR comments for round-N review reports).