### PR TITLE
Issue #694: Ingress v1 Phase 3 — wire ChatRouteResolver into 4 text entries

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -297,6 +297,10 @@ message TransportExtras {
   // chat can address it via `receive_id_type=chat_id`). For p2p DMs the chat_id is bot-specific
   // and not cross-app safe; downstream senders prefer `nyx_lark_union_id` for p2p targets.
   string nyx_lark_chat_id = 8;
+  // The Aevatar registration scope resolved at the relay ingress boundary. This typed field
+  // lets ConversationGAgent build the chat-routing caller scope before any turn runner metadata
+  // exists, without falling back to a generic metadata bag.
+  string nyx_registration_scope_id = 9;
 }
 
 // Represents one normalized activity flowing through the channel pipeline.

--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -301,6 +301,12 @@ message TransportExtras {
   // lets ConversationGAgent build the chat-routing caller scope before any turn runner metadata
   // exists, without falling back to a generic metadata bag.
   string nyx_registration_scope_id = 9;
+  // The sender's NyxID user id, resolved at the relay ingress boundary by calling NyxID `/me`
+  // with the relay-supplied user access token. Lets `ConversationGAgent` build a per-user
+  // owner scope for chat-route policy lookup (matching scope_id-only and per-user scopes
+  // alike) without re-resolving inside the actor turn. Empty when the relay payload did not
+  // surface a user access token or when `/me` resolution failed at ingress.
+  string nyx_sender_user_id = 10;
 }
 
 // Represents one normalized activity flowing through the channel pipeline.

--- a/agents/Aevatar.GAgents.Channel.Runtime/Aevatar.GAgents.Channel.Runtime.csproj
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Aevatar.GAgents.Channel.Runtime.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aevatar.GAgents.Channel.Abstractions\Aevatar.GAgents.Channel.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.ChatRouting.Core\Aevatar.ChatRouting.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core\Aevatar.CQRS.Projection.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
@@ -39,6 +40,6 @@
     <Protobuf Include="protos\*.proto"
               GrpcServices="None"
               ProtoRoot="protos"
-              AdditionalImportDirs="..\Aevatar.GAgents.Channel.Abstractions\protos" />
+              AdditionalImportDirs="..\Aevatar.GAgents.Channel.Abstractions\protos;..\..\src\Aevatar.ChatRouting.Abstractions" />
   </ItemGroup>
 </Project>

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -254,7 +254,13 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         if (platform is null || registrationScopeId is null || senderId is null)
             return null;
 
-        return OwnerScope.ForChannel(registrationScopeId, platform, registrationScopeId, senderId);
+        // The sender's NyxID is resolved by the relay ingress (NyxID `/me` with the
+        // user access token) and stashed in TransportExtras. Using it here matches
+        // per-user channel policies; an empty value falls through to scope-only
+        // policies (same key shape as policy upserts without a per-user binding).
+        var senderNyxUserId = NormalizeOptional(activity.TransportExtras?.NyxSenderUserId)
+                              ?? string.Empty;
+        return OwnerScope.ForChannel(senderNyxUserId, platform, registrationScopeId, senderId);
     }
 
     private static string ExtractCommandName(string? text)

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -1,3 +1,5 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
@@ -118,6 +120,30 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             return;
         }
 
+        // Implement (issue #694):
+        //   Behavior: relay turns consult ChatRouteResolver during admission before runner dispatch.
+        //   Why this shape: routing remains a boundary decision and does not add an actor hop before the existing run handoff.
+        var targetRef = await ResolveInboundTargetRefAsync(activity, CancellationToken.None);
+        if (targetRef.Reject is not null)
+        {
+            var rejected = new ConversationContinueFailedEvent
+            {
+                CommandId = string.Empty,
+                CorrelationId = activity.Id,
+                CausationId = string.Empty,
+                Kind = FailureKind.PermanentAdapterError,
+                ErrorCode = "chat_route_rejected",
+                ErrorSummary = string.IsNullOrWhiteSpace(targetRef.Reject.Reason)
+                    ? "The chat route policy rejected this request."
+                    : targetRef.Reject.Reason,
+                NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
+                FailedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            };
+            await PersistDomainEventAsync(rejected);
+            RemoveNyxRelayReplyToken(runtimeContext.NyxRelayReplyToken?.CorrelationId, activity);
+            return;
+        }
+
         var runner = ResolveRunner();
         var result = await runner.RunInboundAsync(activity, runtimeContext, CancellationToken.None);
 
@@ -130,6 +156,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             // those credentials into the event store / projection / read model.
             var runCopy = result.LlmReplyRequest.Clone();
             runCopy.TargetActorId = Id;
+            runCopy.TargetRef = targetRef.Clone();
             var persistedCopy = runCopy.Clone();
             persistedCopy.ReplyToken = string.Empty;
             persistedCopy.ReplyTokenExpiresAtUnixMs = 0;
@@ -186,6 +213,54 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         Logger.LogWarning(
             "Inbound turn failed: activity={ActivityId} code={Code} kind={Kind}",
             activity.Id, result.ErrorCode, result.FailureKind);
+    }
+
+    private async Task<ChatRouteAction> ResolveInboundTargetRefAsync(
+        ChatActivity activity,
+        CancellationToken ct)
+    {
+        var queryPort = Services.GetService<IChatRoutePolicyQueryPort>();
+        var resolver = Services.GetService<ChatRouteResolver>();
+        var callerScope = TryBuildRelayCallerScope(activity);
+        if (queryPort is null || resolver is null || callerScope is null)
+            return new ChatRouteAction();
+
+        var snapshot = await queryPort.LookupForCallerAsync(callerScope, ct);
+        var input = new ChatRouteInput
+        {
+            SourceKind = ChatSourceKind.NyxRelay,
+            CallerScope = new ChatRouteCallerScope
+            {
+                NyxUserId = callerScope.NyxUserId,
+                Platform = callerScope.Platform,
+                RegistrationScopeId = callerScope.RegistrationScopeId,
+                SenderId = callerScope.SenderId,
+            },
+            Channel = callerScope.Platform,
+            CommandName = ExtractCommandName(activity.Content?.Text),
+            ContentHint = string.Empty,
+            ToolMode = ToolMode.None,
+        };
+        return resolver.Resolve(snapshot, input).Action.Clone();
+    }
+
+    private static OwnerScope? TryBuildRelayCallerScope(ChatActivity activity)
+    {
+        var platform = NormalizeOptional(activity.TransportExtras?.NyxPlatform) ??
+                       NormalizeOptional(activity.ChannelId?.Value);
+        var registrationScopeId = NormalizeOptional(activity.TransportExtras?.NyxRegistrationScopeId) ??
+                                  NormalizeOptional(activity.Bot?.Value);
+        var senderId = NormalizeOptional(activity.From?.CanonicalId);
+        if (platform is null || registrationScopeId is null || senderId is null)
+            return null;
+
+        return OwnerScope.ForChannel(registrationScopeId, platform, registrationScopeId, senderId);
+    }
+
+    private static string ExtractCommandName(string? text)
+    {
+        var first = ChannelTextCommandParser.Tokenize(text).FirstOrDefault();
+        return first is { Length: > 1 } && first[0] == '/' ? first : string.Empty;
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -7,6 +7,7 @@ option csharp_namespace = "Aevatar.GAgents.Channel.Runtime";
 import "google/protobuf/empty.proto";
 import "chat_activity.proto";
 import "channel_contracts.proto";
+import "chat_route_policy.proto";
 
 message OutboundDeliveryReceipt {
   string reply_message_id = 1;
@@ -38,6 +39,10 @@ message NeedsLlmReplyEvent {
   // store, projection, or read model.
   string reply_token = 7;
   int64 reply_token_expires_at_unix_ms = 8;
+  // Transient routing target chosen at ingress. ConversationGAgent may persist a sanitized
+  // copy of the request for retry, but this field is a typed target reference, not the
+  // resolver decision object; reply_token and raw decision telemetry stay out of state.
+  aevatar.chat_routing.v1.ChatRouteAction target_ref = 9;
 }
 
 // Transient actor-inbox envelope used by the NyxID relay endpoint to hand a single

--- a/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
+++ b/agents/Aevatar.GAgents.NyxidChat/Aevatar.GAgents.NyxidChat.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Aevatar.GAgents.Scheduled\Aevatar.GAgents.Scheduled.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.Core\Aevatar.AI.Core.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.ChatRouting.Core\Aevatar.ChatRouting.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Skills\Aevatar.AI.ToolProviders.Skills.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.Lark\Aevatar.AI.ToolProviders.Lark.csproj" />
@@ -52,7 +53,7 @@
     <Protobuf Include="protos\*.proto"
               GrpcServices="None"
               ProtoRoot="protos"
-              AdditionalImportDirs="..\Aevatar.GAgents.Channel.Runtime\protos;..\Aevatar.GAgents.Channel.Abstractions\protos" />
+              AdditionalImportDirs="..\Aevatar.GAgents.Channel.Runtime\protos;..\Aevatar.GAgents.Channel.Abstractions\protos;..\..\src\Aevatar.ChatRouting.Abstractions" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Relay.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Relay.cs
@@ -32,6 +32,7 @@ public static partial class NyxIdChatEndpoints
         [FromServices] NyxIdRelayTransport relayTransport,
         [FromServices] NyxIdRelayAuthValidator relayAuthValidator,
         [FromServices] Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions relayOptions,
+        [FromServices] Aevatar.GAgents.Scheduled.INyxIdCurrentUserResolver nyxIdCurrentUserResolver,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -116,6 +117,16 @@ public static partial class NyxIdChatEndpoints
             activity.TransportExtras ??= new TransportExtras();
             activity.TransportExtras.NyxUserAccessToken = validation.UserAccessToken ?? string.Empty;
             activity.TransportExtras.NyxRegistrationScopeId = scopeId.Trim();
+            // Resolve sender NyxID at ingress so the actor can build a per-user
+            // caller scope for chat-route policy lookup without making an HTTP
+            // call inside the turn. Fail-soft: log + leave empty so policy
+            // resolution falls through to scope-only / default policies.
+            activity.TransportExtras.NyxSenderUserId =
+                await TryResolveSenderNyxUserIdAsync(
+                    nyxIdCurrentUserResolver,
+                    validation.UserAccessToken,
+                    logger,
+                    ct);
             var relayInbound = new NyxRelayInboundActivity
             {
                 Activity = activity,
@@ -232,6 +243,34 @@ public static partial class NyxIdChatEndpoints
                 payload.MessageId,
                 nyxAgentApiKeyId);
             return null;
+        }
+    }
+
+    private static async Task<string> TryResolveSenderNyxUserIdAsync(
+        Aevatar.GAgents.Scheduled.INyxIdCurrentUserResolver resolver,
+        string? userAccessToken,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var token = NormalizeOptional(userAccessToken);
+        if (token is null)
+            return string.Empty;
+
+        try
+        {
+            var resolved = NormalizeOptional(await resolver.ResolveCurrentUserIdAsync(token, ct));
+            return resolved ?? string.Empty;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to resolve sender NyxID at relay ingress; chat-routing per-user policies will not match for this turn.");
+            return string.Empty;
         }
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Relay.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Relay.cs
@@ -115,6 +115,7 @@ public static partial class NyxIdChatEndpoints
             activity.OutboundDelivery ??= new OutboundDeliveryContext();
             activity.TransportExtras ??= new TransportExtras();
             activity.TransportExtras.NyxUserAccessToken = validation.UserAccessToken ?? string.Empty;
+            activity.TransportExtras.NyxRegistrationScopeId = scopeId.Trim();
             var relayInbound = new NyxRelayInboundActivity
             {
                 Activity = activity,

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -115,10 +115,16 @@ public static partial class NyxIdChatEndpoints
         // Conversation creation is fail-fast on registry persistence.
         // NyxId chat depends on the registry being available; there is no
         // degraded mode where a conversation can run without being registered.
-        var actorId = !string.IsNullOrWhiteSpace(decision.Action.ForwardToGagent?.ActorId)
-            ? decision.Action.ForwardToGagent.ActorId.Trim()
+        var forwardedActorId = decision.Action.ForwardToGagent?.ActorId;
+        var actorId = !string.IsNullOrWhiteSpace(forwardedActorId)
+            ? forwardedActorId.Trim()
             : NyxIdChatServiceDefaults.GenerateActorId();
-        if (decision.Action.ForwardToGagent is null)
+        // We only own the actor's lifecycle when we created it in this request.
+        // A forwarded ChatRoute decision reuses an actor that an earlier request
+        // (possibly under a different scope) created; destroying it on a
+        // registry rollback would delete unrelated traffic's target actor.
+        var createdLocally = decision.Action.ForwardToGagent is null;
+        if (createdLocally)
             await actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
         try
         {
@@ -132,7 +138,8 @@ public static partial class NyxIdChatEndpoints
                     scopeId,
                     actorId,
                     registryCommandPort,
-                    actorRuntime);
+                    actorRuntime,
+                    destroyActor: createdLocally);
                 return Results.Json(
                     new { error = "Conversation registration is not admission-visible" },
                     statusCode: StatusCodes.Status503ServiceUnavailable);
@@ -145,7 +152,8 @@ public static partial class NyxIdChatEndpoints
                 scopeId,
                 actorId,
                 registryCommandPort,
-                actorRuntime);
+                actorRuntime,
+                destroyActor: createdLocally);
             throw;
         }
 
@@ -176,7 +184,8 @@ public static partial class NyxIdChatEndpoints
         string scopeId,
         string actorId,
         IGAgentActorRegistryCommandPort registryCommandPort,
-        IActorRuntime actorRuntime)
+        IActorRuntime actorRuntime,
+        bool destroyActor)
     {
         var logger = http.RequestServices?.GetService<ILoggerFactory>()
             ?.CreateLogger("Aevatar.NyxId.Chat.CreateConversation");
@@ -196,6 +205,12 @@ public static partial class NyxIdChatEndpoints
                 actorId);
             return;
         }
+
+        // Only destroy the actor when this request actually created it.
+        // ChatRoute ForwardToGAgent reuses an existing target and must not be
+        // torn down by a rollback in this request.
+        if (!destroyActor)
+            return;
 
         try
         {

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.cs
@@ -1,6 +1,8 @@
 using System.IdentityModel.Tokens.Jwt;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Studio.Application.Studio.Abstractions;
@@ -85,16 +87,39 @@ public static partial class NyxIdChatEndpoints
         string scopeId,
         [FromServices] IGAgentActorRegistryCommandPort registryCommandPort,
         [FromServices] IActorRuntime actorRuntime,
+        [FromServices] IChatRoutePolicyQueryPort queryPort,
+        [FromServices] ChatRouteResolver resolver,
         CancellationToken ct)
     {
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
+        // Implement (issue #694):
+        //   Behavior: direct NyxIdChat creation consults chat routing before choosing the conversation actor.
+        //   Why this shape: the existing create/register path stays intact while the transient decision is consumed at ingress.
+        var callerScope = OwnerScope.ForNyxIdNative(scopeId);
+        var snapshot = await queryPort.LookupForCallerAsync(callerScope, ct);
+        var decision = resolver.Resolve(snapshot, new ChatRouteInput
+        {
+            SourceKind = ChatSourceKind.Direct,
+            CallerScope = ToChatRouteCallerScope(callerScope),
+            Channel = string.Empty,
+            CommandName = string.Empty,
+            ContentHint = string.Empty,
+            ToolMode = ToolMode.None,
+        });
+
+        if (decision.Action.Reject is not null)
+            return ChatRouteRejected(decision.Action.Reject);
+
         // Conversation creation is fail-fast on registry persistence.
         // NyxId chat depends on the registry being available; there is no
         // degraded mode where a conversation can run without being registered.
-        var actorId = NyxIdChatServiceDefaults.GenerateActorId();
-        await actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
+        var actorId = !string.IsNullOrWhiteSpace(decision.Action.ForwardToGagent?.ActorId)
+            ? decision.Action.ForwardToGagent.ActorId.Trim()
+            : NyxIdChatServiceDefaults.GenerateActorId();
+        if (decision.Action.ForwardToGagent is null)
+            await actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
         try
         {
             var receipt = await registryCommandPort.RegisterActorAsync(
@@ -126,6 +151,25 @@ public static partial class NyxIdChatEndpoints
 
         return Results.Ok(new { actorId });
     }
+
+    private static ChatRouteCallerScope ToChatRouteCallerScope(OwnerScope scope) => new()
+    {
+        NyxUserId = scope.NyxUserId,
+        Platform = scope.Platform,
+        RegistrationScopeId = scope.RegistrationScopeId,
+        SenderId = scope.SenderId,
+    };
+
+    private static IResult ChatRouteRejected(Reject reject) =>
+        Results.Json(
+            new
+            {
+                error = "chat_route_rejected",
+                detail = string.IsNullOrWhiteSpace(reject.Reason)
+                    ? "The chat route policy rejected this request."
+                    : reject.Reason,
+            },
+            statusCode: StatusCodes.Status403Forbidden);
 
     private static async Task TryRollbackConversationCreationAsync(
         HttpContext http,

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -2,3 +2,4 @@ version: v1
 directories:
   - agents/Aevatar.GAgents.Channel.Abstractions/protos
   - agents/Aevatar.GAgents.Channel.Runtime/protos
+  - src/Aevatar.ChatRouting.Abstractions

--- a/src/Aevatar.ChatRouting.Abstractions/buf.yaml
+++ b/src/Aevatar.ChatRouting.Abstractions/buf.yaml
@@ -1,0 +1,7 @@
+version: v1
+lint:
+  use:
+    - STANDARD
+  except:
+    - PACKAGE_DIRECTORY_MATCH
+    - PACKAGE_VERSION_SUFFIX

--- a/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -43,6 +44,8 @@ internal static class MessagesApiEndpoints
         MessagesCreateRequest request,
         [FromServices] ILLMProviderFactory providerFactory,
         [FromServices] IResponsesCallerScopeResolver callerScopeResolver,
+        [FromServices] IChatRoutePolicyQueryPort chatRoutePolicyQueryPort,
+        [FromServices] ChatRouteResolver chatRouteResolver,
         [FromServices] IResponsesRouteResolver routeResolver,
         [FromServices] ILlmSessionRegistrationPort sessionRegistrationPort,
         [FromServices] IResponsesCompletionApplicationService completionService,
@@ -52,6 +55,8 @@ internal static class MessagesApiEndpoints
         ArgumentNullException.ThrowIfNull(http);
         ArgumentNullException.ThrowIfNull(providerFactory);
         ArgumentNullException.ThrowIfNull(callerScopeResolver);
+        ArgumentNullException.ThrowIfNull(chatRoutePolicyQueryPort);
+        ArgumentNullException.ThrowIfNull(chatRouteResolver);
         ArgumentNullException.ThrowIfNull(routeResolver);
         ArgumentNullException.ThrowIfNull(sessionRegistrationPort);
         ArgumentNullException.ThrowIfNull(completionService);
@@ -81,6 +86,36 @@ internal static class MessagesApiEndpoints
         catch (ResponsesCallerScopeUnavailableException ex)
         {
             return ToErrorResult(StatusCodes.Status401Unauthorized, "authentication_error", ex.Message);
+        }
+
+        // Implement (issue #694):
+        //   Behavior: Anthropic Messages facade applies the same chat-route model override as Responses.
+        //   Why this shape: Messages shares the LlmSession/LLMRequest path, so routing stays protocol-neutral.
+        var routedModel = normalized.Model;
+        var routeDecision = await ResponsesApiEndpoints.ResolveResponsesChatRouteAsync(
+            chatRoutePolicyQueryPort,
+            chatRouteResolver,
+            callerScope,
+            normalized.Model,
+            ct);
+        if (routeDecision.Action.Reject is not null)
+            return ToErrorResult(
+                StatusCodes.Status403Forbidden,
+                "chat_route_rejected",
+                string.IsNullOrWhiteSpace(routeDecision.Action.Reject.Reason)
+                    ? "The chat route policy rejected this request."
+                    : routeDecision.Action.Reject.Reason);
+        if (!string.IsNullOrWhiteSpace(routeDecision.Action.ForwardToModel?.ModelName))
+        {
+            routedModel = routeDecision.Action.ForwardToModel.ModelName.Trim();
+        }
+        else if (routeDecision.Action.ForwardToGagent is not null)
+        {
+            logger.LogInformation(
+                "Chat route resolved ForwardToGAgent for /v1/messages but v1 falls back to model dispatch: actor={ActorId} usedFallback={UsedFallback} matchedRule={MatchedRuleId}",
+                routeDecision.Action.ForwardToGagent.ActorId,
+                routeDecision.UsedFallback,
+                routeDecision.MatchedRuleId);
         }
 
         // Path B is stateless: register a new LlmSession per request, no
@@ -126,8 +161,8 @@ internal static class MessagesApiEndpoints
         // OpenRouter-style vendor prefix routing (same as Path A). If the
         // model is `vendor/name`, resolve the route value through the catalog;
         // unknown slugs fall through to gateway default.
-        var modelRoute = ResponsesModelRouteParser.Parse(normalized.Model);
-        var effectiveModel = normalized.Model;
+        var modelRoute = ResponsesModelRouteParser.Parse(routedModel);
+        var effectiveModel = routedModel;
         string? resolvedRouteValue = null;
         if (modelRoute.RouteSlug is not null)
         {

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -2,6 +2,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -46,6 +48,8 @@ internal static class ResponsesApiEndpoints
         ResponsesCreateRequest request,
         [FromServices] ILLMProviderFactory providerFactory,
         [FromServices] IResponsesCallerScopeResolver callerScopeResolver,
+        [FromServices] IChatRoutePolicyQueryPort chatRoutePolicyQueryPort,
+        [FromServices] ChatRouteResolver chatRouteResolver,
         [FromServices] IResponsesRouteResolver routeResolver,
         [FromServices] ILlmSessionRegistrationPort responseSessionRegistrationPort,
         [FromServices] ILlmSessionQueryPort responseSessionQueryPort,
@@ -57,6 +61,8 @@ internal static class ResponsesApiEndpoints
         ArgumentNullException.ThrowIfNull(http);
         ArgumentNullException.ThrowIfNull(providerFactory);
         ArgumentNullException.ThrowIfNull(callerScopeResolver);
+        ArgumentNullException.ThrowIfNull(chatRoutePolicyQueryPort);
+        ArgumentNullException.ThrowIfNull(chatRouteResolver);
         ArgumentNullException.ThrowIfNull(routeResolver);
         ArgumentNullException.ThrowIfNull(responseSessionRegistrationPort);
         ArgumentNullException.ThrowIfNull(responseSessionQueryPort);
@@ -91,6 +97,36 @@ internal static class ResponsesApiEndpoints
         catch (ResponsesCallerScopeUnavailableException ex)
         {
             return ToErrorResult(StatusCodes.Status401Unauthorized, "authentication_required", ex.Message);
+        }
+
+        // Implement (issue #694):
+        //   Behavior: /v1/responses applies chat-route model overrides before LLM dispatch.
+        //   Why this shape: the endpoint keeps its existing session/tool flow and consumes only the transient target action.
+        var routedModel = normalized.Model;
+        var routeDecision = await ResolveResponsesChatRouteAsync(
+            chatRoutePolicyQueryPort,
+            chatRouteResolver,
+            callerScope,
+            normalized.Model,
+            ct);
+        if (routeDecision.Action.Reject is not null)
+            return ToErrorResult(
+                StatusCodes.Status403Forbidden,
+                "chat_route_rejected",
+                string.IsNullOrWhiteSpace(routeDecision.Action.Reject.Reason)
+                    ? "The chat route policy rejected this request."
+                    : routeDecision.Action.Reject.Reason);
+        if (!string.IsNullOrWhiteSpace(routeDecision.Action.ForwardToModel?.ModelName))
+        {
+            routedModel = routeDecision.Action.ForwardToModel.ModelName.Trim();
+        }
+        else if (routeDecision.Action.ForwardToGagent is not null)
+        {
+            logger.LogInformation(
+                "Chat route resolved ForwardToGAgent for /v1/responses but v1 falls back to model dispatch: actor={ActorId} usedFallback={UsedFallback} matchedRule={MatchedRuleId}",
+                routeDecision.Action.ForwardToGagent.ActorId,
+                routeDecision.UsedFallback,
+                routeDecision.MatchedRuleId);
         }
 
         LlmSessionSnapshot? previousSnapshot = null;
@@ -165,8 +201,8 @@ internal static class ResponsesApiEndpoints
         // just happens to contain `/`) falls through to default gateway routing
         // with the model string preserved verbatim — NyxID's gateway picks the
         // backend by model name.
-        var modelRoute = ResponsesModelRouteParser.Parse(normalized.Model);
-        var effectiveModel = normalized.Model;
+        var modelRoute = ResponsesModelRouteParser.Parse(routedModel);
+        var effectiveModel = routedModel;
         string? resolvedRouteValue = null;
         if (modelRoute.RouteSlug is not null)
         {
@@ -1171,6 +1207,32 @@ internal static class ResponsesApiEndpoints
                 [ChannelMetadataKeys.RegistrationScopeId] = callerScope.ScopeId,
                 [LLMRequestMetadataKeys.NyxIdAccessToken] = bearerToken,
             });
+    }
+
+    internal static async Task<ChatRouteDecision> ResolveResponsesChatRouteAsync(
+        IChatRoutePolicyQueryPort queryPort,
+        ChatRouteResolver resolver,
+        ResponsesCallerScope callerScope,
+        string model,
+        CancellationToken ct)
+    {
+        var ownerScope = OwnerScope.ForNyxIdNative(callerScope.ScopeId);
+        var snapshot = await queryPort.LookupForCallerAsync(ownerScope, ct);
+        return resolver.Resolve(snapshot, new ChatRouteInput
+        {
+            SourceKind = ChatSourceKind.NyxResponses,
+            CallerScope = new ChatRouteCallerScope
+            {
+                NyxUserId = ownerScope.NyxUserId,
+                Platform = ownerScope.Platform,
+                RegistrationScopeId = ownerScope.RegistrationScopeId,
+                SenderId = ownerScope.SenderId,
+            },
+            Channel = string.Empty,
+            CommandName = string.Empty,
+            ContentHint = string.Empty,
+            ToolMode = ToolMode.None,
+        });
     }
 
     private static LlmSessionRecord BuildResponseSessionRecord(

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -10,6 +10,8 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Authentication.Abstractions;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -186,6 +188,63 @@ public class NyxIdChatEndpointsCoverageTests
         runtime.CreateCalls.Should().ContainSingle(call =>
             call.Type == typeof(NyxIdChatGAgent) &&
             call.Id == createdActorId);
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_WhenChatRouteForwardsToGAgent_ShouldUseTargetActorWithoutCreatingDefaultActor()
+    {
+        var actorStore = new StubGAgentActorStore();
+        var runtime = new StubActorRuntime();
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            new ChatRouteAction { ForwardToGagent = new ForwardToGAgent { ActorId = "existing-agent-1" } },
+            []));
+
+        var result = await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            actorStore,
+            runtime,
+            queryPort,
+            NewChatRouteResolver(),
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        using var doc = JsonDocument.Parse(response.Body);
+        doc.RootElement.GetProperty("actorId").GetString().Should().Be("existing-agent-1");
+        actorStore.AddedActors.Should().ContainSingle(entry =>
+            entry.ScopeId == "scope-a" &&
+            entry.GAgentType == NyxIdChatServiceDefaults.GAgentTypeName &&
+            entry.ActorId == "existing-agent-1");
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_WhenChatRouteRejects_ShouldReturnForbiddenBeforeCreatingActor()
+    {
+        var actorStore = new StubGAgentActorStore();
+        var runtime = new StubActorRuntime();
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            new ChatRouteAction { Reject = new Reject { Reason = "blocked by policy" } },
+            []));
+
+        var result = await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            actorStore,
+            runtime,
+            queryPort,
+            NewChatRouteResolver(),
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        response.Body.Should().Contain("chat_route_rejected");
+        response.Body.Should().Contain("blocked by policy");
+        actorStore.AddedActors.Should().BeEmpty();
+        runtime.CreateCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -1862,38 +1921,54 @@ public class NyxIdChatEndpointsCoverageTests
     private static object[] NormalizeEndpointArgs(MethodInfo method, object[] args)
     {
         var parameters = method.GetParameters();
-        if (parameters.Length == args.Length)
-            return args;
+        var normalized = args.ToList();
 
-        if (parameters.Length == args.Length + 1 && args.All(arg => arg is not IActorDispatchPort))
+        if (parameters.Any(parameter => parameter.ParameterType == typeof(IActorDispatchPort)) &&
+            normalized.All(arg => arg is not IActorDispatchPort))
         {
             var dispatchPortIndex = Array.FindIndex(
                 parameters,
                 parameter => parameter.ParameterType == typeof(IActorDispatchPort));
             if (dispatchPortIndex >= 0)
             {
-                var actorRuntime = args.OfType<IActorRuntime>().FirstOrDefault()
+                var actorRuntime = normalized.OfType<IActorRuntime>().FirstOrDefault()
                     ?? throw new InvalidOperationException("Endpoint test invocation needs IActorRuntime before IActorDispatchPort can be inferred.");
-                var normalized = args.ToList();
                 normalized.Insert(dispatchPortIndex, new StubActorDispatchPort(actorRuntime));
-                return normalized.ToArray();
             }
         }
 
-        if (parameters.Length == args.Length + 1 && args.All(arg => arg is not INyxIdChatSessionProjectionPort))
+        if (parameters.Any(parameter => parameter.ParameterType == typeof(INyxIdChatSessionProjectionPort)) &&
+            normalized.All(arg => arg is not INyxIdChatSessionProjectionPort))
         {
             var projectionPortIndex = Array.FindIndex(
                 parameters,
                 parameter => parameter.ParameterType == typeof(INyxIdChatSessionProjectionPort));
             if (projectionPortIndex >= 0)
             {
-                var normalized = args.ToList();
                 normalized.Insert(projectionPortIndex, new StubNyxIdChatSessionProjectionPort());
-                return normalized.ToArray();
             }
         }
 
-        return args;
+        if (parameters.Any(parameter => parameter.ParameterType == typeof(IChatRoutePolicyQueryPort)) &&
+            normalized.All(arg => arg is not IChatRoutePolicyQueryPort))
+        {
+            var index = Array.FindIndex(
+                parameters,
+                parameter => parameter.ParameterType == typeof(IChatRoutePolicyQueryPort));
+            normalized.Insert(index, StaticChatRoutePolicyQueryPort.ForSnapshot(
+                new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
+        }
+
+        if (parameters.Any(parameter => parameter.ParameterType == typeof(ChatRouteResolver)) &&
+            normalized.All(arg => arg is not ChatRouteResolver))
+        {
+            var index = Array.FindIndex(
+                parameters,
+                parameter => parameter.ParameterType == typeof(ChatRouteResolver));
+            normalized.Insert(index, NewChatRouteResolver());
+        }
+
+        return normalized.ToArray();
     }
 
     private static void EnsureEndpointContextServices(IEnumerable<object> args)
@@ -1936,6 +2011,35 @@ public class NyxIdChatEndpointsCoverageTests
                 EnvironmentName = authenticationEnabled ? Environments.Production : Environments.Development,
             })
             .BuildServiceProvider();
+
+    private static ChatRouteResolver NewChatRouteResolver() =>
+        new(new StaticChatRouteFallbackProvider(string.Empty));
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) => new()
+    {
+        ForwardToModel = new ForwardToModel { ModelName = modelName },
+    };
+
+    private sealed class StaticChatRoutePolicyQueryPort(ChatRoutePolicySnapshot? snapshot) : IChatRoutePolicyQueryPort
+    {
+        public static StaticChatRoutePolicyQueryPort ForSnapshot(ChatRoutePolicySnapshot? snapshot) => new(snapshot);
+
+        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+            OwnerScope callerScope,
+            CancellationToken ct = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class StaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = ForwardToModelAction(modelName),
+            MatchedRuleId = string.Empty,
+            UsedFallback = true,
+            ResolvedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+    }
 
     private sealed class FallbackServiceProvider(
         IServiceProvider primary,

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -373,6 +373,68 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleCreateConversationAsync_WhenForwardedTargetRegistrationNotAdmissionVisible_ShouldNotDestroyForwardedActor()
+    {
+        var actorStore = new StubGAgentActorStore
+        {
+            RegisterStage = GAgentActorRegistryCommandStage.AcceptedForDispatch,
+        };
+        var runtime = new StubActorRuntime();
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            new ChatRouteAction { ForwardToGagent = new ForwardToGAgent { ActorId = "existing-agent-1" } },
+            []));
+
+        var result = await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            actorStore,
+            runtime,
+            queryPort,
+            NewChatRouteResolver(),
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        // We unregister the (just-registered) actor on rollback, but we must
+        // NOT destroy a pre-existing routed target — it belongs to a previous
+        // request (possibly a different scope).
+        actorStore.RemovedActors.Should().ContainSingle(entry => entry.ActorId == "existing-agent-1");
+        runtime.DestroyCalls.Should().BeEmpty(
+            "ForwardToGAgent reuses an existing actor; rollback in this request must not destroy it");
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleCreateConversationAsync_WhenForwardedTargetRegistrationThrows_ShouldNotDestroyForwardedActor()
+    {
+        var actorStore = new StubGAgentActorStore
+        {
+            AddActorExceptionAfterCommit = new OperationCanceledException("cancelled during admission verification"),
+        };
+        var runtime = new StubActorRuntime();
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            new ChatRouteAction { ForwardToGagent = new ForwardToGAgent { ActorId = "existing-agent-2" } },
+            []));
+
+        var act = async () => await InvokeResultAsync(
+            "HandleCreateConversationAsync",
+            new DefaultHttpContext(),
+            "scope-a",
+            actorStore,
+            runtime,
+            queryPort,
+            NewChatRouteResolver(),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        actorStore.RemovedActors.Should().ContainSingle(entry => entry.ActorId == "existing-agent-2");
+        runtime.DestroyCalls.Should().BeEmpty(
+            "ForwardToGAgent reuses an existing actor; even a thrown-rollback path must not destroy it");
+        runtime.CreateCalls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleListConversationsAsync_ShouldReturnRegisteredActors()
     {
         var actorStore = new StubGAgentActorStore
@@ -1438,6 +1500,108 @@ public class NyxIdChatEndpointsCoverageTests
     }
 
     [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldStashSenderNyxUserIdOnTransportExtras_ForChatRoutePolicyLookup()
+    {
+        var relay = CreateRelayInvocationDependencies(relayApiKeyId: "scope-daily");
+        var payload = """
+            {
+              "message_id":"msg-sender-nyxid",
+              "correlation_id":"corr-sender-nyxid",
+              "platform":"lark",
+              "reply_token":"reply-token-sender-nyxid",
+              "agent":{"api_key_id":"scope-daily"},
+              "conversation":{"id":"oc_private_2","type":"private"},
+              "sender":{"platform_id":"ou_user_2","display_name":"Bob"},
+              "content":{"type":"text","text":"ping"}
+            }
+            """;
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        AttachRelayHeaders(context, relay, payload, "msg-sender-nyxid");
+
+        var runtime = new StubActorRuntime();
+        var userResolver = new StubNyxIdCurrentUserResolver { ResolvedUserId = "nyx-user-bob" };
+        var result = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            runtime,
+            relay.Transport,
+            relay.Validator,
+            relay.Options,
+            userResolver,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+        var expectedActorId = BuildScopedRelayConversationActorId("scope-daily", "lark:dm:ou_user_2");
+        var actor = (StubActor)runtime.Actors[expectedActorId];
+        var relayInbound = actor.HandledEnvelopes.Single().Payload.Unpack<NyxRelayInboundActivity>();
+        relayInbound.Activity.TransportExtras.NyxSenderUserId.Should().Be(
+            "nyx-user-bob",
+            "the relay ingress must resolve the sender NyxID via /me so ConversationGAgent can " +
+            "build a per-user owner scope without re-resolving inside the actor turn");
+    }
+
+    [Fact]
+    public async Task HandleRelayWebhookAsync_ShouldLeaveSenderNyxUserIdEmpty_WhenResolverFails()
+    {
+        var relay = CreateRelayInvocationDependencies(relayApiKeyId: "scope-daily");
+        var payload = """
+            {
+              "message_id":"msg-sender-nyxid-fail",
+              "correlation_id":"corr-sender-nyxid-fail",
+              "platform":"lark",
+              "reply_token":"reply-token-sender-nyxid-fail",
+              "agent":{"api_key_id":"scope-daily"},
+              "conversation":{"id":"oc_private_3","type":"private"},
+              "sender":{"platform_id":"ou_user_3","display_name":"Carol"},
+              "content":{"type":"text","text":"ping"}
+            }
+            """;
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider(),
+        };
+        context.Request.ContentType = "application/json";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        AttachRelayHeaders(context, relay, payload, "msg-sender-nyxid-fail");
+
+        var runtime = new StubActorRuntime();
+        var userResolver = new StubNyxIdCurrentUserResolver
+        {
+            OnResolve = (_, _) => throw new HttpRequestException("simulated NyxID /me failure"),
+        };
+        var result = await InvokeResultAsync(
+            "HandleRelayWebhookAsync",
+            context,
+            runtime,
+            relay.Transport,
+            relay.Validator,
+            relay.Options,
+            userResolver,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        var response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(
+            StatusCodes.Status202Accepted,
+            "an unreliable /me must not break ingress; routing falls back to scope-only / default policies");
+        var expectedActorId = BuildScopedRelayConversationActorId("scope-daily", "lark:dm:ou_user_3");
+        var actor = (StubActor)runtime.Actors[expectedActorId];
+        var relayInbound = actor.HandledEnvelopes.Single().Payload.Unpack<NyxRelayInboundActivity>();
+        relayInbound.Activity.TransportExtras.NyxSenderUserId.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleRelayWebhookAsync_ShouldResolveScopeIdFromRegistration_WhenCallbackJwtHasNoScope()
     {
         var relay = CreateRelayInvocationDependencies(relayApiKeyId: "nyx-key-1");
@@ -1968,7 +2132,31 @@ public class NyxIdChatEndpointsCoverageTests
             normalized.Insert(index, NewChatRouteResolver());
         }
 
+        if (parameters.Any(parameter =>
+                parameter.ParameterType == typeof(Aevatar.GAgents.Scheduled.INyxIdCurrentUserResolver)) &&
+            normalized.All(arg => arg is not Aevatar.GAgents.Scheduled.INyxIdCurrentUserResolver))
+        {
+            var index = Array.FindIndex(
+                parameters,
+                parameter => parameter.ParameterType == typeof(Aevatar.GAgents.Scheduled.INyxIdCurrentUserResolver));
+            normalized.Insert(index, new StubNyxIdCurrentUserResolver());
+        }
+
         return normalized.ToArray();
+    }
+
+    private sealed class StubNyxIdCurrentUserResolver : Aevatar.GAgents.Scheduled.INyxIdCurrentUserResolver
+    {
+        public string? ResolvedUserId { get; set; }
+
+        public Func<string, CancellationToken, Task<string?>>? OnResolve { get; set; }
+
+        public Task<string?> ResolveCurrentUserIdAsync(string nyxIdAccessToken, CancellationToken ct = default)
+        {
+            if (OnResolve is not null)
+                return OnResolve(nyxIdAccessToken, ct);
+            return Task.FromResult(ResolvedUserId);
+        }
     }
 
     private static void EnsureEndpointContextServices(IEnumerable<object> args)

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelRuntimeProtoTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ChannelRuntimeProtoTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.GAgents.Scheduled;
@@ -89,6 +90,10 @@ public sealed class ChannelRuntimeProtoTests
                 Conversation = completed.Conversation.Clone(),
                 Content = new MessageContent { Text = "hello" },
             },
+            TargetRef = new ChatRouteAction
+            {
+                ForwardToGagent = new ForwardToGAgent { ActorId = "target-gagent-1" },
+            },
             RequestedAtUnixMs = 42,
         };
         var llmReady = new LlmReplyReadyEvent
@@ -120,6 +125,7 @@ public sealed class ChannelRuntimeProtoTests
         PayloadQuarantineReflection.Descriptor.MessageTypes.Select(x => x.Name)
             .ShouldContain(nameof(PlatformQuarantineEnvelope));
         llmRequested.Clone().ShouldBe(llmRequested);
+        llmRequested.Clone().TargetRef.ForwardToGagent.ActorId.ShouldBe("target-gagent-1");
         llmReady.Clone().ShouldBe(llmReady);
     }
 }

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -4,6 +4,8 @@ using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using Google.Protobuf;
@@ -567,6 +569,84 @@ public sealed class ConversationGAgentDedupTests
         dispatcher.Dispatched.Count.ShouldBe(1);
         dispatcher.Dispatched[0].CorrelationId.ShouldBe("act-direct");
         dispatcher.Dispatched[0].TargetActorId.ShouldBe(agent.Id);
+    }
+
+    [Fact]
+    public async Task HandleNyxRelayInboundActivityAsync_WhenRouteForwardsToGAgent_CarriesTargetRefToDispatcher()
+    {
+        var dispatcher = new RecordingRunDispatcher();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = 42,
+                }),
+        };
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            ForwardToModelAction("fallback-model"),
+            [
+                new ChatRouteRule
+                {
+                    RuleId = "daily",
+                    Priority = 100,
+                    Match = new ChatRouteMatch
+                    {
+                        SourceKind = ChatSourceKind.NyxRelay,
+                        Channel = "lark",
+                        CommandName = "/daily",
+                    },
+                    Action = new ChatRouteAction
+                    {
+                        ForwardToGagent = new ForwardToGAgent { ActorId = "target-gagent-1" },
+                    },
+                },
+            ]));
+        var resolver = new ChatRouteResolver(new StaticChatRouteFallbackProvider("fallback-model"));
+        var (agent, store) = CreateAgent(
+            runner,
+            "channel-conversation:conv:lark:C1:scope:owner",
+            dispatcher,
+            queryPort: queryPort,
+            chatRouteResolver: resolver);
+
+        var inboundActivity = CreateActivity("act-route", "conv:lark:C1");
+        inboundActivity.ChannelId = new ChannelId { Value = "lark" };
+        inboundActivity.Bot = new BotInstanceId { Value = "owner-scope" };
+        inboundActivity.From = new ParticipantRef { CanonicalId = "sender-1" };
+        inboundActivity.Content = new MessageContent { Text = "/daily status" };
+        inboundActivity.TransportExtras = new TransportExtras
+        {
+            NyxPlatform = "lark",
+            NyxRegistrationScopeId = "owner-scope",
+        };
+        inboundActivity.OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-msg-route",
+            CorrelationId = "corr-route",
+        };
+
+        await agent.HandleNyxRelayInboundActivityAsync(new NyxRelayInboundActivity
+        {
+            Activity = inboundActivity,
+            ReplyToken = "runtime-only-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+            CorrelationId = "corr-route",
+        });
+
+        dispatcher.Dispatched.ShouldHaveSingleItem();
+        dispatcher.Dispatched[0].TargetRef.ForwardToGagent.ActorId.ShouldBe("target-gagent-1");
+        dispatcher.Dispatched[0].ReplyToken.ShouldBe("runtime-only-token");
+
+        var events = await store.GetEventsAsync(agent.Id);
+        events.ShouldHaveSingleItem();
+        var parsed = NeedsLlmReplyEvent.Parser.ParseFrom(events[0].EventData.Value);
+        parsed.TargetRef.ForwardToGagent.ActorId.ShouldBe("target-gagent-1");
+        parsed.ReplyToken.ShouldBeEmpty();
     }
 
     [Fact]
@@ -1512,7 +1592,9 @@ public sealed class ConversationGAgentDedupTests
         RecordingTurnRunner runner,
         string agentId,
         IChannelLlmReplyRunDispatcher? dispatcher = null,
-        IConversationCardTurnRunner? cardRunner = null)
+        IConversationCardTurnRunner? cardRunner = null,
+        IChatRoutePolicyQueryPort? queryPort = null,
+        ChatRouteResolver? chatRouteResolver = null)
     {
         var store = new InMemoryEventStore();
         var services = new ServiceCollection();
@@ -1524,6 +1606,10 @@ public sealed class ConversationGAgentDedupTests
             services.AddSingleton(cardRunner);
         if (dispatcher is not null)
             services.AddSingleton(dispatcher);
+        if (queryPort is not null)
+            services.AddSingleton(queryPort);
+        if (chatRouteResolver is not null)
+            services.AddSingleton(chatRouteResolver);
         services.AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
 
         var sp = services.BuildServiceProvider();
@@ -1702,6 +1788,32 @@ public sealed class ConversationGAgentDedupTests
                 AcceptedAtUnixMs: 0));
         }
     }
+
+    private sealed class StaticChatRoutePolicyQueryPort(ChatRoutePolicySnapshot? snapshot) : IChatRoutePolicyQueryPort
+    {
+        public static StaticChatRoutePolicyQueryPort ForSnapshot(ChatRoutePolicySnapshot? snapshot) => new(snapshot);
+
+        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+            OwnerScope callerScope,
+            CancellationToken ct = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class StaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = ForwardToModelAction(modelName),
+            UsedFallback = true,
+            MatchedRuleId = string.Empty,
+            ResolvedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+    }
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) => new()
+    {
+        ForwardToModel = new ForwardToModel { ModelName = modelName },
+    };
 
     private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
     {

--- a/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -434,13 +436,82 @@ public sealed class MainnetMessagesEndpointsTests
         toolNames.Should().NotContain(["use_skill", "ornn_search_skills", "WebSearch"]);
     }
 
+    [Fact]
+    public async Task PostMessages_WhenChatRouteForwardsToModel_RewritesModelBeforeCompletionService()
+    {
+        var provider = new MessagesRecordingLLMProvider
+        {
+            StreamChunks =
+            [
+                new LLMStreamChunk { DeltaContent = "Hi", IsLast = true, Usage = new TokenUsage(1, 1, 2) },
+            ],
+        };
+        var queryPort = MessagesStaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            ForwardToModelAction("routed-claude"),
+            []));
+        await using var app = await CreateAppAsync(provider, chatRoutePolicyQueryPort: queryPort);
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/messages")
+        {
+            Content = JsonContent("""
+            {
+              "model": "original-claude",
+              "max_tokens": 32,
+              "messages": [{"role": "user", "content": "ping"}]
+            }
+            """),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "anthropic-bearer");
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        provider.LastRequest.Should().NotBeNull();
+        provider.LastRequest!.Model.Should().Be("routed-claude");
+    }
+
+    [Fact]
+    public async Task PostMessages_WhenChatRouteRejects_ReturnsForbiddenWithoutLlmCall()
+    {
+        var provider = new MessagesRecordingLLMProvider();
+        var queryPort = MessagesStaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            RejectAction("policy_denied", "blocked by policy"),
+            []));
+        await using var app = await CreateAppAsync(provider, chatRoutePolicyQueryPort: queryPort);
+        var client = app.GetTestClient();
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/messages")
+        {
+            Content = JsonContent("""
+            {
+              "model": "original-claude",
+              "max_tokens": 32,
+              "messages": [{"role": "user", "content": "ping"}]
+            }
+            """),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "anthropic-bearer");
+
+        var response = await client.SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden, body);
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("error").GetProperty("type").GetString().Should().Be("chat_route_rejected");
+        doc.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Be("blocked by policy");
+        provider.LastRequest.Should().BeNull();
+    }
+
     // ----- Test fixtures -------------------------------------------------------
 
     private static async Task<WebApplication> CreateAppAsync(
         MessagesRecordingLLMProvider provider,
         MessagesRecordingSessionStore? sessions = null,
         IResponsesCallerScopeResolver? callerScopeResolver = null,
-        IResponsesToolProvider? responsesToolProvider = null)
+        IResponsesToolProvider? responsesToolProvider = null,
+        IChatRoutePolicyQueryPort? chatRoutePolicyQueryPort = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -454,6 +525,9 @@ public sealed class MainnetMessagesEndpointsTests
         builder.Services.AddSingleton<ILlmSessionQueryPort>(sessions);
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton(callerScopeResolver ?? new MessagesStubCallerScopeResolver());
+        builder.Services.AddSingleton(chatRoutePolicyQueryPort ?? MessagesStaticChatRoutePolicyQueryPort.ForSnapshot(
+            new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
+        builder.Services.AddSingleton(new ChatRouteResolver(new MessagesStaticChatRouteFallbackProvider(string.Empty)));
         builder.Services.AddSingleton<IResponsesRouteResolver>(new MessagesNoopRouteResolver());
         if (responsesToolProvider != null)
             builder.Services.AddSingleton(responsesToolProvider);
@@ -518,6 +592,39 @@ public sealed class MainnetMessagesEndpointsTests
         public Task<string?> ResolveRouteValueAsync(string slug, string bearerToken, CancellationToken ct) =>
             Task.FromResult<string?>(null);
     }
+
+    private sealed class MessagesStaticChatRoutePolicyQueryPort(ChatRoutePolicySnapshot? snapshot)
+        : IChatRoutePolicyQueryPort
+    {
+        public static MessagesStaticChatRoutePolicyQueryPort ForSnapshot(ChatRoutePolicySnapshot? snapshot) =>
+            new(snapshot);
+
+        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+            OwnerScope callerScope,
+            CancellationToken ct = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class MessagesStaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = ForwardToModelAction(modelName),
+            UsedFallback = true,
+            MatchedRuleId = string.Empty,
+            ResolvedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+    }
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) => new()
+    {
+        ForwardToModel = new ForwardToModel { ModelName = modelName },
+    };
+
+    private static ChatRouteAction RejectAction(string code, string message) => new()
+    {
+        Reject = new Reject { Reason = message },
+    };
 
     private sealed class MessagesRecordingSessionStore :
         ILlmSessionRegistrationPort,

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -9,6 +9,8 @@ using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.AI.ToolProviders.Ornn;
 using Aevatar.AI.ToolProviders.Skills;
 using Aevatar.Authentication.Hosting;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -1095,6 +1097,9 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<ILlmSessionQueryPort>(sessions);
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCallerScopeResolver>(new StubResponsesCallerScopeResolver());
+        builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(StaticChatRoutePolicyQueryPort.ForSnapshot(
+            new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
+        builder.Services.AddSingleton(new ChatRouteResolver(new StaticChatRouteFallbackProvider(string.Empty)));
         builder.Services.AddSingleton<IResponsesRouteResolver>(new RecordingResponsesRouteResolver());
 
         await using var app = builder.Build();
@@ -1466,6 +1471,60 @@ public sealed class MainnetResponsesEndpointsTests
     }
 
     [Fact]
+    public async Task PostResponses_WhenChatRouteForwardsToModel_RewritesModelBeforeCompletionService()
+    {
+        var provider = new RecordingLLMProvider
+        {
+            StreamChunks =
+            [
+                new LLMStreamChunk { DeltaContent = "routed", IsLast = true, Usage = new TokenUsage(1, 1, 2) },
+            ],
+        };
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            ForwardToModelAction("routed-model"),
+            []));
+        await using var app = await CreateAppAsync(provider, chatRoutePolicyQueryPort: queryPort);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/responses")
+        {
+            Content = JsonContent("""{"model":"original-model","input":"ping","stream":false}"""),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "route-secret");
+
+        var response = await app.GetTestClient().SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        provider.LastRequest.Should().NotBeNull();
+        provider.LastRequest!.Model.Should().Be("routed-model");
+    }
+
+    [Fact]
+    public async Task PostResponses_WhenChatRouteRejects_ReturnsForbiddenWithoutLlmCall()
+    {
+        var provider = new RecordingLLMProvider();
+        var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
+            RejectAction("policy_denied", "blocked by policy"),
+            []));
+        await using var app = await CreateAppAsync(provider, chatRoutePolicyQueryPort: queryPort);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/v1/responses")
+        {
+            Content = JsonContent("""{"model":"original-model","input":"ping","stream":false}"""),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "route-secret");
+
+        var response = await app.GetTestClient().SendAsync(request);
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden, body);
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("chat_route_rejected");
+        doc.RootElement.GetProperty("error").GetProperty("message").GetString().Should().Be("blocked by policy");
+        provider.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task PostResponses_WithNonSlugLookingPrefix_ShouldPassModelVerbatim()
     {
         // Edge case: `BadSlug/x` has an uppercase prefix that doesn't match the slug pattern
@@ -1498,7 +1557,8 @@ public sealed class MainnetResponsesEndpointsTests
         IResponsesCallerScopeResolver? callerScopeResolver = null,
         IResponsesToolProvider? responsesToolProvider = null,
         IResponsesModelsAggregator? modelsAggregator = null,
-        IResponsesRouteResolver? routeResolver = null)
+        IResponsesRouteResolver? routeResolver = null,
+        IChatRoutePolicyQueryPort? chatRoutePolicyQueryPort = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -1512,6 +1572,9 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<ILlmSessionQueryPort>(responseSessions);
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton(callerScopeResolver ?? new StubResponsesCallerScopeResolver());
+        builder.Services.AddSingleton(chatRoutePolicyQueryPort ?? StaticChatRoutePolicyQueryPort.ForSnapshot(
+            new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
+        builder.Services.AddSingleton(new ChatRouteResolver(new StaticChatRouteFallbackProvider(string.Empty)));
         builder.Services.AddSingleton(modelsAggregator ?? new RecordingResponsesModelsAggregator());
         builder.Services.AddSingleton(routeResolver ?? new RecordingResponsesRouteResolver
         {
@@ -1617,6 +1680,37 @@ public sealed class MainnetResponsesEndpointsTests
             return Task.FromResult(Routes.TryGetValue(slug, out var route) ? route : null);
         }
     }
+
+    private sealed class StaticChatRoutePolicyQueryPort(ChatRoutePolicySnapshot? snapshot) : IChatRoutePolicyQueryPort
+    {
+        public static StaticChatRoutePolicyQueryPort ForSnapshot(ChatRoutePolicySnapshot? snapshot) => new(snapshot);
+
+        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(
+            OwnerScope callerScope,
+            CancellationToken ct = default) =>
+            Task.FromResult(snapshot);
+    }
+
+    private sealed class StaticChatRouteFallbackProvider(string modelName) : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() => new()
+        {
+            Action = ForwardToModelAction(modelName),
+            UsedFallback = true,
+            MatchedRuleId = string.Empty,
+            ResolvedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+    }
+
+    private static ChatRouteAction ForwardToModelAction(string modelName) => new()
+    {
+        ForwardToModel = new ForwardToModel { ModelName = modelName },
+    };
+
+    private static ChatRouteAction RejectAction(string code, string message) => new()
+    {
+        Reject = new Reject { Reason = message },
+    };
 
     private sealed class StubResponsesCallerScopeResolver : IResponsesCallerScopeResolver
     {


### PR DESCRIPTION
## Issue
Closes #694 — Ingress v1 · Phase 3 — wire ChatRouteResolver into 4 text entries

## Implementation summary
See `.implement-loop/runs/implement-issue-694.md`.

Wires the Phase 2 `ChatRouteResolver` into the four text ingress paths — each resolves **before** its existing dispatch, no new actor hop:
- **NyxIdChat create** — resolves before `NyxIdChatGAgent` selection; `ForwardToGAgent` overrides target actor, `Reject` → structured 403.
- **Responses endpoint** — resolves after caller-scope lookup, before provider dispatch; `ForwardToModel` rewrites the model, `Reject` → 401/403.
- **Messages endpoint** — same as Responses (`source_kind = NYX_RESPONSES`).
- **Relay `ConversationGAgent`** — resolves inside the actor turn before runner admission; decision carried via the new typed `NeedsLlmReplyEvent.target_ref`. `reply_token` stays actor-private, never enters the resolver.

Typed proto fields added: `NeedsLlmReplyEvent.target_ref` (`ChatRouteAction`) and the relay caller-scope field on `chat_activity.proto`.

## Stacked-PR position
- Base: `feat/2026-05-19_ingress-phase2-chat-route-resolver` (Phase 2's branch — stacked PR)
- Head: `feat/2026-05-19_ingress-phase3-text-entries`
- Auto-loop iteration: codex-implement-loop / milestone 20 (Ingress v1)

## Notes
- Local gate: `dotnet build aevatar.slnx` passed, `buf lint` passed, `test_stability_guards.sh` passed, channel/hosting/AI test projects all green (557 + 177 + 138). `architecture_guards.sh` clears every guard **except** the pre-existing playground asset drift guard, unrelated to this PR (zero frontend assets touched).
- Gate-fix during the loop: registered `src/Aevatar.ChatRouting.Abstractions` as a buf module (`buf.yaml` + `buf.work.yaml`) so the new cross-module proto import (`chat_route_policy.proto`) resolves under `buf lint`.
- **Deviation**: the issue specified a new `test/Aevatar.ChatRouting.Integration.Tests/` project; codex instead added focused tests to the existing per-surface test projects. Flagged for reviewer judgment.

🤖 Generated by codex-implement-loop. Reviewer is a Claude subagent (see PR comments for round-N review reports).