### PR TITLE
Issue #695: Ingress v1 Phase 4 — policy-aware /ws/voice + dev bypass /ws/voice/{actorId}

### DIFF
--- a/aevatar.slnx
+++ b/aevatar.slnx
@@ -160,6 +160,7 @@
     <Project Path="test/Aevatar.Interop.A2A.Tests/Aevatar.Interop.A2A.Tests.csproj" />
     <Project Path="test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj" />
     <Project Path="test/Aevatar.ChatRouting.Core.Tests/Aevatar.ChatRouting.Core.Tests.csproj" />
+    <Project Path="test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj" />
     <Project Path="test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Core.Tests\Aevatar.AI.Core.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Tests\Aevatar.AI.Tests.csproj" />

--- a/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
+++ b/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Aevatar.Hosting.Tests" />
+    <InternalsVisibleTo Include="Aevatar.ChatRouting.Voice.Integration.Tests" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aevatar.Bootstrap\Aevatar.Bootstrap.csproj" />

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -27,8 +27,10 @@ using Aevatar.GAgents.Platform.Telegram;
 using Aevatar.GAgents.Scheduled;
 using Aevatar.GAgents.StreamingProxy;
 using Aevatar.Foundation.Runtime.Hosting.Maintenance;
+using Aevatar.Foundation.VoicePresence.Hosting;
 using Aevatar.Mainnet.Host.Api.Messages;
 using Aevatar.Mainnet.Host.Api.Responses;
+using Aevatar.Mainnet.Host.Api.Voice;
 using Aevatar.Studio.Hosting;
 using Aevatar.Workflow.Extensions.Hosting;
 using Microsoft.AspNetCore.Builder;
@@ -98,6 +100,18 @@ public static class MainnetHostBuilderExtensions
         // a later phase.
         builder.Services.AddChatRoutingAgents();
         builder.Services.AddChatRoutingCore();
+        // Implement (issue #695):
+        //   Behavior: gate explicit /ws/voice/{actorId} bypass behind voice:bypass or admin.
+        //   Why this shape: policy-aware /ws/voice owns normal routing; actor-id bypass stays dev/admin only.
+        builder.Services.AddAuthorization(options =>
+        {
+            options.AddPolicy("voice-dev", policy =>
+            {
+                policy.RequireAuthenticatedUser();
+                policy.RequireAssertion(context =>
+                    PolicyAwareVoiceEndpoints.IsVoiceDevBypassPrincipal(context.User));
+            });
+        });
         builder.Services.TryAddSingleton<IResponsesCallerScopeResolver, NyxIdResponsesCallerScopeResolver>();
         builder.Services.TryAddSingleton<IResponsesModelsAggregator, NyxIdResponsesModelsAggregator>();
         builder.Services.TryAddSingleton<IResponsesRouteResolver, CachingResponsesRouteResolver>();
@@ -190,6 +204,9 @@ public static class MainnetHostBuilderExtensions
         app.MapChannelCallbackEndpoints();
         app.MapDeviceEventEndpoints();
         app.MapIdentityOAuthEndpoints();
+        app.MapPolicyAwareVoiceEndpoint();
+        app.MapVoicePresenceWebSocket("/ws/voice/{actorId}")
+            .RequireAuthorization("voice-dev");
 
         return app;
     }

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -112,7 +112,11 @@ public static class PolicyAwareVoiceEndpoints
 
         if (!session.IsInitialized)
         {
-            http.Response.StatusCode = StatusCodes.Status404NotFound;
+            // 503 (not 404) so clients treat the routed target as cold, not
+            // missing, and retry. Matches the dev bypass at
+            // VoicePresenceEndpoints.MapVoicePresenceWebSocket so /ws/voice
+            // behaves identically while the GAgent's voice module warms up.
+            http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             await http.Response.WriteAsync("Voice module not initialized.", http.RequestAborted);
             return;
         }

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -1,0 +1,338 @@
+using System.Net.WebSockets;
+using System.Security.Claims;
+using Aevatar.Authentication.Abstractions;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
+using Aevatar.Foundation.VoicePresence.Hosting;
+using Aevatar.Foundation.VoicePresence.Transport;
+using Aevatar.GAgents.Scheduled;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using ScheduledOwnerScope = Aevatar.GAgents.Scheduled.OwnerScope;
+using RoutingOwnerScope = Aevatar.ChatRouting.Core.OwnerScope;
+
+namespace Aevatar.Mainnet.Host.Api.Voice;
+
+public static class PolicyAwareVoiceEndpoints
+{
+    private const string DefaultPattern = "/ws/voice";
+    private const string ScopeClaimType = "scope";
+    private static readonly string[] RoleClaimTypes =
+    [
+        "scope_role",
+        "scope.role",
+        "role",
+        ClaimTypes.Role,
+    ];
+
+    private static readonly HashSet<string> AdminRoleValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "admin",
+        "owner",
+        "scope-admin",
+        "scope_admin",
+    };
+
+    public static IEndpointConventionBuilder MapPolicyAwareVoiceEndpoint(this IEndpointRouteBuilder app) =>
+        app.Map(DefaultPattern, HandlePolicyAwareVoiceAsync);
+
+    // Implement (issue #695):
+    //   Behavior: resolve /ws/voice target through ChatRoutePolicy before WebSocket upgrade.
+    //   Why this shape: the host boundary composes routing, authorization, and voice attach without
+    //   pulling ChatRouting back into Foundation.VoicePresence.
+    private static async Task HandlePolicyAwareVoiceAsync(HttpContext http)
+    {
+        if (!http.WebSockets.IsWebSocketRequest)
+        {
+            http.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await http.Response.WriteAsync("WebSocket required.", http.RequestAborted);
+            return;
+        }
+
+        if (!TryBuildCallerScope(http, out var routingScope, out var scheduledScope, out var channel, out var failure))
+        {
+            http.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await http.Response.WriteAsync(failure, http.RequestAborted);
+            return;
+        }
+
+        var routeInput = BuildRouteInput(http, routingScope, channel);
+        var queryPort = http.RequestServices.GetRequiredService<IChatRoutePolicyQueryPort>();
+        var resolver = http.RequestServices.GetRequiredService<ChatRouteResolver>();
+        var snapshot = await queryPort.LookupForCallerAsync(routingScope, http.RequestAborted);
+        var decision = resolver.Resolve(snapshot, routeInput);
+
+        var action = decision.Action;
+        switch (action.ActionCase)
+        {
+            case ChatRouteAction.ActionOneofCase.Reject:
+                http.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await http.Response.WriteAsync(action.Reject?.Reason ?? "Voice route rejected.", http.RequestAborted);
+                return;
+            case ChatRouteAction.ActionOneofCase.ForwardToModel:
+                http.Response.StatusCode = StatusCodes.Status501NotImplemented;
+                await http.Response.WriteAsync("Voice ForwardToModel is not supported in v1.", http.RequestAborted);
+                return;
+            case ChatRouteAction.ActionOneofCase.ForwardToGagent:
+                break;
+            default:
+                http.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await http.Response.WriteAsync("Voice route did not resolve to a GAgent target.", http.RequestAborted);
+                return;
+        }
+
+        var actorId = action.ForwardToGagent.ActorId?.Trim();
+        if (string.IsNullOrWhiteSpace(actorId))
+        {
+            http.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await http.Response.WriteAsync("Voice route target actor is empty.", http.RequestAborted);
+            return;
+        }
+
+        if (!await CanAttachAsync(http, actorId, scheduledScope, http.RequestAborted))
+        {
+            http.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await http.Response.WriteAsync("Caller is not allowed to attach to this voice target.", http.RequestAborted);
+            return;
+        }
+
+        var sessionResolver = http.RequestServices.GetRequiredService<IVoicePresenceSessionResolver>();
+        var moduleName = FirstNonEmpty(action.ForwardToGagent.VoiceModuleName, routeInput.Voice?.VoiceModuleName);
+        var session = await sessionResolver.ResolveAsync(
+            new VoicePresenceSessionRequest(actorId, moduleName),
+            http.RequestAborted);
+        if (session is null)
+        {
+            http.Response.StatusCode = StatusCodes.Status404NotFound;
+            await http.Response.WriteAsync("Voice session not found for this agent.", http.RequestAborted);
+            return;
+        }
+
+        if (!session.IsInitialized)
+        {
+            http.Response.StatusCode = StatusCodes.Status404NotFound;
+            await http.Response.WriteAsync("Voice module not initialized.", http.RequestAborted);
+            return;
+        }
+
+        if (session.IsTransportAttached)
+        {
+            http.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await http.Response.WriteAsync("Voice transport already attached.", http.RequestAborted);
+            return;
+        }
+
+        var ws = await http.WebSockets.AcceptWebSocketAsync();
+        var transport = new WebSocketVoiceTransport(ws);
+        var attached = false;
+        try
+        {
+            await session.AttachTransportAsync(transport, http.RequestAborted);
+            attached = true;
+            await WaitUntilClosedAsync(ws, http.RequestAborted);
+        }
+        catch when (!attached)
+        {
+            await TryClosePolicyViolationAsync(ws);
+        }
+        finally
+        {
+            if (attached)
+                await session.DetachTransportAsync(transport, http.RequestAborted);
+        }
+    }
+
+    private static ChatRouteInput BuildRouteInput(
+        HttpContext http,
+        RoutingOwnerScope callerScope,
+        string channel)
+    {
+        var voice = new VoiceInput
+        {
+            Codec = ParseEnum(http.Request.Query["codec"].ToString(), VoiceCodec.Pcm16),
+            SampleRateHz = ParseInt(http.Request.Query["sample_rate_hz"].ToString()),
+            Mode = ParseEnum(http.Request.Query["mode"].ToString(), VoiceConversationMode.Unspecified),
+            VadMode = ParseEnum(http.Request.Query["vad_mode"].ToString(), VadMode.Unspecified),
+            VoiceModuleName = NormalizeOptional(http.Request.Query["voice_module_name"].ToString())
+                              ?? NormalizeOptional(http.Request.Query["module"].ToString())
+                              ?? string.Empty,
+        };
+
+        return new ChatRouteInput
+        {
+            SourceKind = ChatSourceKind.Voice,
+            CallerScope = new ChatRouteCallerScope
+            {
+                NyxUserId = callerScope.NyxUserId,
+                Platform = callerScope.Platform,
+                RegistrationScopeId = callerScope.RegistrationScopeId,
+                SenderId = callerScope.SenderId,
+            },
+            Channel = channel,
+            CommandName = string.Empty,
+            ContentHint = string.Empty,
+            ToolMode = ToolMode.None,
+            Voice = voice,
+        };
+    }
+
+    private static bool TryBuildCallerScope(
+        HttpContext http,
+        out RoutingOwnerScope routingScope,
+        out ScheduledOwnerScope scheduledScope,
+        out string channel,
+        out string failure)
+    {
+        var nyxUserId = FirstNonEmpty(
+            http.User.FindFirst(AevatarStandardClaimTypes.ScopeId)?.Value,
+            http.User.FindFirst("uid")?.Value,
+            http.User.FindFirst("sub")?.Value,
+            http.User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+
+        channel = NormalizeOptional(http.Request.Query["channel"].ToString()) ?? RoutingOwnerScope.NyxIdPlatform;
+        if (string.IsNullOrWhiteSpace(nyxUserId))
+        {
+            routingScope = new RoutingOwnerScope();
+            scheduledScope = new ScheduledOwnerScope();
+            failure = "Authenticated caller scope is missing.";
+            return false;
+        }
+
+        if (IsNativeChannel(channel))
+        {
+            routingScope = RoutingOwnerScope.ForNyxIdNative(nyxUserId);
+            scheduledScope = ScheduledOwnerScope.ForNyxIdNative(nyxUserId);
+            channel = string.Empty;
+            failure = string.Empty;
+            return true;
+        }
+
+        var registrationScopeId = FirstNonEmpty(
+            http.Request.Query["registration_scope_id"].ToString(),
+            http.User.FindFirst("registration_scope_id")?.Value,
+            http.User.FindFirst(AevatarStandardClaimTypes.ScopeId)?.Value);
+        var senderId = FirstNonEmpty(
+            http.Request.Query["sender_id"].ToString(),
+            http.User.FindFirst("sender_id")?.Value);
+
+        routingScope = RoutingOwnerScope.ForChannel(nyxUserId, channel, registrationScopeId ?? string.Empty, senderId ?? string.Empty);
+        scheduledScope = ScheduledOwnerScope.ForChannel(nyxUserId, channel, registrationScopeId ?? string.Empty, senderId ?? string.Empty);
+        failure = string.Empty;
+        return true;
+    }
+
+    private static bool IsNativeChannel(string channel) =>
+        string.IsNullOrWhiteSpace(channel) ||
+        string.Equals(channel, "nyxid", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(channel, "cli", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(channel, "web", StringComparison.OrdinalIgnoreCase);
+
+    private static async Task<bool> CanAttachAsync(
+        HttpContext http,
+        string actorId,
+        ScheduledOwnerScope callerScope,
+        CancellationToken ct)
+    {
+        if (IsVoiceDevBypassPrincipal(http.User))
+            return true;
+
+        var catalog = http.RequestServices.GetRequiredService<IUserAgentCatalogQueryPort>();
+        return await catalog.GetForCallerAsync(actorId, callerScope, ct) is not null;
+    }
+
+    internal static bool IsVoiceDevBypassPrincipal(ClaimsPrincipal user) =>
+        HasScope(user, "voice:bypass") || HasAdminRole(user);
+
+    private static bool HasScope(ClaimsPrincipal user, string scope) =>
+        user.Claims
+            .Where(static claim => string.Equals(claim.Type, ScopeClaimType, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(static claim => (claim.Value ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Any(value => string.Equals(value, scope, StringComparison.Ordinal));
+
+    private static bool HasAdminRole(ClaimsPrincipal user) =>
+        user.Claims.Any(static claim =>
+            RoleClaimTypes.Contains(claim.Type, StringComparer.OrdinalIgnoreCase) &&
+            AdminRoleValues.Contains(claim.Value?.Trim() ?? string.Empty));
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            var normalized = NormalizeOptional(value);
+            if (normalized is not null)
+                return normalized;
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static int ParseInt(string value) =>
+        int.TryParse(value, out var parsed) && parsed > 0 ? parsed : 0;
+
+    private static TEnum ParseEnum<TEnum>(string value, TEnum fallback)
+        where TEnum : struct, Enum
+    {
+        var normalized = NormalizeOptional(value);
+        if (normalized is null)
+            return fallback;
+
+        if (Enum.TryParse<TEnum>(normalized, ignoreCase: true, out var parsed))
+            return parsed;
+
+        var candidate = NormalizeEnumToken(normalized);
+        foreach (var enumValue in Enum.GetValues<TEnum>())
+        {
+            var enumToken = NormalizeEnumToken(enumValue.ToString());
+            if (string.Equals(candidate, enumToken, StringComparison.Ordinal) ||
+                candidate.EndsWith(enumToken, StringComparison.Ordinal))
+                return enumValue;
+        }
+
+        return fallback;
+    }
+
+    private static string NormalizeEnumToken(string value) =>
+        new(value
+            .Where(static ch => char.IsLetterOrDigit(ch))
+            .Select(static ch => char.ToLowerInvariant(ch))
+            .ToArray());
+
+    private static async Task WaitUntilClosedAsync(WebSocket ws, CancellationToken ct)
+    {
+        try
+        {
+            while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+                await Task.Delay(500, ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static async Task TryClosePolicyViolationAsync(WebSocket ws)
+    {
+        if (ws.State is not WebSocketState.Open and not WebSocketState.CloseReceived)
+            return;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await ws.CloseAsync(
+                WebSocketCloseStatus.PolicyViolation,
+                "Voice session policy violation.",
+                cts.Token);
+        }
+        catch
+        {
+            // best effort close after websocket upgrade
+        }
+    }
+}

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Aevatar.ChatRouting.Voice.Integration.Tests</AssemblyName>
+    <RootNamespace>Aevatar.ChatRouting.Voice.Integration.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.Mainnet.Host.Api\Aevatar.Mainnet.Host.Api.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.VoicePresence\Aevatar.Foundation.VoicePresence.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+</Project>

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -1,0 +1,441 @@
+using System.Net;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
+using Aevatar.Foundation.VoicePresence;
+using Aevatar.Foundation.VoicePresence.Hosting;
+using Aevatar.Foundation.VoicePresence.Transport;
+using Aevatar.Mainnet.Host.Api.Voice;
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+using RoutingOwnerScope = Aevatar.ChatRouting.Core.OwnerScope;
+using ScheduledOwnerScope = Aevatar.GAgents.Scheduled.OwnerScope;
+
+namespace Aevatar.ChatRouting.Voice.Integration.Tests;
+
+public sealed class PolicyAwareVoiceEndpointsTests
+{
+    [Fact]
+    public async Task PolicyAwareVoice_DefaultRoute_ShouldAttachDefaultVoiceTarget()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(
+            ForwardToGAgent("voice-agent-default", "voice_presence_openai"),
+            []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-default"]);
+        var stateTransitions = new List<VoicePresenceState>();
+        var resolver = new RecordingVoiceSessionResolver(CreateSessionWithStateMachine(stateTransitions), stateTransitions);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice?codec=pcm16&sample_rate_hz=24000");
+        context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(new FakeWebSocket(WebSocketState.CloseReceived)));
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        policyPort.LastCallerScope!.NyxUserId.Should().Be("user-1");
+        resolver.Requests.Should().ContainSingle(request =>
+            request.ActorId == "voice-agent-default" &&
+            request.ModuleName == "voice_presence_openai");
+        catalog.Requests.Should().ContainSingle(request => request.AgentId == "voice-agent-default");
+        stateTransitions.Should().Equal(
+            VoicePresenceState.Idle,
+            VoicePresenceState.UserSpeaking,
+            VoicePresenceState.ResponseInProgress,
+            VoicePresenceState.AudioDraining);
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_VoiceLarkRule_ShouldRouteToRuleTarget()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(
+            ForwardToGAgent("voice-agent-default"),
+            [
+                new ChatRouteRule
+                {
+                    RuleId = "lark-voice",
+                    Priority = 10,
+                    Match = new ChatRouteMatch
+                    {
+                        SourceKind = ChatSourceKind.Voice,
+                        Channel = "lark",
+                    },
+                    Action = ForwardToGAgent("voice-agent-lark"),
+                },
+            ]));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent-lark"]);
+        var resolver = new RecordingVoiceSessionResolver(CreateInitializedSession());
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice?channel=lark&registration_scope_id=bot-1&sender_id=sender-1");
+        context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(new FakeWebSocket(WebSocketState.CloseReceived)));
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent-lark");
+    }
+
+    [Fact]
+    public async Task BypassVoiceEndpoint_WithoutDevScope_ShouldReturnUnauthorized()
+    {
+        await using var app = CreateBypassAuthApp();
+        await app.StartAsync();
+
+        var response = await app.GetTestClient().GetAsync("/ws/voice/agent-1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await app.StopAsync();
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_WhenCallerCannotAttach_ShouldRejectBeforeUpgrade()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("other-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: []);
+        var resolver = new RecordingVoiceSessionResolver(CreateInitializedSession());
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        wsFeature.AcceptCalls.Should().Be(0);
+        resolver.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_WhenSessionMissing_ShouldReturnNotFoundBeforeUpgrade()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = new RecordingVoiceSessionResolver(session: null);
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        wsFeature.AcceptCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_WhenAttachFailsAfterUpgrade_ShouldCloseWithPolicyViolation()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = new RecordingVoiceSessionResolver(new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: static (_, _) => throw new InvalidOperationException("boom"),
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000));
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(socket));
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        socket.CloseCalls.Should().ContainSingle(call => call.Status == WebSocketCloseStatus.PolicyViolation);
+    }
+
+    private static ChatRouteAction ForwardToGAgent(string actorId, string voiceModuleName = "") =>
+        new()
+        {
+            ForwardToGagent = new ForwardToGAgent
+            {
+                ActorId = actorId,
+                VoiceModuleName = voiceModuleName,
+            },
+        };
+
+    private static WebApplication CreatePolicyAwareApp(
+        StaticPolicyPort policyPort,
+        RecordingCatalogQueryPort catalog,
+        RecordingVoiceSessionResolver resolver)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+        builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(policyPort);
+        builder.Services.AddSingleton(new ChatRouteResolver(new StaticFallbackProvider("fallback-model")));
+        builder.Services.AddSingleton<IUserAgentCatalogQueryPort>(catalog);
+        builder.Services.AddSingleton<IVoicePresenceSessionResolver>(resolver);
+        var app = builder.Build();
+        app.MapPolicyAwareVoiceEndpoint();
+        return app;
+    }
+
+    private static WebApplication CreateBypassAuthApp()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication(TestAuthHandler.AuthenticationScheme)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.AuthenticationScheme, _ => { });
+        builder.Services.AddAuthorization(options =>
+        {
+            options.AddPolicy("voice-dev", policy =>
+            {
+                policy.RequireAuthenticatedUser();
+                policy.RequireAssertion(context =>
+                    PolicyAwareVoiceEndpoints.IsVoiceDevBypassPrincipal(context.User));
+            });
+        });
+        builder.Services.AddSingleton<IVoicePresenceSessionResolver>(new RecordingVoiceSessionResolver(null));
+
+        var app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.MapVoicePresenceWebSocket("/ws/voice/{actorId}")
+            .RequireAuthorization("voice-dev");
+        return app;
+    }
+
+    private static DefaultHttpContext CreateVoiceContext(WebApplication app, string uri)
+    {
+        var parsed = new Uri("http://localhost" + uri);
+        var context = new DefaultHttpContext
+        {
+            RequestServices = app.Services,
+            Response =
+            {
+                Body = new MemoryStream(),
+            },
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim("scope_id", "user-1")],
+                authenticationType: "test")),
+        };
+        context.Request.Path = parsed.AbsolutePath;
+        context.Request.QueryString = new QueryString(parsed.Query);
+        return context;
+    }
+
+    private static RouteEndpoint GetEndpoint(WebApplication app, string pattern) =>
+        ((IEndpointRouteBuilder)app).DataSources
+            .SelectMany(static dataSource => dataSource.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => endpoint.RoutePattern.RawText == pattern);
+
+    private static VoicePresenceSession CreateInitializedSession() =>
+        new(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: static (_, _) => Task.CompletedTask,
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000);
+
+    private static VoicePresenceSession CreateSessionWithStateMachine(List<VoicePresenceState> transitions)
+    {
+        var stateMachine = new VoicePresenceStateMachine();
+        transitions.Add(stateMachine.State);
+        return new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: (_, _) =>
+            {
+                stateMachine.OnSpeechStarted();
+                transitions.Add(stateMachine.State);
+                stateMachine.OnResponseStarted(1);
+                transitions.Add(stateMachine.State);
+                stateMachine.OnResponseDone(1);
+                transitions.Add(stateMachine.State);
+                return Task.CompletedTask;
+            },
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000,
+            selfEventDispatcher: (_, _) => Task.CompletedTask,
+            module: null);
+    }
+
+    private sealed class StaticFallbackProvider(string modelName) : IChatRouteFallbackProvider
+    {
+        public ChatRouteDecision GetFallbackDecision() =>
+            new()
+            {
+                Action = new ChatRouteAction
+                {
+                    ForwardToModel = new ForwardToModel { ModelName = modelName },
+                },
+            };
+    }
+
+    private sealed class StaticPolicyPort(ChatRoutePolicySnapshot snapshot) : IChatRoutePolicyQueryPort
+    {
+        public RoutingOwnerScope? LastCallerScope { get; private set; }
+
+        public static StaticPolicyPort For(ChatRoutePolicySnapshot snapshot) => new(snapshot);
+
+        public Task<ChatRoutePolicySnapshot?> LookupForCallerAsync(RoutingOwnerScope callerScope, CancellationToken ct = default)
+        {
+            _ = ct;
+            LastCallerScope = callerScope;
+            return Task.FromResult<ChatRoutePolicySnapshot?>(snapshot);
+        }
+    }
+
+    private sealed class RecordingCatalogQueryPort : IUserAgentCatalogQueryPort
+    {
+        private readonly HashSet<string> _allowedActorIds;
+
+        public RecordingCatalogQueryPort(IEnumerable<string> allowedActorIds)
+        {
+            _allowedActorIds = allowedActorIds.ToHashSet(StringComparer.Ordinal);
+        }
+
+        public List<(string AgentId, ScheduledOwnerScope Caller)> Requests { get; } = [];
+
+        public Task<UserAgentCatalogReadModelEntry?> GetForCallerAsync(
+            string agentId,
+            ScheduledOwnerScope caller,
+            CancellationToken ct = default)
+        {
+            _ = ct;
+            Requests.Add((agentId, caller));
+            return Task.FromResult(_allowedActorIds.Contains(agentId)
+                ? new UserAgentCatalogReadModelEntry { AgentId = agentId, OwnerScope = caller.Clone() }
+                : null);
+        }
+
+        public Task<IReadOnlyList<UserAgentCatalogReadModelEntry>> QueryByCallerAsync(
+            ScheduledOwnerScope caller,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>([]);
+
+        public Task<long?> GetStateVersionForCallerAsync(
+            string agentId,
+            ScheduledOwnerScope caller,
+            CancellationToken ct = default) =>
+            Task.FromResult<long?>(null);
+    }
+
+    private sealed class RecordingVoiceSessionResolver(
+        VoicePresenceSession? session,
+        IReadOnlyList<VoicePresenceState>? stateTransitions = null)
+        : IVoicePresenceSessionResolver
+    {
+        public List<VoicePresenceSessionRequest> Requests { get; } = [];
+        public IReadOnlyList<VoicePresenceState> StateTransitions { get; } = stateTransitions ?? [];
+
+        public Task<VoicePresenceSession?> ResolveAsync(VoicePresenceSessionRequest request, CancellationToken ct = default)
+        {
+            _ = ct;
+            Requests.Add(request);
+            return Task.FromResult(session);
+        }
+    }
+
+    private sealed class FakeHttpWebSocketFeature(FakeWebSocket socket) : IHttpWebSocketFeature
+    {
+        public int AcceptCalls { get; private set; }
+        public bool IsWebSocketRequest => true;
+
+        public Task<WebSocket> AcceptAsync(WebSocketAcceptContext context)
+        {
+            _ = context;
+            AcceptCalls++;
+            return Task.FromResult<WebSocket>(socket);
+        }
+    }
+
+    private sealed class FakeWebSocket(WebSocketState state) : WebSocket
+    {
+        private WebSocketState _state = state;
+
+        public List<(WebSocketCloseStatus Status, string? Description)> CloseCalls { get; } = [];
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override WebSocketState State => _state;
+        public override string? SubProtocol => null;
+
+        public override void Abort() => _state = WebSocketState.Aborted;
+
+        public override Task CloseAsync(
+            WebSocketCloseStatus closeStatus,
+            string? statusDescription,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CloseCalls.Add((closeStatus, statusDescription));
+            _state = WebSocketState.Closed;
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(
+            WebSocketCloseStatus closeStatus,
+            string? statusDescription,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _state = WebSocketState.CloseSent;
+            return Task.CompletedTask;
+        }
+
+        public override void Dispose() => _state = WebSocketState.Closed;
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(
+            ArraySegment<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            _ = buffer;
+            cancellationToken.ThrowIfCancellationRequested();
+            _state = WebSocketState.CloseReceived;
+            return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true));
+        }
+
+        public override Task SendAsync(
+            ArraySegment<byte> buffer,
+            WebSocketMessageType messageType,
+            bool endOfMessage,
+            CancellationToken cancellationToken)
+        {
+            _ = buffer;
+            _ = messageType;
+            _ = endOfMessage;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string AuthenticationScheme = "Test";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            return Request.Headers.ContainsKey("x-test-auth")
+                ? Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(
+                    new ClaimsPrincipal(new ClaimsIdentity(
+                        [new Claim("scope", Request.Headers["x-test-auth"].ToString())],
+                        AuthenticationScheme)),
+                    AuthenticationScheme)))
+                : Task.FromResult(AuthenticateResult.NoResult());
+        }
+    }
+}

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -184,11 +184,14 @@ public sealed class PolicyAwareVoiceEndpointsTests
     }
 
     [Fact]
-    public async Task PolicyAwareVoice_WhenSessionIsNotInitialized_ShouldReturnNotFoundBeforeUpgrade()
+    public async Task PolicyAwareVoice_WhenSessionIsNotInitialized_ShouldReturnRetryableServiceUnavailableBeforeUpgrade()
     {
-        // Fix (review round 1, F3):
-        //   Reviewer found the voice-module-present-but-not-initialized 404 branch untested.
-        //   This asserts an uninitialized session returns HTTP 404 before WebSocket accept.
+        // Codex review (PR #709):
+        //   The routed GAgent exists but its voice module is still warming up.
+        //   Returning 404 made clients treat the policy target as permanently
+        //   absent. Match the dev bypass at VoicePresenceEndpoints.MapVoicePresenceWebSocket
+        //   and return 503 Service Unavailable so callers retry as the cold
+        //   actor finishes initializing.
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
         var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
         var resolver = new RecordingVoiceSessionResolver(new VoicePresenceSession(
@@ -205,7 +208,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
 
         await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
 
-        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
         wsFeature.AcceptCalls.Should().Be(0);
         resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent");
     }

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -120,6 +120,52 @@ public sealed class PolicyAwareVoiceEndpointsTests
     }
 
     [Fact]
+    public async Task PolicyAwareVoice_WhenPolicyForwardsToModel_ShouldReturnNotImplementedBeforeUpgrade()
+    {
+        // Fix (review round 1, F1):
+        //   Reviewer found no coverage for the v1 ForwardToModel boundary.
+        //   This asserts ForwardToModel returns HTTP 501 before accepting the WebSocket.
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToModel("realtime-model"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = new RecordingVoiceSessionResolver(CreateInitializedSession());
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status501NotImplemented);
+        wsFeature.AcceptCalls.Should().Be(0);
+        catalog.Requests.Should().BeEmpty();
+        resolver.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_WhenPolicyRejects_ShouldReturnForbiddenBeforeUpgrade()
+    {
+        // Fix (review round 1, F2):
+        //   Reviewer found no coverage for route-policy Reject decisions.
+        //   This asserts Reject returns HTTP 403 before attach checks or WebSocket accept.
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(Reject("voice denied"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = new RecordingVoiceSessionResolver(CreateInitializedSession());
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        wsFeature.AcceptCalls.Should().Be(0);
+        catalog.Requests.Should().BeEmpty();
+        resolver.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task PolicyAwareVoice_WhenSessionMissing_ShouldReturnNotFoundBeforeUpgrade()
     {
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
@@ -135,6 +181,33 @@ public sealed class PolicyAwareVoiceEndpointsTests
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
         wsFeature.AcceptCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_WhenSessionIsNotInitialized_ShouldReturnNotFoundBeforeUpgrade()
+    {
+        // Fix (review round 1, F3):
+        //   Reviewer found the voice-module-present-but-not-initialized 404 branch untested.
+        //   This asserts an uninitialized session returns HTTP 404 before WebSocket accept.
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = new RecordingVoiceSessionResolver(new VoicePresenceSession(
+            isInitialized: static () => false,
+            isTransportAttached: static () => false,
+            attachTransportAsync: static (_, _) => Task.CompletedTask,
+            detachTransportAsync: static (_, _) => Task.CompletedTask,
+            pcmSampleRateHz: 24000));
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await GetEndpoint(app, "/ws/voice").RequestDelegate!(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        wsFeature.AcceptCalls.Should().Be(0);
+        resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent");
     }
 
     [Fact]
@@ -166,6 +239,18 @@ public sealed class PolicyAwareVoiceEndpointsTests
                 ActorId = actorId,
                 VoiceModuleName = voiceModuleName,
             },
+        };
+
+    private static ChatRouteAction ForwardToModel(string modelName) =>
+        new()
+        {
+            ForwardToModel = new ForwardToModel { ModelName = modelName },
+        };
+
+    private static ChatRouteAction Reject(string reason) =>
+        new()
+        {
+            Reject = new Reject { Reason = reason },
         };
 
     private static WebApplication CreatePolicyAwareApp(


### PR DESCRIPTION
## Issue
Closes #695 — Ingress v1 · Phase 4 — policy-aware /ws/voice + dev bypass /ws/voice/{actorId}

## Implementation summary
See `.implement-loop/runs/implement-issue-695.md`.

- **`PolicyAwareVoiceEndpoints.MapPolicyAwareVoiceEndpoint`** — `/ws/voice` resolves its target through `IChatRoutePolicyQueryPort` + `ChatRouteResolver` with typed `VoiceInput`; before the WS upgrade: `Reject` → 403, `ForwardToModel` → 501 (v1 unsupported), `ForwardToGAgent` → attach-permission check (403) + `IVoicePresenceSessionResolver` (404). Post-upgrade failures close 1008.
- **First `MapVoicePresenceWebSocket` mount** on the Mainnet host: `/ws/voice/{actorId}` kept as dev/admin bypass behind the new `voice-dev` authorization policy (requires `voice:bypass` scope or admin).
- v1 boundary respected: `ForwardToGAgent` only; decision target must be a voice-enabled GAgent; no text downgrade.
- `Aevatar.Foundation.VoicePresence` keeps **zero** ChatRouting dependency (reverse-dep grep clean).

## Stacked-PR position
- Base: `feat/2026-05-19_ingress-phase3-text-entries` (Phase 3's branch — stacked PR)
- Head: `feat/2026-05-19_ingress-phase4-voice-ws`
- Auto-loop iteration: codex-implement-loop / milestone 20 (Ingress v1)

## Notes
- Local gate: `dotnet build aevatar.slnx` passed, `test_stability_guards.sh` passed, `Aevatar.ChatRouting.Voice.Integration.Tests` 6/6 green, Foundation reverse-dep grep clean. `architecture_guards.sh` clears every guard **except** the pre-existing playground asset drift guard, unrelated to this PR (zero frontend assets touched).

🤖 Generated by codex-implement-loop. Reviewer is a Claude subagent (see PR comments for round-N review reports).