### PR TITLE
iter22 cluster-003: drop IEventStore + actorId prefix from ScheduledRetiredActorSpec

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/ScheduledRetiredActorSpec.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ScheduledRetiredActorSpec.cs
@@ -2,9 +2,7 @@ using System.Runtime.CompilerServices;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions.Maintenance;
-using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.TypeSystem;
-using Aevatar.Foundation.Core.Compatibility;
 using Aevatar.GAgents.Channel.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -17,16 +15,13 @@ namespace Aevatar.GAgents.Scheduled;
 /// skill-runner / workflow-agent actors previously hosted by the deleted
 /// <c>Aevatar.GAgents.ChannelRuntime</c> assembly.
 ///
-/// Dynamic discovery is gated on the catalog itself looking retired
-/// (matches a retired runtime-type token, or runtime type unavailable but
-/// stream still has events). On a fully-migrated cluster this gate keeps
-/// the catalog walk a no-op even though the cleanup runs every startup.
+/// Dynamic discovery is gated on the catalog itself matching a retired
+/// runtime-type token. On a fully-migrated cluster this gate keeps the catalog
+/// read-model query a no-op even though the cleanup runs every startup.
 ///
-/// When the gate fires, generated agent ids are read from the
-/// <see cref="UserAgentCatalogDocument"/> read model first (survives event
-/// stream snapshot+compaction), and merged with any catalog upsert events
-/// not yet projected. Without the read-model path, snapshotted entries
-/// would be silently dropped after compaction.
+/// Refactor (iter22/cluster-003):
+///   Old pattern: retired actor discovery replayed catalog event streams and parsed actorId prefixes.
+///   New principle: dynamic targets come only from typed catalog read models; actorId stays opaque.
 /// </summary>
 public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
 {
@@ -40,7 +35,6 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
     // and drive their cleanup. New agents never carry these tokens; delete with the
     // retired workflow_agent constants once all legacy actors are gone.
     private const string LegacyWorkflowAgentType = "workflow_agent";
-    private const string LegacyWorkflowAgentActorIdPrefix = "workflow-agent";
     private const int ReadModelPageSize = 500;
 
     public override string SpecId => "scheduled";
@@ -80,23 +74,17 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
         IServiceProvider services,
         [EnumeratorCancellation] CancellationToken ct)
     {
+        // Refactor (iter22/cluster-003):
+        //   Old pattern: dynamic cleanup replayed catalog event streams and inferred actor type from actorId text.
+        //   New principle: cleanup enumerates typed catalog read-model rows and treats actorId as an opaque address.
         var typeProbe = services.GetRequiredService<IActorTypeProbe>();
-        var eventStore = services.GetRequiredService<IEventStore>();
         var logger = services.GetService<ILogger<ScheduledRetiredActorSpec>>()
                      ?? NullLogger<ScheduledRetiredActorSpec>.Instance;
 
-        if (!await ShouldDiscoverFromCatalogAsync(typeProbe, eventStore, ct).ConfigureAwait(false))
+        if (!await ShouldDiscoverFromCatalogAsync(typeProbe, ct).ConfigureAwait(false))
             yield break;
 
-        var agentIds = new HashSet<string>(StringComparer.Ordinal);
-
         foreach (var actorId in await DiscoverFromReadModelBestEffortAsync(services, logger, ct).ConfigureAwait(false))
-            agentIds.Add(actorId);
-
-        foreach (var actorId in await DiscoverFromCatalogEventsAsync(eventStore, ct).ConfigureAwait(false))
-            agentIds.Add(actorId);
-
-        foreach (var actorId in agentIds)
         {
             yield return new RetiredActorTarget(
                 actorId,
@@ -120,7 +108,6 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
 
     private async Task<bool> ShouldDiscoverFromCatalogAsync(
         IActorTypeProbe typeProbe,
-        IEventStore eventStore,
         CancellationToken ct)
     {
         var catalogTarget = Targets.First(static target =>
@@ -132,14 +119,6 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
 
         if (catalogTarget.MatchesRuntimeType(runtimeTypeName))
             return true;
-
-        if (string.IsNullOrWhiteSpace(runtimeTypeName))
-        {
-            var version = await eventStore
-                .GetVersionAsync(UserAgentCatalogGAgent.WellKnownId, ct)
-                .ConfigureAwait(false);
-            return version > 0;
-        }
 
         return false;
     }
@@ -163,12 +142,11 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
         }
         catch (Exception ex)
         {
-            // Read-model probe is the snapshot+compaction patch — never block startup
-            // when the projection store is unavailable. Fall back to event-stream walk;
-            // un-compacted clusters still get cleaned, compacted ones merely degrade.
+            // Read-model discovery is maintenance best effort; failed typed queries
+            // skip dynamic generated-agent cleanup rather than side-reading events.
             logger.LogWarning(
                 ex,
-                "Retired user-agent discovery from {DocumentType} read model failed; falling back to catalog event stream walk.",
+                "Retired user-agent discovery from {DocumentType} read model failed; skipping dynamic generated-agent targets.",
                 nameof(UserAgentCatalogDocument));
             return [];
         }
@@ -211,52 +189,6 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
         return ids.ToArray();
     }
 
-    private static async Task<IReadOnlyList<string>> DiscoverFromCatalogEventsAsync(
-        IEventStore eventStore,
-        CancellationToken ct)
-    {
-        var events = await eventStore
-            .GetEventsAsync(UserAgentCatalogGAgent.WellKnownId, ct: ct)
-            .ConfigureAwait(false);
-        if (events.Count == 0)
-            return [];
-
-        var agentIds = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var evt in events)
-        {
-            if (ProtobufContractCompatibility.TryUnpack<UserAgentCatalogUpsertedEvent>(evt.EventData, out var upserted))
-                AddCatalogAgentId(agentIds, upserted!.Entry);
-            else if (ProtobufContractCompatibility.TryUnpack<UserAgentCatalogTombstonedEvent>(evt.EventData, out var tombstoned))
-                AddCatalogAgentId(agentIds, tombstoned!.AgentId);
-            else if (ProtobufContractCompatibility.TryUnpack<UserAgentCatalogTombstonesCompactedEvent>(
-                         evt.EventData,
-                         out var compacted))
-            {
-                foreach (var agentId in compacted!.AgentIds)
-                    AddCatalogAgentId(agentIds, agentId);
-            }
-        }
-
-        return agentIds.ToArray();
-    }
-
-    private static void AddCatalogAgentId(HashSet<string> agentIds, UserAgentCatalogEntry? entry)
-    {
-        if (entry == null)
-            return;
-
-        if (IsGeneratedUserAgent(entry.AgentId, entry.AgentType))
-            agentIds.Add(entry.AgentId.Trim());
-    }
-
-    private static void AddCatalogAgentId(HashSet<string> agentIds, string? agentId)
-    {
-        if (!IsGeneratedUserAgent(agentId, agentType: null))
-            return;
-
-        agentIds.Add(agentId!.Trim());
-    }
-
     private static bool IsGeneratedUserAgent(string? agentId, string? agentType)
     {
         var normalizedId = agentId?.Trim();
@@ -269,7 +201,6 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
             return true;
         }
 
-        return normalizedId.StartsWith($"{SkillRunnerDefaults.ActorIdPrefix}-", StringComparison.Ordinal) ||
-               normalizedId.StartsWith($"{LegacyWorkflowAgentActorIdPrefix}-", StringComparison.Ordinal);
+        return false;
     }
 }

--- a/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
+++ b/docs/operations/2026-04-28-retired-actor-startup-cleanup-runbook.md
@@ -41,14 +41,13 @@ A spec declares:
 - `Targets` — well-known retired actor ids and the CLR type name tokens that
   identify them as retired.
 - `DiscoverDynamicTargetsAsync` — optional. The Scheduled spec uses this to read
-  the user-agent catalog and surface generated `skill-runner-*` /
-  `workflow-agent-*` actor ids that need cleaning before the catalog itself is
-  destroyed. Discovery is gated on the catalog runtime type still looking
-  retired (or the catalog state being cleared but its event stream still having
-  events) so warm clusters do not pay the catalog walk on every startup.
-  When the gate fires, ids are read from the `UserAgentCatalogDocument` read
-  model first (survives event-stream snapshot+compaction), then merged with
-  any catalog upsert events not yet projected.
+  the typed `UserAgentCatalogDocument` read model and surface generated
+  `skill-runner` / `workflow_agent` entries that need cleaning before the catalog
+  itself is destroyed. Discovery is gated on the catalog runtime type still
+  looking retired so warm clusters do not pay the catalog read-model query on
+  every startup. Actor ids from the read model are treated as opaque addresses;
+  the decision that a row is a generated user agent comes from
+  `UserAgentCatalogDocument.AgentType`.
 - `DeleteReadModelsForActorAsync` — optional. Each module deletes its own typed
   `IProjectionDocumentReader` / `IProjectionWriteDispatcher` documents (no
   cross-module document knowledge).
@@ -77,7 +76,7 @@ reset path).
 |-------------------|-----------------------------------|---------|
 | `channel-runtime` | `Aevatar.GAgents.Channel.Runtime` | `channel-bot-registration-store`, `projection.durable.scope:channel-bot-registration:channel-bot-registration-store` |
 | `device`          | `Aevatar.GAgents.Device`          | `device-registration-store`, `projection.durable.scope:device-registration:device-registration-store` |
-| `scheduled`       | `Aevatar.GAgents.Scheduled`       | `agent-registry-store`, `projection.durable.scope:agent-registry:agent-registry-store` + dynamic `skill-runner-*` / `workflow-agent-*` discovered from the catalog stream |
+| `scheduled`       | `Aevatar.GAgents.Scheduled`       | `agent-registry-store`, `projection.durable.scope:agent-registry:agent-registry-store` + dynamic generated user agents discovered from typed catalog read-model rows |
 
 ## Configuration
 

--- a/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
+++ b/test/Aevatar.Hosting.Tests/RetiredActorCleanupHostedServiceTests.cs
@@ -114,33 +114,21 @@ public sealed class RetiredActorCleanupHostedServiceTests
     public async Task StartAsync_ShouldCleanRetiredUserAgentsDiscoveredFromCatalogBeforeCatalogReset()
     {
         var eventStore = new InMemoryEventStore();
-        await AppendCatalogEventsAsync(eventStore,
-        [
-            new UserAgentCatalogEntry
+        var documents = new RecordingProjectionStore<UserAgentCatalogDocument>(
+            CatalogDocument("skill-runner-old", SkillRunnerDefaults.AgentType),
+            CatalogDocument("workflow-agent-old", "workflow_agent"),
+            CatalogDocument("skill-runner-current", SkillRunnerDefaults.AgentType),
+            CatalogDocument("skill-runner-proxy", SkillRunnerDefaults.AgentType),
+            new UserAgentCatalogDocument
             {
-                AgentId = "skill-runner-old",
-                AgentType = SkillRunnerDefaults.AgentType,
-            },
-            new UserAgentCatalogEntry
-            {
-                AgentId = "workflow-agent-old",
-                AgentType = "workflow_agent",
-            },
-            new UserAgentCatalogEntry
-            {
-                AgentId = "skill-runner-current",
-                AgentType = SkillRunnerDefaults.AgentType,
-            },
-            new UserAgentCatalogEntry
-            {
-                AgentId = "skill-runner-proxy",
-                AgentType = SkillRunnerDefaults.AgentType,
-            },
-        ]);
+                Id = "skill-runner-prefix-only",
+                ActorId = "agent-registry-store",
+            });
         await AppendSingleEventAsync(eventStore, "skill-runner-old");
         await AppendSingleEventAsync(eventStore, "workflow-agent-old");
         await AppendSingleEventAsync(eventStore, "skill-runner-current");
         await AppendSingleEventAsync(eventStore, "skill-runner-proxy");
+        await AppendSingleEventAsync(eventStore, "skill-runner-prefix-only");
 
         var typeProbe = new StubActorTypeProbe(new Dictionary<string, string?>
         {
@@ -154,10 +142,23 @@ public sealed class RetiredActorCleanupHostedServiceTests
                 "Aevatar.GAgents.Scheduled.SkillRunnerGAgent, Aevatar.GAgents.Scheduled",
             ["skill-runner-proxy"] =
                 "Aevatar.GAgents.ChannelRuntime.SkillRunnerGAgentProxy, Aevatar.GAgents.ChannelRuntime",
+            ["skill-runner-prefix-only"] =
+                "Aevatar.GAgents.ChannelRuntime.SkillRunnerGAgent, Aevatar.GAgents.ChannelRuntime",
         });
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddSingleton<Aevatar.Foundation.Abstractions.Persistence.IEventStore>(eventStore);
+        serviceCollection.AddSingleton<IActorTypeProbe>(typeProbe);
+        serviceCollection.AddSingleton<IProjectionDocumentReader<UserAgentCatalogDocument, string>>(documents);
+        serviceCollection.AddSingleton<IProjectionWriteDispatcher<UserAgentCatalogDocument>>(documents);
+
         var runtime = new RecordingActorRuntime();
         var service = CreateService(
-            typeProbe, runtime, new RecordingStreamProvider(), eventStore, CreateScheduledSpec());
+            typeProbe,
+            runtime,
+            new RecordingStreamProvider(),
+            eventStore,
+            CreateScheduledSpec(),
+            serviceCollection.BuildServiceProvider());
 
         await service.StartAsync(CancellationToken.None);
 
@@ -166,10 +167,12 @@ public sealed class RetiredActorCleanupHostedServiceTests
         runtime.DestroyedActorIds.Should().Contain("agent-registry-store");
         runtime.DestroyedActorIds.Should().NotContain("skill-runner-current");
         runtime.DestroyedActorIds.Should().NotContain("skill-runner-proxy");
+        runtime.DestroyedActorIds.Should().NotContain("skill-runner-prefix-only");
         (await eventStore.GetVersionAsync("skill-runner-old")).Should().Be(0);
         (await eventStore.GetVersionAsync("workflow-agent-old")).Should().Be(0);
         (await eventStore.GetVersionAsync("skill-runner-current")).Should().Be(1);
         (await eventStore.GetVersionAsync("skill-runner-proxy")).Should().Be(1);
+        (await eventStore.GetVersionAsync("skill-runner-prefix-only")).Should().Be(1);
         (await eventStore.GetVersionAsync("agent-registry-store")).Should().Be(0);
     }
 
@@ -177,17 +180,9 @@ public sealed class RetiredActorCleanupHostedServiceTests
     public async Task StartAsync_ShouldSkipCatalogWalk_WhenCatalogRuntimeTypeIsAlreadyCurrent()
     {
         // Once the catalog actor is on the new namespace, the cleanup must not
-        // replay agent-registry-store on every startup nor probe per-entry actors —
+        // query agent-registry-store on every startup nor probe per-entry actors —
         // otherwise warm clusters pay an unbounded scan cost forever.
         var eventStore = new InMemoryEventStore();
-        await AppendCatalogEventsAsync(eventStore,
-        [
-            new UserAgentCatalogEntry
-            {
-                AgentId = "skill-runner-already-migrated",
-                AgentType = SkillRunnerDefaults.AgentType,
-            },
-        ]);
         await AppendSingleEventAsync(eventStore, "skill-runner-already-migrated");
 
         var probedActorIds = new List<string>();
@@ -210,10 +205,9 @@ public sealed class RetiredActorCleanupHostedServiceTests
     [Fact]
     public async Task StartAsync_ShouldDiscoverRetiredUserAgentsFromReadModel_WhenCatalogStreamHasBeenCompacted()
     {
-        // Snapshot+compaction can drop the original UserAgentCatalogUpsertedEvent
-        // entries from agent-registry-store. The discovery must still find the
-        // generated actor ids via the projection read model so they are cleaned
-        // before the catalog itself is destroyed.
+        // Refactor (iter22/cluster-003):
+        //   Old pattern: retired actor discovery replayed catalog event streams after read-model lookup.
+        //   New principle: compacted/generated actor cleanup uses typed UserAgentCatalogDocument rows only.
         var eventStore = new InMemoryEventStore();
         // No catalog events — represents the post-compaction scenario.
         await AppendSingleEventAsync(eventStore, "agent-registry-store");
@@ -293,11 +287,10 @@ public sealed class RetiredActorCleanupHostedServiceTests
     }
 
     [Fact]
-    public async Task StartAsync_ShouldFallBackToCatalogEvents_WhenReadModelDiscoveryThrows()
+    public async Task StartAsync_ShouldSkipDynamicTargets_WhenReadModelDiscoveryThrows()
     {
-        // Projection store unavailable (transient error) must NOT abort startup
-        // cleanup. The read-model path is best-effort; the event-stream walk and
-        // static targets must still run.
+        // Projection store unavailable must NOT abort startup cleanup, but it
+        // also must not fall back to catalog event replay as a query path.
         var eventStore = new InMemoryEventStore();
         await AppendCatalogEventsAsync(eventStore,
         [
@@ -334,10 +327,28 @@ public sealed class RetiredActorCleanupHostedServiceTests
 
         await service.StartAsync(CancellationToken.None);
 
-        runtime.DestroyedActorIds.Should().Contain("skill-runner-recent");
+        runtime.DestroyedActorIds.Should().NotContain("skill-runner-recent");
         runtime.DestroyedActorIds.Should().Contain("agent-registry-store");
-        (await eventStore.GetVersionAsync("skill-runner-recent")).Should().Be(0);
+        (await eventStore.GetVersionAsync("skill-runner-recent")).Should().Be(1);
         (await eventStore.GetVersionAsync("agent-registry-store")).Should().Be(0);
+    }
+
+    [Fact]
+    public void ScheduledRetiredActorSpec_ShouldNotReintroduceCatalogEventReplayOrActorIdPrefixClassification()
+    {
+        // Refactor (iter22/cluster-003):
+        //   Old pattern: retired actor discovery used GetEventsAsync/GetVersionAsync and actorId StartsWith.
+        //   New principle: source stays on typed read-model enumeration without actorId pattern facts.
+        var source = File.ReadAllText(GetScheduledRetiredActorSpecSourcePath());
+        var code = StripLineComments(source);
+
+        code.Should().NotContain("IEventStore");
+        code.Should().NotContain("GetVersionAsync");
+        code.Should().NotContain("GetEventsAsync");
+        code.Should().NotContain("DiscoverFromCatalogEventsAsync");
+        code.Should().NotContain("ActorIdPrefix");
+        code.Should().NotContain("LegacyWorkflowAgentActorIdPrefix");
+        code.Should().NotContain("StartsWith");
     }
 
     [Fact]
@@ -629,6 +640,46 @@ public sealed class RetiredActorCleanupHostedServiceTests
             })
             .ToArray();
         return eventStore.AppendAsync("agent-registry-store", events, expectedVersion: 0);
+    }
+
+    private static UserAgentCatalogDocument CatalogDocument(string agentId, string agentType) =>
+        new()
+        {
+            Id = agentId,
+            ActorId = "agent-registry-store",
+            AgentType = agentType,
+        };
+
+    private static string StripLineComments(string source)
+    {
+        var lines = source
+            .Split('\n')
+            .Select(static line =>
+            {
+                var index = line.IndexOf("//", StringComparison.Ordinal);
+                return index >= 0 ? line[..index] : line;
+            });
+        return string.Join('\n', lines);
+    }
+
+    private static string GetScheduledRetiredActorSpecSourcePath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory.FullName,
+                "agents",
+                "Aevatar.GAgents.Scheduled",
+                "ScheduledRetiredActorSpec.cs");
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate ScheduledRetiredActorSpec.cs from {AppContext.BaseDirectory}");
     }
 
     private sealed class StubActorTypeProbe(IReadOnlyDictionary<string, string?> typeNames) : IActorTypeProbe


### PR DESCRIPTION
## Summary / 摘要

### English

iter22 cluster-003-retired-actor-side-read-and-actor-id-prefix (medium, CLAUDE.md §"权威状态 / ReadModel / Projection" §"Actor 生命周期").

- **Old**: `ScheduledRetiredActorSpec` used `IEventStore.GetVersionAsync` + `GetEventsAsync` to fold catalog events from another actor's event store directly; also relied on `actorId` prefix string-pattern fallback.
- **New**: All dynamic discovery routed through typed catalog read-model (`QueryAsync`); `IEventStore` dependency removed; `actorId` prefix fallback removed (actorId opaque to caller).

Violated: "禁止侧读冒充 query" + "`actorId` 对调用方不透明".

### 中文

iter22 cluster-003-retired-actor-side-read-and-actor-id-prefix（中严重度，CLAUDE.md §"权威状态 / ReadModel / Projection" §"Actor 生命周期"）。

- **Old**：`ScheduledRetiredActorSpec` 直接用 `IEventStore.GetVersionAsync` + `GetEventsAsync` 折叠其他 actor 的 event store；还依赖 `actorId` prefix 字符串模式 fallback。
- **New**：所有动态发现走 typed catalog read-model(`QueryAsync`);删除 `IEventStore` 依赖；删除 `actorId` prefix fallback(actorId 对调用方不透明)。

违反："禁止侧读冒充 query" + "`actorId` 对调用方不透明"。

## Scope

3 files changed (+115/-134). Targeted test pass green. Architecture guards green.

See [reflector decision](./.refactor-loop/runs/meta-reflect-issue760.md), [implement summary](./.refactor-loop/runs/implement-iter22-cluster-003.md), [r3 minimal solver framing](./.refactor-loop/runs/phase9-issue760-r3-minimal.md).

## Stacked-PR

iter22 batch 1. Base = `auto-refact-dev`. Rollup target = `dev`.

Closes #760.

🤖 Auto-loop / codex-refactor-loop iter22

⟦AI:AUTO-LOOP⟧
