### PR TITLE
iter22 cluster-004: ExternalLinkManager reconnect via actor-owned internal events

### DIFF
--- a/src/Aevatar.Foundation.Abstractions/ExternalLinks/external_link_messages.proto
+++ b/src/Aevatar.Foundation.Abstractions/ExternalLinks/external_link_messages.proto
@@ -45,3 +45,24 @@ message ExternalLinkMessageReceivedEvent {
   bytes raw_payload = 3;
   google.protobuf.Timestamp received_at = 4;
 }
+
+// --- Internal callback signals (Infrastructure → Actor turn) ---
+
+message ExternalLinkReconnectDueSignal {
+  string link_id = 1;
+  int32 expected_attempt = 2;
+}
+
+enum ExternalLinkTransportStateSignalKind {
+  EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_UNSPECIFIED = 0;
+  EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_CONNECTED = 1;
+  EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_DISCONNECTED = 2;
+  EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_ERROR = 3;
+  EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_CLOSED = 4;
+}
+
+message ExternalLinkTransportStateChangedSignal {
+  string link_id = 1;
+  ExternalLinkTransportStateSignalKind state = 2;
+  string reason = 3;
+}

--- a/src/Aevatar.Foundation.Abstractions/ExternalLinks/external_link_messages.proto
+++ b/src/Aevatar.Foundation.Abstractions/ExternalLinks/external_link_messages.proto
@@ -48,11 +48,17 @@ message ExternalLinkMessageReceivedEvent {
 
 // --- Internal callback signals (Infrastructure → Actor turn) ---
 
+// Refactor (iter22/cluster-004):
+//   Old pattern: reconnect delay completion was represented by a background task mutating link state directly.
+//   New principle: delay completion is a typed self signal with the expected attempt for actor-turn reconciliation.
 message ExternalLinkReconnectDueSignal {
   string link_id = 1;
   int32 expected_attempt = 2;
 }
 
+// Refactor (iter22/cluster-004):
+//   Old pattern: transport callback state was passed straight into manager mutation from the callback thread.
+//   New principle: callback state is captured as a protobuf enum so the actor turn owns the transition.
 enum ExternalLinkTransportStateSignalKind {
   EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_UNSPECIFIED = 0;
   EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_CONNECTED = 1;
@@ -61,6 +67,9 @@ enum ExternalLinkTransportStateSignalKind {
   EXTERNAL_LINK_TRANSPORT_STATE_SIGNAL_KIND_CLOSED = 4;
 }
 
+// Refactor (iter22/cluster-004):
+//   Old pattern: transport state callbacks directly toggled connection flags and scheduled reconnect work.
+//   New principle: transport callbacks dispatch this typed signal; the actor turn validates the link and applies state.
 message ExternalLinkTransportStateChangedSignal {
   string link_id = 1;
   ExternalLinkTransportStateSignalKind state = 2;

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
@@ -1,5 +1,6 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -18,10 +19,16 @@ namespace Aevatar.Foundation.Core.ExternalLinks;
 /// - No authentication credential refresh.
 /// - Outbound SendAsync failures are surfaced as exceptions to the caller.
 /// </summary>
+// Refactor (iter22/cluster-004):
+//   Old pattern: External link reconnect loop ran on Task.Run, slept with Task.Delay, and mutated ManagedLink outside the actor turn.
+//   New principle: callbacks dispatch typed signals with link id and attempt; actor-turn code validates current state before mutating.
 internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
 {
+    private const string ReconnectCallbackPrefix = "external-link-reconnect";
+
     private readonly string _actorId;
     private readonly IActorDispatchPort _dispatchPort;
+    private readonly IActorRuntimeCallbackScheduler _callbackScheduler;
     private readonly IEnumerable<IExternalLinkTransportFactory> _transportFactories;
     private readonly ILogger _logger;
     private readonly Dictionary<string, ManagedLink> _links = new();
@@ -29,13 +36,39 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
     public ExternalLinkManager(
         string actorId,
         IActorDispatchPort dispatchPort,
+        IActorRuntimeCallbackScheduler callbackScheduler,
         IEnumerable<IExternalLinkTransportFactory> transportFactories,
         ILogger logger)
     {
         _actorId = actorId;
         _dispatchPort = dispatchPort;
+        _callbackScheduler = callbackScheduler;
         _transportFactories = transportFactories;
         _logger = logger;
+    }
+
+    public bool CanHandle(EventEnvelope envelope)
+    {
+        if (envelope.Payload == null)
+            return false;
+
+        return envelope.Payload.Is(ExternalLinkReconnectDueSignal.Descriptor)
+               || envelope.Payload.Is(ExternalLinkTransportStateChangedSignal.Descriptor);
+    }
+
+    public async Task HandleAsync(EventEnvelope envelope, CancellationToken ct = default)
+    {
+        if (envelope.Payload == null)
+            return;
+
+        if (envelope.Payload.Is(ExternalLinkReconnectDueSignal.Descriptor))
+        {
+            await HandleReconnectDueAsync(envelope.Payload.Unpack<ExternalLinkReconnectDueSignal>(), ct);
+            return;
+        }
+
+        if (envelope.Payload.Is(ExternalLinkTransportStateChangedSignal.Descriptor))
+            await HandleTransportStateChangedAsync(envelope.Payload.Unpack<ExternalLinkTransportStateChangedSignal>(), ct);
     }
 
     // ── Lifecycle ─────────────────────────────────────────────
@@ -57,7 +90,8 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             _links[descriptor.LinkId] = link;
 
             transport.OnMessageReceived = (data, innerCt) => OnMessageReceivedAsync(link, data, innerCt);
-            transport.OnStateChanged = (state, reason, innerCt) => OnStateChangedAsync(link, state, reason, innerCt);
+            transport.OnStateChanged = (state, reason, innerCt) =>
+                OnTransportStateChangedSignalAsync(link.Descriptor.LinkId, state, reason, innerCt);
 
             await ConnectLinkAsync(link, ct);
         }
@@ -66,7 +100,10 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         foreach (var link in _links.Values)
+        {
+            await CancelReconnectAsync(link, CancellationToken.None);
             await link.DisposeAsync();
+        }
 
         _links.Clear();
     }
@@ -90,6 +127,7 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
     {
         var link = GetLink(linkId);
         link.IsClosed = true;
+        await CancelReconnectAsync(link, ct);
         link.LifetimeCts.Cancel();
         await link.Transport.DisconnectAsync(ct);
     }
@@ -103,6 +141,7 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             await link.Transport.ConnectAsync(link.Descriptor, ct);
             link.IsConnected = true;
             link.ReconnectAttempt = 0;
+            await CancelReconnectAsync(link, ct);
             await DispatchEventAsync(new ExternalLinkConnectedEvent
             {
                 LinkId = link.Descriptor.LinkId,
@@ -113,68 +152,82 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         {
             _logger.LogWarning(ex, "Failed to connect link '{LinkId}'", link.Descriptor.LinkId);
             link.IsConnected = false;
-            StartReconnectLoop(link);
+            await ScheduleReconnectAsync(link, nextAttempt: 1, ct);
         }
     }
 
     // ── Reconnection ──────────────────────────────────────────
 
-    private void StartReconnectLoop(ManagedLink link)
+    private async Task ScheduleReconnectAsync(ManagedLink link, int nextAttempt, CancellationToken ct)
     {
-        if (link.IsClosed) return;
-        var ct = link.LifetimeCts.Token;
-        _ = Task.Run(async () => await ReconnectLoopAsync(link, ct), ct);
-    }
+        if (link.IsClosed)
+            return;
 
-    private async Task ReconnectLoopAsync(ManagedLink link, CancellationToken ct)
-    {
+        link.ReconnectAttempt = nextAttempt;
         var options = link.Descriptor.Options ?? new ExternalLinkOptions();
-
-        while (!ct.IsCancellationRequested && !link.IsClosed)
+        if (options.MaxReconnectAttempts > 0 && nextAttempt > options.MaxReconnectAttempts)
         {
-            link.ReconnectAttempt++;
-            if (options.MaxReconnectAttempts > 0 && link.ReconnectAttempt > options.MaxReconnectAttempts)
-            {
-                await DispatchEventAsync(new ExternalLinkDisconnectedEvent
-                {
-                    LinkId = link.Descriptor.LinkId,
-                    Reason = "max reconnect attempts reached",
-                    WillReconnect = false,
-                    ReconnectAttempt = link.ReconnectAttempt,
-                }, ct);
-                return;
-            }
-
-            var delay = CalculateBackoff(link.ReconnectAttempt, options);
-            await DispatchEventAsync(new ExternalLinkReconnectingEvent
+            await DispatchEventAsync(new ExternalLinkDisconnectedEvent
             {
                 LinkId = link.Descriptor.LinkId,
-                Attempt = link.ReconnectAttempt,
-                DelayMs = (int)delay.TotalMilliseconds,
+                Reason = "max reconnect attempts reached",
+                WillReconnect = false,
+                ReconnectAttempt = nextAttempt,
             }, ct);
+            return;
+        }
 
-            try
+        var delay = CalculateBackoff(nextAttempt, options);
+        await DispatchEventAsync(new ExternalLinkReconnectingEvent
+        {
+            LinkId = link.Descriptor.LinkId,
+            Attempt = nextAttempt,
+            DelayMs = (int)delay.TotalMilliseconds,
+        }, ct);
+
+        var signal = new ExternalLinkReconnectDueSignal
+        {
+            LinkId = link.Descriptor.LinkId,
+            ExpectedAttempt = nextAttempt,
+        };
+        link.ReconnectLease = await ScheduleSignalAfterDelayAsync(
+            BuildReconnectCallbackId(link.Descriptor.LinkId),
+            delay,
+            signal,
+            ct);
+    }
+
+    private async Task HandleReconnectDueAsync(
+        ExternalLinkReconnectDueSignal signal,
+        CancellationToken ct)
+    {
+        if (!_links.TryGetValue(signal.LinkId, out var link))
+            return;
+
+        if (link.IsClosed || link.IsConnected || signal.ExpectedAttempt != link.ReconnectAttempt)
+            return;
+
+        try
+        {
+            await link.Transport.ConnectAsync(link.Descriptor, ct);
+            link.IsConnected = true;
+            link.ReconnectAttempt = 0;
+            await CancelReconnectAsync(link, ct);
+            await DispatchEventAsync(new ExternalLinkConnectedEvent
             {
-                await Task.Delay(delay, ct);
-                await link.Transport.ConnectAsync(link.Descriptor, ct);
-                link.IsConnected = true;
-                link.ReconnectAttempt = 0;
-                await DispatchEventAsync(new ExternalLinkConnectedEvent
-                {
-                    LinkId = link.Descriptor.LinkId,
-                    ConnectedAt = Timestamp.FromDateTime(DateTime.UtcNow),
-                }, ct);
-                return; // connected
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Reconnect attempt {Attempt} failed for link '{LinkId}'",
-                    link.ReconnectAttempt, link.Descriptor.LinkId);
-            }
+                LinkId = link.Descriptor.LinkId,
+                ConnectedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            }, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex, "Reconnect attempt {Attempt} failed for link '{LinkId}'",
+                signal.ExpectedAttempt, link.Descriptor.LinkId);
+            await ScheduleReconnectAsync(link, signal.ExpectedAttempt + 1, ct);
         }
     }
 
@@ -210,6 +263,7 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             case ExternalLinkStateChange.Connected:
                 link.IsConnected = true;
                 link.ReconnectAttempt = 0;
+                await CancelReconnectAsync(link, ct);
                 await DispatchEventAsync(new ExternalLinkConnectedEvent
                 {
                     LinkId = link.Descriptor.LinkId,
@@ -228,7 +282,7 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
                     ReconnectAttempt = link.ReconnectAttempt,
                 }, ct);
                 if (willReconnect)
-                    StartReconnectLoop(link);
+                    await ScheduleReconnectAsync(link, link.ReconnectAttempt + 1, ct);
                 break;
 
             case ExternalLinkStateChange.Error:
@@ -242,6 +296,7 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             case ExternalLinkStateChange.Closed:
                 link.IsClosed = true;
                 link.IsConnected = false;
+                await CancelReconnectAsync(link, ct);
                 await DispatchEventAsync(new ExternalLinkDisconnectedEvent
                 {
                     LinkId = link.Descriptor.LinkId,
@@ -249,6 +304,78 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
                     WillReconnect = false,
                 }, ct);
                 break;
+        }
+    }
+
+    private async Task HandleTransportStateChangedAsync(
+        ExternalLinkTransportStateChangedSignal signal,
+        CancellationToken ct)
+    {
+        if (!_links.TryGetValue(signal.LinkId, out var link))
+            return;
+
+        await OnStateChangedAsync(link, ToTransportStateChange(signal.State), EmptyToNull(signal.Reason), ct);
+    }
+
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: transport callbacks directly mutated ManagedLink or started reconnect loops from I/O callback threads.
+    //   New principle: callbacks only signal the actor inbox; state changes happen when the signal is handled in the actor turn.
+    private Task OnTransportStateChangedSignalAsync(
+        string linkId,
+        ExternalLinkStateChange state,
+        string? reason,
+        CancellationToken ct)
+    {
+        var signal = new ExternalLinkTransportStateChangedSignal
+        {
+            LinkId = linkId,
+            State = ToSignalKind(state),
+            Reason = reason ?? string.Empty,
+        };
+        return DispatchSignalAsync(signal, ct);
+    }
+
+    private Task<RuntimeCallbackLease> ScheduleSignalAfterDelayAsync(
+        string callbackId,
+        TimeSpan delay,
+        IMessage signal,
+        CancellationToken ct)
+    {
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(signal),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(_actorId, TopologyAudience.Self),
+        };
+
+        return _callbackScheduler.ScheduleTimeoutAsync(
+            new RuntimeCallbackTimeoutRequest
+            {
+                ActorId = _actorId,
+                CallbackId = callbackId,
+                TriggerEnvelope = envelope,
+                DueTime = delay,
+            },
+            ct);
+    }
+
+    private async Task CancelReconnectAsync(ManagedLink link, CancellationToken ct)
+    {
+        if (link.ReconnectLease == null)
+            return;
+
+        try
+        {
+            await _callbackScheduler.CancelAsync(link.ReconnectLease, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "Failed to cancel reconnect callback for link '{LinkId}'", link.Descriptor.LinkId);
+        }
+        finally
+        {
+            link.ReconnectLease = null;
         }
     }
 
@@ -271,6 +398,19 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         return null;
     }
 
+    private Task DispatchSignalAsync(IMessage signal, CancellationToken ct)
+    {
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(signal),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(_actorId, TopologyAudience.Self),
+        };
+
+        return _dispatchPort.DispatchAsync(_actorId, envelope, ct);
+    }
+
     private Task DispatchEventAsync(IMessage evt, CancellationToken ct)
     {
         var envelope = new EventEnvelope
@@ -283,4 +423,29 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
 
         return _dispatchPort.DispatchAsync(_actorId, envelope, ct);
     }
+
+    private static string BuildReconnectCallbackId(string linkId) => $"{ReconnectCallbackPrefix}:{linkId}";
+
+    private static string? EmptyToNull(string value) =>
+        string.IsNullOrEmpty(value) ? null : value;
+
+    private static ExternalLinkTransportStateSignalKind ToSignalKind(ExternalLinkStateChange state) =>
+        state switch
+        {
+            ExternalLinkStateChange.Connected => ExternalLinkTransportStateSignalKind.Connected,
+            ExternalLinkStateChange.Disconnected => ExternalLinkTransportStateSignalKind.Disconnected,
+            ExternalLinkStateChange.Error => ExternalLinkTransportStateSignalKind.Error,
+            ExternalLinkStateChange.Closed => ExternalLinkTransportStateSignalKind.Closed,
+            _ => ExternalLinkTransportStateSignalKind.Unspecified,
+        };
+
+    private static ExternalLinkStateChange ToTransportStateChange(ExternalLinkTransportStateSignalKind state) =>
+        state switch
+        {
+            ExternalLinkTransportStateSignalKind.Connected => ExternalLinkStateChange.Connected,
+            ExternalLinkTransportStateSignalKind.Disconnected => ExternalLinkStateChange.Disconnected,
+            ExternalLinkTransportStateSignalKind.Error => ExternalLinkStateChange.Error,
+            ExternalLinkTransportStateSignalKind.Closed => ExternalLinkStateChange.Closed,
+            _ => ExternalLinkStateChange.Error,
+        };
 }

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
@@ -48,6 +48,9 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         _logger = logger;
     }
 
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: callback envelopes were indistinguishable from user-observable events in the normal handler pipeline.
+    //   New principle: the manager advertises only its typed internal callback signals for actor-turn short-circuiting.
     public bool CanHandle(EventEnvelope envelope)
     {
         if (envelope.Payload == null)
@@ -57,6 +60,9 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
                || envelope.Payload.Is(ExternalLinkTransportStateChangedSignal.Descriptor);
     }
 
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: callback work could continue on background threads after transport callbacks or delayed reconnect loops.
+    //   New principle: internal callback envelopes are unpacked and handled as explicit actor-turn signals.
     public async Task HandleAsync(EventEnvelope envelope, CancellationToken ct = default)
     {
         if (envelope.Payload == null)
@@ -135,6 +141,9 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
 
     // ── Connection ────────────────────────────────────────────
 
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: a failed connect started a background reconnect loop from inside the connection helper.
+    //   New principle: failed connects schedule one typed reconnect callback that must re-enter the actor turn.
     private async Task ConnectLinkAsync(ManagedLink link, CancellationToken ct)
     {
         try
@@ -262,6 +271,9 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         await DispatchEventAsync(evt, ct);
     }
 
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: transport state callbacks directly changed link state and started reconnect loops.
+    //   New principle: this state transition method is only reached after a typed state signal is consumed in the actor turn.
     private async Task OnStateChangedAsync(
         ManagedLink link, ExternalLinkStateChange state, string? reason, CancellationToken ct)
     {

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
@@ -135,7 +135,6 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         var link = GetLink(linkId);
         link.IsClosed = true;
         await CancelReconnectAsync(link, ct);
-        link.LifetimeCts.Cancel();
         await link.Transport.DisconnectAsync(ct);
     }
 

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
@@ -1,6 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.ExternalLinks;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core.Pipeline;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -158,6 +159,9 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
 
     // ── Reconnection ──────────────────────────────────────────
 
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: reconnect scheduling created a background loop that slept and mutated link state outside actor handling.
+    //   New principle: scheduling records the expected attempt and asks the runtime callback scheduler to send a typed self signal.
     private async Task ScheduleReconnectAsync(ManagedLink link, int nextAttempt, CancellationToken ct)
     {
         if (link.IsClosed)
@@ -197,6 +201,9 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             ct);
     }
 
+    // Refactor (iter22/cluster-004):
+    //   Old pattern: reconnect retry logic ran in a long-lived background task with stale in-memory access to ManagedLink.
+    //   New principle: each retry is a checked actor-turn signal; stale attempts are ignored before any transport mutation.
     private async Task HandleReconnectDueAsync(
         ExternalLinkReconnectDueSignal signal,
         CancellationToken ct)
@@ -341,20 +348,12 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         IMessage signal,
         CancellationToken ct)
     {
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-            Payload = Any.Pack(signal),
-            Route = EnvelopeRouteSemantics.CreateTopologyPublication(_actorId, TopologyAudience.Self),
-        };
-
         return _callbackScheduler.ScheduleTimeoutAsync(
             new RuntimeCallbackTimeoutRequest
             {
                 ActorId = _actorId,
                 CallbackId = callbackId,
-                TriggerEnvelope = envelope,
+                TriggerEnvelope = SelfEventEnvelopeFactory.Create(_actorId, signal),
                 DueTime = delay,
             },
             ct);
@@ -400,27 +399,13 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
 
     private Task DispatchSignalAsync(IMessage signal, CancellationToken ct)
     {
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-            Payload = Any.Pack(signal),
-            Route = EnvelopeRouteSemantics.CreateTopologyPublication(_actorId, TopologyAudience.Self),
-        };
-
+        var envelope = SelfEventEnvelopeFactory.Create(_actorId, signal);
         return _dispatchPort.DispatchAsync(_actorId, envelope, ct);
     }
 
     private Task DispatchEventAsync(IMessage evt, CancellationToken ct)
     {
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-            Payload = Any.Pack(evt),
-            Route = EnvelopeRouteSemantics.CreateTopologyPublication(_actorId, TopologyAudience.Self),
-        };
-
+        var envelope = SelfEventEnvelopeFactory.Create(_actorId, evt);
         return _dispatchPort.DispatchAsync(_actorId, envelope, ct);
     }
 

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ManagedLink.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ManagedLink.cs
@@ -1,10 +1,14 @@
 using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 
 namespace Aevatar.Foundation.Core.ExternalLinks;
 
 /// <summary>
 /// Runtime state for a single external connection managed by <see cref="ExternalLinkManager"/>.
 /// </summary>
+// Refactor (iter22/cluster-004):
+//   Old pattern: background reconnect callbacks mutated these fields while sleeping outside the actor turn.
+//   New principle: fields are changed only by ExternalLinkManager while handling typed actor-turn signals.
 internal sealed class ManagedLink : IAsyncDisposable
 {
     public ExternalLinkDescriptor Descriptor { get; }
@@ -13,6 +17,7 @@ internal sealed class ManagedLink : IAsyncDisposable
     public int ReconnectAttempt { get; set; }
     public bool IsConnected { get; set; }
     public bool IsClosed { get; set; }
+    public RuntimeCallbackLease? ReconnectLease { get; set; }
 
     public ManagedLink(ExternalLinkDescriptor descriptor, IExternalLinkTransport transport)
     {

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ManagedLink.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ManagedLink.cs
@@ -13,7 +13,6 @@ internal sealed class ManagedLink : IAsyncDisposable
 {
     public ExternalLinkDescriptor Descriptor { get; }
     public IExternalLinkTransport Transport { get; }
-    public CancellationTokenSource LifetimeCts { get; } = new();
     public int ReconnectAttempt { get; set; }
     public bool IsConnected { get; set; }
     public bool IsClosed { get; set; }
@@ -27,8 +26,6 @@ internal sealed class ManagedLink : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        LifetimeCts.Cancel();
-        LifetimeCts.Dispose();
         try
         {
             await Transport.DisposeAsync();

--- a/src/Aevatar.Foundation.Core/GAgentBase.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.cs
@@ -126,6 +126,9 @@ public abstract class GAgentBase : IAgent, IEventModuleContainer<IEventHandlerCo
         try
         {
             var ctx = CreateHandlerContext(envelope);
+            // Refactor (iter22/cluster-004):
+            //   Old pattern: internal external-link callback envelopes could fall through the normal handler/module pipeline.
+            //   New principle: external-link self signals are consumed by the manager before user handlers observe them.
             if (_externalLinkManager?.CanHandle(envelope) == true)
             {
                 await _externalLinkManager.HandleAsync(envelope, ct);

--- a/src/Aevatar.Foundation.Core/GAgentBase.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.cs
@@ -126,6 +126,12 @@ public abstract class GAgentBase : IAgent, IEventModuleContainer<IEventHandlerCo
         try
         {
             var ctx = CreateHandlerContext(envelope);
+            if (_externalLinkManager?.CanHandle(envelope) == true)
+            {
+                await _externalLinkManager.HandleAsync(envelope, ct);
+                return;
+            }
+
             var pipeline = GetOrBuildPipeline();
 
             foreach (var handler in pipeline)
@@ -496,8 +502,18 @@ public abstract class GAgentBase : IAgent, IEventModuleContainer<IEventHandlerCo
             return;
         }
 
+        var callbackScheduler = Services.GetService<IActorRuntimeCallbackScheduler>();
+        if (callbackScheduler == null)
+        {
+            Logger.LogWarning("IActorRuntimeCallbackScheduler not available, external links disabled for {AgentId}", Id);
+            return;
+        }
+
         var factories = Services.GetServices<IExternalLinkTransportFactory>();
-        _externalLinkManager = new ExternalLinkManager(Id, dispatchPort, factories, Logger);
+        _externalLinkManager = new ExternalLinkManager(Id, dispatchPort, callbackScheduler, factories, Logger);
+        // Refactor (iter22/cluster-004):
+        //   Old pattern: External link reconnect callbacks mutated runtime state from background threads.
+        //   New principle: reconnect callback signals are short-circuited into the manager during the actor event turn.
         await _externalLinkManager.StartAsync(descriptors, ct);
     }
 

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -1,0 +1,206 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core.ExternalLinks;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Foundation.Core.Tests;
+
+public sealed class ExternalLinkManagerTests
+{
+    [Fact]
+    public async Task StartAsync_WhenInitialConnectFails_ShouldScheduleTypedReconnectSignal()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var manager = CreateManager(dispatch, callbacks, transport);
+
+        await manager.StartAsync([Descriptor()]);
+
+        transport.ConnectCalls.Should().Be(1);
+        callbacks.Timeouts.Should().ContainSingle();
+        var request = callbacks.Timeouts[0];
+        request.ActorId.Should().Be("actor-1");
+        request.CallbackId.Should().Be("external-link-reconnect:link-1");
+        var signal = request.TriggerEnvelope.Payload.Unpack<ExternalLinkReconnectDueSignal>();
+        signal.LinkId.Should().Be("link-1");
+        signal.ExpectedAttempt.Should().Be(1);
+        dispatch.Payloads.OfType<ExternalLinkReconnectingEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1" && e.Attempt == 1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenReconnectSignalIsStale_ShouldNotReconnect()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+
+        await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
+        {
+            LinkId = "link-1",
+            ExpectedAttempt = 2,
+        }));
+
+        transport.ConnectCalls.Should().Be(1);
+        dispatch.Payloads.OfType<ExternalLinkConnectedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenReconnectSignalMatchesActiveAttempt_ShouldReconnectAndResetState()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+
+        await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
+        {
+            LinkId = "link-1",
+            ExpectedAttempt = 1,
+        }));
+
+        transport.ConnectCalls.Should().Be(2);
+        dispatch.Payloads.OfType<ExternalLinkConnectedEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1");
+
+        await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
+        {
+            LinkId = "link-1",
+            ExpectedAttempt = 1,
+        }));
+
+        transport.ConnectCalls.Should().Be(2);
+    }
+
+    private static ExternalLinkManager CreateManager(
+        RecordingDispatchPort dispatch,
+        RecordingCallbackScheduler callbacks,
+        RecordingTransport transport) =>
+        new(
+            "actor-1",
+            dispatch,
+            callbacks,
+            [new RecordingTransportFactory(transport)],
+            NullLogger.Instance);
+
+    private static ExternalLinkDescriptor Descriptor() =>
+        new(
+            "link-1",
+            "recording",
+            "memory://link",
+            new ExternalLinkOptions
+            {
+                ReconnectBaseDelay = TimeSpan.FromMilliseconds(100),
+                ReconnectMaxDelay = TimeSpan.FromMilliseconds(100),
+                MaxReconnectAttempts = 3,
+            });
+
+    private static EventEnvelope Envelope(IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication("actor-1", TopologyAudience.Self),
+        };
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public List<IMessage> Payloads { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            actorId.Should().Be("actor-1");
+            envelope.Payload.Should().NotBeNull();
+            Payloads.Add(Unpack(envelope.Payload));
+            return Task.CompletedTask;
+        }
+
+        private static IMessage Unpack(Any payload)
+        {
+            if (payload.Is(ExternalLinkConnectedEvent.Descriptor))
+                return payload.Unpack<ExternalLinkConnectedEvent>();
+            if (payload.Is(ExternalLinkDisconnectedEvent.Descriptor))
+                return payload.Unpack<ExternalLinkDisconnectedEvent>();
+            if (payload.Is(ExternalLinkReconnectingEvent.Descriptor))
+                return payload.Unpack<ExternalLinkReconnectingEvent>();
+            if (payload.Is(ExternalLinkErrorEvent.Descriptor))
+                return payload.Unpack<ExternalLinkErrorEvent>();
+            if (payload.Is(ExternalLinkMessageReceivedEvent.Descriptor))
+                return payload.Unpack<ExternalLinkMessageReceivedEvent>();
+            if (payload.Is(ExternalLinkReconnectDueSignal.Descriptor))
+                return payload.Unpack<ExternalLinkReconnectDueSignal>();
+            if (payload.Is(ExternalLinkTransportStateChangedSignal.Descriptor))
+                return payload.Unpack<ExternalLinkTransportStateChangedSignal>();
+
+            throw new InvalidOperationException($"Unexpected payload '{payload.TypeUrl}'.");
+        }
+    }
+
+    private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            Timeouts.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingTransportFactory(RecordingTransport transport) : IExternalLinkTransportFactory
+    {
+        public bool CanCreate(string transportType) => transportType == "recording";
+        public IExternalLinkTransport Create() => transport;
+    }
+
+    private sealed class RecordingTransport : IExternalLinkTransport
+    {
+        public int ConnectCalls { get; private set; }
+        public int ConnectFailuresRemaining { get; set; }
+        public string TransportType => "recording";
+        public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { private get; set; }
+        public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { private get; set; }
+
+        public Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
+        {
+            ConnectCalls++;
+            if (ConnectFailuresRemaining > 0)
+            {
+                ConnectFailuresRemaining--;
+                throw new InvalidOperationException("connect-failed");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct) => Task.CompletedTask;
+        public Task DisconnectAsync(CancellationToken ct) => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -48,6 +48,30 @@ public sealed class ExternalLinkManagerTests
     }
 
     [Fact]
+    public async Task TransportCallback_WhenStateChanges_ShouldDispatchTypedSelfSignal()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport();
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        dispatch.Payloads.Clear();
+
+        await transport.EmitStateChangedAsync(
+            ExternalLinkStateChange.Disconnected,
+            "socket-lost",
+            CancellationToken.None);
+
+        dispatch.Payloads.OfType<ExternalLinkTransportStateChangedSignal>()
+            .Should().ContainSingle(signal =>
+                signal.LinkId == "link-1" &&
+                signal.State == ExternalLinkTransportStateSignalKind.Disconnected &&
+                signal.Reason == "socket-lost");
+        dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>().Should().BeEmpty();
+        callbacks.Timeouts.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenReconnectSignalIsStale_ShouldNotReconnect()
     {
         var dispatch = new RecordingDispatchPort();
@@ -92,6 +116,62 @@ public sealed class ExternalLinkManagerTests
         }));
 
         transport.ConnectCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenReconnectAttemptFails_ShouldPublishAndScheduleNextAttempt()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 2 };
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        callbacks.Timeouts.Should().ContainSingle();
+        dispatch.Payloads.Clear();
+
+        await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
+        {
+            LinkId = "link-1",
+            ExpectedAttempt = 1,
+        }));
+
+        transport.ConnectCalls.Should().Be(2);
+        callbacks.Timeouts.Should().HaveCount(2);
+        var nextRequest = callbacks.Timeouts[1];
+        nextRequest.CallbackId.Should().Be("external-link-reconnect:link-1");
+        var nextSignal = nextRequest.TriggerEnvelope.Payload.Unpack<ExternalLinkReconnectDueSignal>();
+        nextSignal.LinkId.Should().Be("link-1");
+        nextSignal.ExpectedAttempt.Should().Be(2);
+        dispatch.Payloads.OfType<ExternalLinkReconnectingEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1" && e.Attempt == 2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenReconnectAttemptExceedsMaximum_ShouldPublishTerminalDisconnectedWithoutScheduling()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 4 };
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor(maxReconnectAttempts: 1)]);
+        callbacks.Timeouts.Should().ContainSingle();
+        dispatch.Payloads.Clear();
+
+        await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
+        {
+            LinkId = "link-1",
+            ExpectedAttempt = 1,
+        }));
+
+        transport.ConnectCalls.Should().Be(2);
+        callbacks.Timeouts.Should().ContainSingle();
+        dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>()
+            .Should().ContainSingle(e =>
+                e.LinkId == "link-1" &&
+                e.Reason == "max reconnect attempts reached" &&
+                !e.WillReconnect &&
+                e.ReconnectAttempt == 2);
+        dispatch.Payloads.OfType<ExternalLinkReconnectingEvent>().Should().BeEmpty();
     }
 
     [Fact]
@@ -191,7 +271,7 @@ public sealed class ExternalLinkManagerTests
             [new RecordingTransportFactory(transport)],
             NullLogger.Instance);
 
-    private static ExternalLinkDescriptor Descriptor() =>
+    private static ExternalLinkDescriptor Descriptor(int maxReconnectAttempts = 3) =>
         new(
             "link-1",
             "recording",
@@ -200,7 +280,7 @@ public sealed class ExternalLinkManagerTests
             {
                 ReconnectBaseDelay = TimeSpan.FromMilliseconds(100),
                 ReconnectMaxDelay = TimeSpan.FromMilliseconds(100),
-                MaxReconnectAttempts = 3,
+                MaxReconnectAttempts = maxReconnectAttempts,
             });
 
     private static EventEnvelope Envelope(IMessage payload) =>
@@ -306,6 +386,15 @@ public sealed class ExternalLinkManagerTests
         public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct) => Task.CompletedTask;
         public Task DisconnectAsync(CancellationToken ct) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task EmitStateChangedAsync(
+            ExternalLinkStateChange state,
+            string? reason,
+            CancellationToken ct)
+        {
+            OnStateChanged.Should().NotBeNull();
+            return OnStateChanged(state, reason, ct);
+        }
     }
 
     private sealed class TrackingModule : IEventModule<IEventHandlerContext>

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -1,4 +1,6 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.ExternalLinks;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core.ExternalLinks;
@@ -6,11 +8,23 @@ using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.Foundation.Core.Tests;
 
 public sealed class ExternalLinkManagerTests
 {
+    [Fact]
+    public void CanHandle_ShouldRecognizeOnlyExternalLinkInternalSignals()
+    {
+        var manager = CreateManager(new RecordingDispatchPort(), new RecordingCallbackScheduler(), new RecordingTransport());
+
+        manager.CanHandle(Envelope(new ExternalLinkReconnectDueSignal())).Should().BeTrue();
+        manager.CanHandle(Envelope(new ExternalLinkTransportStateChangedSignal())).Should().BeTrue();
+        manager.CanHandle(new EventEnvelope()).Should().BeFalse();
+        manager.CanHandle(Envelope(new ExternalLinkConnectedEvent())).Should().BeFalse();
+    }
+
     [Fact]
     public async Task StartAsync_WhenInitialConnectFails_ShouldScheduleTypedReconnectSignal()
     {
@@ -78,6 +92,92 @@ public sealed class ExternalLinkManagerTests
         }));
 
         transport.ConnectCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTransportDisconnects_ShouldPublishDisconnectedAndScheduleReconnect()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport();
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        dispatch.Payloads.Clear();
+
+        await manager.HandleAsync(Envelope(new ExternalLinkTransportStateChangedSignal
+        {
+            LinkId = "link-1",
+            State = ExternalLinkTransportStateSignalKind.Disconnected,
+            Reason = "socket-lost",
+        }));
+
+        dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>()
+            .Should().ContainSingle(e =>
+                e.LinkId == "link-1" &&
+                e.Reason == "socket-lost" &&
+                e.WillReconnect);
+        dispatch.Payloads.OfType<ExternalLinkReconnectingEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1" && e.Attempt == 1);
+        callbacks.Timeouts.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTransportCloses_ShouldPublishDisconnectedWithoutReconnect()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport();
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        dispatch.Payloads.Clear();
+
+        await manager.HandleAsync(Envelope(new ExternalLinkTransportStateChangedSignal
+        {
+            LinkId = "link-1",
+            State = ExternalLinkTransportStateSignalKind.Closed,
+            Reason = "remote-closed",
+        }));
+
+        dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>()
+            .Should().ContainSingle(e =>
+                e.LinkId == "link-1" &&
+                e.Reason == "remote-closed" &&
+                !e.WillReconnect);
+        dispatch.Payloads.OfType<ExternalLinkReconnectingEvent>().Should().BeEmpty();
+        callbacks.Timeouts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GAgentBaseHandleEventAsync_WhenExternalLinkSignalArrives_ShouldBypassRegularPipeline()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport();
+        var module = new TrackingModule();
+        var agent = new ExternalLinkAwareAgent();
+        agent.SetId("actor-1");
+        agent.Services = TestRuntimeServices.BuildProvider(services =>
+        {
+            services.AddSingleton<IActorDispatchPort>(dispatch);
+            services.AddSingleton<IActorRuntimeCallbackScheduler>(callbacks);
+            services.AddSingleton<IExternalLinkTransportFactory>(new RecordingTransportFactory(transport));
+        });
+        agent.RegisterModule(module);
+        await agent.ActivateAsync();
+        dispatch.Payloads.Clear();
+
+        await agent.HandleEventAsync(Envelope(new ExternalLinkTransportStateChangedSignal
+        {
+            LinkId = "link-1",
+            State = ExternalLinkTransportStateSignalKind.Disconnected,
+            Reason = "socket-lost",
+        }));
+
+        agent.AllEventHandlerCalls.Should().Be(0);
+        module.InvocationCount.Should().Be(0);
+        dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1" && e.WillReconnect);
+        callbacks.Timeouts.Should().ContainSingle();
     }
 
     private static ExternalLinkManager CreateManager(
@@ -148,6 +248,7 @@ public sealed class ExternalLinkManagerTests
     private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
     {
         public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+        public List<RuntimeCallbackLease> CancelledLeases { get; } = [];
 
         public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
             RuntimeCallbackTimeoutRequest request,
@@ -166,8 +267,11 @@ public sealed class ExternalLinkManagerTests
             CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
-            Task.CompletedTask;
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            CancelledLeases.Add(lease);
+            return Task.CompletedTask;
+        }
 
         public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
             Task.CompletedTask;
@@ -202,5 +306,33 @@ public sealed class ExternalLinkManagerTests
         public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct) => Task.CompletedTask;
         public Task DisconnectAsync(CancellationToken ct) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class TrackingModule : IEventModule<IEventHandlerContext>
+    {
+        public string Name => "tracking";
+        public int Priority => 0;
+        public int InvocationCount { get; private set; }
+        public bool CanHandle(EventEnvelope envelope) => true;
+
+        public Task HandleAsync(EventEnvelope envelope, IEventHandlerContext ctx, CancellationToken ct)
+        {
+            InvocationCount++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ExternalLinkAwareAgent : GAgentBase, IExternalLinkAware
+    {
+        public int AllEventHandlerCalls { get; private set; }
+
+        public IReadOnlyList<ExternalLinkDescriptor> GetLinkDescriptors() => [Descriptor()];
+
+        [AllEventHandler(AllowSelfHandling = true)]
+        public Task HandleAny(EventEnvelope envelope)
+        {
+            AllEventHandlerCalls++;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -108,6 +108,10 @@ public sealed class ExternalLinkManagerTests
         transport.ConnectCalls.Should().Be(2);
         dispatch.Payloads.OfType<ExternalLinkConnectedEvent>()
             .Should().ContainSingle(e => e.LinkId == "link-1");
+        callbacks.CancelledLeases.Should().ContainSingle(lease =>
+            lease.ActorId == "actor-1" &&
+            lease.CallbackId == "external-link-reconnect:link-1" &&
+            lease.Generation == 1);
 
         await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
         {
@@ -116,6 +120,40 @@ public sealed class ExternalLinkManagerTests
         }));
 
         transport.ConnectCalls.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_WhenReconnectIsScheduled_ShouldCancelReconnectLease()
+    {
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var manager = CreateManager(new RecordingDispatchPort(), callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        callbacks.Timeouts.Should().ContainSingle();
+
+        await manager.DisconnectAsync("link-1");
+
+        callbacks.CancelledLeases.Should().ContainSingle(lease =>
+            lease.ActorId == "actor-1" &&
+            lease.CallbackId == "external-link-reconnect:link-1" &&
+            lease.Generation == 1);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WhenReconnectIsScheduled_ShouldCancelReconnectLease()
+    {
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var manager = CreateManager(new RecordingDispatchPort(), callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        callbacks.Timeouts.Should().ContainSingle();
+
+        await manager.DisposeAsync();
+
+        callbacks.CancelledLeases.Should().ContainSingle(lease =>
+            lease.ActorId == "actor-1" &&
+            lease.CallbackId == "external-link-reconnect:link-1" &&
+            lease.Generation == 1);
     }
 
     [Fact]
@@ -206,9 +244,10 @@ public sealed class ExternalLinkManagerTests
     {
         var dispatch = new RecordingDispatchPort();
         var callbacks = new RecordingCallbackScheduler();
-        var transport = new RecordingTransport();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
         var manager = CreateManager(dispatch, callbacks, transport);
         await manager.StartAsync([Descriptor()]);
+        callbacks.Timeouts.Should().ContainSingle();
         dispatch.Payloads.Clear();
 
         await manager.HandleAsync(Envelope(new ExternalLinkTransportStateChangedSignal
@@ -224,7 +263,10 @@ public sealed class ExternalLinkManagerTests
                 e.Reason == "remote-closed" &&
                 !e.WillReconnect);
         dispatch.Payloads.OfType<ExternalLinkReconnectingEvent>().Should().BeEmpty();
-        callbacks.Timeouts.Should().BeEmpty();
+        callbacks.CancelledLeases.Should().ContainSingle(lease =>
+            lease.ActorId == "actor-1" &&
+            lease.CallbackId == "external-link-reconnect:link-1" &&
+            lease.Generation == 1);
     }
 
     [Fact]
@@ -258,6 +300,30 @@ public sealed class ExternalLinkManagerTests
         dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>()
             .Should().ContainSingle(e => e.LinkId == "link-1" && e.WillReconnect);
         callbacks.Timeouts.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GAgentBaseDeactivateAsync_WhenReconnectIsScheduled_ShouldCancelReconnectLease()
+    {
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var agent = new ExternalLinkAwareAgent();
+        agent.SetId("actor-1");
+        agent.Services = TestRuntimeServices.BuildProvider(services =>
+        {
+            services.AddSingleton<IActorDispatchPort>(new RecordingDispatchPort());
+            services.AddSingleton<IActorRuntimeCallbackScheduler>(callbacks);
+            services.AddSingleton<IExternalLinkTransportFactory>(new RecordingTransportFactory(transport));
+        });
+        await agent.ActivateAsync();
+        callbacks.Timeouts.Should().ContainSingle();
+
+        await agent.DeactivateAsync();
+
+        callbacks.CancelledLeases.Should().ContainSingle(lease =>
+            lease.ActorId == "actor-1" &&
+            lease.CallbackId == "external-link-reconnect:link-1" &&
+            lease.Generation == 1);
     }
 
     private static ExternalLinkManager CreateManager(

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -72,6 +72,17 @@ public sealed class ExternalLinkManagerTests
     }
 
     [Fact]
+    public void ExternalLinkManagerSource_ShouldNotUseBackgroundReconnectLoopPrimitives()
+    {
+        var sourcePath = FindRepositoryFile("src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs");
+
+        var source = File.ReadAllText(sourcePath);
+
+        source.Should().NotContain("Task." + "Run(");
+        source.Should().NotContain("Task." + "Delay(");
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenReconnectSignalIsStale_ShouldNotReconnect()
     {
         var dispatch = new RecordingDispatchPort();
@@ -436,6 +447,21 @@ public sealed class ExternalLinkManagerTests
             Payload = Any.Pack(payload),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication("actor-1", TopologyAudience.Self),
         };
+
+    private static string FindRepositoryFile(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find repository file '{relativePath}'.");
+    }
 
     private sealed class RecordingDispatchPort : IActorDispatchPort
     {

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -240,6 +240,64 @@ public sealed class ExternalLinkManagerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenTransportConnectsAfterScheduledReconnect_ShouldCancelLeaseAndIgnoreStaleReconnect()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport { ConnectFailuresRemaining = 1 };
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        callbacks.Timeouts.Should().ContainSingle();
+        dispatch.Payloads.Clear();
+
+        await manager.HandleAsync(Envelope(new ExternalLinkTransportStateChangedSignal
+        {
+            LinkId = "link-1",
+            State = ExternalLinkTransportStateSignalKind.Connected,
+        }));
+
+        callbacks.CancelledLeases.Should().ContainSingle(lease =>
+            lease.ActorId == "actor-1" &&
+            lease.CallbackId == "external-link-reconnect:link-1" &&
+            lease.Generation == 1);
+        dispatch.Payloads.OfType<ExternalLinkConnectedEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1");
+
+        await manager.HandleAsync(Envelope(new ExternalLinkReconnectDueSignal
+        {
+            LinkId = "link-1",
+            ExpectedAttempt = 1,
+        }));
+
+        transport.ConnectCalls.Should().Be(1);
+        dispatch.Payloads.OfType<ExternalLinkConnectedEvent>()
+            .Should().ContainSingle(e => e.LinkId == "link-1");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenTransportErrors_ShouldPublishExternalLinkErrorEvent()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var callbacks = new RecordingCallbackScheduler();
+        var transport = new RecordingTransport();
+        var manager = CreateManager(dispatch, callbacks, transport);
+        await manager.StartAsync([Descriptor()]);
+        dispatch.Payloads.Clear();
+
+        await manager.HandleAsync(Envelope(new ExternalLinkTransportStateChangedSignal
+        {
+            LinkId = "link-1",
+            State = ExternalLinkTransportStateSignalKind.Error,
+            Reason = "socket-error",
+        }));
+
+        dispatch.Payloads.OfType<ExternalLinkErrorEvent>()
+            .Should().ContainSingle(e =>
+                e.LinkId == "link-1" &&
+                e.ErrorMessage == "socket-error");
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenTransportCloses_ShouldPublishDisconnectedWithoutReconnect()
     {
         var dispatch = new RecordingDispatchPort();
@@ -300,6 +358,27 @@ public sealed class ExternalLinkManagerTests
         dispatch.Payloads.OfType<ExternalLinkDisconnectedEvent>()
             .Should().ContainSingle(e => e.LinkId == "link-1" && e.WillReconnect);
         callbacks.Timeouts.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GAgentBaseActivateAsync_WhenCallbackSchedulerIsMissing_ShouldDisableExternalLinksWithoutThrowing()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var transport = new RecordingTransport();
+        var agent = new ExternalLinkAwareAgent();
+        agent.SetId("actor-1");
+        var services = new ServiceCollection();
+        services.AddSingleton<IActorDispatchPort>(dispatch);
+        services.AddSingleton<IExternalLinkTransportFactory>(new RecordingTransportFactory(transport));
+        agent.Services = services.BuildServiceProvider();
+
+        var act = () => agent.ActivateAsync();
+
+        await act.Should().NotThrowAsync();
+        transport.ConnectCalls.Should().Be(0);
+        transport.HasStateChangedHandler.Should().BeFalse();
+        transport.HasMessageReceivedHandler.Should().BeFalse();
+        dispatch.Payloads.Should().BeEmpty();
     }
 
     [Fact]
@@ -436,6 +515,8 @@ public sealed class ExternalLinkManagerTests
         public string TransportType => "recording";
         public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { private get; set; }
         public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { private get; set; }
+        public bool HasMessageReceivedHandler => OnMessageReceived != null;
+        public bool HasStateChangedHandler => OnStateChanged != null;
 
         public Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
         {


### PR DESCRIPTION
## Summary / 摘要

### English

iter22 cluster-004-external-link-reconnect-callback (medium, CLAUDE.md §"Actor 执行模型" §"中间层状态约束").

- **Old**: External link reconnect loop ran on `Task.Run`, slept with `Task.Delay`, and mutated `ManagedLink` connection state outside the actor event turn.
- **New**: Reconnect scheduling emits durable/internal callback events with link id + attempt; actor/event-loop code validates active link state and applies connection state changes; callbacks only signal.

Violated: "回调只发信号" + "业务推进内聚" (actor execution model).

### 中文

iter22 cluster-004-external-link-reconnect-callback（中严重度，CLAUDE.md §"Actor 执行模型" §"中间层状态约束"）。

- **Old**:external link reconnect loop 跑在 `Task.Run`，用 `Task.Delay` 睡，从 actor event turn 外修改 `ManagedLink` 连接态。
- **New**:reconnect 调度发出 durable/internal callback event(带 link id + attempt);actor/event-loop 校验活跃 link 态并应用 connection state 变更;回调只发信号。

违反："回调只发信号" + "业务推进内聚"。

## Scope

5 files changed (+464/-51). New `ExternalLinkManagerTests`. Architecture guards green.

See [audit cluster](./.refactor-loop/runs/audit-iter-22.md#cluster-004), [implement summary](./.refactor-loop/runs/implement-iter22-cluster-004.md).

## Stacked-PR

iter22 batch 1. Base = `auto-refact-dev`. Rollup target = `dev`.

🤖 Auto-loop / codex-refactor-loop iter22

⟦AI:AUTO-LOOP⟧
