### PR TITLE
Add Team Studio member builder entry

### DIFF
--- a/apps/aevatar-console-web/config/proxy.ts
+++ b/apps/aevatar-console-web/config/proxy.ts
@@ -25,6 +25,14 @@ const buildHostPreservingProxyTarget = (target: string) => ({
   ws: true,
 });
 
+const shouldPreserveHost = (target: string) =>
+  /^https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::|\/|$)/i.test(target);
+
+const buildAuthProxyTarget = (target: string) =>
+  shouldPreserveHost(target)
+    ? buildHostPreservingProxyTarget(target)
+    : buildProxyTarget(target);
+
 const studioProxyEntries = [
   '/api/app',
   '/api/auth',
@@ -37,7 +45,7 @@ const studioProxyEntries = [
   '/api/workspace',
 ].reduce<Record<string, ReturnType<typeof buildProxyTarget>>>((entries, path) => {
   const proxyFactory = path === '/api/auth'
-    ? buildHostPreservingProxyTarget
+    ? buildAuthProxyTarget
     : buildProxyTarget;
   entries[`^${path}$`] = proxyFactory(studioApiTarget);
   entries[`${path}/`] = proxyFactory(studioApiTarget);

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -3814,6 +3814,28 @@ describe("StudioPage", () => {
     expect(searchParams.get("tab")).toBe("overview");
   });
 
+  it("returns to the explicit Team handoff target after Studio settles its route", async () => {
+    renderStudioPage(
+      "/studio?scopeId=scope-1&teamId=t-alpha&member=member%3Aworkspace-demo&step=build&tab=studio&returnTo=%2Fteams%2Fscope-1%2Ft-alpha%3FmemberId%3Dworkspace-demo%26tab%3Dmembers"
+    );
+
+    expect(await screen.findByTestId("studio-workflow-build-panel")).toBeTruthy();
+
+    await waitFor(() => {
+      const searchParams = new URLSearchParams(window.location.search);
+      expect(searchParams.get("returnTo")).toBe(
+        "/teams/scope-1/t-alpha?memberId=workspace-demo&tab=members"
+      );
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "返回团队" }));
+
+    expect(window.location.pathname).toBe("/teams/scope-1/t-alpha");
+    const searchParams = new URLSearchParams(window.location.search);
+    expect(searchParams.get("memberId")).toBe("workspace-demo");
+    expect(searchParams.get("tab")).toBe("members");
+  });
+
   it("moves focus from a Script draft to the new Workflow member after create", async () => {
     (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
       ...defaultStudioAppContext,

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -169,6 +169,7 @@ type StudioRouteState = {
   prompt: string;
   executionId: string;
   logsMode: '' | 'popout';
+  returnTo: string;
 };
 
 type StudioBuildFocusKind = 'workflow' | 'script' | 'template' | 'none';
@@ -909,6 +910,11 @@ function buildStudioLoginRoute(returnTo: string): string {
   return `/login?${params.toString()}`;
 }
 
+function readStudioReturnToParam(params: URLSearchParams): string {
+  const returnTo = trimOptional(params.get('returnTo'));
+  return returnTo ? sanitizeReturnTo(returnTo) : '';
+}
+
 function getCurrentStudioReturnTo(): string {
   if (typeof window === 'undefined') {
     return '/studio';
@@ -1232,6 +1238,7 @@ function readStudioRouteState(search?: string): StudioRouteState {
       prompt: '',
       executionId: '',
       logsMode: '',
+      returnTo: '',
     };
   }
 
@@ -1257,6 +1264,7 @@ function readStudioRouteState(search?: string): StudioRouteState {
     prompt: trimOptional(params.get('prompt')),
     executionId: trimOptional(params.get('execution')),
     logsMode: parseLogsMode(params.get('logs')),
+    returnTo: readStudioReturnToParam(params),
   };
 }
 
@@ -4575,6 +4583,7 @@ const StudioPage: React.FC = () => {
         buildStudioRoute({
           scopeId: resolvedStudioScopeId || undefined,
           teamId: routeState.teamId || undefined,
+          returnTo: routeState.returnTo || undefined,
           memberKey: routedBoundMemberKey,
           focus:
             buildPendingBindCandidate.kind === 'script'
@@ -4598,6 +4607,7 @@ const StudioPage: React.FC = () => {
     routeSelectedBackendMemberKey,
     routeState.memberKey,
     routeState.teamId,
+    routeState.returnTo,
     selectedScriptId,
     selectedWorkflowMemberKey,
     scopeServicesQuery,
@@ -4990,6 +5000,7 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: createMemberTeamId || undefined,
+            returnTo: routeState.returnTo || undefined,
             memberKey: createdScriptMember?.memberId
               ? `member:${createdScriptMember.memberId}`
               : undefined,
@@ -5064,6 +5075,7 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId,
             teamId: createMemberTeamId || undefined,
+            returnTo: routeState.returnTo || undefined,
             memberKey: `member:${createdGAgentMember.memberId}`,
             step: 'build',
             tab: 'gagents',
@@ -5445,6 +5457,7 @@ const StudioPage: React.FC = () => {
                   buildStudioRoute({
                     scopeId: resolvedStudioScopeId || undefined,
                     teamId: routeState.teamId || undefined,
+                    returnTo: routeState.returnTo || undefined,
                     focus: `workflow:${fallbackWorkflowId}`,
                     step: 'build',
                     tab: 'studio',
@@ -5456,6 +5469,7 @@ const StudioPage: React.FC = () => {
                   buildStudioRoute({
                     scopeId: resolvedStudioScopeId || undefined,
                     teamId: routeState.teamId || undefined,
+                    returnTo: routeState.returnTo || undefined,
                     step: 'build',
                     tab: 'studio',
                   }),
@@ -6069,6 +6083,7 @@ const StudioPage: React.FC = () => {
         history.replace(buildStudioRoute({
           scopeId: resolvedStudioScopeId || undefined,
           teamId: routeState.teamId || undefined,
+          returnTo: routeState.returnTo || undefined,
           memberKey: nextRouteMemberKey,
           step:
             nextStudioSurface === 'bind'
@@ -6090,6 +6105,7 @@ const StudioPage: React.FC = () => {
       ensureActiveWorkflowDraftLoaded,
       resolvedStudioScopeId,
       routeState.teamId,
+      routeState.returnTo,
     ],
   );
   const handleBindingSelectionChange = useCallback(
@@ -6222,6 +6238,7 @@ const StudioPage: React.FC = () => {
         buildStudioRoute({
           scopeId: resolvedStudioScopeId || undefined,
           teamId: routeState.teamId || undefined,
+          returnTo: routeState.returnTo || undefined,
           memberKey: buildBackendMemberKey(resolvedMemberId) || undefined,
           step: 'invoke',
           tab: 'invoke',
@@ -6239,6 +6256,7 @@ const StudioPage: React.FC = () => {
       routeSelectedBackendMemberId,
       routeState.memberKey,
       routeState.teamId,
+      routeState.returnTo,
       studioScopeMembers,
     ],
   );
@@ -6659,6 +6677,7 @@ const StudioPage: React.FC = () => {
     history.replace(buildStudioRoute({
       scopeId: resolvedStudioScopeId || undefined,
       teamId: routeState.teamId || undefined,
+      returnTo: routeState.returnTo || undefined,
       memberKey: persistedMemberKey,
       step,
       focus: persistedFocus,
@@ -6689,6 +6708,7 @@ const StudioPage: React.FC = () => {
     routeSelectedMemberKey,
     routeState.legacyServiceId,
     routeState.teamId,
+    routeState.returnTo,
     runPrompt,
     selectedWorkflowId,
     selectedExecutionId,
@@ -7765,6 +7785,7 @@ const StudioPage: React.FC = () => {
             buildStudioRoute({
               scopeId: resolvedStudioScopeId || undefined,
               teamId: routeState.teamId || undefined,
+              returnTo: routeState.returnTo || undefined,
               memberKey: normalizedMemberKey,
               step: currentLifecycleStep,
             }),
@@ -7776,6 +7797,7 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: routeState.teamId || undefined,
+            returnTo: routeState.returnTo || undefined,
             memberKey: normalizedMemberKey,
             tab: 'studio',
           }),
@@ -7808,6 +7830,7 @@ const StudioPage: React.FC = () => {
             buildStudioRoute({
               scopeId: resolvedStudioScopeId || undefined,
               teamId: routeState.teamId || undefined,
+              returnTo: routeState.returnTo || undefined,
               memberKey: normalizedMemberKey,
               step: currentLifecycleStep,
             }),
@@ -7819,6 +7842,7 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: routeState.teamId || undefined,
+            returnTo: routeState.returnTo || undefined,
             memberKey: normalizedMemberKey,
             tab: 'scripts',
           }),
@@ -7878,6 +7902,7 @@ const StudioPage: React.FC = () => {
                 buildStudioRoute({
                   scopeId: resolvedStudioScopeId || undefined,
                   teamId: routeState.teamId || undefined,
+                  returnTo: routeState.returnTo || undefined,
                   memberKey: workflowMemberKey,
                   tab: 'studio',
                 }),
@@ -7904,6 +7929,7 @@ const StudioPage: React.FC = () => {
                 buildStudioRoute({
                   scopeId: resolvedStudioScopeId || undefined,
                   teamId: routeState.teamId || undefined,
+                  returnTo: routeState.returnTo || undefined,
                   memberKey: `script:${scriptId}`,
                   tab: 'scripts',
                 }),
@@ -7966,6 +7992,7 @@ const StudioPage: React.FC = () => {
             buildStudioRoute({
               scopeId: resolvedStudioScopeId || undefined,
               teamId: routeState.teamId || undefined,
+              returnTo: routeState.returnTo || undefined,
               memberKey:
                 selectedMemberId ? `member:${selectedMemberId}` : normalizedMemberKey,
               step: currentLifecycleStep,
@@ -7979,6 +8006,7 @@ const StudioPage: React.FC = () => {
             buildStudioRoute({
               scopeId: resolvedStudioScopeId || undefined,
               teamId: routeState.teamId || undefined,
+              returnTo: routeState.returnTo || undefined,
               memberKey: selectedMemberOwnerKey,
               tab: 'studio',
             }),
@@ -7992,6 +8020,7 @@ const StudioPage: React.FC = () => {
             buildStudioRoute({
               scopeId: resolvedStudioScopeId || undefined,
               teamId: routeState.teamId || undefined,
+              returnTo: routeState.returnTo || undefined,
               memberKey: selectedMemberOwnerKey,
               tab: 'scripts',
             }),
@@ -8004,6 +8033,7 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: routeState.teamId || undefined,
+            returnTo: routeState.returnTo || undefined,
             memberKey: selectedMemberOwnerKey,
             step: 'bind',
           }),
@@ -8033,6 +8063,7 @@ const StudioPage: React.FC = () => {
       publishedScopeServices,
       resolvedStudioScopeId,
       routeState.teamId,
+      routeState.returnTo,
       studioSurface,
       visibleWorkflowSummaries,
       workbenchMemberKey,
@@ -8667,34 +8698,36 @@ const StudioPage: React.FC = () => {
     .map((value) => trimOptional(value))
     .filter(Boolean);
   const studioReturnHref = resolvedStudioScopeId
-    ? routeState.teamId
-      ? buildTeamDetailHref({
-          scopeId: resolvedStudioScopeId,
-          teamId: routeState.teamId,
-          tab: 'overview',
-          memberId:
-            currentCanonicalMemberId ||
-            trimOptional(routeSelectedBackendMemberId) ||
-            readMemberIdFromMemberKey(routeState.memberKey) ||
-            undefined,
-          serviceId: trimOptional(workbenchPublishedService?.serviceId) || undefined,
-        })
-      : buildTeamDetailHref({
-        scopeId: resolvedStudioScopeId,
-        tab: 'overview',
-        serviceId:
-          trimOptional(workbenchPublishedService?.serviceId) ||
-          trimOptional(routeState.legacyServiceId) ||
-          undefined,
-      })
+    ? routeState.returnTo ||
+      (routeState.teamId
+        ? buildTeamDetailHref({
+            scopeId: resolvedStudioScopeId,
+            teamId: routeState.teamId,
+            tab: 'overview',
+            memberId:
+              currentCanonicalMemberId ||
+              trimOptional(routeSelectedBackendMemberId) ||
+              readMemberIdFromMemberKey(routeState.memberKey) ||
+              undefined,
+            serviceId: trimOptional(workbenchPublishedService?.serviceId) || undefined,
+          })
+        : buildTeamDetailHref({
+            scopeId: resolvedStudioScopeId,
+            tab: 'overview',
+            serviceId:
+              trimOptional(workbenchPublishedService?.serviceId) ||
+              trimOptional(routeState.legacyServiceId) ||
+              undefined,
+          }))
     : buildTeamsHref();
   const studioReturnLabel = '返回团队';
   const currentStudioReturnTo =
-    typeof window === 'undefined'
+    routeState.returnTo ||
+    (typeof window === 'undefined'
       ? ''
       : sanitizeReturnTo(
           `${window.location.pathname}${window.location.search}${window.location.hash}`,
-        );
+        ));
   const createScriptId = buildScriptIdSlug(createMemberName);
   const createScriptIdAlreadyExists = Boolean(
     createScriptId && availableScopeScriptIds.has(createScriptId),
@@ -8969,6 +9002,7 @@ const StudioPage: React.FC = () => {
           buildStudioRoute({
             scopeId: resolvedStudioScopeId || undefined,
             teamId: routeState.teamId || undefined,
+            returnTo: routeState.returnTo || undefined,
             memberKey: routeSelectedMemberKey || undefined,
             focus: scriptFocusId ? `script:${scriptFocusId}` : undefined,
             step: 'bind',

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -1058,9 +1058,54 @@ describe("TeamDetailPage", () => {
     expect(await screen.findByText("Team Alpha Operator")).toBeTruthy();
     expect(screen.getByText("负责处理升级工单")).toBeTruthy();
     expect(screen.getByText("member-team-alpha")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Edit in Studio" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Build" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Test member" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "View runs" })).toBeNull();
     expect(screen.queryByText("参与者结构")).toBeNull();
     expect(screen.queryByText("运行时参与者身份")).toBeNull();
     expect(screen.queryByRole("button", { name: "打开 Services" })).toBeNull();
+  });
+
+  it("routes member build actions into Studio with Team context", async () => {
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "Edit Team" });
+    fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
+    fireEvent.click(await screen.findByRole("link", { name: "Build" }));
+
+    expect(window.location.pathname).toBe("/studio");
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("scopeId")).toBe("scope-1");
+    expect(params.get("teamId")).toBe("t-alpha");
+    expect(params.get("member")).toBe("member:member-team-alpha");
+    expect(params.get("step")).toBe("build");
+    expect(params.get("tab")).toBeNull();
+    expect(params.get("returnTo")).toBe(
+      "/teams/scope-1/t-alpha?memberId=member-team-alpha&tab=members",
+    );
+  });
+
+  it("opens Studio create-member mode from an empty Team roster", async () => {
+    (studioApi.listTeamMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-1",
+      members: [],
+      nextPageToken: null,
+    });
+
+    renderWithQueryClient(React.createElement(TeamDetailPage));
+
+    await screen.findByRole("button", { name: "Edit Team" });
+    fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
+    fireEvent.click(await screen.findByRole("link", { name: "Create first member" }));
+
+    expect(window.location.pathname).toBe("/studio");
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get("scopeId")).toBe("scope-1");
+    expect(params.get("teamId")).toBe("t-alpha");
+    expect(params.get("tab")).toBe("studio");
+    expect(params.get("intent")).toBe("create-member");
+    expect(params.get("returnTo")).toBe("/teams/scope-1/t-alpha?tab=members");
   });
 
   it("uses the real Team roster when teamId is selected", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -10,6 +10,7 @@ import {
 import { buildScopeHref } from "@/shared/navigation/scopeRoutes";
 import {
   buildTeamDetailHref,
+  buildTeamStudioHref,
   readTeamDetailRouteState,
   type TeamDetailTab,
 } from "@/shared/navigation/teamRoutes";
@@ -600,10 +601,34 @@ const TeamDetailPage: React.FC = () => {
     ) : null;
   const activeWorkflowId =
     trimText(activeWorkflowSummary?.workflowId) || trimText(routeState.workflowId);
+  const buildTeamReturnHref = React.useCallback(
+    (memberId?: string) =>
+      buildTeamDetailHref({
+        memberId: trimText(memberId) || undefined,
+        scopeId,
+        tab: "members",
+        teamId: selectedTeamId,
+      }),
+    [scopeId, selectedTeamId],
+  );
   const teamRosterRows = React.useMemo(
     () =>
       (teamMembersQuery.data?.members ?? []).map((member) => ({
+        buildStudioHref: buildTeamStudioHref({
+          memberId: member.memberId,
+          mode: "build-member",
+          returnTo: buildTeamReturnHref(member.memberId),
+          scopeId,
+          teamId: selectedTeamId,
+        }),
         description: trimText(member.description),
+        editStudioHref: buildTeamStudioHref({
+          memberId: member.memberId,
+          mode: "edit-member",
+          returnTo: buildTeamReturnHref(member.memberId),
+          scopeId,
+          teamId: selectedTeamId,
+        }),
         implementationKind: formatCompositionKind(member.implementationKind),
         key: member.memberId,
         lifecycleLabel: formatStudioMemberLifecycleStage(member.lifecycleStage),
@@ -612,7 +637,17 @@ const TeamDetailPage: React.FC = () => {
         name: trimText(member.displayName) || member.memberId,
         serviceId: trimText(member.publishedServiceId) || "--",
       })),
-    [teamMembersQuery.data?.members, token],
+    [buildTeamReturnHref, scopeId, selectedTeamId, teamMembersQuery.data?.members, token],
+  );
+  const createMemberHref = React.useMemo(
+    () =>
+      buildTeamStudioHref({
+        mode: "create-member",
+        returnTo: buildTeamReturnHref(),
+        scopeId,
+        teamId: selectedTeamId,
+      }),
+    [buildTeamReturnHref, scopeId, selectedTeamId],
   );
   const latestVisibleUpdate =
     teamSummaryQuery.data?.updatedAt ||
@@ -957,6 +992,8 @@ const TeamDetailPage: React.FC = () => {
   const renderMembersTab = () => {
     return (
       <TeamMembersTab
+        createMemberHref={createMemberHref}
+        onNavigate={(href) => history.push(href)}
         rosterError={teamMembersQuery.isError && !isTeamMembersProjectionSyncing}
         rosterLoading={teamMembersQuery.isLoading}
         rosterSyncing={isTeamMembersProjectionSyncing}

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -161,8 +161,8 @@ describe("TeamsHomePage", () => {
     expect(screen.queryByText("当前工作空间")).toBeNull();
     expect(screen.getByText("AI Team")).toBeTruthy();
     expect(screen.getByText("团队列表")).toBeTruthy();
-    expect(screen.getByText("运行正常")).toBeTruthy();
-    expect(screen.getByText("需要处理")).toBeTruthy();
+    expect(screen.queryByText("运行正常")).toBeNull();
+    expect(screen.queryByText("需要处理")).toBeNull();
     expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
     expect(screen.getByRole("heading", { level: 3, name: "客服团队" })).toBeTruthy();
     expect(screen.getByText("Team 标识：t-support")).toBeTruthy();

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -1031,12 +1031,6 @@ const TeamsHomePage: React.FC = () => {
     manualRosterView ??
     (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
   const useCompactRoster = resolvedRosterView === "list";
-  const healthyTeamCount = teamPreviews.filter(
-    (preview) => preview.attention === "healthy",
-  ).length;
-  const attentionTeamCount = teamPreviews.filter(
-    (preview) => preview.attention !== "healthy",
-  ).length;
   const emptyRosterHint =
     scopeId.length > 0
       ? "当前账号还没有创建任何 Team。创建后，这里会展示你的 AI 团队列表。"
@@ -1137,8 +1131,6 @@ const TeamsHomePage: React.FC = () => {
               }}
             >
               <SummaryStatCard accent label="AI Team" value={visibleTeamCount} />
-              <SummaryStatCard label="运行正常" value={healthyTeamCount} />
-              <SummaryStatCard label="需要处理" value={attentionTeamCount} />
             </div>
 
             {teamsQuery.isLoading ? (

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -1,4 +1,5 @@
-import { Typography } from "antd";
+import { EditOutlined, ToolOutlined } from "@ant-design/icons";
+import { Button, Space, Typography } from "antd";
 import React from "react";
 import {
   AevatarInspectorEmpty,
@@ -17,6 +18,8 @@ type TeamRosterMemberRow = {
   readonly key: string;
   readonly lifecycleLabel: string;
   readonly lifecycleStyle: React.CSSProperties;
+  readonly buildStudioHref: string;
+  readonly editStudioHref: string;
   readonly memberId: string;
   readonly name: string;
   readonly serviceId: string;
@@ -28,15 +31,31 @@ type TeamMembersTabProps = {
   readonly rosterRows?: readonly TeamRosterMemberRow[];
   readonly rosterSyncing?: boolean;
   readonly rosterTeamId?: string;
+  readonly createMemberHref?: string;
+  readonly onNavigate?: (href: string) => void;
 };
 
 const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
+  createMemberHref = "",
+  onNavigate,
   rosterError = false,
   rosterLoading = false,
   rosterRows = [],
   rosterSyncing = false,
   rosterTeamId = "",
 }) => {
+  const handleNavigate = React.useCallback(
+    (href: string) => (event: React.MouseEvent<HTMLElement>) => {
+      if (!href || !onNavigate) {
+        return;
+      }
+
+      event.preventDefault();
+      onNavigate(href);
+    },
+    [onNavigate],
+  );
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <AevatarPanel
@@ -74,7 +93,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
             }}
           >
             <div style={{ overflowX: "auto" }}>
-              <div style={{ minWidth: 820 }}>
+              <div style={{ minWidth: 980 }}>
                 <div
                   style={{
                     background: "var(--ant-colorBgContainerDisabled)",
@@ -85,7 +104,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                     fontWeight: 600,
                     gap: 16,
                     gridTemplateColumns:
-                      "minmax(160px, 1.2fr) minmax(220px, 1.4fr) minmax(120px, 0.8fr) minmax(120px, 0.8fr)",
+                      "minmax(160px, 1.1fr) minmax(220px, 1.4fr) minmax(120px, 0.7fr) minmax(120px, 0.7fr) minmax(190px, max-content)",
                     padding: "12px 16px",
                   }}
                 >
@@ -93,6 +112,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                   <span>职责</span>
                   <span>实现</span>
                   <span>服务</span>
+                  <span>操作</span>
                 </div>
                 {rosterRows.map((row, index) => (
                   <div
@@ -104,7 +124,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                       display: "grid",
                       gap: 16,
                       gridTemplateColumns:
-                        "minmax(160px, 1.2fr) minmax(220px, 1.4fr) minmax(120px, 0.8fr) minmax(120px, 0.8fr)",
+                        "minmax(160px, 1.1fr) minmax(220px, 1.4fr) minmax(120px, 0.7fr) minmax(120px, 0.7fr) minmax(190px, max-content)",
                       padding: "14px 16px",
                     }}
                   >
@@ -129,17 +149,49 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                       strong={false}
                       value={row.serviceId}
                     />
+                    <Space wrap size={8}>
+                      <Button
+                        href={row.editStudioHref}
+                        icon={<EditOutlined />}
+                        onClick={handleNavigate(row.editStudioHref)}
+                        size="small"
+                      >
+                        Edit in Studio
+                      </Button>
+                      <Button
+                        href={row.buildStudioHref}
+                        icon={<ToolOutlined />}
+                        onClick={handleNavigate(row.buildStudioHref)}
+                        size="small"
+                        type="primary"
+                      >
+                        Build
+                      </Button>
+                    </Space>
                   </div>
                 ))}
               </div>
             </div>
           </div>
         ) : rosterTeamId ? (
-          <AevatarInspectorEmpty
-            compact
-            title="这支 Team 还没有成员"
-            description="Team 已经是后端事实，但当前 roster 为空。新增 member 后会出现在这里。"
-          />
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            <AevatarInspectorEmpty
+              compact
+              title="这支 Team 还没有成员"
+              description="Team 已经是后端事实，但当前 roster 为空。新增 member 后会出现在这里。"
+            />
+            {createMemberHref ? (
+              <div style={{ display: "flex", justifyContent: "center" }}>
+                <Button
+                  href={createMemberHref}
+                  onClick={handleNavigate(createMemberHref)}
+                  type="primary"
+                >
+                  Create first member
+                </Button>
+              </div>
+            ) : null}
+          </div>
         ) : (
           <AevatarInspectorEmpty
             compact

--- a/apps/aevatar-console-web/src/shared/config/proxyConfig.test.ts
+++ b/apps/aevatar-console-web/src/shared/config/proxyConfig.test.ts
@@ -90,4 +90,31 @@ describe('proxy config', () => {
       ws: true,
     });
   });
+
+  it('preserves auth host only for local Studio targets', () => {
+    process.env.AEVATAR_API_TARGET = 'http://127.0.0.1:5080';
+    process.env.AEVATAR_STUDIO_API_TARGET = 'http://127.0.0.1:5180';
+
+    const localProxyModule = require('../../../config/proxy');
+    const localDevProxy = localProxyModule.default.dev as Record<string, ProxyEntry>;
+
+    expect(resolveProxyEntry(localDevProxy, '/api/auth/me')).toEqual({
+      target: 'http://127.0.0.1:5180',
+      changeOrigin: false,
+      ws: true,
+    });
+
+    jest.resetModules();
+    process.env.AEVATAR_STUDIO_API_TARGET =
+      'https://aevatar-console-backend-api.aevatar.ai';
+
+    const remoteProxyModule = require('../../../config/proxy');
+    const remoteDevProxy = remoteProxyModule.default.dev as Record<string, ProxyEntry>;
+
+    expect(resolveProxyEntry(remoteDevProxy, '/api/auth/me')).toEqual({
+      target: 'https://aevatar-console-backend-api.aevatar.ai',
+      changeOrigin: true,
+      ws: true,
+    });
+  });
 });

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.test.ts
@@ -1,6 +1,7 @@
 import {
   buildTeamCreateHref,
   buildTeamDetailHref,
+  buildTeamStudioHref,
   buildTeamsHref,
   readTeamDetailRouteState,
 } from "./teamRoutes";
@@ -39,6 +40,31 @@ describe("teamRoutes", () => {
         serviceId: "service-1",
       }),
     ).toBe("/teams?scopeId=scope-alpha");
+  });
+
+  it("builds a Team-scoped Studio create-member handoff", () => {
+    expect(
+      buildTeamStudioHref({
+        mode: "create-member",
+        scopeId: " scope-alpha ",
+        teamId: " t-alpha ",
+      }),
+    ).toBe(
+      "/studio?scopeId=scope-alpha&teamId=t-alpha&tab=studio&intent=create-member&returnTo=%2Fteams%2Fscope-alpha%2Ft-alpha%3Ftab%3Dmembers",
+    );
+  });
+
+  it("builds a Team-scoped Studio member build handoff", () => {
+    expect(
+      buildTeamStudioHref({
+        memberId: " member-alpha ",
+        mode: "build-member",
+        scopeId: "scope-alpha",
+        teamId: "t-alpha",
+      }),
+    ).toBe(
+      "/studio?scopeId=scope-alpha&teamId=t-alpha&member=member%3Amember-alpha&step=build&returnTo=%2Fteams%2Fscope-alpha%2Ft-alpha%3FmemberId%3Dmember-alpha%26tab%3Dmembers",
+    );
   });
 
   it("preserves draft team names when returning to the create page", () => {

--- a/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
+++ b/apps/aevatar-console-web/src/shared/navigation/teamRoutes.ts
@@ -1,6 +1,10 @@
+import { buildStudioRoute } from '@/shared/studio/navigation';
+
 type TeamDetailTab =
   | 'overview'
   | 'members';
+
+type TeamToStudioMode = 'create-member' | 'edit-member' | 'build-member';
 
 type QueryValue = string | undefined;
 type TeamDetailRouteState = {
@@ -107,6 +111,57 @@ export function buildTeamDetailHref(options: {
       runId: options.runId,
     },
   );
+}
+
+export function buildTeamStudioHref(options: {
+  memberId?: string;
+  mode: TeamToStudioMode;
+  returnTo?: string;
+  scopeId: string;
+  teamId: string;
+}): string {
+  const scopeId = trimOptional(options.scopeId);
+  const teamId = trimOptional(options.teamId);
+  if (!scopeId || !teamId) {
+    return buildTeamsHref();
+  }
+
+  const memberId = trimOptional(options.memberId);
+  const returnTo =
+    trimOptional(options.returnTo) ||
+    buildTeamDetailHref({
+      memberId: memberId || undefined,
+      scopeId,
+      tab: 'members',
+      teamId,
+    });
+
+  if (options.mode === 'create-member') {
+    return buildStudioRoute({
+      scopeId,
+      teamId,
+      tab: 'studio',
+      intent: 'create-member',
+      returnTo,
+    });
+  }
+
+  if (!memberId) {
+    return buildTeamDetailHref({
+      scopeId,
+      tab: 'members',
+      teamId,
+    });
+  }
+
+  return buildStudioRoute({
+    scopeId,
+    teamId,
+    memberId,
+    step: 'build',
+    tab: options.mode === 'edit-member' ? 'studio' : undefined,
+    returnTo,
+  });
 }
 
 export function readTeamDetailRouteState(

--- a/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.test.ts
@@ -78,6 +78,21 @@ describe('buildStudioRoute', () => {
     ).toBe('/studio?scopeId=scope-1&teamId=t-alpha&tab=studio&intent=create-member');
   });
 
+  it('carries a return target for Team handoffs', () => {
+    expect(
+      buildStudioRoute({
+        scopeId: 'scope-1',
+        teamId: 't-alpha',
+        memberId: 'member-alpha',
+        step: 'build',
+        tab: 'studio',
+        returnTo: '/teams/scope-1/t-alpha?tab=members',
+      }),
+    ).toBe(
+      '/studio?scopeId=scope-1&teamId=t-alpha&member=member%3Amember-alpha&step=build&tab=studio&returnTo=%2Fteams%2Fscope-1%2Ft-alpha%3Ftab%3Dmembers',
+    );
+  });
+
   it('drops invalid Studio intent values', () => {
     expect(
       buildStudioRoute({

--- a/apps/aevatar-console-web/src/shared/studio/navigation.ts
+++ b/apps/aevatar-console-web/src/shared/studio/navigation.ts
@@ -27,6 +27,7 @@ type StudioRouteOptions = {
   prompt?: string;
   executionId?: string;
   logsMode?: 'popout';
+  returnTo?: string;
 } & Record<string, unknown>;
 
 function trimOptional(value: string | null | undefined): string {
@@ -196,6 +197,9 @@ export function buildStudioRoute(options?: StudioRouteOptions): string {
   }
   if (options?.logsMode === 'popout') {
     params.set('logs', 'popout');
+  }
+  if (options?.returnTo?.trim()) {
+    params.set('returnTo', options.returnTo.trim());
   }
 
   const query = params.toString();

--- a/docs/design/2026-05-20-studio-member-builder-entry-decision.md
+++ b/docs/design/2026-05-20-studio-member-builder-entry-decision.md
@@ -1,0 +1,201 @@
+---
+title: "Studio Member Builder Entry Decision"
+status: DECIDED
+date: 2026-05-20
+related:
+  - "./2026-04-20-studio-member-workbench-information-architecture.md"
+  - "./2026-04-20-studio-member-workbench-implementation-checklist.md"
+  - "./2026-04-22-team-member-first-prd.md"
+---
+
+# Studio Member Builder Entry Decision
+
+## Decision
+
+`Studio` is positioned as the **Team Member Builder**.
+
+It is not a Team Detail `Advanced Edit` tab, and it is not a generic Team
+configuration surface. Users enter Studio to create, edit, bind, publish, test,
+and observe a specific Team member.
+
+## Product Boundary
+
+`Team Detail` owns Team-level understanding:
+
+- Team identity and lifecycle
+- Member roster and Team composition
+- Team Activity
+- Team Event Topology
+- Team-level status and operational signals
+
+`Studio` owns member-level building:
+
+- Create a member inside the current Team
+- Edit a member workflow/script implementation
+- Bind the member to a service
+- Publish and test the member
+- Return to Team Detail with the Team context preserved
+
+The user should feel they are building a member of the current Team, not
+jumping into an unrelated editor.
+
+## Entry Points
+
+### Empty Team
+
+When a Team has no members, the primary empty-state action is:
+
+`Create first member`
+
+This opens Studio in create-member mode with the current `scopeId` and `teamId`.
+
+### Team Overview
+
+Team Overview may include a compact builder panel:
+
+- `Build this Team`
+- `Add member`
+- `Continue editing`
+- visible summary of current member/build state when available
+
+This panel is a contextual handoff to Studio, not a replacement for Studio.
+
+### Members Tab
+
+Each member row is the primary Studio entry point for existing members.
+
+V1 row actions:
+
+- `Edit in Studio`
+- `Build`
+
+Do not add `Test member`, `View runs`, or metrics-style actions to the v1
+member row action set. Those can be revisited after Team Activity, run
+drilldown, and Team-scoped test semantics are settled.
+
+This keeps the action attached to the object Studio edits: the member.
+
+### Team Header
+
+Team Header should not expose a primary `Advanced Edit` action.
+
+If a generic Studio entry is still useful as a fallback, it may live under a
+secondary `More` menu as `Open Studio`, but it must still carry Team context and
+should prefer a selected/default member when one is known.
+
+## Route Semantics
+
+Every Team-to-Studio handoff must carry explicit context:
+
+```text
+scopeId
+teamId
+memberId optional
+mode=create-member | edit-member
+returnTo=/teams/{scopeId}/{teamId}
+```
+
+Studio must render that context visibly:
+
+- Team name
+- selected member name, if any
+- current lifecycle stage
+- `Back to Team`
+
+If required context is missing, Studio must show an honest degraded state rather
+than silently opening an unrelated generic editor.
+
+## Team Detail Tabs
+
+Do not add a Team Detail `Advanced Edit` tab.
+
+The intended Team Detail tab direction is:
+
+```text
+Overview / Members / Activity / Topology
+```
+
+Studio is a builder flow launched from Team/member context, not an information
+tab inside Team Detail.
+
+## Team Overview Metrics Decision
+
+Team Overview v1 only displays backend-backed facts.
+
+Do not add frontend-computed Team operational metrics such as daily message
+count, success rate, online rate, average response time, Team-level error rate,
+or Team-level throughput until the backend provides a Team-scoped operational
+summary, Team Activity read model, or equivalent authoritative metric contract.
+
+Allowed v1 facts:
+
+- Team lifecycle
+- Team member count from the Team read model
+- Team roster and member composition
+- current service, revision, and recent run facts when they come from existing
+  member/service/runtime APIs
+- recent run hints that are clearly labeled as member/service runtime hints,
+  not authoritative Team health metrics
+
+Deferred metrics:
+
+- daily messages
+- success rate
+- online rate
+- average response time
+- Team-level health score
+- Team-level failed/waiting/throughput rollups
+
+### Follow-up Implementation Scope
+
+When implementation starts, keep Team Detail Overview mostly as-is because it
+already shows current service, recent run, last update, Team composition, and
+configuration details rather than advanced operational metrics.
+
+The Teams home page should be tightened so it does not present sampled
+member-run status as authoritative Team metrics:
+
+- keep the `AI Team` count, because it comes from the Team roster
+- remove the `运行正常` and `需要处理` summary cards
+- keep per-Team recent member/service run hints only if the copy makes their
+  scope explicit
+- update Teams home tests that assert the old summary cards
+
+This is a product semantics change, not a backend requirement. Full Team
+operational metrics remain blocked on a Team-scoped backend read model/API.
+
+## Rationale
+
+The SaaS Team Workbench mental model is:
+
+1. Understand the Team.
+2. Inspect members and activity.
+3. Choose the member to build or fix.
+4. Enter Studio with that member selected.
+5. Return to Team Detail to observe the result.
+
+Calling this `Advanced Edit` makes the action feel like an administrative
+escape hatch. Calling it `Build` or `Edit in Studio` keeps the product language
+close to the user's task.
+
+## Non-Goals
+
+- Do not make Studio a generic Team settings page.
+- Do not make `Advanced Edit` a first-class Team Detail tab.
+- Do not let Studio infer Team context only from auth/session fallback when the
+  user came from a Team page.
+- Do not move Team-level Activity, Topology, or connector ownership into Studio.
+
+## Implementation Notes
+
+Frontend work should add a shared Team-to-Studio route builder so Team Overview,
+Members tab, empty state, and future Team Activity drilldowns produce consistent
+links.
+
+Tests should cover:
+
+- empty Team CTA links to Studio create-member mode
+- member row action links to Studio edit-member mode
+- `returnTo` returns to the same Team Detail
+- Team Detail does not render an `Advanced Edit` tab
+- missing context produces an explicit degraded state


### PR DESCRIPTION
Closes #757

## Summary

- Simplify the Teams home metric cards by removing the local-only health cards and keeping the backend-backed AI Team count.
- Add Studio-oriented member actions on the Team Members tab: `Edit in Studio` and `Build`.
- Preserve `returnTo` through Studio route normalization so users return to the Team Members tab after editing/building.
- Adjust the local dev proxy auth behavior so real HTTPS backend targets use `changeOrigin: true`, while local targets can still preserve the host.
- Record the product decision in `docs/design/2026-05-20-studio-member-builder-entry-decision.md`.

## Validation

- `npm --prefix apps/aevatar-console-web test -- --runTestsByPath src/pages/studio/index.test.tsx src/shared/studio/navigation.test.ts src/shared/navigation/teamRoutes.test.ts src/pages/teams/detail.test.tsx src/pages/teams/home.test.tsx src/shared/config/proxyConfig.test.ts --runInBand`
- `npm --prefix apps/aevatar-console-web run tsc`
- Browser verified on `http://127.0.0.1:5173` with the frontend connected to `https://aevatar-console-backend-api.aevatar.ai`:
  - Teams home only shows the `AI Team` metric card.
  - Team detail tabs are `概览` and `团队成员`.
  - Team Members exposes `Edit in Studio` and `Build`.
  - Studio preserves `returnTo` and returns to `tab=members`.

## Notes

- The only observed browser console warning was the existing Ant Design `Alert` deprecation warning.
