### PR TITLE
Fix Team Studio member rail scoping

### DIFF
--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -414,6 +414,7 @@ function mockCreateDefaultStudioMembers() {
       lifecycleStage: "bind_ready",
       publishedServiceId: "default",
       lastBoundRevisionId: "rev-2",
+      teamId: "t-alpha",
       createdAt: "2026-04-27T08:00:00Z",
       updatedAt: "2026-04-27T08:05:00Z",
     },
@@ -721,6 +722,11 @@ jest.mock("@/shared/studio/api", () => ({
     listMembers: jest.fn(async () => ({
       scopeId: "scope-1",
       members: mockStudioMembers,
+      nextPageToken: null,
+    })),
+    listTeamMembers: jest.fn(async (_scopeId: string, teamId: string) => ({
+      scopeId: "scope-1",
+      members: mockStudioMembers.filter((member) => member.teamId === teamId),
       nextPageToken: null,
     })),
     getMember: jest.fn(async (_scopeId: string, memberId: string) => {
@@ -3005,6 +3011,14 @@ describe("StudioPage", () => {
       members: mockStudioMembers,
       nextPageToken: null,
     }));
+    (studioApi.listTeamMembers as jest.Mock).mockReset();
+    (studioApi.listTeamMembers as jest.Mock).mockImplementation(
+      async (_scopeId: string, teamId: string) => ({
+        scopeId: "scope-1",
+        members: mockStudioMembers.filter((member) => member.teamId === teamId),
+        nextPageToken: null,
+      })
+    );
     (studioApi.getMember as jest.Mock).mockReset();
     (studioApi.getMember as jest.Mock).mockImplementation(
       async (_scopeId: string, memberId: string) => {
@@ -3801,6 +3815,210 @@ describe("StudioPage", () => {
         teamId: "t-alpha",
       });
     });
+  });
+
+  it("loads only the current Team roster for the Studio member rail", async () => {
+    mockStudioMembers = [
+      {
+        ...mockStudioMembers[0],
+        memberId: "alpha-member",
+        displayName: "Alpha member",
+        teamId: "t-alpha",
+      },
+      {
+        ...mockStudioMembers[0],
+        memberId: "beta-member",
+        displayName: "Beta member",
+        teamId: "t-beta",
+      },
+    ];
+
+    renderStudioPage("/studio?scopeId=scope-1&teamId=t-alpha&tab=studio");
+
+    const rail = await screen.findByLabelText("Team members");
+    expect(await within(rail).findByRole("button", { name: "Alpha member" })).toBeTruthy();
+    expect(within(rail).queryByRole("button", { name: "Beta member" })).toBeNull();
+    expect(studioApi.listTeamMembers).toHaveBeenCalledWith("scope-1", "t-alpha");
+    expect(studioApi.listMembers).not.toHaveBeenCalled();
+  });
+
+  it("does not hydrate Team Studio rail members from scope-level services or drafts", async () => {
+    (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
+      ...defaultStudioAppContext,
+      features: {
+        ...defaultStudioAppContext.features,
+        scripts: true,
+      },
+      scopeId: "scope-1",
+      scopeResolved: true,
+    });
+    mockStudioMembers = [
+      {
+        ...mockStudioMembers[0],
+        memberId: "alpha-member",
+        displayName: "Alpha member",
+        publishedServiceId: "service-alpha",
+        teamId: "t-alpha",
+      },
+      {
+        ...mockStudioMembers[0],
+        memberId: "beta-member",
+        displayName: "Beta member",
+        publishedServiceId: "service-beta",
+        teamId: "t-beta",
+      },
+    ];
+    mockScopeRuntimeApi.listServices.mockResolvedValueOnce([
+      {
+        serviceId: "service-alpha",
+        displayName: "Alpha service",
+        deploymentStatus: "Active",
+        primaryActorId: "actor-alpha",
+        endpoints: [
+          {
+            endpointId: "chat",
+            displayName: "Chat",
+            kind: "chat",
+            description: "Chat with alpha.",
+            requestTypeUrl: "",
+            responseTypeUrl: "",
+          },
+        ],
+      },
+      {
+        serviceId: "service-beta",
+        displayName: "Beta service",
+        deploymentStatus: "Active",
+        primaryActorId: "actor-beta",
+        endpoints: [
+          {
+            endpointId: "chat",
+            displayName: "Chat",
+            kind: "chat",
+            description: "Chat with beta.",
+            requestTypeUrl: "",
+            responseTypeUrl: "",
+          },
+        ],
+      },
+      {
+        serviceId: "global-service",
+        displayName: "Global service",
+        deploymentStatus: "Active",
+        primaryActorId: "actor-global",
+        endpoints: [
+          {
+            endpointId: "chat",
+            displayName: "Chat",
+            kind: "chat",
+            description: "Chat with global.",
+            requestTypeUrl: "",
+            responseTypeUrl: "",
+          },
+        ],
+      },
+    ]);
+    mockScopeRuntimeApi.getServiceRevisions.mockImplementation(
+      async (_scopeId: string, serviceId: string) =>
+        mockBuildServiceRevisionCatalog({
+          serviceId,
+          displayName:
+            serviceId === "service-alpha"
+              ? "Alpha service"
+              : serviceId === "service-beta"
+                ? "Beta service"
+                : "Global service",
+          workflowName:
+            serviceId === "service-alpha"
+              ? "workspace-demo"
+              : serviceId === "service-beta"
+                ? "beta-workflow"
+                : "global-workflow",
+        })
+    );
+    (studioApi.listWorkflows as jest.Mock).mockResolvedValueOnce([
+      {
+        workflowId: "workflow-1",
+        name: "workspace-demo",
+        description: "Workspace workflow",
+        fileName: "workspace-demo.yaml",
+        filePath: "/tmp/workflows/workspace-demo.yaml",
+        directoryId: "dir-1",
+        directoryLabel: "Workspace",
+        stepCount: 2,
+        hasLayout: true,
+        updatedAtUtc: "2026-03-18T00:00:00Z",
+      },
+      {
+        workflowId: "workflow-beta",
+        name: "beta-workflow",
+        description: "Beta workflow",
+        fileName: "beta-workflow.yaml",
+        filePath: "/tmp/workflows/beta-workflow.yaml",
+        directoryId: "dir-1",
+        directoryLabel: "Workspace",
+        stepCount: 1,
+        hasLayout: true,
+        updatedAtUtc: "2026-03-18T00:00:00Z",
+      },
+      {
+        workflowId: "workflow-draft",
+        name: "draft",
+        description: "Loose draft",
+        fileName: "draft.yaml",
+        filePath: "/tmp/workflows/draft.yaml",
+        directoryId: "dir-1",
+        directoryLabel: "Workspace",
+        stepCount: 1,
+        hasLayout: true,
+        updatedAtUtc: "2026-03-18T00:00:00Z",
+      },
+    ]);
+    (scriptsApi.listScripts as jest.Mock).mockResolvedValue([
+      {
+        available: true,
+        scopeId: "scope-1",
+        script: {
+          scopeId: "scope-1",
+          scriptId: "script-1",
+          catalogActorId: "catalog-1",
+          definitionActorId: "definition-1",
+          activeRevision: "rev-script-1",
+          activeSourceHash: "hash-1",
+          updatedAt: "2026-03-18T00:00:00Z",
+        },
+        source: {
+          sourceText: "using System;",
+          definitionActorId: "definition-1",
+          revision: "rev-script-1",
+          sourceHash: "hash-1",
+        },
+      },
+    ]);
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&teamId=t-alpha&focus=script%3Ascript-1&tab=scripts"
+    );
+
+    const rail = await screen.findByLabelText("Team members");
+    expect(await within(rail).findByRole("button", { name: "Alpha member" })).toBeTruthy();
+    expect(within(rail).queryByRole("button", { name: "Beta member" })).toBeNull();
+    expect(within(rail).queryByRole("button", { name: "Beta service" })).toBeNull();
+    expect(within(rail).queryByRole("button", { name: "Global service" })).toBeNull();
+    expect(within(rail).queryByRole("button", { name: "draft" })).toBeNull();
+    expect(within(rail).queryByRole("button", { name: "script-1" })).toBeNull();
+    expect(mockScopeRuntimeApi.getServiceRevisions).toHaveBeenCalledWith(
+      "scope-1",
+      "service-alpha"
+    );
+    expect(mockScopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalledWith(
+      "scope-1",
+      "service-beta"
+    );
+    expect(mockScopeRuntimeApi.getServiceRevisions).not.toHaveBeenCalledWith(
+      "scope-1",
+      "global-service"
+    );
   });
 
   it("returns to canonical Team detail when Studio has Team context", async () => {

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -2358,6 +2358,64 @@ function resolvePublishedServiceIdFromMemberKey(
   return '';
 }
 
+function buildStudioMemberDuplicateKeys(
+  input: {
+    readonly memberSummary?: StudioMemberSummary | null;
+    readonly service?: {
+      readonly serviceId?: string | null;
+      readonly displayName?: string | null;
+    } | null;
+    readonly revision?: StudioMemberBindingRevision | null;
+    readonly matchedWorkflow?: {
+      readonly workflowId?: string | null;
+    } | null;
+    readonly matchedScript?: {
+      readonly script?: {
+        readonly scriptId?: string | null;
+      } | null;
+    } | null;
+  },
+): string[] {
+  const memberSummary = input.memberSummary;
+  const memberId = trimOptional(memberSummary?.memberId);
+  const memberPublishedServiceId = trimOptional(memberSummary?.publishedServiceId);
+  const serviceId = trimOptional(input.service?.serviceId);
+  const matchedWorkflowKey = buildWorkflowMemberKeyFromSummary(input.matchedWorkflow);
+  const matchedScriptId = trimOptional(input.matchedScript?.script?.scriptId);
+  const memberImplementationKind =
+    normalizeStudioMemberBindingImplementationKind(
+      memberSummary?.implementationKind || input.revision?.implementationKind,
+    );
+  const includeImplementationAlias =
+    Boolean(input.revision) ||
+    Boolean(input.matchedWorkflow) ||
+    Boolean(input.matchedScript);
+  const memberImplementationName =
+    includeImplementationAlias
+      ? trimOptional(memberSummary?.displayName) ||
+        trimOptional(input.revision?.workflowName) ||
+        trimOptional(input.revision?.scriptId) ||
+        trimOptional(input.service?.displayName)
+      : '';
+
+  return [
+    memberId ? `member:${memberId}` : '',
+    memberPublishedServiceId ? `member:${memberPublishedServiceId}` : '',
+    serviceId ? `member:${serviceId}` : '',
+    matchedWorkflowKey,
+    matchedScriptId ? `script:${matchedScriptId}` : '',
+    memberImplementationKind === 'workflow' && memberImplementationName
+      ? `workflow:${memberImplementationName}`
+      : '',
+    memberImplementationKind === 'script' && memberImplementationName
+      ? `script:${memberImplementationName}`
+      : '',
+    memberImplementationKind === 'script' && memberPublishedServiceId
+      ? `script:${memberPublishedServiceId}`
+      : '',
+  ];
+}
+
 function resolveStudioMemberOwnerKey(
   memberKey: string,
   publishedMembers: readonly PublishedStudioMemberRecord[],
@@ -2802,6 +2860,7 @@ const StudioPage: React.FC = () => {
     trimOptional(appContextQuery.data?.scopeId) ||
     trimOptional(authSessionQuery.data?.scopeId) ||
     '';
+  const resolvedStudioTeamId = trimOptional(routeState.teamId);
   const workflowWorkspaceContextKey = resolvedStudioScopeId || 'workspace';
   const workspaceSettingsQuery = useQuery({
     queryKey: ['studio-workspace-settings', workflowWorkspaceContextKey],
@@ -2839,11 +2898,24 @@ const StudioPage: React.FC = () => {
         appId: scopeServiceAppId,
       }),
   });
+  const studioMembersQueryKey = useMemo(
+    () =>
+      [
+        'studio-scope-members',
+        resolvedStudioScopeId,
+        resolvedStudioTeamId ? 'team' : 'scope',
+        resolvedStudioTeamId,
+      ] as const,
+    [resolvedStudioScopeId, resolvedStudioTeamId],
+  );
   const studioMembersQuery = useQuery({
-    queryKey: ['studio-scope-members', resolvedStudioScopeId],
+    queryKey: studioMembersQueryKey,
     enabled: studioHostReady && Boolean(resolvedStudioScopeId),
     retry: false,
-    queryFn: () => studioApi.listMembers(resolvedStudioScopeId),
+    queryFn: () =>
+      resolvedStudioTeamId
+        ? studioApi.listTeamMembers(resolvedStudioScopeId, resolvedStudioTeamId)
+        : studioApi.listMembers(resolvedStudioScopeId),
   });
   const selectedWorkflowQuery = useQuery({
     queryKey: ['studio-workflow', workflowWorkspaceContextKey, selectedWorkflowId],
@@ -2895,10 +2967,6 @@ const StudioPage: React.FC = () => {
     gAgentTypesQuery.data,
     selectedGAgentTypeName,
   ]);
-  const publishedScopeServices = useMemo(
-    () => scopeServicesQuery.data ?? [],
-    [scopeServicesQuery.data],
-  );
   const studioScopeMembers = useMemo(
     () => studioMembersQuery.data?.members ?? [],
     [studioMembersQuery.data?.members],
@@ -2916,6 +2984,21 @@ const StudioPage: React.FC = () => {
 
     return members;
   }, [studioScopeMembers]);
+  const publishedScopeServices = useMemo(() => {
+    const services = scopeServicesQuery.data ?? [];
+    if (!resolvedStudioTeamId) {
+      return services;
+    }
+
+    return services.filter((service) => {
+      const serviceId = trimOptional(service.serviceId);
+      return serviceId && studioMemberByPublishedServiceId.has(serviceId);
+    });
+  }, [
+    resolvedStudioTeamId,
+    scopeServicesQuery.data,
+    studioMemberByPublishedServiceId,
+  ]);
   const availableScopeScripts = useMemo(
     () =>
       (scopeScriptsQuery.data ?? []).filter(
@@ -4445,7 +4528,7 @@ const StudioPage: React.FC = () => {
       }
     }
     await queryClient.invalidateQueries({
-      queryKey: ['studio-scope-members', resolvedStudioScopeId],
+      queryKey: studioMembersQueryKey,
     });
     const servicesResult = await scopeServicesQuery.refetch();
     const optimisticBoundServiceId =
@@ -4611,6 +4694,7 @@ const StudioPage: React.FC = () => {
     selectedScriptId,
     selectedWorkflowMemberKey,
     scopeServicesQuery,
+    studioMembersQueryKey,
     studioScopeMembers,
     waitForMemberBindingRun,
   ]);
@@ -4961,7 +5045,7 @@ const StudioPage: React.FC = () => {
               ...(createMemberTeamId ? { teamId: createMemberTeamId } : {}),
             });
             queryClient.setQueryData<StudioMemberRoster>(
-              ['studio-scope-members', resolvedStudioScopeId],
+              studioMembersQueryKey,
               (current) =>
                 upsertStudioMemberRosterMember(
                   current,
@@ -4970,7 +5054,7 @@ const StudioPage: React.FC = () => {
                 ),
             );
             void queryClient.invalidateQueries({
-              queryKey: ['studio-scope-members', resolvedStudioScopeId],
+              queryKey: studioMembersQueryKey,
             });
           } catch (memberError) {
             setInventoryBusyKey('');
@@ -5055,7 +5139,7 @@ const StudioPage: React.FC = () => {
           ...(createMemberTeamId ? { teamId: createMemberTeamId } : {}),
         });
         queryClient.setQueryData<StudioMemberRoster>(
-          ['studio-scope-members', resolvedStudioScopeId],
+          studioMembersQueryKey,
           (current) =>
             upsertStudioMemberRosterMember(
               current,
@@ -5064,7 +5148,7 @@ const StudioPage: React.FC = () => {
             ),
         );
         void queryClient.invalidateQueries({
-          queryKey: ['studio-scope-members', resolvedStudioScopeId],
+          queryKey: studioMembersQueryKey,
         });
         setSelectedWorkflowId('');
         setSelectedScriptId('');
@@ -5164,7 +5248,7 @@ const StudioPage: React.FC = () => {
           ...(createMemberTeamId ? { teamId: createMemberTeamId } : {}),
         });
         await queryClient.invalidateQueries({
-          queryKey: ['studio-scope-members', resolvedStudioScopeId],
+          queryKey: studioMembersQueryKey,
         });
         void message.success(
           `Created member ${workflowName} and opened its workflow draft.`,
@@ -5199,6 +5283,7 @@ const StudioPage: React.FC = () => {
     inventoryDirectoryId,
     queryClient,
     resolvedStudioScopeId,
+    studioMembersQueryKey,
     studioScopeMembers,
     visibleWorkflowSummaries,
   ]);
@@ -5442,7 +5527,7 @@ const StudioPage: React.FC = () => {
             });
             if (resolvedStudioScopeId) {
               await queryClient.invalidateQueries({
-                queryKey: ['studio-scope-members', resolvedStudioScopeId],
+                queryKey: studioMembersQueryKey,
               });
             }
 
@@ -5498,6 +5583,7 @@ const StudioPage: React.FC = () => {
       history,
       queryClient,
       resolvedStudioScopeId,
+      studioMembersQueryKey,
       selectedWorkflowId,
       visibleWorkflowSummaries,
       workflowWorkspaceContextKey,
@@ -8138,37 +8224,18 @@ const StudioPage: React.FC = () => {
       const memberId = trimOptional(memberSummary?.memberId);
       const memberPublishedServiceId = trimOptional(memberSummary?.publishedServiceId);
       const serviceId = trimOptional(service.serviceId);
-      const matchedWorkflowKey = buildWorkflowMemberKeyFromSummary(matchedWorkflow);
-      const matchedScriptId = trimOptional(matchedScript?.script?.scriptId);
-      const memberImplementationKind =
-        normalizeStudioMemberBindingImplementationKind(
-          memberSummary?.implementationKind || serviceRevision?.implementationKind,
-        );
-      const memberImplementationName =
-        trimOptional(memberSummary?.displayName) ||
-        trimOptional(serviceRevision?.workflowName) ||
-        trimOptional(serviceRevision?.scriptId) ||
-        trimOptional(service.displayName);
-      const memberDuplicateKeys = [
-        memberId ? `member:${memberId}` : '',
-        memberPublishedServiceId ? `member:${memberPublishedServiceId}` : '',
-        serviceId ? `member:${serviceId}` : '',
-        matchedWorkflowKey,
-        matchedScriptId ? `script:${matchedScriptId}` : '',
-        memberImplementationKind === 'workflow' && memberImplementationName
-          ? `workflow:${memberImplementationName}`
-          : '',
-        memberImplementationKind === 'script' && memberImplementationName
-          ? `script:${memberImplementationName}`
-          : '',
-        memberImplementationKind === 'script' && memberPublishedServiceId
-          ? `script:${memberPublishedServiceId}`
-          : '',
-      ];
+      const memberDuplicateKeys = buildStudioMemberDuplicateKeys({
+        memberSummary,
+        service,
+        revision: serviceRevision,
+        matchedWorkflow,
+        matchedScript,
+      });
       addItem({
         key:
           `member:${memberId || memberPublishedServiceId || serviceId}`,
         label:
+          (resolvedStudioTeamId ? trimOptional(memberSummary?.displayName) : '') ||
           trimOptional(matchedWorkflow?.name) ||
           trimOptional(matchedScript?.script?.scriptId) ||
           trimOptional(memberSummary?.displayName) ||
@@ -8212,70 +8279,113 @@ const StudioPage: React.FC = () => {
       }, memberDuplicateKeys);
     }
 
-    for (const workflow of visibleWorkflowSummaries) {
-      if (serviceBackedWorkflowIds.has(trimOptional(workflow.workflowId))) {
+    for (const memberSummary of studioScopeMembers) {
+      const memberId = trimOptional(memberSummary.memberId);
+      const memberPublishedServiceId = trimOptional(memberSummary.publishedServiceId);
+      if (!memberId && !memberPublishedServiceId) {
         continue;
       }
-
-      const workflowMemberKey = buildWorkflowMemberKeyFromSummary(workflow);
-      if (!workflowMemberKey) {
-        continue;
-      }
-      const workflowDuplicateKeys = [
-        workflowMemberKey,
-        `workflow:${trimOptional(workflow.name)}`,
-        `workflow:${trimOptional(workflow.fileName).replace(/\.(ya?ml)$/i, '')}`,
-      ];
 
       addItem({
-        key: workflowMemberKey,
-        label: workflow.name,
+        key: `member:${memberId || memberPublishedServiceId}`,
+        label:
+          trimOptional(memberSummary.displayName) ||
+          trimOptional(memberSummary.memberId) ||
+          'Member',
         description: formatStudioAssetMeta({
-          primary: 'Workflow implementation',
+          primary: describeMemberImplementationLabel(memberSummary.implementationKind),
           secondary:
-            trimOptional(workflow.description) ||
-            trimOptional(workflow.fileName) ||
-            'Workspace workflow draft',
-        }) || 'Workspace workflow draft',
-        canDelete: true,
-        canRename: true,
+            trimOptional(memberSummary.description) ||
+            trimOptional(memberSummary.publishedServiceId) ||
+            formatStudioMemberLifecycleStage(memberSummary.lifecycleStage),
+        }) || 'Team member.',
         kind: 'member',
         meta: formatStudioAssetMeta({
-          primary: `${workflow.stepCount} steps`,
-          secondary: workflow.directoryLabel || workflow.fileName,
+          primary:
+            trimOptional(memberSummary.publishedServiceId) ||
+            formatStudioMemberLifecycleStage(memberSummary.lifecycleStage),
+          secondary:
+            trimOptional(memberSummary.lastBoundRevisionId) ||
+            trimOptional(memberSummary.updatedAt),
         }),
-        tone:
-          currentFocusMemberKey === workflowMemberKey
-            ? 'live'
-            : 'idle',
-      }, workflowDuplicateKeys);
+        tone: memberPublishedServiceId ? 'idle' : 'draft',
+      }, buildStudioMemberDuplicateKeys({ memberSummary }));
     }
 
-    for (const scriptDetail of availableScopeScripts) {
-      const scriptId = trimOptional(scriptDetail.script?.scriptId);
-      if (!scriptId || serviceBackedScriptIds.has(scriptId)) {
-        continue;
+    if (!resolvedStudioTeamId) {
+      for (const workflow of visibleWorkflowSummaries) {
+        if (serviceBackedWorkflowIds.has(trimOptional(workflow.workflowId))) {
+          continue;
+        }
+
+        const workflowMemberKey = buildWorkflowMemberKeyFromSummary(workflow);
+        if (!workflowMemberKey) {
+          continue;
+        }
+        const workflowDuplicateKeys = [
+          workflowMemberKey,
+          `workflow:${trimOptional(workflow.name)}`,
+          `workflow:${trimOptional(workflow.fileName).replace(/\.(ya?ml)$/i, '')}`,
+        ];
+
+        addItem({
+          key: workflowMemberKey,
+          label: workflow.name,
+          description: formatStudioAssetMeta({
+            primary: 'Workflow implementation',
+            secondary:
+              trimOptional(workflow.description) ||
+              trimOptional(workflow.fileName) ||
+              'Workspace workflow draft',
+          }) || 'Workspace workflow draft',
+          canDelete: true,
+          canRename: true,
+          kind: 'member',
+          meta: formatStudioAssetMeta({
+            primary: `${workflow.stepCount} steps`,
+            secondary: workflow.directoryLabel || workflow.fileName,
+          }),
+          tone:
+            currentFocusMemberKey === workflowMemberKey
+              ? 'live'
+              : 'idle',
+        }, workflowDuplicateKeys);
       }
-      addItem({
-        key: `script:${scriptId}`,
-        label: scriptId,
-        description: formatStudioAssetMeta({
-          primary: 'Script implementation',
-          secondary:
-            trimOptional(scriptDetail.script?.definitionActorId) ||
-            'Workspace script behavior',
-        }) || 'Workspace script behavior',
-        kind: 'member',
-        meta: formatStudioAssetMeta({
-          primary: scriptDetail.script?.activeRevision || '',
-          secondary: 'Workspace script',
-        }),
-        tone:
-          currentFocusMemberKey === `script:${scriptId}` ? 'live' : 'idle',
-      });
+
+      for (const scriptDetail of availableScopeScripts) {
+        const scriptId = trimOptional(scriptDetail.script?.scriptId);
+        if (!scriptId || serviceBackedScriptIds.has(scriptId)) {
+          continue;
+        }
+        addItem({
+          key: `script:${scriptId}`,
+          label: scriptId,
+          description: formatStudioAssetMeta({
+            primary: 'Script implementation',
+            secondary:
+              trimOptional(scriptDetail.script?.definitionActorId) ||
+              'Workspace script behavior',
+          }) || 'Workspace script behavior',
+          kind: 'member',
+          meta: formatStudioAssetMeta({
+            primary: scriptDetail.script?.activeRevision || '',
+            secondary: 'Workspace script',
+          }),
+          tone:
+            currentFocusMemberKey === `script:${scriptId}` ? 'live' : 'idle',
+        });
+      }
     }
 
-    addItem(currentMemberItem, currentMemberDuplicateKeys);
+    const currentMemberBelongsToRailScope =
+      !resolvedStudioTeamId ||
+      currentMemberDuplicateKeys
+        .map((key) => trimOptional(key))
+        .filter(Boolean)
+        .some((key) => seen.has(key));
+    if (currentMemberBelongsToRailScope) {
+      addItem(currentMemberItem, currentMemberDuplicateKeys);
+    }
 
     const recencyIndexByKey = new Map(
       memberRecencyOrder.map((memberKey, index) => [memberKey, index]),
@@ -8321,12 +8431,14 @@ const StudioPage: React.FC = () => {
     effectiveSelectedMemberKey,
     memberRecencyOrder,
     publishedScopeMembers,
+    resolvedStudioTeamId,
     selectedRailMemberKey,
     serviceBackedScriptIds,
     serviceBackedWorkflowIds,
     selectedWorkflowId,
     selectedWorkflowMemberKey,
     selectedScriptId,
+    studioScopeMembers,
     visibleWorkflowSummaries,
     workbenchPublishedServiceId,
     workbenchStudioMemberId,


### PR DESCRIPTION
## Problem

Studio pages opened with a Team context still rendered the Team members rail from scope-wide data. Even after loading the Team roster, the rail could be repopulated by scope runtime services and workspace workflow/script drafts, so unrelated members appeared under the current Team.

Closes #766

## Solution

- Scope the Studio member roster query by `teamId` when the route has Team context.
- Filter published scope services to the current Team roster before deriving rail entries.
- Keep unbound Team roster members visible, while preventing workspace drafts/scripts and unrelated scope services from hydrating Team rail items.
- Keep legacy no-Team Studio behavior intact.

## Validation

- `npm --prefix apps/aevatar-console-web run tsc`
- `npm --prefix apps/aevatar-console-web run jest -- src/pages/studio/index.test.tsx --runInBand`
- `bash tools/ci/test_stability_guards.sh`
