### PR TITLE
iter21 cluster-002: request-path projection priming via CQRS binders (supersedes #751)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
@@ -34,8 +34,8 @@ public static partial class NyxIdChatEndpoints
         try
         {
             // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+            //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+            //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
@@ -140,8 +140,8 @@ public static partial class NyxIdChatEndpoints
         try
         {
             // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+            //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+            //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs
@@ -1,14 +1,14 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Hosting;
-using Google.Protobuf.WellKnownTypes;
+using Aevatar.Presentation.AGUI;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Any = Google.Protobuf.WellKnownTypes.Any;
 
 namespace Aevatar.GAgents.NyxidChat;
 
@@ -20,9 +20,8 @@ public static partial class NyxIdChatEndpoints
         string actorId,
         NyxIdChatStreamRequest request,
         [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
-        [FromServices] INyxIdChatSessionProjectionPort sessionProjectionPort,
+        [FromServices] ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus> interactionService,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -30,9 +29,13 @@ public static partial class NyxIdChatEndpoints
         IActor? actor = null;
         var accessToken = string.Empty;
         var prompt = string.Empty;
+        var messageId = request.SessionId ?? Guid.NewGuid().ToString("N");
 
         try
         {
+            // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
@@ -77,52 +80,42 @@ public static partial class NyxIdChatEndpoints
             return;
         }
 
-        await NyxIdChatStreamingRunner.RunAsync(
-            http,
-            actorId,
-            sessionProjectionPort,
-            logger,
-            dispatchAsync: async (messageId, runCt) =>
-            {
-                // Refactor (iter1/cluster-004):
-                //   Old pattern: endpoint coupled command dispatch with raw EventEnvelope stream observation.
-                //   New principle: endpoint dispatches through IActorDispatchPort and observes typed projection events.
-                var chatRequest = new ChatRequestEvent
-                {
-                    Prompt = prompt,
-                    SessionId = request.SessionId ?? messageId,
-                    ScopeId = scopeId,
-                };
-                if (request.InputParts is { Count: > 0 })
-                {
-                    foreach (var part in request.InputParts)
-                        chatRequest.InputParts.Add(part.ToProto());
-                }
+        var writer = new NyxIdChatSseWriter(http.Response);
+        try
+        {
+            await writer.StartAsync(ct);
+            await writer.WriteRunStartedAsync(actorId, ct);
+            var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+            await InjectUserConfigMetadataAsync(http, metadata, ct);
+            await InjectUserMemoryAsync(http, metadata, ct);
+            await InjectConnectedServicesAsync(http, accessToken, metadata, ct);
 
-                chatRequest.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = accessToken;
-                chatRequest.Metadata["scope_id"] = scopeId;
-                await InjectUserConfigMetadataAsync(http, chatRequest.Metadata, runCt);
-                await InjectUserMemoryAsync(http, chatRequest.Metadata, runCt);
-                await InjectConnectedServicesAsync(http, accessToken, chatRequest.Metadata, runCt);
-
-                var envelope = new EventEnvelope
+            var result = await interactionService.ExecuteAsync(
+                new NyxIdChatCommand(
+                    actor.Id,
+                    scopeId,
+                    prompt,
+                    messageId,
+                    accessToken,
+                    request.InputParts,
+                    metadata),
+                async (evt, _) =>
                 {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                    Payload = Any.Pack(chatRequest),
-                    Route = new EnvelopeRoute
-                    {
-                        Direct = new DirectRoute { TargetActorId = actor.Id },
-                    },
-                };
+                    await NyxIdChatStreamingRunner.WriteAguiEventAsync(evt, messageId, writer);
+                },
+                null,
+                ct);
 
-                await actorDispatchPort.DispatchAsync(actor.Id, envelope, runCt);
-            },
-            errorMessages: new NyxIdChatStreamingRunner.ErrorMessages(
-                "The chat request failed before completion. Please try again.",
-                "Request timed out.",
-                "The chat request failed. Please try again."),
-            ct);
+            await HandleInteractionFailureAsync(result, writer, "The chat request failed. Please try again.");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "NyxID streaming request failed for actor {ActorId}", actorId);
+            await writer.WriteRunErrorAsync("The chat request failed. Please try again.", CancellationToken.None);
+        }
     }
 
     /// <summary>
@@ -135,17 +128,20 @@ public static partial class NyxIdChatEndpoints
         string actorId,
         NyxIdApprovalRequest request,
         [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
-        [FromServices] INyxIdChatSessionProjectionPort sessionProjectionPort,
+        [FromServices] ICommandInteractionService<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus> interactionService,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         var logger = loggerFactory.CreateLogger("Aevatar.NyxId.Chat.Endpoints");
         IActor? actor = null;
+        var messageId = request.SessionId ?? scopeId;
 
         try
         {
+            // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
@@ -189,42 +185,50 @@ public static partial class NyxIdChatEndpoints
             return;
         }
 
-        await NyxIdChatStreamingRunner.RunAsync(
-            http,
-            actorId,
-            sessionProjectionPort,
-            logger,
-            dispatchAsync: async (_, runCt) =>
-            {
-                // Refactor (iter1/cluster-004):
-                //   Old pattern: approval continuation reused raw EventEnvelope stream completion detection.
-                //   New principle: approval dispatch is a command; completion arrives via typed projection session events.
-                var decisionEvent = new ToolApprovalDecisionEvent
+        var writer = new NyxIdChatSseWriter(http.Response);
+        try
+        {
+            await writer.StartAsync(ct);
+            await writer.WriteRunStartedAsync(actorId, ct);
+            var result = await interactionService.ExecuteAsync(
+                new NyxIdApprovalCommand(
+                    actor.Id,
+                    request.RequestId,
+                    request.Approved,
+                    request.Reason ?? string.Empty,
+                    messageId),
+                async (evt, _) =>
                 {
-                    RequestId = request.RequestId,
-                    SessionId = request.SessionId ?? scopeId,
-                    Approved = request.Approved,
-                    Reason = request.Reason ?? string.Empty,
-                };
+                    await NyxIdChatStreamingRunner.WriteAguiEventAsync(evt, messageId, writer);
+                },
+                null,
+                ct);
 
-                var envelope = new EventEnvelope
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                    Payload = Any.Pack(decisionEvent),
-                    Route = new EnvelopeRoute
-                    {
-                        Direct = new DirectRoute { TargetActorId = actor.Id },
-                    },
-                };
+            await HandleInteractionFailureAsync(result, writer, "The approval continuation failed. Please try again.");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "NyxID approval streaming request failed for actor {ActorId}", actorId);
+            await writer.WriteRunErrorAsync("The approval continuation failed. Please try again.", CancellationToken.None);
+        }
+    }
 
-                await actorDispatchPort.DispatchAsync(actor.Id, envelope, runCt);
-            },
-            errorMessages: new NyxIdChatStreamingRunner.ErrorMessages(
-                "The approval continuation failed before completion. Please try again.",
-                "Approval continuation timed out.",
-                "The approval continuation failed. Please try again."),
-            ct);
+    private static async Task HandleInteractionFailureAsync(
+        CommandInteractionResult<NyxIdChatAcceptedReceipt, NyxIdChatStartError, NyxIdChatCompletionStatus> result,
+        NyxIdChatSseWriter writer,
+        string message)
+    {
+        if (result.Succeeded)
+            return;
+
+        await writer.WriteRunErrorAsync(
+            result.Error == NyxIdChatStartError.ProjectionUnavailable
+                ? "NyxID chat projection pipeline is unavailable."
+                : message,
+            CancellationToken.None);
     }
 
     public sealed record NyxIdApprovalRequest(

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -1,0 +1,444 @@
+using System.Runtime.ExceptionServices;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Presentation.AGUI;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+public sealed record NyxIdChatCommand(
+    string ActorId,
+    string ScopeId,
+    string Prompt,
+    string SessionId,
+    string AccessToken,
+    IReadOnlyList<NyxIdChatEndpoints.ContentPartDto>? InputParts,
+    IReadOnlyDictionary<string, string>? Metadata)
+    : ICommandContextSeed
+{
+    public string? CommandId => SessionId;
+    public string? CorrelationId => SessionId;
+    public IReadOnlyDictionary<string, string>? Headers => null;
+}
+
+public sealed record NyxIdApprovalCommand(
+    string ActorId,
+    string RequestId,
+    bool Approved,
+    string Reason,
+    string SessionId)
+    : ICommandContextSeed
+{
+    public string? CommandId => SessionId;
+    public string? CorrelationId => SessionId;
+    public IReadOnlyDictionary<string, string>? Headers => null;
+}
+
+public sealed record NyxIdChatAcceptedReceipt(
+    string ActorId,
+    string CommandId,
+    string CorrelationId,
+    string SessionId);
+
+public enum NyxIdChatStartError
+{
+    None = 0,
+    ActorNotFound = 1,
+    ProjectionUnavailable = 2,
+}
+
+public enum NyxIdChatCompletionStatus
+{
+    Unknown = 0,
+    Completed = 1,
+    Failed = 2,
+}
+
+internal sealed class NyxIdChatCommandTarget
+    : IActorCommandDispatchTarget,
+      ICommandEventTarget<AGUIEvent>,
+      ICommandInteractionCleanupTarget<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>,
+      ICommandDispatchCleanupAware
+{
+    private readonly INyxIdChatSessionProjectionPort _projectionPort;
+
+    public NyxIdChatCommandTarget(
+        IActor actor,
+        INyxIdChatSessionProjectionPort projectionPort)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        Actor = actor ?? throw new ArgumentNullException(nameof(actor));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+    }
+
+    public IActor Actor { get; }
+    public string TargetId => Actor.Id;
+    public string ActorId => Actor.Id;
+    public string SessionId { get; private set; } = string.Empty;
+    public INyxIdChatSessionProjectionLease? ProjectionLease { get; private set; }
+    public IAsyncDisposable? LiveSinkLease { get; private set; }
+    public IEventSink<AGUIEvent>? LiveSink { get; private set; }
+
+    public void BindLiveObservation(
+        INyxIdChatSessionProjectionLease projectionLease,
+        IAsyncDisposable? liveSinkLease,
+        IEventSink<AGUIEvent> sink,
+        string sessionId)
+    {
+        ProjectionLease = projectionLease ?? throw new ArgumentNullException(nameof(projectionLease));
+        LiveSinkLease = liveSinkLease;
+        LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
+        SessionId = string.IsNullOrWhiteSpace(sessionId)
+            ? throw new ArgumentException("Session id is required.", nameof(sessionId))
+            : sessionId;
+    }
+
+    public IEventSink<AGUIEvent> RequireLiveSink() =>
+        LiveSink ?? throw new InvalidOperationException("NyxID chat live sink is not bound.");
+
+    public Task CleanupAfterDispatchFailureAsync(CancellationToken ct = default) =>
+        ReleaseAsync(ct);
+
+    public Task ReleaseAfterInteractionAsync(
+        NyxIdChatAcceptedReceipt receipt,
+        CommandInteractionCleanupContext<NyxIdChatCompletionStatus> cleanup,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        ArgumentNullException.ThrowIfNull(cleanup);
+        return ReleaseAsync(ct);
+    }
+
+    private async Task ReleaseAsync(CancellationToken ct)
+    {
+        Exception? firstException = null;
+        var projectionLease = ProjectionLease;
+        var sink = LiveSink;
+
+        if (projectionLease != null && sink != null)
+        {
+            try
+            {
+                await _projectionPort.DetachReleaseAndDisposeAsync(
+                    projectionLease,
+                    LiveSinkLease,
+                    sink,
+                    null,
+                    ct);
+                ProjectionLease = null;
+                LiveSinkLease = null;
+                LiveSink = null;
+            }
+            catch (Exception ex)
+            {
+                firstException ??= ex;
+            }
+        }
+        else if (sink != null)
+        {
+            try
+            {
+                sink.Complete();
+                await sink.DisposeAsync();
+                LiveSinkLease = null;
+                LiveSink = null;
+            }
+            catch (Exception ex)
+            {
+                firstException ??= ex;
+            }
+        }
+
+        if (firstException != null)
+            ExceptionDispatchInfo.Capture(firstException).Throw();
+    }
+}
+
+internal sealed class NyxIdChatCommandTargetResolver<TCommand>
+    : ICommandTargetResolver<TCommand, NyxIdChatCommandTarget, NyxIdChatStartError>
+{
+    private readonly IActorRuntime _actorRuntime;
+    private readonly INyxIdChatSessionProjectionPort _projectionPort;
+    private readonly Func<TCommand, string> _actorIdResolver;
+
+    public NyxIdChatCommandTargetResolver(
+        IActorRuntime actorRuntime,
+        INyxIdChatSessionProjectionPort projectionPort,
+        Func<TCommand, string> actorIdResolver)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+        _actorIdResolver = actorIdResolver ?? throw new ArgumentNullException(nameof(actorIdResolver));
+    }
+
+    public async Task<CommandTargetResolution<NyxIdChatCommandTarget, NyxIdChatStartError>> ResolveAsync(
+        TCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var actor = await _actorRuntime.GetAsync(_actorIdResolver(command));
+        if (actor == null)
+        {
+            return CommandTargetResolution<NyxIdChatCommandTarget, NyxIdChatStartError>.Failure(
+                NyxIdChatStartError.ActorNotFound);
+        }
+
+        return CommandTargetResolution<NyxIdChatCommandTarget, NyxIdChatStartError>.Success(
+            new NyxIdChatCommandTarget(actor, _projectionPort));
+    }
+}
+
+internal sealed class NyxIdChatCommandTargetBinder<TCommand>
+    : ICommandTargetBinder<TCommand, NyxIdChatCommandTarget, NyxIdChatStartError>
+{
+    private readonly INyxIdChatSessionProjectionPort _projectionPort;
+    private readonly Func<TCommand, string> _sessionIdResolver;
+
+    public NyxIdChatCommandTargetBinder(
+        INyxIdChatSessionProjectionPort projectionPort,
+        Func<TCommand, string> sessionIdResolver)
+    {
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+        _sessionIdResolver = sessionIdResolver ?? throw new ArgumentNullException(nameof(sessionIdResolver));
+    }
+
+    public async Task<CommandTargetBindingResult<NyxIdChatStartError>> BindAsync(
+        TCommand command,
+        NyxIdChatCommandTarget target,
+        CommandContext context,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var sessionId = _sessionIdResolver(command);
+        var sink = new EventChannel<AGUIEvent>();
+        try
+        {
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
+                token => _projectionPort.EnsureChatProjectionAsync(
+                    target.ActorId,
+                    sessionId,
+                    token),
+                sink,
+                ct);
+            if (attachment == null)
+            {
+                sink.Complete();
+                await sink.DisposeAsync();
+                return CommandTargetBindingResult<NyxIdChatStartError>.Failure(NyxIdChatStartError.ProjectionUnavailable);
+            }
+
+            target.BindLiveObservation(attachment.ProjectionLease, attachment.LiveSinkLease, sink, sessionId);
+            return CommandTargetBindingResult<NyxIdChatStartError>.Success();
+        }
+        catch
+        {
+            sink.Complete();
+            await sink.DisposeAsync();
+            throw;
+        }
+    }
+}
+
+internal sealed class NyxIdChatCommandEnvelopeFactory : ICommandEnvelopeFactory<NyxIdChatCommand>
+{
+    public EventEnvelope CreateEnvelope(NyxIdChatCommand command, CommandContext context)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var chatRequest = new ChatRequestEvent
+        {
+            Prompt = command.Prompt,
+            SessionId = command.SessionId,
+            ScopeId = command.ScopeId,
+        };
+        if (command.InputParts is { Count: > 0 })
+        {
+            foreach (var part in command.InputParts)
+                chatRequest.InputParts.Add(part.ToProto());
+        }
+
+        chatRequest.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = command.AccessToken;
+        chatRequest.Metadata["scope_id"] = command.ScopeId;
+        AppendMetadata(chatRequest.Metadata, command.Metadata);
+
+        return CreateDirectEnvelope(context, chatRequest);
+    }
+
+    private static void AppendMetadata(
+        Google.Protobuf.Collections.MapField<string, string> destination,
+        IReadOnlyDictionary<string, string>? source)
+    {
+        if (source == null)
+            return;
+
+        foreach (var (key, value) in source)
+        {
+            if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
+                destination[key.Trim()] = value.Trim();
+        }
+    }
+
+    private static EventEnvelope CreateDirectEnvelope(CommandContext context, IMessage message) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(message),
+            Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = context.TargetId } },
+            Propagation = new EnvelopePropagation { CorrelationId = context.CorrelationId },
+        };
+}
+
+internal sealed class NyxIdApprovalCommandEnvelopeFactory : ICommandEnvelopeFactory<NyxIdApprovalCommand>
+{
+    public EventEnvelope CreateEnvelope(NyxIdApprovalCommand command, CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(new ToolApprovalDecisionEvent
+            {
+                RequestId = command.RequestId,
+                SessionId = command.SessionId,
+                Approved = command.Approved,
+                Reason = command.Reason,
+            }),
+            Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = context.TargetId } },
+            Propagation = new EnvelopePropagation { CorrelationId = context.CorrelationId },
+        };
+    }
+}
+
+internal sealed class NyxIdChatAcceptedReceiptFactory
+    : ICommandReceiptFactory<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>
+{
+    public NyxIdChatAcceptedReceipt Create(
+        NyxIdChatCommandTarget target,
+        CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new NyxIdChatAcceptedReceipt(
+            target.ActorId,
+            context.CommandId,
+            context.CorrelationId,
+            target.SessionId);
+    }
+}
+
+internal sealed class NyxIdChatCompletionPolicy
+    : ICommandCompletionPolicy<AGUIEvent, NyxIdChatCompletionStatus>
+{
+    public NyxIdChatCompletionStatus IncompleteCompletion => NyxIdChatCompletionStatus.Unknown;
+
+    public bool TryResolve(AGUIEvent evt, out NyxIdChatCompletionStatus completion)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        completion = evt.EventCase switch
+        {
+            AGUIEvent.EventOneofCase.RunFinished => NyxIdChatCompletionStatus.Completed,
+            AGUIEvent.EventOneofCase.RunError => NyxIdChatCompletionStatus.Failed,
+            _ => NyxIdChatCompletionStatus.Unknown,
+        };
+        return completion != NyxIdChatCompletionStatus.Unknown;
+    }
+}
+
+internal sealed class NyxIdChatFinalizeEmitter
+    : ICommandFinalizeEmitter<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus, AGUIEvent>
+{
+    public Task EmitAsync(
+        NyxIdChatAcceptedReceipt receipt,
+        NyxIdChatCompletionStatus completion,
+        bool completed,
+        Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(receipt);
+        ArgumentNullException.ThrowIfNull(emitAsync);
+
+        if (completed)
+            return Task.CompletedTask;
+
+        return emitAsync(
+            new AGUIEvent
+            {
+                RunError = new RunErrorEvent
+                {
+                    Message = "Request timed out.",
+                    Code = "timeout",
+                },
+            },
+            ct).AsTask();
+    }
+}
+
+internal sealed class NyxIdChatDurableCompletionResolver
+    : ICommandDurableCompletionResolver<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>
+{
+    public Task<CommandDurableCompletionObservation<NyxIdChatCompletionStatus>> ResolveAsync(
+        NyxIdChatAcceptedReceipt receipt,
+        CancellationToken ct = default)
+    {
+        _ = receipt;
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(CommandDurableCompletionObservation<NyxIdChatCompletionStatus>.Incomplete);
+    }
+}
+
+internal static class NyxIdChatInteractionFactories
+{
+    public static ICommandTargetResolver<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatStartError> CreateChatResolver(
+        IServiceProvider sp) =>
+        new NyxIdChatCommandTargetResolver<NyxIdChatCommand>(
+            sp.GetRequiredService<IActorRuntime>(),
+            sp.GetRequiredService<INyxIdChatSessionProjectionPort>(),
+            static command => command.ActorId);
+
+    public static ICommandTargetResolver<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatStartError> CreateApprovalResolver(
+        IServiceProvider sp) =>
+        new NyxIdChatCommandTargetResolver<NyxIdApprovalCommand>(
+            sp.GetRequiredService<IActorRuntime>(),
+            sp.GetRequiredService<INyxIdChatSessionProjectionPort>(),
+            static command => command.ActorId);
+
+    public static ICommandTargetBinder<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatStartError> CreateChatBinder(
+        IServiceProvider sp) =>
+        new NyxIdChatCommandTargetBinder<NyxIdChatCommand>(
+            sp.GetRequiredService<INyxIdChatSessionProjectionPort>(),
+            static command => command.SessionId);
+
+    public static ICommandTargetBinder<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatStartError> CreateApprovalBinder(
+        IServiceProvider sp) =>
+        new NyxIdChatCommandTargetBinder<NyxIdApprovalCommand>(
+            sp.GetRequiredService<INyxIdChatSessionProjectionPort>(),
+            static command => command.SessionId);
+}

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -12,6 +12,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.GAgents.NyxidChat;
 
+// Refactor (iter21/cluster-002-request-path-projection-session-priming):
+//   Old pattern: request handlers synchronously ensured projection/session leases and waited on live sinks.
+//   New principle: commands carry stable identity into a shared interaction pipeline; binders own observation.
 public sealed record NyxIdChatCommand(
     string ActorId,
     string ScopeId,
@@ -27,6 +30,9 @@ public sealed record NyxIdChatCommand(
     public IReadOnlyDictionary<string, string>? Headers => null;
 }
 
+// Refactor (iter21/cluster-002-request-path-projection-session-priming):
+//   Old pattern: approval endpoints built their own dispatch and projection wait flow.
+//   New principle: approval uses the same command interaction contract as chat execution.
 public sealed record NyxIdApprovalCommand(
     string ActorId,
     string RequestId,
@@ -40,6 +46,9 @@ public sealed record NyxIdApprovalCommand(
     public IReadOnlyDictionary<string, string>? Headers => null;
 }
 
+// Refactor (iter21/cluster-002-request-path-projection-session-priming):
+//   Old pattern: streaming endpoints implied completion from local live-sink progress.
+//   New principle: accepted receipts expose only dispatch identity; completion is observed separately.
 public sealed record NyxIdChatAcceptedReceipt(
     string ActorId,
     string CommandId,

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs
@@ -1,9 +1,6 @@
 using Aevatar.AI.Abstractions;
-using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Presentation.AGUI;
 using Google.Protobuf.Collections;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.NyxidChat;
@@ -15,130 +12,14 @@ internal static class NyxIdChatStreamingRunner
         string Timeout,
         string UnhandledFailure);
 
-    public static async Task RunAsync(
-        HttpContext http,
-        string actorId,
-        INyxIdChatSessionProjectionPort projectionPort,
-        ILogger logger,
-        Func<string, CancellationToken, Task> dispatchAsync,
-        ErrorMessages errorMessages,
-        CancellationToken ct)
-    {
-        var writer = new NyxIdChatSseWriter(http.Response);
-
-        try
-        {
-            await writer.StartAsync(ct);
-
-            var messageId = Guid.NewGuid().ToString("N");
-            await writer.WriteRunStartedAsync(actorId, ct);
-
-            var eventChannel = new EventChannel<AGUIEvent>();
-            var attachment = await projectionPort.EnsureAndAttachLeaseAsync(
-                token => projectionPort.EnsureChatProjectionAsync(actorId, messageId, token),
-                eventChannel,
-                ct);
-            if (attachment == null)
-                throw new InvalidOperationException("NyxID chat projection pipeline is unavailable.");
-
-            // Refactor (iter1/cluster-004):
-            //   Old pattern: the runner subscribed to raw EventEnvelope and used TaskCompletionSource/timeout as RPC.
-            //   New principle: the runner observes typed AGUIEvent projection session frames and only dispatches commands.
-            var completion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
-            using var ctr = ct.Register(() => completion.TrySetCanceled());
-            var pumpTask = PumpAguiSessionEventsAsync(eventChannel, messageId, writer, completion, ct);
-
-            try
-            {
-                await dispatchAsync(messageId, ct);
-                await completion.Task.WaitAsync(TimeSpan.FromSeconds(120), ct);
-
-                if (string.Equals(completion.Task.Result, "RUN_FINISHED", StringComparison.Ordinal))
-                {
-                    await writer.WriteRunFinishedAsync(CancellationToken.None);
-                }
-            }
-            catch (TimeoutException)
-            {
-                await writer.WriteRunErrorAsync(errorMessages.Timeout, CancellationToken.None);
-            }
-            catch (Exception) when (completion.Task.IsFaulted)
-            {
-                await writer.WriteRunErrorAsync(
-                    errorMessages.DispatchFailedBeforeCompletion,
-                    CancellationToken.None);
-            }
-            finally
-            {
-                await projectionPort.DetachReleaseAndDisposeAsync(
-                    attachment.ProjectionLease,
-                    attachment.LiveSinkLease,
-                    eventChannel,
-                    null,
-                    CancellationToken.None);
-
-                try
-                {
-                    await pumpTask;
-                }
-                catch (OperationCanceledException) when (ct.IsCancellationRequested)
-                {
-                }
-                catch
-                {
-                    if (!completion.Task.IsFaulted)
-                        throw;
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "NyxID streaming request failed for actor {ActorId}", actorId);
-
-            try
-            {
-                await writer.WriteRunErrorAsync(
-                    errorMessages.UnhandledFailure,
-                    CancellationToken.None);
-            }
-            catch
-            {
-                http.Response.StatusCode = StatusCodes.Status500InternalServerError;
-            }
-        }
-    }
-
-    private static async Task PumpAguiSessionEventsAsync(
-        IEventSink<AGUIEvent> eventSink,
-        string messageId,
-        NyxIdChatSseWriter writer,
-        TaskCompletionSource<string> completion,
-        CancellationToken ct)
-    {
-        try
-        {
-            await foreach (var aguiEvent in eventSink.ReadAllAsync(ct))
-            {
-                var terminalFrame = await WriteAguiEventAsync(aguiEvent, messageId, writer);
-                if (!string.IsNullOrWhiteSpace(terminalFrame))
-                    completion.TrySetResult(terminalFrame);
-            }
-        }
-        catch (Exception ex)
-        {
-            completion.TrySetException(ex);
-            throw;
-        }
-    }
-
-    private static async ValueTask<string?> WriteAguiEventAsync(
+    public static async ValueTask<string?> WriteAguiEventAsync(
         AGUIEvent aguiEvent,
         string messageId,
         NyxIdChatSseWriter writer)
     {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
         switch (aguiEvent.EventCase)
         {
             case AGUIEvent.EventOneofCase.TextMessageStart:
@@ -180,6 +61,7 @@ internal static class NyxIdChatStreamingRunner
                     CancellationToken.None);
                 return "RUN_ERROR";
             case AGUIEvent.EventOneofCase.RunFinished:
+                await writer.WriteRunFinishedAsync(CancellationToken.None);
                 return "RUN_FINISHED";
             default:
                 return null;

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs
@@ -7,11 +7,6 @@ namespace Aevatar.GAgents.NyxidChat;
 
 internal static class NyxIdChatStreamingRunner
 {
-    internal sealed record ErrorMessages(
-        string DispatchFailedBeforeCompletion,
-        string Timeout,
-        string UnhandledFailure);
-
     public static async ValueTask<string?> WriteAguiEventAsync(
         AGUIEvent aguiEvent,
         string messageId,

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -1,5 +1,12 @@
 using System.Runtime.CompilerServices;
 using Aevatar.AI.Abstractions.Middleware;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.CQRS.Core.DependencyInjection;
+using Aevatar.CQRS.Core.Interactions;
+using Aevatar.CQRS.Core.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.DependencyInjection;
 using Aevatar.CQRS.Projection.Core.Orchestration;
@@ -31,6 +38,7 @@ public static class ServiceCollectionExtensions
         RuntimeHelpers.RunClassConstructor(typeof(NyxIdChatGAgent).TypeHandle);
         RuntimeHelpers.RunClassConstructor(typeof(AgentRunGAgent).TypeHandle);
 
+        services.AddCqrsCore();
         services.AddHttpClient();
         services.TryAddSingleton(provider => BindRelayOptions(configuration));
         services.TryAddSingleton<Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions>(
@@ -110,8 +118,47 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionProjector<NyxIdChatSessionProjectionContext>,
             NyxIdChatSessionEventProjector>());
+        AddNyxIdStreamingInteractions(services);
 
         return services;
+    }
+
+    private static void AddNyxIdStreamingInteractions(IServiceCollection services)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        services.TryAddSingleton(NyxIdChatInteractionFactories.CreateChatResolver);
+        services.TryAddSingleton(NyxIdChatInteractionFactories.CreateApprovalResolver);
+        services.TryAddSingleton(NyxIdChatInteractionFactories.CreateChatBinder);
+        services.TryAddSingleton(NyxIdChatInteractionFactories.CreateApprovalBinder);
+        services.TryAddSingleton<ICommandEnvelopeFactory<NyxIdChatCommand>, NyxIdChatCommandEnvelopeFactory>();
+        services.TryAddSingleton<ICommandEnvelopeFactory<NyxIdApprovalCommand>, NyxIdApprovalCommandEnvelopeFactory>();
+        services.TryAddSingleton<ICommandTargetDispatcher<NyxIdChatCommandTarget>, ActorCommandTargetDispatcher<NyxIdChatCommandTarget>>();
+        services.TryAddSingleton<ICommandReceiptFactory<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt>, NyxIdChatAcceptedReceiptFactory>();
+        services.TryAddSingleton<ICommandDispatchPipeline<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>, DefaultCommandDispatchPipeline<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>();
+        services.TryAddSingleton<ICommandDispatchPipeline<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>, DefaultCommandDispatchPipeline<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>();
+        services.TryAddSingleton<ICommandCompletionPolicy<AGUIEvent, NyxIdChatCompletionStatus>, NyxIdChatCompletionPolicy>();
+        services.TryAddSingleton<ICommandFinalizeEmitter<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus, AGUIEvent>, NyxIdChatFinalizeEmitter>();
+        services.TryAddSingleton<ICommandDurableCompletionResolver<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>, NyxIdChatDurableCompletionResolver>();
+        services.TryAddSingleton<IEventFrameMapper<AGUIEvent, AGUIEvent>, IdentityEventFrameMapper<AGUIEvent>>();
+        services.TryAddSingleton<IEventOutputStream<AGUIEvent, AGUIEvent>, DefaultEventOutputStream<AGUIEvent, AGUIEvent>>();
+        services.TryAddSingleton<ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>(sp =>
+            new DefaultCommandInteractionService<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, AGUIEvent, NyxIdChatCompletionStatus>(
+                sp.GetRequiredService<ICommandDispatchPipeline<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>(),
+                sp.GetRequiredService<IEventOutputStream<AGUIEvent, AGUIEvent>>(),
+                sp.GetRequiredService<ICommandCompletionPolicy<AGUIEvent, NyxIdChatCompletionStatus>>(),
+                sp.GetRequiredService<ICommandFinalizeEmitter<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus, AGUIEvent>>(),
+                sp.GetRequiredService<ICommandDurableCompletionResolver<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>>(),
+                sp.GetService<ILogger<DefaultCommandInteractionService<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, AGUIEvent, NyxIdChatCompletionStatus>>>()));
+        services.TryAddSingleton<ICommandInteractionService<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>(sp =>
+            new DefaultCommandInteractionService<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, AGUIEvent, NyxIdChatCompletionStatus>(
+                sp.GetRequiredService<ICommandDispatchPipeline<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>>(),
+                sp.GetRequiredService<IEventOutputStream<AGUIEvent, AGUIEvent>>(),
+                sp.GetRequiredService<ICommandCompletionPolicy<AGUIEvent, NyxIdChatCompletionStatus>>(),
+                sp.GetRequiredService<ICommandFinalizeEmitter<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus, AGUIEvent>>(),
+                sp.GetRequiredService<ICommandDurableCompletionResolver<NyxIdChatAcceptedReceipt, NyxIdChatCompletionStatus>>(),
+                sp.GetService<ILogger<DefaultCommandInteractionService<NyxIdApprovalCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, AGUIEvent, NyxIdChatCompletionStatus>>>()));
     }
 
     private static NyxIdRelayOptions BindRelayOptions(IConfiguration? configuration)

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -12,17 +12,23 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IGAgentActorRegistryCommandPort _registryCommandPort;
+    private readonly IStreamingProxyRoomSessionProjectionPort _roomSessionProjectionPort;
     private readonly ILogger<StreamingProxyRoomCommandService> _logger;
 
     public StreamingProxyRoomCommandService(
         IActorRuntime actorRuntime,
         IActorDispatchPort actorDispatchPort,
         IGAgentActorRegistryCommandPort registryCommandPort,
+        IStreamingProxyRoomSessionProjectionPort roomSessionProjectionPort,
         ILogger<StreamingProxyRoomCommandService> logger)
     {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
         _registryCommandPort = registryCommandPort ?? throw new ArgumentNullException(nameof(registryCommandPort));
+        _roomSessionProjectionPort = roomSessionProjectionPort ?? throw new ArgumentNullException(nameof(roomSessionProjectionPort));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -44,6 +50,19 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
 
             var envelope = BuildRoomInitializedEnvelope(actor.Id, roomName);
             await DispatchRoomEnvelopeAsync(actor.Id, envelope, cancellationToken);
+
+            var subscriptionLease = await _roomSessionProjectionPort.EnsureSubscriptionProjectionAsync(
+                actor.Id,
+                StreamingProxyRoomSubscriptionObservationPort.RoomSubscriptionSessionId(actor.Id),
+                cancellationToken);
+            if (subscriptionLease == null)
+            {
+                await TryRollbackRoomCreationAsync(scopeId, roomId, CancellationToken.None);
+                return new StreamingProxyRoomCreateResult(
+                    StreamingProxyRoomCreateStatus.AdmissionUnavailable,
+                    roomId,
+                    roomName);
+            }
 
             var receipt = await _registryCommandPort.RegisterActorAsync(
                 new GAgentActorRegistration(scopeId, StreamingProxyDefaults.GAgentTypeName, roomId),

--- a/agents/Aevatar.GAgents.StreamingProxy/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/ServiceCollectionExtensions.cs
@@ -1,4 +1,10 @@
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.CQRS.Core.DependencyInjection;
+using Aevatar.CQRS.Core.Interactions;
 using Aevatar.CQRS.Projection.Core.DependencyInjection;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Core.Streaming;
@@ -23,6 +29,7 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        services.AddCqrsCore();
         services.TryAddSingleton<StreamingProxyNyxParticipantCoordinator>();
         services.TryAddSingleton<IStreamingProxyRoomCommandService, StreamingProxyRoomCommandService>();
         services.AddProjectionReadModelRuntime();
@@ -43,6 +50,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IProjectionSessionEventCodec<StreamingProxyRoomSessionEnvelope>, StreamingProxyRoomSessionEventCodec>();
         services.TryAddSingleton<IProjectionSessionEventHub<StreamingProxyRoomSessionEnvelope>, ProjectionSessionEventHub<StreamingProxyRoomSessionEnvelope>>();
         services.TryAddSingleton<IStreamingProxyRoomSessionProjectionPort, StreamingProxyRoomSessionProjectionPort>();
+        services.TryAddSingleton<IStreamingProxyRoomSubscriptionObservationPort, StreamingProxyRoomSubscriptionObservationPort>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionProjector<StreamingProxyRoomSessionProjectionContext>,
             StreamingProxyRoomSessionEventProjector>());
@@ -66,9 +74,35 @@ public static class ServiceCollectionExtensions
             StreamingProxyChatSessionTerminalSnapshotMetadataProvider>();
         services.TryAddSingleton<IStreamingProxyChatSessionTerminalQueryPort, StreamingProxyChatSessionTerminalQueryPort>();
         services.TryAddSingleton<StreamingProxyChatDurableCompletionResolver>();
+        AddStreamingProxyRoomInteraction(services);
         AddTerminalSnapshotReadModelProvider(services, configuration);
 
         return services;
+    }
+
+    private static void AddStreamingProxyRoomInteraction(IServiceCollection services)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        services.TryAddSingleton<ICommandTargetResolver<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>, StreamingProxyRoomChatCommandTargetResolver>();
+        services.TryAddSingleton<ICommandTargetBinder<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>, StreamingProxyRoomChatCommandTargetBinder>();
+        services.TryAddSingleton<ICommandEnvelopeFactory<StreamingProxyRoomChatCommand>, StreamingProxyRoomChatCommandEnvelopeFactory>();
+        services.TryAddSingleton<ICommandTargetDispatcher<StreamingProxyRoomChatCommandTarget>, ActorCommandTargetDispatcher<StreamingProxyRoomChatCommandTarget>>();
+        services.TryAddSingleton<ICommandReceiptFactory<StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt>, StreamingProxyRoomChatAcceptedReceiptFactory>();
+        services.TryAddSingleton<ICommandDispatchPipeline<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError>, DefaultCommandDispatchPipeline<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError>>();
+        services.TryAddSingleton<ICommandCompletionPolicy<StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>, StreamingProxyRoomChatCompletionPolicy>();
+        services.TryAddSingleton<ICommandFinalizeEmitter<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus, StreamingProxyRoomSessionEnvelope>, StreamingProxyRoomChatFinalizeEmitter>();
+        services.TryAddSingleton<ICommandDurableCompletionResolver<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus>, StreamingProxyRoomChatDurableCompletionResolverAdapter>();
+        services.TryAddSingleton<IEventOutputStream<StreamingProxyRoomSessionEnvelope, StreamingProxyRoomSessionEnvelope>, StreamingProxyRoomChatOutputStream>();
+        services.TryAddSingleton<ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>(sp =>
+            new DefaultCommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>(
+                sp.GetRequiredService<ICommandDispatchPipeline<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError>>(),
+                sp.GetRequiredService<IEventOutputStream<StreamingProxyRoomSessionEnvelope, StreamingProxyRoomSessionEnvelope>>(),
+                sp.GetRequiredService<ICommandCompletionPolicy<StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>(),
+                sp.GetRequiredService<ICommandFinalizeEmitter<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus, StreamingProxyRoomSessionEnvelope>>(),
+                sp.GetRequiredService<ICommandDurableCompletionResolver<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus>>(),
+                sp.GetService<Microsoft.Extensions.Logging.ILogger<DefaultCommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>>()));
     }
 
     private static void AddTerminalSnapshotReadModelProvider(

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -1,4 +1,5 @@
 using Aevatar.AI.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
@@ -176,7 +177,7 @@ public static class StreamingProxyEndpoints
         [FromServices] IActorRuntime actorRuntime,
         [FromServices] IActorDispatchPort actorDispatchPort,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
-        [FromServices] IStreamingProxyRoomSessionProjectionPort roomSessionProjectionPort,
+        [FromServices] ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus> interactionService,
         [FromServices] StreamingProxyChatDurableCompletionResolver durableCompletionResolver,
         [FromServices] IStreamingProxyParticipantStore participantStore,
         [FromServices] StreamingProxyNyxParticipantCoordinator participantCoordinator,
@@ -186,10 +187,13 @@ public static class StreamingProxyEndpoints
         var logger = loggerFactory.CreateLogger("Aevatar.GAgents.StreamingProxy.Endpoints");
         var writer = new StreamingProxySseWriter(http.Response);
         IActor? actor = null;
-        string? sessionId = null;
+        var sessionId = request.SessionId ?? Guid.NewGuid().ToString("N");
 
         try
         {
+            // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
@@ -219,159 +223,68 @@ public static class StreamingProxyEndpoints
             // Set up SSE response
             await writer.StartAsync(ct);
 
-            var activityChannel = Channel.CreateUnbounded<StreamingProxyStreamSignal>();
-            sessionId = request.SessionId ?? Guid.NewGuid().ToString("N");
-            var eventChannel = new EventChannel<StreamingProxyRoomSessionEnvelope>();
-            var attachment = await roomSessionProjectionPort.EnsureAndAttachLeaseAsync(
-                token => roomSessionProjectionPort.EnsureChatProjectionAsync(actor.Id, sessionId, token),
-                eventChannel,
-                ct);
-            if (attachment == null)
-                throw new InvalidOperationException("StreamingProxy room session projection pipeline is unavailable.");
-
-            Task? pumpTask = null;
-
-            try
-            {
-                pumpTask = PumpRoomSessionEventsAsync(
-                    eventChannel,
-                    writer,
-                    activityChannel.Writer);
-
-                var accessToken = ExtractBearerToken(http);
-                var preferredRoute = request.LlmRoute?.Trim();
-                var defaultModel = request.LlmModel?.Trim();
-
-                // Emit the room topic immediately so the client sees visible progress
-                // even when Nyx participant discovery is slow.
-                var chatRequest = new ChatRequestEvent
+            var accessToken = ExtractBearerToken(http);
+            var preferredRoute = request.LlmRoute?.Trim();
+            var defaultModel = request.LlmModel?.Trim();
+            var result = await interactionService.ExecuteAsync(
+                new StreamingProxyRoomChatCommand(roomId, scopeId, prompt, sessionId),
+                async (frame, token) =>
                 {
-                    Prompt = prompt,
-                    SessionId = sessionId,
-                    ScopeId = scopeId,
-                };
-                var envelope = new EventEnvelope
+                    await MapAndWriteRoomSessionEventAsync(frame, writer);
+                },
+                async (_, token) =>
                 {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-                    Payload = Any.Pack(chatRequest),
-                    Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actor.Id } },
-                };
-                await DispatchRoomEnvelopeAsync(actorDispatchPort, actor.Id, envelope, ct);
+                    IReadOnlyList<StreamingProxyNyxParticipantDefinition> participants = string.IsNullOrWhiteSpace(accessToken)
+                        ? Array.Empty<StreamingProxyNyxParticipantDefinition>()
+                        : await participantCoordinator.EnsureParticipantsJoinedAsync(
+                            scopeId,
+                            roomId,
+                            actor,
+                            participantStore,
+                            accessToken,
+                            token,
+                            preferredRoute,
+                            defaultModel);
 
-                IReadOnlyList<StreamingProxyNyxParticipantDefinition> participants = string.IsNullOrWhiteSpace(accessToken)
-                    ? Array.Empty<StreamingProxyNyxParticipantDefinition>()
-                    : await participantCoordinator.EnsureParticipantsJoinedAsync(
-                        scopeId,
-                        roomId,
-                        actor,
-                        participantStore,
-                        accessToken,
-                        ct,
-                        preferredRoute,
-                        defaultModel);
+                    if (participants.Count == 0 || string.IsNullOrWhiteSpace(accessToken))
+                        return;
 
-                if (participants.Count > 0 && !string.IsNullOrWhiteSpace(accessToken))
-                {
-                    var successfulReplies = await participantCoordinator.GenerateRepliesAsync(
+                    var terminalState = DetermineParticipantTerminalState(await participantCoordinator.GenerateRepliesAsync(
                         participants,
                         actor,
                         prompt,
                         sessionId,
                         accessToken,
-                        ct,
+                        token,
                         participantStore,
-                        roomId);
-                    var participantTerminalState = DetermineParticipantTerminalState(successfulReplies);
+                        roomId));
                     await PublishTerminalStateAsync(
                         actorDispatchPort,
                         actor.Id,
                         sessionId,
-                        participantTerminalState.Status,
-                        participantTerminalState.ErrorMessage,
-                        ct);
-                    await FinalizeFromLiveOrDurableCompletionAsync(
-                        actor.Id,
-                        sessionId,
-                        activityChannel.Reader,
-                        durableCompletionResolver,
-                        writer,
-                        null,
-                        ct);
-                    return;
-                }
+                        terminalState.Status,
+                        terminalState.ErrorMessage,
+                        token);
+                },
+                ct);
 
-                var sawActivity = false;
-                var sawAgentMessage = false;
-                while (!ct.IsCancellationRequested)
-                {
-                    using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                    idleCts.CancelAfter(sawAgentMessage
-                        ? StreamingProxyDefaults.IdleCompletionTimeoutMs
-                        : sawActivity
-                            ? StreamingProxyDefaults.PostTopicTimeoutMs
-                            : StreamingProxyDefaults.InitialResponseTimeoutMs);
-
-                    try
-                    {
-                        if (!await activityChannel.Reader.WaitToReadAsync(idleCts.Token))
-                            break;
-                    }
-                    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-                    {
-                        break;
-                    }
-
-                    while (activityChannel.Reader.TryRead(out var signal))
-                    {
-                        sawActivity = true;
-                        if (signal == StreamingProxyStreamSignal.AgentMessage)
-                            sawAgentMessage = true;
-                        if (signal is StreamingProxyStreamSignal.RunFinished or StreamingProxyStreamSignal.RunFailed)
-                            return;
-                    }
-                }
-
-                var idleTerminalState = DetermineIdleTerminalState(sawAgentMessage);
-                await PublishTerminalStateAsync(
-                    actorDispatchPort,
-                    actor.Id,
-                    sessionId,
-                    idleTerminalState.Status,
-                    idleTerminalState.ErrorMessage,
-                    ct);
-                await FinalizeFromLiveOrDurableCompletionAsync(
-                    actor.Id,
-                    sessionId,
-                    activityChannel.Reader,
-                    durableCompletionResolver,
-                    writer,
-                    null,
-                    ct);
-            }
-            finally
+            if (!result.Succeeded)
             {
-                await roomSessionProjectionPort.DetachReleaseAndDisposeAsync(
-                    attachment.ProjectionLease,
-                    attachment.LiveSinkLease,
-                    eventChannel,
-                    () =>
-                    {
-                        activityChannel.Writer.TryComplete();
-                        return Task.CompletedTask;
-                    },
-                    CancellationToken.None);
-
-                if (pumpTask != null)
+                switch (result.Error)
                 {
-                    try
-                    {
-                        await pumpTask;
-                    }
-                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
-                    {
-                        // Client disconnected.
-                    }
+                    case StreamingProxyRoomChatStartError.RoomNotFound:
+                        http.Response.StatusCode = StatusCodes.Status404NotFound;
+                        return;
+                    case StreamingProxyRoomChatStartError.ProjectionUnavailable:
+                        await writer.WriteRunErrorAsync(
+                            "StreamingProxy room session projection pipeline is unavailable.",
+                            CancellationToken.None);
+                        return;
+                    default:
+                        await writer.WriteRunErrorAsync(
+                            "StreamingProxy chat failed before completion.",
+                            CancellationToken.None);
+                        return;
                 }
             }
         }
@@ -457,7 +370,7 @@ public static class StreamingProxyEndpoints
         string roomId,
         [FromServices] IActorRuntime actorRuntime,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
-        [FromServices] IStreamingProxyRoomSessionProjectionPort roomSessionProjectionPort,
+        [FromServices] IStreamingProxyRoomSubscriptionObservationPort subscriptionObservationPort,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -486,14 +399,8 @@ public static class StreamingProxyEndpoints
             }
 
             await writer.StartAsync(ct);
-            var sessionId = Guid.NewGuid().ToString("N");
             var eventChannel = new EventChannel<StreamingProxyRoomSessionEnvelope>();
-            var attachment = await roomSessionProjectionPort.EnsureAndAttachLeaseAsync(
-                token => roomSessionProjectionPort.EnsureSubscriptionProjectionAsync(actor.Id, sessionId, token),
-                eventChannel,
-                ct);
-            if (attachment == null)
-                throw new InvalidOperationException("StreamingProxy room session projection pipeline is unavailable.");
+            var attachment = await subscriptionObservationPort.AttachAsync(actor.Id, eventChannel, ct);
 
             Task? pumpTask = null;
 
@@ -508,11 +415,9 @@ public static class StreamingProxyEndpoints
             }
             finally
             {
-                await roomSessionProjectionPort.DetachReleaseAndDisposeAsync(
-                    attachment.ProjectionLease,
-                    attachment.LiveSinkLease,
+                await subscriptionObservationPort.DetachAndDisposeAsync(
+                    attachment,
                     eventChannel,
-                    null,
                     CancellationToken.None);
 
                 if (pumpTask != null)
@@ -748,17 +653,7 @@ public static class StreamingProxyEndpoints
     private static bool TryGetObservedTerminalEvent(
         EventEnvelope envelope,
         out StreamingProxyChatSessionTerminalStateChanged terminalEvent)
-    {
-        terminalEvent = new StreamingProxyChatSessionTerminalStateChanged();
-        if (!CommittedStateEventEnvelope.TryGetObservedPayload(envelope, out var payload, out _, out _) ||
-            payload?.Is(StreamingProxyChatSessionTerminalStateChanged.Descriptor) != true)
-        {
-            return false;
-        }
-
-        terminalEvent = payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>();
-        return !string.IsNullOrWhiteSpace(terminalEvent.SessionId);
-    }
+        => StreamingProxyRoomInteractionHelpers.TryGetTerminalEvent(envelope, out terminalEvent);
 
     private static async Task PublishTerminalStateAsync(
         IActorDispatchPort actorDispatchPort,

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -192,8 +192,8 @@ public static class StreamingProxyEndpoints
         try
         {
             // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+            //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+            //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
             if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
                 return;
 
@@ -407,7 +407,7 @@ public static class StreamingProxyEndpoints
             try
             {
                 pumpTask = PumpRoomSessionEventsAsync(eventChannel, writer);
-                await Task.Delay(Timeout.Infinite, ct);
+                await WaitForClientDisconnectAsync(ct);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -704,41 +704,6 @@ public static class StreamingProxyEndpoints
             ? (StreamingProxyChatSessionTerminalStatus.Completed, null)
             : (StreamingProxyChatSessionTerminalStatus.Failed, "StreamingProxy chat completed without any participant replies.");
 
-    private static (StreamingProxyChatSessionTerminalStatus Status, string? ErrorMessage) DetermineIdleTerminalState(
-        bool sawAgentMessage) =>
-        sawAgentMessage
-            ? (StreamingProxyChatSessionTerminalStatus.Completed, null)
-            : (StreamingProxyChatSessionTerminalStatus.Failed, "StreamingProxy chat timed out without any agent replies.");
-
-    private static async Task FinalizeFromLiveOrDurableCompletionAsync(
-        string actorId,
-        string sessionId,
-        ChannelReader<StreamingProxyStreamSignal> signalReader,
-        StreamingProxyChatDurableCompletionResolver durableCompletionResolver,
-        StreamingProxySseWriter writer,
-        TimeSpan? terminalCompletionTimeout,
-        CancellationToken ct)
-    {
-        var timeout = terminalCompletionTimeout ?? TimeSpan.FromMilliseconds(StreamingProxyDefaults.TerminalCompletionTimeoutMs);
-        if (await WaitForTerminalSignalAsync(signalReader, timeout, ct))
-            return;
-
-        var durableCompletion = await durableCompletionResolver.ResolveAsync(actorId, sessionId, ct);
-        switch (durableCompletion)
-        {
-            case StreamingProxyProjectionCompletionStatus.Failed:
-                await writer.WriteRunErrorAsync("StreamingProxy chat failed.", CancellationToken.None);
-                return;
-            case StreamingProxyProjectionCompletionStatus.Completed:
-                await writer.WriteRunFinishedAsync(CancellationToken.None);
-                return;
-            case StreamingProxyProjectionCompletionStatus.Unknown:
-            default:
-                await writer.WriteRunErrorAsync("StreamingProxy completion timed out.", CancellationToken.None);
-                return;
-        }
-    }
-
     private static async Task TryPublishCanceledTerminalStateAsync(
         IActorDispatchPort actorDispatchPort,
         IActor? actor,
@@ -808,31 +773,13 @@ public static class StreamingProxyEndpoints
         }
     }
 
-    private static async Task<bool> WaitForTerminalSignalAsync(
-        ChannelReader<StreamingProxyStreamSignal> signalReader,
-        TimeSpan timeout,
-        CancellationToken ct)
+    private static async Task WaitForClientDisconnectAsync(CancellationToken ct)
     {
-        using var waitCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        waitCts.CancelAfter(timeout);
-
-        try
-        {
-            while (await signalReader.WaitToReadAsync(waitCts.Token))
-            {
-                while (signalReader.TryRead(out var signal))
-                {
-                    if (signal is StreamingProxyStreamSignal.RunFinished or StreamingProxyStreamSignal.RunFailed)
-                        return true;
-                }
-            }
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            return false;
-        }
-
-        return false;
+        var disconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var registration = ct.Register(
+            static state => ((TaskCompletionSource)state!).TrySetCanceled(),
+            disconnected);
+        await disconnected.Task;
     }
 
     private static async Task<IResult?> AuthorizeRoomAsync(

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
@@ -1,0 +1,498 @@
+using System.Runtime.ExceptionServices;
+using Aevatar.AI.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.StreamingProxy;
+
+public sealed record StreamingProxyRoomChatCommand(
+    string RoomId,
+    string ScopeId,
+    string Prompt,
+    string SessionId);
+
+public sealed record StreamingProxyRoomChatAcceptedReceipt(
+    string ActorId,
+    string CommandId,
+    string CorrelationId,
+    string SessionId);
+
+public enum StreamingProxyRoomChatStartError
+{
+    None = 0,
+    RoomNotFound = 1,
+    ProjectionUnavailable = 2,
+}
+
+internal sealed class StreamingProxyRoomChatCommandTarget
+    : IActorCommandDispatchTarget,
+      ICommandEventTarget<StreamingProxyRoomSessionEnvelope>,
+      ICommandInteractionCleanupTarget<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus>,
+      ICommandDispatchCleanupAware
+{
+    private readonly IStreamingProxyRoomSessionProjectionPort _projectionPort;
+
+    public StreamingProxyRoomChatCommandTarget(
+        IActor actor,
+        IStreamingProxyRoomSessionProjectionPort projectionPort)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        Actor = actor ?? throw new ArgumentNullException(nameof(actor));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+    }
+
+    public IActor Actor { get; }
+    public string TargetId => Actor.Id;
+    public string ActorId => Actor.Id;
+    public string SessionId { get; private set; } = string.Empty;
+    public IStreamingProxyRoomSessionProjectionLease? ProjectionLease { get; private set; }
+    public IAsyncDisposable? LiveSinkLease { get; private set; }
+    public IEventSink<StreamingProxyRoomSessionEnvelope>? LiveSink { get; private set; }
+
+    public void BindLiveObservation(
+        IStreamingProxyRoomSessionProjectionLease projectionLease,
+        IAsyncDisposable? liveSinkLease,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        string sessionId)
+    {
+        ProjectionLease = projectionLease ?? throw new ArgumentNullException(nameof(projectionLease));
+        LiveSinkLease = liveSinkLease;
+        LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
+        SessionId = string.IsNullOrWhiteSpace(sessionId)
+            ? throw new ArgumentException("Session id is required.", nameof(sessionId))
+            : sessionId;
+    }
+
+    public IEventSink<StreamingProxyRoomSessionEnvelope> RequireLiveSink() =>
+        LiveSink ?? throw new InvalidOperationException("StreamingProxy room chat live sink is not bound.");
+
+    public Task CleanupAfterDispatchFailureAsync(CancellationToken ct = default) =>
+        ReleaseAsync(ct);
+
+    public Task ReleaseAfterInteractionAsync(
+        StreamingProxyRoomChatAcceptedReceipt receipt,
+        CommandInteractionCleanupContext<StreamingProxyProjectionCompletionStatus> cleanup,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+        ArgumentNullException.ThrowIfNull(cleanup);
+        return ReleaseAsync(ct);
+    }
+
+    private async Task ReleaseAsync(CancellationToken ct)
+    {
+        Exception? firstException = null;
+        var projectionLease = ProjectionLease;
+        var liveSinkLease = LiveSinkLease;
+        var sink = LiveSink;
+
+        if (projectionLease != null && sink != null)
+        {
+            try
+            {
+                await _projectionPort.DetachReleaseAndDisposeAsync(
+                    projectionLease,
+                    liveSinkLease,
+                    sink,
+                    null,
+                    ct);
+                ProjectionLease = null;
+                LiveSinkLease = null;
+                LiveSink = null;
+            }
+            catch (Exception ex)
+            {
+                firstException ??= ex;
+            }
+        }
+        else if (sink != null)
+        {
+            try
+            {
+                sink.Complete();
+                await sink.DisposeAsync();
+                LiveSinkLease = null;
+                LiveSink = null;
+            }
+            catch (Exception ex)
+            {
+                firstException ??= ex;
+            }
+        }
+
+        if (firstException != null)
+            ExceptionDispatchInfo.Capture(firstException).Throw();
+    }
+}
+
+internal sealed class StreamingProxyRoomChatCommandTargetResolver
+    : ICommandTargetResolver<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>
+{
+    private readonly IActorRuntime _actorRuntime;
+    private readonly IStreamingProxyRoomSessionProjectionPort _projectionPort;
+
+    public StreamingProxyRoomChatCommandTargetResolver(
+        IActorRuntime actorRuntime,
+        IStreamingProxyRoomSessionProjectionPort projectionPort)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+    }
+
+    public async Task<CommandTargetResolution<StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>> ResolveAsync(
+        StreamingProxyRoomChatCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
+        if (actor == null)
+        {
+            return CommandTargetResolution<StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>.Failure(
+                StreamingProxyRoomChatStartError.RoomNotFound);
+        }
+
+        return CommandTargetResolution<StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>.Success(
+            new StreamingProxyRoomChatCommandTarget(actor, _projectionPort));
+    }
+}
+
+internal sealed class StreamingProxyRoomChatCommandTargetBinder
+    : ICommandTargetBinder<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>
+{
+    private readonly IStreamingProxyRoomSessionProjectionPort _projectionPort;
+
+    public StreamingProxyRoomChatCommandTargetBinder(
+        IStreamingProxyRoomSessionProjectionPort projectionPort)
+    {
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+    }
+
+    public async Task<CommandTargetBindingResult<StreamingProxyRoomChatStartError>> BindAsync(
+        StreamingProxyRoomChatCommand command,
+        StreamingProxyRoomChatCommandTarget target,
+        CommandContext context,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
+        try
+        {
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
+                token => _projectionPort.EnsureChatProjectionAsync(
+                    target.ActorId,
+                    command.SessionId,
+                    token),
+                sink,
+                ct);
+            if (attachment == null)
+            {
+                sink.Complete();
+                await sink.DisposeAsync();
+                return CommandTargetBindingResult<StreamingProxyRoomChatStartError>.Failure(
+                    StreamingProxyRoomChatStartError.ProjectionUnavailable);
+            }
+
+            target.BindLiveObservation(
+                attachment.ProjectionLease,
+                attachment.LiveSinkLease,
+                sink,
+                command.SessionId);
+            return CommandTargetBindingResult<StreamingProxyRoomChatStartError>.Success();
+        }
+        catch
+        {
+            sink.Complete();
+            await sink.DisposeAsync();
+            throw;
+        }
+    }
+}
+
+internal sealed class StreamingProxyRoomChatCommandEnvelopeFactory
+    : ICommandEnvelopeFactory<StreamingProxyRoomChatCommand>
+{
+    public EventEnvelope CreateEnvelope(StreamingProxyRoomChatCommand command, CommandContext context)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var chatRequest = new ChatRequestEvent
+        {
+            Prompt = command.Prompt,
+            SessionId = command.SessionId,
+            ScopeId = command.ScopeId,
+        };
+
+        return new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(chatRequest),
+            Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = context.TargetId } },
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = context.CorrelationId,
+            },
+        };
+    }
+}
+
+internal sealed class StreamingProxyRoomChatAcceptedReceiptFactory
+    : ICommandReceiptFactory<StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt>
+{
+    public StreamingProxyRoomChatAcceptedReceipt Create(
+        StreamingProxyRoomChatCommandTarget target,
+        CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new StreamingProxyRoomChatAcceptedReceipt(
+            target.ActorId,
+            context.CommandId,
+            context.CorrelationId,
+            target.SessionId);
+    }
+}
+
+internal sealed class StreamingProxyRoomChatCompletionPolicy
+    : ICommandCompletionPolicy<StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>
+{
+    public StreamingProxyProjectionCompletionStatus IncompleteCompletion => StreamingProxyProjectionCompletionStatus.Unknown;
+
+    public bool TryResolve(
+        StreamingProxyRoomSessionEnvelope evt,
+        out StreamingProxyProjectionCompletionStatus completion)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        completion = StreamingProxyProjectionCompletionStatus.Unknown;
+        if (evt.Envelope == null ||
+            !StreamingProxyRoomInteractionHelpers.TryGetTerminalEvent(evt.Envelope, out var terminalEvent))
+        {
+            return false;
+        }
+
+        completion = terminalEvent.Status == StreamingProxyChatSessionTerminalStatus.Failed
+            ? StreamingProxyProjectionCompletionStatus.Failed
+            : StreamingProxyProjectionCompletionStatus.Completed;
+        return true;
+    }
+}
+
+internal sealed class StreamingProxyRoomChatFinalizeEmitter
+    : ICommandFinalizeEmitter<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus, StreamingProxyRoomSessionEnvelope>
+{
+    public Task EmitAsync(
+        StreamingProxyRoomChatAcceptedReceipt receipt,
+        StreamingProxyProjectionCompletionStatus completion,
+        bool completed,
+        Func<StreamingProxyRoomSessionEnvelope, CancellationToken, ValueTask> emitAsync,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(receipt);
+        ArgumentNullException.ThrowIfNull(emitAsync);
+
+        if (completed)
+            return Task.CompletedTask;
+
+        return emitAsync(
+            new StreamingProxyRoomSessionEnvelope
+            {
+                Envelope = StreamingProxyRoomInteractionHelpers.CreateTerminalEnvelope(
+                    receipt.ActorId,
+                    receipt.SessionId,
+                    completion == StreamingProxyProjectionCompletionStatus.Failed
+                        ? StreamingProxyChatSessionTerminalStatus.Failed
+                        : StreamingProxyChatSessionTerminalStatus.Failed,
+                    "StreamingProxy completion timed out."),
+            },
+            ct).AsTask();
+    }
+}
+
+internal sealed class StreamingProxyRoomChatDurableCompletionResolverAdapter
+    : ICommandDurableCompletionResolver<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyProjectionCompletionStatus>
+{
+    private readonly StreamingProxyChatDurableCompletionResolver _inner;
+
+    public StreamingProxyRoomChatDurableCompletionResolverAdapter(
+        StreamingProxyChatDurableCompletionResolver inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public async Task<CommandDurableCompletionObservation<StreamingProxyProjectionCompletionStatus>> ResolveAsync(
+        StreamingProxyRoomChatAcceptedReceipt receipt,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(receipt);
+
+        var completion = await _inner.ResolveAsync(receipt.ActorId, receipt.SessionId, ct);
+        return completion switch
+        {
+            StreamingProxyProjectionCompletionStatus.Completed => new(true, completion),
+            StreamingProxyProjectionCompletionStatus.Failed => new(true, completion),
+            _ => CommandDurableCompletionObservation<StreamingProxyProjectionCompletionStatus>.Incomplete,
+        };
+    }
+}
+
+internal sealed class StreamingProxyRoomChatOutputStream
+    : IEventOutputStream<StreamingProxyRoomSessionEnvelope, StreamingProxyRoomSessionEnvelope>
+{
+    public async Task PumpAsync(
+        IAsyncEnumerable<StreamingProxyRoomSessionEnvelope> events,
+        Func<StreamingProxyRoomSessionEnvelope, CancellationToken, ValueTask> emitAsync,
+        Func<StreamingProxyRoomSessionEnvelope, bool>? shouldStop = null,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(emitAsync);
+
+        var sawActivity = false;
+        var sawAgentMessage = false;
+        await using var enumerator = events.GetAsyncEnumerator(ct);
+        while (!ct.IsCancellationRequested)
+        {
+            using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            idleCts.CancelAfter(sawAgentMessage
+                ? StreamingProxyDefaults.IdleCompletionTimeoutMs
+                : sawActivity
+                    ? StreamingProxyDefaults.PostTopicTimeoutMs
+                    : StreamingProxyDefaults.InitialResponseTimeoutMs);
+
+            bool hasNext;
+            try
+            {
+                hasNext = await enumerator.MoveNextAsync().AsTask().WaitAsync(idleCts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (!hasNext)
+                return;
+
+            var evt = enumerator.Current;
+            var signal = StreamingProxyRoomInteractionHelpers.ResolveSignal(evt);
+            if (signal.HasValue)
+            {
+                sawActivity = true;
+                if (signal == StreamingProxyEndpoints.StreamingProxyStreamSignal.AgentMessage)
+                    sawAgentMessage = true;
+            }
+
+            await emitAsync(evt, ct);
+
+            if (shouldStop?.Invoke(evt) == true)
+                return;
+        }
+    }
+}
+
+internal static class StreamingProxyRoomInteractionHelpers
+{
+    public static StreamingProxyEndpoints.StreamingProxyStreamSignal? ResolveSignal(StreamingProxyRoomSessionEnvelope sessionEnvelope)
+    {
+        var envelope = sessionEnvelope.Envelope;
+        if (envelope == null)
+            return null;
+
+        if (TryGetTerminalEvent(envelope, out var terminalEvent))
+        {
+            return terminalEvent.Status == StreamingProxyChatSessionTerminalStatus.Failed
+                ? StreamingProxyEndpoints.StreamingProxyStreamSignal.RunFailed
+                : StreamingProxyEndpoints.StreamingProxyStreamSignal.RunFinished;
+        }
+
+        var payload = envelope.Payload;
+        if (CommittedStateEventEnvelope.TryGetObservedPayload(envelope, out var observedPayload, out _, out _) &&
+            observedPayload != null)
+        {
+            payload = observedPayload;
+        }
+
+        if (payload == null)
+            return null;
+
+        if (payload.Is(GroupChatTopicEvent.Descriptor))
+            return StreamingProxyEndpoints.StreamingProxyStreamSignal.TopicStarted;
+        if (payload.Is(GroupChatMessageEvent.Descriptor))
+            return StreamingProxyEndpoints.StreamingProxyStreamSignal.AgentMessage;
+
+        return null;
+    }
+
+    public static bool TryGetTerminalEvent(
+        EventEnvelope envelope,
+        out StreamingProxyChatSessionTerminalStateChanged terminalEvent)
+    {
+        terminalEvent = new StreamingProxyChatSessionTerminalStateChanged();
+        if (CommittedStateEventEnvelope.TryGetObservedPayload(envelope, out var payload, out _, out _) &&
+            payload?.Is(StreamingProxyChatSessionTerminalStateChanged.Descriptor) == true)
+        {
+            terminalEvent = payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>();
+            return !string.IsNullOrWhiteSpace(terminalEvent.SessionId);
+        }
+
+        if (envelope.Payload?.Is(StreamingProxyChatSessionTerminalStateChanged.Descriptor) == true)
+        {
+            terminalEvent = envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>();
+            return !string.IsNullOrWhiteSpace(terminalEvent.SessionId);
+        }
+
+        return false;
+    }
+
+    public static EventEnvelope CreateTerminalEnvelope(
+        string actorId,
+        string sessionId,
+        StreamingProxyChatSessionTerminalStatus status,
+        string? errorMessage)
+    {
+        var terminalEvent = new StreamingProxyChatSessionTerminalStateChanged
+        {
+            SessionId = sessionId,
+            Status = status,
+            TerminalAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            ErrorMessage = errorMessage ?? string.Empty,
+        };
+        return new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(terminalEvent),
+            Route = new EnvelopeRoute
+            {
+                Direct = new DirectRoute
+                {
+                    TargetActorId = actorId,
+                },
+            },
+        };
+    }
+}

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
@@ -9,12 +9,24 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.StreamingProxy;
 
+// Refactor (iter21/cluster-002-request-path-projection-session-priming):
+//   Old pattern: room chat endpoints created projection leases and inferred completion in handler code.
+//   New principle: room chat commands enter a shared interaction pipeline and bind observation by session.
 public sealed record StreamingProxyRoomChatCommand(
     string RoomId,
     string ScopeId,
     string Prompt,
-    string SessionId);
+    string SessionId)
+    : ICommandContextSeed
+{
+    public string? CommandId => SessionId;
+    public string? CorrelationId => SessionId;
+    public IReadOnlyDictionary<string, string>? Headers => null;
+}
 
+// Refactor (iter21/cluster-002-request-path-projection-session-priming):
+//   Old pattern: endpoint-local state mixed accepted dispatch with terminal observation.
+//   New principle: receipt exposes accepted dispatch identity; projection/durable completion stays separate.
 public sealed record StreamingProxyRoomChatAcceptedReceipt(
     string ActorId,
     string CommandId,
@@ -374,42 +386,56 @@ internal sealed class StreamingProxyRoomChatOutputStream
 
         var sawActivity = false;
         var sawAgentMessage = false;
-        await using var enumerator = events.GetAsyncEnumerator(ct);
-        while (!ct.IsCancellationRequested)
+        var enumerator = events.GetAsyncEnumerator(ct);
+        try
         {
-            using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            idleCts.CancelAfter(sawAgentMessage
-                ? StreamingProxyDefaults.IdleCompletionTimeoutMs
-                : sawActivity
-                    ? StreamingProxyDefaults.PostTopicTimeoutMs
-                    : StreamingProxyDefaults.InitialResponseTimeoutMs);
+            while (!ct.IsCancellationRequested)
+            {
+                using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                idleCts.CancelAfter(sawAgentMessage
+                    ? StreamingProxyDefaults.IdleCompletionTimeoutMs
+                    : sawActivity
+                        ? StreamingProxyDefaults.PostTopicTimeoutMs
+                        : StreamingProxyDefaults.InitialResponseTimeoutMs);
 
-            bool hasNext;
+                bool hasNext;
+                try
+                {
+                    hasNext = await enumerator.MoveNextAsync().AsTask().WaitAsync(idleCts.Token);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (!hasNext)
+                    return;
+
+                var evt = enumerator.Current;
+                var signal = StreamingProxyRoomInteractionHelpers.ResolveSignal(evt);
+                if (signal.HasValue)
+                {
+                    sawActivity = true;
+                    if (signal == StreamingProxyEndpoints.StreamingProxyStreamSignal.AgentMessage)
+                        sawAgentMessage = true;
+                }
+
+                await emitAsync(evt, ct);
+
+                if (shouldStop?.Invoke(evt) == true)
+                    return;
+            }
+        }
+        finally
+        {
             try
             {
-                hasNext = await enumerator.MoveNextAsync().AsTask().WaitAsync(idleCts.Token);
+                await enumerator.DisposeAsync();
             }
-            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            catch (NotSupportedException)
             {
-                return;
+                // ChannelReader.ReadAllAsync may not support async enumerator disposal after an idle timeout.
             }
-
-            if (!hasNext)
-                return;
-
-            var evt = enumerator.Current;
-            var signal = StreamingProxyRoomInteractionHelpers.ResolveSignal(evt);
-            if (signal.HasValue)
-            {
-                sawActivity = true;
-                if (signal == StreamingProxyEndpoints.StreamingProxyStreamSignal.AgentMessage)
-                    sawAgentMessage = true;
-            }
-
-            await emitAsync(evt, ct);
-
-            if (shouldStop?.Invoke(evt) == true)
-                return;
         }
     }
 }

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSubscriptionObservationPort.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSubscriptionObservationPort.cs
@@ -15,7 +15,9 @@ public interface IStreamingProxyRoomSubscriptionObservationPort
         CancellationToken ct = default);
 }
 
-// refactor helper, no behavior change
+// Refactor (iter21/cluster-002-request-path-projection-session-priming):
+//   Old pattern: passive room streams ensured projection sessions through endpoint-local priming.
+//   New principle: attach-only observation carries explicit leases for deterministic stream cleanup.
 public sealed record StreamingProxyRoomSubscriptionObservationAttachment(
     IStreamingProxyRoomSessionProjectionLease ProjectionLease,
     IAsyncDisposable? LiveSinkLease);

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSubscriptionObservationPort.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSubscriptionObservationPort.cs
@@ -1,0 +1,102 @@
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+
+namespace Aevatar.GAgents.StreamingProxy;
+
+public interface IStreamingProxyRoomSubscriptionObservationPort
+{
+    Task<StreamingProxyRoomSubscriptionObservationAttachment> AttachAsync(
+        string roomId,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default);
+
+    Task DetachAndDisposeAsync(
+        StreamingProxyRoomSubscriptionObservationAttachment attachment,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default);
+}
+
+// refactor helper, no behavior change
+public sealed record StreamingProxyRoomSubscriptionObservationAttachment(
+    IStreamingProxyRoomSessionProjectionLease ProjectionLease,
+    IAsyncDisposable? LiveSinkLease);
+
+internal sealed class StreamingProxyRoomSubscriptionObservationPort
+    : IStreamingProxyRoomSubscriptionObservationPort
+{
+    private readonly IStreamingProxyRoomSessionProjectionPort _projectionPort;
+
+    public StreamingProxyRoomSubscriptionObservationPort(
+        IStreamingProxyRoomSessionProjectionPort projectionPort)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
+    }
+
+    public static string RoomSubscriptionSessionId(string roomId) =>
+        $"room:{NormalizeRoomId(roomId)}:subscription";
+
+    public async Task<StreamingProxyRoomSubscriptionObservationAttachment> AttachAsync(
+        string roomId,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
+        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
+        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        ArgumentNullException.ThrowIfNull(sink);
+
+        var normalizedRoomId = NormalizeRoomId(roomId);
+        var lease = new StreamingProxyRoomSessionRuntimeLease(
+            new StreamingProxyRoomSessionProjectionContext
+            {
+                RootActorId = normalizedRoomId,
+                SessionId = RoomSubscriptionSessionId(normalizedRoomId),
+                ProjectionKind = StreamingProxyProjectionKinds.RoomSubscriptionSession,
+            });
+        var liveSinkLease = await _projectionPort.AttachLiveSinkAsync(lease, sink, ct);
+        return new StreamingProxyRoomSubscriptionObservationAttachment(lease, liveSinkLease);
+    }
+
+    public async Task DetachAndDisposeAsync(
+        StreamingProxyRoomSubscriptionObservationAttachment attachment,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(attachment);
+        ArgumentNullException.ThrowIfNull(sink);
+
+        Exception? firstException = null;
+        try
+        {
+            await _projectionPort.DetachLiveSinkAsync(attachment.LiveSinkLease, ct);
+        }
+        catch (Exception ex)
+        {
+            firstException ??= ex;
+        }
+
+        try
+        {
+            sink.Complete();
+            await sink.DisposeAsync();
+        }
+        catch (Exception ex)
+        {
+            firstException ??= ex;
+        }
+
+        if (firstException != null)
+            throw firstException;
+    }
+
+    private static string NormalizeRoomId(string roomId)
+    {
+        var normalized = roomId?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException("Room id is required.", nameof(roomId));
+
+        return normalized;
+    }
+}

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -10,8 +10,10 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Authentication.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Core.Commands;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
@@ -940,6 +942,203 @@ public class NyxIdChatEndpointsCoverageTests
         body.Should().Contain("RUN_STARTED");
         body.Should().Contain("RUN_ERROR");
         body.Should().Contain("The approval continuation failed. Please try again.");
+    }
+
+    [Fact]
+    public async Task NyxIdChatInteraction_ShouldBindDispatchEmitFinalizeAndCleanup()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort
+        {
+            Messages =
+            {
+                new AGUIEvent { TextMessageContent = new AguiTextMessageContentEvent { Delta = "hi" } },
+                new AGUIEvent { RunFinished = new RunFinishedEvent() },
+            },
+        };
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+        var emitted = new List<AGUIEvent>();
+
+        var result = await interaction.ExecuteAsync(
+            new NyxIdChatCommand(
+                actor.Id,
+                "scope-a",
+                "hello",
+                "session-1",
+                "access-token",
+                null,
+                new Dictionary<string, string> { [" custom "] = " value " }),
+            (evt, _) =>
+            {
+                emitted.Add(evt);
+                return ValueTask.CompletedTask;
+            },
+            null,
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeTrue();
+        result.Receipt.Should().Be(new NyxIdChatAcceptedReceipt(actor.Id, "session-1", "session-1", "session-1"));
+        result.FinalizeResult.Should().NotBeNull();
+        result.FinalizeResult!.Completed.Should().BeTrue();
+        result.FinalizeResult.Completion.Should().Be(NyxIdChatCompletionStatus.Completed);
+        projectionPort.EnsureCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
+        projectionPort.AttachCount.Should().Be(1);
+        projectionPort.DetachCount.Should().Be(1);
+        projectionPort.ReleaseCount.Should().Be(1);
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var envelope = dispatchPort.Dispatches.Single().Envelope;
+        envelope.Route?.Direct?.TargetActorId.Should().Be(actor.Id);
+        envelope.Propagation?.CorrelationId.Should().Be("session-1");
+        var request = envelope.Payload.Unpack<ChatRequestEvent>();
+        request.Prompt.Should().Be("hello");
+        request.SessionId.Should().Be("session-1");
+        request.ScopeId.Should().Be("scope-a");
+        request.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken].Should().Be("access-token");
+        request.Metadata["scope_id"].Should().Be("scope-a");
+        request.Metadata["custom"].Should().Be("value");
+        emitted.Select(x => x.EventCase).Should().ContainInOrder(
+            AGUIEvent.EventOneofCase.TextMessageContent,
+            AGUIEvent.EventOneofCase.RunFinished);
+    }
+
+    [Fact]
+    public async Task NyxIdChatInteraction_ShouldReturnProjectionUnavailableAndDisposeSink_WhenBinderCannotAttach()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort { ReturnNullLease = true };
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(new StubActorDispatchPort(runtime))
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+
+        var result = await interaction.ExecuteAsync(
+            new NyxIdChatCommand(actor.Id, "scope-a", "hello", "session-1", "token", null, null),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(NyxIdChatStartError.ProjectionUnavailable);
+        projectionPort.AttachCount.Should().Be(0);
+        projectionPort.DetachCount.Should().Be(0);
+        projectionPort.ReleaseCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NyxIdChatInteraction_ShouldCleanupBoundLease_WhenDispatchFails()
+    {
+        var actor = new StubActor("actor-1");
+        var runtime = new StubActorRuntime();
+        runtime.Actors[actor.Id] = actor;
+        var projectionPort = new StubNyxIdChatSessionProjectionPort();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(new ThrowingActorDispatchPort(new InvalidOperationException("dispatch failed")))
+            .AddSingleton<INyxIdChatSessionProjectionPort>(projectionPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>();
+
+        var act = async () => await interaction.ExecuteAsync(
+            new NyxIdChatCommand(actor.Id, "scope-a", "hello", "session-1", "token", null, null),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("dispatch failed");
+        projectionPort.AttachCount.Should().Be(1);
+        projectionPort.DetachCount.Should().Be(1);
+        projectionPort.ReleaseCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void NyxIdApprovalEnvelopeFactory_ShouldBuildTypedDecisionEnvelope()
+    {
+        var factory = new NyxIdApprovalCommandEnvelopeFactory();
+        var envelope = factory.CreateEnvelope(
+            new NyxIdApprovalCommand("actor-1", "request-1", false, "deny", "session-1"),
+            new CommandContext("actor-1", "command-1", "correlation-1", new Dictionary<string, string>()));
+
+        envelope.Route?.Direct?.TargetActorId.Should().Be("actor-1");
+        envelope.Propagation?.CorrelationId.Should().Be("correlation-1");
+        var decision = envelope.Payload.Unpack<ToolApprovalDecisionEvent>();
+        decision.RequestId.Should().Be("request-1");
+        decision.SessionId.Should().Be("session-1");
+        decision.Approved.Should().BeFalse();
+        decision.Reason.Should().Be("deny");
+    }
+
+    [Fact]
+    public async Task NyxIdFinalizeEmitter_ShouldEmitTimeoutOnlyWhenCompletionMissing()
+    {
+        var emitter = new NyxIdChatFinalizeEmitter();
+        var emitted = new List<AGUIEvent>();
+
+        await emitter.EmitAsync(
+            new NyxIdChatAcceptedReceipt("actor-1", "command-1", "correlation-1", "session-1"),
+            NyxIdChatCompletionStatus.Unknown,
+            completed: false,
+            (evt, _) =>
+            {
+                emitted.Add(evt);
+                return ValueTask.CompletedTask;
+            });
+
+        emitted.Should().ContainSingle();
+        emitted[0].RunError.Message.Should().Be("Request timed out.");
+
+        await emitter.EmitAsync(
+            new NyxIdChatAcceptedReceipt("actor-1", "command-1", "correlation-1", "session-1"),
+            NyxIdChatCompletionStatus.Completed,
+            completed: true,
+            (evt, _) =>
+            {
+                emitted.Add(evt);
+                return ValueTask.CompletedTask;
+            });
+
+        emitted.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddNyxIdChat_ShouldResolveRealInteractionServices()
+    {
+        var runtime = new StubActorRuntime();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(new StubActorDispatchPort(runtime))
+            .AddSingleton<INyxIdChatSessionProjectionPort>(new StubNyxIdChatSessionProjectionPort())
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+
+        services.GetRequiredService<
+            ICommandInteractionService<NyxIdChatCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>()
+            .Should().NotBeNull();
+        services.GetRequiredService<
+            ICommandInteractionService<NyxIdApprovalCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>>()
+            .Should().NotBeNull();
+        services.GetRequiredService<ICommandEnvelopeFactory<NyxIdChatCommand>>()
+            .Should().BeOfType<NyxIdChatCommandEnvelopeFactory>();
+        services.GetRequiredService<ICommandTargetBinder<NyxIdChatCommand, NyxIdChatCommandTarget, NyxIdChatStartError>>()
+            .Should().BeOfType<NyxIdChatCommandTargetBinder<NyxIdChatCommand>>();
     }
 
     [Fact]
@@ -2217,6 +2416,17 @@ public class NyxIdChatEndpointsCoverageTests
         }
     }
 
+    private sealed class ThrowingActorDispatchPort(Exception exception) : IActorDispatchPort
+    {
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            _ = actorId;
+            _ = envelope;
+            _ = ct;
+            return Task.FromException(exception);
+        }
+    }
+
     private sealed class StubAgent : IAgent
     {
         public string Id => "agent";
@@ -2304,6 +2514,10 @@ public class NyxIdChatEndpointsCoverageTests
         public List<AGUIEvent> Messages { get; } = [];
         public List<(string ActorId, string SessionId)> EnsureCalls { get; } = [];
         public bool ProjectionEnabled => true;
+        public bool ReturnNullLease { get; init; }
+        public int AttachCount { get; private set; }
+        public int DetachCount { get; private set; }
+        public int ReleaseCount { get; private set; }
 
         public async Task<INyxIdChatSessionProjectionLease?> EnsureChatProjectionAsync(
             string actorId,
@@ -2312,8 +2526,10 @@ public class NyxIdChatEndpointsCoverageTests
         {
             ct.ThrowIfCancellationRequested();
             EnsureCalls.Add((actorId, sessionId));
+            if (ReturnNullLease)
+                return null;
+
             _lease = new StubNyxIdChatSessionProjectionLease(actorId, sessionId);
-            await PublishBufferedMessagesAsync(ct);
             return _lease;
         }
 
@@ -2323,6 +2539,7 @@ public class NyxIdChatEndpointsCoverageTests
             CancellationToken ct = default)
         {
             _ = lease;
+            AttachCount++;
             _sink = sink;
             await PublishBufferedMessagesAsync(ct);
             return null;
@@ -2334,6 +2551,7 @@ public class NyxIdChatEndpointsCoverageTests
         {
             _ = liveSinkLease;
             ct.ThrowIfCancellationRequested();
+            DetachCount++;
             return Task.CompletedTask;
         }
 
@@ -2343,6 +2561,7 @@ public class NyxIdChatEndpointsCoverageTests
         {
             _ = lease;
             ct.ThrowIfCancellationRequested();
+            ReleaseCount++;
             return Task.CompletedTask;
         }
 

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -10,6 +10,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Authentication.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
@@ -101,6 +102,9 @@ public class NyxIdChatEndpointsCoverageTests
         streamingRunner.Should().NotContain(".HandleEventAsync(");
         streamingEndpoints.Should().NotContain("actor.HandleEventAsync");
         streamingEndpoints.Should().NotContain(".HandleEventAsync(");
+        streamingEndpoints.Should().NotContain("INyxIdChatSessionProjectionPort");
+        streamingRunner.Should().NotContain("TaskCompletionSource");
+        streamingRunner.Should().NotContain("WaitAsync(TimeSpan.FromSeconds(120))");
     }
 
     [Fact]
@@ -527,7 +531,7 @@ public class NyxIdChatEndpointsCoverageTests
         var context = new DefaultHttpContext();
         context.Request.Headers.Authorization = "Bearer";
         var runtime = new StubActorRuntime();
-        var subscriptions = new StubNyxIdChatSessionProjectionPort();
+        var interactionService = new StubNyxIdChatInteractionService<NyxIdChatCommand>();
 
         await InvokeTaskAsync(
             "HandleStreamMessageAsync",
@@ -537,10 +541,11 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
             new StubGAgentActorStore(),
-            subscriptions,
+            interactionService,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        interactionService.Commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -558,7 +563,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest(null),
             runtime,
             new StubGAgentActorStore(),
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdChatCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
         context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -580,7 +585,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             new StubActorRuntime(),
             actorStore,
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdChatCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -606,7 +611,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             new StubActorRuntime(),
             actorStore,
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdChatCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -625,6 +630,7 @@ public class NyxIdChatEndpointsCoverageTests
         var context = new DefaultHttpContext();
         context.Request.Headers.Authorization = "Bearer";
         var runtime = new StubActorRuntime();
+        var interactionService = new StubNyxIdChatInteractionService<NyxIdApprovalCommand>();
 
         await InvokeTaskAsync(
             "HandleApproveAsync",
@@ -634,10 +640,11 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
             runtime,
             new StubGAgentActorStore(),
-            new StubNyxIdChatSessionProjectionPort(),
+            interactionService,
             NullLoggerFactory.Instance,
             CancellationToken.None);
         context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        interactionService.Commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -655,7 +662,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest(null),
             runtime,
             new StubGAgentActorStore(),
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdApprovalCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
         context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -677,7 +684,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
             new StubActorRuntime(),
             actorStore,
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdApprovalCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -703,7 +710,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req"),
             new StubActorRuntime(),
             actorStore,
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdApprovalCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -733,9 +740,9 @@ public class NyxIdChatEndpointsCoverageTests
 
         var runtime = new StubActorRuntime();
         runtime.Actors["actor-1"] = new StubActor("actor-1");
-        var subscriptions = new StubNyxIdChatSessionProjectionPort
+        var interactionService = new StubNyxIdChatInteractionService<NyxIdChatCommand>
         {
-            Messages =
+            Frames =
             {
                 new AGUIEvent { TextMessageStart = new AguiTextMessageStartEvent() },
                 new AGUIEvent { TextMessageContent = new AguiTextMessageContentEvent { Delta = "hello" } },
@@ -752,22 +759,24 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello there"),
             runtime,
             new StubGAgentActorStore(),
-            subscriptions,
+            interactionService,
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        var actor = runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject;
-        var chatRequest = actor.HandledEnvelopes.Should().ContainSingle().Subject.Payload.Unpack<ChatRequestEvent>();
-        chatRequest.Prompt.Should().Be("hello there");
-        chatRequest.ScopeId.Should().Be("scope-a");
-        chatRequest.Metadata[LLMRequestMetadataKeys.NyxIdAccessToken].Should().Be("valid-token");
-        chatRequest.Metadata.Should().NotContainKey(NyxRefreshTokenMetadataKey);
-        chatRequest.Metadata["scope_id"].Should().Be("scope-a");
-        chatRequest.Metadata[LLMRequestMetadataKeys.ModelOverride].Should().Be("relay-model");
-        chatRequest.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference].Should().Be("/relay-route");
-        chatRequest.Metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride].Should().Be("7");
-        chatRequest.Metadata[LLMRequestMetadataKeys.UserMemoryPrompt].Should().Be("remember this");
+        var chatCommand = interactionService.Commands.Should().ContainSingle().Subject;
+        chatCommand.Should().BeOfType<NyxIdChatCommand>();
+        var command = (NyxIdChatCommand)chatCommand;
+        command.ActorId.Should().Be("actor-1");
+        command.Prompt.Should().Be("hello there");
+        command.ScopeId.Should().Be("scope-a");
+        command.AccessToken.Should().Be("valid-token");
+        command.Metadata.Should().NotBeNull();
+        command.Metadata!.Should().NotContainKey(NyxRefreshTokenMetadataKey);
+        command.Metadata[LLMRequestMetadataKeys.ModelOverride].Should().Be("relay-model");
+        command.Metadata[LLMRequestMetadataKeys.NyxIdRoutePreference].Should().Be("/relay-route");
+        command.Metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride].Should().Be("7");
+        command.Metadata[LLMRequestMetadataKeys.UserMemoryPrompt].Should().Be("remember this");
 
         context.Response.Body.Position = 0;
         var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
@@ -792,7 +801,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             new ThrowingActorRuntime(new InvalidOperationException("runtime failed")),
             new StubGAgentActorStore(),
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdChatCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -817,7 +826,10 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdChatStreamRequest("hello"),
             runtime,
             new StubGAgentActorStore(),
-            new ThrowingNyxIdChatSessionProjectionPort(new InvalidOperationException("subscription failed")),
+            new StubNyxIdChatInteractionService<NyxIdChatCommand>
+            {
+                Exception = new InvalidOperationException("subscription failed"),
+            },
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -838,9 +850,9 @@ public class NyxIdChatEndpointsCoverageTests
 
         var runtime = new StubActorRuntime();
         runtime.Actors["actor-1"] = new StubActor("actor-1");
-        var subscriptions = new StubNyxIdChatSessionProjectionPort
+        var interactionService = new StubNyxIdChatInteractionService<NyxIdApprovalCommand>
         {
-            Messages =
+            Frames =
             {
                 new AGUIEvent { TextMessageStart = new AguiTextMessageStartEvent() },
                 new AGUIEvent { TextMessageEnd = new AguiTextMessageEndEvent() },
@@ -856,17 +868,19 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1", Approved: false, Reason: "deny", SessionId: "session-1"),
             runtime,
             new StubGAgentActorStore(),
-            subscriptions,
+            interactionService,
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        var actor = runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject;
-        var decision = actor.HandledEnvelopes.Should().ContainSingle().Subject.Payload.Unpack<ToolApprovalDecisionEvent>();
-        decision.RequestId.Should().Be("req-1");
-        decision.Approved.Should().BeFalse();
-        decision.Reason.Should().Be("deny");
-        decision.SessionId.Should().Be("session-1");
+        var approvalCommand = interactionService.Commands.Should().ContainSingle().Subject;
+        approvalCommand.Should().BeOfType<NyxIdApprovalCommand>();
+        var command = (NyxIdApprovalCommand)approvalCommand;
+        command.ActorId.Should().Be("actor-1");
+        command.RequestId.Should().Be("req-1");
+        command.Approved.Should().BeFalse();
+        command.Reason.Should().Be("deny");
+        command.SessionId.Should().Be("session-1");
 
         context.Response.Body.Position = 0;
         var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
@@ -888,7 +902,7 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1"),
             new ThrowingActorRuntime(new InvalidOperationException("runtime failed")),
             new StubGAgentActorStore(),
-            new StubNyxIdChatSessionProjectionPort(),
+            new StubNyxIdChatInteractionService<NyxIdApprovalCommand>(),
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -913,7 +927,10 @@ public class NyxIdChatEndpointsCoverageTests
             new NyxIdChatEndpoints.NyxIdApprovalRequest("req-1"),
             runtime,
             new StubGAgentActorStore(),
-            new ThrowingNyxIdChatSessionProjectionPort(new InvalidOperationException("approval subscription failed")),
+            new StubNyxIdChatInteractionService<NyxIdApprovalCommand>
+            {
+                Exception = new InvalidOperationException("approval subscription failed"),
+            },
             NullLoggerFactory.Instance,
             CancellationToken.None);
 
@@ -1888,19 +1905,6 @@ public class NyxIdChatEndpointsCoverageTests
             }
         }
 
-        if (parameters.Length == args.Length + 1 && args.All(arg => arg is not INyxIdChatSessionProjectionPort))
-        {
-            var projectionPortIndex = Array.FindIndex(
-                parameters,
-                parameter => parameter.ParameterType == typeof(INyxIdChatSessionProjectionPort));
-            if (projectionPortIndex >= 0)
-            {
-                var normalized = args.ToList();
-                normalized.Insert(projectionPortIndex, new StubNyxIdChatSessionProjectionPort());
-                return normalized.ToArray();
-            }
-        }
-
         return args;
     }
 
@@ -2221,6 +2225,57 @@ public class NyxIdChatEndpointsCoverageTests
         public Task<IReadOnlyList<System.Type>> GetSubscribedEventTypesAsync() => Task.FromResult<IReadOnlyList<System.Type>>([]);
         public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class StubNyxIdChatInteractionService<TCommand>
+        : ICommandInteractionService<TCommand, NyxIdChatAcceptedReceipt, NyxIdChatStartError, AGUIEvent, NyxIdChatCompletionStatus>
+    {
+        public List<TCommand> Commands { get; } = [];
+        public List<AGUIEvent> Frames { get; } = [];
+        public Exception? Exception { get; init; }
+        public NyxIdChatStartError? Failure { get; init; }
+
+        public async Task<CommandInteractionResult<NyxIdChatAcceptedReceipt, NyxIdChatStartError, NyxIdChatCompletionStatus>> ExecuteAsync(
+            TCommand command,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<NyxIdChatAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Commands.Add(command);
+
+            if (Exception != null)
+                throw Exception;
+
+            if (Failure.HasValue)
+            {
+                return CommandInteractionResult<NyxIdChatAcceptedReceipt, NyxIdChatStartError, NyxIdChatCompletionStatus>
+                    .Failure(Failure.Value);
+            }
+
+            var (actorId, sessionId) = ResolveReceiptParts(command);
+            var receipt = new NyxIdChatAcceptedReceipt(actorId, sessionId, sessionId, sessionId);
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+
+            foreach (var frame in Frames)
+                await emitAsync(frame, ct);
+
+            return CommandInteractionResult<NyxIdChatAcceptedReceipt, NyxIdChatStartError, NyxIdChatCompletionStatus>
+                .Success(
+                    receipt,
+                    new CommandInteractionFinalizeResult<NyxIdChatCompletionStatus>(
+                        NyxIdChatCompletionStatus.Completed,
+                        true));
+        }
+
+        private static (string ActorId, string SessionId) ResolveReceiptParts(TCommand command) =>
+            command switch
+            {
+                NyxIdChatCommand chat => (chat.ActorId, chat.SessionId),
+                NyxIdApprovalCommand approval => (approval.ActorId, approval.SessionId),
+                _ => ("actor", "session"),
+            };
     }
 
     private sealed class StubNyxIdRelayScopeResolver : INyxIdRelayScopeResolver

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -7,6 +7,7 @@ using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Abstractions.Streaming;
@@ -93,6 +94,9 @@ public class StreamingProxyCoverageTests
             "agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs"));
 
         endpoints.Should().NotContain("actor.HandleEventAsync");
+        endpoints.Should().NotContain("EnsureAndAttachLeaseAsync");
+        endpoints.Should().NotContain("EnsureChatProjectionAsync");
+        endpoints.Should().NotContain("EnsureSubscriptionProjectionAsync");
     }
 
     [Fact]
@@ -215,7 +219,7 @@ public class StreamingProxyCoverageTests
         var context = CreateScopedHttpContext();
         var runtime = new StubActorRuntime();
         var dispatchPort = new StubActorDispatchPort(runtime);
-        var projectionPort = new StubRoomSessionProjectionPort();
+        var interactionService = new StubStreamingProxyRoomChatInteractionService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
         var participantStore = new StubParticipantStore();
         var actorStore = new StubGAgentActorStore();
@@ -224,10 +228,11 @@ public class StreamingProxyCoverageTests
         var method = typeof(StreamingProxyEndpoints).GetMethod(
             "HandleChatAsync",
             BindingFlags.NonPublic | BindingFlags.Static)!;
-        var task = method.Invoke(null, [context, "scope-a", "room-a", new ChatTopicRequest(null), runtime, dispatchPort, actorStore, projectionPort, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
+        var task = method.Invoke(null, [context, "scope-a", "room-a", new ChatTopicRequest(null), runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
         await InvokeTaskAsync(task);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        interactionService.Commands.Should().BeEmpty();
     }
 
     [Fact]
@@ -237,7 +242,7 @@ public class StreamingProxyCoverageTests
         context.Response.Body = new MemoryStream();
         var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
         var dispatchPort = new StubActorDispatchPort(runtime);
-        var projectionPort = new StubRoomSessionProjectionPort();
+        var interactionService = new StubStreamingProxyRoomChatInteractionService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
         var participantStore = new StubParticipantStore();
         var actorStore = new StubGAgentActorStore();
@@ -248,7 +253,7 @@ public class StreamingProxyCoverageTests
             BindingFlags.NonPublic | BindingFlags.Static)!;
         var task = method.Invoke(
             null,
-            [context, "scope-a", "room-a", new ChatTopicRequest("hello"), runtime, dispatchPort, actorStore, projectionPort, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
+            [context, "scope-a", "room-a", new ChatTopicRequest("hello"), runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
         await InvokeTaskAsync(task);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
@@ -263,18 +268,19 @@ public class StreamingProxyCoverageTests
     {
         var context = CreateScopedHttpContext();
         var runtime = new StubActorRuntime();
-        var projectionPort = new StubRoomSessionProjectionPort();
         var actorStore = new StubGAgentActorStore();
+        var observationPort = new StubRoomSubscriptionObservationPort();
         var method = typeof(StreamingProxyEndpoints).GetMethod(
             "HandleMessageStreamAsync",
             BindingFlags.NonPublic | BindingFlags.Static)!;
 
         var task = method.Invoke(
             null,
-            [context, "scope-a", "missing", runtime, actorStore, projectionPort, NullLoggerFactory.Instance, CancellationToken.None]);
+            [context, "scope-a", "missing", runtime, actorStore, observationPort, NullLoggerFactory.Instance, CancellationToken.None]);
         await InvokeTaskAsync(task);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        observationPort.AttachCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -283,9 +289,8 @@ public class StreamingProxyCoverageTests
         var context = CreateScopedHttpContext();
         context.Response.Body = new MemoryStream();
         var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
-        var dispatchPort = new StubActorDispatchPort(runtime);
-        var projectionPort = new StubRoomSessionProjectionPort();
         var actorStore = new StubGAgentActorStore();
+        var observationPort = new StubRoomSubscriptionObservationPort();
         using var cts = new CancellationTokenSource();
 
         var method = typeof(StreamingProxyEndpoints).GetMethod(
@@ -293,10 +298,10 @@ public class StreamingProxyCoverageTests
             BindingFlags.NonPublic | BindingFlags.Static)!;
         var task = InvokeTaskAsync(method.Invoke(
             null,
-            [context, "scope-a", "room-a", runtime, actorStore, projectionPort, NullLoggerFactory.Instance, cts.Token]));
+            [context, "scope-a", "room-a", runtime, actorStore, observationPort, NullLoggerFactory.Instance, cts.Token]));
 
-        await projectionPort.Attached.Task;
-        await projectionPort.PublishAsync(
+        await observationPort.Attached.Task;
+        await observationPort.PublishAsync(
             CreateCommittedEnvelope(
                 new GroupChatMessageEvent
                 {
@@ -325,10 +330,7 @@ public class StreamingProxyCoverageTests
         cts.Cancel();
         await task;
 
-        projectionPort.EnsureCalls.Should().ContainSingle(x =>
-            x.actorId == "room-a" &&
-            x.projectionKind == StreamingProxyProjectionKinds.RoomSubscriptionSession);
-        projectionPort.EnsureCalls.Single().sessionId.Should().NotBeNullOrWhiteSpace();
+        observationPort.AttachCalls.Should().ContainSingle(x => x.RoomId == "room-a");
         context.Response.Body.Position = 0;
         var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
         body.Should().Contain("AGENT_MESSAGE");
@@ -397,24 +399,16 @@ public class StreamingProxyCoverageTests
         context.Response.Body = new MemoryStream();
         var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
         var dispatchPort = new StubActorDispatchPort(runtime);
-        var projectionPort = new StubRoomSessionProjectionPort();
+        var interactionService = new StubStreamingProxyRoomChatInteractionService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(
             new StubTerminalQueryPort(StreamingProxyChatSessionTerminalStatus.Completed));
         var participantStore = new StubParticipantStore();
         var actorStore = new StubGAgentActorStore();
         var coordinator = CreateNyxParticipantCoordinator();
         var request = new ChatTopicRequest("Discuss webhook relay", "session-123");
-
-        var method = typeof(StreamingProxyEndpoints).GetMethod(
-            "HandleChatAsync",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
-        var task = InvokeTaskAsync(method.Invoke(
-            null,
-            [context, "scope-a", "room-a", request, runtime, dispatchPort, actorStore, projectionPort, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]));
-
-        await projectionPort.Attached.Task;
-        await projectionPort.PublishAsync(
-            CreateCommittedEnvelope(
+        interactionService.Frames.Add(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = CreateCommittedEnvelope(
                 new GroupChatTopicEvent
                 {
                     Prompt = "Discuss webhook relay",
@@ -436,9 +430,11 @@ public class StreamingProxyCoverageTests
                         },
                     },
                 },
-                version: 2));
-        await projectionPort.PublishAsync(
-            CreateCommittedEnvelope(
+                version: 2),
+        });
+        interactionService.Frames.Add(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = CreateCommittedEnvelope(
                 new GroupChatMessageEvent
                 {
                     AgentId = "agent-1",
@@ -470,13 +466,37 @@ public class StreamingProxyCoverageTests
                         },
                     },
                 },
-                version: 3));
+                version: 3),
+        });
+        interactionService.Frames.Add(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = CreateCommittedEnvelope(
+                new StreamingProxyChatSessionTerminalStateChanged
+                {
+                    SessionId = "session-123",
+                    Status = StreamingProxyChatSessionTerminalStatus.Completed,
+                    TerminalAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                },
+                new StreamingProxyGAgentState
+                {
+                    RoomName = "Room A",
+                },
+                version: 4),
+        });
 
-        await task;
+        var method = typeof(StreamingProxyEndpoints).GetMethod(
+            "HandleChatAsync",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        await InvokeTaskAsync(method.Invoke(
+            null,
+            [context, "scope-a", "room-a", request, runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]));
 
-        projectionPort.EnsureCalls.Should().ContainSingle(x =>
-            x.actorId == "room-a" && x.sessionId == "session-123");
-        dispatchPort.Dispatches.Should().HaveCount(2);
+        interactionService.Commands.Should().ContainSingle().Which.Should().Be(new StreamingProxyRoomChatCommand(
+            "room-a",
+            "scope-a",
+            "Discuss webhook relay",
+            "session-123"));
+        dispatchPort.Dispatches.Should().BeEmpty();
 
         context.Response.Body.Position = 0;
         var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
@@ -493,7 +513,10 @@ public class StreamingProxyCoverageTests
         var actor = new StubActor("room-a");
         var runtime = new StubActorRuntime(new List<IActor> { actor });
         var dispatchPort = new StubActorDispatchPort(runtime);
-        var projectionPort = new StubRoomSessionProjectionPort();
+        var interactionService = new StubStreamingProxyRoomChatInteractionService
+        {
+            WaitForCancellation = true,
+        };
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
         var participantStore = new StubParticipantStore();
         var actorStore = new StubGAgentActorStore();
@@ -505,9 +528,9 @@ public class StreamingProxyCoverageTests
             BindingFlags.NonPublic | BindingFlags.Static)!;
         var task = InvokeTaskAsync(method.Invoke(
             null,
-            [context, "scope-a", "room-a", new ChatTopicRequest("Cancel me", "session-cancel"), runtime, dispatchPort, actorStore, projectionPort, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, cts.Token]));
+            [context, "scope-a", "room-a", new ChatTopicRequest("Cancel me", "session-cancel"), runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, cts.Token]));
 
-        await projectionPort.Attached.Task;
+        await interactionService.Started.Task;
         cts.Cancel();
         await task;
 
@@ -1389,6 +1412,111 @@ public class StreamingProxyCoverageTests
         public Task<IReadOnlyList<System.Type>> GetSubscribedEventTypesAsync() => Task.FromResult<IReadOnlyList<System.Type>>([]);
         public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
         public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class StubStreamingProxyRoomChatInteractionService
+        : ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>
+    {
+        public List<StreamingProxyRoomChatCommand> Commands { get; } = [];
+        public List<StreamingProxyRoomSessionEnvelope> Frames { get; } = [];
+        public bool WaitForCancellation { get; init; }
+        public StreamingProxyRoomChatStartError? Failure { get; init; }
+        public TaskCompletionSource<bool> Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<CommandInteractionResult<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyProjectionCompletionStatus>> ExecuteAsync(
+            StreamingProxyRoomChatCommand command,
+            Func<StreamingProxyRoomSessionEnvelope, CancellationToken, ValueTask> emitAsync,
+            Func<StreamingProxyRoomChatAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            Commands.Add(command);
+            Started.TrySetResult(true);
+
+            if (Failure.HasValue)
+            {
+                return CommandInteractionResult<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyProjectionCompletionStatus>
+                    .Failure(Failure.Value);
+            }
+
+            var receipt = new StreamingProxyRoomChatAcceptedReceipt(
+                command.RoomId,
+                "command-id",
+                "correlation-id",
+                command.SessionId);
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+
+            if (WaitForCancellation)
+                await WaitUntilCanceledAsync(ct);
+
+            foreach (var frame in Frames)
+                await emitAsync(frame, ct);
+
+            return CommandInteractionResult<StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyProjectionCompletionStatus>
+                .Success(
+                    receipt,
+                    new CommandInteractionFinalizeResult<StreamingProxyProjectionCompletionStatus>(
+                        StreamingProxyProjectionCompletionStatus.Completed,
+                        true));
+        }
+
+        private static async Task WaitUntilCanceledAsync(CancellationToken ct)
+        {
+            var canceled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            await using var registration = ct.Register(static state =>
+                ((TaskCompletionSource<bool>)state!).TrySetCanceled(), canceled);
+            await canceled.Task;
+        }
+    }
+
+    private sealed class StubRoomSubscriptionObservationPort : IStreamingProxyRoomSubscriptionObservationPort
+    {
+        private IEventSink<StreamingProxyRoomSessionEnvelope>? _sink;
+
+        public List<(string RoomId, IEventSink<StreamingProxyRoomSessionEnvelope> Sink)> AttachCalls { get; } = [];
+        public TaskCompletionSource<bool> Attached { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<StreamingProxyRoomSubscriptionObservationAttachment> AttachAsync(
+            string roomId,
+            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _sink = sink;
+            AttachCalls.Add((roomId, sink));
+            Attached.TrySetResult(true);
+            return Task.FromResult(new StreamingProxyRoomSubscriptionObservationAttachment(
+                new StubRoomSessionProjectionLease(
+                    roomId,
+                    $"room:{roomId}:subscription"),
+                null));
+        }
+
+        public Task DetachAndDisposeAsync(
+            StreamingProxyRoomSubscriptionObservationAttachment attachment,
+            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            _ = attachment;
+            _ = ct;
+            sink.Complete();
+            return sink.DisposeAsync().AsTask();
+        }
+
+        public async Task PublishAsync(EventEnvelope envelope, CancellationToken ct = default)
+        {
+            if (_sink == null)
+                throw new InvalidOperationException("Subscription sink is not attached.");
+
+            await _sink.PushAsync(
+                new StreamingProxyRoomSessionEnvelope
+                {
+                    Envelope = envelope,
+                },
+                ct);
+        }
     }
 
     private sealed class StubRoomSessionProjectionPort : IStreamingProxyRoomSessionProjectionPort

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Reflection;
 using System.Security.Claims;
 using System.Threading.Channels;
+using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -9,6 +10,7 @@ using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Core.Commands;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Studio.Application.Studio.Abstractions;
@@ -58,6 +60,30 @@ public class StreamingProxyCoverageTests
         terminalQueryDescriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
         roomCommandDescriptor.Should().NotBeNull();
         roomCommandDescriptor!.Lifetime.Should().Be(ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddStreamingProxy_ShouldResolveRealRoomInteractionGraph()
+    {
+        var runtime = new StubActorRuntime();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(new StubActorDispatchPort(runtime))
+            .AddSingleton<IStreamingProxyRoomSessionProjectionPort>(new StubRoomSessionProjectionPort())
+            .AddSingleton<IStreamingProxyChatSessionTerminalQueryPort>(new StubTerminalQueryPort())
+            .AddStreamingProxy()
+            .BuildServiceProvider();
+
+        services.GetRequiredService<
+            ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>()
+            .Should().NotBeNull();
+        services.GetRequiredService<ICommandEnvelopeFactory<StreamingProxyRoomChatCommand>>()
+            .Should().BeOfType<StreamingProxyRoomChatCommandEnvelopeFactory>();
+        services.GetRequiredService<ICommandTargetBinder<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatStartError>>()
+            .Should().BeOfType<StreamingProxyRoomChatCommandTargetBinder>();
+        services.GetRequiredService<IStreamingProxyRoomSubscriptionObservationPort>()
+            .Should().BeOfType<StreamingProxyRoomSubscriptionObservationPort>();
     }
 
     [Fact]
@@ -338,6 +364,27 @@ public class StreamingProxyCoverageTests
     }
 
     [Fact]
+    public async Task StreamingProxyRoomSubscriptionObservationPort_ShouldAttachNormalizedRoomSessionAndDispose()
+    {
+        var projectionPort = new StubRoomSessionProjectionPort();
+        var observationPort = new StreamingProxyRoomSubscriptionObservationPort(projectionPort);
+        await using var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
+
+        var attachment = await observationPort.AttachAsync(" room-a ", sink, CancellationToken.None);
+        await observationPort.DetachAndDisposeAsync(attachment, sink, CancellationToken.None);
+
+        attachment.ProjectionLease.ActorId.Should().Be("room-a");
+        attachment.ProjectionLease.SessionId.Should().Be("room:room-a:subscription");
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachCount.Should().Be(1);
+        projectionPort.AttachedLeases.Should().ContainSingle(x =>
+            x.ActorId == "room-a" &&
+            x.SessionId == "room:room-a:subscription");
+        projectionPort.DetachCount.Should().Be(1);
+        projectionPort.ReleaseCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task StreamingProxyRoomSessionEventProjector_ShouldIgnoreDifferentChatSessionEvents()
     {
         var sessionHub = new RecordingRoomSessionEventHub();
@@ -542,67 +589,239 @@ public class StreamingProxyCoverageTests
     }
 
     [Fact]
-    public async Task FinalizeFromLiveOrDurableCompletionAsync_ShouldUseSingleDurableFallback_AfterLiveTimeout()
+    public async Task StreamingProxyRoomInteraction_ShouldBindDispatchEmitFinalizeAndCleanup()
     {
-        var context = new DefaultHttpContext();
-        context.Response.Body = new MemoryStream();
-        var writer = AgentCoverageTestSupport.CreateNonPublicInstance(
-            typeof(StreamingProxyGAgent).Assembly,
-            "Aevatar.GAgents.StreamingProxy.StreamingProxySseWriter",
-            context.Response);
-        var terminalQueryPort = new StubTerminalQueryPort(StreamingProxyChatSessionTerminalStatus.Completed);
-        var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(terminalQueryPort);
-        var signalChannel = Channel.CreateUnbounded<StreamingProxyStreamSignal>();
-        signalChannel.Writer.TryComplete();
+        var actor = new StubActor("room-a");
+        var runtime = new StubActorRuntime([actor]);
+        var projectionPort = new StubRoomSessionProjectionPort();
+        projectionPort.Messages.Add(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = CreateCommittedEnvelope(
+                new GroupChatMessageEvent
+                {
+                    AgentId = "agent-1",
+                    AgentName = "Alice",
+                    Content = "hello",
+                    SessionId = "session-123",
+                },
+                new StreamingProxyGAgentState { RoomName = "Room A" },
+                version: 2),
+        });
+        projectionPort.Messages.Add(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = StreamingProxyRoomInteractionHelpers.CreateTerminalEnvelope(
+                actor.Id,
+                "session-123",
+                StreamingProxyChatSessionTerminalStatus.Completed,
+                null),
+        });
+        var dispatchPort = new StubActorDispatchPort(runtime);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddSingleton<IStreamingProxyRoomSessionProjectionPort>(projectionPort)
+            .AddSingleton<IStreamingProxyChatSessionTerminalQueryPort>(new StubTerminalQueryPort())
+            .AddStreamingProxy()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>();
+        var emitted = new List<StreamingProxyRoomSessionEnvelope>();
 
-        var method = typeof(StreamingProxyEndpoints).GetMethod(
-            "FinalizeFromLiveOrDurableCompletionAsync",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = await interaction.ExecuteAsync(
+            new StreamingProxyRoomChatCommand(actor.Id, "scope-a", "Discuss claims", "session-123"),
+            (frame, _) =>
+            {
+                emitted.Add(frame);
+                return ValueTask.CompletedTask;
+            });
 
-        await InvokeTaskAsync(method.Invoke(
-            null,
-            ["room-a", "session-123", signalChannel.Reader, durableCompletionResolver, writer, TimeSpan.FromMilliseconds(50), CancellationToken.None]));
-
-        context.Response.Body.Position = 0;
-        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
-        body.Should().Contain("RUN_FINISHED");
-        body.Should().NotContain("RUN_ERROR");
-        terminalQueryPort.QueryCount.Should().Be(1);
+        result.Succeeded.Should().BeTrue();
+        result.Receipt.Should().Be(new StreamingProxyRoomChatAcceptedReceipt(actor.Id, "session-123", "session-123", "session-123"));
+        result.FinalizeResult.Should().NotBeNull();
+        result.FinalizeResult!.Completed.Should().BeTrue();
+        result.FinalizeResult.Completion.Should().Be(StreamingProxyProjectionCompletionStatus.Completed);
+        projectionPort.EnsureCalls.Should().ContainSingle(x =>
+            x.actorId == actor.Id &&
+            x.sessionId == "session-123" &&
+            x.projectionKind == StreamingProxyProjectionKinds.RoomChatSession);
+        projectionPort.AttachCount.Should().Be(1);
+        projectionPort.DetachCount.Should().Be(1);
+        projectionPort.ReleaseCount.Should().Be(1);
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var request = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        request.Prompt.Should().Be("Discuss claims");
+        request.SessionId.Should().Be("session-123");
+        request.ScopeId.Should().Be("scope-a");
+        emitted.Should().HaveCount(2);
+        emitted.Last().Envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().Status
+            .Should().Be(StreamingProxyChatSessionTerminalStatus.Completed);
     }
 
     [Fact]
-    public async Task FinalizeFromLiveOrDurableCompletionAsync_ShouldEmitRunError_WhenTerminalStateNeverAppears()
+    public async Task StreamingProxyRoomInteraction_ShouldReturnProjectionUnavailableAndDisposeSink_WhenBinderCannotAttach()
     {
-        var context = new DefaultHttpContext();
-        context.Response.Body = new MemoryStream();
-        var writer = AgentCoverageTestSupport.CreateNonPublicInstance(
-            typeof(StreamingProxyGAgent).Assembly,
-            "Aevatar.GAgents.StreamingProxy.StreamingProxySseWriter",
-            context.Response);
-        var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
-        var signalChannel = Channel.CreateUnbounded<StreamingProxyStreamSignal>();
-        signalChannel.Writer.TryComplete();
+        var actor = new StubActor("room-a");
+        var runtime = new StubActorRuntime([actor]);
+        var projectionPort = new StubRoomSessionProjectionPort { ReturnNullLease = true };
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(new StubActorDispatchPort(runtime))
+            .AddSingleton<IStreamingProxyRoomSessionProjectionPort>(projectionPort)
+            .AddSingleton<IStreamingProxyChatSessionTerminalQueryPort>(new StubTerminalQueryPort())
+            .AddStreamingProxy()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>();
 
-        var method = typeof(StreamingProxyEndpoints).GetMethod(
-            "FinalizeFromLiveOrDurableCompletionAsync",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = await interaction.ExecuteAsync(
+            new StreamingProxyRoomChatCommand(actor.Id, "scope-a", "prompt", "session-123"),
+            (_, _) => ValueTask.CompletedTask);
 
-        await InvokeTaskAsync(method.Invoke(
-            null,
-            [
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(StreamingProxyRoomChatStartError.ProjectionUnavailable);
+        projectionPort.AttachCount.Should().Be(0);
+        projectionPort.DetachCount.Should().Be(0);
+        projectionPort.ReleaseCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StreamingProxyRoomInteraction_ShouldCleanupBoundLease_WhenDispatchFails()
+    {
+        var actor = new StubActor("room-a");
+        var runtime = new StubActorRuntime([actor]);
+        var projectionPort = new StubRoomSessionProjectionPort();
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IActorRuntime>(runtime)
+            .AddSingleton<IActorDispatchPort>(new ThrowingActorDispatchPort(new InvalidOperationException("dispatch failed")))
+            .AddSingleton<IStreamingProxyRoomSessionProjectionPort>(projectionPort)
+            .AddSingleton<IStreamingProxyChatSessionTerminalQueryPort>(new StubTerminalQueryPort())
+            .AddStreamingProxy()
+            .BuildServiceProvider();
+        var interaction = services.GetRequiredService<
+            ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus>>();
+
+        var act = async () => await interaction.ExecuteAsync(
+            new StreamingProxyRoomChatCommand(actor.Id, "scope-a", "prompt", "session-123"),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("dispatch failed");
+        projectionPort.AttachCount.Should().Be(1);
+        projectionPort.DetachCount.Should().Be(1);
+        projectionPort.ReleaseCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void StreamingProxyRoomChatEnvelopeFactory_ShouldBuildTypedChatEnvelope()
+    {
+        var factory = new StreamingProxyRoomChatCommandEnvelopeFactory();
+        var envelope = factory.CreateEnvelope(
+            new StreamingProxyRoomChatCommand("room-a", "scope-a", "topic", "session-123"),
+            new CommandContext("room-a", "command-1", "correlation-1", new Dictionary<string, string>()));
+
+        envelope.Route?.Direct?.TargetActorId.Should().Be("room-a");
+        envelope.Propagation?.CorrelationId.Should().Be("correlation-1");
+        var request = envelope.Payload.Unpack<ChatRequestEvent>();
+        request.Prompt.Should().Be("topic");
+        request.ScopeId.Should().Be("scope-a");
+        request.SessionId.Should().Be("session-123");
+    }
+
+    [Fact]
+    public async Task StreamingProxyRoomChatFinalizeEmitter_ShouldEmitFailedTerminalOnlyWhenCompletionMissing()
+    {
+        var emitter = new StreamingProxyRoomChatFinalizeEmitter();
+        var emitted = new List<StreamingProxyRoomSessionEnvelope>();
+
+        await emitter.EmitAsync(
+            new StreamingProxyRoomChatAcceptedReceipt("room-a", "command-1", "correlation-1", "session-123"),
+            StreamingProxyProjectionCompletionStatus.Unknown,
+            completed: false,
+            (frame, _) =>
+            {
+                emitted.Add(frame);
+                return ValueTask.CompletedTask;
+            });
+
+        emitted.Should().ContainSingle();
+        var terminal = emitted[0].Envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>();
+        terminal.SessionId.Should().Be("session-123");
+        terminal.Status.Should().Be(StreamingProxyChatSessionTerminalStatus.Failed);
+        terminal.ErrorMessage.Should().Be("StreamingProxy completion timed out.");
+
+        await emitter.EmitAsync(
+            new StreamingProxyRoomChatAcceptedReceipt("room-a", "command-1", "correlation-1", "session-123"),
+            StreamingProxyProjectionCompletionStatus.Completed,
+            completed: true,
+            (frame, _) =>
+            {
+                emitted.Add(frame);
+                return ValueTask.CompletedTask;
+            });
+
+        emitted.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task StreamingProxyRoomChatOutputStream_ShouldStopOnTerminalEvent()
+    {
+        var stream = new StreamingProxyRoomChatOutputStream();
+        var channel = Channel.CreateUnbounded<StreamingProxyRoomSessionEnvelope>();
+        await channel.Writer.WriteAsync(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = StreamingProxyRoomInteractionHelpers.CreateTerminalEnvelope(
                 "room-a",
                 "session-123",
-                signalChannel.Reader,
-                durableCompletionResolver,
-                writer,
-                TimeSpan.FromMilliseconds(50),
-                CancellationToken.None,
-            ]));
+                StreamingProxyChatSessionTerminalStatus.Completed,
+                null),
+        });
+        await channel.Writer.WriteAsync(new StreamingProxyRoomSessionEnvelope
+        {
+            Envelope = CreateTopologyEnvelope(new GroupChatMessageEvent
+            {
+                AgentId = "agent-1",
+                AgentName = "Alice",
+                Content = "should not emit",
+                SessionId = "session-123",
+            }),
+        });
+        channel.Writer.TryComplete();
+        var emitted = new List<StreamingProxyRoomSessionEnvelope>();
 
-        context.Response.Body.Position = 0;
-        var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
-        body.Should().Contain("RUN_ERROR");
-        body.Should().Contain("StreamingProxy completion timed out.");
+        await stream.PumpAsync(
+            channel.Reader.ReadAllAsync(),
+            (frame, _) =>
+            {
+                emitted.Add(frame);
+                return ValueTask.CompletedTask;
+            },
+            frame => StreamingProxyRoomInteractionHelpers.ResolveSignal(frame) is
+                StreamingProxyStreamSignal.RunFinished or StreamingProxyStreamSignal.RunFailed);
+
+        emitted.Should().ContainSingle();
+        emitted[0].Envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().Status
+            .Should().Be(StreamingProxyChatSessionTerminalStatus.Completed);
+    }
+
+    [Fact]
+    public async Task StreamingProxyRoomChatOutputStream_ShouldTimeout_WhenNoInitialEventArrives()
+    {
+        var stream = new StreamingProxyRoomChatOutputStream();
+        var channel = Channel.CreateUnbounded<StreamingProxyRoomSessionEnvelope>();
+        var emitted = new List<StreamingProxyRoomSessionEnvelope>();
+
+        await stream.PumpAsync(
+            channel.Reader.ReadAllAsync(),
+            (frame, _) =>
+            {
+                emitted.Add(frame);
+                return ValueTask.CompletedTask;
+            });
+
+        emitted.Should().BeEmpty();
     }
 
     [Fact]
@@ -617,22 +836,6 @@ public class StreamingProxyCoverageTests
         failed.ErrorMessage.Should().Be("StreamingProxy chat completed without any participant replies.");
 
         var completed = ((StreamingProxyChatSessionTerminalStatus Status, string? ErrorMessage))method.Invoke(null, [1])!;
-        completed.Status.Should().Be(StreamingProxyChatSessionTerminalStatus.Completed);
-        completed.ErrorMessage.Should().BeNull();
-    }
-
-    [Fact]
-    public void DetermineIdleTerminalState_ShouldFail_WhenNoAgentMessageWasObserved()
-    {
-        var method = typeof(StreamingProxyEndpoints).GetMethod(
-            "DetermineIdleTerminalState",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
-
-        var failed = ((StreamingProxyChatSessionTerminalStatus Status, string? ErrorMessage))method.Invoke(null, [false])!;
-        failed.Status.Should().Be(StreamingProxyChatSessionTerminalStatus.Failed);
-        failed.ErrorMessage.Should().Be("StreamingProxy chat timed out without any agent replies.");
-
-        var completed = ((StreamingProxyChatSessionTerminalStatus Status, string? ErrorMessage))method.Invoke(null, [true])!;
         completed.Status.Should().Be(StreamingProxyChatSessionTerminalStatus.Completed);
         completed.ErrorMessage.Should().BeNull();
     }
@@ -1404,6 +1607,17 @@ public class StreamingProxyCoverageTests
         }
     }
 
+    private sealed class ThrowingActorDispatchPort(Exception exception) : IActorDispatchPort
+    {
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            _ = actorId;
+            _ = envelope;
+            _ = ct;
+            return Task.FromException(exception);
+        }
+    }
+
     private sealed class StubAgent : IAgent
     {
         public string Id => "agent";
@@ -1525,8 +1739,14 @@ public class StreamingProxyCoverageTests
         private IStreamingProxyRoomSessionProjectionLease? _lease;
 
         public bool ProjectionEnabled => true;
+        public bool ReturnNullLease { get; init; }
 
         public List<(string actorId, string sessionId, string projectionKind)> EnsureCalls { get; } = [];
+        public List<StreamingProxyRoomSessionEnvelope> Messages { get; } = [];
+        public List<IStreamingProxyRoomSessionProjectionLease> AttachedLeases { get; } = [];
+        public int AttachCount { get; private set; }
+        public int DetachCount { get; private set; }
+        public int ReleaseCount { get; private set; }
 
         public TaskCompletionSource<bool> Attached { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1564,6 +1784,9 @@ public class StreamingProxyCoverageTests
             _ = ct;
 
             EnsureCalls.Add((actorId, sessionId, projectionKind));
+            if (ReturnNullLease)
+                return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(null);
+
             _lease = new StubRoomSessionProjectionLease(actorId, sessionId);
             return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(_lease);
         }
@@ -1574,9 +1797,13 @@ public class StreamingProxyCoverageTests
             CancellationToken ct = default)
         {
             _ = ct;
+            AttachCount++;
             _lease = lease;
             _sink = sink;
+            AttachedLeases.Add(lease);
             Attached.TrySetResult(true);
+            foreach (var message in Messages)
+                sink.Push(message);
             return Task.FromResult<IAsyncDisposable?>(null);
         }
 
@@ -1586,6 +1813,7 @@ public class StreamingProxyCoverageTests
         {
             _ = liveSinkLease;
             _ = ct;
+            DetachCount++;
             return Task.CompletedTask;
         }
 
@@ -1595,6 +1823,7 @@ public class StreamingProxyCoverageTests
         {
             _ = lease;
             _ = ct;
+            ReleaseCount++;
             return Task.CompletedTask;
         }
 

--- a/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgents.StreamingProxy;
 using Aevatar.GAgents.StreamingProxy.Application.Rooms;
@@ -17,10 +18,12 @@ public sealed class StreamingProxyRoomCommandServiceTests
         var runtime = new RecordingActorRuntime(operations, actor);
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
+            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -38,6 +41,9 @@ public sealed class StreamingProxyRoomCommandServiceTests
         runtime.LastCreatedActor.Should().NotBeNull();
         dispatchPort.Dispatches.Should().ContainSingle();
         dispatchPort.Dispatches[0].ActorId.Should().Be(result.RoomId);
+        projectionPort.EnsureSubscriptionCalls.Should().ContainSingle(x =>
+            x.ActorId == result.RoomId &&
+            x.SubscriptionId == $"room:{result.RoomId}:subscription");
         runtime.LastCreatedActor!.ReceivedEnvelopes.Should().ContainSingle();
         var envelope = runtime.LastCreatedActor.ReceivedEnvelopes[0];
         envelope.Route.Direct.TargetActorId.Should().Be(result.RoomId);
@@ -51,6 +57,7 @@ public sealed class StreamingProxyRoomCommandServiceTests
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
+            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:register:{result.RoomId}");
     }
 
@@ -61,10 +68,12 @@ public sealed class StreamingProxyRoomCommandServiceTests
         var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
+            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var act = async () => await service.CreateRoomAsync(
@@ -77,6 +86,7 @@ public sealed class StreamingProxyRoomCommandServiceTests
         registry.RegisteredActors.Should().BeEmpty();
         registry.UnregisteredActors.Should().BeEmpty();
         runtime.DestroyedActorIds.Should().BeEmpty();
+        projectionPort.EnsureSubscriptionCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -86,10 +96,12 @@ public sealed class StreamingProxyRoomCommandServiceTests
         var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
+            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -104,6 +116,9 @@ public sealed class StreamingProxyRoomCommandServiceTests
             .RoomName
             .Should()
             .Be("Group Chat");
+        projectionPort.EnsureSubscriptionCalls.Should().ContainSingle(x =>
+            x.ActorId == result.RoomId &&
+            x.SubscriptionId == $"room:{result.RoomId}:subscription");
     }
 
     [Fact]
@@ -116,10 +131,12 @@ public sealed class StreamingProxyRoomCommandServiceTests
         {
             RegisterStage = GAgentActorRegistryCommandStage.AcceptedForDispatch,
         };
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
+            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -133,7 +150,46 @@ public sealed class StreamingProxyRoomCommandServiceTests
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
+            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:register:{result.RoomId}",
+            $"registry:unregister:{result.RoomId}",
+            $"runtime:destroy:{result.RoomId}");
+    }
+
+    [Fact]
+    public async Task CreateRoomAsync_ShouldRollbackCreatedRoom_WhenSubscriptionProjectionIsUnavailable()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var registry = new RecordingGAgentActorRegistryCommandPort(operations);
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations)
+        {
+            EnsureSubscriptionResult = null,
+        };
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            registry,
+            projectionPort,
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.CreateRoomAsync(
+            new StreamingProxyRoomCreateCommand("scope-a", "Incident Room"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomCreateStatus.AdmissionUnavailable);
+        projectionPort.EnsureSubscriptionCalls.Should().ContainSingle(x =>
+            x.ActorId == result.RoomId &&
+            x.SubscriptionId == $"room:{result.RoomId}:subscription");
+        registry.RegisteredActors.Should().BeEmpty();
+        registry.UnregisteredActors.Should().ContainSingle();
+        runtime.DestroyedActorIds.Should().ContainSingle(result.RoomId);
+        operations.Should().ContainInOrder(
+            $"runtime:create:{result.RoomId}",
+            $"dispatch:{result.RoomId}",
+            $"actor:init:{result.RoomId}",
+            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:unregister:{result.RoomId}",
             $"runtime:destroy:{result.RoomId}");
     }
@@ -149,10 +205,12 @@ public sealed class StreamingProxyRoomCommandServiceTests
             ThrowOnRegister = new InvalidOperationException("registry unavailable"),
             ThrowOnUnregister = new InvalidOperationException("registry unregister unavailable"),
         };
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
+            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -166,6 +224,7 @@ public sealed class StreamingProxyRoomCommandServiceTests
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
+            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:register:{result.RoomId}",
             $"registry:unregister:{result.RoomId}");
     }
@@ -180,10 +239,12 @@ public sealed class StreamingProxyRoomCommandServiceTests
         {
             ThrowOnRegister = new OperationCanceledException("client disconnected"),
         };
+        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
+            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var act = async () => await service.CreateRoomAsync(
@@ -198,6 +259,71 @@ public sealed class StreamingProxyRoomCommandServiceTests
         unregisterIndex.Should().BeGreaterThanOrEqualTo(0);
         destroyIndex.Should().BeGreaterThan(unregisterIndex);
     }
+
+    private sealed class RecordingRoomSessionProjectionPort(List<string> operations)
+        : IStreamingProxyRoomSessionProjectionPort
+    {
+        public List<(string ActorId, string SubscriptionId)> EnsureSubscriptionCalls { get; } = [];
+        public IStreamingProxyRoomSessionProjectionLease? EnsureSubscriptionResult { get; init; } =
+            new RecordingRoomSessionProjectionLease("pending", "pending");
+        public bool ProjectionEnabled => true;
+
+        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureChatProjectionAsync(
+            string actorId,
+            string sessionId,
+            CancellationToken ct = default)
+        {
+            _ = actorId;
+            _ = sessionId;
+            ct.ThrowIfCancellationRequested();
+            throw new NotSupportedException("Room creation should not ensure chat projections.");
+        }
+
+        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureSubscriptionProjectionAsync(
+            string actorId,
+            string subscriptionId,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            operations.Add($"projection:ensure-subscription:{actorId}:{subscriptionId}");
+            EnsureSubscriptionCalls.Add((actorId, subscriptionId));
+            return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(EnsureSubscriptionResult is null
+                ? null
+                : new RecordingRoomSessionProjectionLease(actorId, subscriptionId));
+        }
+
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
+            IStreamingProxyRoomSessionProjectionLease lease,
+            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            _ = lease;
+            _ = sink;
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<IAsyncDisposable?>(null);
+        }
+
+        public Task DetachLiveSinkAsync(
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default)
+        {
+            _ = liveSinkLease;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task ReleaseActorProjectionAsync(
+            IStreamingProxyRoomSessionProjectionLease lease,
+            CancellationToken ct = default)
+        {
+            _ = lease;
+            ct.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record RecordingRoomSessionProjectionLease(string ActorId, string SessionId)
+        : IStreamingProxyRoomSessionProjectionLease;
 
     private sealed class RecordingGAgentActorRegistryCommandPort(List<string> operations)
         : IGAgentActorRegistryCommandPort

--- a/test/Aevatar.Integration.Tests/ClaimComplexBusinessScenarioTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimComplexBusinessScenarioTests.cs
@@ -82,6 +82,24 @@ public class ClaimComplexBusinessScenarioTests
             aiCalls[0].CorrelationId.Should().Be(runId);
             aiCalls[0].Prompt.Should().Contain(claimCase.CaseId);
 
+            await ClaimIntegrationTestKit.WaitForMessageAsync(
+                runtime,
+                analystActor.Id,
+                nameof(ClaimAnalystReviewRequested),
+                CancellationToken.None);
+            await ClaimIntegrationTestKit.WaitForMessageAsync(
+                runtime,
+                fraudActor.Id,
+                nameof(ClaimFraudScoringRequested),
+                CancellationToken.None);
+            await ClaimIntegrationTestKit.WaitForMessageAsync(
+                runtime,
+                complianceActor.Id,
+                nameof(ClaimComplianceCheckRequested),
+                CancellationToken.None);
+            analystActor = (await runtime.GetAsync(analystActor.Id))!;
+            fraudActor = (await runtime.GetAsync(fraudActor.Id))!;
+            complianceActor = (await runtime.GetAsync(complianceActor.Id))!;
             ClaimIntegrationTestKit.ReadMessages(analystActor).Should().ContainSingle(x => x == nameof(ClaimAnalystReviewRequested));
             ClaimIntegrationTestKit.ReadMessages(fraudActor).Should().ContainSingle(x => x == nameof(ClaimFraudScoringRequested));
             ClaimIntegrationTestKit.ReadMessages(complianceActor).Should().ContainSingle(x => x == nameof(ClaimComplianceCheckRequested));
@@ -92,6 +110,12 @@ public class ClaimComplexBusinessScenarioTests
                 (await runtime.ExistsAsync(manualReviewActorId)).Should().BeTrue();
                 var manualReviewActor = await runtime.GetAsync(manualReviewActorId);
                 manualReviewActor.Should().NotBeNull();
+                await ClaimIntegrationTestKit.WaitForMessageAsync(
+                    runtime,
+                    manualReviewActorId,
+                    nameof(ClaimManualReviewRequested),
+                    CancellationToken.None);
+                manualReviewActor = await runtime.GetAsync(manualReviewActorId);
                 ClaimIntegrationTestKit.ReadMessages(manualReviewActor!).Should().ContainSingle(x => x == nameof(ClaimManualReviewRequested));
             }
             else

--- a/test/Aevatar.Integration.Tests/ClaimIntegrationTestKit.cs
+++ b/test/Aevatar.Integration.Tests/ClaimIntegrationTestKit.cs
@@ -152,4 +152,36 @@ internal static class ClaimIntegrationTestKit
 
     public static IReadOnlyList<string> ReadMessages(IActor actor) =>
         ((ClaimMessageSinkGAgent)actor.Agent).State.MessageTypes.ToArray();
+
+    public static async Task WaitForMessageAsync(
+        IActorRuntime runtime,
+        string actorId,
+        string messageType,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(messageType);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeout.CancelAfter(TimeSpan.FromSeconds(10));
+
+        try
+        {
+            while (!timeout.Token.IsCancellationRequested)
+            {
+                var actor = await runtime.GetAsync(actorId);
+                if (actor != null && ReadMessages(actor).Contains(messageType, StringComparer.Ordinal))
+                    return;
+
+                await Task.Yield();
+                timeout.Token.ThrowIfCancellationRequested();
+            }
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested && !ct.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"Timed out waiting for claim sink message. actor_id={actorId} message_type={messageType}");
+        }
+    }
 }

--- a/tools/ci/query_projection_priming_guard.sh
+++ b/tools/ci/query_projection_priming_guard.sh
@@ -18,8 +18,22 @@ hits="$(
     || true
 )"
 
-if [[ -n "${hits}" ]]; then
-  echo "${hits}"
+endpoint_lifecycle_hits="$(
+  rg -n "EnsureAndAttachLeaseAsync|EnsureChatProjectionAsync|EnsureSubscriptionProjectionAsync|INyxIdChatSessionProjectionPort" \
+    agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs \
+    agents/Aevatar.GAgents.NyxidChat/NyxIdChatEndpoints.Streaming.cs \
+    agents/Aevatar.GAgents.NyxidChat/NyxIdChatStreamingRunner.cs \
+    || true
+)"
+
+if [[ -n "${hits}${endpoint_lifecycle_hits}" ]]; then
+  if [[ -n "${hits}" ]]; then
+    echo "${hits}"
+  fi
+  if [[ -n "${endpoint_lifecycle_hits}" ]]; then
+    echo "${endpoint_lifecycle_hits}"
+    echo "Streaming endpoints and runner must use interaction services or attach-only observation ports, not projection lifecycle APIs."
+  fi
   echo "Query/read paths must not trigger projection priming, activation, or lifecycle control."
   exit 1
 fi


### PR DESCRIPTION
## Summary / 摘要

### English

iter21 cluster-002-request-path-projection-session-priming (high, CLAUDE.md §"权威状态 / ReadModel / Projection" §"Projection Pipeline").

- **Old**: Endpoint-local projection priming spun a temporary projection session at request time and awaited completion; mixed read-side query with write-side stream lifecycle in the request path.
- **New**: Active streams reuse CQRS interaction binders; passive streams use attach-only deterministic room sessions; request path no longer primes projection or awaits projection lifecycle.

Violated: "禁止 query-time replay/priming" + "Projection 只消费 committed 事实" — request-time priming was masking projection lifecycle as part of the request/response contract.

### 中文

iter21 cluster-002-request-path-projection-session-priming（高严重度，CLAUDE.md §"权威状态 / ReadModel / Projection" §"Projection Pipeline"）。

- **Old**：endpoint 本地 projection priming 在请求时启动临时 projection session 并 await 完成；request path 混入读侧 query 与写侧 stream 生命周期。
- **New**：active stream 复用 CQRS interaction binder；passive stream 用 attach-only 确定性 room session；request path 不再 prime projection,也不 await projection 生命周期。

违反："禁止 query-time replay/priming" + "Projection 只消费 committed 事实" — 把 projection 生命周期伪装成请求/响应契约的一部分。

## Scope

13 files changed. Targeted test pass: NyxIdChatEndpointsCoverageTests + StreamingProxyCoverageTests + StreamingProxyRoomCommandServiceTests green locally. Architecture guards green.

See [implement summary](./.refactor-loop/runs/implement-iter21-cluster-002.md), [Phase 9 r2 judge consensus](./.refactor-loop/runs/phase9-issue748-r2-judge.md).

## Stacked-PR

iter21 batch 2. Base = `auto-refact-dev`. Rollup target = `dev`.

Closes #748.

**Supersedes #751** (iter20 cluster-002 retry-fix 在 r5 反弹引入新 design 违规;reflector r2 判 re-design;iter21 cluster-002 重新框定后已经把 identity 分离规范考虑进去)。

🤖 Auto-loop / codex-refactor-loop iter21

⟦AI:AUTO-LOOP⟧
