### PR TITLE
cluster-025: voice host session state moves to actor; remote audio disabled until raw transport

### DIFF
--- a/src/Aevatar.Foundation.VoicePresence/Hosting/CompositeVoicePresenceSessionResolver.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/CompositeVoicePresenceSessionResolver.cs
@@ -3,6 +3,10 @@ namespace Aevatar.Foundation.VoicePresence.Hosting;
 /// <summary>
 /// Default host resolver that prefers direct in-process module attachment and falls back to runtime-neutral remote bridging.
 /// </summary>
+// Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+//   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+//   New principle: fallback remote sessions are setup/control only.
+//   Media endpoints fail fast until raw remote audio transport exists.
 public sealed class CompositeVoicePresenceSessionResolver : IVoicePresenceSessionResolver
 {
     private readonly InProcessActorVoicePresenceSessionResolver _inProcessResolver;

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs
@@ -15,7 +15,6 @@ namespace Aevatar.Foundation.VoicePresence.Hosting;
 public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSessionResolver
 {
     private const string DefaultVoiceModuleName = "voice_presence";
-    private const string RemoteAudioTransportUnavailable = "remote_audio_transport_unavailable";
     private readonly IServiceProvider _services;
     private readonly IReadOnlyDictionary<string, VoicePresenceModuleRegistration> _registrationsByName;
     private readonly IReadOnlyList<VoicePresenceModuleRegistration> _registrations;
@@ -133,14 +132,17 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
                     SessionId = sessionId,
                 }, ct);
 
-                await DispatchCloseRequestAsync(sessionId, RemoteAudioTransportUnavailable, ct);
+                await DispatchCloseRequestAsync(
+                    sessionId,
+                    VoiceRemoteAudioTransportUnavailableException.Reason,
+                    ct);
             }
             finally
             {
                 await transport.DisposeAsync();
             }
 
-            throw new NotSupportedException(RemoteAudioTransportUnavailable);
+            throw new VoiceRemoteAudioTransportUnavailableException();
         }
 
         private async Task DetachTransportAsync(IVoiceTransport? expectedTransport, CancellationToken ct)

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs
@@ -145,6 +145,9 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
             throw new VoiceRemoteAudioTransportUnavailableException();
         }
 
+        // Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+        //   Old pattern: detach released host-held attachment state, subscription, and relay task.
+        //   New principle: host has no attachment fact to release; detach only sends best-effort actor close.
         private async Task DetachTransportAsync(IVoiceTransport? expectedTransport, CancellationToken ct)
         {
             _ = expectedTransport;

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs
@@ -1,5 +1,4 @@
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,11 +6,16 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Aevatar.Foundation.VoicePresence.Hosting;
 
 /// <summary>
-/// Resolves runtime-neutral host sessions that bridge transports through actor dispatch + actor stream observation.
+/// Resolves runtime-neutral host sessions that dispatch remote voice setup/control messages.
 /// </summary>
+// Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+//   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+//   New principle: actor owns remote session identity; host dispatches setup/control only.
+//   Remote media attach fails until a non-envelope raw audio transport exists.
 public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSessionResolver
 {
     private const string DefaultVoiceModuleName = "voice_presence";
+    private const string RemoteAudioTransportUnavailable = "remote_audio_transport_unavailable";
     private readonly IServiceProvider _services;
     private readonly IReadOnlyDictionary<string, VoicePresenceModuleRegistration> _registrationsByName;
     private readonly IReadOnlyList<VoicePresenceModuleRegistration> _registrations;
@@ -35,8 +39,7 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
 
         var actorRuntime = _services.GetService<IActorRuntime>();
         var dispatchPort = _services.GetService<IActorDispatchPort>();
-        var subscriptions = _services.GetService<IActorEventSubscriptionProvider>();
-        if (actorRuntime == null || dispatchPort == null || subscriptions == null)
+        if (actorRuntime == null || dispatchPort == null)
             return null;
 
         if (!await actorRuntime.ExistsAsync(request.ActorId))
@@ -50,8 +53,7 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
             request.ActorId,
             target.Value.ModuleName,
             target.Value.PcmSampleRateHz,
-            dispatchPort,
-            subscriptions);
+            dispatchPort);
 
         return bridge.CreateSession();
     }
@@ -93,194 +95,58 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
         private readonly string _moduleName;
         private readonly int _pcmSampleRateHz;
         private readonly IActorDispatchPort _dispatchPort;
-        private readonly IActorEventSubscriptionProvider _subscriptions;
-        private readonly Lock _gate = new();
-        private AttachmentState? _state;
 
         public RemoteActorVoicePresenceSessionBridge(
             string actorId,
             string moduleName,
             int pcmSampleRateHz,
-            IActorDispatchPort dispatchPort,
-            IActorEventSubscriptionProvider subscriptions)
+            IActorDispatchPort dispatchPort)
         {
             _actorId = actorId;
             _moduleName = moduleName;
             _pcmSampleRateHz = pcmSampleRateHz;
             _dispatchPort = dispatchPort;
-            _subscriptions = subscriptions;
         }
 
         public VoicePresenceSession CreateSession() =>
             new(
                 isInitialized: static () => true,
-                isTransportAttached: () => TryGetState() != null,
+                isTransportAttached: static () => false,
                 attachTransportAsync: AttachTransportAsync,
                 detachTransportAsync: DetachTransportAsync,
                 pcmSampleRateHz: _pcmSampleRateHz);
 
+        // Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+        //   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+        //   New principle: remote attach keeps setup/control envelopes but rejects PCM transport.
+        //   Chunks never cross EventEnvelope; audio waits for a raw transport.
         private async Task AttachTransportAsync(IVoiceTransport transport, CancellationToken ct)
         {
             ArgumentNullException.ThrowIfNull(transport);
             ct.ThrowIfCancellationRequested();
 
             var sessionId = Guid.NewGuid().ToString("N");
-            var relayCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            var subscription = await _subscriptions.SubscribeAsync<VoiceRemoteTransportOutput>(
-                _actorId,
-                HandleOutputAsync,
-                ct);
-            var state = new AttachmentState(sessionId, transport, relayCts, subscription);
-
-            lock (_gate)
-            {
-                if (_state != null)
-                    throw new InvalidOperationException("A voice transport is already attached.");
-
-                _state = state;
-            }
-
             try
             {
-                state.RelayTask = RunTransportRelayAsync(state);
                 await DispatchAsync(new VoiceRemoteSessionOpenRequested
                 {
                     SessionId = sessionId,
                 }, ct);
+
+                await DispatchCloseRequestAsync(sessionId, RemoteAudioTransportUnavailable, ct);
             }
-            catch
+            finally
             {
-                await ReleaseStateAsync(state, dispatchCloseRequest: false, awaitRelayCompletion: false);
-                throw;
+                await transport.DisposeAsync();
             }
+
+            throw new NotSupportedException(RemoteAudioTransportUnavailable);
         }
 
         private async Task DetachTransportAsync(IVoiceTransport? expectedTransport, CancellationToken ct)
         {
-            var state = TryGetState();
-            if (state == null)
-            {
-                await DispatchCloseRequestAsync(sessionId: null, "host_detach");
-                return;
-            }
-
-            if (expectedTransport != null && !ReferenceEquals(expectedTransport, state.Transport))
-                return;
-
-            _ = ct;
-            await ReleaseStateAsync(state, dispatchCloseRequest: true, awaitRelayCompletion: true);
-        }
-
-        private async Task RunTransportRelayAsync(AttachmentState state)
-        {
-            try
-            {
-                await foreach (var frame in state.Transport.ReceiveFramesAsync(state.RelayCancellation.Token))
-                {
-                    if (frame.IsAudio)
-                    {
-                        if (frame.AudioPcm16.IsEmpty)
-                            continue;
-
-                        await DispatchAsync(new VoiceRemoteAudioInputReceived
-                        {
-                            SessionId = state.SessionId,
-                            Pcm16 = ByteString.CopyFrom(frame.AudioPcm16.Span),
-                        }, state.RelayCancellation.Token);
-                        continue;
-                    }
-
-                    if (frame.Control == null)
-                        continue;
-
-                    await DispatchAsync(new VoiceRemoteControlInputReceived
-                    {
-                        SessionId = state.SessionId,
-                        ControlFrame = frame.Control.Clone(),
-                    }, state.RelayCancellation.Token);
-                }
-            }
-            catch (OperationCanceledException) when (state.RelayCancellation.IsCancellationRequested)
-            {
-            }
-            catch
-            {
-            }
-            finally
-            {
-                await ReleaseStateAsync(state, dispatchCloseRequest: true, awaitRelayCompletion: false);
-            }
-        }
-
-        private async Task HandleOutputAsync(VoiceRemoteTransportOutput output)
-        {
-            var state = TryGetState();
-            if (state == null ||
-                !string.Equals(output.ModuleName, _moduleName, StringComparison.OrdinalIgnoreCase) ||
-                !string.Equals(output.SessionId, state.SessionId, StringComparison.Ordinal))
-            {
-                return;
-            }
-
-            switch (output.OutputCase)
-            {
-                case VoiceRemoteTransportOutput.OutputOneofCase.AudioOutput:
-                    try
-                    {
-                        await state.Transport.SendAudioAsync(output.AudioOutput.Pcm16.Memory, CancellationToken.None);
-                    }
-                    catch
-                    {
-                        await ReleaseStateAsync(state, dispatchCloseRequest: true, awaitRelayCompletion: false);
-                    }
-
-                    break;
-                case VoiceRemoteTransportOutput.OutputOneofCase.SessionClosed:
-                    await ReleaseStateAsync(state, dispatchCloseRequest: false, awaitRelayCompletion: false);
-                    break;
-                case VoiceRemoteTransportOutput.OutputOneofCase.None:
-                default:
-                    break;
-            }
-        }
-
-        private async Task ReleaseStateAsync(
-            AttachmentState state,
-            bool dispatchCloseRequest,
-            bool awaitRelayCompletion)
-        {
-            var release = false;
-            lock (_gate)
-            {
-                if (ReferenceEquals(_state, state))
-                {
-                    _state = null;
-                    release = true;
-                }
-            }
-
-            if (!release)
-                return;
-
-            state.RelayCancellation.Cancel();
-
-            if (dispatchCloseRequest)
-                await DispatchCloseRequestAsync(state.SessionId, "host_detach");
-
-            if (awaitRelayCompletion && state.RelayTask != null)
-            {
-                try
-                {
-                    await state.RelayTask;
-                }
-                catch (OperationCanceledException)
-                {
-                }
-            }
-
-            await state.Subscription.DisposeAsync();
-            await state.Transport.DisposeAsync();
-            state.RelayCancellation.Dispose();
+            _ = expectedTransport;
+            await DispatchCloseRequestAsync(sessionId: null, "host_detach", ct);
         }
 
         private Task DispatchAsync(IMessage message, CancellationToken ct) =>
@@ -289,7 +155,7 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
                 VoicePresenceSessionDispatch.BuildDirectEnvelope(_actorId, _moduleName, message),
                 ct);
 
-        private async Task DispatchCloseRequestAsync(string? sessionId, string reason)
+        private async Task DispatchCloseRequestAsync(string? sessionId, string reason, CancellationToken ct)
         {
             try
             {
@@ -299,37 +165,12 @@ public sealed class RemoteActorVoicePresenceSessionResolver : IVoicePresenceSess
                         SessionId = sessionId ?? string.Empty,
                         Reason = reason,
                     },
-                    CancellationToken.None);
+                    ct);
             }
             catch
             {
                 // cleanup is best-effort after transport shutdown
             }
-        }
-
-        private AttachmentState? TryGetState()
-        {
-            lock (_gate)
-            {
-                return _state;
-            }
-        }
-
-        private sealed class AttachmentState(
-            string sessionId,
-            IVoiceTransport transport,
-            CancellationTokenSource relayCancellation,
-            IAsyncDisposable subscription)
-        {
-            public string SessionId { get; } = sessionId;
-
-            public IVoiceTransport Transport { get; } = transport;
-
-            public CancellationTokenSource RelayCancellation { get; } = relayCancellation;
-
-            public IAsyncDisposable Subscription { get; } = subscription;
-
-            public Task? RelayTask { get; set; }
         }
     }
 }

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
@@ -18,8 +18,6 @@ namespace Aevatar.Foundation.VoicePresence.Hosting;
 //   Remote setup/control remains actor-owned; chunks never cross EventEnvelope.
 public static class VoicePresenceEndpoints
 {
-    private const string RemoteAudioTransportUnavailable = "remote_audio_transport_unavailable";
-
     public static IEndpointConventionBuilder MapVoicePresenceWebSocket(
         this IEndpointRouteBuilder endpoints,
         string pattern) =>
@@ -92,7 +90,7 @@ public static class VoicePresenceEndpoints
                 attached = true;
                 await WaitUntilClosedAsync(ws, ctx.RequestAborted);
             }
-            catch (NotSupportedException ex) when (IsRemoteAudioTransportUnavailable(ex))
+            catch (VoiceRemoteAudioTransportUnavailableException)
             {
                 await TryCloseUnsupportedRemoteAudioAsync(ws);
             }
@@ -196,13 +194,13 @@ public static class VoicePresenceEndpoints
                 ctx.Response.Headers.Location = ctx.Request.Path.ToString();
                 await ctx.Response.WriteAsync(transportSession.AnswerSdp);
             }
-            catch (NotSupportedException ex) when (IsRemoteAudioTransportUnavailable(ex))
+            catch (VoiceRemoteAudioTransportUnavailableException)
             {
                 if (!attached)
                     await transportSession.Transport.DisposeAsync();
 
                 ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                await ctx.Response.WriteAsync(RemoteAudioTransportUnavailable);
+                await ctx.Response.WriteAsync(VoiceRemoteAudioTransportUnavailableException.Reason);
             }
             catch
             {
@@ -291,7 +289,7 @@ public static class VoicePresenceEndpoints
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
             await ws.CloseAsync(
                 WebSocketCloseStatus.PolicyViolation,
-                RemoteAudioTransportUnavailable,
+                VoiceRemoteAudioTransportUnavailableException.Reason,
                 cts.Token);
         }
         catch
@@ -299,9 +297,6 @@ public static class VoicePresenceEndpoints
             // best effort close after websocket upgrade
         }
     }
-
-    private static bool IsRemoteAudioTransportUnavailable(NotSupportedException ex) =>
-        string.Equals(ex.Message, RemoteAudioTransportUnavailable, StringComparison.Ordinal);
 
     private static async Task WaitUntilClosedAsync(WebSocket ws, CancellationToken ct)
     {
@@ -341,4 +336,13 @@ public static class VoicePresenceEndpoints
 
         await session.DetachTransportAsync(transport);
     }
+}
+
+// Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+//   Old pattern: resolver and endpoints matched duplicated private exception-message constants.
+//   New principle: remote media unavailability is a typed host signal with one shared reason.
+internal sealed class VoiceRemoteAudioTransportUnavailableException()
+    : NotSupportedException(Reason)
+{
+    public const string Reason = "remote_audio_transport_unavailable";
 }

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
@@ -12,8 +12,14 @@ namespace Aevatar.Foundation.VoicePresence.Hosting;
 /// <summary>
 /// Extension methods to map voice-presence WebSocket endpoints onto an ASP.NET host.
 /// </summary>
+// Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+//   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+//   New principle: media endpoints expose remote audio unavailability honestly.
+//   Remote setup/control remains actor-owned; chunks never cross EventEnvelope.
 public static class VoicePresenceEndpoints
 {
+    private const string RemoteAudioTransportUnavailable = "remote_audio_transport_unavailable";
+
     public static IEndpointConventionBuilder MapVoicePresenceWebSocket(
         this IEndpointRouteBuilder endpoints,
         string pattern) =>
@@ -85,6 +91,10 @@ public static class VoicePresenceEndpoints
                 await session.AttachTransportAsync(transport, ctx.RequestAborted);
                 attached = true;
                 await WaitUntilClosedAsync(ws, ctx.RequestAborted);
+            }
+            catch (NotSupportedException ex) when (IsRemoteAudioTransportUnavailable(ex))
+            {
+                await TryCloseUnsupportedRemoteAudioAsync(ws);
             }
             catch (InvalidOperationException) when (!attached)
             {
@@ -186,6 +196,14 @@ public static class VoicePresenceEndpoints
                 ctx.Response.Headers.Location = ctx.Request.Path.ToString();
                 await ctx.Response.WriteAsync(transportSession.AnswerSdp);
             }
+            catch (NotSupportedException ex) when (IsRemoteAudioTransportUnavailable(ex))
+            {
+                if (!attached)
+                    await transportSession.Transport.DisposeAsync();
+
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await ctx.Response.WriteAsync(RemoteAudioTransportUnavailable);
+            }
             catch
             {
                 if (!attached)
@@ -262,6 +280,28 @@ public static class VoicePresenceEndpoints
             // best effort close after websocket upgrade
         }
     }
+
+    private static async Task TryCloseUnsupportedRemoteAudioAsync(WebSocket ws)
+    {
+        if (ws.State is not WebSocketState.Open and not WebSocketState.CloseReceived)
+            return;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await ws.CloseAsync(
+                WebSocketCloseStatus.PolicyViolation,
+                RemoteAudioTransportUnavailable,
+                cts.Token);
+        }
+        catch
+        {
+            // best effort close after websocket upgrade
+        }
+    }
+
+    private static bool IsRemoteAudioTransportUnavailable(NotSupportedException ex) =>
+        string.Equals(ex.Message, RemoteAudioTransportUnavailable, StringComparison.Ordinal);
 
     private static async Task WaitUntilClosedAsync(WebSocket ws, CancellationToken ct)
     {

--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs
@@ -63,9 +63,10 @@ internal static class VoicePresenceSessionDispatch
             case VoiceRemoteSessionCloseRequested closeRequested:
                 signal.RemoteSessionCloseRequested = closeRequested.Clone();
                 break;
-            case VoiceRemoteAudioInputReceived audioInput:
-                signal.RemoteAudioInputReceived = audioInput.Clone();
-                break;
+            // Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+            //   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+            //   New principle: direct host envelopes carry setup/control only.
+            //   Raw audio chunks must never be wrapped as VoiceModuleSignal payloads.
             case VoiceRemoteControlInputReceived controlInput:
                 signal.RemoteControlInputReceived = controlInput.Clone();
                 break;

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -20,6 +20,10 @@ namespace Aevatar.Foundation.VoicePresence.Modules;
 /// transports without entering the grain inbox or event pipeline. Only control events
 /// (state transitions, tool calls, drain ack) are dispatched as actor events.
 /// </summary>
+// Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+//   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+//   New principle: actor owns remote session identity and lifecycle.
+//   Remote audio chunks are ignored until a non-envelope raw media transport exists.
 public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IAudioFastPath, IRouteBypassModule
 {
     private static readonly JsonFormatter PayloadJsonFormatter = new(JsonFormatter.Settings.Default);
@@ -144,7 +148,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IAudioFast
                 await HandleRemoteSessionCloseRequestedAsync(signal.RemoteSessionCloseRequested, ctx, ct);
                 break;
             case VoiceModuleSignal.SignalOneofCase.RemoteAudioInputReceived:
-                await HandleRemoteAudioInputReceivedAsync(signal.RemoteAudioInputReceived, ct);
+                HandleRemoteAudioInputReceived(signal.RemoteAudioInputReceived);
                 break;
             case VoiceModuleSignal.SignalOneofCase.RemoteControlInputReceived:
                 await HandleRemoteControlInputReceivedAsync(signal.RemoteControlInputReceived, ct);
@@ -366,19 +370,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IAudioFast
                 await CloseRemoteSessionAsync("provider_disconnected", ctx, ct);
                 break;
             case VoiceProviderEvent.EventOneofCase.AudioReceived:
-                if (!string.IsNullOrWhiteSpace(_remoteSessionId))
-                {
-                    await PublishRemoteOutputAsync(
-                        new VoiceRemoteTransportOutput
-                        {
-                            ModuleName = Name,
-                            SessionId = _remoteSessionId,
-                            AudioOutput = providerEvent.AudioReceived.Clone(),
-                        },
-                        ctx,
-                        ct);
-                }
-
                 break;
             case VoiceProviderEvent.EventOneofCase.Error:
             case VoiceProviderEvent.EventOneofCase.None:
@@ -492,18 +483,13 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IAudioFast
             ct);
     }
 
-    private async Task HandleRemoteAudioInputReceivedAsync(
-        VoiceRemoteAudioInputReceived request,
-        CancellationToken ct)
+    // Refactor (iter15/cluster-025-voice-host-session-state-actorization):
+    //   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
+    //   New principle: remote setup/control may use envelopes; PCM chunks may not.
+    //   The actor keeps the stale proto arm inert for compatibility.
+    private void HandleRemoteAudioInputReceived(VoiceRemoteAudioInputReceived request)
     {
-        if (string.IsNullOrWhiteSpace(_remoteSessionId) ||
-            !string.Equals(_remoteSessionId, request.SessionId, StringComparison.Ordinal) ||
-            request.Pcm16.IsEmpty)
-        {
-            return;
-        }
-
-        await _provider.SendAudioAsync(request.Pcm16.Memory, ct);
+        _ = request;
     }
 
     private async Task HandleRemoteControlInputReceivedAsync(

--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -147,9 +147,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IAudioFast
             case VoiceModuleSignal.SignalOneofCase.RemoteSessionCloseRequested:
                 await HandleRemoteSessionCloseRequestedAsync(signal.RemoteSessionCloseRequested, ctx, ct);
                 break;
-            case VoiceModuleSignal.SignalOneofCase.RemoteAudioInputReceived:
-                HandleRemoteAudioInputReceived(signal.RemoteAudioInputReceived);
-                break;
             case VoiceModuleSignal.SignalOneofCase.RemoteControlInputReceived:
                 await HandleRemoteControlInputReceivedAsync(signal.RemoteControlInputReceived, ct);
                 break;
@@ -481,15 +478,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IAudioFast
             string.IsNullOrWhiteSpace(request.Reason) ? "remote_session_closed" : request.Reason,
             ctx,
             ct);
-    }
-
-    // Refactor (iter15/cluster-025-voice-host-session-state-actorization):
-    //   Old pattern: voice host resolver locks shared mutable lease state outside actor lifecycle
-    //   New principle: remote setup/control may use envelopes; PCM chunks may not.
-    //   The actor keeps the stale proto arm inert for compatibility.
-    private void HandleRemoteAudioInputReceived(VoiceRemoteAudioInputReceived request)
-    {
-        _ = request;
     }
 
     private async Task HandleRemoteControlInputReceivedAsync(

--- a/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
@@ -331,14 +331,10 @@ public class RemoteActorVoicePresenceSessionResolverTests
 
         public bool Disposed { get; private set; }
 
-        public TaskCompletionSource DisposedTask { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public List<byte[]> AudioFrames { get; } = [];
-
         public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
         {
             _ = ct;
-            AudioFrames.Add(pcm16.ToArray());
+            _ = pcm16;
             return Task.CompletedTask;
         }
 
@@ -363,7 +359,6 @@ public class RemoteActorVoicePresenceSessionResolverTests
         {
             Disposed = true;
             _frames.Writer.TryComplete();
-            DisposedTask.TrySetResult();
             return ValueTask.CompletedTask;
         }
     }
@@ -375,8 +370,6 @@ public class RemoteActorVoicePresenceSessionResolverTests
         public bool Disposed { get; private set; }
 
         public bool ReceiveStarted { get; private set; }
-
-        public TaskCompletionSource DisposedTask { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
         {
@@ -407,7 +400,6 @@ public class RemoteActorVoicePresenceSessionResolverTests
         public ValueTask DisposeAsync()
         {
             Disposed = true;
-            DisposedTask.TrySetResult();
             return ValueTask.CompletedTask;
         }
     }

--- a/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
@@ -14,6 +14,41 @@ namespace Aevatar.Foundation.VoicePresence.Tests;
 public class RemoteActorVoicePresenceSessionResolverTests
 {
     [Fact]
+    public void Remote_voice_host_bridge_sources_should_not_reintroduce_host_owned_attachment_state()
+    {
+        var resolverSource = File.ReadAllText(Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "src",
+            "Aevatar.Foundation.VoicePresence",
+            "Hosting",
+            "RemoteActorVoicePresenceSessionResolver.cs")));
+        var dispatchSource = File.ReadAllText(Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "..",
+            "src",
+            "Aevatar.Foundation.VoicePresence",
+            "Hosting",
+            "VoicePresenceSessionDispatch.cs")));
+
+        resolverSource.ShouldNotContain("IActorEventSubscriptionProvider");
+        resolverSource.ShouldNotContain("AttachmentState");
+        resolverSource.ShouldNotContain("_gate");
+        resolverSource.ShouldNotContain("_state");
+        resolverSource.ShouldNotContain("ReceiveFramesAsync");
+        resolverSource.ShouldNotContain("VoiceRemoteAudioInputReceived");
+        dispatchSource.ShouldNotContain("case VoiceRemoteAudioInputReceived");
+    }
+
+    [Fact]
     public async Task AttachTransportAsync_should_dispatch_open_then_close_and_fail_remote_audio_transport()
     {
         var runtime = new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1")));

--- a/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
@@ -1,7 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.VoicePresence;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Aevatar.Foundation.VoicePresence.Hosting;
@@ -15,12 +14,11 @@ namespace Aevatar.Foundation.VoicePresence.Tests;
 public class RemoteActorVoicePresenceSessionResolverTests
 {
     [Fact]
-    public async Task ResolveAsync_should_bridge_remote_voice_outputs_through_actor_stream()
+    public async Task AttachTransportAsync_should_dispatch_open_then_close_and_fail_remote_audio_transport()
     {
         var runtime = new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1")));
         var dispatchPort = new RecordingDispatchPort();
-        var subscriptions = new RecordingSubscriptionProvider();
-        using var services = BuildServices(runtime, dispatchPort, subscriptions);
+        using var services = BuildServices(runtime, dispatchPort);
         var resolver = new RemoteActorVoicePresenceSessionResolver(
             services,
         [
@@ -36,43 +34,23 @@ public class RemoteActorVoicePresenceSessionResolverTests
         session.PcmSampleRateHz.ShouldBe(16000);
 
         var transport = new HoldingVoiceTransport();
-        await session.AttachTransportAsync(transport, CancellationToken.None);
+        var ex = await Should.ThrowAsync<NotSupportedException>(
+            () => session.AttachTransportAsync(transport, CancellationToken.None));
 
-        dispatchPort.Dispatches.ShouldHaveSingleItem();
+        ex.Message.ShouldBe("remote_audio_transport_unavailable");
+        transport.Disposed.ShouldBeTrue();
+        session.IsTransportAttached.ShouldBeFalse();
+
+        dispatchPort.Dispatches.Count.ShouldBe(2);
         var openSignal = dispatchPort.Dispatches[0].Envelope.Payload!.Unpack<VoiceModuleSignal>();
         openSignal.ModuleName.ShouldBe("voice_presence_openai");
         openSignal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.RemoteSessionOpenRequested);
 
-        await subscriptions.PublishAsync(
-            "agent-1",
-            new VoiceRemoteTransportOutput
-            {
-                ModuleName = "voice_presence_openai",
-                SessionId = openSignal.RemoteSessionOpenRequested.SessionId,
-                AudioOutput = new VoiceAudioReceived
-                {
-                    Pcm16 = ByteString.CopyFrom([1, 2, 3]),
-                    SampleRateHz = 16000,
-                },
-            });
-
-        transport.AudioFrames.ShouldHaveSingleItem();
-        transport.AudioFrames[0].ShouldBe([1, 2, 3]);
-
-        await subscriptions.PublishAsync(
-            "agent-1",
-            new VoiceRemoteTransportOutput
-            {
-                ModuleName = "voice_presence_openai",
-                SessionId = openSignal.RemoteSessionOpenRequested.SessionId,
-                SessionClosed = new VoiceRemoteSessionClosed
-                {
-                    Reason = "provider_disconnected",
-                },
-            });
-
-        await transport.DisposedTask.Task;
-        transport.Disposed.ShouldBeTrue();
+        var closeSignal = dispatchPort.Dispatches[1].Envelope.Payload!.Unpack<VoiceModuleSignal>();
+        closeSignal.ModuleName.ShouldBe("voice_presence_openai");
+        closeSignal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.RemoteSessionCloseRequested);
+        closeSignal.RemoteSessionCloseRequested.SessionId.ShouldBe(openSignal.RemoteSessionOpenRequested.SessionId);
+        closeSignal.RemoteSessionCloseRequested.Reason.ShouldBe("remote_audio_transport_unavailable");
     }
 
     [Fact]
@@ -80,8 +58,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
     {
         var runtime = new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1")));
         var dispatchPort = new RecordingDispatchPort();
-        var subscriptions = new RecordingSubscriptionProvider();
-        using var services = BuildServices(runtime, dispatchPort, subscriptions);
+        using var services = BuildServices(runtime, dispatchPort);
         var resolver = new RemoteActorVoicePresenceSessionResolver(services);
 
         var session = await resolver.ResolveAsync(new VoicePresenceSessionRequest("agent-1", "voice_presence"));
@@ -109,8 +86,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
 
         using (var actorMissingServices = BuildServices(
                    new StubActorRuntime(actor: null),
-                   new RecordingDispatchPort(),
-                   new RecordingSubscriptionProvider()))
+                   new RecordingDispatchPort()))
         {
             var resolver = new RemoteActorVoicePresenceSessionResolver(actorMissingServices);
             var session = await resolver.ResolveAsync(new VoicePresenceSessionRequest("agent-1"));
@@ -119,8 +95,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
 
         using var services = BuildServices(
             new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1"))),
-            new RecordingDispatchPort(),
-            new RecordingSubscriptionProvider());
+            new RecordingDispatchPort());
         var unknownModuleResolver = new RemoteActorVoicePresenceSessionResolver(
             services,
         [
@@ -141,8 +116,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
     {
         using var services = BuildServices(
             new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1"))),
-            new RecordingDispatchPort(),
-            new RecordingSubscriptionProvider());
+            new RecordingDispatchPort());
 
         var noRegistrationResolver = new RemoteActorVoicePresenceSessionResolver(services);
         var explicitSession = await noRegistrationResolver.ResolveAsync(
@@ -164,12 +138,11 @@ public class RemoteActorVoicePresenceSessionResolverTests
     }
 
     [Fact]
-    public async Task AttachTransportAsync_should_relay_input_audio_and_control_frames_and_detach_on_completion()
+    public async Task AttachTransportAsync_should_never_dispatch_remote_audio_input_for_transport_frames()
     {
         var runtime = new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1")));
         var dispatchPort = new RecordingDispatchPort();
-        var subscriptions = new RecordingSubscriptionProvider();
-        using var services = BuildServices(runtime, dispatchPort, subscriptions);
+        using var services = BuildServices(runtime, dispatchPort);
         var resolver = new RemoteActorVoicePresenceSessionResolver(services);
         var session = await resolver.ResolveAsync(new VoicePresenceSessionRequest("agent-1", "voice_presence"));
 
@@ -188,105 +161,91 @@ public class RemoteActorVoicePresenceSessionResolverTests
             }),
         ]);
 
-        await session.AttachTransportAsync(transport, CancellationToken.None);
-        await transport.DisposedTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Should.ThrowAsync<NotSupportedException>(
+            () => session.AttachTransportAsync(transport, CancellationToken.None));
 
-        dispatchPort.Dispatches.Count.ShouldBeGreaterThanOrEqualTo(3);
         dispatchPort.Dispatches.ShouldContain(dispatch =>
             dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
             VoiceModuleSignal.SignalOneofCase.RemoteSessionOpenRequested);
-        dispatchPort.Dispatches.ShouldContain(dispatch =>
+        dispatchPort.Dispatches.ShouldNotContain(dispatch =>
             dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
             VoiceModuleSignal.SignalOneofCase.RemoteAudioInputReceived);
         dispatchPort.Dispatches.ShouldContain(dispatch =>
             dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
-            VoiceModuleSignal.SignalOneofCase.RemoteControlInputReceived);
-        dispatchPort.Dispatches.ShouldContain(dispatch =>
-            dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
             VoiceModuleSignal.SignalOneofCase.RemoteSessionCloseRequested);
+        transport.ReceiveStarted.ShouldBeFalse();
+        transport.Disposed.ShouldBeTrue();
     }
 
     [Fact]
-    public async Task DetachTransportAsync_should_ignore_mismatched_expected_transport()
+    public async Task AttachTransportAsync_should_allow_repeated_unsupported_attempts_without_host_attachment_state()
     {
         var runtime = new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1")));
         var dispatchPort = new RecordingDispatchPort();
-        var subscriptions = new RecordingSubscriptionProvider();
-        using var services = BuildServices(runtime, dispatchPort, subscriptions);
+        using var services = BuildServices(runtime, dispatchPort);
         var resolver = new RemoteActorVoicePresenceSessionResolver(services);
         var session = await resolver.ResolveAsync(new VoicePresenceSessionRequest("agent-1", "voice_presence"));
 
         session.ShouldNotBeNull();
-        var transport = new HoldingVoiceTransport();
-        await session.AttachTransportAsync(transport, CancellationToken.None);
+        await Should.ThrowAsync<NotSupportedException>(
+            () => session.AttachTransportAsync(new HoldingVoiceTransport(), CancellationToken.None));
+        await Should.ThrowAsync<NotSupportedException>(
+            () => session.AttachTransportAsync(new HoldingVoiceTransport(), CancellationToken.None));
 
-        await session.DetachTransportAsync(new StubVoiceTransport(), CancellationToken.None);
-
-        transport.Disposed.ShouldBeFalse();
-        session.IsTransportAttached.ShouldBeTrue();
-
-        await session.DetachTransportAsync(transport, CancellationToken.None);
-        await transport.DisposedTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        dispatchPort.Dispatches.Count(dispatch =>
+            dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
+            VoiceModuleSignal.SignalOneofCase.RemoteSessionOpenRequested).ShouldBe(2);
+        dispatchPort.Dispatches.Count(dispatch =>
+            dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
+            VoiceModuleSignal.SignalOneofCase.RemoteSessionCloseRequested).ShouldBe(2);
         session.IsTransportAttached.ShouldBeFalse();
     }
 
     [Fact]
-    public async Task Remote_output_send_failure_should_release_transport_and_issue_close()
+    public void BuildDirectEnvelope_should_reject_remote_audio_input_payloads()
     {
-        var runtime = new StubActorRuntime(new StubActor("agent-1", new PlainAgent("agent-1")));
-        var dispatchPort = new RecordingDispatchPort();
-        var subscriptions = new RecordingSubscriptionProvider();
-        using var services = BuildServices(runtime, dispatchPort, subscriptions);
-        var resolver = new RemoteActorVoicePresenceSessionResolver(services);
-        var session = await resolver.ResolveAsync(new VoicePresenceSessionRequest("agent-1", "voice_presence"));
-
-        session.ShouldNotBeNull();
-        var transport = new ThrowingSendVoiceTransport();
-        await session.AttachTransportAsync(transport, CancellationToken.None);
-
-        var openSignal = dispatchPort.Dispatches[0].Envelope.Payload!.Unpack<VoiceModuleSignal>();
-        await subscriptions.PublishAsync(
-            "agent-1",
-            new VoiceRemoteTransportOutput
-            {
-                ModuleName = "other_module",
-                SessionId = openSignal.RemoteSessionOpenRequested.SessionId,
-                AudioOutput = new VoiceAudioReceived
+        Should.Throw<InvalidOperationException>(() =>
+            VoicePresenceSessionDispatch.BuildDirectEnvelope(
+                "agent-1",
+                "voice_presence",
+                new VoiceRemoteAudioInputReceived
                 {
-                    Pcm16 = ByteString.CopyFrom([9]),
-                    SampleRateHz = 16000,
-                },
-            });
-        transport.Disposed.ShouldBeFalse();
+                    SessionId = "remote-1",
+                    Pcm16 = ByteString.CopyFrom([1, 2]),
+                }));
+    }
 
-        await subscriptions.PublishAsync(
+    [Fact]
+    public void BuildDirectEnvelope_should_keep_remote_control_payloads()
+    {
+        var envelope = VoicePresenceSessionDispatch.BuildDirectEnvelope(
             "agent-1",
-            new VoiceRemoteTransportOutput
+            "voice_presence",
+            new VoiceRemoteControlInputReceived
             {
-                ModuleName = "voice_presence",
-                SessionId = openSignal.RemoteSessionOpenRequested.SessionId,
-                AudioOutput = new VoiceAudioReceived
+                SessionId = "remote-1",
+                ControlFrame = new VoiceControlFrame
                 {
-                    Pcm16 = ByteString.CopyFrom([9]),
-                    SampleRateHz = 16000,
+                    DrainAcknowledged = new VoiceDrainAcknowledged
+                    {
+                        ResponseId = 1,
+                        PlayoutSequence = 2,
+                    },
                 },
             });
 
-        await transport.DisposedTask.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        dispatchPort.Dispatches.ShouldContain(dispatch =>
-            dispatch.Envelope.Payload!.Unpack<VoiceModuleSignal>().SignalCase ==
-            VoiceModuleSignal.SignalOneofCase.RemoteSessionCloseRequested);
+        var signal = envelope.Payload!.Unpack<VoiceModuleSignal>();
+        signal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.RemoteControlInputReceived);
+        signal.RemoteControlInputReceived.SessionId.ShouldBe("remote-1");
     }
 
     private static ServiceProvider BuildServices(
         IActorRuntime runtime,
-        IActorDispatchPort dispatchPort,
-        IActorEventSubscriptionProvider subscriptions)
+        IActorDispatchPort dispatchPort)
     {
         var services = new ServiceCollection();
         services.AddSingleton(runtime);
         services.AddSingleton(dispatchPort);
-        services.AddSingleton(subscriptions);
         return services.BuildServiceProvider();
     }
 
@@ -366,51 +325,6 @@ public class RemoteActorVoicePresenceSessionResolverTests
         }
     }
 
-    private sealed class RecordingSubscriptionProvider : IActorEventSubscriptionProvider
-    {
-        private readonly Dictionary<string, List<Func<VoiceRemoteTransportOutput, Task>>> _handlers = new(StringComparer.Ordinal);
-
-        public Task<IAsyncDisposable> SubscribeAsync<TMessage>(
-            string actorId,
-            Func<TMessage, Task> handler,
-            CancellationToken ct = default)
-            where TMessage : class, IMessage, new()
-        {
-            ct.ThrowIfCancellationRequested();
-            if (typeof(TMessage) != typeof(VoiceRemoteTransportOutput))
-                throw new NotSupportedException(typeof(TMessage).Name);
-
-            if (!_handlers.TryGetValue(actorId, out var handlers))
-            {
-                handlers = [];
-                _handlers[actorId] = handlers;
-            }
-
-            var typedHandler = (Func<VoiceRemoteTransportOutput, Task>)(object)handler;
-            handlers.Add(typedHandler);
-
-            return Task.FromResult<IAsyncDisposable>(new SubscriptionLease(() => handlers.Remove(typedHandler)));
-        }
-
-        public async Task PublishAsync(string actorId, VoiceRemoteTransportOutput output)
-        {
-            if (!_handlers.TryGetValue(actorId, out var handlers))
-                return;
-
-            foreach (var handler in handlers.ToArray())
-                await handler(output);
-        }
-
-        private sealed class SubscriptionLease(Action release) : IAsyncDisposable
-        {
-            public ValueTask DisposeAsync()
-            {
-                release();
-                return ValueTask.CompletedTask;
-            }
-        }
-    }
-
     private sealed class HoldingVoiceTransport : IVoiceTransport
     {
         private readonly Channel<VoiceTransportFrame> _frames = Channel.CreateUnbounded<VoiceTransportFrame>();
@@ -460,6 +374,8 @@ public class RemoteActorVoicePresenceSessionResolverTests
 
         public bool Disposed { get; private set; }
 
+        public bool ReceiveStarted { get; private set; }
+
         public TaskCompletionSource DisposedTask { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
@@ -479,6 +395,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
         public async IAsyncEnumerable<VoiceTransportFrame> ReceiveFramesAsync(
             [EnumeratorCancellation] CancellationToken ct)
         {
+            ReceiveStarted = true;
             foreach (var frame in _frames)
             {
                 ct.ThrowIfCancellationRequested();
@@ -490,74 +407,6 @@ public class RemoteActorVoicePresenceSessionResolverTests
         public ValueTask DisposeAsync()
         {
             Disposed = true;
-            DisposedTask.TrySetResult();
-            return ValueTask.CompletedTask;
-        }
-    }
-
-    private sealed class StubVoiceTransport : IVoiceTransport
-    {
-        public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
-        {
-            _ = pcm16;
-            _ = ct;
-            return Task.CompletedTask;
-        }
-
-        public Task SendControlAsync(VoiceControlFrame frame, CancellationToken ct)
-        {
-            _ = frame;
-            _ = ct;
-            return Task.CompletedTask;
-        }
-
-        public async IAsyncEnumerable<VoiceTransportFrame> ReceiveFramesAsync(
-            [EnumeratorCancellation] CancellationToken ct)
-        {
-            _ = ct;
-            await Task.CompletedTask;
-            yield break;
-        }
-
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-    }
-
-    private sealed class ThrowingSendVoiceTransport : IVoiceTransport
-    {
-        private readonly Channel<VoiceTransportFrame> _frames = Channel.CreateUnbounded<VoiceTransportFrame>();
-
-        public bool Disposed { get; private set; }
-
-        public TaskCompletionSource DisposedTask { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
-        {
-            _ = pcm16;
-            _ = ct;
-            throw new InvalidOperationException("boom");
-        }
-
-        public Task SendControlAsync(VoiceControlFrame frame, CancellationToken ct)
-        {
-            _ = frame;
-            _ = ct;
-            return Task.CompletedTask;
-        }
-
-        public async IAsyncEnumerable<VoiceTransportFrame> ReceiveFramesAsync(
-            [EnumeratorCancellation] CancellationToken ct)
-        {
-            while (await _frames.Reader.WaitToReadAsync(ct))
-            {
-                while (_frames.Reader.TryRead(out var frame))
-                    yield return frame;
-            }
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            Disposed = true;
-            _frames.Writer.TryComplete();
             DisposedTask.TrySetResult();
             return ValueTask.CompletedTask;
         }

--- a/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs
@@ -37,7 +37,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
         var ex = await Should.ThrowAsync<NotSupportedException>(
             () => session.AttachTransportAsync(transport, CancellationToken.None));
 
-        ex.Message.ShouldBe("remote_audio_transport_unavailable");
+        ex.Message.ShouldBe(VoiceRemoteAudioTransportUnavailableException.Reason);
         transport.Disposed.ShouldBeTrue();
         session.IsTransportAttached.ShouldBeFalse();
 
@@ -50,7 +50,7 @@ public class RemoteActorVoicePresenceSessionResolverTests
         closeSignal.ModuleName.ShouldBe("voice_presence_openai");
         closeSignal.SignalCase.ShouldBe(VoiceModuleSignal.SignalOneofCase.RemoteSessionCloseRequested);
         closeSignal.RemoteSessionCloseRequested.SessionId.ShouldBe(openSignal.RemoteSessionOpenRequested.SessionId);
-        closeSignal.RemoteSessionCloseRequested.Reason.ShouldBe("remote_audio_transport_unavailable");
+        closeSignal.RemoteSessionCloseRequested.Reason.ShouldBe(VoiceRemoteAudioTransportUnavailableException.Reason);
     }
 
     [Fact]

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
@@ -203,6 +203,29 @@ public class VoicePresenceEndpointsTests
     }
 
     [Fact]
+    public async Task Request_should_close_websocket_with_policy_violation_when_remote_audio_is_unavailable()
+    {
+        var socket = new RecordingCloseWebSocket(WebSocketState.Open);
+        var session = new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: static (_, _) => throw new VoiceRemoteAudioTransportUnavailableException(),
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000);
+        using var app = CreateApp((_, _) => Task.FromResult<VoicePresenceSession?>(session));
+        var context = CreateHttpContext(app);
+        context.Features.Set<IHttpWebSocketFeature>(new RecordingHttpWebSocketFeature(socket));
+        context.Request.RouteValues["actorId"] = "agent-1";
+
+        await GetVoiceEndpoint(app).RequestDelegate!(context);
+
+        socket.CloseCalls.ShouldBe(1);
+        socket.LastCloseStatus.ShouldBe(WebSocketCloseStatus.PolicyViolation);
+        socket.LastCloseDescription.ShouldBe(VoiceRemoteAudioTransportUnavailableException.Reason);
+        socket.State.ShouldBe(WebSocketState.Closed);
+    }
+
+    [Fact]
     public async Task Request_should_prefer_route_module_name_over_query()
     {
         var module = CreateModule(new RecordingVoiceProvider());
@@ -396,6 +419,99 @@ public class VoicePresenceEndpointsTests
             Requests.Add(request);
             RequestedActorIds.Add(request.ActorId);
             return Task.FromResult(session);
+        }
+    }
+
+    private sealed class RecordingCloseWebSocket : WebSocket
+    {
+        private WebSocketState _state;
+
+        public RecordingCloseWebSocket(WebSocketState state)
+        {
+            _state = state;
+        }
+
+        public int CloseCalls { get; private set; }
+
+        public WebSocketCloseStatus? LastCloseStatus { get; private set; }
+
+        public string? LastCloseDescription { get; private set; }
+
+        public override WebSocketCloseStatus? CloseStatus => LastCloseStatus;
+
+        public override string? CloseStatusDescription => LastCloseDescription;
+
+        public override WebSocketState State => _state;
+
+        public override string? SubProtocol => null;
+
+        public override void Abort()
+        {
+            _state = WebSocketState.Aborted;
+        }
+
+        public override Task CloseAsync(
+            WebSocketCloseStatus closeStatus,
+            string? statusDescription,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CloseCalls++;
+            LastCloseStatus = closeStatus;
+            LastCloseDescription = statusDescription;
+            _state = WebSocketState.Closed;
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(
+            WebSocketCloseStatus closeStatus,
+            string? statusDescription,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LastCloseStatus = closeStatus;
+            LastCloseDescription = statusDescription;
+            _state = WebSocketState.CloseSent;
+            return Task.CompletedTask;
+        }
+
+        public override void Dispose()
+        {
+            _state = WebSocketState.Closed;
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(
+            ArraySegment<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            _ = buffer;
+            cancellationToken.ThrowIfCancellationRequested();
+            _state = WebSocketState.CloseReceived;
+            return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true));
+        }
+
+        public override Task SendAsync(
+            ArraySegment<byte> buffer,
+            WebSocketMessageType messageType,
+            bool endOfMessage,
+            CancellationToken cancellationToken)
+        {
+            _ = buffer;
+            _ = messageType;
+            _ = endOfMessage;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingHttpWebSocketFeature(RecordingCloseWebSocket socket) : IHttpWebSocketFeature
+    {
+        public bool IsWebSocketRequest => true;
+
+        public Task<WebSocket> AcceptAsync(WebSocketAcceptContext context)
+        {
+            _ = context;
+            return Task.FromResult<WebSocket>(socket);
         }
     }
 }

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -334,7 +334,7 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
-    public async Task Remote_session_signals_should_forward_audio_and_publish_remote_outputs()
+    public async Task Remote_session_signals_should_keep_lifecycle_but_not_forward_audio_chunks()
     {
         var provider = new RecordingVoiceProvider();
         var module = CreateModule(provider);
@@ -350,6 +350,8 @@ public class VoicePresenceModuleTests
             },
         }), ctx, CancellationToken.None);
 
+        module.IsTransportAttached.ShouldBeFalse();
+
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
         {
             ModuleName = "voice_presence",
@@ -360,8 +362,7 @@ public class VoicePresenceModuleTests
             },
         }), ctx, CancellationToken.None);
 
-        provider.AudioFrames.ShouldHaveSingleItem();
-        provider.AudioFrames[0].ShouldBe([5, 6]);
+        provider.AudioFrames.ShouldBeEmpty();
 
         await module.HandleAsync(CreateEnvelope(new VoiceProviderEvent
         {
@@ -372,11 +373,7 @@ public class VoicePresenceModuleTests
             },
         }), ctx, CancellationToken.None);
 
-        ctx.PublishedEvents.ShouldHaveSingleItem();
-        var audioOutput = ctx.PublishedEvents[0];
-        audioOutput.ShouldBeOfType<VoiceRemoteTransportOutput>();
-        ((VoiceRemoteTransportOutput)audioOutput).SessionId.ShouldBe("remote-1");
-        ((VoiceRemoteTransportOutput)audioOutput).OutputCase.ShouldBe(VoiceRemoteTransportOutput.OutputOneofCase.AudioOutput);
+        ctx.PublishedEvents.ShouldBeEmpty();
 
         await module.HandleAsync(CreateEnvelope(new VoiceProviderEvent
         {
@@ -386,8 +383,8 @@ public class VoicePresenceModuleTests
             },
         }), ctx, CancellationToken.None);
 
-        ctx.PublishedEvents.Count.ShouldBe(2);
-        var closedOutput = ctx.PublishedEvents[1].ShouldBeOfType<VoiceRemoteTransportOutput>();
+        ctx.PublishedEvents.Count.ShouldBe(1);
+        var closedOutput = ctx.PublishedEvents[0].ShouldBeOfType<VoiceRemoteTransportOutput>();
         closedOutput.OutputCase.ShouldBe(VoiceRemoteTransportOutput.OutputOneofCase.SessionClosed);
         closedOutput.SessionClosed.Reason.ShouldBe("provider_disconnected");
     }
@@ -588,7 +585,7 @@ public class VoicePresenceModuleTests
     }
 
     [Fact]
-    public async Task Remote_session_inputs_and_close_should_ignore_mismatches_and_handle_matches()
+    public async Task Remote_session_inputs_and_close_should_ignore_audio_and_handle_control_and_close()
     {
         var provider = new RecordingVoiceProvider();
         var module = CreateModule(provider);
@@ -627,6 +624,12 @@ public class VoicePresenceModuleTests
         }), ctx, CancellationToken.None);
 
         provider.AudioFrames.ShouldBeEmpty();
+        module.StateMachine.LastDrainAckResponseId.ShouldBe(-1);
+
+        await module.HandleAsync(CreateEnvelope(new VoiceProviderEvent
+        {
+            ResponseStarted = new VoiceResponseStarted { ResponseId = 8 },
+        }), ctx, CancellationToken.None);
 
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
         {
@@ -643,7 +646,14 @@ public class VoicePresenceModuleTests
             RemoteControlInputReceived = new VoiceRemoteControlInputReceived
             {
                 SessionId = "remote-1",
-                ControlFrame = new VoiceControlFrame(),
+                ControlFrame = new VoiceControlFrame
+                {
+                    DrainAcknowledged = new VoiceDrainAcknowledged
+                    {
+                        ResponseId = 8,
+                        PlayoutSequence = 9,
+                    },
+                },
             },
         }), ctx, CancellationToken.None);
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
@@ -656,7 +666,8 @@ public class VoicePresenceModuleTests
             },
         }), ctx, CancellationToken.None);
 
-        provider.AudioFrames.ShouldHaveSingleItem();
+        provider.AudioFrames.ShouldBeEmpty();
+        module.StateMachine.LastDrainAckResponseId.ShouldBe(8);
         ctx.PublishedEvents.ShouldBeEmpty();
 
         await module.HandleAsync(CreateEnvelope(new VoiceModuleSignal

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWhipEndpointsTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWhipEndpointsTests.cs
@@ -224,6 +224,28 @@ public class VoicePresenceWhipEndpointsTests
     }
 
     [Fact]
+    public async Task Post_should_return_service_unavailable_and_dispose_transport_when_remote_audio_is_unavailable()
+    {
+        var transport = new StubVoiceTransport();
+        var factory = new FakeWebRtcVoiceTransportFactory(new WebRtcVoiceTransportSession(transport, "answer", Task.CompletedTask));
+        var session = new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: static (_, _) => throw new VoiceRemoteAudioTransportUnavailableException(),
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000);
+        using var app = CreateApp((_, _) => Task.FromResult<VoicePresenceSession?>(session), factory);
+        var context = CreateContext(app, HttpMethods.Post, "v=0\r\noffer");
+        context.Request.RouteValues["actorId"] = "agent-1";
+
+        await GetWhipEndpoint(app, HttpMethods.Post).RequestDelegate!(context);
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status503ServiceUnavailable);
+        (await ReadBodyAsync(context)).ShouldBe(VoiceRemoteAudioTransportUnavailableException.Reason);
+        transport.Disposed.ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task Delete_should_reject_missing_actor_id()
     {
         using var app = CreateApp(static (_, _) => Task.FromResult<VoicePresenceSession?>(null));


### PR DESCRIPTION
## Summary / 摘要

### English

iter15 cluster-025-voice-host-session-state-actorization (severity:medium, rule_ids: AG-ACTOR-LIFECYCLE-01).

- **Old**: voice host resolver `RemoteActorVoicePresenceSessionResolver` locks shared mutable lease state (`_gate`, `_state`, `AttachmentState`) outside actor lifecycle, and relays PCM audio chunks through `EventEnvelope` (`VoiceRemoteAudioInputReceived` / `VoiceRemoteTransportOutput.AudioOutput`).
- **New**: actor owns remote session id and lease via existing `VoicePresenceModule` open/close handlers + `EventEnvelope` at function-call boundary only. Host-side lease state collapsed. Remote audio chunk envelope relay disabled until raw media transport exists; attach fails with `remote_audio_transport_unavailable`.

Violated: CLAUDE.md "## Actor 执行模型" — "回调只发信号" + "业务推进内聚"; also AGENTS architecture "no chunk-data through EventEnvelope" (per Phase 9 #701 unanimous consensus).

### 中文

iter15 cluster-025-voice-host-session-state-actorization(严重度:medium,规则 ID:AG-ACTOR-LIFECYCLE-01)。

- **Old**: 语音 host resolver `RemoteActorVoicePresenceSessionResolver` 在 actor 生命周期外用 `_gate`/`_state`/`AttachmentState` 锁定可变 lease 状态;并把 PCM 音频 chunk 通过 `EventEnvelope` (`VoiceRemoteAudioInputReceived` / `VoiceRemoteTransportOutput.AudioOutput`) 中继。
- **New**: actor 通过现有 `VoicePresenceModule` 的 open/close handler + 仅在 function-call 边界使用的 `EventEnvelope` 持有 remote session id 与 lease。host 侧 lease 状态被合并。remote 音频 chunk envelope 中继被禁用,直到 raw media transport 出现;attach 以 `remote_audio_transport_unavailable` 失败。

违反:CLAUDE.md "## Actor 执行模型" — "回调只发信号" + "业务推进内聚";同时违反 AGENTS 架构 "chunk 数据不走 EventEnvelope"(按 Phase 9 #701 3/3 unanimous 共识)。

## Scope / 范围

7 files changed, +172 / -440 (net -268).
- `src/Aevatar.Foundation.VoicePresence/Hosting/RemoteActorVoicePresenceSessionResolver.cs`
- `src/Aevatar.Foundation.VoicePresence/Hosting/CompositeVoicePresenceSessionResolver.cs`
- `src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs`
- `src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceSessionDispatch.cs`
- `src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs`
- `test/Aevatar.Foundation.VoicePresence.Tests/RemoteActorVoicePresenceSessionResolverTests.cs`
- `test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs`

Validation: build pass; `Aevatar.Foundation.VoicePresence.Tests` 118/118 pass; `architecture_guards.sh` + `test_stability_guards.sh` pass.

No new actor type / envelope kind / pipeline phase / core abstraction. No proto removal in this patch (compatibility surface preserved). No external repo changes.

## Phase 9 design source

Closes #681 after merge. Built on Phase 9 #701 round 5 consensus (architect+tests+quality solvers all `propose:A`). See implement summary in `.refactor-loop/runs/implement-cluster-025-voice-host-session-state-actorization.md`.

🤖 Auto-loop / codex-refactor-loop iter15 (Phase 9 consensus → implement)
