### PR TITLE
Support Studio Team entry member invocation

### DIFF
--- a/agents/Aevatar.GAgents.StudioTeam/StudioTeamGAgent.cs
+++ b/agents/Aevatar.GAgents.StudioTeam/StudioTeamGAgent.cs
@@ -89,6 +89,40 @@ public sealed class StudioTeamGAgent : GAgentBase<StudioTeamState>, IProjectedAc
         await PersistDomainEventAsync(evt);
     }
 
+    [EventHandler(EndpointName = "setEntryMember")]
+    public async Task HandleEntryMemberChanged(StudioTeamEntryMemberChangedEvent evt)
+    {
+        if (string.IsNullOrEmpty(State.TeamId))
+        {
+            throw new InvalidOperationException("team not yet created.");
+        }
+
+        if (State.LifecycleStage == StudioTeamLifecycleStage.Archived)
+        {
+            throw new InvalidOperationException(
+                $"team '{State.TeamId}' is archived; entry member updates are not allowed.");
+        }
+
+        if (!string.Equals(State.ScopeId, evt.ScopeId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"team '{State.TeamId}' (scope {State.ScopeId}) cannot update entry member in scope {evt.ScopeId}.");
+        }
+
+        if (evt.HasEntryMemberId && !ContainsMember(State.MemberIds, evt.EntryMemberId))
+        {
+            throw new InvalidOperationException(
+                $"entry member '{evt.EntryMemberId}' must belong to team '{State.TeamId}'.");
+        }
+
+        var currentEntry = State.HasEntryMemberId ? State.EntryMemberId : null;
+        var requestedEntry = evt.HasEntryMemberId ? evt.EntryMemberId : null;
+        if (string.Equals(currentEntry, requestedEntry, StringComparison.Ordinal))
+            return;
+
+        await PersistDomainEventAsync(evt);
+    }
+
     [EventHandler(EndpointName = "archiveTeam")]
     public async Task HandleArchived(StudioTeamArchivedEvent evt)
     {
@@ -176,6 +210,24 @@ public sealed class StudioTeamGAgent : GAgentBase<StudioTeamState>, IProjectedAc
             MemberCount = memberCountAfter,
             ChangedAtUtc = evt.ReassignedAtUtc,
         };
+
+        if (effect == StudioTeamRosterEffect.Removed
+            && State.HasEntryMemberId
+            && string.Equals(State.EntryMemberId, evt.MemberId, StringComparison.Ordinal))
+        {
+            await PersistDomainEventsAsync(
+                [
+                    rosterEvent,
+                    new StudioTeamEntryMemberChangedEvent
+                    {
+                        TeamId = State.TeamId,
+                        ScopeId = State.ScopeId,
+                        ChangedAtUtc = evt.ReassignedAtUtc,
+                    },
+                ]);
+            return;
+        }
+
         await PersistDomainEventAsync(rosterEvent);
     }
 
@@ -188,6 +240,7 @@ public sealed class StudioTeamGAgent : GAgentBase<StudioTeamState>, IProjectedAc
             .On<StudioTeamUpdatedEvent>(ApplyUpdated)
             .On<StudioTeamArchivedEvent>(ApplyArchived)
             .On<StudioTeamMemberRosterChangedEvent>(ApplyRosterChanged)
+            .On<StudioTeamEntryMemberChangedEvent>(ApplyEntryMemberChanged)
             .OrCurrent();
     }
 
@@ -239,6 +292,11 @@ public sealed class StudioTeamGAgent : GAgentBase<StudioTeamState>, IProjectedAc
                 break;
             case StudioTeamRosterEffect.Removed:
                 RemoveMember(next.MemberIds, evt.MemberId);
+                if (next.HasEntryMemberId
+                    && string.Equals(next.EntryMemberId, evt.MemberId, StringComparison.Ordinal))
+                {
+                    next.ClearEntryMemberId();
+                }
                 break;
             case StudioTeamRosterEffect.Noop:
             case StudioTeamRosterEffect.Unspecified:
@@ -246,6 +304,18 @@ public sealed class StudioTeamGAgent : GAgentBase<StudioTeamState>, IProjectedAc
                 // No roster change (UpdatedAtUtc still advances).
                 break;
         }
+        next.UpdatedAtUtc = evt.ChangedAtUtc;
+        return next;
+    }
+
+    private static StudioTeamState ApplyEntryMemberChanged(
+        StudioTeamState state, StudioTeamEntryMemberChangedEvent evt)
+    {
+        var next = state.Clone();
+        if (evt.HasEntryMemberId)
+            next.EntryMemberId = evt.EntryMemberId;
+        else
+            next.ClearEntryMemberId();
         next.UpdatedAtUtc = evt.ChangedAtUtc;
         return next;
     }

--- a/agents/Aevatar.GAgents.StudioTeam/studio_team_messages.proto
+++ b/agents/Aevatar.GAgents.StudioTeam/studio_team_messages.proto
@@ -32,6 +32,7 @@ message StudioTeamState {
   repeated string member_ids = 6;
   google.protobuf.Timestamp created_at_utc = 7;
   google.protobuf.Timestamp updated_at_utc = 8;
+  optional string entry_member_id = 20;
   // Reserved for v2: last_activity_at_utc, etc.
 }
 
@@ -82,4 +83,11 @@ message StudioTeamMemberRosterChangedEvent {
   StudioTeamRosterEffect effect = 4;
   int32  member_count = 5;       // size of member_ids after this event
   google.protobuf.Timestamp changed_at_utc = 6;
+}
+
+message StudioTeamEntryMemberChangedEvent {
+  string team_id = 1;
+  string scope_id = 2;
+  optional string entry_member_id = 3;
+  google.protobuf.Timestamp changed_at_utc = 4;
 }

--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Aevatar.Configuration;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -249,8 +250,8 @@ public sealed class AppScopedWorkflowService
                         var identity = new ServiceIdentity
                         {
                             TenantId = normalizedScopeId,
-                            AppId = "default",
-                            Namespace = "default",
+                            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+                            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
                             ServiceId = normalizedWorkflowId,
                         };
                         var svc = await _serviceLifecycleQueryPort.GetServiceAsync(identity, ct);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamCommandPort.cs
@@ -28,4 +28,15 @@ public interface IStudioTeamCommandPort
         string scopeId,
         string teamId,
         CancellationToken ct = default);
+
+    Task SetEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        string memberId,
+        CancellationToken ct = default);
+
+    Task ClearEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default);
 }

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamGAgentStreamInvocationService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamGAgentStreamInvocationService.cs
@@ -1,0 +1,19 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Presentation.AGUI;
+
+namespace Aevatar.Studio.Application.Studio.Abstractions;
+
+public interface IStudioTeamGAgentStreamInvocationService
+{
+    Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+        StudioTeamGAgentStreamInvocationRequest request,
+        Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+        Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+        CancellationToken ct = default);
+}
+
+public sealed record StudioTeamGAgentStreamInvocationRequest(
+    string ScopeId,
+    string TeamId,
+    string EndpointId,
+    StaticGAgentStreamInvocationInput Input);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamGAgentStreamInvocationService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamGAgentStreamInvocationService.cs
@@ -1,19 +1,46 @@
-using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Presentation.AGUI;
 
 namespace Aevatar.Studio.Application.Studio.Abstractions;
 
 public interface IStudioTeamGAgentStreamInvocationService
 {
-    Task<StaticGAgentStreamInvocationResult> InvokeAsync(
-        StudioTeamGAgentStreamInvocationRequest request,
+    Task<StudioTeamStreamInvocationResult> InvokeAsync(
+        StudioTeamStreamInvocationRequest request,
         Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
-        Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+        Func<StudioTeamStreamInvocationAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
         CancellationToken ct = default);
 }
 
-public sealed record StudioTeamGAgentStreamInvocationRequest(
+public sealed record StudioTeamStreamInvocationRequest(
     string ScopeId,
     string TeamId,
     string EndpointId,
-    StaticGAgentStreamInvocationInput Input);
+    StudioTeamStreamInvocationInput Input);
+
+public sealed record StudioTeamStreamInvocationInput(
+    string Prompt,
+    string? PreferredActorId = null,
+    string? SessionId = null,
+    string? RevisionId = null,
+    IReadOnlyDictionary<string, string>? Headers = null,
+    IReadOnlyList<StudioTeamStreamInvocationInputPart>? InputParts = null,
+    TimeSpan? Timeout = null);
+
+public sealed record StudioTeamStreamInvocationInputPart(
+    string Type,
+    string? Text = null,
+    string? DataBase64 = null,
+    string? MediaType = null,
+    string? Uri = null,
+    string? Name = null);
+
+public sealed record StudioTeamStreamInvocationAcceptedReceipt(
+    string RunId,
+    string ThreadId,
+    string CorrelationId);
+
+public sealed record StudioTeamStreamInvocationResult(
+    StudioTeamStreamInvocationAcceptedReceipt? AcceptedReceipt,
+    string StartError,
+    string CompletionStatus,
+    bool CompletionObserved);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamService.cs
@@ -35,6 +35,17 @@ public interface IStudioTeamService
         string scopeId,
         string teamId,
         CancellationToken ct = default);
+
+    Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        SetStudioTeamEntryMemberRequest request,
+        CancellationToken ct = default);
+
+    Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamService.cs
@@ -36,13 +36,13 @@ public interface IStudioTeamService
         string teamId,
         CancellationToken ct = default);
 
-    Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+    Task SetEntryMemberAsync(
         string scopeId,
         string teamId,
         SetStudioTeamEntryMemberRequest request,
         CancellationToken ct = default);
 
-    Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+    Task ClearEntryMemberAsync(
         string scopeId,
         string teamId,
         CancellationToken ct = default);

--- a/src/Aevatar.Studio.Application/Studio/Contracts/TeamContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/TeamContracts.cs
@@ -20,7 +20,10 @@ public sealed record StudioTeamSummaryResponse(
     string LifecycleStage,
     int MemberCount,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt)
+{
+    public string? EntryMemberId { get; init; }
+}
 
 public sealed record StudioTeamRosterResponse(
     string ScopeId,
@@ -62,6 +65,9 @@ public readonly struct PatchValue<T>
 public sealed record UpdateStudioTeamRequest(
     PatchValue<string> DisplayName = default,
     PatchValue<string> Description = default);
+
+public sealed record SetStudioTeamEntryMemberRequest(
+    string MemberId);
 
 /// <summary>
 /// Centralized input bounds for team contract — mirrors

--- a/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Application/Studio/DependencyInjection/ServiceCollectionExtensions.cs
@@ -20,6 +20,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<SettingsService>();
         services.TryAddSingleton<IStudioMemberService, StudioMemberService>();
         services.TryAddSingleton<IStudioTeamService, StudioTeamService>();
+        services.TryAddSingleton<IStudioTeamGAgentStreamInvocationService, StudioTeamGAgentStreamInvocationService>();
+        services.Replace(ServiceDescriptor.Singleton<ITeamEntryMemberResolver, StudioTeamEntryMemberResolver>());
         services.TryAddSingleton<IUserLlmPreferenceService, UserLlmPreferenceService>();
 
         // Override the platform's deterministic resolver so existing

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioMemberService.cs
@@ -16,14 +16,6 @@ namespace Aevatar.Studio.Application.Studio.Services;
 /// </summary>
 public sealed class StudioMemberService : IStudioMemberService
 {
-    // Mirrors the values pinned in ScopeWorkflowCapabilityOptions
-    // (FixedServiceAppId / FixedServiceNamespace). Adding a runtime options
-    // dependency here would force every Studio.Application consumer to wire
-    // the platform Application layer just to read two const strings; copying
-    // the constants keeps the layer boundary clean and matches what
-    // AppScopedWorkflowService already does for the same reason.
-    private const string ServiceAppId = "default";
-    private const string ServiceNamespace = "default";
     private const string DefaultSmokePrompt = "Hello from Studio Bind.";
 
     private readonly IStudioMemberCommandPort _memberCommandPort;
@@ -376,8 +368,8 @@ public sealed class StudioMemberService : IStudioMemberService
         var identity = new ServiceIdentity
         {
             TenantId = normalizedScopeId,
-            AppId = ServiceAppId,
-            Namespace = ServiceNamespace,
+            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
             ServiceId = publishedServiceId,
         };
 

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamEntryMemberResolver.cs
@@ -1,0 +1,96 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+
+namespace Aevatar.Studio.Application.Studio.Services;
+
+public sealed class StudioTeamEntryMemberResolver : ITeamEntryMemberResolver
+{
+    private readonly IStudioTeamQueryPort _teamQueryPort;
+    private readonly IStudioMemberQueryPort _memberQueryPort;
+
+    public StudioTeamEntryMemberResolver(
+        IStudioTeamQueryPort teamQueryPort,
+        IStudioMemberQueryPort memberQueryPort)
+    {
+        _teamQueryPort = teamQueryPort ?? throw new ArgumentNullException(nameof(teamQueryPort));
+        _memberQueryPort = memberQueryPort ?? throw new ArgumentNullException(nameof(memberQueryPort));
+    }
+
+    public async Task<TeamEntryMemberResolution> ResolveAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default)
+    {
+        var team = await _teamQueryPort.GetAsync(scopeId, teamId, ct);
+        if (team == null)
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.TeamNotFound,
+                scopeId,
+                teamId,
+                $"team '{teamId}' not found in scope '{scopeId}'.");
+        }
+
+        if (string.Equals(team.LifecycleStage, TeamLifecycleStageNames.Archived, StringComparison.Ordinal))
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.TeamArchived,
+                team.ScopeId,
+                team.TeamId,
+                $"team '{team.TeamId}' is archived.");
+        }
+
+        var entryMemberId = team.EntryMemberId?.Trim() ?? string.Empty;
+        if (entryMemberId.Length == 0)
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.EntryMemberNotConfigured,
+                team.ScopeId,
+                team.TeamId,
+                $"team '{team.TeamId}' has no entry member configured.");
+        }
+
+        var member = await _memberQueryPort.GetAsync(team.ScopeId, entryMemberId, ct);
+        if (member == null)
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.EntryMemberNotFound,
+                team.ScopeId,
+                team.TeamId,
+                $"entry member '{entryMemberId}' not found in scope '{team.ScopeId}'.");
+        }
+
+        if (!string.Equals(member.Summary.TeamId, team.TeamId, StringComparison.Ordinal))
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.EntryMemberMismatch,
+                team.ScopeId,
+                team.TeamId,
+                $"entry member '{entryMemberId}' does not belong to team '{team.TeamId}'.");
+        }
+
+        if (!string.Equals(member.Summary.LifecycleStage, MemberLifecycleStageNames.BindReady, StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(member.Summary.PublishedServiceId))
+        {
+            throw Failure(
+                TeamEntryMemberErrorCodes.EntryMemberNotReady,
+                team.ScopeId,
+                team.TeamId,
+                $"entry member '{entryMemberId}' is not bind-ready.");
+        }
+
+        return new TeamEntryMemberResolution(
+            ScopeId: team.ScopeId,
+            TeamId: team.TeamId,
+            EntryMemberId: entryMemberId,
+            PublishedServiceId: member.Summary.PublishedServiceId);
+    }
+
+    private static TeamEntryMemberResolutionException Failure(
+        string code,
+        string scopeId,
+        string teamId,
+        string message) =>
+        new(code, scopeId, teamId, message);
+}

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
@@ -1,5 +1,7 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
 
@@ -7,9 +9,6 @@ namespace Aevatar.Studio.Application.Studio.Services;
 
 public sealed class StudioTeamGAgentStreamInvocationService : IStudioTeamGAgentStreamInvocationService
 {
-    private const string ServiceAppId = "default";
-    private const string ServiceNamespace = "default";
-
     private readonly ITeamEntryMemberResolver _teamEntryMemberResolver;
     private readonly IStaticGAgentStreamInvocationPort<AGUIEvent> _staticInvocationPort;
 
@@ -23,10 +22,10 @@ public sealed class StudioTeamGAgentStreamInvocationService : IStudioTeamGAgentS
             ?? throw new ArgumentNullException(nameof(staticInvocationPort));
     }
 
-    public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
-        StudioTeamGAgentStreamInvocationRequest request,
+    public async Task<StudioTeamStreamInvocationResult> InvokeAsync(
+        StudioTeamStreamInvocationRequest request,
         Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
-        Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+        Func<StudioTeamStreamInvocationAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -40,17 +39,27 @@ public sealed class StudioTeamGAgentStreamInvocationService : IStudioTeamGAgentS
         var resolution = await _teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
         var identity = new ServiceIdentity
         {
-            TenantId = resolution.ScopeId,
-            AppId = ServiceAppId,
-            Namespace = ServiceNamespace,
-            ServiceId = resolution.PublishedServiceId,
+            TenantId = NormalizeRequired(resolution.ScopeId, nameof(resolution.ScopeId)),
+            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
+            ServiceId = NormalizeRequired(
+                resolution.PublishedServiceId,
+                nameof(resolution.PublishedServiceId)),
         };
 
-        return await _staticInvocationPort.InvokeAsync(
-            new StaticGAgentStreamInvocationRequest(identity, endpointId, input),
+        var result = await _staticInvocationPort.InvokeAsync(
+            new StaticGAgentStreamInvocationRequest(identity, endpointId, MapInput(input)),
             emitAsync,
-            onAcceptedAsync,
+            onAcceptedAsync == null
+                ? null
+                : (receipt, token) => onAcceptedAsync(MapAcceptedReceipt(receipt), token),
             ct);
+
+        return new StudioTeamStreamInvocationResult(
+            result.Accepted == null ? null : MapAcceptedReceipt(result.Accepted),
+            result.StartError.ToString(),
+            result.CompletionStatus.ToString(),
+            result.CompletionObserved);
     }
 
     private static string NormalizeRequired(string? value, string fieldName)
@@ -61,4 +70,57 @@ public sealed class StudioTeamGAgentStreamInvocationService : IStudioTeamGAgentS
 
         return normalized;
     }
+
+    private static StaticGAgentStreamInvocationInput MapInput(StudioTeamStreamInvocationInput input) =>
+        new(
+            Prompt: input.Prompt,
+            PreferredActorId: input.PreferredActorId,
+            SessionId: input.SessionId,
+            RevisionId: input.RevisionId,
+            Headers: input.Headers,
+            InputParts: MapInputParts(input.InputParts),
+            Timeout: input.Timeout);
+
+    private static IReadOnlyList<GAgentDraftRunInputPart>? MapInputParts(
+        IReadOnlyList<StudioTeamStreamInvocationInputPart>? inputParts)
+    {
+        if (inputParts == null)
+            return null;
+
+        var mapped = new List<GAgentDraftRunInputPart>(inputParts.Count);
+        foreach (var part in inputParts)
+        {
+            mapped.Add(new GAgentDraftRunInputPart
+            {
+                Kind = MapInputPartKind(part.Type),
+                Text = part.Text,
+                DataBase64 = part.DataBase64,
+                MediaType = part.MediaType,
+                Uri = part.Uri,
+                Name = part.Name,
+            });
+        }
+
+        return mapped;
+    }
+
+    private static GAgentDraftRunInputPartKind MapInputPartKind(string type)
+    {
+        var normalized = NormalizeRequired(type, nameof(StudioTeamStreamInvocationInputPart.Type));
+        return normalized.ToLowerInvariant() switch
+        {
+            "text" => GAgentDraftRunInputPartKind.Text,
+            "image" => GAgentDraftRunInputPartKind.Image,
+            "audio" => GAgentDraftRunInputPartKind.Audio,
+            "video" => GAgentDraftRunInputPartKind.Video,
+            _ => GAgentDraftRunInputPartKind.Unspecified,
+        };
+    }
+
+    private static StudioTeamStreamInvocationAcceptedReceipt MapAcceptedReceipt(
+        StaticGAgentStreamAcceptedReceipt receipt) =>
+        new(
+            receipt.GAgentReceipt.CommandId,
+            receipt.GAgentReceipt.ActorId,
+            receipt.GAgentReceipt.CorrelationId);
 }

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamGAgentStreamInvocationService.cs
@@ -1,0 +1,64 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Presentation.AGUI;
+using Aevatar.Studio.Application.Studio.Abstractions;
+
+namespace Aevatar.Studio.Application.Studio.Services;
+
+public sealed class StudioTeamGAgentStreamInvocationService : IStudioTeamGAgentStreamInvocationService
+{
+    private const string ServiceAppId = "default";
+    private const string ServiceNamespace = "default";
+
+    private readonly ITeamEntryMemberResolver _teamEntryMemberResolver;
+    private readonly IStaticGAgentStreamInvocationPort<AGUIEvent> _staticInvocationPort;
+
+    public StudioTeamGAgentStreamInvocationService(
+        ITeamEntryMemberResolver teamEntryMemberResolver,
+        IStaticGAgentStreamInvocationPort<AGUIEvent> staticInvocationPort)
+    {
+        _teamEntryMemberResolver = teamEntryMemberResolver
+            ?? throw new ArgumentNullException(nameof(teamEntryMemberResolver));
+        _staticInvocationPort = staticInvocationPort
+            ?? throw new ArgumentNullException(nameof(staticInvocationPort));
+    }
+
+    public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+        StudioTeamGAgentStreamInvocationRequest request,
+        Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+        Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(emitAsync);
+
+        var scopeId = NormalizeRequired(request.ScopeId, nameof(request.ScopeId));
+        var teamId = NormalizeRequired(request.TeamId, nameof(request.TeamId));
+        var endpointId = NormalizeRequired(request.EndpointId, nameof(request.EndpointId));
+        var input = request.Input ?? throw new InvalidOperationException("input is required.");
+
+        var resolution = await _teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
+        var identity = new ServiceIdentity
+        {
+            TenantId = resolution.ScopeId,
+            AppId = ServiceAppId,
+            Namespace = ServiceNamespace,
+            ServiceId = resolution.PublishedServiceId,
+        };
+
+        return await _staticInvocationPort.InvokeAsync(
+            new StaticGAgentStreamInvocationRequest(identity, endpointId, input),
+            emitAsync,
+            onAcceptedAsync,
+            ct);
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+
+        return normalized;
+    }
+}

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
@@ -12,13 +12,16 @@ public sealed class StudioTeamService : IStudioTeamService
 {
     private readonly IStudioTeamCommandPort _commandPort;
     private readonly IStudioTeamQueryPort _queryPort;
+    private readonly IStudioMemberQueryPort _memberQueryPort;
 
     public StudioTeamService(
         IStudioTeamCommandPort commandPort,
-        IStudioTeamQueryPort queryPort)
+        IStudioTeamQueryPort queryPort,
+        IStudioMemberQueryPort memberQueryPort)
     {
         _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _memberQueryPort = memberQueryPort ?? throw new ArgumentNullException(nameof(memberQueryPort));
     }
 
     public Task<StudioTeamSummaryResponse> CreateAsync(
@@ -99,5 +102,59 @@ public sealed class StudioTeamService : IStudioTeamService
     {
         await _commandPort.ArchiveAsync(scopeId, teamId, ct);
         return await GetAsync(scopeId, teamId, ct);
+    }
+
+    public async Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        SetStudioTeamEntryMemberRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var normalizedMemberId = NormalizeRequired(request.MemberId, nameof(request.MemberId));
+        var team = await GetAsync(scopeId, teamId, ct);
+        EnsureTeamWritable(team);
+
+        var member = await _memberQueryPort.GetAsync(scopeId, normalizedMemberId, ct)
+            ?? throw new StudioMemberNotFoundException(scopeId, normalizedMemberId);
+
+        if (!string.Equals(member.Summary.TeamId, team.TeamId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"member '{normalizedMemberId}' does not belong to team '{team.TeamId}'.");
+        }
+
+        await _commandPort.SetEntryMemberAsync(scopeId, team.TeamId, normalizedMemberId, ct);
+        return await GetAsync(scopeId, team.TeamId, ct);
+    }
+
+    public async Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default)
+    {
+        var team = await GetAsync(scopeId, teamId, ct);
+        EnsureTeamWritable(team);
+
+        await _commandPort.ClearEntryMemberAsync(scopeId, team.TeamId, ct);
+        return await GetAsync(scopeId, team.TeamId, ct);
+    }
+
+    private static void EnsureTeamWritable(StudioTeamSummaryResponse team)
+    {
+        if (string.Equals(team.LifecycleStage, TeamLifecycleStageNames.Archived, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"team '{team.TeamId}' is archived; entry member updates are not allowed.");
+        }
+    }
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+        return normalized;
     }
 }

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
@@ -104,7 +104,7 @@ public sealed class StudioTeamService : IStudioTeamService
         return await GetAsync(scopeId, teamId, ct);
     }
 
-    public async Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+    public async Task SetEntryMemberAsync(
         string scopeId,
         string teamId,
         SetStudioTeamEntryMemberRequest request,
@@ -126,10 +126,9 @@ public sealed class StudioTeamService : IStudioTeamService
         }
 
         await _commandPort.SetEntryMemberAsync(scopeId, team.TeamId, normalizedMemberId, ct);
-        return await GetAsync(scopeId, team.TeamId, ct);
     }
 
-    public async Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+    public async Task ClearEntryMemberAsync(
         string scopeId,
         string teamId,
         CancellationToken ct = default)
@@ -138,7 +137,6 @@ public sealed class StudioTeamService : IStudioTeamService
         EnsureTeamWritable(team);
 
         await _commandPort.ClearEntryMemberAsync(scopeId, team.TeamId, ct);
-        return await GetAsync(scopeId, team.TeamId, ct);
     }
 
     private static void EnsureTeamWritable(StudioTeamSummaryResponse team)

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
@@ -1,10 +1,17 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Hosting;
+using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.Studio.Hosting.Endpoints;
 
@@ -41,6 +48,14 @@ internal static class StudioTeamEndpoints
                 "/api/scopes/{scopeId}/teams/{teamId}/archive",
                 HandleArchiveAsync)
             .WithTags("StudioTeams");
+        app.MapPut(
+                "/api/scopes/{scopeId}/teams/{teamId}/entry-member",
+                HandleSetEntryMemberAsync)
+            .WithTags("StudioTeams");
+        app.MapDelete(
+                "/api/scopes/{scopeId}/teams/{teamId}/entry-member",
+                HandleClearEntryMemberAsync)
+            .WithTags("StudioTeams");
 
         // Team -> members listing: queries the member read model filtered by
         // team_id (per ADR-0017 §HTTP endpoints — the team read model itself
@@ -48,6 +63,10 @@ internal static class StudioTeamEndpoints
         app.MapGet(
                 "/api/scopes/{scopeId}/teams/{teamId}/members",
                 HandleListMembersAsync)
+            .WithTags("StudioTeams");
+        app.MapPost(
+                "/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream",
+                HandleInvokeTeamStreamAsync)
             .WithTags("StudioTeams");
     }
 
@@ -229,6 +248,179 @@ internal static class StudioTeamEndpoints
         }
     }
 
+    internal static async Task<IResult> HandleSetEntryMemberAsync(
+        HttpContext http,
+        string scopeId,
+        string teamId,
+        SetStudioTeamEntryMemberRequest request,
+        [FromServices] IStudioTeamService teamService,
+        CancellationToken ct)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
+        try
+        {
+            return Results.Ok(await teamService.SetEntryMemberAsync(scopeId, teamId, request, ct));
+        }
+        catch (StudioTeamNotFoundException ex)
+        {
+            return NotFound(ex);
+        }
+        catch (StudioMemberNotFoundException ex)
+        {
+            return MemberNotFound(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_STUDIO_TEAM_ENTRY_MEMBER_REQUEST", ex.Message);
+        }
+    }
+
+    internal static async Task<IResult> HandleClearEntryMemberAsync(
+        HttpContext http,
+        string scopeId,
+        string teamId,
+        [FromServices] IStudioTeamService teamService,
+        CancellationToken ct)
+    {
+        if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+            return denied;
+
+        try
+        {
+            return Results.Ok(await teamService.ClearEntryMemberAsync(scopeId, teamId, ct));
+        }
+        catch (StudioTeamNotFoundException ex)
+        {
+            return NotFound(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest("INVALID_STUDIO_TEAM_ENTRY_MEMBER_REQUEST", ex.Message);
+        }
+    }
+
+    internal static async Task HandleInvokeTeamStreamAsync(
+        HttpContext http,
+        string scopeId,
+        string teamId,
+        string endpointId,
+        StudioTeamGAgentStreamHttpRequest request,
+        [FromServices] IStudioTeamGAgentStreamInvocationService streamInvocationService,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
+            var responseStarted = false;
+            var writer = new AGUISseWriter(http.Response);
+
+            async Task EnsureSseStartedAsync(CancellationToken token)
+            {
+                if (responseStarted)
+                    return;
+
+                http.Response.StatusCode = StatusCodes.Status200OK;
+                http.Response.Headers.ContentType = "text/event-stream; charset=utf-8";
+                http.Response.Headers.CacheControl = "no-store";
+                http.Response.Headers["X-Accel-Buffering"] = "no";
+                await http.Response.StartAsync(token);
+                responseStarted = true;
+            }
+
+            async ValueTask EmitAsync(AGUIEvent aguiEvent, CancellationToken token)
+            {
+                await EnsureSseStartedAsync(token);
+                await writer.WriteAsync(aguiEvent, token);
+            }
+
+            async ValueTask OnAcceptedAsync(StaticGAgentStreamAcceptedReceipt receipt, CancellationToken token)
+            {
+                http.Response.Headers["X-Correlation-Id"] = receipt.GAgentReceipt.CorrelationId;
+                await EnsureSseStartedAsync(token);
+                await writer.WriteAsync(
+                    new AGUIEvent
+                    {
+                        RunStarted = new RunStartedEvent
+                        {
+                            ThreadId = receipt.GAgentReceipt.ActorId,
+                            RunId = receipt.GAgentReceipt.CommandId,
+                        },
+                    },
+                    token);
+            }
+
+            try
+            {
+                await streamInvocationService.InvokeAsync(
+                    new StudioTeamGAgentStreamInvocationRequest(
+                        scopeId,
+                        teamId,
+                        endpointId,
+                        new StaticGAgentStreamInvocationInput(
+                            Prompt: request.Prompt?.Trim() ?? string.Empty,
+                            PreferredActorId: NormalizeOptional(request.ActorId),
+                            SessionId: request.SessionId,
+                            RevisionId: NormalizeOptional(request.RevisionId),
+                            Headers: await BuildScopedHeadersAsync(scopeId, request.Headers, http, ct),
+                            InputParts: MapInputParts(request.InputParts))),
+                    EmitAsync,
+                    OnAcceptedAsync,
+                    ct);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                await EnsureSseStartedAsync(CancellationToken.None);
+                await writer.WriteAsync(
+                    new AGUIEvent
+                    {
+                        RunError = new RunErrorEvent
+                        {
+                            Message = "Studio team GAgent stream timed out.",
+                        },
+                    },
+                    CancellationToken.None);
+            }
+            catch (Exception ex) when (responseStarted)
+            {
+                var isAuthRequired = ex is NyxIdAuthenticationRequiredException;
+                await writer.WriteAsync(
+                    new AGUIEvent
+                    {
+                        RunError = new RunErrorEvent
+                        {
+                            Message = isAuthRequired
+                                ? "NyxID authentication required. Please sign in."
+                                : ex.Message,
+                            Code = isAuthRequired ? "authentication_required" : null,
+                        },
+                    },
+                    CancellationToken.None);
+            }
+        }
+        catch (TeamEntryMemberResolutionException ex)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                ResolveTeamEntryHttpStatusCode(ex.Code),
+                ex.Code,
+                ex.Message,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                StatusCodes.Status400BadRequest,
+                "INVALID_STUDIO_TEAM_GAGENT_STREAM_REQUEST",
+                ex.Message,
+                ct);
+        }
+    }
+
     /// <summary>
     /// Lists members assigned to a given team. Queries the member read model
     /// filtered by <c>team_id</c> (ADR-0017 §HTTP endpoints) — the team read
@@ -312,6 +504,134 @@ internal static class StudioTeamEndpoints
     private static IResult BadRequest(string code, string message) =>
         Results.BadRequest(new { code, message });
 
+    private static async Task<Dictionary<string, string>> BuildScopedHeadersAsync(
+        string scopeId,
+        IReadOnlyDictionary<string, string>? headers,
+        HttpContext http,
+        CancellationToken ct)
+    {
+        var scopedHeaders = headers == null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+        scopedHeaders.Remove("scope_id");
+        scopedHeaders.Remove(WorkflowRunCommandMetadataKeys.ScopeId);
+        InjectBearerToken(http, scopedHeaders);
+        await InjectUserLlmPreferencesAsync(http, scopedHeaders, ct);
+        return scopedHeaders;
+    }
+
+    private static void InjectBearerToken(HttpContext http, Dictionary<string, string> headers)
+    {
+        var auth = http.Request.Headers.Authorization.FirstOrDefault();
+        if (auth == null || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        var bearerToken = auth["Bearer ".Length..].Trim();
+        headers[LLMRequestMetadataKeys.NyxIdAccessToken] = bearerToken;
+        headers[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
+    }
+
+    private static async Task InjectUserLlmPreferencesAsync(
+        HttpContext http,
+        Dictionary<string, string> headers,
+        CancellationToken ct)
+    {
+        var preferencesStore = http.RequestServices.GetService<INyxIdUserLlmPreferencesStore>();
+        if (preferencesStore != null)
+        {
+            try
+            {
+                var preferences = await preferencesStore.GetOwnerAsync(ct);
+                if (!headers.ContainsKey(LLMRequestMetadataKeys.ModelOverride) &&
+                    !string.IsNullOrWhiteSpace(preferences.DefaultModel))
+                    headers[LLMRequestMetadataKeys.ModelOverride] = preferences.DefaultModel.Trim();
+                if (!headers.ContainsKey(LLMRequestMetadataKeys.NyxIdRoutePreference) &&
+                    !string.IsNullOrWhiteSpace(preferences.PreferredRoute))
+                    headers[LLMRequestMetadataKeys.NyxIdRoutePreference] = preferences.PreferredRoute.Trim();
+            }
+            catch
+            {
+                // Best-effort; fall back to provider defaults if config unavailable.
+            }
+            return;
+        }
+
+        var userConfigStore = http.RequestServices.GetService<IUserConfigQueryPort>();
+        if (userConfigStore == null)
+            return;
+
+        try
+        {
+            var userConfig = await userConfigStore.GetAsync(ct);
+            if (!headers.ContainsKey(LLMRequestMetadataKeys.ModelOverride) &&
+                !string.IsNullOrWhiteSpace(userConfig.DefaultModel))
+                headers[LLMRequestMetadataKeys.ModelOverride] = userConfig.DefaultModel.Trim();
+            if (!headers.ContainsKey(LLMRequestMetadataKeys.NyxIdRoutePreference) &&
+                !string.IsNullOrWhiteSpace(userConfig.PreferredLlmRoute))
+                headers[LLMRequestMetadataKeys.NyxIdRoutePreference] = userConfig.PreferredLlmRoute.Trim();
+        }
+        catch
+        {
+            // Best-effort; fall back to provider defaults if config unavailable.
+        }
+    }
+
+    private static IReadOnlyList<GAgentDraftRunInputPart>? MapInputParts(
+        IReadOnlyList<StudioTeamStreamContentPartHttpRequest>? parts)
+    {
+        if (parts is not { Count: > 0 })
+            return null;
+
+        return parts
+            .Where(p => p != null)
+            .Select(p => new GAgentDraftRunInputPart
+            {
+                Kind = p.Type?.ToLowerInvariant() switch
+                {
+                    "image" => GAgentDraftRunInputPartKind.Image,
+                    "audio" => GAgentDraftRunInputPartKind.Audio,
+                    "video" => GAgentDraftRunInputPartKind.Video,
+                    "text" => GAgentDraftRunInputPartKind.Text,
+                    _ => GAgentDraftRunInputPartKind.Unspecified,
+                },
+                Text = p.Text,
+                DataBase64 = p.DataBase64,
+                MediaType = p.MediaType,
+                Uri = p.Uri,
+                Name = p.Name,
+            }).ToList();
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static int ResolveTeamEntryHttpStatusCode(string code) =>
+        code switch
+        {
+            TeamEntryMemberErrorCodes.TeamNotFound => StatusCodes.Status404NotFound,
+            TeamEntryMemberErrorCodes.TeamArchived => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberNotConfigured => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberMismatch => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberNotReady => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberNotFound => StatusCodes.Status409Conflict,
+            _ => StatusCodes.Status400BadRequest,
+        };
+
+    private static async Task WriteJsonErrorResponseAsync(
+        HttpContext http,
+        int statusCode,
+        string code,
+        string message,
+        CancellationToken ct)
+    {
+        http.Response.StatusCode = statusCode;
+        http.Response.ContentType = "application/json";
+        await http.Response.WriteAsJsonAsync(new { code, message }, cancellationToken: ct);
+    }
+
     private static IResult NotFound(StudioTeamNotFoundException ex) =>
         Results.Json(
             new
@@ -322,4 +642,31 @@ internal static class StudioTeamEndpoints
                 teamId = ex.TeamId,
             },
             statusCode: StatusCodes.Status404NotFound);
+
+    private static IResult MemberNotFound(StudioMemberNotFoundException ex) =>
+        Results.Json(
+            new
+            {
+                code = "STUDIO_MEMBER_NOT_FOUND",
+                message = ex.Message,
+                scopeId = ex.ScopeId,
+                memberId = ex.MemberId,
+            },
+            statusCode: StatusCodes.Status404NotFound);
+
+    public sealed record StudioTeamGAgentStreamHttpRequest(
+        string? Prompt,
+        string? ActorId = null,
+        string? SessionId = null,
+        Dictionary<string, string>? Headers = null,
+        string? RevisionId = null,
+        IReadOnlyList<StudioTeamStreamContentPartHttpRequest>? InputParts = null);
+
+    public sealed record StudioTeamStreamContentPartHttpRequest(
+        string Type,
+        string? Text = null,
+        string? DataBase64 = null,
+        string? MediaType = null,
+        string? Uri = null,
+        string? Name = null);
 }

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
@@ -1,17 +1,10 @@
-using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.Foundation.Abstractions.Connectors;
-using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.Hosting;
-using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
-using Aevatar.Workflow.Application.Abstractions.Runs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.Studio.Hosting.Endpoints;
 
@@ -63,10 +56,6 @@ internal static class StudioTeamEndpoints
         app.MapGet(
                 "/api/scopes/{scopeId}/teams/{teamId}/members",
                 HandleListMembersAsync)
-            .WithTags("StudioTeams");
-        app.MapPost(
-                "/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream",
-                HandleInvokeTeamStreamAsync)
             .WithTags("StudioTeams");
     }
 
@@ -261,7 +250,8 @@ internal static class StudioTeamEndpoints
 
         try
         {
-            return Results.Ok(await teamService.SetEntryMemberAsync(scopeId, teamId, request, ct));
+            await teamService.SetEntryMemberAsync(scopeId, teamId, request, ct);
+            return Results.Accepted(BuildTeamLocation(scopeId, teamId));
         }
         catch (StudioTeamNotFoundException ex)
         {
@@ -289,7 +279,8 @@ internal static class StudioTeamEndpoints
 
         try
         {
-            return Results.Ok(await teamService.ClearEntryMemberAsync(scopeId, teamId, ct));
+            await teamService.ClearEntryMemberAsync(scopeId, teamId, ct);
+            return Results.Accepted(BuildTeamLocation(scopeId, teamId));
         }
         catch (StudioTeamNotFoundException ex)
         {
@@ -298,126 +289,6 @@ internal static class StudioTeamEndpoints
         catch (InvalidOperationException ex)
         {
             return BadRequest("INVALID_STUDIO_TEAM_ENTRY_MEMBER_REQUEST", ex.Message);
-        }
-    }
-
-    internal static async Task HandleInvokeTeamStreamAsync(
-        HttpContext http,
-        string scopeId,
-        string teamId,
-        string endpointId,
-        StudioTeamGAgentStreamHttpRequest request,
-        [FromServices] IStudioTeamGAgentStreamInvocationService streamInvocationService,
-        CancellationToken ct)
-    {
-        try
-        {
-            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
-                return;
-
-            var responseStarted = false;
-            var writer = new AGUISseWriter(http.Response);
-
-            async Task EnsureSseStartedAsync(CancellationToken token)
-            {
-                if (responseStarted)
-                    return;
-
-                http.Response.StatusCode = StatusCodes.Status200OK;
-                http.Response.Headers.ContentType = "text/event-stream; charset=utf-8";
-                http.Response.Headers.CacheControl = "no-store";
-                http.Response.Headers["X-Accel-Buffering"] = "no";
-                await http.Response.StartAsync(token);
-                responseStarted = true;
-            }
-
-            async ValueTask EmitAsync(AGUIEvent aguiEvent, CancellationToken token)
-            {
-                await EnsureSseStartedAsync(token);
-                await writer.WriteAsync(aguiEvent, token);
-            }
-
-            async ValueTask OnAcceptedAsync(StaticGAgentStreamAcceptedReceipt receipt, CancellationToken token)
-            {
-                http.Response.Headers["X-Correlation-Id"] = receipt.GAgentReceipt.CorrelationId;
-                await EnsureSseStartedAsync(token);
-                await writer.WriteAsync(
-                    new AGUIEvent
-                    {
-                        RunStarted = new RunStartedEvent
-                        {
-                            ThreadId = receipt.GAgentReceipt.ActorId,
-                            RunId = receipt.GAgentReceipt.CommandId,
-                        },
-                    },
-                    token);
-            }
-
-            try
-            {
-                await streamInvocationService.InvokeAsync(
-                    new StudioTeamGAgentStreamInvocationRequest(
-                        scopeId,
-                        teamId,
-                        endpointId,
-                        new StaticGAgentStreamInvocationInput(
-                            Prompt: request.Prompt?.Trim() ?? string.Empty,
-                            PreferredActorId: NormalizeOptional(request.ActorId),
-                            SessionId: request.SessionId,
-                            RevisionId: NormalizeOptional(request.RevisionId),
-                            Headers: await BuildScopedHeadersAsync(scopeId, request.Headers, http, ct),
-                            InputParts: MapInputParts(request.InputParts))),
-                    EmitAsync,
-                    OnAcceptedAsync,
-                    ct);
-            }
-            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-            {
-                await EnsureSseStartedAsync(CancellationToken.None);
-                await writer.WriteAsync(
-                    new AGUIEvent
-                    {
-                        RunError = new RunErrorEvent
-                        {
-                            Message = "Studio team GAgent stream timed out.",
-                        },
-                    },
-                    CancellationToken.None);
-            }
-            catch (Exception ex) when (responseStarted)
-            {
-                var isAuthRequired = ex is NyxIdAuthenticationRequiredException;
-                await writer.WriteAsync(
-                    new AGUIEvent
-                    {
-                        RunError = new RunErrorEvent
-                        {
-                            Message = isAuthRequired
-                                ? "NyxID authentication required. Please sign in."
-                                : ex.Message,
-                            Code = isAuthRequired ? "authentication_required" : null,
-                        },
-                    },
-                    CancellationToken.None);
-            }
-        }
-        catch (TeamEntryMemberResolutionException ex)
-        {
-            await WriteJsonErrorResponseAsync(
-                http,
-                ResolveTeamEntryHttpStatusCode(ex.Code),
-                ex.Code,
-                ex.Message,
-                ct);
-        }
-        catch (InvalidOperationException ex)
-        {
-            await WriteJsonErrorResponseAsync(
-                http,
-                StatusCodes.Status400BadRequest,
-                "INVALID_STUDIO_TEAM_GAGENT_STREAM_REQUEST",
-                ex.Message,
-                ct);
         }
     }
 
@@ -504,133 +375,8 @@ internal static class StudioTeamEndpoints
     private static IResult BadRequest(string code, string message) =>
         Results.BadRequest(new { code, message });
 
-    private static async Task<Dictionary<string, string>> BuildScopedHeadersAsync(
-        string scopeId,
-        IReadOnlyDictionary<string, string>? headers,
-        HttpContext http,
-        CancellationToken ct)
-    {
-        var scopedHeaders = headers == null
-            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
-        scopedHeaders.Remove("scope_id");
-        scopedHeaders.Remove(WorkflowRunCommandMetadataKeys.ScopeId);
-        InjectBearerToken(http, scopedHeaders);
-        await InjectUserLlmPreferencesAsync(http, scopedHeaders, ct);
-        return scopedHeaders;
-    }
-
-    private static void InjectBearerToken(HttpContext http, Dictionary<string, string> headers)
-    {
-        var auth = http.Request.Headers.Authorization.FirstOrDefault();
-        if (auth == null || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
-            return;
-
-        var bearerToken = auth["Bearer ".Length..].Trim();
-        headers[LLMRequestMetadataKeys.NyxIdAccessToken] = bearerToken;
-        headers[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
-    }
-
-    private static async Task InjectUserLlmPreferencesAsync(
-        HttpContext http,
-        Dictionary<string, string> headers,
-        CancellationToken ct)
-    {
-        var preferencesStore = http.RequestServices.GetService<INyxIdUserLlmPreferencesStore>();
-        if (preferencesStore != null)
-        {
-            try
-            {
-                var preferences = await preferencesStore.GetOwnerAsync(ct);
-                if (!headers.ContainsKey(LLMRequestMetadataKeys.ModelOverride) &&
-                    !string.IsNullOrWhiteSpace(preferences.DefaultModel))
-                    headers[LLMRequestMetadataKeys.ModelOverride] = preferences.DefaultModel.Trim();
-                if (!headers.ContainsKey(LLMRequestMetadataKeys.NyxIdRoutePreference) &&
-                    !string.IsNullOrWhiteSpace(preferences.PreferredRoute))
-                    headers[LLMRequestMetadataKeys.NyxIdRoutePreference] = preferences.PreferredRoute.Trim();
-            }
-            catch
-            {
-                // Best-effort; fall back to provider defaults if config unavailable.
-            }
-            return;
-        }
-
-        var userConfigStore = http.RequestServices.GetService<IUserConfigQueryPort>();
-        if (userConfigStore == null)
-            return;
-
-        try
-        {
-            var userConfig = await userConfigStore.GetAsync(ct);
-            if (!headers.ContainsKey(LLMRequestMetadataKeys.ModelOverride) &&
-                !string.IsNullOrWhiteSpace(userConfig.DefaultModel))
-                headers[LLMRequestMetadataKeys.ModelOverride] = userConfig.DefaultModel.Trim();
-            if (!headers.ContainsKey(LLMRequestMetadataKeys.NyxIdRoutePreference) &&
-                !string.IsNullOrWhiteSpace(userConfig.PreferredLlmRoute))
-                headers[LLMRequestMetadataKeys.NyxIdRoutePreference] = userConfig.PreferredLlmRoute.Trim();
-        }
-        catch
-        {
-            // Best-effort; fall back to provider defaults if config unavailable.
-        }
-    }
-
-    private static IReadOnlyList<GAgentDraftRunInputPart>? MapInputParts(
-        IReadOnlyList<StudioTeamStreamContentPartHttpRequest>? parts)
-    {
-        if (parts is not { Count: > 0 })
-            return null;
-
-        return parts
-            .Where(p => p != null)
-            .Select(p => new GAgentDraftRunInputPart
-            {
-                Kind = p.Type?.ToLowerInvariant() switch
-                {
-                    "image" => GAgentDraftRunInputPartKind.Image,
-                    "audio" => GAgentDraftRunInputPartKind.Audio,
-                    "video" => GAgentDraftRunInputPartKind.Video,
-                    "text" => GAgentDraftRunInputPartKind.Text,
-                    _ => GAgentDraftRunInputPartKind.Unspecified,
-                },
-                Text = p.Text,
-                DataBase64 = p.DataBase64,
-                MediaType = p.MediaType,
-                Uri = p.Uri,
-                Name = p.Name,
-            }).ToList();
-    }
-
-    private static string? NormalizeOptional(string? value)
-    {
-        var normalized = value?.Trim();
-        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
-    }
-
-    private static int ResolveTeamEntryHttpStatusCode(string code) =>
-        code switch
-        {
-            TeamEntryMemberErrorCodes.TeamNotFound => StatusCodes.Status404NotFound,
-            TeamEntryMemberErrorCodes.TeamArchived => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberNotConfigured => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberMismatch => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberNotReady => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberNotFound => StatusCodes.Status409Conflict,
-            _ => StatusCodes.Status400BadRequest,
-        };
-
-    private static async Task WriteJsonErrorResponseAsync(
-        HttpContext http,
-        int statusCode,
-        string code,
-        string message,
-        CancellationToken ct)
-    {
-        http.Response.StatusCode = statusCode;
-        http.Response.ContentType = "application/json";
-        await http.Response.WriteAsJsonAsync(new { code, message }, cancellationToken: ct);
-    }
+    private static string BuildTeamLocation(string scopeId, string teamId) =>
+        $"/api/scopes/{Uri.EscapeDataString(scopeId)}/teams/{Uri.EscapeDataString(teamId)}";
 
     private static IResult NotFound(StudioTeamNotFoundException ex) =>
         Results.Json(
@@ -654,19 +400,4 @@ internal static class StudioTeamEndpoints
             },
             statusCode: StatusCodes.Status404NotFound);
 
-    public sealed record StudioTeamGAgentStreamHttpRequest(
-        string? Prompt,
-        string? ActorId = null,
-        string? SessionId = null,
-        Dictionary<string, string>? Headers = null,
-        string? RevisionId = null,
-        IReadOnlyList<StudioTeamStreamContentPartHttpRequest>? InputParts = null);
-
-    public sealed record StudioTeamStreamContentPartHttpRequest(
-        string Type,
-        string? Text = null,
-        string? DataBase64 = null,
-        string? MediaType = null,
-        string? Uri = null,
-        string? Name = null);
 }

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioTeamCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioTeamCommandService.cs
@@ -126,6 +126,45 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
         await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
     }
 
+    public async Task SetEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        string memberId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = StudioTeamConventions.NormalizeScopeId(scopeId);
+        var normalizedTeamId = StudioTeamConventions.NormalizeTeamId(teamId);
+        var normalizedMemberId = Aevatar.GAgents.StudioMember.StudioMemberConventions.NormalizeMemberId(memberId);
+
+        var evt = new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = normalizedTeamId,
+            ScopeId = normalizedScopeId,
+            EntryMemberId = normalizedMemberId,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+
+        await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
+    }
+
+    public async Task ClearEntryMemberAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default)
+    {
+        var normalizedScopeId = StudioTeamConventions.NormalizeScopeId(scopeId);
+        var normalizedTeamId = StudioTeamConventions.NormalizeTeamId(teamId);
+
+        var evt = new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = normalizedTeamId,
+            ScopeId = normalizedScopeId,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+
+        await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
+    }
+
     private async Task DispatchAsync(string scopeId, string teamId, IMessage payload, CancellationToken ct)
     {
         var actorId = StudioTeamConventions.BuildActorId(scopeId, teamId);

--- a/src/Aevatar.Studio.Projection/Projectors/StudioTeamCurrentStateProjector.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioTeamCurrentStateProjector.cs
@@ -72,6 +72,8 @@ public sealed class StudioTeamCurrentStateProjector
             // a counter field that drifts independently of the set of ids.
             MemberCount = state.MemberIds.Count,
         };
+        if (state.HasEntryMemberId)
+            document.EntryMemberId = state.EntryMemberId;
 
         await _writeDispatcher.UpsertAsync(document, ct);
     }

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioTeamQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioTeamQueryPort.cs
@@ -90,7 +90,10 @@ public sealed class ProjectionStudioTeamQueryPort : IStudioTeamQueryPort
             LifecycleStage: NormalizeLifecycleStageWire(document.LifecycleStage),
             MemberCount: document.MemberCount,
             CreatedAt: document.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue,
-            UpdatedAt: document.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue);
+            UpdatedAt: document.UpdatedAt?.ToDateTimeOffset() ?? DateTimeOffset.MinValue)
+        {
+            EntryMemberId = document.HasEntryMemberId ? document.EntryMemberId : null,
+        };
     }
 
     private static string NormalizeLifecycleStageWire(string? wire) => wire switch

--- a/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
+++ b/src/Aevatar.Studio.Projection/ReadModels/studio_projection_readmodels.proto
@@ -223,4 +223,8 @@ message StudioTeamCurrentStateDocument {
 
   // ── Aggregate (derived from StudioTeamState.member_ids.size()). ──
   int32 member_count = 30;
+
+  // Optional team-owned entry member selection. Binding readiness and
+  // published service identity stay on StudioMemberCurrentStateDocument.
+  optional string entry_member_id = 40;
 }

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IStaticGAgentStreamInvocationPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IStaticGAgentStreamInvocationPort.cs
@@ -1,0 +1,40 @@
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public interface IStaticGAgentStreamInvocationPort<TFrame>
+{
+    Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+        StaticGAgentStreamInvocationRequest request,
+        Func<TFrame, CancellationToken, ValueTask> emitAsync,
+        Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+        CancellationToken ct = default);
+}
+
+public sealed record StaticGAgentStreamInvocationRequest(
+    ServiceIdentity Identity,
+    string EndpointId,
+    StaticGAgentStreamInvocationInput Input);
+
+public sealed record StaticGAgentStreamInvocationInput(
+    string Prompt,
+    string? PreferredActorId = null,
+    string? SessionId = null,
+    string? RevisionId = null,
+    IReadOnlyDictionary<string, string>? Headers = null,
+    IReadOnlyList<GAgentDraftRunInputPart>? InputParts = null,
+    ServiceInvocationCaller? Caller = null,
+    TimeSpan? Timeout = null);
+
+public sealed record StaticGAgentStreamAcceptedReceipt(
+    ServiceInvocationAcceptedReceipt ServiceReceipt,
+    GAgentDraftRunAcceptedReceipt GAgentReceipt);
+
+public sealed record StaticGAgentStreamInvocationResult(
+    StaticGAgentStreamAcceptedReceipt? Accepted,
+    GAgentDraftRunStartError StartError,
+    GAgentDraftRunCompletionStatus CompletionStatus,
+    bool CompletionObserved)
+{
+    public bool Succeeded => StartError == GAgentDraftRunStartError.None && Accepted is not null;
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/ITeamEntryMemberResolver.cs
@@ -1,0 +1,44 @@
+namespace Aevatar.GAgentService.Abstractions.Ports;
+
+public interface ITeamEntryMemberResolver
+{
+    Task<TeamEntryMemberResolution> ResolveAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default);
+}
+
+public sealed record TeamEntryMemberResolution(
+    string ScopeId,
+    string TeamId,
+    string EntryMemberId,
+    string PublishedServiceId);
+
+public static class TeamEntryMemberErrorCodes
+{
+    public const string TeamNotFound = "TEAM_NOT_FOUND";
+    public const string TeamArchived = "TEAM_ARCHIVED";
+    public const string EntryMemberNotConfigured = "TEAM_ENTRY_MEMBER_NOT_CONFIGURED";
+    public const string EntryMemberNotFound = "TEAM_ENTRY_MEMBER_NOT_FOUND";
+    public const string EntryMemberMismatch = "TEAM_ENTRY_MEMBER_MISMATCH";
+    public const string EntryMemberNotReady = "TEAM_ENTRY_MEMBER_NOT_READY";
+}
+
+public sealed class TeamEntryMemberResolutionException : Exception
+{
+    public TeamEntryMemberResolutionException(
+        string code,
+        string scopeId,
+        string teamId,
+        string message)
+        : base(message)
+    {
+        Code = code;
+        ScopeId = scopeId;
+        TeamId = teamId;
+    }
+
+    public string Code { get; }
+    public string ScopeId { get; }
+    public string TeamId { get; }
+}

--- a/src/platform/Aevatar.GAgentService.Abstractions/Services/ScopeServiceIdentityDefaults.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Services/ScopeServiceIdentityDefaults.cs
@@ -1,0 +1,7 @@
+namespace Aevatar.GAgentService.Abstractions.Services;
+
+public static class ScopeServiceIdentityDefaults
+{
+    public const string ServiceAppId = "default";
+    public const string ServiceNamespace = "default";
+}

--- a/src/platform/Aevatar.GAgentService.Application/Aevatar.GAgentService.Application.csproj
+++ b/src/platform/Aevatar.GAgentService.Application/Aevatar.GAgentService.Application.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\..\Aevatar.Presentation.AGUI\Aevatar.Presentation.AGUI.csproj" />
     <ProjectReference Include="..\..\Aevatar.Scripting.Core\Aevatar.Scripting.Core.csproj" />
-    <ProjectReference Include="..\..\Aevatar.Studio.Application\Aevatar.Studio.Application.csproj" />
     <ProjectReference Include="..\..\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/DefaultTeamEntryMemberResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/DefaultTeamEntryMemberResolver.cs
@@ -1,0 +1,35 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Application.Workflows;
+
+namespace Aevatar.GAgentService.Application.Bindings;
+
+public sealed class DefaultTeamEntryMemberResolver : ITeamEntryMemberResolver
+{
+    public Task<TeamEntryMemberResolution> ResolveAsync(
+        string scopeId,
+        string teamId,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(scopeId, nameof(scopeId));
+        var normalizedTeamId = NormalizeTeamId(teamId);
+
+        // TODO: replace this deterministic development resolver with an actor-owned team
+        // catalog that defines authoritative entry membership, ownership, and cleanup semantics.
+        return Task.FromResult(new TeamEntryMemberResolution(
+            normalizedScopeId,
+            normalizedTeamId,
+            normalizedTeamId,
+            normalizedTeamId));
+    }
+
+    private static string NormalizeTeamId(string teamId)
+    {
+        var normalized = ScopeWorkflowCapabilityOptions.NormalizeRequired(teamId, nameof(teamId));
+        if (normalized.IndexOfAny([':', '/', '\\', '?', '#']) >= 0)
+            throw new InvalidOperationException("teamId must not contain ':', '/', '\\', '?' or '#'.");
+
+        return normalized;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/DefaultTeamEntryMemberResolver.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/DefaultTeamEntryMemberResolver.cs
@@ -3,6 +3,14 @@ using Aevatar.GAgentService.Application.Workflows;
 
 namespace Aevatar.GAgentService.Application.Bindings;
 
+/// <summary>
+/// Transitional resolver kept only while team invoke still has a platform
+/// GAgentService route. It is not actor-owned team authority, and callers
+/// must not treat <c>teamId == entryMemberId == publishedServiceId</c> as a
+/// durable business fact. Once Team authority lives only in Studio, delete
+/// this resolver and require the owning module to provide
+/// <see cref="ITeamEntryMemberResolver"/>.
+/// </summary>
 public sealed class DefaultTeamEntryMemberResolver : ITeamEntryMemberResolver
 {
     public Task<TeamEntryMemberResolution> ResolveAsync(
@@ -15,8 +23,9 @@ public sealed class DefaultTeamEntryMemberResolver : ITeamEntryMemberResolver
         var normalizedScopeId = ScopeWorkflowCapabilityOptions.NormalizeRequired(scopeId, nameof(scopeId));
         var normalizedTeamId = NormalizeTeamId(teamId);
 
-        // TODO: replace this deterministic development resolver with an actor-owned team
-        // catalog that defines authoritative entry membership, ownership, and cleanup semantics.
+        // Transitional compatibility only. This deterministic mapping exists
+        // while Team is still migrating out of GAgentService; Studio replaces
+        // it with a read-model resolver when Studio owns the team authority.
         return Task.FromResult(new TeamEntryMemberResolution(
             normalizedScopeId,
             normalizedTeamId,

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunActorPreparationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunActorPreparationService.cs
@@ -1,7 +1,6 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Helpers;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgentService.Application.ScopeGAgents;

--- a/src/platform/Aevatar.GAgentService.Application/Services/StaticGAgentStreamInvocationApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/StaticGAgentStreamInvocationApplicationService.cs
@@ -1,0 +1,237 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Governance.Abstractions.Ports;
+using Aevatar.Presentation.AGUI;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Application.Services;
+
+public sealed class StaticGAgentStreamInvocationApplicationService : IStaticGAgentStreamInvocationPort<AGUIEvent>
+{
+    private static readonly TimeSpan DefaultInteractionTimeout = TimeSpan.FromMinutes(2);
+
+    private readonly ServiceInvocationResolutionService _resolutionService;
+    private readonly IInvokeAdmissionAuthorizer _admissionAuthorizer;
+    private readonly IServiceRunRegistrationPort _serviceRunRegistrationPort;
+    private readonly ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> _interactionService;
+
+    public StaticGAgentStreamInvocationApplicationService(
+        ServiceInvocationResolutionService resolutionService,
+        IInvokeAdmissionAuthorizer admissionAuthorizer,
+        IServiceRunRegistrationPort serviceRunRegistrationPort,
+        ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> interactionService)
+    {
+        _resolutionService = resolutionService ?? throw new ArgumentNullException(nameof(resolutionService));
+        _admissionAuthorizer = admissionAuthorizer ?? throw new ArgumentNullException(nameof(admissionAuthorizer));
+        _serviceRunRegistrationPort = serviceRunRegistrationPort
+            ?? throw new ArgumentNullException(nameof(serviceRunRegistrationPort));
+        _interactionService = interactionService ?? throw new ArgumentNullException(nameof(interactionService));
+    }
+
+    public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+        StaticGAgentStreamInvocationRequest request,
+        Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+        Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(emitAsync);
+
+        var input = request.Input ?? throw new InvalidOperationException("input is required.");
+        var identity = NormalizeIdentity(request.Identity);
+        var endpointId = NormalizeRequired(request.EndpointId, nameof(request.EndpointId));
+        var prompt = input.Prompt?.Trim() ?? string.Empty;
+        var preferredActorId = NormalizeOptional(input.PreferredActorId);
+        var revisionId = NormalizeOptional(input.RevisionId);
+        var headers = CopyHeaders(input.Headers);
+
+        var invocationRequest = BuildInvocationRequest(identity, endpointId, prompt, revisionId, headers, input.Caller);
+        var target = await _resolutionService.ResolveAsync(invocationRequest, ct);
+        await _admissionAuthorizer.AuthorizeAsync(
+            target.Service.ServiceKey,
+            target.Service.DeploymentId,
+            target.Artifact,
+            target.Endpoint,
+            invocationRequest,
+            ct);
+
+        EnsureStaticChatTarget(target, invocationRequest);
+        var actorTypeName = target.Artifact.DeploymentPlan.StaticPlan?.ActorTypeName?.Trim() ?? string.Empty;
+        if (actorTypeName.Length == 0)
+            throw new InvalidOperationException("Static GAgent service has no actor type configured.");
+
+        StaticGAgentStreamAcceptedReceipt? accepted = null;
+
+        async ValueTask OnAcceptedAsync(GAgentDraftRunAcceptedReceipt gagentReceipt, CancellationToken token)
+        {
+            var serviceReceipt = CreateServiceReceipt(target, gagentReceipt);
+            accepted = new StaticGAgentStreamAcceptedReceipt(serviceReceipt, gagentReceipt);
+            await RegisterServiceRunAsync(target, invocationRequest, gagentReceipt, token);
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(accepted, token);
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(input.Timeout ?? DefaultInteractionTimeout);
+
+        var interaction = await _interactionService.ExecuteAsync(
+            new GAgentDraftRunCommand(
+                ScopeId: identity.TenantId,
+                ActorTypeName: actorTypeName,
+                Prompt: prompt,
+                PreferredActorId: preferredActorId,
+                SessionId: input.SessionId,
+                Headers: headers,
+                InputParts: input.InputParts,
+                UseCorrelationIdAsFallbackSessionId: false),
+            emitAsync,
+            OnAcceptedAsync,
+            timeoutCts.Token);
+
+        var completion = interaction.FinalizeResult?.Completion ?? GAgentDraftRunCompletionStatus.Unknown;
+        var completed = interaction.FinalizeResult?.Completed ?? false;
+        return new StaticGAgentStreamInvocationResult(
+            accepted,
+            interaction.Error,
+            completion,
+            completed);
+    }
+
+    private static ServiceIdentity NormalizeIdentity(ServiceIdentity? identity)
+    {
+        if (identity == null)
+            throw new InvalidOperationException("service identity is required.");
+
+        return new ServiceIdentity
+        {
+            TenantId = NormalizeRequired(identity.TenantId, nameof(identity.TenantId)),
+            AppId = NormalizeRequired(identity.AppId, nameof(identity.AppId)),
+            Namespace = NormalizeRequired(identity.Namespace, nameof(identity.Namespace)),
+            ServiceId = NormalizeRequired(identity.ServiceId, nameof(identity.ServiceId)),
+        };
+    }
+
+    private static ServiceInvocationRequest BuildInvocationRequest(
+        ServiceIdentity identity,
+        string endpointId,
+        string prompt,
+        string revisionId,
+        IReadOnlyDictionary<string, string>? headers,
+        ServiceInvocationCaller? caller)
+    {
+        var chatRequest = new ChatRequestEvent
+        {
+            Prompt = prompt,
+            ScopeId = identity.TenantId,
+        };
+        CopyHeaders(headers, chatRequest.Metadata);
+
+        return new ServiceInvocationRequest
+        {
+            Identity = identity.Clone(),
+            EndpointId = endpointId,
+            RevisionId = revisionId,
+            Payload = Any.Pack(chatRequest),
+            Caller = caller?.Clone(),
+        };
+    }
+
+    private static void EnsureStaticChatTarget(
+        ServiceInvocationResolvedTarget target,
+        ServiceInvocationRequest invocationRequest)
+    {
+        if (target.Artifact.ImplementationKind != ServiceImplementationKind.Static)
+        {
+            throw new InvalidOperationException(
+                "Only static GAgent services support stream invocation.");
+        }
+
+        if (target.Endpoint.Kind != ServiceEndpointKind.Chat)
+        {
+            throw new InvalidOperationException(
+                "Only chat endpoints support static GAgent stream invocation.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(target.Endpoint.RequestTypeUrl) &&
+            !string.Equals(target.Endpoint.RequestTypeUrl, invocationRequest.Payload?.TypeUrl, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Endpoint '{target.Endpoint.EndpointId}' expects payload '{target.Endpoint.RequestTypeUrl}', but got '{invocationRequest.Payload?.TypeUrl}'.");
+        }
+    }
+
+    private async Task RegisterServiceRunAsync(
+        ServiceInvocationResolvedTarget target,
+        ServiceInvocationRequest invocationRequest,
+        GAgentDraftRunAcceptedReceipt receipt,
+        CancellationToken ct)
+    {
+        var record = new ServiceRunRecord
+        {
+            ScopeId = invocationRequest.Identity?.TenantId ?? string.Empty,
+            ServiceId = invocationRequest.Identity?.ServiceId ?? string.Empty,
+            ServiceKey = target.Service.ServiceKey ?? string.Empty,
+            RunId = receipt.CommandId,
+            CommandId = receipt.CommandId,
+            CorrelationId = receipt.CorrelationId,
+            EndpointId = target.Endpoint.EndpointId ?? string.Empty,
+            ImplementationKind = ServiceImplementationKind.Static,
+            TargetActorId = receipt.ActorId,
+            RevisionId = target.Service.RevisionId ?? string.Empty,
+            DeploymentId = target.Service.DeploymentId ?? string.Empty,
+            Status = ServiceRunStatus.Accepted,
+            Identity = invocationRequest.Identity?.Clone(),
+        };
+        await _serviceRunRegistrationPort.RegisterAsync(record, ct);
+    }
+
+    private static ServiceInvocationAcceptedReceipt CreateServiceReceipt(
+        ServiceInvocationResolvedTarget target,
+        GAgentDraftRunAcceptedReceipt receipt) =>
+        new()
+        {
+            RequestId = receipt.CommandId,
+            ServiceKey = target.Service.ServiceKey,
+            DeploymentId = target.Service.DeploymentId,
+            TargetActorId = receipt.ActorId,
+            EndpointId = target.Endpoint.EndpointId,
+            CommandId = receipt.CommandId,
+            CorrelationId = receipt.CorrelationId,
+        };
+
+    private static string NormalizeRequired(string? value, string fieldName)
+    {
+        var normalized = value?.Trim() ?? string.Empty;
+        if (normalized.Length == 0)
+            throw new InvalidOperationException($"{fieldName} is required.");
+
+        return normalized;
+    }
+
+    private static string NormalizeOptional(string? value) => value?.Trim() ?? string.Empty;
+
+    private static IReadOnlyDictionary<string, string>? CopyHeaders(IReadOnlyDictionary<string, string>? headers)
+    {
+        if (headers is not { Count: > 0 })
+            return null;
+
+        return headers
+            .Where(x => !string.IsNullOrWhiteSpace(x.Key))
+            .ToDictionary(x => x.Key.Trim(), x => x.Value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static void CopyHeaders(
+        IReadOnlyDictionary<string, string>? source,
+        IDictionary<string, string> target)
+    {
+        if (source == null)
+            return;
+
+        foreach (var (key, value) in source)
+            target[key] = value;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowCapabilityOptions.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Workflows/ScopeWorkflowCapabilityOptions.cs
@@ -1,13 +1,14 @@
 using System.Security.Cryptography;
 using System.Text;
+using Aevatar.GAgentService.Abstractions.Services;
 
 namespace Aevatar.GAgentService.Application.Workflows;
 
 public sealed class ScopeWorkflowCapabilityOptions
 {
     public const string SectionName = "ScopeWorkflowServices";
-    public const string FixedServiceAppId = "default";
-    public const string FixedServiceNamespace = "default";
+    public const string FixedServiceAppId = ScopeServiceIdentityDefaults.ServiceAppId;
+    public const string FixedServiceNamespace = ScopeServiceIdentityDefaults.ServiceNamespace;
 
     // Keep the setter for configuration binding/object initializers, but pin the runtime identity.
     public string ServiceAppId

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ using Aevatar.GAgentService.Hosting.Demo;
 using Aevatar.GAgentService.Governance.Hosting.DependencyInjection;
 using Aevatar.GAgentService.Projection.DependencyInjection;
 using Aevatar.GAgentService.Projection.ReadModels;
+using Aevatar.Presentation.AGUI;
 using Aevatar.Scripting.Core.Ports;
 using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Scripting.Hosting.DependencyInjection;
@@ -72,6 +73,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IServiceLifecycleQueryPort, ServiceLifecycleQueryApplicationService>();
         services.TryAddSingleton<IServiceServingQueryPort, ServiceServingQueryApplicationService>();
         services.TryAddSingleton<IServiceInvocationPort, ServiceInvocationApplicationService>();
+        services.TryAddSingleton<IStaticGAgentStreamInvocationPort<AGUIEvent>, StaticGAgentStreamInvocationApplicationService>();
         services.AddScopeGAgentDraftRunInteraction();
         services.AddOptions<ScopeWorkflowCapabilityOptions>()
             .Bind(configuration.GetSection(ScopeWorkflowCapabilityOptions.SectionName));
@@ -81,6 +83,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IScopeBindingCommandPort, ScopeBindingCommandApplicationService>();
         services.TryAddSingleton<IScopeBindingReadinessQueryPort, ScopeBindingReadinessQueryService>();
         services.TryAddSingleton<IMemberPublishedServiceResolver, DefaultMemberPublishedServiceResolver>();
+        services.TryAddSingleton<ITeamEntryMemberResolver, DefaultTeamEntryMemberResolver>();
         services.AddOptions<ScopeScriptCapabilityOptions>()
             .Bind(configuration.GetSection(ScopeScriptCapabilityOptions.SectionName));
         services.TryAddSingleton<ScopeScriptQueryApplicationService>();

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -83,6 +83,9 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IScopeBindingCommandPort, ScopeBindingCommandApplicationService>();
         services.TryAddSingleton<IScopeBindingReadinessQueryPort, ScopeBindingReadinessQueryService>();
         services.TryAddSingleton<IMemberPublishedServiceResolver, DefaultMemberPublishedServiceResolver>();
+        // Transitional platform fallback. It is replaced by Studio's
+        // actor-readmodel resolver when Studio is registered, and should be
+        // removed once Team authority no longer lives in GAgentService.
         services.TryAddSingleton<ITeamEntryMemberResolver, DefaultTeamEntryMemberResolver>();
         services.AddOptions<ScopeScriptCapabilityOptions>()
             .Bind(configuration.GetSection(ScopeScriptCapabilityOptions.SectionName));

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -62,6 +62,7 @@ public static class ScopeServiceEndpoints
         group.MapPost("/{scopeId}/invoke/{endpointId}", HandleInvokeDefaultAsync);
         group.MapPost("/{scopeId}/members/{memberId}/invoke/{endpointId}:stream", HandleInvokeMemberStreamAsync);
         group.MapPost("/{scopeId}/members/{memberId}/invoke/{endpointId}", HandleInvokeMemberAsync);
+        group.MapPost("/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream", HandleInvokeTeamStreamAsync);
         group.MapPost("/{scopeId}/teams/{teamId}/invoke/{endpointId}", HandleInvokeTeamAsync);
         group.MapGet("/{scopeId}/runs", HandleListDefaultRunsAsync);
         group.MapGet("/{scopeId}/runs/{runId}", HandleGetDefaultRunAsync);
@@ -784,6 +785,66 @@ public static class ScopeServiceEndpoints
         catch (InvalidOperationException ex)
         {
             return CreateScopeInvokeFailureResult(ex);
+        }
+    }
+
+    private static async Task HandleInvokeTeamStreamAsync(
+        HttpContext http,
+        string scopeId,
+        string teamId,
+        string endpointId,
+        StreamScopeServiceHttpRequest request,
+        [FromServices] ITeamEntryMemberResolver teamEntryMemberResolver,
+        [FromServices] ServiceInvocationResolutionService resolutionService,
+        [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
+        [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
+        [FromServices] ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
+        [FromServices] ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> gagentDraftRunService,
+        [FromServices] IScriptRuntimeCommandPort scriptRuntimeCommandPort,
+        [FromServices] IScriptServiceAguiProjectionPort scriptServiceAguiProjectionPort,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
+                return;
+
+            var teamResolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
+            await HandleInvokeStreamAsync(
+                http,
+                teamResolution.ScopeId,
+                teamResolution.PublishedServiceId,
+                endpointId,
+                request,
+                null,
+                resolutionService,
+                admissionAuthorizer,
+                serviceRunRegistrationPort,
+                chatRunService,
+                gagentDraftRunService,
+                scriptRuntimeCommandPort,
+                scriptServiceAguiProjectionPort,
+                options,
+                ct);
+        }
+        catch (TeamEntryMemberResolutionException ex)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                ResolveTeamEntryHttpStatusCode(ex.Code),
+                ex.Code,
+                ex.Message,
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            await WriteJsonErrorResponseAsync(
+                http,
+                StatusCodes.Status400BadRequest,
+                "INVALID_TEAM_SERVICE_STREAM_REQUEST",
+                ex.Message,
+                ct);
         }
     }
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1,6 +1,5 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
@@ -21,6 +20,7 @@ using Aevatar.GAgentService.Governance.Abstractions.Queries;
 using Aevatar.Hosting;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Scripting.Core.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.GAgentService.Hosting.Serialization;
 using Aevatar.Presentation.AGUI;
@@ -62,6 +62,7 @@ public static class ScopeServiceEndpoints
         group.MapPost("/{scopeId}/invoke/{endpointId}", HandleInvokeDefaultAsync);
         group.MapPost("/{scopeId}/members/{memberId}/invoke/{endpointId}:stream", HandleInvokeMemberStreamAsync);
         group.MapPost("/{scopeId}/members/{memberId}/invoke/{endpointId}", HandleInvokeMemberAsync);
+        group.MapPost("/{scopeId}/teams/{teamId}/invoke/{endpointId}", HandleInvokeTeamAsync);
         group.MapGet("/{scopeId}/runs", HandleListDefaultRunsAsync);
         group.MapGet("/{scopeId}/runs/{runId}", HandleGetDefaultRunAsync);
         group.MapGet("/{scopeId}/members/{memberId}/runs", HandleListMemberRunsAsync);
@@ -779,6 +780,49 @@ public static class ScopeServiceEndpoints
                 artifactStore,
                 options,
                 ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return CreateScopeInvokeFailureResult(ex);
+        }
+    }
+
+    private static async Task<IResult> HandleInvokeTeamAsync(
+        HttpContext http,
+        string scopeId,
+        string teamId,
+        string endpointId,
+        InvokeScopeServiceHttpRequest request,
+        [FromServices] ITeamEntryMemberResolver teamEntryMemberResolver,
+        [FromServices] IServiceInvocationPort invocationPort,
+        [FromServices] IServiceCatalogQueryReader catalogReader,
+        [FromServices] IServiceRevisionArtifactStore artifactStore,
+        [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
+                return denied;
+
+            var teamResolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
+            return await HandleInvokeAsyncCore(
+                http,
+                teamResolution.ScopeId,
+                teamResolution.PublishedServiceId,
+                endpointId,
+                request,
+                null,
+                BuildTeamApiPath(teamResolution.ScopeId, teamResolution.TeamId),
+                invocationPort,
+                catalogReader,
+                artifactStore,
+                options,
+                ct);
+        }
+        catch (TeamEntryMemberResolutionException ex)
+        {
+            return CreateTeamEntryFailureResult(ex);
         }
         catch (InvalidOperationException ex)
         {
@@ -2420,6 +2464,9 @@ public static class ScopeServiceEndpoints
     private static string BuildMemberApiPath(string scopeId, string memberId) =>
         $"/api/scopes/{Uri.EscapeDataString(scopeId)}/members/{Uri.EscapeDataString(memberId)}";
 
+    private static string BuildTeamApiPath(string scopeId, string teamId) =>
+        $"/api/scopes/{Uri.EscapeDataString(scopeId)}/teams/{Uri.EscapeDataString(teamId)}";
+
     private static string? BuildTypedInvokeRequestExampleBody(string? requestTypeUrl, bool prettyPrinted) =>
         ServiceEndpointContractMath.BuildTypedInvokeRequestExampleBody(requestTypeUrl, prettyPrinted);
 
@@ -3024,6 +3071,31 @@ const response = await fetch("{{invokePath}}", {
             message,
         });
     }
+
+    private static IResult CreateTeamEntryFailureResult(TeamEntryMemberResolutionException ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+        var statusCode = ResolveTeamEntryHttpStatusCode(ex.Code);
+        return Results.Json(
+            new
+            {
+                code = ex.Code,
+                message = ex.Message,
+            },
+            statusCode: statusCode);
+    }
+
+    private static int ResolveTeamEntryHttpStatusCode(string code) =>
+        code switch
+        {
+            TeamEntryMemberErrorCodes.TeamNotFound => StatusCodes.Status404NotFound,
+            TeamEntryMemberErrorCodes.TeamArchived => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberNotConfigured => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberMismatch => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberNotReady => StatusCodes.Status409Conflict,
+            TeamEntryMemberErrorCodes.EntryMemberNotFound => StatusCodes.Status409Conflict,
+            _ => StatusCodes.Status400BadRequest,
+        };
 
     private static bool IsScopeInvokeNotFoundFailure(string message) =>
         message.Contains(" was not found.", StringComparison.Ordinal) ||

--- a/test/Aevatar.Architecture.Tests/Rules/LayerDependencyTests.cs
+++ b/test/Aevatar.Architecture.Tests/Rules/LayerDependencyTests.cs
@@ -9,6 +9,19 @@ public class LayerDependencyTests
     private static readonly ArchitectureModel Arch = ArchitectureTestBase.ProductionArchitecture;
 
     [Fact]
+    public void StudioApplication_ShouldNot_DependOn_GAgentServiceApplication()
+    {
+        var root = FindRepositoryRoot();
+        var projectPath = Path.Combine(root, "src", "Aevatar.Studio.Application", "Aevatar.Studio.Application.csproj");
+        var project = File.ReadAllText(projectPath);
+
+        Assert.DoesNotContain(
+            "Aevatar.GAgentService.Application.csproj",
+            project,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WorkflowCore_ShouldNot_DependOn_AICore()
     {
         IArchRule rule = Types().That()
@@ -151,5 +164,19 @@ public class LayerDependencyTests
                 Types().That().ResideInNamespaceMatching(@"Aevatar\.GAgentService(\..+)?"))
             .Because("Projection Providers must not depend on GAgentService business layer");
         rule.Check(Arch);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "aevatar.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root was not found.");
     }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -18,6 +18,7 @@ using Aevatar.Hosting;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
@@ -47,6 +48,11 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         services.Should().Contain(x => x.ServiceType == typeof(IServiceServingQueryPort));
         services.Should().Contain(x => x.ServiceType == typeof(IScopeBindingReadinessQueryPort));
         services.Should().Contain(x => x.ServiceType == typeof(IServiceInvocationPort));
+        services.Should().Contain(x => x.ServiceType == typeof(IStaticGAgentStreamInvocationPort<AGUIEvent>));
+        services.Should().Contain(x =>
+            x.ServiceType == typeof(ITeamEntryMemberResolver) &&
+            x.ImplementationType != null &&
+            x.ImplementationType.FullName == "Aevatar.GAgentService.Application.Bindings.DefaultTeamEntryMemberResolver");
         services.Should().Contain(x => x.ServiceType == typeof(IServiceGovernanceCommandPort));
         services.Should().Contain(x => x.ServiceType == typeof(IServiceGovernanceQueryPort));
         services.Should().Contain(x => x.ServiceType == typeof(IActivationCapabilityViewReader));
@@ -186,6 +192,8 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         endpoints.Should().Contain("/api/scopes/{scopeId}/workflow/draft-run");
         endpoints.Should().Contain("/api/scopes/{scopeId}/invoke/chat:stream");
         endpoints.Should().Contain("/api/scopes/{scopeId}/invoke/{endpointId}");
+        endpoints.Should().NotContain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
+        endpoints.Should().Contain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs/{runId}");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs/{runId}/audit");

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -49,6 +49,9 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         services.Should().Contain(x => x.ServiceType == typeof(IScopeBindingReadinessQueryPort));
         services.Should().Contain(x => x.ServiceType == typeof(IServiceInvocationPort));
         services.Should().Contain(x => x.ServiceType == typeof(IStaticGAgentStreamInvocationPort<AGUIEvent>));
+        // Transitional platform fallback only. Studio registration replaces it
+        // with the actor-readmodel resolver; remove this assertion when Team
+        // invoke no longer needs a GAgentService compatibility resolver.
         services.Should().Contain(x =>
             x.ServiceType == typeof(ITeamEntryMemberResolver) &&
             x.ImplementationType != null &&
@@ -192,7 +195,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         endpoints.Should().Contain("/api/scopes/{scopeId}/workflow/draft-run");
         endpoints.Should().Contain("/api/scopes/{scopeId}/invoke/chat:stream");
         endpoints.Should().Contain("/api/scopes/{scopeId}/invoke/{endpointId}");
-        endpoints.Should().NotContain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
+        endpoints.Should().Contain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
         endpoints.Should().Contain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs");
         endpoints.Should().Contain("/api/scopes/{scopeId}/runs/{runId}");

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -37,6 +37,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -2047,6 +2048,15 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task TeamInvokeStreamEndpoint_ShouldNotBeMappedByGAgentServiceHosting()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        host.RoutePatterns.Should().NotContain(
+            "/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
+    }
+
+    [Fact]
     public async Task InvokeStreamEndpoint_WhenAuthenticationIsDisabled_ShouldExecuteExplicitServiceFlowWithoutClaims()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync(authenticationEnabled: false);
@@ -2435,6 +2445,83 @@ public sealed class ScopeServiceEndpointsTests
             ServiceId = "member-a",
         });
         host.InvocationPort.LastRequest.EndpointId.Should().Be("chat");
+    }
+
+    [Fact]
+    public async Task TeamInvokeEndpoint_ShouldMapTeamEntryToPublishedServiceIdentity()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Result = new TeamEntryMemberResolution(
+            "scope-a",
+            "team-a",
+            "member-a",
+            "member-a");
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-a/invoke/chat", new
+        {
+            payloadTypeUrl = "type.googleapis.com/google.protobuf.Empty",
+            payloadBase64 = "",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.OriginalString.Should().Be("/api/scopes/scope-a/teams/team-a");
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a"));
+        host.InvocationPort.LastRequest.Should().NotBeNull();
+        host.InvocationPort.LastRequest!.Identity.Should().BeEquivalentTo(new ServiceIdentity
+        {
+            TenantId = "scope-a",
+            AppId = "default",
+            Namespace = "default",
+            ServiceId = "member-a",
+        });
+        host.InvocationPort.LastRequest.EndpointId.Should().Be("chat");
+    }
+
+    [Fact]
+    public async Task TeamInvokeEndpoint_ShouldMapMissingTeamToNotFound()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Exception = new TeamEntryMemberResolutionException(
+            TeamEntryMemberErrorCodes.TeamNotFound,
+            "scope-a",
+            "team-missing",
+            "team 'team-missing' not found.");
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-missing/invoke/chat", new
+        {
+            payloadTypeUrl = "type.googleapis.com/google.protobuf.Empty",
+            payloadBase64 = "",
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be(TeamEntryMemberErrorCodes.TeamNotFound);
+        host.InvocationPort.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TeamInvokeEndpoint_ShouldMapEntryMemberFailureToConflict()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Exception = new TeamEntryMemberResolutionException(
+            TeamEntryMemberErrorCodes.EntryMemberNotReady,
+            "scope-a",
+            "team-a",
+            "entry member 'member-a' is not bind-ready.");
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-a/invoke/chat", new
+        {
+            payloadTypeUrl = "type.googleapis.com/google.protobuf.Empty",
+            payloadBase64 = "",
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be(TeamEntryMemberErrorCodes.EntryMemberNotReady);
+        host.InvocationPort.LastRequest.Should().BeNull();
     }
 
     [Fact]
@@ -4134,6 +4221,7 @@ public sealed class ScopeServiceEndpointsTests
             FakeServiceCatalogQueryReader serviceCatalogReader,
             FakeServiceTrafficViewQueryReader trafficViewReader,
             FakeServiceRevisionArtifactStore artifactStore,
+            FakeTeamEntryMemberResolver teamEntryMemberResolver,
             FakeCommandInteractionService interactionService,
             FakeWorkflowExecutionQueryApplicationService workflowQueryService,
             FakeWorkflowRunBindingReader runBindingReader,
@@ -4155,6 +4243,7 @@ public sealed class ScopeServiceEndpointsTests
             ServiceCatalogReader = serviceCatalogReader;
             TrafficViewReader = trafficViewReader;
             ArtifactStore = artifactStore;
+            TeamEntryMemberResolver = teamEntryMemberResolver;
             InteractionService = interactionService;
             WorkflowQueryService = workflowQueryService;
             RunBindingReader = runBindingReader;
@@ -4166,6 +4255,14 @@ public sealed class ScopeServiceEndpointsTests
         }
 
         public HttpClient Client { get; }
+
+        public IReadOnlyList<string> RoutePatterns => ((IEndpointRouteBuilder)_app).DataSources
+            .SelectMany(x => x.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(x => x.RoutePattern.RawText)
+            .Where(x => x != null)
+            .Select(x => x!)
+            .ToList();
 
         public RecordingServiceGovernanceCommandPort CommandPort { get; }
 
@@ -4186,6 +4283,8 @@ public sealed class ScopeServiceEndpointsTests
         public FakeServiceTrafficViewQueryReader TrafficViewReader { get; }
 
         public FakeServiceRevisionArtifactStore ArtifactStore { get; }
+
+        public FakeTeamEntryMemberResolver TeamEntryMemberResolver { get; }
 
         public FakeCommandInteractionService InteractionService { get; }
 
@@ -4222,6 +4321,7 @@ public sealed class ScopeServiceEndpointsTests
             var serviceCatalogReader = new FakeServiceCatalogQueryReader();
             var trafficViewReader = new FakeServiceTrafficViewQueryReader();
             var artifactStore = new FakeServiceRevisionArtifactStore();
+            var teamEntryMemberResolver = new FakeTeamEntryMemberResolver();
             var interactionService = new FakeCommandInteractionService();
             var gagentDraftRunInteractionService = new FakeGAgentDraftRunInteractionService();
             var scriptRuntimeCommandPort = new NoOpScriptRuntimeCommandPort();
@@ -4258,6 +4358,7 @@ public sealed class ScopeServiceEndpointsTests
             builder.Services.AddSingleton<IServiceCatalogQueryReader>(serviceCatalogReader);
             builder.Services.AddSingleton<IServiceTrafficViewQueryReader>(trafficViewReader);
             builder.Services.AddSingleton<IServiceRevisionArtifactStore>(artifactStore);
+            builder.Services.AddSingleton<ITeamEntryMemberResolver>(teamEntryMemberResolver);
             builder.Services.AddSingleton<ServiceInvocationResolutionService>();
             builder.Services.AddSingleton<IInvokeAdmissionAuthorizer, AllowAllInvokeAdmissionAuthorizer>();
             builder.Services.AddSingleton<ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus>>(interactionService);
@@ -4375,6 +4476,7 @@ public sealed class ScopeServiceEndpointsTests
                 serviceCatalogReader,
                 trafficViewReader,
                 artifactStore,
+                teamEntryMemberResolver,
                 interactionService,
                 workflowQueryService,
                 runBindingReader,
@@ -4726,6 +4828,28 @@ public sealed class ScopeServiceEndpointsTests
                 LastEventId: binding.SourceEventId ?? string.Empty,
                 CreatedAt: binding.CreatedAt ?? DateTimeOffset.UtcNow,
                 UpdatedAt: binding.UpdatedAt ?? DateTimeOffset.UtcNow);
+    }
+
+    private sealed class FakeTeamEntryMemberResolver : ITeamEntryMemberResolver
+    {
+        public List<(string ScopeId, string TeamId)> Calls { get; } = [];
+
+        public TeamEntryMemberResolution Result { get; set; } =
+            new("scope-a", "team-a", "member-a", "member-a");
+
+        public TeamEntryMemberResolutionException? Exception { get; set; }
+
+        public Task<TeamEntryMemberResolution> ResolveAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default)
+        {
+            Calls.Add((scopeId, teamId));
+            if (Exception != null)
+                throw Exception;
+
+            return Task.FromResult(Result);
+        }
     }
 
     private sealed class RecordingServiceInvocationPort : IServiceInvocationPort

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -2048,12 +2048,137 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
-    public async Task TeamInvokeStreamEndpoint_ShouldNotBeMappedByGAgentServiceHosting()
+    public async Task TeamInvokeStreamEndpoint_ShouldResolveEntryMemberAndDelegateToWorkflowPipeline()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Result = new TeamEntryMemberResolution(
+            "scope-a",
+            "team-a",
+            "member-a",
+            "member-a");
+        var service = BuildService("scope-a", "member-a", "definition-actor-member-a");
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            "dep-team-member-a-1",
+                            "rev-team-member-a-1",
+                            "definition-actor-member-a",
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.ArtifactStore.SaveAsync(
+            service.ServiceKey,
+            "rev-team-member-a-1",
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = "member-a",
+                },
+                RevisionId = "rev-team-member-a-1",
+                ImplementationKind = ServiceImplementationKind.Workflow,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    WorkflowPlan = new WorkflowServiceDeploymentPlan
+                    {
+                        WorkflowName = "member-a",
+                        WorkflowYaml = "name: member_a\nsteps:\n  - run: echo member",
+                        DefinitionActorId = "definition-actor-member-a",
+                    },
+                },
+            },
+            CancellationToken.None);
+        host.InteractionService.ResultFactory = async (request, emitAsync, onAcceptedAsync, ct) =>
+        {
+            var receipt = new WorkflowChatRunAcceptedReceipt("run-actor-team-a", "member-a", "cmd-team-a", "corr-team-a");
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+            return CommandInteractionResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowProjectionCompletionStatus>
+                .Success(receipt, new CommandInteractionFinalizeResult<WorkflowProjectionCompletionStatus>(WorkflowProjectionCompletionStatus.Completed, true));
+        };
 
-        host.RoutePatterns.Should().NotContain(
-            "/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-a/invoke/chat:stream", new
+        {
+            prompt = "hello team",
+            headers = new Dictionary<string, string> { ["channel"] = "team-tests" },
+        });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        body.Should().Contain("aevatar.run.context");
+        host.TeamEntryMemberResolver.Calls.Should().ContainSingle().Which.Should().Be(("scope-a", "team-a"));
+        host.InteractionService.LastRequest.Should().NotBeNull();
+        host.InteractionService.LastRequest!.ActorId.Should().Be("definition-actor-member-a");
+        host.InteractionService.LastRequest.ScopeId.Should().Be("scope-a");
+        host.InteractionService.LastRequest.Metadata.Should().ContainKey("channel").WhoseValue.Should().Be("team-tests");
+    }
+
+    [Fact]
+    public async Task TeamInvokeStreamEndpoint_ShouldMapMissingEntryToConflict()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        host.TeamEntryMemberResolver.Exception = new TeamEntryMemberResolutionException(
+            TeamEntryMemberErrorCodes.EntryMemberNotConfigured,
+            "scope-a",
+            "team-a",
+            "team 'team-a' has no entry member configured.");
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/teams/team-a/invoke/chat:stream", new
+        {
+            prompt = "hello team",
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be(TeamEntryMemberErrorCodes.EntryMemberNotConfigured);
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TeamInvokeStreamEndpoint_ShouldReturnForbiddenBeforeResolvingEntry_WhenScopeClaimDoesNotMatch()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        using var request = CreateAuthenticatedJsonRequest(
+            HttpMethod.Post,
+            "/api/scopes/scope-a/teams/team-a/invoke/chat:stream",
+            new
+            {
+                prompt = "hello team",
+            },
+            "scope-b");
+
+        var response = await host.Client.SendAsync(request);
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("SCOPE_ACCESS_DENIED");
+        host.TeamEntryMemberResolver.Calls.Should().BeEmpty();
+        host.InteractionService.LastRequest.Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Application/DefaultTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/DefaultTeamEntryMemberResolverTests.cs
@@ -7,7 +7,7 @@ namespace Aevatar.GAgentService.Tests.Application;
 public sealed class DefaultTeamEntryMemberResolverTests
 {
     [Fact]
-    public async Task ResolveAsync_ShouldMapTeamToStableEntryMemberAndPublishedServiceId()
+    public async Task ResolveAsync_ShouldKeepTransitionalDeterministicMappingUntilTeamMigratesToStudio()
     {
         var resolver = new DefaultTeamEntryMemberResolver();
 

--- a/test/Aevatar.GAgentService.Tests/Application/DefaultTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/DefaultTeamEntryMemberResolverTests.cs
@@ -1,0 +1,43 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Application.Bindings;
+using FluentAssertions;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class DefaultTeamEntryMemberResolverTests
+{
+    [Fact]
+    public async Task ResolveAsync_ShouldMapTeamToStableEntryMemberAndPublishedServiceId()
+    {
+        var resolver = new DefaultTeamEntryMemberResolver();
+
+        var result = await resolver.ResolveAsync(" scope-a ", " team-a ");
+
+        result.ScopeId.Should().Be("scope-a");
+        result.TeamId.Should().Be("team-a");
+        result.EntryMemberId.Should().Be("team-a");
+        result.PublishedServiceId.Should().Be("team-a");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectBlankTeamId()
+    {
+        var resolver = new DefaultTeamEntryMemberResolver();
+
+        var act = () => resolver.ResolveAsync("scope-a", " ");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*teamId is required*");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldRejectTeamIdThatBreaksServiceKeySegments()
+    {
+        var resolver = new DefaultTeamEntryMemberResolver();
+
+        var act = () => resolver.ResolveAsync("scope-a", "foo:bar");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*teamId must not contain*");
+    }
+}

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunActorPreparationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunActorPreparationServiceTests.cs
@@ -1,7 +1,6 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Application.ScopeGAgents;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 
 namespace Aevatar.GAgentService.Tests.Application;

--- a/test/Aevatar.GAgentService.Tests/Application/StaticGAgentStreamInvocationApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/StaticGAgentStreamInvocationApplicationServiceTests.cs
@@ -1,0 +1,445 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.GAgentService.Application.Services;
+using Aevatar.GAgentService.Governance.Abstractions.Ports;
+using Aevatar.GAgentService.Infrastructure.Artifacts;
+using Aevatar.GAgentService.Tests.TestSupport;
+using Aevatar.Presentation.AGUI;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Tests.Application;
+
+public sealed class StaticGAgentStreamInvocationApplicationServiceTests
+{
+    [Fact]
+    public async Task InvokeAsync_ShouldThrow_WhenResolvedServiceIsNotStatic()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var interaction = new RecordingGAgentDraftRunInteractionService();
+        var registration = new RecordingServiceRunRegistrationPort();
+        var service = await CreateServiceAsync(
+            identity,
+            CreateArtifact(identity, ServiceImplementationKind.Workflow),
+            interaction,
+            registration);
+
+        var act = () => service.InvokeAsync(
+            NewRequest(identity),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Only static GAgent services support stream invocation*");
+        interaction.Commands.Should().BeEmpty();
+        registration.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldRegisterStaticRunWithGAgentCommandId()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var receipt = new GAgentDraftRunAcceptedReceipt(
+            ActorId: "gagent-actor-1",
+            ActorTypeName: typeof(TestStaticServiceAgent).AssemblyQualifiedName!,
+            CommandId: "cmd-gagent-1",
+            CorrelationId: "corr-gagent-1");
+        var interaction = new RecordingGAgentDraftRunInteractionService
+        {
+            Receipt = receipt,
+        };
+        var registration = new RecordingServiceRunRegistrationPort();
+        var service = await CreateServiceAsync(
+            identity,
+            CreateArtifact(identity, ServiceImplementationKind.Static),
+            interaction,
+            registration);
+
+        StaticGAgentStreamAcceptedReceipt? accepted = null;
+
+        var result = await service.InvokeAsync(
+            NewRequest(
+                identity,
+                input: new StaticGAgentStreamInvocationInput(
+                    Prompt: "  hello static  ",
+                    PreferredActorId: "  preferred-actor  ",
+                    SessionId: "session-1",
+                    Headers: new Dictionary<string, string>
+                    {
+                        ["x-trace"] = "trace-1",
+                    },
+                    InputParts:
+                    [
+                        new GAgentDraftRunInputPart
+                        {
+                            Kind = GAgentDraftRunInputPartKind.Text,
+                            Text = "part-1",
+                        },
+                    ])),
+            (_, _) => ValueTask.CompletedTask,
+            (receipt, _) =>
+            {
+                accepted = receipt;
+                return ValueTask.CompletedTask;
+            });
+
+        result.Succeeded.Should().BeTrue();
+        result.Accepted.Should().BeSameAs(accepted);
+        result.CompletionStatus.Should().Be(GAgentDraftRunCompletionStatus.RunFinished);
+        result.CompletionObserved.Should().BeTrue();
+
+        registration.Records.Should().ContainSingle();
+        var record = registration.Records[0];
+        record.ScopeId.Should().Be(identity.TenantId);
+        record.ServiceId.Should().Be(identity.ServiceId);
+        record.ServiceKey.Should().Be(ServiceKeys.Build(identity));
+        record.RunId.Should().Be(receipt.CommandId);
+        record.CommandId.Should().Be(receipt.CommandId);
+        record.CorrelationId.Should().Be(receipt.CorrelationId);
+        record.TargetActorId.Should().Be(receipt.ActorId);
+        record.ImplementationKind.Should().Be(ServiceImplementationKind.Static);
+        record.Status.Should().Be(ServiceRunStatus.Accepted);
+        record.Identity.Should().BeEquivalentTo(identity);
+
+        accepted.Should().NotBeNull();
+        accepted!.ServiceReceipt.CommandId.Should().Be(receipt.CommandId);
+        accepted.ServiceReceipt.CorrelationId.Should().Be(receipt.CorrelationId);
+        accepted.ServiceReceipt.TargetActorId.Should().Be(receipt.ActorId);
+        accepted.GAgentReceipt.Should().Be(receipt);
+
+        interaction.Commands.Should().ContainSingle();
+        var command = interaction.Commands[0];
+        command.ScopeId.Should().Be(identity.TenantId);
+        command.Prompt.Should().Be("hello static");
+        command.PreferredActorId.Should().Be("preferred-actor");
+        command.SessionId.Should().Be("session-1");
+        command.Headers.Should().Contain("x-trace", "trace-1");
+        command.InputParts.Should().ContainSingle()
+            .Which.Text.Should().Be("part-1");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldForwardAGUIFramesThroughEmitCallback()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var frame = new AGUIEvent
+        {
+            TextMessageContent = new Aevatar.Presentation.AGUI.TextMessageContentEvent
+            {
+                MessageId = "msg-1",
+                Delta = "hello",
+            },
+        };
+        var interaction = new RecordingGAgentDraftRunInteractionService
+        {
+            Frames = [frame],
+        };
+        var service = await CreateServiceAsync(
+            identity,
+            CreateArtifact(identity, ServiceImplementationKind.Static),
+            interaction,
+            new RecordingServiceRunRegistrationPort());
+
+        var emitted = new List<AGUIEvent>();
+
+        var result = await service.InvokeAsync(
+            NewRequest(identity),
+            (aguiEvent, _) =>
+            {
+                emitted.Add(aguiEvent);
+                return ValueTask.CompletedTask;
+            });
+
+        result.Succeeded.Should().BeTrue();
+        emitted.Should().ContainSingle()
+            .Which.TextMessageContent.Delta.Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldReturnStartError_WhenGAgentInteractionFailsBeforeAccepted()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var interaction = new RecordingGAgentDraftRunInteractionService
+        {
+            Failure = GAgentDraftRunStartError.UnknownActorType,
+        };
+        var registration = new RecordingServiceRunRegistrationPort();
+        var service = await CreateServiceAsync(
+            identity,
+            CreateArtifact(identity, ServiceImplementationKind.Static),
+            interaction,
+            registration);
+
+        var result = await service.InvokeAsync(
+            NewRequest(identity),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeFalse();
+        result.Accepted.Should().BeNull();
+        result.StartError.Should().Be(GAgentDraftRunStartError.UnknownActorType);
+        registration.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldThrow_WhenResolvedEndpointIsNotChat()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var interaction = new RecordingGAgentDraftRunInteractionService();
+        var registration = new RecordingServiceRunRegistrationPort();
+        var service = await CreateServiceAsync(
+            identity,
+            CreateArtifact(
+                identity,
+                ServiceImplementationKind.Static,
+                endpointKind: ServiceEndpointKind.Command,
+                requestTypeUrl: Any.Pack(new ChatRequestEvent()).TypeUrl),
+            interaction,
+            registration);
+
+        var act = () => service.InvokeAsync(
+            NewRequest(identity),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Only chat endpoints support static GAgent stream invocation*");
+        interaction.Commands.Should().BeEmpty();
+        registration.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldThrow_WhenEndpointRequestTypeDoesNotMatchChatPayload()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var interaction = new RecordingGAgentDraftRunInteractionService();
+        var registration = new RecordingServiceRunRegistrationPort();
+        var service = await CreateServiceAsync(
+            identity,
+            CreateArtifact(
+                identity,
+                ServiceImplementationKind.Static,
+                requestTypeUrl: "type.googleapis.com/test.other"),
+            interaction,
+            registration);
+
+        var act = () => service.InvokeAsync(
+            NewRequest(identity),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*expects payload 'type.googleapis.com/test.other'*");
+        interaction.Commands.Should().BeEmpty();
+        registration.Records.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldThrow_WhenStaticPlanHasNoActorType()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var interaction = new RecordingGAgentDraftRunInteractionService();
+        var registration = new RecordingServiceRunRegistrationPort();
+        var artifact = CreateArtifact(identity, ServiceImplementationKind.Static);
+        artifact.DeploymentPlan.StaticPlan!.ActorTypeName = " ";
+        var service = await CreateServiceAsync(
+            identity,
+            artifact,
+            interaction,
+            registration);
+
+        var act = () => service.InvokeAsync(
+            NewRequest(identity),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Static GAgent service has no actor type configured*");
+        interaction.Commands.Should().BeEmpty();
+        registration.Records.Should().BeEmpty();
+    }
+
+    private static async Task<StaticGAgentStreamInvocationApplicationService> CreateServiceAsync(
+        ServiceIdentity identity,
+        PreparedServiceRevisionArtifact artifact,
+        RecordingGAgentDraftRunInteractionService interaction,
+        RecordingServiceRunRegistrationPort registration)
+    {
+        var artifactStore = new ConfiguredServiceRevisionArtifactStore();
+        await artifactStore.SaveAsync(ServiceKeys.Build(identity), "r1", artifact);
+
+        var resolutionService = new ServiceInvocationResolutionService(
+            new CatalogQueryReader(identity),
+            new TrafficViewQueryReader(identity),
+            artifactStore);
+
+        return new StaticGAgentStreamInvocationApplicationService(
+            resolutionService,
+            new NoOpInvokeAdmissionAuthorizer(),
+            registration,
+            interaction);
+    }
+
+    private static StaticGAgentStreamInvocationRequest NewRequest(
+        ServiceIdentity identity,
+        StaticGAgentStreamInvocationInput? input = null) =>
+        new(
+            identity.Clone(),
+            "chat",
+            input ?? new StaticGAgentStreamInvocationInput("hello"));
+
+    private static PreparedServiceRevisionArtifact CreateArtifact(
+        ServiceIdentity identity,
+        ServiceImplementationKind implementationKind,
+        ServiceEndpointKind endpointKind = ServiceEndpointKind.Chat,
+        string? requestTypeUrl = null)
+    {
+        var endpoint = GAgentServiceTestKit.CreateEndpointDescriptor(
+            endpointId: "chat",
+            kind: endpointKind,
+            requestTypeUrl: requestTypeUrl ?? Any.Pack(new ChatRequestEvent()).TypeUrl);
+
+        var artifact = GAgentServiceTestKit.CreatePreparedStaticArtifact(identity, "r1", endpoint);
+        artifact.ImplementationKind = implementationKind;
+        if (implementationKind == ServiceImplementationKind.Workflow)
+        {
+            artifact.DeploymentPlan = new ServiceDeploymentPlan
+            {
+                WorkflowPlan = new WorkflowServiceDeploymentPlan
+                {
+                    WorkflowName = "wf",
+                    WorkflowYaml = "name: wf",
+                    DefinitionActorId = "workflow-definition-1",
+                },
+            };
+        }
+
+        return artifact;
+    }
+
+    private sealed class CatalogQueryReader(ServiceIdentity identity) : IServiceCatalogQueryReader
+    {
+        public Task<ServiceCatalogSnapshot?> GetAsync(ServiceIdentity requestedIdentity, CancellationToken ct = default) =>
+            Task.FromResult<ServiceCatalogSnapshot?>(new ServiceCatalogSnapshot(
+                ServiceKeys.Build(identity),
+                identity.TenantId,
+                identity.AppId,
+                identity.Namespace,
+                identity.ServiceId,
+                "Static Service",
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                ServiceDeploymentStatus.Active.ToString(),
+                [],
+                [],
+                DateTimeOffset.UtcNow));
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryAllAsync(int take = 1000, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryByScopeAsync(
+            string tenantId,
+            string appId,
+            string @namespace,
+            int take = 200,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
+    }
+
+    private sealed class TrafficViewQueryReader(ServiceIdentity identity) : IServiceTrafficViewQueryReader
+    {
+        public Task<ServiceTrafficViewSnapshot?> GetAsync(ServiceIdentity requestedIdentity, CancellationToken ct = default) =>
+            Task.FromResult<ServiceTrafficViewSnapshot?>(new ServiceTrafficViewSnapshot(
+                ServiceKeys.Build(identity),
+                1,
+                string.Empty,
+                [
+                    new ServiceTrafficEndpointSnapshot(
+                        "chat",
+                        [
+                            new ServiceTrafficTargetSnapshot(
+                                "dep-1",
+                                "r1",
+                                "primary-actor-1",
+                                100,
+                                ServiceServingState.Active.ToString()),
+                        ]),
+                ],
+                DateTimeOffset.UtcNow));
+    }
+
+    private sealed class NoOpInvokeAdmissionAuthorizer : IInvokeAdmissionAuthorizer
+    {
+        public Task AuthorizeAsync(
+            string serviceKey,
+            string deploymentId,
+            PreparedServiceRevisionArtifact artifact,
+            ServiceEndpointDescriptor endpoint,
+            ServiceInvocationRequest request,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingServiceRunRegistrationPort : IServiceRunRegistrationPort
+    {
+        public List<ServiceRunRecord> Records { get; } = [];
+
+        public Task<ServiceRunRegistrationResult> RegisterAsync(
+            ServiceRunRecord record,
+            CancellationToken ct = default)
+        {
+            Records.Add(record.Clone());
+            return Task.FromResult(new ServiceRunRegistrationResult("service-run-actor", record.RunId));
+        }
+
+        public Task UpdateStatusAsync(
+            string runActorId,
+            string runId,
+            ServiceRunStatus status,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class RecordingGAgentDraftRunInteractionService
+        : ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus>
+    {
+        public List<GAgentDraftRunCommand> Commands { get; } = [];
+
+        public IReadOnlyList<AGUIEvent> Frames { get; init; } = [];
+
+        public GAgentDraftRunAcceptedReceipt Receipt { get; init; } = new(
+            "gagent-actor-default",
+            typeof(TestStaticServiceAgent).AssemblyQualifiedName!,
+            "cmd-default",
+            "corr-default");
+
+        public GAgentDraftRunStartError? Failure { get; init; }
+
+        public async Task<CommandInteractionResult<GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, GAgentDraftRunCompletionStatus>> ExecuteAsync(
+            GAgentDraftRunCommand command,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<GAgentDraftRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            Commands.Add(command);
+            if (Failure.HasValue)
+                return CommandInteractionResult<GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, GAgentDraftRunCompletionStatus>
+                    .Failure(Failure.Value);
+
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(Receipt, ct);
+
+            foreach (var frame in Frames)
+                await emitAsync(frame, ct);
+
+            return CommandInteractionResult<GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, GAgentDraftRunCompletionStatus>
+                .Success(
+                    Receipt,
+                    new CommandInteractionFinalizeResult<GAgentDraftRunCompletionStatus>(
+                        GAgentDraftRunCompletionStatus.RunFinished,
+                        true));
+        }
+    }
+}

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioTeamCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioTeamCommandServiceTests.cs
@@ -158,6 +158,39 @@ public sealed class ActorDispatchStudioTeamCommandServiceTests
     }
 
     [Fact]
+    public async Task SetEntryMemberAsync_ShouldDispatchEntryMemberChangedEvent()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var service = new ActorDispatchStudioTeamCommandService(
+            new RecordingBootstrap(), dispatch);
+
+        await service.SetEntryMemberAsync(ScopeId, "t-1", "m-1", CancellationToken.None);
+
+        dispatch.Dispatches.Should().ContainSingle();
+        var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioTeamEntryMemberChangedEvent>();
+        evt.TeamId.Should().Be("t-1");
+        evt.ScopeId.Should().Be(ScopeId);
+        evt.EntryMemberId.Should().Be("m-1");
+        evt.HasEntryMemberId.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ClearEntryMemberAsync_ShouldDispatchEntryMemberChangedEventWithoutMemberId()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var service = new ActorDispatchStudioTeamCommandService(
+            new RecordingBootstrap(), dispatch);
+
+        await service.ClearEntryMemberAsync(ScopeId, "t-1", CancellationToken.None);
+
+        dispatch.Dispatches.Should().ContainSingle();
+        var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioTeamEntryMemberChangedEvent>();
+        evt.TeamId.Should().Be("t-1");
+        evt.ScopeId.Should().Be(ScopeId);
+        evt.HasEntryMemberId.Should().BeFalse();
+    }
+
+    [Fact]
     public void Constructor_ShouldRejectNullDependencies()
     {
         FluentActions.Invoking(() =>

--- a/test/Aevatar.Studio.Tests/StudioApplicationServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioApplicationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,34 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.DependencyInjection;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioApplicationServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddStudioApplication_ShouldReplacePlatformTeamEntryMemberResolver()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITeamEntryMemberResolver, PlaceholderTeamEntryMemberResolver>();
+
+        services.AddStudioApplication();
+
+        services.Should().ContainSingle(x => x.ServiceType == typeof(ITeamEntryMemberResolver))
+            .Which.ImplementationType.Should().Be(typeof(StudioTeamEntryMemberResolver));
+        services.Should().ContainSingle(x => x.ServiceType == typeof(IStudioTeamGAgentStreamInvocationService))
+            .Which.ImplementationType.Should().Be(typeof(StudioTeamGAgentStreamInvocationService));
+    }
+
+    private sealed class PlaceholderTeamEntryMemberResolver : ITeamEntryMemberResolver
+    {
+        public Task<TeamEntryMemberResolution> ResolveAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default) =>
+            throw new NotImplementedException();
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioTeamCurrentStateProjectorTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamCurrentStateProjectorTests.cs
@@ -31,6 +31,7 @@ public sealed class StudioTeamCurrentStateProjectorTests
             DisplayName = "Team Alpha",
             Description = "alpha desc",
             LifecycleStage = StudioTeamLifecycleStage.Active,
+            EntryMemberId = "m-1",
             CreatedAtUtc = Timestamp.FromDateTime(DateTime.UtcNow.AddDays(-1)),
             UpdatedAtUtc = Timestamp.FromDateTime(DateTime.UtcNow),
         };
@@ -59,6 +60,7 @@ public sealed class StudioTeamCurrentStateProjectorTests
         written.Description.Should().Be("alpha desc");
         written.LifecycleStage.Should().Be(TeamLifecycleStageNames.Active);
         written.MemberCount.Should().Be(2);
+        written.EntryMemberId.Should().Be("m-1");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
@@ -263,6 +263,118 @@ public sealed class StudioTeamEndpointTests
     }
 
     [Fact]
+    public async Task HandleSetEntryMemberAsync_ShouldReturn200_WhenSuccessful()
+    {
+        var service = new InMemoryTeamService(NewSummary());
+        var result = await InvokeTeamHandle(
+            "HandleSetEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest("m-1"),
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        service.SetEntryRequests.Should().ContainSingle()
+            .Which.MemberId.Should().Be("m-1");
+    }
+
+    [Fact]
+    public async Task HandleSetEntryMemberAsync_ShouldReturn404_WhenTeamMissing()
+    {
+        var service = new ThrowingTeamService(new StudioTeamNotFoundException(ScopeId, TeamId));
+        var result = await InvokeTeamHandle(
+            "HandleSetEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest("m-1"),
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task HandleSetEntryMemberAsync_ShouldReturn404_WhenMemberMissing()
+    {
+        var service = new ThrowingTeamService(new StudioMemberNotFoundException(ScopeId, "m-missing"));
+        var result = await InvokeTeamHandle(
+            "HandleSetEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest("m-missing"),
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task HandleSetEntryMemberAsync_ShouldReturn400_WhenValidationFails()
+    {
+        var service = new ThrowingTeamService(new InvalidOperationException("team is archived"));
+        var result = await InvokeTeamHandle(
+            "HandleSetEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest("m-1"),
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task HandleClearEntryMemberAsync_ShouldReturn200_WhenSuccessful()
+    {
+        var service = new InMemoryTeamService(NewSummary());
+        var result = await InvokeTeamHandle(
+            "HandleClearEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        service.ClearEntryCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleClearEntryMemberAsync_ShouldReturn404_WhenTeamMissing()
+    {
+        var service = new ThrowingTeamService(new StudioTeamNotFoundException(ScopeId, TeamId));
+        var result = await InvokeTeamHandle(
+            "HandleClearEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task HandleClearEntryMemberAsync_ShouldReturn400_WhenValidationFails()
+    {
+        var service = new ThrowingTeamService(new InvalidOperationException("team is archived"));
+        var result = await InvokeTeamHandle(
+            "HandleClearEntryMemberAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            service,
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
     public async Task HandleListMembersAsync_ShouldReturn200_WithFilteredMembers()
     {
         var teamService = new InMemoryTeamService(NewSummary());
@@ -348,6 +460,8 @@ public sealed class StudioTeamEndpointTests
     private sealed class InMemoryTeamService : IStudioTeamService
     {
         private readonly StudioTeamSummaryResponse _summary;
+        public List<SetStudioTeamEntryMemberRequest> SetEntryRequests { get; } = [];
+        public int ClearEntryCalls { get; private set; }
 
         public InMemoryTeamService(StudioTeamSummaryResponse summary) => _summary = summary;
 
@@ -370,6 +484,25 @@ public sealed class StudioTeamEndpointTests
         public Task<StudioTeamSummaryResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) =>
             Task.FromResult(_summary);
+
+        public Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            SetStudioTeamEntryMemberRequest request,
+            CancellationToken ct = default)
+        {
+            SetEntryRequests.Add(request);
+            return Task.FromResult(_summary);
+        }
+
+        public Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default)
+        {
+            ClearEntryCalls++;
+            return Task.FromResult(_summary);
+        }
     }
 
     private sealed class ThrowingTeamService : IStudioTeamService
@@ -387,6 +520,15 @@ public sealed class StudioTeamEndpointTests
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default) => throw _ex;
         public Task<StudioTeamSummaryResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) => throw _ex;
+        public Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            SetStudioTeamEntryMemberRequest request,
+            CancellationToken ct = default) => throw _ex;
+        public Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default) => throw _ex;
     }
 
     private sealed class InMemoryMemberService : IStudioMemberService

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
@@ -5,6 +5,7 @@ using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Hosting.Endpoints;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -263,7 +264,7 @@ public sealed class StudioTeamEndpointTests
     }
 
     [Fact]
-    public async Task HandleSetEntryMemberAsync_ShouldReturn200_WhenSuccessful()
+    public async Task HandleSetEntryMemberAsync_ShouldReturn202WithoutBody_WhenAccepted()
     {
         var service = new InMemoryTeamService(NewSummary());
         var result = await InvokeTeamHandle(
@@ -275,7 +276,8 @@ public sealed class StudioTeamEndpointTests
             service,
             CancellationToken.None);
 
-        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        var accepted = result.Should().BeOfType<Accepted>().Subject;
+        accepted.Location.Should().Be($"/api/scopes/{ScopeId}/teams/{TeamId}");
         service.SetEntryRequests.Should().ContainSingle()
             .Which.MemberId.Should().Be("m-1");
     }
@@ -329,7 +331,7 @@ public sealed class StudioTeamEndpointTests
     }
 
     [Fact]
-    public async Task HandleClearEntryMemberAsync_ShouldReturn200_WhenSuccessful()
+    public async Task HandleClearEntryMemberAsync_ShouldReturn202WithoutBody_WhenAccepted()
     {
         var service = new InMemoryTeamService(NewSummary());
         var result = await InvokeTeamHandle(
@@ -340,7 +342,8 @@ public sealed class StudioTeamEndpointTests
             service,
             CancellationToken.None);
 
-        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        var accepted = result.Should().BeOfType<Accepted>().Subject;
+        accepted.Location.Should().Be($"/api/scopes/{ScopeId}/teams/{TeamId}");
         service.ClearEntryCalls.Should().Be(1);
     }
 
@@ -485,23 +488,23 @@ public sealed class StudioTeamEndpointTests
             string scopeId, string teamId, CancellationToken ct = default) =>
             Task.FromResult(_summary);
 
-        public Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+        public Task SetEntryMemberAsync(
             string scopeId,
             string teamId,
             SetStudioTeamEntryMemberRequest request,
             CancellationToken ct = default)
         {
             SetEntryRequests.Add(request);
-            return Task.FromResult(_summary);
+            return Task.CompletedTask;
         }
 
-        public Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+        public Task ClearEntryMemberAsync(
             string scopeId,
             string teamId,
             CancellationToken ct = default)
         {
             ClearEntryCalls++;
-            return Task.FromResult(_summary);
+            return Task.CompletedTask;
         }
     }
 
@@ -520,12 +523,12 @@ public sealed class StudioTeamEndpointTests
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default) => throw _ex;
         public Task<StudioTeamSummaryResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) => throw _ex;
-        public Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+        public Task SetEntryMemberAsync(
             string scopeId,
             string teamId,
             SetStudioTeamEntryMemberRequest request,
             CancellationToken ct = default) => throw _ex;
-        public Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+        public Task ClearEntryMemberAsync(
             string scopeId,
             string teamId,
             CancellationToken ct = default) => throw _ex;

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointsRouteBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointsRouteBindingTests.cs
@@ -1,10 +1,23 @@
+using System.Net;
+using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Hosting.Endpoints;
+using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.Studio.Tests;
 
@@ -23,6 +36,7 @@ public sealed class StudioTeamEndpointsRouteBindingTests
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddSingleton<IStudioTeamService, NoOpTeamService>();
         builder.Services.AddSingleton<IStudioMemberService, NoOpMemberServiceForTeam>();
+        builder.Services.AddSingleton<IStudioTeamGAgentStreamInvocationService, NoOpTeamStreamInvocationService>();
         builder.Services.AddRouting();
         var app = builder.Build();
 
@@ -32,8 +46,274 @@ public sealed class StudioTeamEndpointsRouteBindingTests
             .SelectMany(d => d.Endpoints)
             .ToList();
 
-        // Six routes: create, list, get, patch, archive, list-members.
-        endpoints.Should().HaveCount(6);
+        // Nine routes: create, list, get, patch, archive, entry set,
+        // entry clear, list-members, stream invoke.
+        endpoints.Should().HaveCount(9);
+        endpoints.OfType<RouteEndpoint>()
+            .Select(x => x.RoutePattern.RawText)
+            .Should()
+            .Contain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
+    }
+
+    [Fact]
+    public async Task HandleInvokeTeamStreamAsync_ShouldDelegateToStudioGAgentStreamService()
+    {
+        var service = new RecordingTeamStreamInvocationService();
+        await using var provider = CreateRequestServices();
+        var http = new DefaultHttpContext
+        {
+            RequestServices = provider,
+        };
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+        http.Request.Headers.Authorization = "Bearer token-1";
+
+        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
+            http,
+            "scope-a",
+            "team-a",
+            "chat",
+            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest(
+                Prompt: "  hello team  ",
+                ActorId: "actor-preferred",
+                SessionId: "session-1",
+                Headers: new Dictionary<string, string>
+                {
+                    ["scope_id"] = "spoofed",
+                    [WorkflowRunCommandMetadataKeys.ScopeId] = "spoofed-workflow",
+                    ["x-trace"] = "trace-1",
+                },
+                RevisionId: "rev-1",
+                InputParts:
+                [
+                    new StudioTeamEndpoints.StudioTeamStreamContentPartHttpRequest(
+                        Type: "image",
+                        DataBase64: "aGVsbG8=",
+                        MediaType: "image/png",
+                        Name: "sample.png"),
+                ]),
+            service,
+            CancellationToken.None);
+
+        body.Position = 0;
+        var text = await new StreamReader(body).ReadToEndAsync();
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        http.Response.ContentType.Should().Be("text/event-stream; charset=utf-8");
+        http.Response.Headers["X-Correlation-Id"].ToString().Should().Be("corr-1");
+        text.Should().Contain("runStarted");
+        text.Should().Contain("cmd-1");
+
+        service.LastRequest.Should().NotBeNull();
+        service.LastRequest!.ScopeId.Should().Be("scope-a");
+        service.LastRequest.TeamId.Should().Be("team-a");
+        service.LastRequest.EndpointId.Should().Be("chat");
+        service.LastRequest.Input.Prompt.Should().Be("hello team");
+        service.LastRequest.Input.PreferredActorId.Should().Be("actor-preferred");
+        service.LastRequest.Input.SessionId.Should().Be("session-1");
+        service.LastRequest.Input.RevisionId.Should().Be("rev-1");
+        service.LastRequest.Input.Headers.Should().Contain("x-trace", "trace-1");
+        service.LastRequest.Input.Headers.Should().Contain("nyxid.access_token", "token-1");
+        service.LastRequest.Input.Headers.Should().Contain(ConnectorRequest.HttpAuthorizationMetadataKey, "Bearer token-1");
+        service.LastRequest.Input.Headers.Should().NotContainKey("scope_id");
+        service.LastRequest.Input.Headers.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
+        service.LastRequest.Input.InputParts.Should().ContainSingle()
+            .Which.Kind.Should().Be(GAgentDraftRunInputPartKind.Image);
+    }
+
+    [Fact]
+    public async Task HandleInvokeTeamStreamAsync_ShouldInjectOwnerLlmPreferencesWithoutOverridingClientHeaders()
+    {
+        var service = new RecordingTeamStreamInvocationService();
+        await using var provider = CreateRequestServices(services =>
+            services.AddSingleton<INyxIdUserLlmPreferencesStore>(
+                new StubOwnerLlmPreferencesStore("gpt-5.5", "/api/v1/proxy/s/nyx")));
+        var http = new DefaultHttpContext
+        {
+            RequestServices = provider,
+        };
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+
+        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
+            http,
+            "scope-a",
+            "team-a",
+            "chat",
+            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest(
+                Prompt: "hello",
+                Headers: new Dictionary<string, string>
+                {
+                    [LLMRequestMetadataKeys.ModelOverride] = "client-model",
+                }),
+            service,
+            CancellationToken.None);
+
+        service.LastRequest.Should().NotBeNull();
+        service.LastRequest!.Input.Headers.Should().Contain(
+            LLMRequestMetadataKeys.ModelOverride,
+            "client-model");
+        service.LastRequest.Input.Headers.Should().Contain(
+            LLMRequestMetadataKeys.NyxIdRoutePreference,
+            "/api/v1/proxy/s/nyx");
+    }
+
+    [Fact]
+    public async Task HandleInvokeTeamStreamAsync_ShouldMapEntryMemberFailureBeforeSseStarts()
+    {
+        var service = new RecordingTeamStreamInvocationService
+        {
+            Exception = new TeamEntryMemberResolutionException(
+                TeamEntryMemberErrorCodes.EntryMemberNotConfigured,
+                "scope-a",
+                "team-a",
+                "team 'team-a' has no entry member configured."),
+        };
+        await using var provider = CreateRequestServices();
+        var http = new DefaultHttpContext
+        {
+            RequestServices = provider,
+        };
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+
+        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
+            http,
+            "scope-a",
+            "team-a",
+            "chat",
+            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
+            service,
+            CancellationToken.None);
+
+        body.Position = 0;
+        using var document = await JsonDocument.ParseAsync(body);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        document.RootElement.GetProperty("code").GetString()
+            .Should().Be(TeamEntryMemberErrorCodes.EntryMemberNotConfigured);
+    }
+
+    [Fact]
+    public async Task HandleInvokeTeamStreamAsync_ShouldWriteRunError_WhenServiceFailsAfterSseStarts()
+    {
+        var service = new RecordingTeamStreamInvocationService
+        {
+            ExceptionAfterAccepted = new InvalidOperationException("stream failed"),
+        };
+        await using var provider = CreateRequestServices();
+        var http = new DefaultHttpContext
+        {
+            RequestServices = provider,
+        };
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+
+        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
+            http,
+            "scope-a",
+            "team-a",
+            "chat",
+            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
+            service,
+            CancellationToken.None);
+
+        body.Position = 0;
+        var text = await new StreamReader(body).ReadToEndAsync();
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        text.Should().Contain("runStarted");
+        text.Should().Contain("runError");
+        text.Should().Contain("stream failed");
+    }
+
+    [Fact]
+    public async Task HandleInvokeTeamStreamAsync_ShouldWriteAuthRunError_WhenNyxIdAuthFailsAfterSseStarts()
+    {
+        var service = new RecordingTeamStreamInvocationService
+        {
+            ExceptionAfterAccepted = new NyxIdAuthenticationRequiredException("nyx"),
+        };
+        await using var provider = CreateRequestServices();
+        var http = new DefaultHttpContext
+        {
+            RequestServices = provider,
+        };
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+
+        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
+            http,
+            "scope-a",
+            "team-a",
+            "chat",
+            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
+            service,
+            CancellationToken.None);
+
+        body.Position = 0;
+        var text = await new StreamReader(body).ReadToEndAsync();
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        text.Should().Contain("runStarted");
+        text.Should().Contain("runError");
+        text.Should().Contain("authentication_required");
+        text.Should().Contain("NyxID authentication required. Please sign in.");
+    }
+
+    [Fact]
+    public async Task HandleInvokeTeamStreamAsync_ShouldWriteTimeoutRunError_WhenServiceTimesOut()
+    {
+        var service = new RecordingTeamStreamInvocationService
+        {
+            ExceptionAfterAccepted = new OperationCanceledException("interaction timeout"),
+        };
+        await using var provider = CreateRequestServices();
+        var http = new DefaultHttpContext
+        {
+            RequestServices = provider,
+        };
+        await using var body = new MemoryStream();
+        http.Response.Body = body;
+
+        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
+            http,
+            "scope-a",
+            "team-a",
+            "chat",
+            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
+            service,
+            CancellationToken.None);
+
+        body.Position = 0;
+        var text = await new StreamReader(body).ReadToEndAsync();
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        text.Should().Contain("runStarted");
+        text.Should().Contain("runError");
+        text.Should().Contain("Studio team GAgent stream timed out.");
+    }
+
+    private static ServiceProvider CreateRequestServices(Action<IServiceCollection>? configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(
+            new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Aevatar:Authentication:Enabled"] = "false",
+                })
+                .Build());
+        services.AddSingleton<IHostEnvironment>(
+            new TestHostEnvironment
+            {
+                EnvironmentName = Environments.Development,
+                ApplicationName = "Aevatar.Studio.Tests",
+                ContentRootPath = Directory.GetCurrentDirectory(),
+            });
+        configure?.Invoke(services);
+        return services.BuildServiceProvider();
     }
 
     private sealed class NoOpTeamService : IStudioTeamService
@@ -56,6 +336,19 @@ public sealed class StudioTeamEndpointsRouteBindingTests
 
         public Task<StudioTeamSummaryResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) =>
+            Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
+
+        public Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            SetStudioTeamEntryMemberRequest request,
+            CancellationToken ct = default) =>
+            Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
+
+        public Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default) =>
             Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
     }
 
@@ -100,5 +393,79 @@ public sealed class StudioTeamEndpointsRouteBindingTests
         public Task<StudioMemberDetailResponse> UpdateAsync(
             string scopeId, string memberId, UpdateStudioMemberRequest request, CancellationToken ct = default) =>
             Task.FromException<StudioMemberDetailResponse>(new NotImplementedException());
+    }
+
+    private sealed class NoOpTeamStreamInvocationService : IStudioTeamGAgentStreamInvocationService
+    {
+        public Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+            StudioTeamGAgentStreamInvocationRequest request,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default) =>
+            Task.FromException<StaticGAgentStreamInvocationResult>(new NotImplementedException());
+    }
+
+    private sealed class RecordingTeamStreamInvocationService : IStudioTeamGAgentStreamInvocationService
+    {
+        public StudioTeamGAgentStreamInvocationRequest? LastRequest { get; private set; }
+
+        public TeamEntryMemberResolutionException? Exception { get; set; }
+
+        public Exception? ExceptionAfterAccepted { get; set; }
+
+        public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+            StudioTeamGAgentStreamInvocationRequest request,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            LastRequest = request;
+            if (Exception != null)
+                throw Exception;
+
+            var accepted = new StaticGAgentStreamAcceptedReceipt(
+                new ServiceInvocationAcceptedReceipt
+                {
+                    RequestId = "cmd-1",
+                    CommandId = "cmd-1",
+                    CorrelationId = "corr-1",
+                    TargetActorId = "actor-1",
+                    EndpointId = request.EndpointId,
+                },
+                new GAgentDraftRunAcceptedReceipt("actor-1", "RoleGAgent", "cmd-1", "corr-1"));
+
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(accepted, ct);
+
+            if (ExceptionAfterAccepted != null)
+                throw ExceptionAfterAccepted;
+
+            return new StaticGAgentStreamInvocationResult(
+                accepted,
+                GAgentDraftRunStartError.None,
+                GAgentDraftRunCompletionStatus.RunFinished,
+                CompletionObserved: true);
+        }
+    }
+
+    private sealed class StubOwnerLlmPreferencesStore(
+        string defaultModel,
+        string preferredRoute) : INyxIdUserLlmPreferencesStore
+    {
+        public Task<NyxIdUserLlmPreferences> GetOwnerAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(new NyxIdUserLlmPreferences(defaultModel, preferredRoute));
+
+        public Task<NyxIdUserLlmPreferences> GetForBindingAsync(
+            string bindingId,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+        public string ApplicationName { get; set; } = "Aevatar.Studio.Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 }

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointsRouteBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointsRouteBindingTests.cs
@@ -1,23 +1,10 @@
-using System.Net;
-using System.Text.Json;
-using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.Foundation.Abstractions.Connectors;
-using Aevatar.GAgentService.Abstractions;
-using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.GAgentService.Abstractions.ScopeGAgents;
-using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Hosting.Endpoints;
-using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.Studio.Tests;
 
@@ -36,7 +23,6 @@ public sealed class StudioTeamEndpointsRouteBindingTests
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddSingleton<IStudioTeamService, NoOpTeamService>();
         builder.Services.AddSingleton<IStudioMemberService, NoOpMemberServiceForTeam>();
-        builder.Services.AddSingleton<IStudioTeamGAgentStreamInvocationService, NoOpTeamStreamInvocationService>();
         builder.Services.AddRouting();
         var app = builder.Build();
 
@@ -46,274 +32,14 @@ public sealed class StudioTeamEndpointsRouteBindingTests
             .SelectMany(d => d.Endpoints)
             .ToList();
 
-        // Nine routes: create, list, get, patch, archive, entry set,
-        // entry clear, list-members, stream invoke.
-        endpoints.Should().HaveCount(9);
+        // Eight routes: create, list, get, patch, archive, entry set,
+        // entry clear, list-members. Team stream invoke is owned by
+        // GAgentService ScopeServiceEndpoints.
+        endpoints.Should().HaveCount(8);
         endpoints.OfType<RouteEndpoint>()
             .Select(x => x.RoutePattern.RawText)
             .Should()
-            .Contain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
-    }
-
-    [Fact]
-    public async Task HandleInvokeTeamStreamAsync_ShouldDelegateToStudioGAgentStreamService()
-    {
-        var service = new RecordingTeamStreamInvocationService();
-        await using var provider = CreateRequestServices();
-        var http = new DefaultHttpContext
-        {
-            RequestServices = provider,
-        };
-        await using var body = new MemoryStream();
-        http.Response.Body = body;
-        http.Request.Headers.Authorization = "Bearer token-1";
-
-        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
-            http,
-            "scope-a",
-            "team-a",
-            "chat",
-            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest(
-                Prompt: "  hello team  ",
-                ActorId: "actor-preferred",
-                SessionId: "session-1",
-                Headers: new Dictionary<string, string>
-                {
-                    ["scope_id"] = "spoofed",
-                    [WorkflowRunCommandMetadataKeys.ScopeId] = "spoofed-workflow",
-                    ["x-trace"] = "trace-1",
-                },
-                RevisionId: "rev-1",
-                InputParts:
-                [
-                    new StudioTeamEndpoints.StudioTeamStreamContentPartHttpRequest(
-                        Type: "image",
-                        DataBase64: "aGVsbG8=",
-                        MediaType: "image/png",
-                        Name: "sample.png"),
-                ]),
-            service,
-            CancellationToken.None);
-
-        body.Position = 0;
-        var text = await new StreamReader(body).ReadToEndAsync();
-
-        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        http.Response.ContentType.Should().Be("text/event-stream; charset=utf-8");
-        http.Response.Headers["X-Correlation-Id"].ToString().Should().Be("corr-1");
-        text.Should().Contain("runStarted");
-        text.Should().Contain("cmd-1");
-
-        service.LastRequest.Should().NotBeNull();
-        service.LastRequest!.ScopeId.Should().Be("scope-a");
-        service.LastRequest.TeamId.Should().Be("team-a");
-        service.LastRequest.EndpointId.Should().Be("chat");
-        service.LastRequest.Input.Prompt.Should().Be("hello team");
-        service.LastRequest.Input.PreferredActorId.Should().Be("actor-preferred");
-        service.LastRequest.Input.SessionId.Should().Be("session-1");
-        service.LastRequest.Input.RevisionId.Should().Be("rev-1");
-        service.LastRequest.Input.Headers.Should().Contain("x-trace", "trace-1");
-        service.LastRequest.Input.Headers.Should().Contain("nyxid.access_token", "token-1");
-        service.LastRequest.Input.Headers.Should().Contain(ConnectorRequest.HttpAuthorizationMetadataKey, "Bearer token-1");
-        service.LastRequest.Input.Headers.Should().NotContainKey("scope_id");
-        service.LastRequest.Input.Headers.Should().NotContainKey(WorkflowRunCommandMetadataKeys.ScopeId);
-        service.LastRequest.Input.InputParts.Should().ContainSingle()
-            .Which.Kind.Should().Be(GAgentDraftRunInputPartKind.Image);
-    }
-
-    [Fact]
-    public async Task HandleInvokeTeamStreamAsync_ShouldInjectOwnerLlmPreferencesWithoutOverridingClientHeaders()
-    {
-        var service = new RecordingTeamStreamInvocationService();
-        await using var provider = CreateRequestServices(services =>
-            services.AddSingleton<INyxIdUserLlmPreferencesStore>(
-                new StubOwnerLlmPreferencesStore("gpt-5.5", "/api/v1/proxy/s/nyx")));
-        var http = new DefaultHttpContext
-        {
-            RequestServices = provider,
-        };
-        await using var body = new MemoryStream();
-        http.Response.Body = body;
-
-        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
-            http,
-            "scope-a",
-            "team-a",
-            "chat",
-            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest(
-                Prompt: "hello",
-                Headers: new Dictionary<string, string>
-                {
-                    [LLMRequestMetadataKeys.ModelOverride] = "client-model",
-                }),
-            service,
-            CancellationToken.None);
-
-        service.LastRequest.Should().NotBeNull();
-        service.LastRequest!.Input.Headers.Should().Contain(
-            LLMRequestMetadataKeys.ModelOverride,
-            "client-model");
-        service.LastRequest.Input.Headers.Should().Contain(
-            LLMRequestMetadataKeys.NyxIdRoutePreference,
-            "/api/v1/proxy/s/nyx");
-    }
-
-    [Fact]
-    public async Task HandleInvokeTeamStreamAsync_ShouldMapEntryMemberFailureBeforeSseStarts()
-    {
-        var service = new RecordingTeamStreamInvocationService
-        {
-            Exception = new TeamEntryMemberResolutionException(
-                TeamEntryMemberErrorCodes.EntryMemberNotConfigured,
-                "scope-a",
-                "team-a",
-                "team 'team-a' has no entry member configured."),
-        };
-        await using var provider = CreateRequestServices();
-        var http = new DefaultHttpContext
-        {
-            RequestServices = provider,
-        };
-        await using var body = new MemoryStream();
-        http.Response.Body = body;
-
-        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
-            http,
-            "scope-a",
-            "team-a",
-            "chat",
-            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
-            service,
-            CancellationToken.None);
-
-        body.Position = 0;
-        using var document = await JsonDocument.ParseAsync(body);
-
-        http.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
-        document.RootElement.GetProperty("code").GetString()
-            .Should().Be(TeamEntryMemberErrorCodes.EntryMemberNotConfigured);
-    }
-
-    [Fact]
-    public async Task HandleInvokeTeamStreamAsync_ShouldWriteRunError_WhenServiceFailsAfterSseStarts()
-    {
-        var service = new RecordingTeamStreamInvocationService
-        {
-            ExceptionAfterAccepted = new InvalidOperationException("stream failed"),
-        };
-        await using var provider = CreateRequestServices();
-        var http = new DefaultHttpContext
-        {
-            RequestServices = provider,
-        };
-        await using var body = new MemoryStream();
-        http.Response.Body = body;
-
-        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
-            http,
-            "scope-a",
-            "team-a",
-            "chat",
-            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
-            service,
-            CancellationToken.None);
-
-        body.Position = 0;
-        var text = await new StreamReader(body).ReadToEndAsync();
-
-        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        text.Should().Contain("runStarted");
-        text.Should().Contain("runError");
-        text.Should().Contain("stream failed");
-    }
-
-    [Fact]
-    public async Task HandleInvokeTeamStreamAsync_ShouldWriteAuthRunError_WhenNyxIdAuthFailsAfterSseStarts()
-    {
-        var service = new RecordingTeamStreamInvocationService
-        {
-            ExceptionAfterAccepted = new NyxIdAuthenticationRequiredException("nyx"),
-        };
-        await using var provider = CreateRequestServices();
-        var http = new DefaultHttpContext
-        {
-            RequestServices = provider,
-        };
-        await using var body = new MemoryStream();
-        http.Response.Body = body;
-
-        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
-            http,
-            "scope-a",
-            "team-a",
-            "chat",
-            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
-            service,
-            CancellationToken.None);
-
-        body.Position = 0;
-        var text = await new StreamReader(body).ReadToEndAsync();
-
-        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        text.Should().Contain("runStarted");
-        text.Should().Contain("runError");
-        text.Should().Contain("authentication_required");
-        text.Should().Contain("NyxID authentication required. Please sign in.");
-    }
-
-    [Fact]
-    public async Task HandleInvokeTeamStreamAsync_ShouldWriteTimeoutRunError_WhenServiceTimesOut()
-    {
-        var service = new RecordingTeamStreamInvocationService
-        {
-            ExceptionAfterAccepted = new OperationCanceledException("interaction timeout"),
-        };
-        await using var provider = CreateRequestServices();
-        var http = new DefaultHttpContext
-        {
-            RequestServices = provider,
-        };
-        await using var body = new MemoryStream();
-        http.Response.Body = body;
-
-        await StudioTeamEndpoints.HandleInvokeTeamStreamAsync(
-            http,
-            "scope-a",
-            "team-a",
-            "chat",
-            new StudioTeamEndpoints.StudioTeamGAgentStreamHttpRequest("hello"),
-            service,
-            CancellationToken.None);
-
-        body.Position = 0;
-        var text = await new StreamReader(body).ReadToEndAsync();
-
-        http.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        text.Should().Contain("runStarted");
-        text.Should().Contain("runError");
-        text.Should().Contain("Studio team GAgent stream timed out.");
-    }
-
-    private static ServiceProvider CreateRequestServices(Action<IServiceCollection>? configure = null)
-    {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddSingleton<IConfiguration>(
-            new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string?>
-                {
-                    ["Aevatar:Authentication:Enabled"] = "false",
-                })
-                .Build());
-        services.AddSingleton<IHostEnvironment>(
-            new TestHostEnvironment
-            {
-                EnvironmentName = Environments.Development,
-                ApplicationName = "Aevatar.Studio.Tests",
-                ContentRootPath = Directory.GetCurrentDirectory(),
-            });
-        configure?.Invoke(services);
-        return services.BuildServiceProvider();
+            .NotContain("/api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream");
     }
 
     private sealed class NoOpTeamService : IStudioTeamService
@@ -338,18 +64,18 @@ public sealed class StudioTeamEndpointsRouteBindingTests
             string scopeId, string teamId, CancellationToken ct = default) =>
             Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
 
-        public Task<StudioTeamSummaryResponse> SetEntryMemberAsync(
+        public Task SetEntryMemberAsync(
             string scopeId,
             string teamId,
             SetStudioTeamEntryMemberRequest request,
             CancellationToken ct = default) =>
-            Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
+            Task.FromException(new NotImplementedException());
 
-        public Task<StudioTeamSummaryResponse> ClearEntryMemberAsync(
+        public Task ClearEntryMemberAsync(
             string scopeId,
             string teamId,
             CancellationToken ct = default) =>
-            Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
+            Task.FromException(new NotImplementedException());
     }
 
     private sealed class NoOpMemberServiceForTeam : IStudioMemberService
@@ -393,79 +119,5 @@ public sealed class StudioTeamEndpointsRouteBindingTests
         public Task<StudioMemberDetailResponse> UpdateAsync(
             string scopeId, string memberId, UpdateStudioMemberRequest request, CancellationToken ct = default) =>
             Task.FromException<StudioMemberDetailResponse>(new NotImplementedException());
-    }
-
-    private sealed class NoOpTeamStreamInvocationService : IStudioTeamGAgentStreamInvocationService
-    {
-        public Task<StaticGAgentStreamInvocationResult> InvokeAsync(
-            StudioTeamGAgentStreamInvocationRequest request,
-            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
-            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
-            CancellationToken ct = default) =>
-            Task.FromException<StaticGAgentStreamInvocationResult>(new NotImplementedException());
-    }
-
-    private sealed class RecordingTeamStreamInvocationService : IStudioTeamGAgentStreamInvocationService
-    {
-        public StudioTeamGAgentStreamInvocationRequest? LastRequest { get; private set; }
-
-        public TeamEntryMemberResolutionException? Exception { get; set; }
-
-        public Exception? ExceptionAfterAccepted { get; set; }
-
-        public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
-            StudioTeamGAgentStreamInvocationRequest request,
-            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
-            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
-            CancellationToken ct = default)
-        {
-            LastRequest = request;
-            if (Exception != null)
-                throw Exception;
-
-            var accepted = new StaticGAgentStreamAcceptedReceipt(
-                new ServiceInvocationAcceptedReceipt
-                {
-                    RequestId = "cmd-1",
-                    CommandId = "cmd-1",
-                    CorrelationId = "corr-1",
-                    TargetActorId = "actor-1",
-                    EndpointId = request.EndpointId,
-                },
-                new GAgentDraftRunAcceptedReceipt("actor-1", "RoleGAgent", "cmd-1", "corr-1"));
-
-            if (onAcceptedAsync != null)
-                await onAcceptedAsync(accepted, ct);
-
-            if (ExceptionAfterAccepted != null)
-                throw ExceptionAfterAccepted;
-
-            return new StaticGAgentStreamInvocationResult(
-                accepted,
-                GAgentDraftRunStartError.None,
-                GAgentDraftRunCompletionStatus.RunFinished,
-                CompletionObserved: true);
-        }
-    }
-
-    private sealed class StubOwnerLlmPreferencesStore(
-        string defaultModel,
-        string preferredRoute) : INyxIdUserLlmPreferencesStore
-    {
-        public Task<NyxIdUserLlmPreferences> GetOwnerAsync(CancellationToken cancellationToken = default) =>
-            Task.FromResult(new NyxIdUserLlmPreferences(defaultModel, preferredRoute));
-
-        public Task<NyxIdUserLlmPreferences> GetForBindingAsync(
-            string bindingId,
-            CancellationToken cancellationToken = default) =>
-            throw new NotSupportedException();
-    }
-
-    private sealed class TestHostEnvironment : IHostEnvironment
-    {
-        public string EnvironmentName { get; set; } = Environments.Development;
-        public string ApplicationName { get; set; } = "Aevatar.Studio.Tests";
-        public string ContentRootPath { get; set; } = string.Empty;
-        public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 }

--- a/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEntryMemberResolverTests.cs
@@ -1,0 +1,190 @@
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioTeamEntryMemberResolverTests
+{
+    private const string ScopeId = "scope-1";
+    private const string TeamId = "t-1";
+    private const string EntryMemberId = "m-1";
+    private const string PublishedServiceId = "member-m-1";
+
+    [Fact]
+    public async Task ResolveAsync_ShouldReturnPublishedService_WhenEntryMemberReady()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember()));
+
+        var result = await resolver.ResolveAsync(ScopeId, TeamId);
+
+        result.ScopeId.Should().Be(ScopeId);
+        result.TeamId.Should().Be(TeamId);
+        result.EntryMemberId.Should().Be(EntryMemberId);
+        result.PublishedServiceId.Should().Be(PublishedServiceId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowTeamNotFound_WhenTeamMissing()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(null),
+            new MemberQueryPort(NewMember()));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.TeamNotFound);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowTeamArchived_WhenTeamArchived()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam(lifecycleStage: TeamLifecycleStageNames.Archived)),
+            new MemberQueryPort(NewMember()));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.TeamArchived);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowNotConfigured_WhenEntryMissing()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam(entryMemberId: null)),
+            new MemberQueryPort(NewMember()));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotConfigured);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowMemberNotFound_WhenMemberMissing()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(null));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotFound);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowMismatch_WhenMemberBelongsToAnotherTeam()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember(teamId: "other-team")));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberMismatch);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowNotReady_WhenMemberNotBindReady()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember(lifecycleStage: MemberLifecycleStageNames.BuildReady)));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ShouldThrowNotReady_WhenPublishedServiceMissing()
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(NewTeam()),
+            new MemberQueryPort(NewMember(publishedServiceId: "")));
+
+        var act = () => resolver.ResolveAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
+    }
+
+    private static StudioTeamSummaryResponse NewTeam(
+        string lifecycleStage = TeamLifecycleStageNames.Active,
+        string? entryMemberId = EntryMemberId) =>
+        new(
+            TeamId: TeamId,
+            ScopeId: ScopeId,
+            DisplayName: "Team Alpha",
+            Description: string.Empty,
+            LifecycleStage: lifecycleStage,
+            MemberCount: 1,
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            EntryMemberId = entryMemberId,
+        };
+
+    private static StudioMemberDetailResponse NewMember(
+        string? teamId = TeamId,
+        string lifecycleStage = MemberLifecycleStageNames.BindReady,
+        string publishedServiceId = PublishedServiceId)
+    {
+        var summary = new StudioMemberSummaryResponse(
+            MemberId: EntryMemberId,
+            ScopeId: ScopeId,
+            DisplayName: "Member Alpha",
+            Description: string.Empty,
+            ImplementationKind: MemberImplementationKindNames.Workflow,
+            LifecycleStage: lifecycleStage,
+            PublishedServiceId: publishedServiceId,
+            LastBoundRevisionId: "rev-1",
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            TeamId = teamId,
+        };
+
+        return new StudioMemberDetailResponse(summary, null, null);
+    }
+
+    private sealed class TeamQueryPort(StudioTeamSummaryResponse? team) : IStudioTeamQueryPort
+    {
+        public Task<StudioTeamRosterResponse> ListAsync(
+            string scopeId,
+            StudioTeamRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new StudioTeamRosterResponse(scopeId, team == null ? [] : [team]));
+
+        public Task<StudioTeamSummaryResponse?> GetAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default) =>
+            Task.FromResult(team);
+    }
+
+    private sealed class MemberQueryPort(StudioMemberDetailResponse? member) : IStudioMemberQueryPort
+    {
+        public Task<StudioMemberRosterResponse> ListAsync(
+            string scopeId,
+            StudioMemberRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new StudioMemberRosterResponse(scopeId, member == null ? [] : [member.Summary]));
+
+        public Task<StudioMemberDetailResponse?> GetAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            Task.FromResult(member);
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioTeamGAgentStateTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamGAgentStateTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.StudioMember;
 using Aevatar.GAgents.StudioTeam;
 using FluentAssertions;
@@ -88,6 +90,333 @@ public sealed class StudioTeamGAgentStateTests
 
         updated.DisplayName.Should().Be("Platform");
         updated.Description.Should().Be("New description");
+    }
+
+    [Fact]
+    public void EntryMemberChanged_WithMemberId_ShouldPersistEntryMemberId()
+    {
+        var created = CreateActiveTeam();
+        var withMember = _agent.Apply(created, new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        var changedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1));
+        var withEntry = _agent.Apply(withMember, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = changedAt,
+        });
+
+        withEntry.EntryMemberId.Should().Be("m-1");
+        withEntry.UpdatedAtUtc.Should().Be(changedAt);
+    }
+
+    [Fact]
+    public void EntryMemberChanged_WithoutMemberId_ShouldClearEntryMemberId()
+    {
+        var created = CreateActiveTeam();
+        var withMember = _agent.Apply(created, new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var withEntry = _agent.Apply(withMember, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+
+        var changedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(2));
+        var cleared = _agent.Apply(withEntry, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            ChangedAtUtc = changedAt,
+        });
+
+        cleared.HasEntryMemberId.Should().BeFalse();
+        cleared.EntryMemberId.Should().BeEmpty();
+        cleared.UpdatedAtUtc.Should().Be(changedAt);
+    }
+
+    [Fact]
+    public void RosterChanged_RemovingEntryMember_ShouldClearEntryMemberId()
+    {
+        var created = CreateActiveTeam();
+        var withMember = _agent.Apply(created, new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var withEntry = _agent.Apply(withMember, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+
+        var afterRemove = _agent.Apply(withEntry, new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Removed,
+            MemberCount = 0,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(2)),
+        });
+
+        afterRemove.MemberIds.Should().BeEmpty();
+        afterRemove.HasEntryMemberId.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleMemberReassigned_ShouldPersistEntryClear_WhenEntryMemberLeavesTeam()
+    {
+        var created = CreateActiveTeam();
+        var withMember = _agent.Apply(created, new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var withEntry = _agent.Apply(withMember, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+        var eventSourcing = new RecordingEventSourcing(withEntry);
+        var agent = NewHandlerAgent(withEntry, eventSourcing);
+
+        await agent.HandleMemberReassigned(new StudioMemberReassignedEvent
+        {
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            FromTeamId = "team-1",
+            ToTeamId = "team-2",
+            ReassignedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(2)),
+        });
+
+        eventSourcing.RaisedEvents.Should().HaveCount(2);
+        eventSourcing.RaisedEvents[0].Should().BeOfType<StudioTeamMemberRosterChangedEvent>()
+            .Which.Effect.Should().Be(StudioTeamRosterEffect.Removed);
+        eventSourcing.RaisedEvents[1].Should().BeOfType<StudioTeamEntryMemberChangedEvent>()
+            .Which.HasEntryMemberId.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleMemberReassigned_ShouldOnlyPersistNoop_WhenDuplicateEntryMemberRemovalArrives()
+    {
+        var created = CreateActiveTeam();
+        var eventSourcing = new RecordingEventSourcing(created);
+        var agent = NewHandlerAgent(created, eventSourcing);
+
+        await agent.HandleMemberReassigned(new StudioMemberReassignedEvent
+        {
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            FromTeamId = "team-1",
+            ReassignedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(2)),
+        });
+
+        eventSourcing.RaisedEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<StudioTeamMemberRosterChangedEvent>()
+            .Which.Effect.Should().Be(StudioTeamRosterEffect.Noop);
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldReject_WhenTeamNotCreated()
+    {
+        var state = new StudioTeamState();
+        var agent = NewHandlerAgent(state, new RecordingEventSourcing(state));
+
+        var act = () => agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*team not yet created*");
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldReject_WhenTeamArchived()
+    {
+        var archived = _agent.Apply(CreateActiveTeam(), new StudioTeamArchivedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            ArchivedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var agent = NewHandlerAgent(archived, new RecordingEventSourcing(archived));
+
+        var act = () => agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            ScopeId = "scope-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*archived*");
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldReject_WhenScopeDoesNotMatch()
+    {
+        var created = CreateActiveTeam();
+        var agent = NewHandlerAgent(created, new RecordingEventSourcing(created));
+
+        var act = () => agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            ScopeId = "other-scope",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*cannot update entry member in scope other-scope*");
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldReject_WhenEntryMemberIsNotInRoster()
+    {
+        var created = CreateActiveTeam();
+        var agent = NewHandlerAgent(created, new RecordingEventSourcing(created));
+
+        var act = () => agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*must belong to team*");
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldPersist_WhenEntryMemberChanges()
+    {
+        var withMember = _agent.Apply(CreateActiveTeam(), new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var eventSourcing = new RecordingEventSourcing(withMember);
+        var agent = NewHandlerAgent(withMember, eventSourcing);
+        var changedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1));
+
+        await agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = changedAt,
+        });
+
+        eventSourcing.RaisedEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<StudioTeamEntryMemberChangedEvent>()
+            .Which.Should().Match<StudioTeamEntryMemberChangedEvent>(evt =>
+                evt.EntryMemberId == "m-1"
+                && evt.HasEntryMemberId
+                && evt.ChangedAtUtc.Equals(changedAt));
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldPersist_WhenEntryMemberIsCleared()
+    {
+        var withMember = _agent.Apply(CreateActiveTeam(), new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var withEntry = _agent.Apply(withMember, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+        var eventSourcing = new RecordingEventSourcing(withEntry);
+        var agent = NewHandlerAgent(withEntry, eventSourcing);
+        var changedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(2));
+
+        await agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            ChangedAtUtc = changedAt,
+        });
+
+        eventSourcing.RaisedEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<StudioTeamEntryMemberChangedEvent>()
+            .Which.Should().Match<StudioTeamEntryMemberChangedEvent>(evt =>
+                !evt.HasEntryMemberId
+                && evt.ChangedAtUtc.Equals(changedAt));
+    }
+
+    [Fact]
+    public async Task HandleEntryMemberChanged_ShouldSkipPersist_WhenEntryMemberUnchanged()
+    {
+        var withMember = _agent.Apply(CreateActiveTeam(), new StudioTeamMemberRosterChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            Effect = StudioTeamRosterEffect.Added,
+            MemberCount = 1,
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        });
+        var withEntry = _agent.Apply(withMember, new StudioTeamEntryMemberChangedEvent
+        {
+            TeamId = "team-1",
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(1)),
+        });
+        var eventSourcing = new RecordingEventSourcing(withEntry);
+        var agent = NewHandlerAgent(withEntry, eventSourcing);
+
+        await agent.HandleEntryMemberChanged(new StudioTeamEntryMemberChangedEvent
+        {
+            ScopeId = "scope-1",
+            EntryMemberId = "m-1",
+            ChangedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddSeconds(2)),
+        });
+
+        eventSourcing.RaisedEvents.Should().BeEmpty();
     }
 
     [Fact]
@@ -273,5 +602,56 @@ public sealed class StudioTeamGAgentStateTests
                 ?? throw new InvalidOperationException("TransitionState returned null.");
             return (StudioTeamState)result;
         }
+    }
+
+    private static StudioTeamGAgent NewHandlerAgent(
+        StudioTeamState state,
+        RecordingEventSourcing eventSourcing)
+    {
+        var agent = new StudioTeamGAgent
+        {
+            EventSourcing = eventSourcing,
+        };
+        StudioTeamStateSetter.Set(agent, state);
+        return agent;
+    }
+
+    private static class StudioTeamStateSetter
+    {
+        private static readonly FieldInfo StateField =
+            typeof(StudioTeamGAgent).BaseType!
+                .GetField("_state", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GAgent state field not found.");
+
+        public static void Set(StudioTeamGAgent agent, StudioTeamState state) =>
+            StateField.SetValue(agent, state.Clone());
+    }
+
+    private sealed class RecordingEventSourcing(StudioTeamState replayState)
+        : IEventSourcingBehavior<StudioTeamState>
+    {
+        public List<IMessage> RaisedEvents { get; } = [];
+        public long CurrentVersion => 0;
+
+        public void RaiseEvent<TEvent>(TEvent evt) where TEvent : IMessage =>
+            RaisedEvents.Add(evt);
+
+        public Task<EventStoreCommitResult> ConfirmEventsAsync(
+            CancellationToken ct = default) =>
+            Task.FromResult(new EventStoreCommitResult());
+
+        public Task PersistSnapshotAsync(StudioTeamState currentState, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task<StudioTeamState?> ReplayAsync(string agentId, CancellationToken ct = default) =>
+            Task.FromResult<StudioTeamState?>(replayState.Clone());
+
+        public void DiscardPendingEvents() =>
+            RaisedEvents.Clear();
+
+        public StudioTeamState TransitionState(StudioTeamState current, IMessage evt) =>
+            _agent.Apply(current, evt);
+
+        private readonly StudioTeamStateApplier _agent = new();
     }
 }

--- a/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
@@ -22,20 +23,32 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
         var staticPort = new RecordingStaticGAgentStreamInvocationPort();
         var service = CreateService(staticPort);
         var emitted = new List<AGUIEvent>();
-        StaticGAgentStreamAcceptedReceipt? accepted = null;
+        StudioTeamStreamInvocationAcceptedReceipt? accepted = null;
 
         var result = await service.InvokeAsync(
-            new StudioTeamGAgentStreamInvocationRequest(
+            new StudioTeamStreamInvocationRequest(
                 ScopeId,
                 TeamId,
                 "chat",
-                new StaticGAgentStreamInvocationInput(
+                new StudioTeamStreamInvocationInput(
                     Prompt: "hello team",
+                    PreferredActorId: "actor-preferred",
                     SessionId: "session-1",
+                    RevisionId: "rev-1",
                     Headers: new Dictionary<string, string>
                     {
                         ["x-trace"] = "trace-1",
-                    })),
+                    },
+                    InputParts:
+                    [
+                        new StudioTeamStreamInvocationInputPart("text", Text: "hello"),
+                        new StudioTeamStreamInvocationInputPart(
+                            "image",
+                            DataBase64: "aW1hZ2U=",
+                            MediaType: "image/png",
+                            Name: "image.png"),
+                    ],
+                    Timeout: TimeSpan.FromSeconds(15))),
             (frame, _) =>
             {
                 emitted.Add(frame);
@@ -47,21 +60,38 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
                 return ValueTask.CompletedTask;
             });
 
-        result.Succeeded.Should().BeTrue();
-        accepted.Should().NotBeNull();
+        result.AcceptedReceipt.Should().NotBeNull();
+        result.AcceptedReceipt!.RunId.Should().Be("cmd-1");
+        result.AcceptedReceipt.ThreadId.Should().Be("actor-1");
+        result.AcceptedReceipt.CorrelationId.Should().Be("corr-1");
+        result.StartError.Should().Be(nameof(GAgentDraftRunStartError.None));
+        result.CompletionStatus.Should().Be(nameof(GAgentDraftRunCompletionStatus.RunFinished));
+        result.CompletionObserved.Should().BeTrue();
+        accepted.Should().BeEquivalentTo(result.AcceptedReceipt);
         emitted.Should().ContainSingle()
             .Which.RunStarted.RunId.Should().Be("cmd-1");
 
         staticPort.Requests.Should().ContainSingle();
         var delegated = staticPort.Requests[0];
         delegated.Identity.TenantId.Should().Be(ScopeId);
-        delegated.Identity.AppId.Should().Be("default");
-        delegated.Identity.Namespace.Should().Be("default");
+        delegated.Identity.AppId.Should().Be(ScopeServiceIdentityDefaults.ServiceAppId);
+        delegated.Identity.Namespace.Should().Be(ScopeServiceIdentityDefaults.ServiceNamespace);
         delegated.Identity.ServiceId.Should().Be(PublishedServiceId);
         delegated.EndpointId.Should().Be("chat");
         delegated.Input.Prompt.Should().Be("hello team");
+        delegated.Input.PreferredActorId.Should().Be("actor-preferred");
         delegated.Input.SessionId.Should().Be("session-1");
+        delegated.Input.RevisionId.Should().Be("rev-1");
         delegated.Input.Headers.Should().Contain("x-trace", "trace-1");
+        delegated.Input.Timeout.Should().Be(TimeSpan.FromSeconds(15));
+        delegated.Input.InputParts.Should().NotBeNull();
+        delegated.Input.InputParts!.Should().HaveCount(2);
+        delegated.Input.InputParts[0].Kind.Should().Be(GAgentDraftRunInputPartKind.Text);
+        delegated.Input.InputParts[0].Text.Should().Be("hello");
+        delegated.Input.InputParts[1].Kind.Should().Be(GAgentDraftRunInputPartKind.Image);
+        delegated.Input.InputParts[1].DataBase64.Should().Be("aW1hZ2U=");
+        delegated.Input.InputParts[1].MediaType.Should().Be("image/png");
+        delegated.Input.InputParts[1].Name.Should().Be("image.png");
     }
 
     [Fact]
@@ -132,15 +162,17 @@ public sealed class StudioTeamGAgentStreamInvocationServiceTests
         var resolver = new StudioTeamEntryMemberResolver(
             new TeamQueryPort(team ?? NewTeam()),
             new MemberQueryPort(member ?? NewMember()));
-        return new StudioTeamGAgentStreamInvocationService(resolver, staticPort);
+        return new StudioTeamGAgentStreamInvocationService(
+            resolver,
+            staticPort);
     }
 
-    private static StudioTeamGAgentStreamInvocationRequest NewRequest() =>
+    private static StudioTeamStreamInvocationRequest NewRequest() =>
         new(
             ScopeId,
             TeamId,
             "chat",
-            new StaticGAgentStreamInvocationInput("hello"));
+            new StudioTeamStreamInvocationInput("hello"));
 
     private static StudioTeamSummaryResponse NewTeam(
         string lifecycleStage = TeamLifecycleStageNames.Active,

--- a/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamGAgentStreamInvocationServiceTests.cs
@@ -1,0 +1,259 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.Presentation.AGUI;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Application.Studio.Contracts;
+using Aevatar.Studio.Application.Studio.Services;
+using FluentAssertions;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioTeamGAgentStreamInvocationServiceTests
+{
+    private const string ScopeId = "scope-1";
+    private const string TeamId = "team-1";
+    private const string EntryMemberId = "member-1";
+    private const string PublishedServiceId = "published-service-1";
+
+    [Fact]
+    public async Task InvokeAsync_ShouldResolveEntryMemberAndDelegateToPublishedServiceIdentity()
+    {
+        var staticPort = new RecordingStaticGAgentStreamInvocationPort();
+        var service = CreateService(staticPort);
+        var emitted = new List<AGUIEvent>();
+        StaticGAgentStreamAcceptedReceipt? accepted = null;
+
+        var result = await service.InvokeAsync(
+            new StudioTeamGAgentStreamInvocationRequest(
+                ScopeId,
+                TeamId,
+                "chat",
+                new StaticGAgentStreamInvocationInput(
+                    Prompt: "hello team",
+                    SessionId: "session-1",
+                    Headers: new Dictionary<string, string>
+                    {
+                        ["x-trace"] = "trace-1",
+                    })),
+            (frame, _) =>
+            {
+                emitted.Add(frame);
+                return ValueTask.CompletedTask;
+            },
+            (receipt, _) =>
+            {
+                accepted = receipt;
+                return ValueTask.CompletedTask;
+            });
+
+        result.Succeeded.Should().BeTrue();
+        accepted.Should().NotBeNull();
+        emitted.Should().ContainSingle()
+            .Which.RunStarted.RunId.Should().Be("cmd-1");
+
+        staticPort.Requests.Should().ContainSingle();
+        var delegated = staticPort.Requests[0];
+        delegated.Identity.TenantId.Should().Be(ScopeId);
+        delegated.Identity.AppId.Should().Be("default");
+        delegated.Identity.Namespace.Should().Be("default");
+        delegated.Identity.ServiceId.Should().Be(PublishedServiceId);
+        delegated.EndpointId.Should().Be("chat");
+        delegated.Input.Prompt.Should().Be("hello team");
+        delegated.Input.SessionId.Should().Be("session-1");
+        delegated.Input.Headers.Should().Contain("x-trace", "trace-1");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldRejectArchivedTeam()
+    {
+        var service = CreateService(
+            new RecordingStaticGAgentStreamInvocationPort(),
+            team: NewTeam(lifecycleStage: TeamLifecycleStageNames.Archived));
+
+        var act = () => service.InvokeAsync(
+            NewRequest(),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.TeamArchived);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldRejectMissingEntryMember()
+    {
+        var service = CreateService(
+            new RecordingStaticGAgentStreamInvocationPort(),
+            team: NewTeam(entryMemberId: null));
+
+        var act = () => service.InvokeAsync(
+            NewRequest(),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotConfigured);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldRejectEntryMemberFromAnotherTeam()
+    {
+        var service = CreateService(
+            new RecordingStaticGAgentStreamInvocationPort(),
+            member: NewMember(teamId: "other-team"));
+
+        var act = () => service.InvokeAsync(
+            NewRequest(),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberMismatch);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldRejectEntryMemberThatIsNotReady()
+    {
+        var service = CreateService(
+            new RecordingStaticGAgentStreamInvocationPort(),
+            member: NewMember(lifecycleStage: MemberLifecycleStageNames.BuildReady));
+
+        var act = () => service.InvokeAsync(
+            NewRequest(),
+            (_, _) => ValueTask.CompletedTask);
+
+        await act.Should().ThrowAsync<TeamEntryMemberResolutionException>()
+            .Where(ex => ex.Code == TeamEntryMemberErrorCodes.EntryMemberNotReady);
+    }
+
+    private static StudioTeamGAgentStreamInvocationService CreateService(
+        RecordingStaticGAgentStreamInvocationPort staticPort,
+        StudioTeamSummaryResponse? team = null,
+        StudioMemberDetailResponse? member = null)
+    {
+        var resolver = new StudioTeamEntryMemberResolver(
+            new TeamQueryPort(team ?? NewTeam()),
+            new MemberQueryPort(member ?? NewMember()));
+        return new StudioTeamGAgentStreamInvocationService(resolver, staticPort);
+    }
+
+    private static StudioTeamGAgentStreamInvocationRequest NewRequest() =>
+        new(
+            ScopeId,
+            TeamId,
+            "chat",
+            new StaticGAgentStreamInvocationInput("hello"));
+
+    private static StudioTeamSummaryResponse NewTeam(
+        string lifecycleStage = TeamLifecycleStageNames.Active,
+        string? entryMemberId = EntryMemberId) =>
+        new(
+            TeamId: TeamId,
+            ScopeId: ScopeId,
+            DisplayName: "Team Alpha",
+            Description: string.Empty,
+            LifecycleStage: lifecycleStage,
+            MemberCount: 1,
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            EntryMemberId = entryMemberId,
+        };
+
+    private static StudioMemberDetailResponse NewMember(
+        string? teamId = TeamId,
+        string lifecycleStage = MemberLifecycleStageNames.BindReady,
+        string publishedServiceId = PublishedServiceId)
+    {
+        var summary = new StudioMemberSummaryResponse(
+            MemberId: EntryMemberId,
+            ScopeId: ScopeId,
+            DisplayName: "Member Alpha",
+            Description: string.Empty,
+            ImplementationKind: MemberImplementationKindNames.GAgent,
+            LifecycleStage: lifecycleStage,
+            PublishedServiceId: publishedServiceId,
+            LastBoundRevisionId: "rev-1",
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            TeamId = teamId,
+        };
+
+        return new StudioMemberDetailResponse(summary, null, null);
+    }
+
+    private sealed class TeamQueryPort(StudioTeamSummaryResponse? team) : IStudioTeamQueryPort
+    {
+        public Task<StudioTeamRosterResponse> ListAsync(
+            string scopeId,
+            StudioTeamRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new StudioTeamRosterResponse(scopeId, team == null ? [] : [team]));
+
+        public Task<StudioTeamSummaryResponse?> GetAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default) =>
+            Task.FromResult(team);
+    }
+
+    private sealed class MemberQueryPort(StudioMemberDetailResponse? member) : IStudioMemberQueryPort
+    {
+        public Task<StudioMemberRosterResponse> ListAsync(
+            string scopeId,
+            StudioMemberRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new StudioMemberRosterResponse(scopeId, member == null ? [] : [member.Summary]));
+
+        public Task<StudioMemberDetailResponse?> GetAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            Task.FromResult(member);
+    }
+
+    private sealed class RecordingStaticGAgentStreamInvocationPort : IStaticGAgentStreamInvocationPort<AGUIEvent>
+    {
+        public List<StaticGAgentStreamInvocationRequest> Requests { get; } = [];
+
+        public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+            StaticGAgentStreamInvocationRequest request,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            var accepted = new StaticGAgentStreamAcceptedReceipt(
+                new ServiceInvocationAcceptedReceipt
+                {
+                    RequestId = "cmd-1",
+                    ServiceKey = "scope-1:default:default:published-service-1",
+                    DeploymentId = "dep-1",
+                    TargetActorId = "actor-1",
+                    EndpointId = request.EndpointId,
+                    CommandId = "cmd-1",
+                    CorrelationId = "corr-1",
+                },
+                new GAgentDraftRunAcceptedReceipt("actor-1", "RoleGAgent", "cmd-1", "corr-1"));
+
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(accepted, ct);
+
+            await emitAsync(
+                new AGUIEvent
+                {
+                    RunStarted = new RunStartedEvent
+                    {
+                        ThreadId = "actor-1",
+                        RunId = "cmd-1",
+                    },
+                },
+                ct);
+
+            return new StaticGAgentStreamInvocationResult(
+                accepted,
+                GAgentDraftRunStartError.None,
+                GAgentDraftRunCompletionStatus.RunFinished,
+                CompletionObserved: true);
+        }
+    }
+}

--- a/test/Aevatar.Studio.Tests/StudioTeamQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamQueryPortTests.cs
@@ -28,6 +28,7 @@ public sealed class ProjectionStudioTeamQueryPortTests
         summary.Description.Should().Be("alpha desc");
         summary.LifecycleStage.Should().Be(TeamLifecycleStageNames.Active);
         summary.MemberCount.Should().Be(2);
+        summary.EntryMemberId.Should().Be("m-1");
     }
 
     [Fact]
@@ -160,6 +161,7 @@ public sealed class ProjectionStudioTeamQueryPortTests
             LifecycleStage = lifecycleStage,
             CreatedAt = now,
             MemberCount = memberCount,
+            EntryMemberId = "m-1",
         };
     }
 

--- a/test/Aevatar.Studio.Tests/StudioTeamServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamServiceTests.cs
@@ -158,24 +158,24 @@ public sealed class StudioTeamServiceTests
     }
 
     [Fact]
-    public async Task SetEntryMemberAsync_ShouldValidateTeamAndMemberThenDelegateAndReRead()
+    public async Task SetEntryMemberAsync_ShouldValidateTeamAndMemberThenDelegateWithoutPostDispatchRead()
     {
         var commandPort = new RecordingCommandPort();
-        var summary = NewSummary();
+        var queryPort = new InMemoryQueryPort(NewSummary());
         var member = NewMember(TeamId);
         var service = new StudioTeamService(
             commandPort,
-            new InMemoryQueryPort(summary),
+            queryPort,
             new InMemoryMemberQueryPort(member));
 
-        var result = await service.SetEntryMemberAsync(
+        await service.SetEntryMemberAsync(
             ScopeId,
             TeamId,
             new SetStudioTeamEntryMemberRequest(EntryMemberId));
 
         commandPort.SetEntryCalls.Should().Be(1);
         commandPort.LastEntryMemberId.Should().Be(EntryMemberId);
-        result.Should().NotBeNull();
+        queryPort.GetCalls.Should().Be(1);
     }
 
     [Fact]
@@ -262,18 +262,19 @@ public sealed class StudioTeamServiceTests
     }
 
     [Fact]
-    public async Task ClearEntryMemberAsync_ShouldValidateTeamThenDelegateAndReRead()
+    public async Task ClearEntryMemberAsync_ShouldValidateTeamThenDelegateWithoutPostDispatchRead()
     {
         var commandPort = new RecordingCommandPort();
+        var queryPort = new InMemoryQueryPort(NewSummary());
         var service = new StudioTeamService(
             commandPort,
-            new InMemoryQueryPort(NewSummary()),
+            queryPort,
             new InMemoryMemberQueryPort(NewMember(TeamId)));
 
-        var result = await service.ClearEntryMemberAsync(ScopeId, TeamId);
+        await service.ClearEntryMemberAsync(ScopeId, TeamId);
 
         commandPort.ClearEntryCalls.Should().Be(1);
-        result.Should().NotBeNull();
+        queryPort.GetCalls.Should().Be(1);
     }
 
     [Fact]
@@ -361,6 +362,7 @@ public sealed class StudioTeamServiceTests
     private sealed class InMemoryQueryPort : IStudioTeamQueryPort
     {
         private readonly StudioTeamSummaryResponse? _summary;
+        public int GetCalls { get; private set; }
 
         public InMemoryQueryPort(StudioTeamSummaryResponse? summary) => _summary = summary;
 
@@ -369,8 +371,11 @@ public sealed class StudioTeamServiceTests
             Task.FromResult(new StudioTeamRosterResponse(scopeId, _summary == null ? [] : [_summary]));
 
         public Task<StudioTeamSummaryResponse?> GetAsync(
-            string scopeId, string teamId, CancellationToken ct = default) =>
-            Task.FromResult(_summary);
+            string scopeId, string teamId, CancellationToken ct = default)
+        {
+            GetCalls++;
+            return Task.FromResult(_summary);
+        }
     }
 
     private sealed class RecordingCommandPort : IStudioTeamCommandPort

--- a/test/Aevatar.Studio.Tests/StudioTeamServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamServiceTests.cs
@@ -9,13 +9,14 @@ public sealed class StudioTeamServiceTests
 {
     private const string ScopeId = "scope-1";
     private const string TeamId = "t-1";
+    private const string EntryMemberId = "m-1";
 
     [Fact]
     public async Task CreateAsync_ShouldValidateAndDelegate()
     {
         var commandPort = new RecordingCommandPort();
         var queryPort = new InMemoryQueryPort(NewSummary());
-        var service = new StudioTeamService(commandPort, queryPort);
+        var service = new StudioTeamService(commandPort, queryPort, new InMemoryMemberQueryPort(null));
 
         var result = await service.CreateAsync(
             ScopeId,
@@ -29,7 +30,10 @@ public sealed class StudioTeamServiceTests
     [Fact]
     public async Task CreateAsync_ShouldRejectEmptyDisplayName()
     {
-        var service = new StudioTeamService(new RecordingCommandPort(), new InMemoryQueryPort(null));
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(null),
+            new InMemoryMemberQueryPort(null));
 
         var act = () => service.CreateAsync(
             ScopeId,
@@ -43,7 +47,7 @@ public sealed class StudioTeamServiceTests
     public async Task GetAsync_ShouldThrowNotFound_WhenTeamMissing()
     {
         var queryPort = new InMemoryQueryPort(summary: null);
-        var service = new StudioTeamService(new RecordingCommandPort(), queryPort);
+        var service = new StudioTeamService(new RecordingCommandPort(), queryPort, new InMemoryMemberQueryPort(null));
 
         var act = () => service.GetAsync(ScopeId, "missing-team");
 
@@ -54,7 +58,10 @@ public sealed class StudioTeamServiceTests
     public async Task GetAsync_ShouldReturnSummary_WhenTeamExists()
     {
         var summary = NewSummary();
-        var service = new StudioTeamService(new RecordingCommandPort(), new InMemoryQueryPort(summary));
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(null));
 
         var result = await service.GetAsync(ScopeId, TeamId);
 
@@ -65,7 +72,10 @@ public sealed class StudioTeamServiceTests
     public async Task UpdateAsync_ShouldRejectEmptyDisplayName()
     {
         var summary = NewSummary();
-        var service = new StudioTeamService(new RecordingCommandPort(), new InMemoryQueryPort(summary));
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(null));
 
         var act = () => service.UpdateAsync(
             ScopeId, TeamId,
@@ -79,7 +89,10 @@ public sealed class StudioTeamServiceTests
     public async Task UpdateAsync_ShouldRejectDisplayNameOverCap()
     {
         var summary = NewSummary();
-        var service = new StudioTeamService(new RecordingCommandPort(), new InMemoryQueryPort(summary));
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(null));
 
         var act = () => service.UpdateAsync(
             ScopeId, TeamId,
@@ -95,7 +108,10 @@ public sealed class StudioTeamServiceTests
     public async Task UpdateAsync_ShouldRejectDescriptionOverCap()
     {
         var summary = NewSummary();
-        var service = new StudioTeamService(new RecordingCommandPort(), new InMemoryQueryPort(summary));
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(null));
 
         var act = () => service.UpdateAsync(
             ScopeId, TeamId,
@@ -112,7 +128,10 @@ public sealed class StudioTeamServiceTests
     {
         var commandPort = new RecordingCommandPort();
         var summary = NewSummary();
-        var service = new StudioTeamService(commandPort, new InMemoryQueryPort(summary));
+        var service = new StudioTeamService(
+            commandPort,
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(null));
 
         var result = await service.UpdateAsync(
             ScopeId, TeamId,
@@ -127,7 +146,10 @@ public sealed class StudioTeamServiceTests
     {
         var commandPort = new RecordingCommandPort();
         var summary = NewSummary();
-        var service = new StudioTeamService(commandPort, new InMemoryQueryPort(summary));
+        var service = new StudioTeamService(
+            commandPort,
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(null));
 
         var result = await service.ArchiveAsync(ScopeId, TeamId);
 
@@ -136,11 +158,164 @@ public sealed class StudioTeamServiceTests
     }
 
     [Fact]
+    public async Task SetEntryMemberAsync_ShouldValidateTeamAndMemberThenDelegateAndReRead()
+    {
+        var commandPort = new RecordingCommandPort();
+        var summary = NewSummary();
+        var member = NewMember(TeamId);
+        var service = new StudioTeamService(
+            commandPort,
+            new InMemoryQueryPort(summary),
+            new InMemoryMemberQueryPort(member));
+
+        var result = await service.SetEntryMemberAsync(
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest(EntryMemberId));
+
+        commandPort.SetEntryCalls.Should().Be(1);
+        commandPort.LastEntryMemberId.Should().Be(EntryMemberId);
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SetEntryMemberAsync_ShouldRejectMissingTeam()
+    {
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(null),
+            new InMemoryMemberQueryPort(NewMember(TeamId)));
+
+        var act = () => service.SetEntryMemberAsync(
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest(EntryMemberId));
+
+        await act.Should().ThrowAsync<StudioTeamNotFoundException>();
+    }
+
+    [Fact]
+    public async Task SetEntryMemberAsync_ShouldRejectMissingMember()
+    {
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(NewSummary()),
+            new InMemoryMemberQueryPort(null));
+
+        var act = () => service.SetEntryMemberAsync(
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest(EntryMemberId));
+
+        await act.Should().ThrowAsync<StudioMemberNotFoundException>();
+    }
+
+    [Fact]
+    public async Task SetEntryMemberAsync_ShouldRejectMemberOutsideTeam()
+    {
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(NewSummary()),
+            new InMemoryMemberQueryPort(NewMember("other-team")));
+
+        var act = () => service.SetEntryMemberAsync(
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest(EntryMemberId));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*does not belong to team*");
+    }
+
+    [Fact]
+    public async Task SetEntryMemberAsync_ShouldRejectArchivedTeam()
+    {
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(NewSummary(TeamLifecycleStageNames.Archived)),
+            new InMemoryMemberQueryPort(NewMember(TeamId)));
+
+        var act = () => service.SetEntryMemberAsync(
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest(EntryMemberId));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*archived*");
+    }
+
+    [Fact]
+    public async Task SetEntryMemberAsync_ShouldRejectBlankMemberId()
+    {
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            new InMemoryQueryPort(NewSummary()),
+            new InMemoryMemberQueryPort(NewMember(TeamId)));
+
+        var act = () => service.SetEntryMemberAsync(
+            ScopeId,
+            TeamId,
+            new SetStudioTeamEntryMemberRequest("  "));
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*MemberId is required*");
+    }
+
+    [Fact]
+    public async Task ClearEntryMemberAsync_ShouldValidateTeamThenDelegateAndReRead()
+    {
+        var commandPort = new RecordingCommandPort();
+        var service = new StudioTeamService(
+            commandPort,
+            new InMemoryQueryPort(NewSummary()),
+            new InMemoryMemberQueryPort(NewMember(TeamId)));
+
+        var result = await service.ClearEntryMemberAsync(ScopeId, TeamId);
+
+        commandPort.ClearEntryCalls.Should().Be(1);
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ClearEntryMemberAsync_ShouldRejectMissingTeam()
+    {
+        var commandPort = new RecordingCommandPort();
+        var service = new StudioTeamService(
+            commandPort,
+            new InMemoryQueryPort(null),
+            new InMemoryMemberQueryPort(null));
+
+        var act = () => service.ClearEntryMemberAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<StudioTeamNotFoundException>();
+        commandPort.ClearEntryCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ClearEntryMemberAsync_ShouldRejectArchivedTeam()
+    {
+        var commandPort = new RecordingCommandPort();
+        var service = new StudioTeamService(
+            commandPort,
+            new InMemoryQueryPort(NewSummary(TeamLifecycleStageNames.Archived)),
+            new InMemoryMemberQueryPort(null));
+
+        var act = () => service.ClearEntryMemberAsync(ScopeId, TeamId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*archived*");
+        commandPort.ClearEntryCalls.Should().Be(0);
+    }
+
+    [Fact]
     public async Task ListAsync_ShouldDelegate()
     {
         var summary = NewSummary();
         var queryPort = new InMemoryQueryPort(summary);
-        var service = new StudioTeamService(new RecordingCommandPort(), queryPort);
+        var service = new StudioTeamService(
+            new RecordingCommandPort(),
+            queryPort,
+            new InMemoryMemberQueryPort(null));
 
         var result = await service.ListAsync(ScopeId);
 
@@ -148,16 +323,40 @@ public sealed class StudioTeamServiceTests
         result.Teams.Should().ContainSingle();
     }
 
-    private static StudioTeamSummaryResponse NewSummary() =>
+    private static StudioTeamSummaryResponse NewSummary(
+        string lifecycleStage = TeamLifecycleStageNames.Active) =>
         new(
             TeamId: TeamId,
             ScopeId: ScopeId,
             DisplayName: "Alpha",
             Description: "desc",
-            LifecycleStage: TeamLifecycleStageNames.Active,
+            LifecycleStage: lifecycleStage,
             MemberCount: 0,
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
-            UpdatedAt: DateTimeOffset.UtcNow);
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            EntryMemberId = EntryMemberId,
+        };
+
+    private static StudioMemberDetailResponse NewMember(string? teamId)
+    {
+        var summary = new StudioMemberSummaryResponse(
+            MemberId: EntryMemberId,
+            ScopeId: ScopeId,
+            DisplayName: "Member",
+            Description: string.Empty,
+            ImplementationKind: MemberImplementationKindNames.Workflow,
+            LifecycleStage: MemberLifecycleStageNames.BindReady,
+            PublishedServiceId: "member-m-1",
+            LastBoundRevisionId: "rev-1",
+            CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            TeamId = teamId,
+        };
+
+        return new StudioMemberDetailResponse(summary, null, null);
+    }
 
     private sealed class InMemoryQueryPort : IStudioTeamQueryPort
     {
@@ -179,6 +378,9 @@ public sealed class StudioTeamServiceTests
         public int CreateCalls { get; private set; }
         public int UpdateCalls { get; private set; }
         public int ArchiveCalls { get; private set; }
+        public int SetEntryCalls { get; private set; }
+        public int ClearEntryCalls { get; private set; }
+        public string? LastEntryMemberId { get; private set; }
 
         public Task<StudioTeamSummaryResponse> CreateAsync(
             string scopeId, CreateStudioTeamRequest request, CancellationToken ct = default)
@@ -208,5 +410,46 @@ public sealed class StudioTeamServiceTests
             ArchiveCalls++;
             return Task.CompletedTask;
         }
+
+        public Task SetEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            string memberId,
+            CancellationToken ct = default)
+        {
+            SetEntryCalls++;
+            LastEntryMemberId = memberId;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearEntryMemberAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default)
+        {
+            ClearEntryCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class InMemoryMemberQueryPort : IStudioMemberQueryPort
+    {
+        private readonly StudioMemberDetailResponse? _detail;
+
+        public InMemoryMemberQueryPort(StudioMemberDetailResponse? detail) => _detail = detail;
+
+        public Task<StudioMemberRosterResponse> ListAsync(
+            string scopeId,
+            StudioMemberRosterPageRequest? page = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new StudioMemberRosterResponse(
+                scopeId,
+                _detail == null ? [] : [_detail.Summary]));
+
+        public Task<StudioMemberDetailResponse?> GetAsync(
+            string scopeId,
+            string memberId,
+            CancellationToken ct = default) =>
+            Task.FromResult(_detail);
     }
 }


### PR DESCRIPTION
## Summary

Add entry-member support for Studio Teams. A team can now configure an `entryMemberId` and invoke the published service behind that entry member through team-level APIs, including both regular and streaming invocation.

## Changes

- Adds entry-member state, event, and projection support to Studio Team.
- Adds HTTP APIs to set and clear a team entry member.
- Adds team entry-member resolution with checks for team status, member ownership, bind readiness, and published service availability.
- Adds team-level invocation endpoints:
  - `POST /api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}`
  - `POST /api/scopes/{scopeId}/teams/{teamId}/invoke/{endpointId}:stream`
- Adds static GAgent stream invocation support using the existing service invocation and run registration flow.

## Notes

`DefaultTeamEntryMemberResolver` and the Team invoke-related implementations currently added under `GAgentService` are transitional. They will be removed from `GAgentService` once the Team capability boundary is consolidated into Studio.

## Validation

Covers entry-member state changes, auto-clear behavior, projection/query mapping, HTTP endpoints, team invocation, stream invocation, and static GAgent stream invocation.
