### PR TITLE
refactor: cluster-035 projection live sink → explicit IAsyncDisposable lease

### DIFF
--- a/.refactor-loop/runs/fix-pr725-r2.md
+++ b/.refactor-loop/runs/fix-pr725-r2.md
@@ -1,0 +1,25 @@
+# fix PR #725 r2 - architect + tests reject
+
+## Evidence fixed
+- Removed the legacy production `BindLiveObservation(lease, sink, ...)` compatibility overloads from:
+  - `GAgentApprovalCommandTarget`
+  - `GAgentDraftRunCommandTarget`
+  - `WorkflowRunCommandTarget`
+- Updated direct test bindings to pass an explicit fake `IAsyncDisposable` live-sink lease.
+- Updated GAgent approval and draft-run projection fakes to return a non-null recording live-sink lease from `AttachLiveSinkAsync`.
+- Replaced stale `(projection lease, sink)` detach assertions with assertions that `DetachLiveSinkAsync` receives and disposes the same live-sink lease bound into the target.
+- Updated workflow projection fakes so detach semantics follow the new explicit live-sink lease instead of old projection-lease side state.
+- Updated GAgent projection DI tests to assert observed materializer wrapper registrations by inner projector type.
+
+## Verification
+- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo` - pass, 499 tests
+- `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo` - pass, 163 tests
+- `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "FullyQualifiedName~GAgentApprovalInteractionTests|FullyQualifiedName~GAgentDraftRunInteractionCoverageTests"` - pass, 28 tests
+- `bash tools/ci/test_stability_guards.sh` - pass
+- Static scan for `Task.Delay`, `[Skip]`, and `WaitUntilAsync` in touched test/application paths - no matches
+
+## Notes
+- The requested r2 review files were not present in this worktree under `.refactor-loop/runs/`; I read the full matching files from sibling checkout `../aevatar/.refactor-loop/runs/review-pr725-{architect,tests}-r2.md` and cross-checked the same evidence in PR #725 comments.
+
+## Status
+FIX_DONE:725:r2:pass

--- a/.refactor-loop/runs/test-add-cluster-035.md
+++ b/.refactor-loop/runs/test-add-cluster-035.md
@@ -1,0 +1,78 @@
+# test-add cluster-035
+
+## Summary
+
+Status: ok
+
+Cluster intent: replace process-local live-sink subscription registries with explicit caller-owned `IAsyncDisposable` leases.
+
+Changed test files:
+
+| File | Lines |
+|---|---:|
+| `test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs` | 250 |
+| `test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs` | 619 |
+| `test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs` | 761 |
+| `test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs` | 1486 |
+| `test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs` | 390 |
+
+Existing test file used for endpoint partial coverage:
+
+| File | Lines |
+|---|---:|
+| `test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs` | 5355 |
+
+## Coverage Mapping
+
+`{{uncovered_lines}}` was not expanded in the controller prompt, so line mapping below uses the Codecov file-level miss/partial list and the current source line ranges.
+
+| Uncovered file / range | Test coverage |
+|---|---|
+| `src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs:41-65` | Existing `EnsureAndAttachLeaseAsync_WhenAttachThrows_ShouldReleaseAndDisposeThenRethrow` covers release + sink disposal. `liveSinkLease != null` inside the catch is structurally unreachable for a normal throwing `await attachAsync(...)` assignment. |
+| `src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs:88-98` | `DetachReleaseAndDisposeAsync_WhenLeaseIsNull_ShouldSkipDetachAndReleaseButCloseSink`; `DetachReleaseAndDisposeAsync_WhenDetachThrows_ShouldStillReleaseCloseSinkAndRethrowDetachFailure`. |
+| `src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs:100-122` | `DetachReleaseAndDisposeAsync_ShouldRunCleanupSequence`; `DetachReleaseAndDisposeAsync_WhenDetachThrows_ShouldStillReleaseCloseSinkAndRethrowDetachFailure`. |
+| `src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs:124-144` | `DetachReleaseAndDisposeAsync_WhenSinkCompleteThrows_ShouldStillDisposeAndRethrowCompleteFailure`. |
+| `src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs:100-129` | `CleanupAfterDispatchFailureAsync_WhenOnlySinkIsBound_ShouldCompleteDisposeAndSkipProjectionDetach`; `CleanupAfterDispatchFailureAsync_WhenOnlyProjectionLeaseIsBound_ShouldReleaseLeaseAndSkipProjectionDetach`. |
+| `src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs:125-156` | `CommandTargetCleanup_WhenOnlySinkIsBound_ShouldCompleteDisposeAndClearInteractionSink`; `CommandTargetCleanup_WhenOnlyProjectionLeaseIsBound_ShouldReleaseLeaseWithoutDetach`. |
+| `src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTarget.cs:98-128` | `ScriptEvolutionCommandTarget_ReleaseAsync_WhenOnlyProjectionLeaseIsBound_ShouldReleaseWithoutDetach`. |
+| `src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTargetBinder.cs:35-54` | `ScriptEvolutionCommandTargetBinder_ShouldReturnProjectionDisabled_WhenActivationFails`. |
+| `src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs:113-121,156-164` | Existing `ScopeDraftRunEndpoint_ShouldReturnBadRequest_WhenEventFormatIsInvalid` and `ScopeDraftRunEndpoint_ShouldReturnBadRequest_WhenWorkflowYamlsAreMissing`. |
+| `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs:76-80` | `DetachLiveObservationAsync_WhenNoLiveSinkIsBound_ShouldNoopWithoutProjectionCalls`. |
+| `src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs:83-99` | `DetachLiveObservationAsync_WhenLiveSinkLeaseIsNull_ShouldDetachWithExplicitNullLease`. |
+
+All listed uncovered file areas have direct behavioral coverage or existing endpoint coverage. No `TEST_BLOCKED` items.
+
+## Verification
+
+Passed:
+
+```bash
+dotnet test test/Aevatar.CQRS.Core.Tests/Aevatar.CQRS.Core.Tests.csproj --nologo --filter "EventSinkProjectionLeaseOrchestratorTests"
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "GAgentApprovalInteractionTests|GAgentDraftRunInteractionCoverageTests"
+dotnet test test/Aevatar.Scripting.Core.Tests/Aevatar.Scripting.Core.Tests.csproj --nologo --filter "RuntimeScriptInfrastructurePortsTests"
+dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo --filter "WorkflowRunCommandTargetAndPolicyTests"
+```
+
+Passed with coverage collection:
+
+```bash
+dotnet test test/Aevatar.CQRS.Core.Tests/Aevatar.CQRS.Core.Tests.csproj --nologo --filter "EventSinkProjectionLeaseOrchestratorTests" --collect:"XPlat Code Coverage"
+dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "GAgentApprovalInteractionTests|GAgentDraftRunInteractionCoverageTests" --collect:"XPlat Code Coverage"
+dotnet test test/Aevatar.Scripting.Core.Tests/Aevatar.Scripting.Core.Tests.csproj --nologo --filter "RuntimeScriptInfrastructurePortsTests" --collect:"XPlat Code Coverage"
+dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo --filter "WorkflowRunCommandTargetAndPolicyTests" --collect:"XPlat Code Coverage"
+```
+
+Coverage artifacts:
+
+| Project | Cobertura XML |
+|---|---|
+| CQRS Core Tests | `test/Aevatar.CQRS.Core.Tests/TestResults/1fbe643c-f14d-42c0-b496-328fce01bd0e/coverage.cobertura.xml` |
+| GAgentService Tests | `test/Aevatar.GAgentService.Tests/TestResults/bbad77a7-1ebc-461a-a8ed-f610c72dfe7c/coverage.cobertura.xml` |
+| Scripting Core Tests | `test/Aevatar.Scripting.Core.Tests/TestResults/614f8d59-78b6-4496-b31e-8ebeedd5043f/coverage.cobertura.xml` |
+| Workflow Application Tests | `test/Aevatar.Workflow.Application.Tests/TestResults/e27d7db3-9869-4a93-9546-ea1ea5bce382/coverage.cobertura.xml` |
+
+Passed:
+
+```bash
+bash /Users/auric/aevatar/tools/ci/test_stability_guards.sh
+```

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs
@@ -34,11 +34,11 @@ internal static class NyxIdChatStreamingRunner
             await writer.WriteRunStartedAsync(actorId, ct);
 
             var eventChannel = new EventChannel<AGUIEvent>();
-            var projectionLease = await projectionPort.EnsureAndAttachAsync(
+            var attachment = await projectionPort.EnsureAndAttachLeaseAsync(
                 token => projectionPort.EnsureChatProjectionAsync(actorId, messageId, token),
                 eventChannel,
                 ct);
-            if (projectionLease == null)
+            if (attachment == null)
                 throw new InvalidOperationException("NyxID chat projection pipeline is unavailable.");
 
             // Refactor (iter1/cluster-004):
@@ -71,7 +71,8 @@ internal static class NyxIdChatStreamingRunner
             finally
             {
                 await projectionPort.DetachReleaseAndDisposeAsync(
-                    projectionLease,
+                    attachment.ProjectionLease,
+                    attachment.LiveSinkLease,
                     eventChannel,
                     null,
                     CancellationToken.None);

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -222,11 +222,11 @@ public static class StreamingProxyEndpoints
             var activityChannel = Channel.CreateUnbounded<StreamingProxyStreamSignal>();
             sessionId = request.SessionId ?? Guid.NewGuid().ToString("N");
             var eventChannel = new EventChannel<StreamingProxyRoomSessionEnvelope>();
-            var projectionLease = await roomSessionProjectionPort.EnsureAndAttachAsync(
+            var attachment = await roomSessionProjectionPort.EnsureAndAttachLeaseAsync(
                 token => roomSessionProjectionPort.EnsureChatProjectionAsync(actor.Id, sessionId, token),
                 eventChannel,
                 ct);
-            if (projectionLease == null)
+            if (attachment == null)
                 throw new InvalidOperationException("StreamingProxy room session projection pipeline is unavailable.");
 
             Task? pumpTask = null;
@@ -352,7 +352,8 @@ public static class StreamingProxyEndpoints
             finally
             {
                 await roomSessionProjectionPort.DetachReleaseAndDisposeAsync(
-                    projectionLease,
+                    attachment.ProjectionLease,
+                    attachment.LiveSinkLease,
                     eventChannel,
                     () =>
                     {
@@ -487,11 +488,11 @@ public static class StreamingProxyEndpoints
             await writer.StartAsync(ct);
             var sessionId = Guid.NewGuid().ToString("N");
             var eventChannel = new EventChannel<StreamingProxyRoomSessionEnvelope>();
-            var projectionLease = await roomSessionProjectionPort.EnsureAndAttachAsync(
+            var attachment = await roomSessionProjectionPort.EnsureAndAttachLeaseAsync(
                 token => roomSessionProjectionPort.EnsureSubscriptionProjectionAsync(actor.Id, sessionId, token),
                 eventChannel,
                 ct);
-            if (projectionLease == null)
+            if (attachment == null)
                 throw new InvalidOperationException("StreamingProxy room session projection pipeline is unavailable.");
 
             Task? pumpTask = null;
@@ -508,7 +509,8 @@ public static class StreamingProxyEndpoints
             finally
             {
                 await roomSessionProjectionPort.DetachReleaseAndDisposeAsync(
-                    projectionLease,
+                    attachment.ProjectionLease,
+                    attachment.LiveSinkLease,
                     eventChannel,
                     null,
                     CancellationToken.None);

--- a/src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs
+++ b/src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs
@@ -9,7 +9,25 @@ public static class EventSinkProjectionLeaseOrchestrator
 {
     public static async Task<TLease?> EnsureAndAttachAsync<TLease, TEvent>(
         Func<CancellationToken, Task<TLease?>> ensureAsync,
-        Func<TLease, IEventSink<TEvent>, CancellationToken, Task> attachAsync,
+        Func<TLease, IEventSink<TEvent>, CancellationToken, Task<IAsyncDisposable?>> attachAsync,
+        Func<TLease, CancellationToken, Task> releaseAsync,
+        IEventSink<TEvent> sink,
+        CancellationToken ct = default)
+        where TLease : class
+    {
+        var attachment = await EnsureAndAttachLeaseAsync(
+            ensureAsync,
+            attachAsync,
+            releaseAsync,
+            sink,
+            ct).ConfigureAwait(false);
+
+        return attachment?.ProjectionLease;
+    }
+
+    public static async Task<EventSinkProjectionAttachment<TLease>?> EnsureAndAttachLeaseAsync<TLease, TEvent>(
+        Func<CancellationToken, Task<TLease?>> ensureAsync,
+        Func<TLease, IEventSink<TEvent>, CancellationToken, Task<IAsyncDisposable?>> attachAsync,
         Func<TLease, CancellationToken, Task> releaseAsync,
         IEventSink<TEvent> sink,
         CancellationToken ct = default)
@@ -22,6 +40,7 @@ public static class EventSinkProjectionLeaseOrchestrator
         ct.ThrowIfCancellationRequested();
 
         TLease? lease = null;
+        IAsyncDisposable? liveSinkLease = null;
         try
         {
             lease = await ensureAsync(ct);
@@ -31,11 +50,23 @@ public static class EventSinkProjectionLeaseOrchestrator
                 return null;
             }
 
-            await attachAsync(lease, sink, ct);
-            return lease;
+            liveSinkLease = await attachAsync(lease, sink, ct);
+            return new EventSinkProjectionAttachment<TLease>(lease, liveSinkLease);
         }
         catch
         {
+            if (liveSinkLease != null)
+            {
+                try
+                {
+                    await liveSinkLease.DisposeAsync();
+                }
+                catch
+                {
+                    // Best effort cleanup path.
+                }
+            }
+
             if (lease != null)
             {
                 try
@@ -55,8 +86,9 @@ public static class EventSinkProjectionLeaseOrchestrator
 
     public static async Task DetachReleaseAndDisposeAsync<TLease, TEvent>(
         TLease? lease,
+        IAsyncDisposable? liveSinkLease,
         IEventSink<TEvent> sink,
-        Func<TLease, IEventSink<TEvent>, CancellationToken, Task> detachAsync,
+        Func<IAsyncDisposable?, CancellationToken, Task> detachAsync,
         Func<TLease, CancellationToken, Task> releaseAsync,
         Func<Task>? onDetachedAsync = null,
         CancellationToken ct = default)
@@ -73,7 +105,7 @@ public static class EventSinkProjectionLeaseOrchestrator
         {
             try
             {
-                await detachAsync(lease, sink, CancellationToken.None);
+                await detachAsync(liveSinkLease, CancellationToken.None);
             }
             catch (Exception ex)
             {

--- a/src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs
+++ b/src/Aevatar.CQRS.Core.Abstractions/Streaming/EventSinkProjectionLeaseOrchestrator.cs
@@ -7,24 +7,7 @@ namespace Aevatar.CQRS.Core.Abstractions.Streaming;
 /// </summary>
 public static class EventSinkProjectionLeaseOrchestrator
 {
-    public static async Task<TLease?> EnsureAndAttachAsync<TLease, TEvent>(
-        Func<CancellationToken, Task<TLease?>> ensureAsync,
-        Func<TLease, IEventSink<TEvent>, CancellationToken, Task<IAsyncDisposable?>> attachAsync,
-        Func<TLease, CancellationToken, Task> releaseAsync,
-        IEventSink<TEvent> sink,
-        CancellationToken ct = default)
-        where TLease : class
-    {
-        var attachment = await EnsureAndAttachLeaseAsync(
-            ensureAsync,
-            attachAsync,
-            releaseAsync,
-            sink,
-            ct).ConfigureAwait(false);
-
-        return attachment?.ProjectionLease;
-    }
-
+    // Refactor (iter17/cluster-035): Old pattern: helper returned only the projection lease and lost the live sink cleanup handle. New principle: attach returns the full attachment so callers own both lifecycle leases explicitly.
     public static async Task<EventSinkProjectionAttachment<TLease>?> EnsureAndAttachLeaseAsync<TLease, TEvent>(
         Func<CancellationToken, Task<TLease?>> ensureAsync,
         Func<TLease, IEventSink<TEvent>, CancellationToken, Task<IAsyncDisposable?>> attachAsync,
@@ -84,6 +67,7 @@ public static class EventSinkProjectionLeaseOrchestrator
         }
     }
 
+    // Refactor (iter17/cluster-035): Old pattern: detach found subscriptions through hidden process-local registries. New principle: callers pass the live sink lease returned by attach so cleanup is explicit and runtime-neutral.
     public static async Task DetachReleaseAndDisposeAsync<TLease, TEvent>(
         TLease? lease,
         IAsyncDisposable? liveSinkLease,

--- a/src/Aevatar.CQRS.Core.Abstractions/Streaming/IEventSinkProjectionLifecyclePort.cs
+++ b/src/Aevatar.CQRS.Core.Abstractions/Streaming/IEventSinkProjectionLifecyclePort.cs
@@ -7,11 +7,13 @@ public interface IEventSinkProjectionLifecyclePort<TLease, TEvent>
 {
     bool ProjectionEnabled { get; }
 
+    // Refactor (iter17/cluster-035): Old pattern: attach hid live sink subscriptions behind port-owned process registries. New principle: attach returns an explicit cleanup lease owned by the caller.
     Task<IAsyncDisposable?> AttachLiveSinkAsync(
         TLease lease,
         IEventSink<TEvent> sink,
         CancellationToken ct = default);
 
+    // Refactor (iter17/cluster-035): Old pattern: detach looked up subscriptions by projection lease and sink. New principle: detach consumes the exact live sink lease produced by attach.
     Task DetachLiveSinkAsync(
         IAsyncDisposable? liveSinkLease,
         CancellationToken ct = default);
@@ -26,25 +28,7 @@ public interface IEventSinkProjectionLifecyclePort<TLease, TEvent>
 /// </summary>
 public static class EventSinkProjectionLifecyclePortExtensions
 {
-    public static Task<TLease?> EnsureAndAttachAsync<TLease, TEvent>(
-        this IEventSinkProjectionLifecyclePort<TLease, TEvent> lifecyclePort,
-        Func<CancellationToken, Task<TLease?>> ensureAsync,
-        IEventSink<TEvent> sink,
-        CancellationToken ct = default)
-        where TLease : class
-    {
-        ArgumentNullException.ThrowIfNull(lifecyclePort);
-        ArgumentNullException.ThrowIfNull(ensureAsync);
-        ArgumentNullException.ThrowIfNull(sink);
-
-        return EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync(
-            ensureAsync,
-            (lease, eventSink, token) => lifecyclePort.AttachLiveSinkAsync(lease, eventSink, token),
-            (lease, token) => lifecyclePort.ReleaseActorProjectionAsync(lease, token),
-            sink,
-            ct);
-    }
-
+    // Refactor (iter17/cluster-035): Old pattern: extension returned only the actor projection lease and made live sink cleanup unreachable. New principle: extension returns the full attachment with both projection and live sink leases.
     public static Task<EventSinkProjectionAttachment<TLease>?> EnsureAndAttachLeaseAsync<TLease, TEvent>(
         this IEventSinkProjectionLifecyclePort<TLease, TEvent> lifecyclePort,
         Func<CancellationToken, Task<TLease?>> ensureAsync,
@@ -64,6 +48,7 @@ public static class EventSinkProjectionLifecyclePortExtensions
             ct);
     }
 
+    // Refactor (iter17/cluster-035): Old pattern: cleanup depended on hidden actorId-to-subscription lookup. New principle: cleanup is driven by the explicit live sink lease carried from attach.
     public static Task DetachReleaseAndDisposeAsync<TLease, TEvent>(
         this IEventSinkProjectionLifecyclePort<TLease, TEvent> lifecyclePort,
         TLease? lease,
@@ -87,6 +72,7 @@ public static class EventSinkProjectionLifecyclePortExtensions
     }
 }
 
+// Refactor (iter17/cluster-035): Old pattern: attach returned only a projection lease and discarded the live sink subscription lease. New principle: attachment carries every lifecycle handle required for deterministic detach.
 public sealed record EventSinkProjectionAttachment<TLease>(
     TLease ProjectionLease,
     IAsyncDisposable? LiveSinkLease);

--- a/src/Aevatar.CQRS.Core.Abstractions/Streaming/IEventSinkProjectionLifecyclePort.cs
+++ b/src/Aevatar.CQRS.Core.Abstractions/Streaming/IEventSinkProjectionLifecyclePort.cs
@@ -7,14 +7,13 @@ public interface IEventSinkProjectionLifecyclePort<TLease, TEvent>
 {
     bool ProjectionEnabled { get; }
 
-    Task AttachLiveSinkAsync(
+    Task<IAsyncDisposable?> AttachLiveSinkAsync(
         TLease lease,
         IEventSink<TEvent> sink,
         CancellationToken ct = default);
 
     Task DetachLiveSinkAsync(
-        TLease lease,
-        IEventSink<TEvent> sink,
+        IAsyncDisposable? liveSinkLease,
         CancellationToken ct = default);
 
     Task ReleaseActorProjectionAsync(
@@ -46,9 +45,29 @@ public static class EventSinkProjectionLifecyclePortExtensions
             ct);
     }
 
+    public static Task<EventSinkProjectionAttachment<TLease>?> EnsureAndAttachLeaseAsync<TLease, TEvent>(
+        this IEventSinkProjectionLifecyclePort<TLease, TEvent> lifecyclePort,
+        Func<CancellationToken, Task<TLease?>> ensureAsync,
+        IEventSink<TEvent> sink,
+        CancellationToken ct = default)
+        where TLease : class
+    {
+        ArgumentNullException.ThrowIfNull(lifecyclePort);
+        ArgumentNullException.ThrowIfNull(ensureAsync);
+        ArgumentNullException.ThrowIfNull(sink);
+
+        return EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync(
+            ensureAsync,
+            (lease, eventSink, token) => lifecyclePort.AttachLiveSinkAsync(lease, eventSink, token),
+            (lease, token) => lifecyclePort.ReleaseActorProjectionAsync(lease, token),
+            sink,
+            ct);
+    }
+
     public static Task DetachReleaseAndDisposeAsync<TLease, TEvent>(
         this IEventSinkProjectionLifecyclePort<TLease, TEvent> lifecyclePort,
         TLease? lease,
+        IAsyncDisposable? liveSinkLease,
         IEventSink<TEvent> sink,
         Func<Task>? onDetachedAsync = null,
         CancellationToken ct = default)
@@ -59,10 +78,15 @@ public static class EventSinkProjectionLifecyclePortExtensions
 
         return EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
             lease,
+            liveSinkLease,
             sink,
-            (runtimeLease, eventSink, token) => lifecyclePort.DetachLiveSinkAsync(runtimeLease, eventSink, token),
+            (subscriptionLease, token) => lifecyclePort.DetachLiveSinkAsync(subscriptionLease, token),
             (runtimeLease, token) => lifecyclePort.ReleaseActorProjectionAsync(runtimeLease, token),
             onDetachedAsync,
             ct);
     }
 }
+
+public sealed record EventSinkProjectionAttachment<TLease>(
+    TLease ProjectionLease,
+    IAsyncDisposable? LiveSinkLease);

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/EventSinkProjectionLifecyclePortBase.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/EventSinkProjectionLifecyclePortBase.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 
@@ -6,7 +5,6 @@ namespace Aevatar.CQRS.Projection.Core.Orchestration;
 
 /// <summary>
 /// Event-sink specialized lifecycle port base with runtime lease resolution hook.
-/// Sink subscriptions are process-local transient I/O handles (not business fact state).
 /// </summary>
 public abstract class EventSinkProjectionLifecyclePortBase<TLeaseContract, TRuntimeLease, TEvent>
     : IEventSinkProjectionLifecyclePort<TLeaseContract, TEvent>
@@ -18,10 +16,6 @@ public abstract class EventSinkProjectionLifecyclePortBase<TLeaseContract, TRunt
     private readonly IProjectionScopeActivationService<TRuntimeLease> _activationService;
     private readonly IProjectionScopeReleaseService<TRuntimeLease> _releaseService;
     private readonly IProjectionSessionEventHub<TEvent> _sessionEventHub;
-
-    // Keyed by object identity (ReferenceEqualityComparer) to avoid RuntimeHelpers.GetHashCode collisions.
-    private readonly ConcurrentDictionary<object, IAsyncDisposable> _sinkSubscriptions =
-        new(ReferenceEqualityComparer.Instance);
 
     protected EventSinkProjectionLifecyclePortBase(
         Func<bool> projectionEnabledAccessor,
@@ -47,7 +41,7 @@ public abstract class EventSinkProjectionLifecyclePortBase<TLeaseContract, TRunt
         return await _activationService.EnsureAsync(request, ct);
     }
 
-    public async Task AttachLiveSinkAsync(
+    public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
         TLeaseContract lease,
         IEventSink<TEvent> sink,
         CancellationToken ct = default)
@@ -57,7 +51,7 @@ public abstract class EventSinkProjectionLifecyclePortBase<TLeaseContract, TRunt
         ct.ThrowIfCancellationRequested();
 
         if (!ProjectionEnabled)
-            return;
+            return null;
 
         var runtimeLease = ResolveRuntimeLease(lease);
         if (runtimeLease is not IProjectionPortSessionLease portLease)
@@ -66,32 +60,22 @@ public abstract class EventSinkProjectionLifecyclePortBase<TLeaseContract, TRunt
                 $"Runtime lease `{runtimeLease.GetType().FullName}` must implement `{typeof(IProjectionPortSessionLease).FullName}`.");
         }
 
-        var subscription = await _sessionEventHub.SubscribeAsync(
+        // Refactor (iter17/cluster-035): Old: ConcurrentDictionary registry. New: explicit IAsyncDisposable lease per attach.
+        return await _sessionEventHub.SubscribeAsync(
             portLease.ScopeId,
             portLease.SessionId,
             evt => sink.PushAsync(evt, CancellationToken.None),
             ct).ConfigureAwait(false);
-
-        var previous = _sinkSubscriptions.TryGetValue(sink, out var existing) ? existing : null;
-        _sinkSubscriptions[sink] = subscription;
-        if (previous != null)
-            await previous.DisposeAsync().ConfigureAwait(false);
     }
 
     public async Task DetachLiveSinkAsync(
-        TLeaseContract lease,
-        IEventSink<TEvent> sink,
+        IAsyncDisposable? liveSinkLease,
         CancellationToken ct = default)
     {
-        ArgumentNullException.ThrowIfNull(lease);
-        ArgumentNullException.ThrowIfNull(sink);
         ct.ThrowIfCancellationRequested();
 
-        if (!ProjectionEnabled)
-            return;
-
-        if (_sinkSubscriptions.TryRemove(sink, out var subscription))
-            await subscription.DisposeAsync().ConfigureAwait(false);
+        if (liveSinkLease != null)
+            await liveSinkLease.DisposeAsync().ConfigureAwait(false);
     }
 
     public Task ReleaseActorProjectionAsync(

--- a/src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTarget.cs
+++ b/src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTarget.cs
@@ -39,13 +39,21 @@ public sealed class ScriptEvolutionCommandTarget
     public string TargetId => Actor.Id;
     public string SessionActorId => Actor.Id;
     public IScriptEvolutionProjectionLease? ProjectionLease { get; private set; }
+    public IAsyncDisposable? LiveSinkLease { get; private set; }
     public IEventSink<ScriptEvolutionSessionCompletedEvent>? LiveSink { get; private set; }
 
     public void BindLiveObservation(
         IScriptEvolutionProjectionLease lease,
+        IEventSink<ScriptEvolutionSessionCompletedEvent> sink) =>
+        BindLiveObservation(lease, null, sink);
+
+    public void BindLiveObservation(
+        IScriptEvolutionProjectionLease lease,
+        IAsyncDisposable? liveSinkLease,
         IEventSink<ScriptEvolutionSessionCompletedEvent> sink)
     {
         ProjectionLease = lease ?? throw new ArgumentNullException(nameof(lease));
+        LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
     }
 
@@ -78,6 +86,7 @@ public sealed class ScriptEvolutionCommandTarget
             {
                 await _projectionPort.DetachReleaseAndDisposeAsync(
                     ProjectionLease,
+                    LiveSinkLease,
                     LiveSink,
                     onDetachedAsync: null,
                     ct);
@@ -88,6 +97,7 @@ public sealed class ScriptEvolutionCommandTarget
             }
 
             ProjectionLease = null;
+            LiveSinkLease = null;
             LiveSink = null;
         }
         else
@@ -97,6 +107,7 @@ public sealed class ScriptEvolutionCommandTarget
                 try
                 {
                     await LiveSink.DisposeAsync();
+                    LiveSinkLease = null;
                 }
                 catch (Exception ex)
                 {
@@ -111,6 +122,7 @@ public sealed class ScriptEvolutionCommandTarget
                 try
                 {
                     await _projectionPort.ReleaseActorProjectionAsync(ProjectionLease, ct);
+                    LiveSinkLease = null;
                 }
                 catch (Exception ex)
                 {

--- a/src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTarget.cs
+++ b/src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTarget.cs
@@ -44,11 +44,6 @@ public sealed class ScriptEvolutionCommandTarget
 
     public void BindLiveObservation(
         IScriptEvolutionProjectionLease lease,
-        IEventSink<ScriptEvolutionSessionCompletedEvent> sink) =>
-        BindLiveObservation(lease, null, sink);
-
-    public void BindLiveObservation(
-        IScriptEvolutionProjectionLease lease,
         IAsyncDisposable? liveSinkLease,
         IEventSink<ScriptEvolutionSessionCompletedEvent> sink)
     {

--- a/src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTargetBinder.cs
+++ b/src/Aevatar.Scripting.Infrastructure/Ports/ScriptEvolutionCommandTargetBinder.cs
@@ -39,7 +39,7 @@ public sealed class ScriptEvolutionCommandTargetBinder
                     ScriptEvolutionStartError.ProjectionDisabled);
             }
 
-            var projectionLease = await _projectionPort.EnsureAndAttachAsync(
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
                 token => _projectionPort.EnsureActorProjectionAsync(
                     target.SessionActorId,
                     target.ProposalId,
@@ -47,14 +47,14 @@ public sealed class ScriptEvolutionCommandTargetBinder
                 sink,
                 ct);
 
-            if (projectionLease == null)
+            if (attachment == null)
             {
                 await sink.DisposeAsync();
                 return CommandTargetBindingResult<ScriptEvolutionStartError>.Failure(
                     ScriptEvolutionStartError.ProjectionDisabled);
             }
 
-            target.BindLiveObservation(projectionLease, sink);
+            target.BindLiveObservation(attachment.ProjectionLease, attachment.LiveSinkLease, sink);
             return CommandTargetBindingResult<ScriptEvolutionStartError>.Success();
         }
         catch

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs
@@ -46,12 +46,6 @@ internal sealed class GAgentApprovalCommandTarget
 
     public void BindLiveObservation(
         IGAgentDraftRunProjectionLease lease,
-        IEventSink<AGUIEvent> sink,
-        string sessionId) =>
-        BindLiveObservation(lease, null, sink, sessionId);
-
-    public void BindLiveObservation(
-        IGAgentDraftRunProjectionLease lease,
         IAsyncDisposable? liveSinkLease,
         IEventSink<AGUIEvent> sink,
         string sessionId)

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs
@@ -36,6 +36,7 @@ internal sealed class GAgentApprovalCommandTarget
     public string SessionId { get; private set; } = string.Empty;
     public IGAgentDraftRunProjectionLease? ProjectionLease { get; private set; }
     public IGAgentRunTerminalProjectionLease? TerminalProjectionLease { get; private set; }
+    public IAsyncDisposable? LiveSinkLease { get; private set; }
     public IEventSink<AGUIEvent>? LiveSink { get; private set; }
 
     public void BindTerminalProjection(IGAgentRunTerminalProjectionLease? lease)
@@ -46,9 +47,17 @@ internal sealed class GAgentApprovalCommandTarget
     public void BindLiveObservation(
         IGAgentDraftRunProjectionLease lease,
         IEventSink<AGUIEvent> sink,
+        string sessionId) =>
+        BindLiveObservation(lease, null, sink, sessionId);
+
+    public void BindLiveObservation(
+        IGAgentDraftRunProjectionLease lease,
+        IAsyncDisposable? liveSinkLease,
+        IEventSink<AGUIEvent> sink,
         string sessionId)
     {
         ProjectionLease = lease ?? throw new ArgumentNullException(nameof(lease));
+        LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
         SessionId = sessionId;
     }
@@ -81,10 +90,12 @@ internal sealed class GAgentApprovalCommandTarget
             {
                 await _projectionPort.DetachReleaseAndDisposeAsync(
                     projectionLease,
+                    LiveSinkLease,
                     sink,
                     null,
                     ct);
                 ProjectionLease = null;
+                LiveSinkLease = null;
                 LiveSink = null;
             }
             catch (Exception ex)
@@ -100,6 +111,7 @@ internal sealed class GAgentApprovalCommandTarget
                 {
                     sink.Complete();
                     await sink.DisposeAsync();
+                    LiveSinkLease = null;
                     LiveSink = null;
                 }
                 catch (Exception ex)
@@ -114,6 +126,7 @@ internal sealed class GAgentApprovalCommandTarget
                 {
                     await _projectionPort.ReleaseActorProjectionAsync(projectionLease, ct);
                     ProjectionLease = null;
+                    LiveSinkLease = null;
                 }
                 catch (Exception ex)
                 {
@@ -212,7 +225,7 @@ internal sealed class GAgentApprovalCommandTargetBinder
                 ct);
             target.BindTerminalProjection(terminalProjectionLease);
 
-            var projectionLease = await _projectionPort.EnsureAndAttachAsync(
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
                 token => _projectionPort.EnsureActorProjectionAsync(
                     target.ActorId,
                     context.CorrelationId,
@@ -220,7 +233,7 @@ internal sealed class GAgentApprovalCommandTargetBinder
                 sink,
                 ct);
 
-            if (projectionLease == null)
+            if (attachment == null)
             {
                 sink.Complete();
                 await sink.DisposeAsync();
@@ -228,7 +241,8 @@ internal sealed class GAgentApprovalCommandTargetBinder
             }
 
             target.BindLiveObservation(
-                projectionLease,
+                attachment.ProjectionLease,
+                attachment.LiveSinkLease,
                 sink,
                 command.SessionId?.Trim() ?? string.Empty);
             return CommandTargetBindingResult<GAgentApprovalStartError>.Success();

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
@@ -43,6 +43,7 @@ internal sealed class GAgentDraftRunCommandTarget
     public string SessionId { get; private set; } = string.Empty;
     public IGAgentDraftRunProjectionLease? ProjectionLease { get; private set; }
     public IGAgentRunTerminalProjectionLease? TerminalProjectionLease { get; private set; }
+    public IAsyncDisposable? LiveSinkLease { get; private set; }
     public IEventSink<AGUIEvent>? LiveSink { get; private set; }
     private IEventSink<AGUIEvent>? InteractionLiveSink { get; set; }
     public bool AwaitingApprovalTerminalFact { get; private set; }
@@ -55,9 +56,17 @@ internal sealed class GAgentDraftRunCommandTarget
     public void BindLiveObservation(
         IGAgentDraftRunProjectionLease lease,
         IEventSink<AGUIEvent> sink,
+        string sessionId) =>
+        BindLiveObservation(lease, null, sink, sessionId);
+
+    public void BindLiveObservation(
+        IGAgentDraftRunProjectionLease lease,
+        IAsyncDisposable? liveSinkLease,
+        IEventSink<AGUIEvent> sink,
         string sessionId)
     {
         ProjectionLease = lease ?? throw new ArgumentNullException(nameof(lease));
+        LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
         InteractionLiveSink = new ApprovalObservingEventSink(sink, MarkAwaitingApprovalTerminalFact);
         SessionId = sessionId;
@@ -105,10 +114,12 @@ internal sealed class GAgentDraftRunCommandTarget
             {
                 await _projectionPort.DetachReleaseAndDisposeAsync(
                     projectionLease,
+                    LiveSinkLease,
                     sink,
                     null,
                     ct);
                 ProjectionLease = null;
+                LiveSinkLease = null;
                 LiveSink = null;
                 InteractionLiveSink = null;
             }
@@ -125,6 +136,7 @@ internal sealed class GAgentDraftRunCommandTarget
                 {
                     sink.Complete();
                     await sink.DisposeAsync();
+                    LiveSinkLease = null;
                     LiveSink = null;
                     InteractionLiveSink = null;
                 }
@@ -140,6 +152,7 @@ internal sealed class GAgentDraftRunCommandTarget
                 {
                     await _projectionPort.ReleaseActorProjectionAsync(projectionLease, ct);
                     ProjectionLease = null;
+                    LiveSinkLease = null;
                     InteractionLiveSink = null;
                 }
                 catch (Exception ex)
@@ -314,7 +327,7 @@ internal sealed class GAgentDraftRunCommandTargetBinder
                 ct);
             target.BindTerminalProjection(terminalProjectionLease);
 
-            var projectionLease = await _projectionPort.EnsureAndAttachAsync(
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
                 token => _projectionPort.EnsureActorProjectionAsync(
                     target.ActorId,
                     context.CommandId,
@@ -322,7 +335,7 @@ internal sealed class GAgentDraftRunCommandTargetBinder
                 sink,
                 ct);
 
-            if (projectionLease == null)
+            if (attachment == null)
             {
                 sink.Complete();
                 await sink.DisposeAsync();
@@ -330,7 +343,8 @@ internal sealed class GAgentDraftRunCommandTargetBinder
             }
 
             target.BindLiveObservation(
-                projectionLease,
+                attachment.ProjectionLease,
+                attachment.LiveSinkLease,
                 sink,
                 ResolveSessionId(command, context));
             return CommandTargetBindingResult<GAgentDraftRunStartError>.Success();

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
@@ -55,12 +55,6 @@ internal sealed class GAgentDraftRunCommandTarget
 
     public void BindLiveObservation(
         IGAgentDraftRunProjectionLease lease,
-        IEventSink<AGUIEvent> sink,
-        string sessionId) =>
-        BindLiveObservation(lease, null, sink, sessionId);
-
-    public void BindLiveObservation(
-        IGAgentDraftRunProjectionLease lease,
         IAsyncDisposable? liveSinkLease,
         IEventSink<AGUIEvent> sink,
         string sessionId)

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1749,11 +1749,11 @@ public static class ScopeServiceEndpoints
         CopyHeaders(headers, chatRequest.Metadata);
         var inputPayload = Any.Pack(chatRequest);
         var eventChannel = new EventChannel<AGUIEvent>();
-        var projectionLease = await scriptServiceAguiProjectionPort.EnsureAndAttachAsync(
+        var attachment = await scriptServiceAguiProjectionPort.EnsureAndAttachLeaseAsync(
             token => scriptServiceAguiProjectionPort.EnsureRunProjectionAsync(actorId, runId, token),
             eventChannel,
             ct);
-        if (projectionLease == null)
+        if (attachment == null)
             throw new InvalidOperationException("Script execution projection pipeline is unavailable.");
 
         try
@@ -1804,7 +1804,8 @@ public static class ScopeServiceEndpoints
         finally
         {
             await scriptServiceAguiProjectionPort.DetachReleaseAndDisposeAsync(
-                projectionLease,
+                attachment.ProjectionLease,
+                attachment.LiveSinkLease,
                 eventChannel,
                 null,
                 CancellationToken.None);

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
@@ -47,14 +47,22 @@ internal sealed class WorkflowRunCommandTarget
     public string TargetId => Actor.Id;
     public string ActorId => Actor.Id;
     public IWorkflowExecutionProjectionLease? ProjectionLease { get; private set; }
+    public IAsyncDisposable? LiveSinkLease { get; private set; }
     public IEventSink<WorkflowRunEventEnvelope>? LiveSink { get; private set; }
     public bool DispatchFailureCleanupCompleted { get; private set; }
 
     public void BindLiveObservation(
         IWorkflowExecutionProjectionLease lease,
+        IEventSink<WorkflowRunEventEnvelope> sink) =>
+        BindLiveObservation(lease, null, sink);
+
+    public void BindLiveObservation(
+        IWorkflowExecutionProjectionLease lease,
+        IAsyncDisposable? liveSinkLease,
         IEventSink<WorkflowRunEventEnvelope> sink)
     {
         ProjectionLease = lease ?? throw new ArgumentNullException(nameof(lease));
+        LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
     }
 
@@ -85,7 +93,8 @@ internal sealed class WorkflowRunCommandTarget
         {
             try
             {
-                await _projectionPort.DetachLiveSinkAsync(ProjectionLease, sink, ct);
+                await _projectionPort.DetachLiveSinkAsync(LiveSinkLease, ct);
+                LiveSinkLease = null;
             }
             catch (Exception ex)
             {
@@ -128,6 +137,7 @@ internal sealed class WorkflowRunCommandTarget
     {
         Exception? firstException = null;
         var projectionLease = ProjectionLease;
+        var liveSinkLease = LiveSinkLease;
         var liveSink = LiveSink;
 
         if (projectionLease != null && liveSink != null)
@@ -136,10 +146,12 @@ internal sealed class WorkflowRunCommandTarget
             {
                 await _projectionPort.DetachReleaseAndDisposeAsync(
                     projectionLease,
+                    liveSinkLease,
                     liveSink,
                     onDetachedAsync,
                     ct);
                 ProjectionLease = null;
+                LiveSinkLease = null;
                 LiveSink = null;
             }
             catch (Exception ex)
@@ -154,6 +166,7 @@ internal sealed class WorkflowRunCommandTarget
                 try
                 {
                     await CompleteAndDisposeLiveSinkAsync(liveSink, ct);
+                    LiveSinkLease = null;
                     LiveSink = null;
                 }
                 catch (Exception ex)
@@ -168,6 +181,7 @@ internal sealed class WorkflowRunCommandTarget
                 {
                     await _projectionPort.ReleaseActorProjectionAsync(projectionLease, ct);
                     ProjectionLease = null;
+                    LiveSinkLease = null;
                 }
                 catch (Exception ex)
                 {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
@@ -53,11 +53,6 @@ internal sealed class WorkflowRunCommandTarget
 
     public void BindLiveObservation(
         IWorkflowExecutionProjectionLease lease,
-        IEventSink<WorkflowRunEventEnvelope> sink) =>
-        BindLiveObservation(lease, null, sink);
-
-    public void BindLiveObservation(
-        IWorkflowExecutionProjectionLease lease,
         IAsyncDisposable? liveSinkLease,
         IEventSink<WorkflowRunEventEnvelope> sink)
     {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetBinder.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetBinder.cs
@@ -38,7 +38,7 @@ internal sealed class WorkflowRunCommandTargetBinder
                     WorkflowChatRunStartError.ProjectionDisabled);
             }
 
-            var projectionLease = await _projectionPort.EnsureAndAttachAsync(
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
                 token => _projectionPort.EnsureActorProjectionAsync(
                     target.ActorId,
                     context.CommandId,
@@ -46,14 +46,14 @@ internal sealed class WorkflowRunCommandTargetBinder
                 sink,
                 ct);
 
-            if (projectionLease == null)
+            if (attachment == null)
             {
                 await target.RollbackCreatedActorsAsync(CancellationToken.None);
                 return CommandTargetBindingResult<WorkflowChatRunStartError>.Failure(
                     WorkflowChatRunStartError.ProjectionDisabled);
             }
 
-            target.BindLiveObservation(projectionLease, sink);
+            target.BindLiveObservation(attachment.ProjectionLease, attachment.LiveSinkLease, sink);
             return CommandTargetBindingResult<WorkflowChatRunStartError>.Success();
         }
         catch (Exception ex)

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -2255,7 +2255,7 @@ public class NyxIdChatEndpointsCoverageTests
             return _lease;
         }
 
-        public async Task AttachLiveSinkAsync(
+        public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
             INyxIdChatSessionProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default)
@@ -2263,15 +2263,14 @@ public class NyxIdChatEndpointsCoverageTests
             _ = lease;
             _sink = sink;
             await PublishBufferedMessagesAsync(ct);
+            return null;
         }
 
         public Task DetachLiveSinkAsync(
-            INyxIdChatSessionProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
-            _ = lease;
-            _ = sink;
+            _ = liveSinkLease;
             ct.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }
@@ -2342,15 +2341,14 @@ public class NyxIdChatEndpointsCoverageTests
             throw exception;
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             INyxIdChatSessionProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default) =>
-            Task.CompletedTask;
+            Task.FromResult<IAsyncDisposable?>(null);
 
         public Task DetachLiveSinkAsync(
-            INyxIdChatSessionProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>
             Task.CompletedTask;
 

--- a/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
@@ -30,7 +30,7 @@ public sealed class NyxIdChatProjectionSessionTests
         var sink = new RecordingEventSink();
 
         var lease = await port.EnsureChatProjectionAsync("chat-actor-1", "session-1", CancellationToken.None);
-        await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
         await hub.Handler!(new AGUIEvent
         {
             TextMessageContent = new Aevatar.Presentation.AGUI.TextMessageContentEvent
@@ -39,7 +39,7 @@ public sealed class NyxIdChatProjectionSessionTests
                 Delta = "hello",
             },
         });
-        await port.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        await port.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
         await port.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
 
         var request = activation.Requests.Should().ContainSingle().Subject;

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -1440,7 +1440,7 @@ public class StreamingProxyCoverageTests
             return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(_lease);
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IStreamingProxyRoomSessionProjectionLease lease,
             IEventSink<StreamingProxyRoomSessionEnvelope> sink,
             CancellationToken ct = default)
@@ -1449,16 +1449,14 @@ public class StreamingProxyCoverageTests
             _lease = lease;
             _sink = sink;
             Attached.TrySetResult(true);
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
 
         public Task DetachLiveSinkAsync(
-            IStreamingProxyRoomSessionProjectionLease lease,
-            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
-            _ = lease;
-            _ = sink;
+            _ = liveSinkLease;
             _ = ct;
             return Task.CompletedTask;
         }

--- a/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
@@ -4,6 +4,9 @@ using System.Runtime.CompilerServices;
 
 namespace Aevatar.CQRS.Core.Tests;
 
+// Test-add (test-coverage/cluster-035):
+//   Covers refactor-introduced behavior in EventSinkProjectionLeaseOrchestrator.cs:41-144.
+//   Cluster intent: live sink subscription handles are explicit caller-owned leases, not process registries.
 public sealed class EventSinkProjectionLeaseOrchestratorTests
 {
     [Fact]
@@ -106,17 +109,111 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
         sink.DisposeCalls.Should().Be(1);
     }
 
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenLeaseIsNull_ShouldSkipDetachAndReleaseButCloseSink()
+    {
+        var sink = new TrackingEventSink();
+        var detachCalls = 0;
+        var releaseCalls = 0;
+
+        await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync<TestLease, string>(
+            null,
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) =>
+            {
+                detachCalls++;
+                return Task.CompletedTask;
+            },
+            (_, _) =>
+            {
+                releaseCalls++;
+                return Task.CompletedTask;
+            },
+            ct: CancellationToken.None);
+
+        detachCalls.Should().Be(0);
+        releaseCalls.Should().Be(0);
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenDetachThrows_ShouldStillReleaseCloseSinkAndRethrowDetachFailure()
+    {
+        var sink = new TrackingEventSink();
+        var lease = new TestLease("lease-4");
+        var sequence = new List<string>();
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            lease,
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) =>
+            {
+                sequence.Add("detach");
+                throw new InvalidOperationException("detach failed");
+            },
+            (_, _) =>
+            {
+                sequence.Add("release");
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                sequence.Add("onDetached");
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("detach failed");
+        sequence.Should().Equal("detach", "onDetached", "release");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenSinkCompleteThrows_ShouldStillDisposeAndRethrowCompleteFailure()
+    {
+        var sink = new TrackingEventSink
+        {
+            CompleteException = new InvalidOperationException("complete failed"),
+        };
+        var lease = new TestLease("lease-5");
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            lease,
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            ct: CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("complete failed");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
     private sealed record TestLease(string Id);
 
     private sealed class TrackingAsyncDisposable : IAsyncDisposable
     {
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public int DisposeCalls { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCalls++;
+            return ValueTask.CompletedTask;
+        }
     }
 
     private sealed class TrackingEventSink : IEventSink<string>
     {
         public int CompleteCalls { get; private set; }
         public int DisposeCalls { get; private set; }
+        public Exception? CompleteException { get; init; }
 
         public void Push(string evt)
         {
@@ -133,6 +230,8 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
         public void Complete()
         {
             CompleteCalls++;
+            if (CompleteException != null)
+                throw CompleteException;
         }
 
         public async IAsyncEnumerable<string> ReadAllAsync([EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
@@ -13,6 +13,7 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
         var lease = new TestLease("lease-1");
         var attachCalls = 0;
 
+        var liveSinkLease = new TrackingAsyncDisposable();
         var resolved = await EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync<TestLease, string>(
             _ => Task.FromResult<TestLease?>(lease),
             (runtimeLease, eventSink, _) =>
@@ -20,7 +21,7 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
                 runtimeLease.Id.Should().Be("lease-1");
                 eventSink.Should().BeSameAs(sink);
                 attachCalls++;
-                return Task.CompletedTask;
+                return Task.FromResult<IAsyncDisposable?>(liveSinkLease);
             },
             (_, _) => Task.CompletedTask,
             sink,
@@ -38,7 +39,7 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
 
         var resolved = await EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync<TestLease, string>(
             _ => Task.FromResult<TestLease?>(null),
-            (_, _, _) => Task.CompletedTask,
+            (_, _, _) => Task.FromResult<IAsyncDisposable?>(null),
             (_, _) => Task.CompletedTask,
             sink,
             CancellationToken.None);
@@ -56,7 +57,7 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
 
         Func<Task> act = () => EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync<TestLease, string>(
             _ => Task.FromResult<TestLease?>(lease),
-            (_, _, _) => throw new InvalidOperationException("attach failed"),
+            (_, _, _) => Task.FromException<IAsyncDisposable?>(new InvalidOperationException("attach failed")),
             (_, _) =>
             {
                 releaseCalls++;
@@ -79,8 +80,9 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
 
         await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
             lease,
+            new TrackingAsyncDisposable(),
             sink,
-            (_, _, _) =>
+            (_, _) =>
             {
                 sequence.Add("detach");
                 return Task.CompletedTask;
@@ -103,6 +105,11 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
     }
 
     private sealed record TestLease(string Id);
+
+    private sealed class TrackingAsyncDisposable : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
 
     private sealed class TrackingEventSink : IEventSink<string>
     {

--- a/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
@@ -77,6 +77,75 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
     }
 
     [Fact]
+    public async Task EnsureAndAttachLeaseAsync_WhenEnsureThrows_ShouldDisposeSinkAndRethrow()
+    {
+        var sink = new TrackingEventSink();
+        var attachCalls = 0;
+        var releaseCalls = 0;
+
+        Func<Task> act = () => EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync<TestLease, string>(
+            _ => Task.FromException<TestLease?>(new InvalidOperationException("ensure failed")),
+            (_, _, _) =>
+            {
+                attachCalls++;
+                return Task.FromResult<IAsyncDisposable?>(null);
+            },
+            (_, _) =>
+            {
+                releaseCalls++;
+                return Task.CompletedTask;
+            },
+            sink,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("ensure failed");
+        attachCalls.Should().Be(0);
+        releaseCalls.Should().Be(0);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EnsureAndAttachLeaseAsync_WhenReleaseCleanupThrows_ShouldStillDisposeSinkAndRethrowAttachFailure()
+    {
+        var sink = new TrackingEventSink();
+        var lease = new TestLease("lease-cleanup");
+        var releaseCalls = 0;
+
+        Func<Task> act = () => EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync<TestLease, string>(
+            _ => Task.FromResult<TestLease?>(lease),
+            (_, _, _) => Task.FromException<IAsyncDisposable?>(new InvalidOperationException("attach failed")),
+            (_, _) =>
+            {
+                releaseCalls++;
+                throw new InvalidOperationException("release cleanup failed");
+            },
+            sink,
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("attach failed");
+        releaseCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task EnsureAndAttachLeaseAsync_WhenCanceledBeforeEnsure_ShouldThrowWithoutDisposingSink()
+    {
+        var sink = new TrackingEventSink();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        Func<Task> act = () => EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync<TestLease, string>(
+            _ => Task.FromResult<TestLease?>(new TestLease("lease-canceled")),
+            (_, _, _) => Task.FromResult<IAsyncDisposable?>(null),
+            (_, _) => Task.CompletedTask,
+            sink,
+            cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        sink.DisposeCalls.Should().Be(0);
+    }
+
+    [Fact]
     public async Task DetachReleaseAndDisposeAsync_ShouldRunCleanupSequence()
     {
         var sink = new TrackingEventSink();
@@ -139,6 +208,38 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
     }
 
     [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenLeaseIsNull_ShouldStillRunOnDetachedAndCloseSink()
+    {
+        var sink = new TrackingEventSink();
+        var sequence = new List<string>();
+
+        await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync<TestLease, string>(
+            null,
+            null,
+            sink,
+            (_, _) =>
+            {
+                sequence.Add("detach");
+                return Task.CompletedTask;
+            },
+            (_, _) =>
+            {
+                sequence.Add("release");
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                sequence.Add("onDetached");
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        sequence.Should().Equal("onDetached");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
     public async Task DetachReleaseAndDisposeAsync_WhenDetachThrows_ShouldStillReleaseCloseSinkAndRethrowDetachFailure()
     {
         var sink = new TrackingEventSink();
@@ -174,6 +275,77 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
     }
 
     [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenOnDetachedThrows_ShouldStillReleaseCloseSinkAndRethrowCallbackFailure()
+    {
+        var sink = new TrackingEventSink();
+        var lease = new TestLease("lease-on-detached");
+        var sequence = new List<string>();
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            lease,
+            null,
+            sink,
+            (liveSinkLease, _) =>
+            {
+                liveSinkLease.Should().BeNull();
+                sequence.Add("detach");
+                return Task.CompletedTask;
+            },
+            (_, _) =>
+            {
+                sequence.Add("release");
+                return Task.CompletedTask;
+            },
+            () =>
+            {
+                sequence.Add("onDetached");
+                throw new InvalidOperationException("on detached failed");
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("on detached failed");
+        sequence.Should().Equal("detach", "onDetached", "release");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenReleaseThrows_ShouldStillCloseSinkAndRethrowReleaseFailure()
+    {
+        var sink = new TrackingEventSink();
+        var lease = new TestLease("lease-release");
+        var sequence = new List<string>();
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            lease,
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) =>
+            {
+                sequence.Add("detach");
+                return Task.CompletedTask;
+            },
+            (_, _) =>
+            {
+                sequence.Add("release");
+                throw new InvalidOperationException("release failed");
+            },
+            () =>
+            {
+                sequence.Add("onDetached");
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("release failed");
+        sequence.Should().Equal("detach", "onDetached", "release");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
     public async Task DetachReleaseAndDisposeAsync_WhenSinkCompleteThrows_ShouldStillDisposeAndRethrowCompleteFailure()
     {
         var sink = new TrackingEventSink
@@ -196,6 +368,74 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
         sink.DisposeCalls.Should().Be(1);
     }
 
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenSinkDisposeThrows_ShouldRethrowDisposeFailure()
+    {
+        var sink = new TrackingEventSink
+        {
+            DisposeException = new InvalidOperationException("dispose failed"),
+        };
+        var lease = new TestLease("lease-dispose");
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            lease,
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            ct: CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("dispose failed");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenMultipleCleanupStepsThrow_ShouldRethrowFirstFailure()
+    {
+        var sink = new TrackingEventSink
+        {
+            CompleteException = new InvalidOperationException("complete failed"),
+            DisposeException = new InvalidOperationException("dispose failed"),
+        };
+        var lease = new TestLease("lease-first-failure");
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            lease,
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) => throw new InvalidOperationException("detach failed"),
+            (_, _) => throw new InvalidOperationException("release failed"),
+            () => throw new InvalidOperationException("on detached failed"),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("detach failed");
+        sink.CompleteCalls.Should().Be(1);
+        sink.DisposeCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DetachReleaseAndDisposeAsync_WhenCanceledBeforeDetach_ShouldThrowWithoutClosingSink()
+    {
+        var sink = new TrackingEventSink();
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = async () => await EventSinkProjectionLeaseOrchestrator.DetachReleaseAndDisposeAsync(
+            new TestLease("lease-canceled"),
+            new TrackingAsyncDisposable(),
+            sink,
+            (_, _) => Task.CompletedTask,
+            (_, _) => Task.CompletedTask,
+            ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        sink.CompleteCalls.Should().Be(0);
+        sink.DisposeCalls.Should().Be(0);
+    }
+
     private sealed record TestLease(string Id);
 
     private sealed class TrackingAsyncDisposable : IAsyncDisposable
@@ -214,6 +454,7 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
         public int CompleteCalls { get; private set; }
         public int DisposeCalls { get; private set; }
         public Exception? CompleteException { get; init; }
+        public Exception? DisposeException { get; init; }
 
         public void Push(string evt)
         {
@@ -244,6 +485,9 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
         public ValueTask DisposeAsync()
         {
             DisposeCalls++;
+            if (DisposeException != null)
+                throw DisposeException;
+
             return ValueTask.CompletedTask;
         }
     }

--- a/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLeaseOrchestratorTests.cs
@@ -7,14 +7,14 @@ namespace Aevatar.CQRS.Core.Tests;
 public sealed class EventSinkProjectionLeaseOrchestratorTests
 {
     [Fact]
-    public async Task EnsureAndAttachAsync_WhenLeaseResolved_ShouldAttachAndReturnLease()
+    public async Task EnsureAndAttachLeaseAsync_WhenLeaseResolved_ShouldAttachAndReturnAttachment()
     {
         var sink = new TrackingEventSink();
         var lease = new TestLease("lease-1");
         var attachCalls = 0;
 
         var liveSinkLease = new TrackingAsyncDisposable();
-        var resolved = await EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync<TestLease, string>(
+        var attachment = await EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync<TestLease, string>(
             _ => Task.FromResult<TestLease?>(lease),
             (runtimeLease, eventSink, _) =>
             {
@@ -27,35 +27,37 @@ public sealed class EventSinkProjectionLeaseOrchestratorTests
             sink,
             CancellationToken.None);
 
-        resolved.Should().BeSameAs(lease);
+        attachment.Should().NotBeNull();
+        attachment!.ProjectionLease.Should().BeSameAs(lease);
+        attachment.LiveSinkLease.Should().BeSameAs(liveSinkLease);
         attachCalls.Should().Be(1);
         sink.DisposeCalls.Should().Be(0);
     }
 
     [Fact]
-    public async Task EnsureAndAttachAsync_WhenLeaseIsNull_ShouldDisposeSinkAndReturnNull()
+    public async Task EnsureAndAttachLeaseAsync_WhenLeaseIsNull_ShouldDisposeSinkAndReturnNull()
     {
         var sink = new TrackingEventSink();
 
-        var resolved = await EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync<TestLease, string>(
+        var attachment = await EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync<TestLease, string>(
             _ => Task.FromResult<TestLease?>(null),
             (_, _, _) => Task.FromResult<IAsyncDisposable?>(null),
             (_, _) => Task.CompletedTask,
             sink,
             CancellationToken.None);
 
-        resolved.Should().BeNull();
+        attachment.Should().BeNull();
         sink.DisposeCalls.Should().Be(1);
     }
 
     [Fact]
-    public async Task EnsureAndAttachAsync_WhenAttachThrows_ShouldReleaseAndDisposeThenRethrow()
+    public async Task EnsureAndAttachLeaseAsync_WhenAttachThrows_ShouldReleaseAndDisposeThenRethrow()
     {
         var sink = new TrackingEventSink();
         var lease = new TestLease("lease-2");
         var releaseCalls = 0;
 
-        Func<Task> act = () => EventSinkProjectionLeaseOrchestrator.EnsureAndAttachAsync<TestLease, string>(
+        Func<Task> act = () => EventSinkProjectionLeaseOrchestrator.EnsureAndAttachLeaseAsync<TestLease, string>(
             _ => Task.FromResult<TestLease?>(lease),
             (_, _, _) => Task.FromException<IAsyncDisposable?>(new InvalidOperationException("attach failed")),
             (_, _) =>

--- a/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLifecyclePortExtensionsTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLifecyclePortExtensionsTests.cs
@@ -7,35 +7,37 @@ namespace Aevatar.CQRS.Core.Tests;
 public sealed class EventSinkProjectionLifecyclePortExtensionsTests
 {
     [Fact]
-    public async Task EnsureAndAttachAsync_WhenLeaseResolved_ShouldAttachViaLifecyclePort()
+    public async Task EnsureAndAttachLeaseAsync_WhenLeaseResolved_ShouldAttachViaLifecyclePort()
     {
         var sink = new TrackingEventSink();
         var lifecyclePort = new TrackingLifecyclePort();
         var lease = new TestLease("lease-1");
 
-        var resolved = await lifecyclePort.EnsureAndAttachAsync(
+        var attachment = await lifecyclePort.EnsureAndAttachLeaseAsync(
             _ => Task.FromResult<TestLease?>(lease),
             sink,
             CancellationToken.None);
 
-        resolved.Should().BeSameAs(lease);
+        attachment.Should().NotBeNull();
+        attachment!.ProjectionLease.Should().BeSameAs(lease);
+        attachment.LiveSinkLease.Should().NotBeNull();
         lifecyclePort.AttachCalls.Should().Be(1);
         lifecyclePort.ReleaseCalls.Should().Be(0);
         sink.DisposeCalls.Should().Be(0);
     }
 
     [Fact]
-    public async Task EnsureAndAttachAsync_WhenLeaseIsNull_ShouldDisposeSink()
+    public async Task EnsureAndAttachLeaseAsync_WhenLeaseIsNull_ShouldDisposeSink()
     {
         var sink = new TrackingEventSink();
         var lifecyclePort = new TrackingLifecyclePort();
 
-        var resolved = await lifecyclePort.EnsureAndAttachAsync(
+        var attachment = await lifecyclePort.EnsureAndAttachLeaseAsync(
             _ => Task.FromResult<TestLease?>(null),
             sink,
             CancellationToken.None);
 
-        resolved.Should().BeNull();
+        attachment.Should().BeNull();
         lifecyclePort.AttachCalls.Should().Be(0);
         lifecyclePort.ReleaseCalls.Should().Be(0);
         sink.DisposeCalls.Should().Be(1);

--- a/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLifecyclePortExtensionsTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/EventSinkProjectionLifecyclePortExtensionsTests.cs
@@ -51,6 +51,7 @@ public sealed class EventSinkProjectionLifecyclePortExtensionsTests
 
         await lifecyclePort.DetachReleaseAndDisposeAsync(
             lease,
+            new TrackingAsyncDisposable(),
             sink,
             () =>
             {
@@ -75,19 +76,18 @@ public sealed class EventSinkProjectionLifecyclePortExtensionsTests
         public int ReleaseCalls { get; private set; }
         public bool ProjectionEnabled => true;
 
-        public Task AttachLiveSinkAsync(TestLease lease, IEventSink<string> sink, CancellationToken ct = default)
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(TestLease lease, IEventSink<string> sink, CancellationToken ct = default)
         {
             _ = lease;
             _ = sink;
             ct.ThrowIfCancellationRequested();
             AttachCalls++;
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(new TrackingAsyncDisposable());
         }
 
-        public Task DetachLiveSinkAsync(TestLease lease, IEventSink<string> sink, CancellationToken ct = default)
+        public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
         {
-            _ = lease;
-            _ = sink;
+            _ = liveSinkLease;
             ct.ThrowIfCancellationRequested();
             DetachCalls++;
             return Task.CompletedTask;
@@ -100,6 +100,11 @@ public sealed class EventSinkProjectionLifecyclePortExtensionsTests
             ReleaseCalls++;
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class TrackingAsyncDisposable : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class TrackingEventSink : IEventSink<string>

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionPortBaseCoverageTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionPortBaseCoverageTests.cs
@@ -90,9 +90,10 @@ public sealed class EventSinkProjectionLifecyclePortBaseTests
         var lease = new TestPortRuntimeLease("actor-1", "session-1");
         var sink = new TestEventSink();
 
-        await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
+        var liveSinkLease = await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
         await fixture.SessionEventHub.PublishHandler!("evt-1");
 
+        liveSinkLease.Should().BeSameAs(fixture.SessionEventHub.LastSubscription);
         fixture.Service.ResolveRuntimeLeaseCalls.Should().Be(1);
         fixture.SessionEventHub.SubscribeCalls.Should().Be(1);
         fixture.SessionEventHub.LastScopeId.Should().Be("actor-1");
@@ -101,19 +102,29 @@ public sealed class EventSinkProjectionLifecyclePortBaseTests
     }
 
     [Fact]
-    public async Task AttachLiveSinkAsync_ShouldReplacePreviousSubscription_ForSameSink()
+    public async Task AttachLiveSinkAsync_ShouldReturnIndependentExplicitLeases_ForSameSink()
     {
         var fixture = CreateFixture(enabled: true);
         var lease = new TestPortRuntimeLease("actor-1", "session-1");
         var sink = new TestEventSink();
 
-        await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
+        var firstLease = await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
         var firstSubscription = fixture.SessionEventHub.LastSubscription!;
 
-        await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
+        var secondLease = await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
+        var secondSubscription = fixture.SessionEventHub.LastSubscription!;
+
+        firstLease.Should().BeSameAs(firstSubscription);
+        secondLease.Should().BeSameAs(secondSubscription);
+        firstSubscription.DisposeCalls.Should().Be(0);
+        secondSubscription.DisposeCalls.Should().Be(0);
+        fixture.SessionEventHub.SubscribeCalls.Should().Be(2);
+
+        await fixture.Service.DetachSinkPublicAsync(firstLease, CancellationToken.None);
+        await fixture.Service.DetachSinkPublicAsync(secondLease, CancellationToken.None);
 
         firstSubscription.DisposeCalls.Should().Be(1);
-        fixture.SessionEventHub.SubscribeCalls.Should().Be(2);
+        secondSubscription.DisposeCalls.Should().Be(1);
     }
 
     [Fact]
@@ -123,10 +134,10 @@ public sealed class EventSinkProjectionLifecyclePortBaseTests
         var lease = new TestPortRuntimeLease("actor-1", "session-1");
         var sink = new TestEventSink();
 
-        await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
+        var liveSinkLease = await fixture.Service.AttachSinkPublicAsync(lease, sink, CancellationToken.None);
         var subscription = fixture.SessionEventHub.LastSubscription!;
 
-        await fixture.Service.DetachSinkPublicAsync(lease, sink, CancellationToken.None);
+        await fixture.Service.DetachSinkPublicAsync(liveSinkLease, CancellationToken.None);
 
         fixture.Service.ResolveRuntimeLeaseCalls.Should().Be(1);
         subscription.DisposeCalls.Should().Be(1);
@@ -142,6 +153,20 @@ public sealed class EventSinkProjectionLifecyclePortBaseTests
 
         fixture.Release.Calls.Should().Be(1);
         fixture.Release.LastLease.Should().BeSameAs(lease);
+    }
+
+    [Fact]
+    public void EventSinkProjectionLifecyclePortBase_Source_ShouldNotKeepSinkSubscriptionRegistry()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "../../../../../src/Aevatar.CQRS.Projection.Core/Orchestration/EventSinkProjectionLifecyclePortBase.cs"));
+        var source = File.ReadAllText(sourcePath);
+
+        source.Should().Contain(
+            "Refactor (iter17/cluster-035): Old: ConcurrentDictionary registry. New: explicit IAsyncDisposable lease per attach.");
+        source.Should().NotContain("ConcurrentDictionary<");
+        source.Should().NotContain("_sinkSubscriptions");
     }
 
     private static Fixture CreateFixture(bool enabled)
@@ -197,17 +222,16 @@ internal sealed class TestEventSinkProjectionLifecyclePort
             },
             ct);
 
-    public Task AttachSinkPublicAsync(
+    public Task<IAsyncDisposable?> AttachSinkPublicAsync(
         TestPortRuntimeLease lease,
         IEventSink<string> sink,
         CancellationToken ct = default) =>
         AttachLiveSinkAsync(lease, sink, ct);
 
     public Task DetachSinkPublicAsync(
-        TestPortRuntimeLease lease,
-        IEventSink<string> sink,
+        IAsyncDisposable? liveSinkLease,
         CancellationToken ct = default) =>
-        DetachLiveSinkAsync(lease, sink, ct);
+        DetachLiveSinkAsync(liveSinkLease, ct);
 
     public Task ReleaseProjectionPublicAsync(
         TestPortRuntimeLease lease,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -822,7 +822,7 @@ public sealed class ScopeServiceEndpointsStreamTests
             return Task.FromResult<IGAgentDraftRunProjectionLease?>(new StubDraftRunProjectionLease(actorId, commandId));
         }
 
-        public async Task AttachLiveSinkAsync(
+        public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default)
@@ -846,15 +846,15 @@ public sealed class ScopeServiceEndpointsStreamTests
                     break;
                 }
             }
+
+            return null;
         }
 
         public Task DetachLiveSinkAsync(
-            IGAgentDraftRunProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
-            _ = lease;
-            _ = sink;
+            _ = liveSinkLease;
             _ = ct;
             return Task.CompletedTask;
         }
@@ -941,7 +941,7 @@ public sealed class ScopeServiceEndpointsStreamTests
             return Task.FromResult<IScriptServiceAguiProjectionLease?>(new StubScriptServiceAguiProjectionLease(actorId, runId));
         }
 
-        public async Task AttachLiveSinkAsync(
+        public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IScriptServiceAguiProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default)
@@ -960,15 +960,15 @@ public sealed class ScopeServiceEndpointsStreamTests
                     break;
                 }
             }
+
+            return null;
         }
 
         public Task DetachLiveSinkAsync(
-            IScriptServiceAguiProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
-            _ = lease;
-            _ = sink;
+            _ = liveSinkLease;
             _ = ct;
             return Task.CompletedTask;
         }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -5057,7 +5057,7 @@ public sealed class ScopeServiceEndpointsTests
             return Task.FromResult<IScriptServiceAguiProjectionLease?>(new NoOpScriptServiceAguiProjectionLease(actorId, runId));
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IScriptServiceAguiProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default)
@@ -5065,16 +5065,14 @@ public sealed class ScopeServiceEndpointsTests
             _ = lease;
             _ = sink;
             ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
 
         public Task DetachLiveSinkAsync(
-            IScriptServiceAguiProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
-            _ = lease;
-            _ = sink;
+            _ = liveSinkLease;
             ct.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
@@ -12,6 +12,9 @@ using System.Runtime.CompilerServices;
 
 namespace Aevatar.GAgentService.Tests.Application;
 
+// Test-add (test-coverage/cluster-035):
+//   Covers refactor-introduced behavior in GAgentApprovalInteraction.cs:75-147.
+//   Cluster intent: approval cleanup owns typed live-sink leases and detaches without a process registry.
 public sealed class GAgentApprovalInteractionTests
 {
     [Fact]
@@ -141,6 +144,62 @@ public sealed class GAgentApprovalInteractionTests
         target.LiveSink.Should().BeNull();
         terminalPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, terminalLease));
         target.TerminalProjectionLease.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CleanupAfterDispatchFailureAsync_WhenOnlySinkIsBound_ShouldCompleteDisposeAndSkipProjectionDetach()
+    {
+        var projectionPort = new ApprovalProjectionPort();
+        var terminalPort = new ApprovalTerminalProjectionPort();
+        var target = new GAgentApprovalCommandTarget(
+            new ApprovalStubActor("actor-1", new ApprovalStubAgent()),
+            projectionPort,
+            terminalPort);
+        var sink = new RecordingAguiEventSink();
+        var terminalLease = new ApprovalTerminalProjectionLease(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.Approval);
+        target.BindTerminalProjection(terminalLease);
+        target.BindLiveObservation(new ApprovalProjectionLease("actor-1", "cmd-1"), new RecordingLiveSinkLease(), sink, "session-1");
+        SetProperty(target, nameof(GAgentApprovalCommandTarget.ProjectionLease), null);
+
+        await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
+
+        projectionPort.DetachedLiveSinkLeases.Should().BeEmpty();
+        projectionPort.ReleaseCalls.Should().BeEmpty();
+        sink.Completed.Should().BeTrue();
+        sink.DisposeCalls.Should().Be(1);
+        target.LiveSink.Should().BeNull();
+        target.LiveSinkLease.Should().BeNull();
+        terminalPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, terminalLease));
+    }
+
+    [Fact]
+    public async Task CleanupAfterDispatchFailureAsync_WhenOnlyProjectionLeaseIsBound_ShouldReleaseLeaseAndSkipProjectionDetach()
+    {
+        var projectionPort = new ApprovalProjectionPort();
+        var terminalPort = new ApprovalTerminalProjectionPort();
+        var target = new GAgentApprovalCommandTarget(
+            new ApprovalStubActor("actor-1", new ApprovalStubAgent()),
+            projectionPort,
+            terminalPort);
+        var lease = new ApprovalProjectionLease("actor-1", "cmd-1");
+        var terminalLease = new ApprovalTerminalProjectionLease(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.Approval);
+        target.BindTerminalProjection(terminalLease);
+        target.BindLiveObservation(lease, new RecordingLiveSinkLease(), new RecordingAguiEventSink(), "session-1");
+        SetProperty(target, nameof(GAgentApprovalCommandTarget.LiveSink), null);
+
+        await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
+
+        projectionPort.DetachedLiveSinkLeases.Should().BeEmpty();
+        projectionPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, lease));
+        target.ProjectionLease.Should().BeNull();
+        target.LiveSinkLease.Should().BeNull();
+        terminalPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, terminalLease));
     }
 
     [Fact]
@@ -547,5 +606,14 @@ public sealed class GAgentApprovalInteractionTests
             DisposeCalls++;
             return ValueTask.CompletedTask;
         }
+    }
+
+    private static void SetProperty(object instance, string propertyName, object? value)
+    {
+        var property = instance.GetType().GetProperty(
+            propertyName,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        property.Should().NotBeNull();
+        property!.SetValue(instance, value);
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
@@ -71,6 +71,7 @@ public sealed class GAgentApprovalInteractionTests
 
         result.Succeeded.Should().BeTrue();
         target.ProjectionLease.Should().BeSameAs(projectionPort.LeaseToReturn);
+        target.LiveSinkLease.Should().BeSameAs(projectionPort.LiveSinkLeaseToReturn);
         target.LiveSink.Should().NotBeNull();
         projectionPort.EnsureCalls.Should().ContainSingle(x => x.actorId == "actor-1" && x.commandId == "corr-1");
         projectionPort.AttachCalls.Should().ContainSingle();
@@ -126,11 +127,13 @@ public sealed class GAgentApprovalInteractionTests
             "corr-1",
             GAgentRunTerminalInteractionKind.Approval);
         target.BindTerminalProjection(terminalLease);
-        target.BindLiveObservation(lease, sink, "session-1");
+        var liveSinkLease = new RecordingLiveSinkLease();
+        target.BindLiveObservation(lease, liveSinkLease, sink, "session-1");
 
         await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
 
-        projectionPort.DetachCalls.Should().ContainSingle(x => ReferenceEquals(x.lease, lease));
+        projectionPort.DetachedLiveSinkLeases.Should().ContainSingle(x => ReferenceEquals(x, liveSinkLease));
+        liveSinkLease.DisposeCount.Should().Be(1);
         projectionPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, lease));
         sink.Completed.Should().BeTrue();
         sink.DisposeCalls.Should().Be(1);
@@ -359,10 +362,11 @@ public sealed class GAgentApprovalInteractionTests
     private sealed class ApprovalProjectionPort : IGAgentDraftRunProjectionPort
     {
         public ApprovalProjectionLease? LeaseToReturn { get; init; } = new("actor-1", "cmd-1");
+        public RecordingLiveSinkLease LiveSinkLeaseToReturn { get; } = new();
         public bool ProjectionEnabled => true;
         public List<(string actorId, string commandId)> EnsureCalls { get; } = [];
         public List<(IGAgentDraftRunProjectionLease lease, IEventSink<AGUIEvent> sink)> AttachCalls { get; } = [];
-        public List<(IGAgentDraftRunProjectionLease lease, IEventSink<AGUIEvent> sink)> DetachCalls { get; } = [];
+        public List<IAsyncDisposable?> DetachedLiveSinkLeases { get; } = [];
         public List<IGAgentDraftRunProjectionLease> ReleaseCalls { get; } = [];
 
         public Task<IGAgentDraftRunProjectionLease?> EnsureActorProjectionAsync(
@@ -380,12 +384,21 @@ public sealed class GAgentApprovalInteractionTests
             CancellationToken ct = default)
         {
             AttachCalls.Add((lease, sink));
-            return Task.FromResult<IAsyncDisposable?>(null);
+            return Task.FromResult<IAsyncDisposable?>(LiveSinkLeaseToReturn);
         }
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
-            CancellationToken ct = default) =>
-            Task.CompletedTask;
+            CancellationToken ct = default)
+        {
+            DetachedLiveSinkLeases.Add(liveSinkLease);
+            if (liveSinkLease != null)
+            {
+                return liveSinkLease.DisposeAsync().AsTask();
+            }
+
+            return Task.CompletedTask;
+        }
 
         public Task ReleaseActorProjectionAsync(
             IGAgentDraftRunProjectionLease lease,
@@ -397,6 +410,17 @@ public sealed class GAgentApprovalInteractionTests
     }
 
     private sealed record ApprovalProjectionLease(string ActorId, string CommandId) : IGAgentDraftRunProjectionLease;
+
+    private sealed class RecordingLiveSinkLease : IAsyncDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
 
     private sealed class ApprovalTerminalProjectionPort : IGAgentRunTerminalProjectionPort
     {

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
@@ -374,23 +374,18 @@ public sealed class GAgentApprovalInteractionTests
             return Task.FromResult<IGAgentDraftRunProjectionLease?>(LeaseToReturn);
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default)
         {
             AttachCalls.Add((lease, sink));
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
         public Task DetachLiveSinkAsync(
-            IGAgentDraftRunProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
-            CancellationToken ct = default)
-        {
-            DetachCalls.Add((lease, sink));
-            return Task.CompletedTask;
-        }
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
 
         public Task ReleaseActorProjectionAsync(
             IGAgentDraftRunProjectionLease lease,

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
@@ -14,6 +14,9 @@ using System.Runtime.CompilerServices;
 
 namespace Aevatar.GAgentService.Tests.Application;
 
+// Test-add (test-coverage/cluster-035):
+//   Covers refactor-introduced behavior in GAgentDraftRunInteraction.cs:99-175.
+//   Cluster intent: draft-run cleanup owns typed live-sink leases and detaches without a process registry.
 public sealed class GAgentDraftRunInteractionCoverageTests
 {
     [Fact]
@@ -87,6 +90,70 @@ public sealed class GAgentDraftRunInteractionCoverageTests
         target.LiveSink.Should().BeNull();
         terminalPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, terminalLease));
         target.TerminalProjectionLease.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CommandTargetCleanup_WhenOnlySinkIsBound_ShouldCompleteDisposeAndClearInteractionSink()
+    {
+        var projectionPort = new DraftRunProjectionPort();
+        var terminalPort = new RecordingGAgentRunTerminalProjectionPort();
+        var target = new GAgentDraftRunCommandTarget(
+            new DraftRunStubActor("actor-1", new DraftRunExpectedAgent()),
+            typeof(DraftRunExpectedAgent).AssemblyQualifiedName!,
+            projectionPort,
+            terminalPort);
+        var sink = new DraftRunRecordingSink();
+        var terminalLease = new RecordingGAgentRunTerminalProjectionLease(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.DraftRun);
+        target.BindTerminalProjection(terminalLease);
+        target.BindLiveObservation(new DraftRunProjectionLease("actor-1", "cmd-1"), new RecordingLiveSinkLease(), sink, "session-1");
+        SetProperty(target, nameof(GAgentDraftRunCommandTarget.ProjectionLease), null);
+
+        await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
+
+        projectionPort.DetachedLiveSinkLeases.Should().BeEmpty();
+        projectionPort.ReleaseCalls.Should().BeEmpty();
+        sink.Completed.Should().BeTrue();
+        sink.DisposeCalls.Should().Be(1);
+        target.LiveSink.Should().BeNull();
+        target.LiveSinkLease.Should().BeNull();
+        var requireLiveSink = () => target.RequireLiveSink();
+        requireLiveSink.Should().Throw<InvalidOperationException>()
+            .WithMessage("GAgent draft-run live sink is not bound.");
+        terminalPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, terminalLease));
+    }
+
+    [Fact]
+    public async Task CommandTargetCleanup_WhenOnlyProjectionLeaseIsBound_ShouldReleaseLeaseWithoutDetach()
+    {
+        var projectionPort = new DraftRunProjectionPort();
+        var terminalPort = new RecordingGAgentRunTerminalProjectionPort();
+        var target = new GAgentDraftRunCommandTarget(
+            new DraftRunStubActor("actor-1", new DraftRunExpectedAgent()),
+            typeof(DraftRunExpectedAgent).AssemblyQualifiedName!,
+            projectionPort,
+            terminalPort);
+        var lease = new DraftRunProjectionLease("actor-1", "cmd-1");
+        var terminalLease = new RecordingGAgentRunTerminalProjectionLease(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.DraftRun);
+        target.BindTerminalProjection(terminalLease);
+        target.BindLiveObservation(lease, new RecordingLiveSinkLease(), new DraftRunRecordingSink(), "session-1");
+        SetProperty(target, nameof(GAgentDraftRunCommandTarget.LiveSink), null);
+
+        await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
+
+        projectionPort.DetachedLiveSinkLeases.Should().BeEmpty();
+        projectionPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, lease));
+        target.ProjectionLease.Should().BeNull();
+        target.LiveSinkLease.Should().BeNull();
+        var requireLiveSink = () => target.RequireLiveSink();
+        requireLiveSink.Should().Throw<InvalidOperationException>()
+            .WithMessage("GAgent draft-run live sink is not bound.");
+        terminalPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, terminalLease));
     }
 
     [Fact]
@@ -681,5 +748,14 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             DisposeCalls++;
             return ValueTask.CompletedTask;
         }
+    }
+
+    private static void SetProperty(object instance, string propertyName, object? value)
+    {
+        var property = instance.GetType().GetProperty(
+            propertyName,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        property.Should().NotBeNull();
+        property!.SetValue(instance, value);
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
@@ -500,23 +500,18 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             return Task.FromResult<IGAgentDraftRunProjectionLease?>(LeaseToReturn);
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default)
         {
             AttachCalls.Add((lease, sink));
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
         public Task DetachLiveSinkAsync(
-            IGAgentDraftRunProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
-            CancellationToken ct = default)
-        {
-            DetachCalls.Add((lease, sink));
-            return Task.CompletedTask;
-        }
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
 
         public Task ReleaseActorProjectionAsync(
             IGAgentDraftRunProjectionLease lease,

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
@@ -73,11 +73,13 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             GAgentRunTerminalInteractionKind.DraftRun);
         var sink = new DraftRunRecordingSink();
         target.BindTerminalProjection(terminalLease);
-        target.BindLiveObservation(lease, sink, "session-1");
+        var liveSinkLease = new RecordingLiveSinkLease();
+        target.BindLiveObservation(lease, liveSinkLease, sink, "session-1");
 
         await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
 
-        projectionPort.DetachCalls.Should().ContainSingle(x => ReferenceEquals(x.lease, lease));
+        projectionPort.DetachedLiveSinkLeases.Should().ContainSingle(x => ReferenceEquals(x, liveSinkLease));
+        liveSinkLease.DisposeCount.Should().Be(1);
         projectionPort.ReleaseCalls.Should().ContainSingle(x => ReferenceEquals(x, lease));
         sink.Completed.Should().BeTrue();
         sink.DisposeCalls.Should().Be(1);
@@ -104,7 +106,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             GAgentRunTerminalInteractionKind.DraftRun);
         var sink = new DraftRunRecordingSink();
         target.BindTerminalProjection(terminalLease);
-        target.BindLiveObservation(lease, sink, "session-1");
+        target.BindLiveObservation(lease, new RecordingLiveSinkLease(), sink, "session-1");
         sink.Push(new AGUIEvent
         {
             Custom = new CustomEvent
@@ -152,7 +154,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             "corr-1",
             GAgentRunTerminalInteractionKind.DraftRun);
         target.BindTerminalProjection(terminalLease);
-        target.BindLiveObservation(lease, new DraftRunRecordingSink(), "session-1");
+        target.BindLiveObservation(lease, new RecordingLiveSinkLease(), new DraftRunRecordingSink(), "session-1");
 
         await target.ReleaseAfterInteractionAsync(
             new GAgentDraftRunAcceptedReceipt(
@@ -187,7 +189,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             "corr-1",
             GAgentRunTerminalInteractionKind.DraftRun);
         target.BindTerminalProjection(terminalLease);
-        target.BindLiveObservation(lease, new DraftRunRecordingSink(), "session-1");
+        target.BindLiveObservation(lease, new RecordingLiveSinkLease(), new DraftRunRecordingSink(), "session-1");
 
         await target.ReleaseAfterInteractionAsync(
             new GAgentDraftRunAcceptedReceipt(
@@ -485,10 +487,11 @@ public sealed class GAgentDraftRunInteractionCoverageTests
     private sealed class DraftRunProjectionPort : IGAgentDraftRunProjectionPort
     {
         public DraftRunProjectionLease? LeaseToReturn { get; init; } = new("actor-1", "cmd-1");
+        public RecordingLiveSinkLease LiveSinkLeaseToReturn { get; } = new();
         public bool ProjectionEnabled => true;
         public List<(string actorId, string commandId)> EnsureCalls { get; } = [];
         public List<(IGAgentDraftRunProjectionLease lease, IEventSink<AGUIEvent> sink)> AttachCalls { get; } = [];
-        public List<(IGAgentDraftRunProjectionLease lease, IEventSink<AGUIEvent> sink)> DetachCalls { get; } = [];
+        public List<IAsyncDisposable?> DetachedLiveSinkLeases { get; } = [];
         public List<IGAgentDraftRunProjectionLease> ReleaseCalls { get; } = [];
 
         public Task<IGAgentDraftRunProjectionLease?> EnsureActorProjectionAsync(
@@ -506,12 +509,21 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             CancellationToken ct = default)
         {
             AttachCalls.Add((lease, sink));
-            return Task.FromResult<IAsyncDisposable?>(null);
+            return Task.FromResult<IAsyncDisposable?>(LiveSinkLeaseToReturn);
         }
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
-            CancellationToken ct = default) =>
-            Task.CompletedTask;
+            CancellationToken ct = default)
+        {
+            DetachedLiveSinkLeases.Add(liveSinkLease);
+            if (liveSinkLease != null)
+            {
+                return liveSinkLease.DisposeAsync().AsTask();
+            }
+
+            return Task.CompletedTask;
+        }
 
         public Task ReleaseActorProjectionAsync(
             IGAgentDraftRunProjectionLease lease,
@@ -523,6 +535,17 @@ public sealed class GAgentDraftRunInteractionCoverageTests
     }
 
     private sealed record DraftRunProjectionLease(string ActorId, string CommandId) : IGAgentDraftRunProjectionLease;
+
+    private sealed class RecordingLiveSinkLease : IAsyncDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
 
     private sealed class RecordingGAgentRunTerminalProjectionPort : IGAgentRunTerminalProjectionPort
     {

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionTests.cs
@@ -105,15 +105,14 @@ public sealed class GAgentDraftRunInteractionTests
             CancellationToken ct = default) =>
             Task.FromResult<IGAgentDraftRunProjectionLease?>(null);
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
             CancellationToken ct = default) =>
-            Task.CompletedTask;
+            Task.FromResult<IAsyncDisposable?>(null);
 
         public Task DetachLiveSinkAsync(
-            IGAgentDraftRunProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>
             Task.CompletedTask;
 

--- a/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
@@ -56,7 +56,7 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
         activation.Requests[0].ProjectionKind.Should().Be("service-draft-run-session");
         activation.Requests[0].SessionId.Should().Be("cmd-1");
 
-        await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
         await hub.Handler!(new AGUIEvent
         {
             RunFinished = new RunFinishedEvent
@@ -65,7 +65,7 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
                 RunId = "cmd-1",
             },
         });
-        await port.DetachLiveSinkAsync(lease, sink, CancellationToken.None);
+        await port.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
         await port.ReleaseActorProjectionAsync(lease, CancellationToken.None);
 
         hub.SubscribeCalls.Should().Be(1);

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -31,7 +31,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
         var sink = new RecordingEventSink();
 
         var lease = await port.EnsureRunProjectionAsync("script-actor-1", "run-1", CancellationToken.None);
-        await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
         await hub.Handler!(new AGUIEvent
         {
             RunFinished = new RunFinishedEvent
@@ -40,7 +40,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
                 RunId = "run-1",
             },
         });
-        await port.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        await port.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
         await port.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
 
         var request = activation.Requests.Should().ContainSingle().Subject;

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceConfigurationProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceConfigurationProjectionInfrastructureTests.cs
@@ -76,12 +76,28 @@ public sealed class ServiceConfigurationProjectionInfrastructureTests
         services.Should().Contain(x =>
             x.ServiceType == typeof(IServiceConfigurationQueryReader) &&
             x.ImplementationType == typeof(ServiceConfigurationQueryReader));
-        services.Should().Contain(x =>
+        services.Should().ContainSingle(x =>
             x.ServiceType == typeof(IProjectionMaterializer<ServiceConfigurationProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceConfigurationProjector));
-        services.Should().Contain(x =>
+            IsObservedProjectionMaterializerFor<ServiceConfigurationProjector>(x.ImplementationType));
+        services.Should().ContainSingle(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceConfigurationProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceConfigurationProjector));
+            IsObservedProjectionArtifactMaterializerFor<ServiceConfigurationProjector>(x.ImplementationType));
+    }
+
+    private static bool IsObservedProjectionMaterializerFor<TProjector>(System.Type? type)
+    {
+        return type?.IsGenericType == true &&
+               type.Name.StartsWith("ObservedProjectionMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
+    }
+
+    private static bool IsObservedProjectionArtifactMaterializerFor<TProjector>(System.Type? type)
+    {
+        return type?.IsGenericType == true &&
+               type.Name.StartsWith("ObservedProjectionArtifactMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -319,15 +319,31 @@ public sealed class ServiceProjectionInfrastructureTests
         services.Should().Contain(x =>
             x.ServiceType == typeof(IGAgentRunTerminalProjectionPort) &&
             x.ImplementationType == typeof(GAgentRunTerminalProjectionPort));
-        services.Should().Contain(x =>
+        services.Should().ContainSingle(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceCatalogProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceCatalogProjector));
-        services.Should().Contain(x =>
+            IsObservedProjectionArtifactMaterializerFor<ServiceCatalogProjector>(x.ImplementationType));
+        services.Should().ContainSingle(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceRevisionCatalogProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceRevisionCatalogProjector));
-        services.Should().Contain(x =>
+            IsObservedProjectionArtifactMaterializerFor<ServiceRevisionCatalogProjector>(x.ImplementationType));
+        services.Should().ContainSingle(x =>
             x.ServiceType == typeof(ICurrentStateProjectionMaterializer<GAgentRunTerminalProjectionContext>) &&
-            x.ImplementationType == typeof(GAgentRunTerminalProjector));
+            IsObservedCurrentStateMaterializerFor<GAgentRunTerminalProjector>(x.ImplementationType));
+    }
+
+    private static bool IsObservedProjectionArtifactMaterializerFor<TProjector>(System.Type? type)
+    {
+        return type?.IsGenericType == true &&
+               type.Name.StartsWith("ObservedProjectionArtifactMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
+    }
+
+    private static bool IsObservedCurrentStateMaterializerFor<TProjector>(System.Type? type)
+    {
+        return type?.IsGenericType == true &&
+               type.Name.StartsWith("ObservedCurrentStateProjectionMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectionInfrastructureTests.cs
@@ -137,21 +137,37 @@ public sealed class ServiceServingProjectionInfrastructureTests
         services.Should().Contain(x =>
             x.ServiceType == typeof(IServiceTrafficViewProjectionPort) &&
             x.ImplementationType == typeof(ServiceTrafficViewProjectionPort));
-        services.Should().Contain(x =>
-            x.ServiceType == typeof(ICurrentStateProjectionMaterializer<ServiceServingSetProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceServingSetProjector));
-        services.Should().Contain(x =>
-            x.ServiceType == typeof(ICurrentStateProjectionMaterializer<ServiceTrafficViewProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceTrafficViewProjector));
-        services.Should().Contain(x =>
+        services.Should().ContainSingle(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceDeploymentCatalogProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceDeploymentCatalogProjector));
+            IsObservedProjectionArtifactMaterializerFor<ServiceDeploymentCatalogProjector>(x.ImplementationType));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceRolloutProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceRolloutProjector));
+            IsObservedProjectionArtifactMaterializerFor<ServiceRolloutProjector>(x.ImplementationType));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IProjectionArtifactMaterializer<ServiceRolloutProjectionContext>) &&
-            x.ImplementationType == typeof(ServiceRolloutCommandObservationProjector));
+            IsObservedProjectionArtifactMaterializerFor<ServiceRolloutCommandObservationProjector>(x.ImplementationType));
+        services.Should().ContainSingle(x =>
+            x.ServiceType == typeof(ICurrentStateProjectionMaterializer<ServiceServingSetProjectionContext>) &&
+            IsObservedCurrentStateMaterializerFor<ServiceServingSetProjector>(x.ImplementationType));
+        services.Should().ContainSingle(x =>
+            x.ServiceType == typeof(ICurrentStateProjectionMaterializer<ServiceTrafficViewProjectionContext>) &&
+            IsObservedCurrentStateMaterializerFor<ServiceTrafficViewProjector>(x.ImplementationType));
+    }
+
+    private static bool IsObservedProjectionArtifactMaterializerFor<TProjector>(Type? type)
+    {
+        return type?.IsGenericType == true &&
+               type.Name.StartsWith("ObservedProjectionArtifactMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
+    }
+
+    private static bool IsObservedCurrentStateMaterializerFor<TProjector>(Type? type)
+    {
+        return type?.IsGenericType == true &&
+               type.Name.StartsWith("ObservedCurrentStateProjectionMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/ClaimIntegrationTestKit.cs
+++ b/test/Aevatar.Integration.Tests/ClaimIntegrationTestKit.cs
@@ -115,7 +115,7 @@ internal static class ClaimIntegrationTestKit
         var lease = await projectionPort.EnsureActorProjectionAsync(runtimeActorId, ct);
         lease.Should().NotBeNull();
         await using var sink = new EventChannel<EventEnvelope>(capacity: 32);
-        await projectionPort.AttachLiveSinkAsync(lease!, sink, ct);
+        var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease!, sink, ct);
 
         try
         {
@@ -137,7 +137,7 @@ internal static class ClaimIntegrationTestKit
         }
         finally
         {
-            await projectionPort.DetachLiveSinkAsync(lease!, sink, ct);
+            await projectionPort.DetachLiveSinkAsync(liveSinkLease, ct);
             await projectionPort.ReleaseActorProjectionAsync(lease!, ct);
         }
     }

--- a/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
@@ -188,7 +188,7 @@ public sealed class ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests
                 CancellationToken.None);
             lease.Should().NotBeNull();
             await using var sink = new EventChannel<EventEnvelope>(capacity: 32);
-            await executionProjectionNode1.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+            var liveSinkLease = await executionProjectionNode1.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
 
             try
             {
@@ -232,7 +232,7 @@ public sealed class ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests
             }
             finally
             {
-                await executionProjectionNode1.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+                await executionProjectionNode1.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
                 await executionProjectionNode1.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
             }
 

--- a/test/Aevatar.Integration.Tests/ScriptBehaviorReadModelIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptBehaviorReadModelIntegrationTests.cs
@@ -54,7 +54,7 @@ public sealed class ScriptBehaviorReadModelIntegrationTests
         var lease = await projectionPort.EnsureActorProjectionAsync(runtimeActorId, CancellationToken.None);
         lease.Should().NotBeNull();
         await using var sink = new EventChannel<EventEnvelope>(capacity: 32);
-        await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
 
         try
         {
@@ -91,7 +91,7 @@ public sealed class ScriptBehaviorReadModelIntegrationTests
         }
         finally
         {
-            await projectionPort.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+            await projectionPort.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
             await projectionPort.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
         }
     }

--- a/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationTestKit.cs
+++ b/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationTestKit.cs
@@ -153,7 +153,7 @@ internal static class ScriptEvolutionIntegrationTestKit
         var lease = await projectionPort.EnsureActorProjectionAsync(runtimeActorId, ct)
             ?? throw new InvalidOperationException($"Failed to ensure script execution projection. actor_id={runtimeActorId}");
         await using var sink = new EventChannel<EventEnvelope>(capacity: 64);
-        await projectionPort.AttachLiveSinkAsync(lease, sink, ct);
+        var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease, sink, ct);
 
         try
         {
@@ -172,7 +172,7 @@ internal static class ScriptEvolutionIntegrationTestKit
         }
         finally
         {
-            await projectionPort.DetachLiveSinkAsync(lease, sink, ct);
+            await projectionPort.DetachLiveSinkAsync(liveSinkLease, ct);
             await projectionPort.ReleaseActorProjectionAsync(lease, ct);
         }
     }
@@ -200,7 +200,7 @@ internal static class ScriptEvolutionIntegrationTestKit
             if (!IsReady(snapshot))
             {
                 await using var sink = new EventChannel<EventEnvelope>(capacity: 32);
-                await projectionPort.AttachLiveSinkAsync(lease, sink, ct);
+                var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease, sink, ct);
                 try
                 {
                     snapshot = await queryService.GetSnapshotAsync(runtimeActorId, ct);
@@ -212,7 +212,7 @@ internal static class ScriptEvolutionIntegrationTestKit
                 }
                 finally
                 {
-                    await projectionPort.DetachLiveSinkAsync(lease, sink, ct);
+                    await projectionPort.DetachLiveSinkAsync(liveSinkLease, ct);
                 }
             }
 

--- a/test/Aevatar.Integration.Tests/ScriptGAgentEndToEndTests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptGAgentEndToEndTests.cs
@@ -52,7 +52,7 @@ public sealed class ScriptGAgentEndToEndTests
         var lease = await projectionPort.EnsureActorProjectionAsync(runtimeActorId, CancellationToken.None);
         lease.Should().NotBeNull();
         await using var sink = new EventChannel<EventEnvelope>(capacity: 32);
-        await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
 
         try
         {
@@ -86,7 +86,7 @@ public sealed class ScriptGAgentEndToEndTests
         }
         finally
         {
-            await projectionPort.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+            await projectionPort.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
             await projectionPort.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
         }
     }

--- a/test/Aevatar.Integration.Tests/TestDoubles/Protocols/TextNormalizationProtocolSampleActors.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/Protocols/TextNormalizationProtocolSampleActors.cs
@@ -261,7 +261,7 @@ public sealed class TextNormalizationScriptingProtocolGAgent : GAgentBase<TextNo
         var lease = await _projectionPort.EnsureActorProjectionAsync(runtimeActorId, CancellationToken.None)
             ?? throw new InvalidOperationException("Script projection lease is required for text normalization sample.");
         await using var sink = new EventChannel<EventEnvelope>(capacity: 16);
-        await _projectionPort.AttachLiveSinkAsync(lease, sink, CancellationToken.None);
+        var liveSinkLease = await _projectionPort.AttachLiveSinkAsync(lease, sink, CancellationToken.None);
 
         try
         {
@@ -291,7 +291,7 @@ public sealed class TextNormalizationScriptingProtocolGAgent : GAgentBase<TextNo
         }
         finally
         {
-            await _projectionPort.DetachLiveSinkAsync(lease, sink, CancellationToken.None);
+            await _projectionPort.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
             await _projectionPort.ReleaseActorProjectionAsync(lease, CancellationToken.None);
         }
     }

--- a/test/Aevatar.Integration.Tests/TextNormalizationProtocolContractTests.cs
+++ b/test/Aevatar.Integration.Tests/TextNormalizationProtocolContractTests.cs
@@ -41,7 +41,7 @@ public sealed class TextNormalizationProtocolContractTests
         var lease = await projectionPort.EnsureActorProjectionAsync(runtimeActorId, CancellationToken.None);
         lease.Should().NotBeNull();
         await using var sink = new EventChannel<Aevatar.Foundation.Abstractions.EventEnvelope>(capacity: 32);
-        await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
 
         try
         {
@@ -78,7 +78,7 @@ public sealed class TextNormalizationProtocolContractTests
         }
         finally
         {
-            await projectionPort.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+            await projectionPort.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
             await projectionPort.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
         }
     }

--- a/test/Aevatar.Integration.Tests/WorkflowYamlScriptParityTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowYamlScriptParityTests.cs
@@ -149,7 +149,7 @@ public class WorkflowYamlScriptParityTests
         var lease = await projectionPort.EnsureActorProjectionAsync(runtimeActorId, CancellationToken.None);
         lease.Should().NotBeNull();
         await using var sink = new EventChannel<EventEnvelope>(capacity: 16);
-        await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var liveSinkLease = await projectionPort.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
 
         try
         {
@@ -177,7 +177,7 @@ public class WorkflowYamlScriptParityTests
         }
         finally
         {
-            await projectionPort.DetachLiveSinkAsync(lease!, sink, CancellationToken.None);
+            await projectionPort.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
             await projectionPort.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
         }
     }

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs
@@ -21,6 +21,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Scripting.Core.Tests.Runtime;
 
+// Test-add (test-coverage/cluster-035):
+//   Covers refactor-introduced behavior in ScriptEvolutionCommandTarget.cs:74-132 and ScriptEvolutionCommandTargetBinder.cs:35-54.
+//   Cluster intent: script evolution carries explicit live-sink projection leases through target binding and cleanup.
 public class RuntimeScriptInfrastructurePortsTests
 {
     [Fact]
@@ -744,6 +747,62 @@ public class RuntimeScriptInfrastructurePortsTests
         projectionPort.ReleaseCount.Should().Be(0);
     }
 
+    [Fact]
+    public async Task ScriptEvolutionCommandTarget_ReleaseAsync_WhenOnlyProjectionLeaseIsBound_ShouldReleaseWithoutDetach()
+    {
+        var projectionPort = new TestProjectionPort();
+        var target = new ScriptEvolutionCommandTarget(
+            new TestActor("script-evolution-session:proposal-1"),
+            "proposal-1",
+            projectionPort,
+            projectionPort);
+        var lease = new TestProjectionLease("script-evolution-session:proposal-1", "proposal-1");
+        target.BindLiveObservation(lease, new TestLiveSinkLease(), new ScriptEvolutionScopedEventSink("proposal-1", new EventChannel<ScriptEvolutionSessionCompletedEvent>()));
+        SetProperty(target, nameof(ScriptEvolutionCommandTarget.LiveSink), null);
+
+        await target.ReleaseAsync(CancellationToken.None);
+
+        projectionPort.DetachCount.Should().Be(0);
+        projectionPort.ReleaseCount.Should().Be(1);
+        target.ProjectionLease.Should().BeNull();
+        target.LiveSinkLease.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ScriptEvolutionCommandTargetBinder_ShouldReturnProjectionDisabled_WhenActivationFails()
+    {
+        var projectionPort = new TestProjectionPort { ReturnNullLease = true };
+        var binder = new ScriptEvolutionCommandTargetBinder(projectionPort);
+        var target = new ScriptEvolutionCommandTarget(
+            new TestActor("script-evolution-session:proposal-disabled"),
+            "proposal-disabled",
+            projectionPort,
+            projectionPort);
+
+        var result = await binder.BindAsync(
+            new ScriptEvolutionProposal(
+                ProposalId: "proposal-disabled",
+                ScriptId: "script-1",
+                BaseRevision: "rev-1",
+                CandidateRevision: "rev-2",
+                CandidateSource: "source-rev-2",
+                CandidateSourceHash: "hash-rev-2",
+                Reason: "rollout"),
+            target,
+            new CommandContext(
+                "script-evolution-session:proposal-disabled",
+                "cmd-1",
+                "corr-1",
+                new Dictionary<string, string>()),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(ScriptEvolutionStartError.ProjectionDisabled);
+        target.ProjectionLease.Should().BeNull();
+        projectionPort.DetachCount.Should().Be(0);
+        projectionPort.ReleaseCount.Should().Be(0);
+    }
+
     private static ProjectionScriptDefinitionSnapshotPort CreateDefinitionSnapshotPort(
         TestEventStore eventStore)
     {
@@ -1414,5 +1473,14 @@ public class RuntimeScriptInfrastructurePortsTests
     private sealed class TestLiveSinkLease : IAsyncDisposable
     {
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static void SetProperty(object instance, string propertyName, object? value)
+    {
+        var property = instance.GetType().GetProperty(
+            propertyName,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        property.Should().NotBeNull();
+        property!.SetValue(instance, value);
     }
 }

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs
@@ -1325,27 +1325,19 @@ public class RuntimeScriptInfrastructurePortsTests
         public async Task<bool> ActivateAsync(string actorId, CancellationToken ct = default) =>
             await EnsureActorProjectionAsync(actorId, actorId, ct) != null;
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IScriptEvolutionProjectionLease lease,
             IEventSink<ScriptEvolutionSessionCompletedEvent> sink,
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             _sinks[lease.ActorId] = sink;
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
-        public Task DetachLiveSinkAsync(
-            IScriptEvolutionProjectionLease lease,
-            IEventSink<ScriptEvolutionSessionCompletedEvent> sink,
-            CancellationToken ct = default)
-        {
-            _ = sink;
-            ct.ThrowIfCancellationRequested();
-            DetachCount++;
-            _sinks.Remove(lease.ActorId);
-            return Task.CompletedTask;
-        }
+    public Task DetachLiveSinkAsync(
+        IAsyncDisposable? liveSinkLease,
+        CancellationToken ct = default) =>
+        Task.CompletedTask;
 
         public Task ReleaseActorProjectionAsync(
             IScriptEvolutionProjectionLease lease,
@@ -1381,23 +1373,18 @@ public class RuntimeScriptInfrastructurePortsTests
         public async Task<bool> ActivateAsync(string actorId, CancellationToken ct = default) =>
             await EnsureActorProjectionAsync(actorId, ct) != null;
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IScriptExecutionProjectionLease lease,
             IEventSink<EventEnvelope> sink,
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
-        public Task DetachLiveSinkAsync(
-            IScriptExecutionProjectionLease lease,
-            IEventSink<EventEnvelope> sink,
-            CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
-        }
+    public Task DetachLiveSinkAsync(
+        IAsyncDisposable? liveSinkLease,
+        CancellationToken ct = default) =>
+        Task.CompletedTask;
 
         public Task ReleaseActorProjectionAsync(
             IScriptExecutionProjectionLease lease,

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/RuntimeScriptInfrastructurePortsTests.cs
@@ -1332,12 +1332,20 @@ public class RuntimeScriptInfrastructurePortsTests
         {
             ct.ThrowIfCancellationRequested();
             _sinks[lease.ActorId] = sink;
-            return Task.FromResult<IAsyncDisposable?>(null);
+            return Task.FromResult<IAsyncDisposable?>(new TestLiveSinkLease());
         }
-    public Task DetachLiveSinkAsync(
-        IAsyncDisposable? liveSinkLease,
-        CancellationToken ct = default) =>
-        Task.CompletedTask;
+
+        public async Task DetachLiveSinkAsync(
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            DetachCount++;
+            if (liveSinkLease != null)
+            {
+                await liveSinkLease.DisposeAsync();
+            }
+        }
 
         public Task ReleaseActorProjectionAsync(
             IScriptEvolutionProjectionLease lease,
@@ -1379,12 +1387,19 @@ public class RuntimeScriptInfrastructurePortsTests
             CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult<IAsyncDisposable?>(null);
+            return Task.FromResult<IAsyncDisposable?>(new TestLiveSinkLease());
         }
-    public Task DetachLiveSinkAsync(
-        IAsyncDisposable? liveSinkLease,
-        CancellationToken ct = default) =>
-        Task.CompletedTask;
+
+        public async Task DetachLiveSinkAsync(
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (liveSinkLease != null)
+            {
+                await liveSinkLease.DisposeAsync();
+            }
+        }
 
         public Task ReleaseActorProjectionAsync(
             IScriptExecutionProjectionLease lease,
@@ -1393,7 +1408,11 @@ public class RuntimeScriptInfrastructurePortsTests
             ct.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }
+        private sealed record NoOpScriptExecutionProjectionLease(string ActorId) : IScriptExecutionProjectionLease;
     }
 
-    private sealed record NoOpScriptExecutionProjectionLease(string ActorId) : IScriptExecutionProjectionLease;
+    private sealed class TestLiveSinkLease : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
 }

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
@@ -591,7 +591,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             return EnsureActorProjectionAsync(actorId, ct);
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IScriptExecutionProjectionLease lease,
             IEventSink<EventEnvelope> sink,
             CancellationToken ct = default)
@@ -599,19 +599,12 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             _ = lease;
             _ = sink;
             ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
-        public Task DetachLiveSinkAsync(
-            IScriptExecutionProjectionLease lease,
-            IEventSink<EventEnvelope> sink,
-            CancellationToken ct = default)
-        {
-            _ = lease;
-            _ = sink;
-            ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
-        }
+    public Task DetachLiveSinkAsync(
+        IAsyncDisposable? liveSinkLease,
+        CancellationToken ct = default) =>
+        Task.CompletedTask;
 
         public Task ReleaseActorProjectionAsync(
             IScriptExecutionProjectionLease lease,

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
@@ -982,18 +982,17 @@ internal sealed class RecordingExecutionProjectionPort
         return EnsureActorProjectionAsync(actorId, ct);
     }
 
-    public Task AttachLiveSinkAsync(IScriptExecutionProjectionLease lease, IEventSink<EventEnvelope> sink, CancellationToken ct = default)
+    public Task<IAsyncDisposable?> AttachLiveSinkAsync(IScriptExecutionProjectionLease lease, IEventSink<EventEnvelope> sink, CancellationToken ct = default)
     {
         _ = lease;
         _ = sink;
         ct.ThrowIfCancellationRequested();
-        return Task.CompletedTask;
+        return Task.FromResult<IAsyncDisposable?>(null);
     }
 
-    public Task DetachLiveSinkAsync(IScriptExecutionProjectionLease lease, IEventSink<EventEnvelope> sink, CancellationToken ct = default)
+    public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
     {
-        _ = lease;
-        _ = sink;
+        _ = liveSinkLease;
         ct.ThrowIfCancellationRequested();
         return Task.CompletedTask;
     }
@@ -1175,21 +1174,21 @@ internal sealed class RecordingEvolutionProjectionPort
     public async Task<bool> ActivateAsync(string actorId, CancellationToken ct = default) =>
         await EnsureActorProjectionAsync(actorId, actorId, ct) != null;
 
-    public async Task AttachLiveSinkAsync(IScriptEvolutionProjectionLease lease, IEventSink<ScriptEvolutionSessionCompletedEvent> sink, CancellationToken ct = default)
+    public async Task<IAsyncDisposable?> AttachLiveSinkAsync(IScriptEvolutionProjectionLease lease, IEventSink<ScriptEvolutionSessionCompletedEvent> sink, CancellationToken ct = default)
     {
         _ = lease;
         _ = sink;
         await Task.CompletedTask;
         ct.ThrowIfCancellationRequested();
+        return null;
     }
 
-    public Task DetachLiveSinkAsync(IScriptEvolutionProjectionLease lease, IEventSink<ScriptEvolutionSessionCompletedEvent> sink, CancellationToken ct = default)
+    public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
     {
-        _ = sink;
+        _ = liveSinkLease;
         ct.ThrowIfCancellationRequested();
         if (DetachException != null)
             throw DetachException;
-        DetachedLeases.Add(lease);
         return Task.CompletedTask;
     }
 

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
@@ -762,8 +762,8 @@ public sealed class ScriptEvolutionCommandTargetTests
             new RecordingEvolutionProjectionPort(),
             new RecordingEvolutionProjectionPort());
 
-        Action nullLease = () => target.BindLiveObservation(null!, new RecordingCompletedEventSink());
-        Action nullSink = () => target.BindLiveObservation(new RecordingEvolutionProjectionLease("session-1", "proposal-1"), null!);
+        Action nullLease = () => target.BindLiveObservation(null!, new RecordingLiveSinkLease(), new RecordingCompletedEventSink());
+        Action nullSink = () => target.BindLiveObservation(new RecordingEvolutionProjectionLease("session-1", "proposal-1"), new RecordingLiveSinkLease(), null!);
 
         nullLease.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("lease");
         nullSink.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("sink");
@@ -794,12 +794,14 @@ public sealed class ScriptEvolutionCommandTargetTests
             projectionPort,
             projectionPort);
         var lease = new RecordingEvolutionProjectionLease("session-1", "proposal-1");
+        var liveSinkLease = new RecordingLiveSinkLease();
         var sink = new RecordingCompletedEventSink();
-        target.BindLiveObservation(lease, sink);
+        target.BindLiveObservation(lease, liveSinkLease, sink);
 
         await target.ReleaseAsync(CancellationToken.None);
 
-        projectionPort.DetachedLeases.Should().ContainSingle().Which.Should().BeSameAs(lease);
+        projectionPort.DetachedLiveSinkLeases.Should().ContainSingle().Which.Should().BeSameAs(liveSinkLease);
+        liveSinkLease.DisposeCount.Should().Be(1);
         projectionPort.ReleasedLeases.Should().ContainSingle().Which.Should().BeSameAs(lease);
         sink.DisposeCount.Should().Be(1);
         target.ProjectionLease.Should().BeNull();
@@ -815,8 +817,8 @@ public sealed class ScriptEvolutionCommandTargetTests
             new RecordingEvolutionProjectionPort(),
             new RecordingEvolutionProjectionPort());
         var sink = new RecordingCompletedEventSink();
-        target.BindLiveObservation(new RecordingEvolutionProjectionLease("session-1", "proposal-1"), sink);
-        target.BindLiveObservation(new RecordingEvolutionProjectionLease("session-1", "proposal-1"), sink);
+        target.BindLiveObservation(new RecordingEvolutionProjectionLease("session-1", "proposal-1"), new RecordingLiveSinkLease(), sink);
+        target.BindLiveObservation(new RecordingEvolutionProjectionLease("session-1", "proposal-1"), new RecordingLiveSinkLease(), sink);
         target.GetType().GetProperty(nameof(ScriptEvolutionCommandTarget.ProjectionLease))!.SetValue(target, null);
 
         await target.ReleaseAsync(CancellationToken.None);
@@ -829,6 +831,7 @@ public sealed class ScriptEvolutionCommandTargetTests
     public async Task CleanupMethods_ShouldDelegateToReleaseAsync()
     {
         var projectionPort = new RecordingEvolutionProjectionPort();
+        var liveSinkLease = new RecordingLiveSinkLease();
         var target = new ScriptEvolutionCommandTarget(
             new FakeActor("session-1"),
             "proposal-1",
@@ -836,6 +839,7 @@ public sealed class ScriptEvolutionCommandTargetTests
             projectionPort);
         target.BindLiveObservation(
             new RecordingEvolutionProjectionLease("session-1", "proposal-1"),
+            liveSinkLease,
             new RecordingCompletedEventSink());
 
         await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
@@ -847,7 +851,8 @@ public sealed class ScriptEvolutionCommandTargetTests
                 CommandDurableCompletionObservation<ScriptEvolutionInteractionCompletion>.Incomplete),
             CancellationToken.None);
 
-        projectionPort.DetachedLeases.Should().HaveCount(1);
+        projectionPort.DetachedLiveSinkLeases.Should().ContainSingle().Which.Should().BeSameAs(liveSinkLease);
+        liveSinkLease.DisposeCount.Should().Be(1);
     }
 
     [Fact]
@@ -864,6 +869,7 @@ public sealed class ScriptEvolutionCommandTargetTests
             projectionPort);
         target.BindLiveObservation(
             new RecordingEvolutionProjectionLease("session-1", "proposal-1"),
+            new RecordingLiveSinkLease(),
             new RecordingCompletedEventSink());
 
         var act = () => target.ReleaseAsync(CancellationToken.None);
@@ -1160,7 +1166,7 @@ internal sealed class RecordingEvolutionProjectionPort
       IScriptEvolutionReadModelActivationPort
 {
     public bool ProjectionEnabled => true;
-    public List<IScriptEvolutionProjectionLease> DetachedLeases { get; } = [];
+    public List<IAsyncDisposable?> DetachedLiveSinkLeases { get; } = [];
     public List<IScriptEvolutionProjectionLease> ReleasedLeases { get; } = [];
     public Exception? DetachException { get; set; }
     public Exception? ReleaseException { get; set; }
@@ -1180,16 +1186,19 @@ internal sealed class RecordingEvolutionProjectionPort
         _ = sink;
         await Task.CompletedTask;
         ct.ThrowIfCancellationRequested();
-        return null;
+        return new RecordingLiveSinkLease();
     }
 
-    public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
+    public async Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
     {
-        _ = liveSinkLease;
         ct.ThrowIfCancellationRequested();
         if (DetachException != null)
             throw DetachException;
-        return Task.CompletedTask;
+        DetachedLiveSinkLeases.Add(liveSinkLease);
+        if (liveSinkLease != null)
+        {
+            await liveSinkLease.DisposeAsync();
+        }
     }
 
     public Task ReleaseActorProjectionAsync(IScriptEvolutionProjectionLease lease, CancellationToken ct = default)
@@ -1203,6 +1212,17 @@ internal sealed class RecordingEvolutionProjectionPort
 }
 
 internal sealed record RecordingEvolutionProjectionLease(string ActorId, string ProposalId) : IScriptEvolutionProjectionLease;
+
+internal sealed class RecordingLiveSinkLease : IAsyncDisposable
+{
+    public int DisposeCount { get; private set; }
+
+    public ValueTask DisposeAsync()
+    {
+        DisposeCount++;
+        return ValueTask.CompletedTask;
+    }
+}
 
 internal sealed class RecordingCompletedEventSink : IEventSink<ScriptEvolutionSessionCompletedEvent>
 {

--- a/test/Aevatar.Scripting.Core.Tests/ScriptingProjectWiringTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/ScriptingProjectWiringTests.cs
@@ -41,14 +41,23 @@ public sealed class ScriptingProjectWiringTests
         provider.GetRequiredService<IScriptReadModelQueryApplicationService>().Should().NotBeNull();
         provider.GetRequiredService<IScriptEvolutionApplicationService>().Should().NotBeNull();
         provider.GetServices<ICurrentStateProjectionMaterializer<ScriptExecutionMaterializationContext>>()
-            .Should().Contain(x => x is ScriptReadModelProjector)
-            .And.Contain(x => x is ScriptNativeDocumentProjector)
-            .And.Contain(x => x is ScriptNativeGraphProjector);
+            .Should().Contain(x => IsObservedCurrentStateMaterializerFor<ScriptReadModelProjector>(x))
+            .And.Contain(x => IsObservedCurrentStateMaterializerFor<ScriptNativeDocumentProjector>(x))
+            .And.Contain(x => IsObservedCurrentStateMaterializerFor<ScriptNativeGraphProjector>(x));
         provider.GetServices<ICurrentStateProjectionMaterializer<ScriptAuthorityProjectionContext>>()
-            .Should().Contain(x => x is ScriptDefinitionSnapshotProjector)
-            .And.Contain(x => x is ScriptCatalogEntryProjector);
+            .Should().Contain(x => IsObservedCurrentStateMaterializerFor<ScriptDefinitionSnapshotProjector>(x))
+            .And.Contain(x => IsObservedCurrentStateMaterializerFor<ScriptCatalogEntryProjector>(x));
         provider.GetServices<ICurrentStateProjectionMaterializer<ScriptEvolutionMaterializationContext>>()
-            .Should().ContainSingle(x => x is ScriptEvolutionReadModelProjector);
+            .Should().ContainSingle(x => IsObservedCurrentStateMaterializerFor<ScriptEvolutionReadModelProjector>(x));
+    }
+
+    private static bool IsObservedCurrentStateMaterializerFor<TProjector>(object materializer)
+    {
+        var type = materializer.GetType();
+        return type.IsGenericType &&
+               type.Name.StartsWith("ObservedCurrentStateProjectionMaterializer`", StringComparison.Ordinal) &&
+               type.GenericTypeArguments.Length == 2 &&
+               type.GenericTypeArguments[1] == typeof(TProjector);
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -288,7 +288,11 @@ public sealed class WorkflowApplicationLayerTests
             readModelActivationPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        target.BindLiveObservation(new FakeProjectionLease(actorId, commandId), new EventChannel<WorkflowRunEventEnvelope>());
+        var projectionLease = new FakeProjectionLease(actorId, commandId);
+        target.BindLiveObservation(
+            projectionLease,
+            new FakeLiveSinkLease(projectionLease),
+            new EventChannel<WorkflowRunEventEnvelope>());
         return target;
     }
 
@@ -491,15 +495,25 @@ public sealed class WorkflowApplicationLayerTests
             CancellationToken ct = default)
         {
             if (lease is FakeProjectionLease trackingLease)
+            {
                 trackingLease.LiveSinkAttached = true;
+                return Task.FromResult<IAsyncDisposable?>(new FakeLiveSinkLease(trackingLease));
+            }
 
             return Task.FromResult<IAsyncDisposable?>(null);
         }
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
             DetachCalls.Add(liveSinkLease);
+            if (liveSinkLease is FakeLiveSinkLease fakeLease)
+            {
+                fakeLease.ProjectionLease.LiveSinkAttached = false;
+                return fakeLease.DisposeAsync().AsTask();
+            }
+
             return Task.CompletedTask;
         }
 
@@ -541,6 +555,13 @@ public sealed class WorkflowApplicationLayerTests
         public string CommandId { get; }
         public bool LiveSinkAttached { get; set; } = true;
         public bool Released { get; set; }
+    }
+
+    private sealed class FakeLiveSinkLease(FakeProjectionLease projectionLease) : IAsyncDisposable
+    {
+        public FakeProjectionLease ProjectionLease { get; } = projectionLease;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -462,7 +462,7 @@ public sealed class WorkflowApplicationLayerTests
           IWorkflowExecutionMaterializationActivationPort
     {
         public bool ProjectionEnabled => true;
-        public List<(IWorkflowExecutionProjectionLease Lease, IEventSink<WorkflowRunEventEnvelope> Sink)> DetachCalls { get; } = [];
+        public List<IAsyncDisposable?> DetachCalls { get; } = [];
         public List<IWorkflowExecutionProjectionLease> ReleaseAttempts { get; } = [];
         public List<IWorkflowExecutionProjectionLease> ReleaseCalls { get; } = [];
         public TaskCompletionSource<bool> Released { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -485,7 +485,7 @@ public sealed class WorkflowApplicationLayerTests
             CancellationToken ct = default) =>
             Task.FromResult<IWorkflowExecutionProjectionLease?>(new FakeProjectionLease(rootActorId, commandId));
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default)
@@ -493,24 +493,13 @@ public sealed class WorkflowApplicationLayerTests
             if (lease is FakeProjectionLease trackingLease)
                 trackingLease.LiveSinkAttached = true;
 
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
         public Task DetachLiveSinkAsync(
-            IWorkflowExecutionProjectionLease lease,
-            IEventSink<WorkflowRunEventEnvelope> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)
         {
-            DetachCalls.Add((lease, sink));
-            if (DetachFailureCount > 0)
-            {
-                DetachFailureCount--;
-                throw DetachException ?? new InvalidOperationException("detach failed");
-            }
-
-            if (lease is FakeProjectionLease trackingLease)
-                trackingLease.LiveSinkAttached = false;
-
+            DetachCalls.Add(liveSinkLease);
             return Task.CompletedTask;
         }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
@@ -97,15 +97,13 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
             CancellationToken ct = default) =>
             Task.FromResult<IWorkflowExecutionProjectionLease?>(null);
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             Aevatar.CQRS.Core.Abstractions.Streaming.IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default) =>
-            Task.CompletedTask;
-
+            Task.FromResult<IAsyncDisposable?>(null);
         public Task DetachLiveSinkAsync(
-            IWorkflowExecutionProjectionLease lease,
-            Aevatar.CQRS.Core.Abstractions.Streaming.IEventSink<WorkflowRunEventEnvelope> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>
             Task.CompletedTask;
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -15,6 +15,9 @@ namespace Aevatar.Workflow.Application.Tests;
 // Test-add (test-coverage/cluster-036):
 //   Covers refactor-introduced behavior in WorkflowRunCommandTarget.cs:116-122,286-290,293-309.
 //   Cluster intent: workflow target owns detached durable fallback and cleanup decisions.
+// Test-add (test-coverage/cluster-035):
+//   Covers refactor-introduced behavior in WorkflowRunCommandTarget.cs:76-189.
+//   Cluster intent: workflow run targets detach explicit live-sink leases without process-local lookup state.
 public sealed class WorkflowRunCommandTargetAndPolicyTests
 {
     [Fact]
@@ -110,7 +113,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             actorPort: actorPort,
             currentStateQueryPort: queryPort,
             createdActorIds: ["definition-1", "run-1"]);
-        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeLiveSinkLease("run-1"), new FakeEventSink());
         var receipt = new WorkflowChatRunAcceptedReceipt("run-1", "direct", "cmd-1", "corr-1");
 
         await target.PublishDetachedCommandSignalAsync(
@@ -140,7 +143,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             actorPort: actorPort,
             currentStateQueryPort: queryPort,
             createdActorIds: ["definition-1", "run-1"]);
-        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeLiveSinkLease("run-1"), new FakeEventSink());
         var receipt = new WorkflowChatRunAcceptedReceipt("run-1", "direct", "cmd-1", "corr-1");
 
         await target.PublishDetachedCommandSignalAsync(
@@ -170,7 +173,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             actorPort: actorPort,
             currentStateQueryPort: queryPort,
             createdActorIds: ["definition-1", "run-1"]);
-        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeLiveSinkLease("run-1"), new FakeEventSink());
         var receipt = new WorkflowChatRunAcceptedReceipt("run-1", "direct", "cmd-1", "corr-1");
 
         await target.PublishDetachedCommandSignalAsync(
@@ -200,7 +203,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             actorPort: actorPort,
             currentStateQueryPort: queryPort,
             createdActorIds: ["definition-1", "run-1"]);
-        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeLiveSinkLease("run-1"), new FakeEventSink());
         var receipt = new WorkflowChatRunAcceptedReceipt("run-1", "direct", "cmd-1", "corr-1");
 
         await target.PublishDetachedCommandSignalAsync(
@@ -242,6 +245,36 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         await target.DetachLiveObservationAsync(CancellationToken.None);
 
         projectionPort.Events.Should().Equal("detach:run-1");
+        sink.DisposeCalls.Should().Be(1);
+        target.LiveSink.Should().BeNull();
+        target.ProjectionLease.Should().BeSameAs(lease);
+    }
+
+    [Fact]
+    public async Task DetachLiveObservationAsync_WhenNoLiveSinkIsBound_ShouldNoopWithoutProjectionCalls()
+    {
+        var projectionPort = new FakeProjectionPort();
+        var target = CreateTarget(projectionPort);
+
+        await target.DetachLiveObservationAsync(CancellationToken.None);
+
+        projectionPort.Events.Should().BeEmpty();
+        target.LiveSink.Should().BeNull();
+        target.ProjectionLease.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DetachLiveObservationAsync_WhenLiveSinkLeaseIsNull_ShouldDetachWithExplicitNullLease()
+    {
+        var projectionPort = new FakeProjectionPort();
+        var sink = new FakeEventSink();
+        var lease = new FakeProjectionLease("run-1", "cmd-1");
+        var target = CreateTarget(projectionPort);
+        target.BindLiveObservation(lease, null, sink);
+
+        await target.DetachLiveObservationAsync(CancellationToken.None);
+
+        projectionPort.Events.Should().Equal("detach:");
         sink.DisposeCalls.Should().Be(1);
         target.LiveSink.Should().BeNull();
         target.ProjectionLease.Should().BeSameAs(lease);

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -54,7 +54,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             projectionPort: projectionPort,
             actorPort: actorPort,
             createdActorIds: ["definition-1", "run-1"]);
-        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeLiveSinkLease("run-1"), new FakeEventSink());
         var detached = false;
 
         await target.ReleaseAsync(
@@ -81,7 +81,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             projectionPort: projectionPort,
             createdActorIds: ["definition-1", "run-1"]);
         var lease = new FakeProjectionLease("run-1", "cmd-1");
-        target.BindLiveObservation(lease, new FakeEventSink());
+        target.BindLiveObservation(lease, new FakeLiveSinkLease("run-1"), new FakeEventSink());
 
         await target.ReleaseAfterInteractionAsync(
             new WorkflowChatRunAcceptedReceipt("run-1", "direct", "cmd-1", "corr-1"),
@@ -221,8 +221,8 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         var target = CreateTarget(projectionPort);
         var lease = new FakeProjectionLease("run-1", "cmd-1");
         var sink = new FakeEventSink();
-        target.BindLiveObservation(lease, sink);
-        target.BindLiveObservation(lease, sink);
+        target.BindLiveObservation(lease, new FakeLiveSinkLease("run-1"), sink);
+        target.BindLiveObservation(lease, new FakeLiveSinkLease("run-1"), sink);
 
         await target.ReleaseAsync(destroyCreatedActors: false, ct: CancellationToken.None);
 
@@ -237,7 +237,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         var target = CreateTarget(projectionPort);
         var lease = new FakeProjectionLease("run-1", "cmd-1");
         var sink = new FakeEventSink();
-        target.BindLiveObservation(lease, sink);
+        target.BindLiveObservation(lease, new FakeLiveSinkLease("run-1"), sink);
 
         await target.DetachLiveObservationAsync(CancellationToken.None);
 
@@ -262,7 +262,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             projectionPort: projectionPort,
             actorPort: actorPort,
             createdActorIds: ["definition-1"]);
-        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(new FakeProjectionLease("run-1", "cmd-1"), new FakeLiveSinkLease("run-1"), new FakeEventSink());
 
         var act = async () => await target.CleanupAfterDispatchFailureAsync(CancellationToken.None);
 
@@ -375,12 +375,13 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(string rootActorId, string commandId, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task AttachLiveSinkAsync(IWorkflowExecutionProjectionLease lease, IEventSink<WorkflowRunEventEnvelope> sink, CancellationToken ct = default) =>
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(IWorkflowExecutionProjectionLease lease, IEventSink<WorkflowRunEventEnvelope> sink, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task DetachLiveSinkAsync(IWorkflowExecutionProjectionLease lease, IEventSink<WorkflowRunEventEnvelope> sink, CancellationToken ct = default)
+        public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
         {
-            Events.Add($"detach:{lease.ActorId}");
+            var actorId = liveSinkLease is FakeLiveSinkLease fakeLease ? fakeLease.ActorId : string.Empty;
+            Events.Add($"detach:{actorId}");
             if (DetachException != null)
                 throw DetachException;
             return Task.CompletedTask;
@@ -424,6 +425,11 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             DisposeCalls++;
             return ValueTask.CompletedTask;
         }
+    }
+
+    private sealed record FakeLiveSinkLease(string ActorId) : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -739,7 +739,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             return Task.FromResult<IWorkflowExecutionProjectionLease?>(EnsureLease);
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default)
@@ -751,18 +751,12 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
                 throw AttachException;
 
             Events.Add("attach");
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
         public Task DetachLiveSinkAsync(
-            IWorkflowExecutionProjectionLease lease,
-            IEventSink<WorkflowRunEventEnvelope> sink,
-            CancellationToken ct = default)
-        {
-            _ = sink;
-            Events.Add($"detach:{lease.ActorId}");
-            return Task.CompletedTask;
-        }
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
 
         public Task ReleaseActorProjectionAsync(
             IWorkflowExecutionProjectionLease lease,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -452,8 +452,8 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         var lease = new FakeProjectionLease("actor-1", "cmd-1");
         var sink = new FakeEventSink();
 
-        var actOnLease = () => target.BindLiveObservation(null!, sink);
-        var actOnSink = () => target.BindLiveObservation(lease, null!);
+        var actOnLease = () => target.BindLiveObservation(null!, new FakeLiveSinkLease("actor-1"), sink);
+        var actOnSink = () => target.BindLiveObservation(lease, new FakeLiveSinkLease("actor-1"), null!);
 
         actOnLease.Should().Throw<ArgumentNullException>();
         actOnSink.Should().Throw<ArgumentNullException>();
@@ -478,7 +478,10 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        target.BindLiveObservation(new FakeProjectionLease("actor-1", "cmd-1"), new FakeEventSink());
+        target.BindLiveObservation(
+            new FakeProjectionLease("actor-1", "cmd-1"),
+            new FakeLiveSinkLease("actor-1"),
+            new FakeEventSink());
 
         await target.ReleaseAfterInteractionAsync(
             new WorkflowChatRunAcceptedReceipt("actor-1", "workflow-1", "cmd-1", "corr-1"),
@@ -636,7 +639,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        target.BindLiveObservation(new FakeProjectionLease("actor-1", "cmd-1"), sink);
+        target.BindLiveObservation(new FakeProjectionLease("actor-1", "cmd-1"), new FakeLiveSinkLease("actor-1"), sink);
         return target;
     }
 
@@ -755,8 +758,12 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         }
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
-            CancellationToken ct = default) =>
-            Task.CompletedTask;
+            CancellationToken ct = default)
+        {
+            var actorId = liveSinkLease is FakeLiveSinkLease fakeLease ? fakeLease.ActorId : string.Empty;
+            Events.Add($"detach:{actorId}");
+            return Task.CompletedTask;
+        }
 
         public Task ReleaseActorProjectionAsync(
             IWorkflowExecutionProjectionLease lease,
@@ -812,6 +819,13 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         public string ActorId { get; } = actorId;
         public string CommandId { get; } = commandId;
+    }
+
+    private sealed class FakeLiveSinkLease(string actorId) : IAsyncDisposable
+    {
+        public string ActorId { get; } = actorId;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class FakeEventSink : IEventSink<WorkflowRunEventEnvelope>

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -371,15 +371,13 @@ public sealed class WorkflowRunFallbackCoverageTests
             CancellationToken ct = default) =>
             Task.FromResult<IWorkflowExecutionProjectionLease?>(new FakeProjectionLease(rootActorId, commandId));
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default) =>
-            Task.CompletedTask;
-
+            Task.FromResult<IAsyncDisposable?>(null);
         public Task DetachLiveSinkAsync(
-            IWorkflowExecutionProjectionLease lease,
-            IEventSink<WorkflowRunEventEnvelope> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>
             Task.CompletedTask;
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -192,7 +192,10 @@ public sealed class WorkflowRunFallbackCoverageTests
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        target.BindLiveObservation(new FakeProjectionLease(actorId, commandId), new EventChannel<WorkflowRunEventEnvelope>());
+        target.BindLiveObservation(
+            new FakeProjectionLease(actorId, commandId),
+            new FakeLiveSinkLease(),
+            new EventChannel<WorkflowRunEventEnvelope>());
         return target;
     }
 
@@ -429,6 +432,11 @@ public sealed class WorkflowRunFallbackCoverageTests
     {
         public string ActorId { get; } = actorId;
         public string CommandId { get; } = commandId;
+    }
+
+    private sealed class FakeLiveSinkLease : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class FakeActor(string id) : IActor

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -252,7 +252,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
             return Task.FromResult<IWorkflowExecutionProjectionLease?>(EnsureLease);
         }
 
-        public Task AttachLiveSinkAsync(
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default)
@@ -262,12 +262,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
                 throw AttachException;
 
             AttachCalls.Add((lease, sink));
-            return Task.CompletedTask;
+            return Task.FromResult<IAsyncDisposable?>(null);
         }
-
         public Task DetachLiveSinkAsync(
-            IWorkflowExecutionProjectionLease lease,
-            IEventSink<WorkflowRunEventEnvelope> sink,
+            IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>
             Task.CompletedTask;
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -87,7 +87,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "direct", null), CancellationToken.None);
         result.Target.Should().NotBeNull();
-        result.Target!.BindLiveObservation(new FakeProjectionLease("actor-1", "cmd-1"), new EventChannel<WorkflowRunEventEnvelope>());
+        result.Target!.BindLiveObservation(
+            new FakeProjectionLease("actor-1", "cmd-1"),
+            null,
+            new EventChannel<WorkflowRunEventEnvelope>());
 
         await result.Target.PublishDetachedCommandSignalAsync(
             new DetachedCommandTimeout<WorkflowChatRunAcceptedReceipt, WorkflowProjectionCompletionStatus>(

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
@@ -48,12 +48,12 @@ public sealed class WorkflowExecutionProjectionPortTests
         });
         var sink = new RecordingRunEventSink();
 
-        await port.AttachLiveSinkAsync(lease, sink);
+        var liveSinkLease = await port.AttachLiveSinkAsync(lease, sink);
         await hub.Handler!(new WorkflowRunEventEnvelope
         {
             Custom = new WorkflowCustomEventPayload { Name = "event-1" },
         });
-        await port.DetachLiveSinkAsync(lease, sink);
+        await port.DetachLiveSinkAsync(liveSinkLease);
 
         hub.SubscribeCalls.Should().Be(1);
         hub.LastScopeId.Should().Be("actor-1");


### PR DESCRIPTION
## 摘要

iter17 cluster-035。`EventSinkProjectionLifecyclePortBase` 不再用 `_sinkSubscriptions` ConcurrentDictionary 持 sink → subscription;改为 `AttachLiveSinkAsync` 返回显式 `IAsyncDisposable` lease,caller 持有 + dispose;port 对 sink lifecycle stateless。

## 来源

iter17 audit cluster-035(rule_ids: PROJ-LIFE-001, MID-STATE-001)。违反 CLAUDE.md "投影编排 Actor 化" + "中间层状态约束(禁止进程内注册表持事实状态)"。

## 改了什么

**核心**:`EventSinkProjectionLifecyclePortBase` 移除 `_sinkSubscriptions`;`AttachLiveSinkAsync` 返回 lease。

**调整 callers**(7+ 个 caller 改 lease 持有):
- `Scripting`(ScriptEvolutionCommandTarget / Binder)
- `Workflow`(WorkflowRunCommandTarget / Binder)
- `GAgentService`(ScopeServiceEndpoints / GAgentApprovalInteraction / GAgentDraftRunInteraction)
- `NyxIdChat`(NyxIdChatStreamingRunner)
- `StreamingProxy`(StreamingProxyEndpoints)

**测试**:多 test 文件更新 lease assertion + source-regression(无 ConcurrentDictionary 持 subscription)。

## 范围

43 files,**+335 / -256**。

## Stacked-PR

iter17 batch B(独立 cluster,base=`auto-refact-dev`)。

🤖 Auto-loop / codex-refactor-loop iter17 cluster-035
