### PR TITLE
refactor: cluster-001 stream-only ILLMProvider(删 ChatAsync 非流式入口)

### DIFF
--- a/src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs
+++ b/src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs
@@ -1,11 +1,11 @@
 // ─────────────────────────────────────────────────────────────
 // ILLMProvider — 大语言模型提供者接口
-// 定义 LLM 调用契约：同步 Chat 与流式 ChatStream
+// 定义 LLM 调用契约：provider execution is stream-only.
 // ─────────────────────────────────────────────────────────────
 
 namespace Aevatar.AI.Abstractions.LLMProviders;
 
-/// <summary>大语言模型提供者接口。封装 Chat 与流式 ChatStream 调用。</summary>
+/// <summary>大语言模型提供者接口。封装流式 ChatStream 调用。</summary>
 public interface ILLMProvider
 {
     /// <summary>提供者名称，用于从 Factory 中按名获取。</summary>
@@ -14,16 +14,10 @@ public interface ILLMProvider
     /// <summary>提供者能力描述。用于多模态请求分发与 failover 兼容性校验。</summary>
     LLMProviderCapabilities Capabilities => LLMProviderCapabilities.TextOnly;
 
-    /// <summary>同步 Chat 调用。返回完整响应内容与 tool_calls。</summary>
-    // Refactor (iter15/cluster-024):
-    //   Old pattern: formal conversation entrypoints could call provider ChatAsync as a parallel executor.
-    //   New principle: provider ChatAsync is a boundary compatibility contract only; formal entrypoints call ChatStreamAsync.
-    /// <param name="request">LLM 请求，包含消息、工具、模型参数等。</param>
-    /// <param name="ct">取消令牌。</param>
-    /// <returns>LLM 响应，包含文本内容、工具调用、Token 用量等。</returns>
-    Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default);
-
     /// <summary>流式 Chat 调用。按 chunk 返回文本增量与工具调用增量。</summary>
+    // Refactor (iter18/cluster-001):
+    //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+    //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
     /// <param name="request">LLM 请求。</param>
     /// <param name="ct">取消令牌。</param>
     /// <returns>LLM 流式 chunk 的异步序列。</returns>

--- a/src/Aevatar.AI.Core/Chat/ChatStreamContentAggregator.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatStreamContentAggregator.cs
@@ -11,9 +11,9 @@ public static class ChatStreamContentAggregator
         bool emptyAsNull = true,
         CancellationToken ct = default)
     {
-        // Refactor (iter15/cluster-024):
-        //   Old pattern: offline callers duplicated StringBuilder loops after direct provider.ChatAsync removal.
-        //   New principle: ChatStreamAsync remains the only authoritative AI executor, with one narrow text aggregation adapter for offline consumers.
+        // Refactor (iter18/cluster-001):
+        //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+        //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
         var content = new StringBuilder();
         await foreach (var chunk in stream.WithCancellation(ct))
         {
@@ -29,11 +29,13 @@ public static class ChatStreamContentAggregator
         LLMRequest request,
         CancellationToken ct = default)
     {
-        // Refactor (iter15/cluster-024):
-        //   Old pattern: ToolCallLoop treated provider.ChatAsync as a second authoritative LLM response path.
-        //   New principle: stream-derived LLMResponse aggregation preserves content, reasoning, tool calls, usage, and finish reason from provider.ChatStreamAsync.
+        // Refactor (iter18/cluster-001):
+        //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+        //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
+        // New pattern: offline aggregation consumes ChatStreamAsync; provider execution remains stream-first.
         var content = new StringBuilder();
         var reasoningContent = new StringBuilder();
+        List<ContentPart>? contentParts = null;
         var toolCalls = new StreamingToolCallAccumulator();
         TokenUsage? usage = null;
         string? finishReason = null;
@@ -45,6 +47,12 @@ public static class ChatStreamContentAggregator
 
             if (!string.IsNullOrEmpty(chunk.DeltaReasoningContent))
                 reasoningContent.Append(chunk.DeltaReasoningContent);
+
+            if (chunk.DeltaContentPart != null)
+            {
+                contentParts ??= [];
+                contentParts.Add(chunk.DeltaContentPart);
+            }
 
             if (chunk.DeltaToolCall != null)
                 toolCalls.TrackDelta(chunk.DeltaToolCall);
@@ -61,6 +69,7 @@ public static class ChatStreamContentAggregator
         {
             Content = content.Length > 0 ? content.ToString() : null,
             ReasoningContent = reasoningContent.Length > 0 ? reasoningContent.ToString() : null,
+            ContentParts = contentParts,
             ToolCalls = finalToolCalls.Count > 0 ? finalToolCalls : null,
             Usage = usage,
             FinishReason = finishReason,

--- a/src/Aevatar.AI.Core/LLMProviders/FailoverLLMProviderFactory.cs
+++ b/src/Aevatar.AI.Core/LLMProviders/FailoverLLMProviderFactory.cs
@@ -165,6 +165,9 @@ public sealed class FailoverLLMProviderFactory : ILLMProviderFactory
 /// <summary>
 /// Wrapper provider that executes primary first and falls back to secondary provider when primary is invalid.
 /// </summary>
+// Refactor (iter18/cluster-001):
+//   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+//   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
 public sealed class FailoverLLMProvider : ILLMProvider
 {
     private readonly ILLMProvider? _primary;
@@ -186,42 +189,6 @@ public sealed class FailoverLLMProvider : ILLMProvider
         _primary = primary;
         _fallback = fallback;
         _logger = logger ?? NullLogger.Instance;
-    }
-
-    public async Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-    {
-        var primary = ResolveCompatiblePrimary(request);
-        var fallback = ResolveCompatibleFallback(request);
-
-        if (primary == null)
-            return await RequireFallback(fallback).ChatAsync(request, ct);
-
-        if (fallback == null)
-            return await primary.ChatAsync(request, ct);
-
-        try
-        {
-            var response = await primary.ChatAsync(request, ct);
-            if (HasUsableOutput(response))
-                return response;
-
-            _logger.LogWarning(
-                "Failover provider {Name}: primary provider {Primary} returned empty response, switching to fallback {Fallback}.",
-                Name,
-                primary.Name,
-                fallback.Name);
-        }
-        catch (Exception ex) when (CanFailover(ex, ct))
-        {
-            _logger.LogWarning(
-                ex,
-                "Failover provider {Name}: primary provider {Primary} failed, switching to fallback {Fallback}.",
-                Name,
-                primary.Name,
-                fallback.Name);
-        }
-
-        return await fallback.ChatAsync(request, ct);
     }
 
     public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
@@ -346,16 +313,6 @@ public sealed class FailoverLLMProvider : ILLMProvider
         var requested = string.Join(", ", Capabilities.SupportedInputModalities);
         return new InvalidOperationException(
             $"No compatible LLM provider is available for failover provider '{Name}'. Advertised modalities: {requested}.");
-    }
-
-    private static bool HasUsableOutput(LLMResponse? response)
-    {
-        if (response == null)
-            return false;
-
-        return !string.IsNullOrWhiteSpace(response.Content)
-               || response.ContentParts is { Count: > 0 }
-               || response.ToolCalls is { Count: > 0 };
     }
 
     private static bool IsMeaningfulChunk(LLMStreamChunk chunk) =>

--- a/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.MEAI/MEAILLMProvider.cs
@@ -67,25 +67,12 @@ public sealed class MEAILLMProvider : ILLMProvider
         _logger = logger ?? NullLogger.Instance;
     }
 
-    // ─── ILLMProvider.ChatAsync ───
-
-    /// <summary>Single-turn LLM call. Converts Aevatar's LLMRequest into a list of MEAI ChatMessage instances.</summary>
-    public async Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-    {
-        var messages = ConvertMessages(request.Messages);
-        var options = BuildOptions(request);
-
-        _logger.LogDebug("MEAI ChatAsync: {MessageCount} messages, model={Model}",
-            messages.Count, options?.ModelId);
-
-        var response = await _client.GetResponseAsync(messages, options, ct);
-
-        return ConvertResponse(response);
-    }
-
     // ─── ILLMProvider.ChatStreamAsync ───
 
     /// <summary>Streaming LLM call. Returns an async-enumerable stream of chunks.</summary>
+    // Refactor (iter18/cluster-001):
+    //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+    //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
     public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         LLMRequest request,
         [EnumeratorCancellation] CancellationToken ct = default)
@@ -168,47 +155,41 @@ public sealed class MEAILLMProvider : ILLMProvider
                 Name);
 
             var fallback = ConvertResponse(await _client.GetResponseAsync(messages, options, ct));
-            if (!string.IsNullOrEmpty(fallback.Content))
-            {
-                yield return new LLMStreamChunk
-                {
-                    DeltaContent = fallback.Content,
-                };
-            }
-
-            if (fallback.ContentParts is { Count: > 0 })
-            {
-                foreach (var contentPart in fallback.ContentParts)
-                {
-                    yield return new LLMStreamChunk
-                    {
-                        DeltaContentPart = contentPart,
-                    };
-                }
-            }
-
-            if (fallback.ToolCalls is { Count: > 0 })
-            {
-                foreach (var toolCall in fallback.ToolCalls)
-                {
-                    yield return new LLMStreamChunk
-                    {
-                        DeltaToolCall = toolCall,
-                    };
-                }
-            }
-
-            yield return new LLMStreamChunk
-            {
-                IsLast = true,
-                Usage = fallback.Usage,
-                FinishReason = fallback.FinishReason,
-            };
+            foreach (var fallbackChunk in MapResponseToStreamChunks(fallback))
+                yield return fallbackChunk;
             yield break;
         }
 
         // The final chunk marks the end
         yield return new LLMStreamChunk { IsLast = true, FinishReason = lastFinishReason };
+    }
+
+    private static IEnumerable<LLMStreamChunk> MapResponseToStreamChunks(LLMResponse fallback)
+    {
+        // Refactor (iter18/cluster-001):
+        //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+        //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
+        if (!string.IsNullOrEmpty(fallback.Content))
+            yield return new LLMStreamChunk { DeltaContent = fallback.Content };
+
+        if (fallback.ContentParts is { Count: > 0 })
+        {
+            foreach (var contentPart in fallback.ContentParts)
+                yield return new LLMStreamChunk { DeltaContentPart = contentPart };
+        }
+
+        if (fallback.ToolCalls is { Count: > 0 })
+        {
+            foreach (var toolCall in fallback.ToolCalls)
+                yield return new LLMStreamChunk { DeltaToolCall = toolCall };
+        }
+
+        yield return new LLMStreamChunk
+        {
+            IsLast = true,
+            Usage = fallback.Usage,
+            FinishReason = fallback.FinishReason,
+        };
     }
 
     // ─── Conversion: Aevatar -> MEAI ───

--- a/src/Aevatar.AI.LLMProviders.NyxId/NyxIdLLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.NyxId/NyxIdLLMProvider.cs
@@ -47,20 +47,9 @@ public sealed class NyxIdLLMProvider : ILLMProvider
 
     public string Name { get; }
 
-    public async Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-    {
-        var route = await ResolveRouteAsync(request, ct);
-        var provider = CreateDelegateProvider(route.Request, route.Endpoint, route.RouteName, route.AccessToken);
-        try
-        {
-            return await provider.ChatAsync(route.Request, ct);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw TranslateUpstreamFailure(ex, route);
-        }
-    }
-
+    // Refactor (iter18/cluster-001):
+    //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+    //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
     public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         LLMRequest request,
         CancellationToken ct = default)

--- a/src/Aevatar.AI.LLMProviders.Tornado/TornadoLLMProvider.cs
+++ b/src/Aevatar.AI.LLMProviders.Tornado/TornadoLLMProvider.cs
@@ -49,20 +49,12 @@ public sealed class TornadoLLMProvider : ILLMProvider
         _logger = logger ?? NullLogger.Instance;
     }
 
-    // ─── ILLMProvider.ChatAsync ───
-
-    /// <summary>单轮 LLM 调用。</summary>
-    public async Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-    {
-        var chatRequest = MapRequest(request);
-        _logger.LogDebug("Tornado ChatAsync: {Model}, {MsgCount} 条消息", _modelName, request.Messages.Count);
-        var result = await _api.Chat.CreateChatCompletion(chatRequest).WaitAsync(ct);
-        return MapResponse(result);
-    }
-
     // ─── ILLMProvider.ChatStreamAsync ───
 
     /// <summary>流式 LLM 调用。</summary>
+    // Refactor (iter18/cluster-001):
+    //   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+    //   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
     public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         LLMRequest request, [EnumeratorCancellation] CancellationToken ct = default)
     {
@@ -191,40 +183,6 @@ public sealed class TornadoLLMProvider : ILLMProvider
 
     // ─── 转换：LlmTornado → Aevatar ───
 
-    private static LLMResponse MapResponse(ChatResult? result)
-    {
-        if (result == null)
-            return new LLMResponse { Content = null, FinishReason = "error" };
-
-        var choice = result.Choices?.FirstOrDefault();
-        var content = choice?.Message?.Content;
-        List<AevatarToolCall>? toolCalls = null;
-
-        if (choice?.Message?.ToolCalls is { Count: > 0 })
-        {
-            toolCalls = choice.Message.ToolCalls
-                .Select(ConvertToolCall)
-                .ToList();
-        }
-
-        TokenUsage? usage = null;
-        if (result.Usage != null)
-        {
-            usage = new TokenUsage(
-                result.Usage.PromptTokens,
-                result.Usage.CompletionTokens,
-                result.Usage.TotalTokens);
-        }
-
-        return new LLMResponse
-        {
-            Content = content,
-            ToolCalls = toolCalls,
-            Usage = usage,
-            FinishReason = choice?.FinishReason?.ToString(),
-        };
-    }
-
     private static TokenUsage? MapUsage(ChatUsage? usage)
     {
         if (usage == null)
@@ -234,16 +192,6 @@ public sealed class TornadoLLMProvider : ILLMProvider
             usage.PromptTokens,
             usage.CompletionTokens,
             usage.TotalTokens);
-    }
-
-    private static AevatarToolCall ConvertToolCall(LlmTornado.ChatFunctions.ToolCall toolCall)
-    {
-        return new AevatarToolCall
-        {
-            Id = toolCall.Id ?? Guid.NewGuid().ToString("N"),
-            Name = toolCall.FunctionCall?.Name ?? string.Empty,
-            ArgumentsJson = toolCall.FunctionCall?.Arguments ?? "{}",
-        };
     }
 
     // Keep delta semantics: missing stream IDs should remain empty for downstream merge.

--- a/test/Aevatar.AI.Core.Tests/Middleware/MiddlewarePipelineTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Middleware/MiddlewarePipelineTests.cs
@@ -265,10 +265,6 @@ public class MiddlewarePipelineTests
     {
         public string Name => "fake";
 
-        public Task<Aevatar.AI.Abstractions.LLMProviders.LLMResponse> ChatAsync(
-            Aevatar.AI.Abstractions.LLMProviders.LLMRequest request, CancellationToken ct) =>
-            Task.FromResult(new Aevatar.AI.Abstractions.LLMProviders.LLMResponse { Content = "response" });
-
         public IAsyncEnumerable<Aevatar.AI.Abstractions.LLMProviders.LLMStreamChunk> ChatStreamAsync(
             Aevatar.AI.Abstractions.LLMProviders.LLMRequest request, CancellationToken ct) =>
             AsyncEnumerable.Empty<Aevatar.AI.Abstractions.LLMProviders.LLMStreamChunk>();

--- a/test/Aevatar.AI.Core.Tests/Observability/GenAIObservabilityMiddlewareTests.cs
+++ b/test/Aevatar.AI.Core.Tests/Observability/GenAIObservabilityMiddlewareTests.cs
@@ -378,8 +378,6 @@ public class GenAIObservabilityMiddlewareTests : IDisposable
     private sealed class FakeLLMProvider(string name = "fake") : ILLMProvider
     {
         public string Name => name;
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct) =>
-            Task.FromResult(new LLMResponse { Content = "r" });
         public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(LLMRequest request, CancellationToken ct) =>
             AsyncEnumerable.Empty<LLMStreamChunk>();
     }

--- a/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
@@ -76,22 +76,24 @@ public class AIComponentCoverageTests
         IReadOnlyList<MeaiChatMessage>? capturedMessages = null;
         var client = new StubChatClient
         {
-            OnGetResponse = (messages, _, _) =>
+            OnGetStreamingResponse = (messages, _, _) =>
             {
                 capturedMessages = messages.ToList();
-                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "ok")));
+                return Stream(["ok"]);
             },
         };
 
         var provider = new MEAILLMProvider("meai-reasoning-outbound", client);
-        await provider.ChatAsync(new LLMRequest
+        await foreach (var _ in provider.ChatStreamAsync(new LLMRequest
         {
             Messages =
             [
                 new AevatarChatMessage { Role = "user", Content = "hi" },
                 new AevatarChatMessage { Role = "assistant", Content = "thought", ReasoningContent = "reasoning-text" },
             ],
-        });
+        }))
+        {
+        }
 
         capturedMessages.Should().NotBeNull();
         capturedMessages!.Should().HaveCount(2);
@@ -114,15 +116,15 @@ public class AIComponentCoverageTests
         IReadOnlyList<MeaiChatMessage>? capturedMessages = null;
         var client = new StubChatClient
         {
-            OnGetResponse = (messages, _, _) =>
+            OnGetStreamingResponse = (messages, _, _) =>
             {
                 capturedMessages = messages.ToList();
-                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "ok")));
+                return Stream(["ok"]);
             },
         };
 
         var provider = new MEAILLMProvider("meai-reasoning-tools", client);
-        await provider.ChatAsync(new LLMRequest
+        await foreach (var _ in provider.ChatStreamAsync(new LLMRequest
         {
             Messages =
             [
@@ -142,7 +144,9 @@ public class AIComponentCoverageTests
                 },
                 new AevatarChatMessage { Role = "tool", ToolCallId = "tc1", Content = "result" },
             ],
-        });
+        }))
+        {
+        }
 
         capturedMessages.Should().NotBeNull();
         var assistantWithTools = capturedMessages![1];
@@ -167,22 +171,24 @@ public class AIComponentCoverageTests
         IReadOnlyList<MeaiChatMessage>? capturedMessages = null;
         var client = new StubChatClient
         {
-            OnGetResponse = (messages, _, _) =>
+            OnGetStreamingResponse = (messages, _, _) =>
             {
                 capturedMessages = messages.ToList();
-                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "ok")));
+                return Stream(["ok"]);
             },
         };
 
         var provider = new MEAILLMProvider("meai-reasoning-empty-assistant", client);
-        await provider.ChatAsync(new LLMRequest
+        await foreach (var _ in provider.ChatStreamAsync(new LLMRequest
         {
             Messages =
             [
                 new AevatarChatMessage { Role = "user", Content = "hi" },
                 new AevatarChatMessage { Role = "assistant", Content = string.Empty, ReasoningContent = "thinking-only" },
             ],
-        });
+        }))
+        {
+        }
 
         capturedMessages.Should().NotBeNull();
         var assistantMsg = capturedMessages![1];
@@ -271,39 +277,29 @@ public class AIComponentCoverageTests
 
         var client = new StubChatClient
         {
-            OnGetResponse = (messages, options, _) =>
+            OnGetStreamingResponse = (messages, options, _) =>
             {
                 capturedMessages = messages.ToList();
                 capturedOptions = options;
 
-                var assistant = new MeaiChatMessage(ChatRole.Assistant, "hello");
-                assistant.Contents.Add(new FunctionCallContent("call-1", "calc", new Dictionary<string, object?>
-                {
-                    ["x"] = 1,
-                }));
-
-                var response = new ChatResponse(assistant)
-                {
-                    Usage = new UsageDetails
-                    {
-                        InputTokenCount = 3,
-                        OutputTokenCount = 2,
-                        TotalTokenCount = 5,
-                    },
-                };
-                return Task.FromResult(response);
-            },
-            OnGetStreamingResponse = (_, options, _) =>
-            {
-                capturedStreamingOptions = options;
-                return Stream(["a", "b"]);
+                return Stream([
+                    new ChatResponseUpdate(ChatRole.Assistant, "hello"),
+                    new ChatResponseUpdate(
+                        ChatRole.Assistant,
+                        [
+                            new FunctionCallContent("call-1", "calc", new Dictionary<string, object?>
+                            {
+                                ["x"] = 1,
+                            }),
+                        ]),
+                ]);
             },
         };
 
         var provider = new MEAILLMProvider("meai", client);
 
         var tool = new StubTool("search");
-        var response = await provider.ChatAsync(new LLMRequest
+        var response = await ChatStreamContentAggregator.AggregateResponseAsync(provider, new LLMRequest
         {
             RequestId = "session-1",
             Metadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -338,10 +334,6 @@ public class AIComponentCoverageTests
         response.ToolCalls.Should().NotBeNull();
         response.ToolCalls![0].Id.Should().Be("call-1");
         response.ToolCalls[0].Name.Should().Be("calc");
-        response.Usage.Should().NotBeNull();
-        response.Usage!.PromptTokens.Should().Be(3);
-        response.Usage.CompletionTokens.Should().Be(2);
-        response.Usage.TotalTokens.Should().Be(5);
 
         capturedMessages.Should().NotBeNull();
         capturedMessages!.Should().HaveCount(2);
@@ -356,6 +348,16 @@ public class AIComponentCoverageTests
         capturedOptions.MaxOutputTokens.Should().Be(42);
         capturedOptions.Tools.Should().NotBeNull();
         capturedOptions.Tools.Should().ContainSingle();
+
+        client = new StubChatClient
+        {
+            OnGetStreamingResponse = (_, options, _) =>
+            {
+                capturedStreamingOptions = options;
+                return Stream(["a", "b"]);
+            },
+        };
+        provider = new MEAILLMProvider("meai", client);
 
         var chunks = new List<LLMStreamChunk>();
         await foreach (var chunk in provider.ChatStreamAsync(new LLMRequest
@@ -483,7 +485,7 @@ public class AIComponentCoverageTests
         };
 
         var provider = new MEAILLMProvider("meai-text-content", client);
-        var response = await provider.ChatAsync(new LLMRequest
+        var response = await ChatStreamContentAggregator.AggregateResponseAsync(provider, new LLMRequest
         {
             Messages = [new AevatarChatMessage { Role = "user", Content = "hi" }],
         });
@@ -581,7 +583,7 @@ public class AIComponentCoverageTests
     }
 
     [Fact]
-    public void TornadoProvider_PrivateMappers_ShouldMapRequestAndResponse()
+    public void TornadoProvider_PrivateMappers_ShouldMapRequestAndStreamDeltas()
     {
         var provider = new TornadoLLMProvider(
             "tor",
@@ -623,53 +625,6 @@ public class AIComponentCoverageTests
         mappedRequest.Metadata.Should().NotBeNull();
         mappedRequest.Metadata![LLMRequestMetadataKeys.RequestId].Should().Be("session-tornado");
         mappedRequest.Metadata["workflow.run_id"].Should().Be("run-tornado");
-
-        var chatResult = new ChatResult
-        {
-            Choices =
-            [
-                new ChatChoice
-                {
-                    Message = new LlmTornado.Chat.ChatMessage(ChatMessageRoles.Assistant, "reply")
-                    {
-                        ToolCalls =
-                        [
-                            new LlmTornado.ChatFunctions.ToolCall
-                            {
-                                Id = "tc-1",
-                                FunctionCall = new FunctionCall
-                                {
-                                    Name = "calc",
-                                    Arguments = "{\"x\":1}",
-                                },
-                            },
-                        ],
-                    },
-                    FinishReason = ChatMessageFinishReasons.StopSequence,
-                },
-            ],
-            Usage = new ChatUsage(LLmProviders.OpenAi)
-            {
-                PromptTokens = 2,
-                CompletionTokens = 3,
-                TotalTokens = 5,
-            },
-        };
-
-        var mappedResponse = InvokePrivateStatic<LLMResponse>(typeof(TornadoLLMProvider), "MapResponse", chatResult);
-        mappedResponse.Content.Should().Be("reply");
-        mappedResponse.ToolCalls.Should().NotBeNull();
-        mappedResponse.ToolCalls![0].Id.Should().Be("tc-1");
-        mappedResponse.ToolCalls[0].Name.Should().Be("calc");
-        mappedResponse.ToolCalls[0].ArgumentsJson.Should().Be("{\"x\":1}");
-        mappedResponse.Usage.Should().NotBeNull();
-        mappedResponse.Usage!.PromptTokens.Should().Be(2);
-        mappedResponse.Usage.CompletionTokens.Should().Be(3);
-        mappedResponse.Usage.TotalTokens.Should().Be(5);
-        mappedResponse.FinishReason.Should().Contain("Stop");
-
-        var mappedNullResponse = InvokePrivateStatic<LLMResponse>(typeof(TornadoLLMProvider), "MapResponse", new object?[] { null });
-        mappedNullResponse.FinishReason.Should().Be("error");
 
         var deltaToolCall = InvokePrivateStatic<Aevatar.AI.Abstractions.LLMProviders.ToolCall>(
             typeof(TornadoLLMProvider),
@@ -749,37 +704,8 @@ public class AIComponentCoverageTests
     }
 
     [Fact]
-    public void TornadoProvider_MapResponseAndToolCallConverters_ShouldHandleSparsePayloads()
+    public void TornadoProvider_ToolCallDeltaConverter_ShouldHandleSparsePayloads()
     {
-        var sparseResult = new ChatResult
-        {
-            Choices =
-            [
-                new ChatChoice
-                {
-                    Message = null,
-                    FinishReason = ChatMessageFinishReasons.Length,
-                },
-            ],
-        };
-
-        var response = InvokePrivateStatic<LLMResponse>(typeof(TornadoLLMProvider), "MapResponse", sparseResult);
-        response.Content.Should().BeNull();
-        response.ToolCalls.Should().BeNull();
-        response.Usage.Should().BeNull();
-        response.FinishReason.Should().Contain("Length");
-
-        var generatedToolCall = InvokePrivateStatic<Aevatar.AI.Abstractions.LLMProviders.ToolCall>(
-            typeof(TornadoLLMProvider),
-            "ConvertToolCall",
-            new LlmTornado.ChatFunctions.ToolCall
-            {
-                FunctionCall = null,
-            });
-        generatedToolCall.Id.Should().NotBeNullOrWhiteSpace();
-        generatedToolCall.Name.Should().BeEmpty();
-        generatedToolCall.ArgumentsJson.Should().Be("{}");
-
         var emptyDelta = InvokePrivateStatic<Aevatar.AI.Abstractions.LLMProviders.ToolCall>(
             typeof(TornadoLLMProvider),
             "ConvertToolCallDelta",
@@ -882,6 +808,15 @@ public class AIComponentCoverageTests
         foreach (var part in parts)
         {
             yield return new ChatResponseUpdate(ChatRole.Assistant, part);
+            await Task.Yield();
+        }
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> Stream(IEnumerable<ChatResponseUpdate> updates)
+    {
+        foreach (var update in updates)
+        {
+            yield return update;
             await Task.Yield();
         }
     }

--- a/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
@@ -388,22 +388,31 @@ public class AIComponentCoverageTests
             OnGetResponse = (_, _, _) =>
             {
                 nonStreamingFallbackCalls++;
-                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "fallback-content")));
+                return Task.FromResult(new ChatResponse(new MeaiChatMessage(ChatRole.Assistant, "fallback-content"))
+                {
+                    Usage = new UsageDetails
+                    {
+                        InputTokenCount = 3,
+                        OutputTokenCount = 2,
+                        TotalTokenCount = 5,
+                    },
+                });
             },
         };
         var emptyStreamProvider = new MEAILLMProvider("meai-empty-stream", emptyStreamClient);
-        var emptyStreamChunks = new List<LLMStreamChunk>();
-        await foreach (var chunk in emptyStreamProvider.ChatStreamAsync(new LLMRequest
-        {
-            Messages = [new AevatarChatMessage { Role = "user", Content = "hello fallback" }],
-        }))
-        {
-            emptyStreamChunks.Add(chunk);
-        }
+        var emptyStreamResponse = await ChatStreamContentAggregator.AggregateResponseAsync(
+            emptyStreamProvider,
+            new LLMRequest
+            {
+                Messages = [new AevatarChatMessage { Role = "user", Content = "hello fallback" }],
+            });
 
         nonStreamingFallbackCalls.Should().Be(1);
-        emptyStreamChunks.Should().Contain(x => x.DeltaContent == "fallback-content");
-        emptyStreamChunks.Last().IsLast.Should().BeTrue();
+        emptyStreamResponse.Content.Should().Be("fallback-content");
+        emptyStreamResponse.Usage.Should().NotBeNull();
+        emptyStreamResponse.Usage!.PromptTokens.Should().Be(3);
+        emptyStreamResponse.Usage.CompletionTokens.Should().Be(2);
+        emptyStreamResponse.Usage.TotalTokens.Should().Be(5);
 
         var reasoningOnlyFallbackCalls = 0;
         var reasoningOnlyClient = new StubChatClient

--- a/test/Aevatar.AI.Tests/AIGAgentBaseToolRefreshTests.cs
+++ b/test/Aevatar.AI.Tests/AIGAgentBaseToolRefreshTests.cs
@@ -146,13 +146,6 @@ public class AIGAgentBaseToolRefreshTests
     {
         public string Name => name;
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            _ = request;
-            return Task.FromResult(new LLMResponse { Content = "ok" });
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.AI.Tests/AgentCoverageTestSupport.cs
+++ b/test/Aevatar.AI.Tests/AgentCoverageTestSupport.cs
@@ -123,7 +123,7 @@ internal sealed class TestRecordingEventPublisher : IEventPublisher
 }
 
 internal sealed class StubChatProviderFactory(
-    Func<LLMRequest, CancellationToken, Task<LLMResponse>> onChatAsync)
+    Func<LLMRequest, CancellationToken, Task<LLMResponse>> buildResponseAsync)
     : ILLMProviderFactory, ILLMProvider
 {
     public string Name => "test-provider";
@@ -142,7 +142,7 @@ internal sealed class StubChatProviderFactory(
         LLMRequest request,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        var response = await onChatAsync(request, ct);
+        var response = await buildResponseAsync(request, ct);
         if (!string.IsNullOrEmpty(response.Content))
             yield return new LLMStreamChunk { DeltaContent = response.Content };
 

--- a/test/Aevatar.AI.Tests/AgentCoverageTestSupport.cs
+++ b/test/Aevatar.AI.Tests/AgentCoverageTestSupport.cs
@@ -138,18 +138,19 @@ internal sealed class StubChatProviderFactory(
 
     public IReadOnlyList<string> GetAvailableProviders() => [Name];
 
-    public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) => onChatAsync(request, ct);
-
     public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         LLMRequest request,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        _ = request;
-        ct.ThrowIfCancellationRequested();
-        await Task.Yield();
-        throw new InvalidOperationException("Streaming path should not be used in this test.");
-#pragma warning disable CS0162
-        yield break;
-#pragma warning restore CS0162
+        var response = await onChatAsync(request, ct);
+        if (!string.IsNullOrEmpty(response.Content))
+            yield return new LLMStreamChunk { DeltaContent = response.Content };
+
+        yield return new LLMStreamChunk
+        {
+            IsLast = true,
+            Usage = response.Usage,
+            FinishReason = response.FinishReason,
+        };
     }
 }

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -408,6 +408,39 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
+    public void ProviderContractSurfaces_ShouldNotDeclareNonStreamingChatAsync()
+    {
+        var root = FindRepositoryRoot();
+        var providerContractFile = Path.Combine(
+            root,
+            "src",
+            "Aevatar.AI.Abstractions",
+            "LLMProviders",
+            "ILLMProvider.cs");
+        var concreteProviderRoots = new[]
+        {
+            Path.Combine(root, "src", "Aevatar.AI.LLMProviders.MEAI"),
+            Path.Combine(root, "src", "Aevatar.AI.LLMProviders.NyxId"),
+            Path.Combine(root, "src", "Aevatar.AI.LLMProviders.Tornado"),
+        };
+
+        var scannedFiles = new[] { providerContractFile }
+            .Concat(concreteProviderRoots.SelectMany(scanRoot =>
+                Directory.EnumerateFiles(scanRoot, "*.cs", SearchOption.AllDirectories)));
+        var offenders = scannedFiles
+            .SelectMany(file => File.ReadLines(file)
+                .Select((line, index) => new { file, line, index })
+                .Where(x => !x.line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                .Where(x => System.Text.RegularExpressions.Regex.IsMatch(
+                    x.line,
+                    @"Task<LLMResponse>\s+ChatAsync\s*\("))
+                .Select(x => $"{Path.GetRelativePath(root, x.file)}:{x.index + 1}:{x.line.Trim()}"))
+            .ToArray();
+
+        offenders.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task ChatStreamAsync_WhenAgentMiddlewareTerminates_ShouldEmitSyntheticContentChunk()
     {
         var provider = new StreamingProvider(["ignored"]);

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -369,7 +369,6 @@ public sealed class ChatRuntimeStreamingBufferTests
         var result = await runtime.ChatAsync("hello");
 
         result.Should().Be("short-circuit");
-        provider.ChatCallCount.Should().Be(0);
         provider.StreamCallCount.Should().Be(0);
     }
 
@@ -382,7 +381,6 @@ public sealed class ChatRuntimeStreamingBufferTests
         var result = await runtime.ChatAsync("hello");
 
         result.Should().Be("stream-answer");
-        provider.ChatCallCount.Should().Be(0);
         provider.StreamCallCount.Should().Be(1);
     }
 
@@ -563,13 +561,6 @@ public sealed class ChatRuntimeStreamingBufferTests
         public string Name => "queued-streaming-provider";
         public List<LLMRequest> StreamRequests { get; } = [];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            _ = request;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new LLMResponse());
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
@@ -592,18 +583,8 @@ public sealed class ChatRuntimeStreamingBufferTests
         IReadOnlyList<LLMStreamChunk>? streamToolDeltas = null) : ILLMProvider
     {
         public string Name => "streaming-provider";
-        public int ChatCallCount { get; private set; }
         public int StreamCallCount { get; private set; }
         public LLMRequest? LastStreamRequest { get; private set; }
-        public LLMRequest? LastChatRequest { get; private set; }
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            LastChatRequest = request;
-            ChatCallCount++;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new LLMResponse { Content = string.Concat(chunks) });
-        }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -419,6 +419,7 @@ public sealed class ChatRuntimeStreamingBufferTests
             "ILLMProvider.cs");
         var concreteProviderRoots = new[]
         {
+            Path.Combine(root, "src", "Aevatar.AI.Core", "LLMProviders"),
             Path.Combine(root, "src", "Aevatar.AI.LLMProviders.MEAI"),
             Path.Combine(root, "src", "Aevatar.AI.LLMProviders.NyxId"),
             Path.Combine(root, "src", "Aevatar.AI.LLMProviders.Tornado"),

--- a/test/Aevatar.AI.Tests/ChatStreamContentAggregatorTests.cs
+++ b/test/Aevatar.AI.Tests/ChatStreamContentAggregatorTests.cs
@@ -1,0 +1,103 @@
+using System.Runtime.CompilerServices;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core.Chat;
+using FluentAssertions;
+
+namespace Aevatar.AI.Tests;
+
+public sealed class ChatStreamContentAggregatorTests
+{
+    [Fact]
+    public async Task AggregateResponseAsync_ShouldPreserveTextReasoningContentPartsUsageAndFinishReason()
+    {
+        var imagePart = ContentPart.ImageUriPart("https://example.test/image.png");
+        var provider = new StubProvider([
+            new LLMStreamChunk { DeltaContent = "hel" },
+            new LLMStreamChunk { DeltaReasoningContent = "think " },
+            new LLMStreamChunk { DeltaContent = "lo" },
+            new LLMStreamChunk { DeltaContentPart = imagePart },
+            new LLMStreamChunk
+            {
+                IsLast = true,
+                Usage = new TokenUsage(3, 5, 8),
+                FinishReason = "stop",
+            },
+        ]);
+
+        var response = await ChatStreamContentAggregator.AggregateResponseAsync(
+            provider,
+            new LLMRequest { Messages = [] });
+
+        response.Content.Should().Be("hello");
+        response.ReasoningContent.Should().Be("think ");
+        response.ContentParts.Should().ContainSingle().Which.Should().BeSameAs(imagePart);
+        response.Usage.Should().BeEquivalentTo(new TokenUsage(3, 5, 8));
+        response.FinishReason.Should().Be("stop");
+    }
+
+    [Fact]
+    public async Task AggregateResponseAsync_ShouldReconstructStreamedToolCallDeltas()
+    {
+        var provider = new StubProvider([
+            new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall { Id = "call-1", Name = "lookup", ArgumentsJson = "{\"q\":" },
+            },
+            new LLMStreamChunk
+            {
+                DeltaToolCall = new ToolCall { Id = "call-1", Name = string.Empty, ArgumentsJson = "\"aevatar\"}" },
+            },
+            new LLMStreamChunk { IsLast = true, FinishReason = "tool_calls" },
+        ]);
+
+        var response = await ChatStreamContentAggregator.AggregateResponseAsync(
+            provider,
+            new LLMRequest { Messages = [] });
+
+        response.ToolCalls.Should().ContainSingle().Which.Should().BeEquivalentTo(new ToolCall
+        {
+            Id = "call-1",
+            Name = "lookup",
+            ArgumentsJson = "{\"q\":\"aevatar\"}",
+        });
+        response.FinishReason.Should().Be("tool_calls");
+    }
+
+    [Fact]
+    public async Task AggregateResponseAsync_ShouldReturnNullContentValues_WhenStreamHasNoContent()
+    {
+        var provider = new StubProvider([
+            new LLMStreamChunk { Usage = new TokenUsage(1, 0, 1) },
+            new LLMStreamChunk { IsLast = true, FinishReason = "stop" },
+        ]);
+
+        var response = await ChatStreamContentAggregator.AggregateResponseAsync(
+            provider,
+            new LLMRequest { Messages = [] });
+
+        response.Content.Should().BeNull();
+        response.ReasoningContent.Should().BeNull();
+        response.ContentParts.Should().BeNull();
+        response.ToolCalls.Should().BeNull();
+        response.Usage.Should().BeEquivalentTo(new TokenUsage(1, 0, 1));
+        response.FinishReason.Should().Be("stop");
+    }
+
+    private sealed class StubProvider(IReadOnlyList<LLMStreamChunk> chunks) : ILLMProvider
+    {
+        public string Name => "stub";
+
+        public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
+            LLMRequest request,
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            _ = request;
+            foreach (var chunk in chunks)
+            {
+                ct.ThrowIfCancellationRequested();
+                yield return chunk;
+                await Task.Yield();
+            }
+        }
+    }
+}

--- a/test/Aevatar.AI.Tests/ChatbotClassifierGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/ChatbotClassifierGAgentTests.cs
@@ -137,13 +137,6 @@ public class ChatbotClassifierGAgentTests
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            _ = request;
-            ct.ThrowIfCancellationRequested();
-            throw new InvalidOperationException("Provider boundary ChatAsync should not be used by classifier.");
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.AI.Tests/ContextCompressorTests.cs
+++ b/test/Aevatar.AI.Tests/ContextCompressorTests.cs
@@ -774,12 +774,6 @@ public class ContextCompressorTests
 
         public string Name => "queue";
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(_responses.Count > 0 ? _responses.Dequeue() : new LLMResponse());
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
@@ -830,9 +824,6 @@ public class ContextCompressorTests
     private sealed class CapturingLLMProvider(Func<LLMRequest, LLMResponse> handler) : ILLMProvider
     {
         public string Name => "capturing";
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            Task.FromResult(handler(request));
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.AI.Tests/FailoverLLMProviderFactoryTests.cs
+++ b/test/Aevatar.AI.Tests/FailoverLLMProviderFactoryTests.cs
@@ -157,43 +157,6 @@ public sealed class FailoverLLMProviderFactoryTests
     }
 
     [Fact]
-    public async Task ChatStreamAsync_WhenPrimaryThrowsBeforeMeaningfulChunk_ShouldFallback()
-    {
-        var fallbackStreamCalls = 0;
-        var primaryProvider = new StubProvider("openai")
-        {
-            OnChatStreamAsync = static (_, _) => ThrowingStream(),
-        };
-        var fallbackProvider = new StubProvider("openai")
-        {
-            OnChatStreamAsync = (_, _) =>
-            {
-                fallbackStreamCalls++;
-                return ContentStream(["fallback-stream"]);
-            },
-        };
-
-        var factory = new FailoverLLMProviderFactory(
-            primaryFactory: new StubFactory(
-                providers: new Dictionary<string, ILLMProvider>(StringComparer.OrdinalIgnoreCase)
-                {
-                    ["openai"] = primaryProvider,
-                },
-                defaultName: "openai"),
-            fallbackFactory: new StubFactory(
-                providers: new Dictionary<string, ILLMProvider>(StringComparer.OrdinalIgnoreCase)
-                {
-                    ["openai"] = fallbackProvider,
-                },
-                defaultName: "openai"));
-
-        var chunks = await ReadAllAsync(factory.GetProvider("openai").ChatStreamAsync(new LLMRequest { Messages = [] }));
-
-        fallbackStreamCalls.Should().Be(1);
-        chunks.Select(x => x.DeltaContent).Should().Contain("fallback-stream");
-    }
-
-    [Fact]
     public async Task ChatStreamAsync_WhenPrimaryEmitsMeaningfulChunkThenFails_ShouldNotFallback()
     {
         var fallbackStreamCalls = 0;

--- a/test/Aevatar.AI.Tests/FailoverLLMProviderFactoryTests.cs
+++ b/test/Aevatar.AI.Tests/FailoverLLMProviderFactoryTests.cs
@@ -7,11 +7,11 @@ namespace Aevatar.AI.Tests;
 public sealed class FailoverLLMProviderFactoryTests
 {
     [Fact]
-    public async Task GetProvider_WhenPrimaryMissing_ShouldResolveFromFallback()
+    public async Task ChatStreamAsync_WhenPrimaryMissing_ShouldResolveFromFallback()
     {
         var fallbackProvider = new StubProvider("openai")
         {
-            OnChatAsync = static (_, _) => Task.FromResult(new LLMResponse { Content = "fallback-ok" }),
+            OnChatStreamAsync = static (_, _) => ContentStream(["fallback-ok"]),
         };
         var factory = new FailoverLLMProviderFactory(
             primaryFactory: new StubFactory(throwOnGetProvider: new InvalidOperationException("primary missing")),
@@ -23,29 +23,27 @@ public sealed class FailoverLLMProviderFactoryTests
                 defaultName: "openai"));
 
         var provider = factory.GetProvider("openai");
-        var response = await provider.ChatAsync(new LLMRequest { Messages = [] });
+        var chunks = await ReadAllAsync(provider.ChatStreamAsync(new LLMRequest { Messages = [] }));
 
-        response.Content.Should().Be("fallback-ok");
+        chunks.Select(x => x.DeltaContent).Should().Contain("fallback-ok");
     }
 
     [Fact]
-    public async Task ChatAsync_WhenPrimaryThrows_ShouldFallback()
+    public async Task ChatStreamAsync_WhenPrimaryThrowsBeforeMeaningfulChunk_ShouldFallbackToSecondary()
     {
-        var primaryCalls = 0;
         var fallbackCalls = 0;
 
         var primaryProvider = new StubProvider("openai")
         {
-            OnChatAsync = (_, _) =>
-            {
-                primaryCalls++;
-                throw new InvalidOperationException("primary failed");
-            },
+            OnChatStreamAsync = static (_, _) => ThrowingStream(),
         };
         var fallbackProvider = new StubProvider("openai")
         {
-            OnChatAsync = static (_, _) => Task.FromResult(new LLMResponse { Content = "fallback-response" }),
-            OnChatAsyncWithCounter = () => fallbackCalls++,
+            OnChatStreamAsync = (_, _) =>
+            {
+                fallbackCalls++;
+                return ContentStream(["fallback-response"]);
+            },
         };
 
         var factory = new FailoverLLMProviderFactory(
@@ -62,31 +60,36 @@ public sealed class FailoverLLMProviderFactoryTests
                 },
                 defaultName: "openai"));
 
-        var response = await factory.GetProvider("openai").ChatAsync(new LLMRequest { Messages = [] });
+        var chunks = await ReadAllAsync(factory.GetProvider("openai").ChatStreamAsync(new LLMRequest { Messages = [] }));
 
-        primaryCalls.Should().Be(1);
         fallbackCalls.Should().Be(1);
-        response.Content.Should().Be("fallback-response");
+        chunks.Select(x => x.DeltaContent).Should().Contain("fallback-response");
     }
 
     [Fact]
-    public async Task GetProvider_WhenPreferFallbackDefaultEnabled_ShouldUseFallbackDefaultProvider()
+    public async Task ChatStreamAsync_WhenPreferFallbackDefaultEnabled_ShouldUseFallbackDefaultProvider()
     {
         var fallbackDefaultCalls = 0;
         var fallbackNamedCalls = 0;
         var primaryProvider = new StubProvider("openai")
         {
-            OnChatAsync = (_, _) => throw new InvalidOperationException("primary failed"),
+            OnChatStreamAsync = static (_, _) => ThrowingStream(),
         };
         var fallbackDefaultProvider = new StubProvider("deepseek")
         {
-            OnChatAsync = static (_, _) => Task.FromResult(new LLMResponse { Content = "fallback-default" }),
-            OnChatAsyncWithCounter = () => fallbackDefaultCalls++,
+            OnChatStreamAsync = (_, _) =>
+            {
+                fallbackDefaultCalls++;
+                return ContentStream(["fallback-default"]);
+            },
         };
         var fallbackNamedProvider = new StubProvider("openai")
         {
-            OnChatAsync = static (_, _) => Task.FromResult(new LLMResponse { Content = "fallback-named" }),
-            OnChatAsyncWithCounter = () => fallbackNamedCalls++,
+            OnChatStreamAsync = (_, _) =>
+            {
+                fallbackNamedCalls++;
+                return ContentStream(["fallback-named"]);
+            },
         };
 
         var factory = new FailoverLLMProviderFactory(
@@ -109,25 +112,28 @@ public sealed class FailoverLLMProviderFactoryTests
                 FallbackToDefaultProviderWhenNamedProviderMissing = true,
             });
 
-        var response = await factory.GetProvider("openai").ChatAsync(new LLMRequest { Messages = [] });
+        var chunks = await ReadAllAsync(factory.GetProvider("openai").ChatStreamAsync(new LLMRequest { Messages = [] }));
 
         fallbackDefaultCalls.Should().Be(1);
         fallbackNamedCalls.Should().Be(0);
-        response.Content.Should().Be("fallback-default");
+        chunks.Select(x => x.DeltaContent).Should().Contain("fallback-default");
     }
 
     [Fact]
-    public async Task ChatAsync_WhenPrimaryReturnsEmpty_ShouldFallback()
+    public async Task ChatStreamAsync_WhenPrimaryCompletesWithoutMeaningfulOutput_ShouldFallback()
     {
         var fallbackCalls = 0;
         var primaryProvider = new StubProvider("openai")
         {
-            OnChatAsync = static (_, _) => Task.FromResult(new LLMResponse { Content = "" }),
+            OnChatStreamAsync = static (_, _) => EmptyMeaninglessStream(),
         };
         var fallbackProvider = new StubProvider("openai")
         {
-            OnChatAsync = static (_, _) => Task.FromResult(new LLMResponse { Content = "fallback-non-empty" }),
-            OnChatAsyncWithCounter = () => fallbackCalls++,
+            OnChatStreamAsync = (_, _) =>
+            {
+                fallbackCalls++;
+                return ContentStream(["fallback-non-empty"]);
+            },
         };
 
         var factory = new FailoverLLMProviderFactory(
@@ -144,10 +150,10 @@ public sealed class FailoverLLMProviderFactoryTests
                 },
                 defaultName: "openai"));
 
-        var response = await factory.GetProvider("openai").ChatAsync(new LLMRequest { Messages = [] });
+        var chunks = await ReadAllAsync(factory.GetProvider("openai").ChatStreamAsync(new LLMRequest { Messages = [] }));
 
         fallbackCalls.Should().Be(1);
-        response.Content.Should().Be("fallback-non-empty");
+        chunks.Select(x => x.DeltaContent).Should().Contain("fallback-non-empty");
     }
 
     [Fact]
@@ -343,17 +349,7 @@ public sealed class FailoverLLMProviderFactoryTests
     {
         public string Name => name;
 
-        public Func<LLMRequest, CancellationToken, Task<LLMResponse>>? OnChatAsync { get; init; }
         public Func<LLMRequest, CancellationToken, IAsyncEnumerable<LLMStreamChunk>>? OnChatStreamAsync { get; init; }
-        public Action? OnChatAsyncWithCounter { get; init; }
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            OnChatAsyncWithCounter?.Invoke();
-            return OnChatAsync != null
-                ? OnChatAsync(request, ct)
-                : Task.FromResult(new LLMResponse { Content = "ok" });
-        }
 
         public IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.AI.Tests/LLMProviderServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.AI.Tests/LLMProviderServiceCollectionExtensionsTests.cs
@@ -71,12 +71,6 @@ public class LLMProviderServiceCollectionExtensionsTests
     {
         public string Name => "stub";
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new LLMResponse());
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.AI.Tests/MultimodalPipelineTests.cs
+++ b/test/Aevatar.AI.Tests/MultimodalPipelineTests.cs
@@ -181,9 +181,6 @@ public class MultimodalPipelineTests
         public StreamingProvider(IReadOnlyList<LLMStreamChunk> chunks) => _chunks = chunks;
         public string Name => "streaming-test";
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            Task.FromResult(new LLMResponse { Content = "response" });
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
         {

--- a/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatGAgentTests.cs
@@ -235,15 +235,6 @@ public class NyxIdChatGAgentTests
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new LLMResponse
-            {
-                Content = "non-streaming path should not be used",
-            });
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.AI.Tests/RoleGAgentReplayContractTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentReplayContractTests.cs
@@ -649,17 +649,6 @@ public class RoleGAgentReplayContractTests
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new LLMResponse
-            {
-                Content = response,
-                FinishReason = "stop",
-                Usage = new TokenUsage(1, 1, 2),
-            });
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
@@ -726,13 +715,6 @@ public class RoleGAgentReplayContractTests
         public ILLMProvider GetDefault() => this;
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            _ = request;
-            ct.ThrowIfCancellationRequested();
-            throw exception;
-        }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -1674,8 +1674,6 @@ public class StreamingProxyCoverageTests
     private sealed class StubLlmProvider : ILLMProvider
     {
         public string Name => "stub";
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-            => Task.FromResult(new LLMResponse { Content = string.Empty });
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(LLMRequest request, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
         {
             await Task.CompletedTask;

--- a/test/Aevatar.AI.Tests/StreamingProxyNyxParticipantCoordinatorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyNyxParticipantCoordinatorTests.cs
@@ -379,20 +379,18 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
 
         public List<LLMRequest> Requests { get; } = [];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
+        private LLMResponse BuildResponse(LLMRequest request)
         {
-            Requests.Add(request);
-
             if (_responseFactory != null)
-                return Task.FromResult(_responseFactory(request));
+                return _responseFactory(request);
 
             if (request.RequestId?.Contains("node-a", StringComparison.OrdinalIgnoreCase) == true)
                 throw new InvalidOperationException("node-a is unavailable");
 
-            return Task.FromResult(new LLMResponse
+            return new LLMResponse
             {
                 Content = $"reply from {request.RequestId}",
-            });
+            };
         }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -155,7 +155,7 @@ public class ToolCallLoopTests
                 ReasoningContent = "stream-reasoning",
                 FinishReason = "stop",
             },
-        ], throwOnChatAsync: true);
+        ]);
         bool? observedIsStreaming = null;
         var middleware = new DelegateLlmCallMiddleware(async (context, next) =>
         {
@@ -777,29 +777,17 @@ public class ToolCallLoopTests
         forwardedToolMessage.ContentParts[1].DataBase64.Should().Be("Zm9v");
     }
 
-    private sealed class QueueLLMProvider : ILLMProvider
+        private sealed class QueueLLMProvider : ILLMProvider
     {
         private readonly Queue<LLMResponse> _responses;
-        private readonly bool _throwOnChatAsync;
 
-        public QueueLLMProvider(IEnumerable<LLMResponse> responses, bool throwOnChatAsync = false)
+        public QueueLLMProvider(IEnumerable<LLMResponse> responses)
         {
             _responses = new Queue<LLMResponse>(responses);
-            _throwOnChatAsync = throwOnChatAsync;
         }
 
         public string Name => "queue";
         public List<LLMRequest> Requests { get; } = [];
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            if (_throwOnChatAsync)
-                throw new InvalidOperationException("Provider boundary ChatAsync should not be used by ToolCallLoop.");
-
-            Requests.Add(request);
-            return Task.FromResult(_responses.Count > 0 ? _responses.Dequeue() : new LLMResponse());
-        }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
+++ b/test/Aevatar.AI.Tests/ToolCallLoopTests.cs
@@ -777,7 +777,7 @@ public class ToolCallLoopTests
         forwardedToolMessage.ContentParts[1].DataBase64.Should().Be("Zm9v");
     }
 
-        private sealed class QueueLLMProvider : ILLMProvider
+    private sealed class QueueLLMProvider : ILLMProvider
     {
         private readonly Queue<LLMResponse> _responses;
 

--- a/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapRealProviderIntegrationTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/AIFeatureBootstrapRealProviderIntegrationTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core.Chat;
 using Aevatar.Bootstrap.Extensions.AI;
 using Aevatar.Configuration;
 using FluentAssertions;
@@ -60,7 +61,10 @@ public class AIFeatureBootstrapRealProviderIntegrationTests
         };
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
-        var response = await llmFactory.GetDefault().ChatAsync(request, cts.Token);
+        var response = await ChatStreamContentAggregator.AggregateResponseAsync(
+            llmFactory.GetDefault(),
+            request,
+            cts.Token);
 
         response.Content.Should().NotBeNullOrWhiteSpace();
     }

--- a/test/Aevatar.Bootstrap.Tests/NyxIdGateway403DiagnosticTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/NyxIdGateway403DiagnosticTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Core.Chat;
 using Aevatar.AI.LLMProviders.NyxId;
 using FluentAssertions;
 using OpenAI;
@@ -106,7 +107,7 @@ public class NyxIdGateway403DiagnosticTests
         Console.Error.WriteLine("=== NyxIdLLMProvider request ===");
         try
         {
-            var response = await provider.ChatAsync(request);
+            var response = await ChatStreamContentAggregator.AggregateResponseAsync(provider, request);
             Console.Error.WriteLine($"Success! Response: {response.Content?[..Math.Min(response.Content.Length, 200)]}");
         }
         catch (Exception ex)

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCompletionApplicationServiceTests.cs
@@ -631,9 +631,6 @@ public sealed class ResponsesCompletionApplicationServiceTests
 
         public List<LLMRequest> Requests { get; } = [];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ConversationReplyGeneratorTests.cs
@@ -641,9 +641,6 @@ public sealed class ConversationReplyGeneratorTests
         public ILLMProvider GetDefault() => this;
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            Task.FromResult(new LLMResponse { Content = "non-streaming path should not be used" });
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)
@@ -673,12 +670,6 @@ public sealed class ConversationReplyGeneratorTests
         public ILLMProvider GetDefault() => this;
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            Task.FromResult(new LLMResponse
-            {
-                Content = "non-streaming path should not be used",
-            });
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
@@ -711,9 +702,6 @@ public sealed class ConversationReplyGeneratorTests
         public ILLMProvider GetDefault() => this;
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            Task.FromResult(new LLMResponse { Content = "non-streaming path should not be used" });
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -1141,9 +1141,6 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     {
         public string Name => "stub";
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default) =>
-            Task.FromResult(new LLMResponse { Content = string.Concat(deltas) });
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.GAgents.Household.Tests/HouseholdEntityDeviceInboundTests.cs
+++ b/test/Aevatar.GAgents.Household.Tests/HouseholdEntityDeviceInboundTests.cs
@@ -246,12 +246,6 @@ public class HouseholdEntityDeviceInboundTests : IAsyncLifetime
     {
         public string Name => name;
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(new LLMResponse { Content = "NO_ACTION — no intervention needed." });
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
@@ -483,12 +483,6 @@ public sealed class MainnetMessagesEndpointsTests
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            LastRequest = request;
-            return Task.FromResult(new LLMResponse { Content = "ok" });
-        }
-
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [EnumeratorCancellation] CancellationToken ct = default)

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -93,7 +93,6 @@ public sealed class MainnetResponsesEndpointsTests
         root.GetProperty("usage").GetProperty("output_tokens").GetInt32().Should().Be(2);
         root.GetProperty("usage").GetProperty("total_tokens").GetInt32().Should().Be(5);
 
-        provider.ChatCallCount.Should().Be(0);
         provider.StreamCallCount.Should().Be(1);
         provider.LastRequest.Should().NotBeNull();
         provider.LastRequest!.Model.Should().Be("gpt-5.4");
@@ -1542,11 +1541,7 @@ public sealed class MainnetResponsesEndpointsTests
 
         public LLMRequest? LastRequest { get; private set; }
 
-        public int ChatCallCount { get; private set; }
-
         public int StreamCallCount { get; private set; }
-
-        public LLMResponse ChatResponse { get; init; } = new() { Content = "ok" };
 
         public IReadOnlyList<LLMStreamChunk> StreamChunks { get; init; } = [];
 
@@ -1557,13 +1552,6 @@ public sealed class MainnetResponsesEndpointsTests
         public ILLMProvider GetDefault() => this;
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            LastRequest = request;
-            ChatCallCount++;
-            return Task.FromResult(ChatResponse);
-        }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/test/Aevatar.Integration.Tests/MakerRecursiveRegressionTests.cs
+++ b/test/Aevatar.Integration.Tests/MakerRecursiveRegressionTests.cs
@@ -217,23 +217,24 @@ public class MakerRecursiveRegressionTests
 
         public string Name => "mock-maker";
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
+        private LLMResponse BuildResponse(LLMRequest request)
         {
             var userMessage = request.Messages.LastOrDefault(x => x.Role == "user")?.Content ?? "";
             var response = Resolve(userMessage);
-            return Task.FromResult(new LLMResponse
+            return new LLMResponse
             {
                 Content = response,
                 FinishReason = "stop",
                 Usage = new TokenUsage(50, 20, 70),
-            });
+            };
         }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
         {
-            var full = await ChatAsync(request, ct);
+            ct.ThrowIfCancellationRequested();
+            var full = BuildResponse(request);
             foreach (var ch in full.Content ?? "")
                 yield return new LLMStreamChunk { DeltaContent = ch.ToString() };
             yield return new LLMStreamChunk { IsLast = true, Usage = full.Usage };

--- a/test/Aevatar.Integration.Tests/MakerRunReportVerificationTests.cs
+++ b/test/Aevatar.Integration.Tests/MakerRunReportVerificationTests.cs
@@ -244,26 +244,28 @@ public class MakerRunReportVerificationTests
     {
         public string Name => "atomic-only";
 
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
+        private static LLMResponse BuildResponse(LLMRequest request)
         {
             var userMessage = request.Messages.LastOrDefault(x => x.Role == "user")?.Content ?? "";
             var content = Resolve(userMessage);
-            return Task.FromResult(new LLMResponse
+            return new LLMResponse
             {
                 Content = content,
                 FinishReason = "stop",
                 Usage = new TokenUsage(16, 16, 32),
-            });
+            };
         }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
         {
-            var full = await ChatAsync(request, ct);
+            ct.ThrowIfCancellationRequested();
+            var full = BuildResponse(request);
             foreach (var ch in full.Content ?? "")
                 yield return new LLMStreamChunk { DeltaContent = ch.ToString() };
             yield return new LLMStreamChunk { IsLast = true, Usage = full.Usage };
+            await Task.CompletedTask;
         }
 
         public ILLMProvider GetProvider(string name) => this;

--- a/test/Aevatar.Integration.Tests/MockLLMProvider.cs
+++ b/test/Aevatar.Integration.Tests/MockLLMProvider.cs
@@ -27,7 +27,7 @@ public sealed class MockLLMProvider : ILLMProvider, ILLMProviderFactory
 
     public string Name => "mock";
 
-    public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
+    private LLMResponse BuildResponse(LLMRequest request)
     {
         var systemPrompt = request.Messages.FirstOrDefault(m => m.Role == "system")?.Content ?? "";
         var userMessage = request.Messages.LastOrDefault(m => m.Role == "user")?.Content ?? "";
@@ -45,25 +45,27 @@ public sealed class MockLLMProvider : ILLMProvider, ILLMProviderFactory
 
         CallLog.Add((systemPrompt, userMessage, response));
 
-        return Task.FromResult(new LLMResponse
+        return new LLMResponse
         {
             Content = response,
             FinishReason = "stop",
             Usage = new TokenUsage(100, 50, 150),
-        });
+        };
     }
 
     public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
         LLMRequest request,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        var full = await ChatAsync(request, ct);
+        ct.ThrowIfCancellationRequested();
+        var full = BuildResponse(request);
         // 模拟逐字输出
         foreach (var ch in full.Content ?? "")
         {
             yield return new LLMStreamChunk { DeltaContent = ch.ToString() };
         }
         yield return new LLMStreamChunk { IsLast = true, Usage = full.Usage };
+        await Task.CompletedTask;
     }
 
     // ─── ILLMProviderFactory 实现 ───

--- a/test/Aevatar.Studio.Tests/StudioGenerateGAgentStreamingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioGenerateGAgentStreamingTests.cs
@@ -26,7 +26,6 @@ public sealed class StudioGenerateGAgentStreamingTests
         var result = await agent.GenerateAsync("write script", "request-script", metadata: null);
 
         result.Should().Be("script draft");
-        provider.ChatCallCount.Should().Be(0);
         provider.StreamCallCount.Should().Be(1);
     }
 
@@ -42,7 +41,6 @@ public sealed class StudioGenerateGAgentStreamingTests
         var result = await agent.GenerateAsync("write workflow", "request-workflow", metadata: null);
 
         result.Should().Be("workflow yaml");
-        provider.ChatCallCount.Should().Be(0);
         provider.StreamCallCount.Should().Be(1);
     }
 
@@ -63,8 +61,6 @@ public sealed class StudioGenerateGAgentStreamingTests
 
         scriptResult.Should().BeEmpty();
         workflowResult.Should().BeEmpty();
-        scriptProvider.ChatCallCount.Should().Be(0);
-        workflowProvider.ChatCallCount.Should().Be(0);
         scriptProvider.StreamCallCount.Should().BeGreaterThan(0);
         workflowProvider.StreamCallCount.Should().BeGreaterThan(0);
     }
@@ -99,8 +95,6 @@ public sealed class StudioGenerateGAgentStreamingTests
     {
         public string Name => "studio-test-provider";
 
-        public int ChatCallCount { get; private set; }
-
         public int StreamCallCount { get; private set; }
 
         public ILLMProvider GetProvider(string name)
@@ -112,14 +106,6 @@ public sealed class StudioGenerateGAgentStreamingTests
         public ILLMProvider GetDefault() => this;
 
         public IReadOnlyList<string> GetAvailableProviders() => [Name];
-
-        public Task<LLMResponse> ChatAsync(LLMRequest request, CancellationToken ct = default)
-        {
-            _ = request;
-            ChatCallCount++;
-            ct.ThrowIfCancellationRequested();
-            throw new InvalidOperationException("Provider boundary ChatAsync should not be used by Studio generate GAgents.");
-        }
 
         public async IAsyncEnumerable<LLMStreamChunk> ChatStreamAsync(
             LLMRequest request,

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -57,6 +57,7 @@ fi
 #   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
 if rg -n "Task<LLMResponse>[[:space:]]+ChatAsync[[:space:]]*\(" \
   src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs \
+  src/Aevatar.AI.Core/LLMProviders \
   src/Aevatar.AI.LLMProviders.* \
   -g '*.cs'
 then

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -52,6 +52,18 @@ if rg -n "GetAwaiter\(\)\.GetResult\(\)" src; then
   exit 1
 fi
 
+# Refactor (iter18/cluster-001):
+#   Old pattern: ILLMProvider 仍暴露 ChatAsync 非流式入口,provider/failover 可绕过流式链路
+#   New principle: Provider contract 只暴露 ChatStreamAsync;非流式聚合用现有 ChatStreamContentAggregator;无新 offline adapter
+if rg -n "Task<LLMResponse>[[:space:]]+ChatAsync[[:space:]]*\(" \
+  src/Aevatar.AI.Abstractions/LLMProviders/ILLMProvider.cs \
+  src/Aevatar.AI.LLMProviders.* \
+  -g '*.cs'
+then
+  echo "Provider-level Task<LLMResponse> ChatAsync is forbidden. Use ChatStreamAsync plus ChatStreamContentAggregator for offline aggregation."
+  exit 1
+fi
+
 if rg -n "CommandContext\.Metadata|AgentRunContext\.Metadata|LLMCallContext\.Metadata|ToolCallContext\.Metadata|GAgentExecutionHookContext\.Metadata" \
   src test
 then


### PR DESCRIPTION
## 摘要

iter18 cluster-001(high, R-AI-STREAM-001)。

- **Old**:`ILLMProvider` 暴露 `ChatAsync` 非流式入口,provider/failover 可绕过流式链路;reasoning/tool/tool result/完成态不在统一流。
- **New**:Provider contract **只**暴露 `ChatStreamAsync`;`ChatAsync` 非流式聚合用现有 `ChatStreamContentAggregator` 包 `ChatStreamAsync`;**无新 offline adapter**(per Phase 9 r2 共识不引入新抽象)。

违反:CLAUDE.md「单一主干,插件扩展」+「扩展对称性」(provider 应统一流式契约)。

## Design decision

Phase 9 r2 3/3 unanimous structural framing:stream-only contract + 已有 aggregator wraps stream。详见 [issue #728](https://github.com/aevatarAI/aevatar/issues/728)。

## 范围

~15 文件:
- `ILLMProvider.cs`:删 `ChatAsync`
- MEAI / Tornado / NyxId 3 provider:删 `ChatAsync` 实现,SDK 非流式 API 内部包到 stream adapter
- FailoverLLMProviderFactory:走 stream + aggregator
- ChatStreamContentAggregator:支持 sink wrap stream
- 测试覆盖更新

## 关联

- Design issue:#728
- Audit:cluster-001 (audit-iter-18.md)

🤖 Auto-loop / codex-refactor-loop iter18