### PR TITLE
Issue #696: Ingress v1 Phase 5 — docs + full guards (ingress layer v1 shipped)

### DIFF
--- a/docs/canon/architecture-vocabulary.md
+++ b/docs/canon/architecture-vocabulary.md
@@ -38,6 +38,7 @@ owner: eanzhao
 | ReadModel | Interface | ReadModel 是**查询副本**（actor-scoped current-state replica）。它的查询契约（IXxxQueryPort）才是 Interface / Seam。 |
 | Projection Pipeline | Adapter | Projection 是**物化机制**（committed event → readmodel），不是某个 seam 上的具体实现。"Projection 通道下的具体投影器"才类比 Adapter。 |
 | Service（如 `WriteService`、`QueryService`） | Module（无脑套用） | aevatar 的应用层契约必须承载业务语义、不是纯转发空壳；一个 "Service" 是不是 Module 取决于它的 Interface 是不是足够 deep。多数情况下，正确的形态是更窄的 `IXxxQueryPort` / `IActorDispatchPort`，而不是泛 `Service`。 |
+| Router | 新的转发 Actor / hot-path 调度中心 | 在 ingress 语境里，router = **config actor + boundary resolver**：`ChatRoutePolicyGAgent` 只作为 per-scope 配置权威持有策略，`ChatRouteResolver` 只在入口边界做无状态、瞬时决策；它不是新增 actor hop，也不持久化决策。见 [ADR-0024: Chat Route Policy — Config Actor + Boundary Resolver](../adr/0024-chat-route-policy.md)。 |
 
 ## 2. 关键原则（与 CLAUDE.md 已有规则的映射）
 


### PR DESCRIPTION
## Issue
Closes #696 — Ingress v1 · Phase 5 — docs + full guards + close #672 #674

**Ingress layer v1 shipped.** This PR is the top of the 6-PR stacked train (#699 → #703 → #704 → #705 → #709 → this).

## Implementation summary
See `.implement-loop/runs/implement-issue-696.md`.

- Adds the **"router = config actor + boundary resolver"** entry to `docs/canon/architecture-vocabulary.md`, citing [ADR-0024: Chat Route Policy](../adr/0024-chat-route-policy.md) — `ChatRoutePolicyGAgent` holds per-scope config, `ChatRouteResolver` is a stateless boundary decision; no new actor hop, no persisted decision.
- Full guard/test suite run and results recorded honestly in the implement summary.

## Stacked-PR position
- Base: `feat/2026-05-19_ingress-phase4-voice-ws` (Phase 4's branch — top of the stack)
- Head: `feat/2026-05-19_ingress-phase5-docs-guards`
- Auto-loop iteration: codex-implement-loop / milestone 20 (Ingress v1)

## Guard / test status
- `docs lint` (`tools/docs/lint.sh`) passed — 43 files, 0 errors.
- `architecture_guards.sh`: every guard passes **except** the pre-existing playground asset drift guard (`cli-app.js` vs `demo-app.js`) — unrelated, no frontend assets touched in this milestone.
- `dotnet test aevatar.slnx`: 6 observed failures, all pre-existing baseline (DI-registration / Ornn-`NyxIdApiClient` / workflow-coverage tests) — none touch ChatRouting; a 1-line docs diff cannot cause them. Per issue body, ~15 baseline failures are expected and excluded.

## Remaining milestone closeout (controller / human)
The codex-implement-loop never merges PRs, so the GitHub issue-lifecycle steps in the issue body are deferred to human merge time:
- Update #672 / #674 trivial-check tables; close #672, #674, and phase tracking issues #691–#696 once this stack lands.
- Update the project `MEMORY.md` ingress-v1 entry from "plan" to "shipped".

🤖 Generated by codex-implement-loop. Reviewer is a Claude subagent (see PR comments for round-N review reports).