### PR TITLE
iter23 cluster-002: command-path projection activation cleanup

### DIFF
--- a/.refactor-loop/runs/implement-cluster-002.md
+++ b/.refactor-loop/runs/implement-cluster-002.md
@@ -1,0 +1,42 @@
+# Implement cluster-002-command-path-projection-activation
+
+## Modified Files
+
+- `agents/Aevatar.GAgents.Scheduled/SkillRunnerCommandPort.cs` — 82 lines
+- `agents/Aevatar.GAgents.Scheduled/UserAgentCatalogCommandPort.cs` — 95 lines
+- `agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs` — 153 lines
+- `test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs` — 228 lines
+- `test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogCommandPortTests.cs` — 217 lines
+- `test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs` — 384 lines
+- `tools/ci/query_projection_priming_guard.sh` — 53 lines
+
+## Summary
+
+- Removed scheduled runner command-port projection activation before initialize/trigger/disable/enable dispatch.
+- Removed catalog command-port projection activation before upsert/tombstone dispatch.
+- Removed streaming room subscription projection lease setup from room creation admission and rollback semantics.
+- Updated focused tests to assert command acceptance is based on actor lifecycle/dispatch/registry semantics, not projection activation.
+- Extended the query projection priming guard to block the three command-path regression files from reintroducing projection activation.
+
+## Tests
+
+- `dotnet build aevatar.slnx --nologo` — passed, existing warnings only.
+- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --nologo` — passed, 819 tests.
+- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo` — passed, 569 tests.
+- `bash tools/ci/test_stability_guards.sh` — passed.
+- `bash tools/ci/query_projection_priming_guard.sh` — passed.
+- `bash tools/ci/architecture_guards.sh` — passed.
+
+## Deviations
+
+- The prompt placeholders were not expanded in the user message. I recovered the actual cluster context from `/Users/auric/aevatar/.refactor-loop/runs/audit-iter-23.md` and `/Users/auric/aevatar/.refactor-loop/runs/cluster-iter23-002-spec.md`.
+- `/CLAUDE.md` was absent; I used this worktree's `CLAUDE.md` plus injected `AGENTS.md` instructions.
+- Did not run full `dotnet test aevatar.slnx --nologo`; ran the affected test projects plus required build and guards.
+
+## SCOPE_EXTEND
+
+- `tools/ci/query_projection_priming_guard.sh` — add static guard required by cluster spec to block command ports from reintroducing projection activation before dispatch.
+
+IMPLEMENT_DONE:cluster-002:ok
+
+⟦AI:AUTO-LOOP⟧

--- a/.refactor-loop/runs/scope-extend-cluster-002.log
+++ b/.refactor-loop/runs/scope-extend-cluster-002.log
@@ -1,0 +1,3 @@
+SCOPE_EXTEND: tools/ci/query_projection_priming_guard.sh add static guard required by cluster spec to block command ports from reintroducing projection activation before dispatch
+
+⟦AI:AUTO-LOOP⟧

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerCommandPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerCommandPort.cs
@@ -4,22 +4,22 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.Scheduled;
 
+// Refactor (iter23/cluster-002):
+//   Old pattern: Command ports synchronously activate projection scopes before dispatch and sometimes turn projection lease failure into command admission failure.
+//   New principle: Command ports dispatch accepted commands; projection activation is owned by committed-state hooks, explicit observation binders, startup activators, or background materializers.
 internal sealed class SkillRunnerCommandPort : ISkillRunnerCommandPort
 {
     private const string PublisherActorId = "scheduled.skill-runner";
 
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
-    private readonly UserAgentCatalogProjectionPort _catalogProjectionPort;
 
     public SkillRunnerCommandPort(
         IActorRuntime actorRuntime,
-        IActorDispatchPort actorDispatchPort,
-        UserAgentCatalogProjectionPort catalogProjectionPort)
+        IActorDispatchPort actorDispatchPort)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
-        _catalogProjectionPort = catalogProjectionPort ?? throw new ArgumentNullException(nameof(catalogProjectionPort));
     }
 
     public async Task InitializeAsync(
@@ -32,15 +32,6 @@ internal sealed class SkillRunnerCommandPort : ISkillRunnerCommandPort
         ArgumentNullException.ThrowIfNull(command);
 
         await EnsureSkillRunnerActorAsync(agentId, ct);
-        // Refactor (iter1/cluster-001):
-        //   Old pattern: initialize only primed the catalog actor stream because runners pushed execution updates there.
-        //   New principle: prime both membership and runner streams before dispatch so runner committed facts project directly.
-        //
-        // Prime projection scopes BEFORE dispatch — a late prime can't recover
-        // committed events the projector already missed.
-        await _catalogProjectionPort.EnsureProjectionForActorAsync(UserAgentCatalogGAgent.WellKnownId, ct);
-        await _catalogProjectionPort.EnsureProjectionForActorAsync(agentId, ct);
-
         await DispatchAsync(agentId, command, ct);
 
         if (runImmediately)
@@ -53,7 +44,6 @@ internal sealed class SkillRunnerCommandPort : ISkillRunnerCommandPort
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
         await EnsureSkillRunnerActorAsync(agentId, ct);
-        await _catalogProjectionPort.EnsureProjectionForActorAsync(agentId, ct);
         await DispatchAsync(agentId, new TriggerSkillRunnerExecutionCommand { Reason = reason ?? string.Empty }, ct);
     }
 
@@ -61,7 +51,6 @@ internal sealed class SkillRunnerCommandPort : ISkillRunnerCommandPort
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
         await EnsureSkillRunnerActorAsync(agentId, ct);
-        await _catalogProjectionPort.EnsureProjectionForActorAsync(agentId, ct);
         await DispatchAsync(agentId, new DisableSkillRunnerCommand { Reason = reason ?? string.Empty }, ct);
     }
 
@@ -69,7 +58,6 @@ internal sealed class SkillRunnerCommandPort : ISkillRunnerCommandPort
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
         await EnsureSkillRunnerActorAsync(agentId, ct);
-        await _catalogProjectionPort.EnsureProjectionForActorAsync(agentId, ct);
         await DispatchAsync(agentId, new EnableSkillRunnerCommand { Reason = reason ?? string.Empty }, ct);
     }
 

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogCommandPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogCommandPort.cs
@@ -23,31 +23,28 @@ namespace Aevatar.GAgents.Scheduled;
 ///   Old pattern: Command dispatch polled projection documents to report observed state.
 ///   New principle: Command ACKs are accepted-only; observation belongs to explicit query/projection paths.
 ///
-/// Refactor (iter5/cluster-012):
-///   Old pattern: Accepted-only dispatch returned dead result records that callers ignored.
-///   New principle: Command success is represented by Task completion; no synthetic receipt is produced.
+/// Refactor (iter23/cluster-002):
+///   Old pattern: Command ports synchronously activate projection scopes before dispatch and sometimes turn projection lease failure into command admission failure.
+///   New principle: Command ports dispatch accepted commands; projection activation is owned by committed-state hooks, explicit observation binders, startup activators, or background materializers.
 /// </summary>
 internal sealed class UserAgentCatalogCommandPort : IUserAgentCatalogCommandPort
 {
     private const string PublisherActorId = "scheduled.user-agent-catalog";
 
-    private readonly UserAgentCatalogProjectionPort _projectionPort;
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
 
     public UserAgentCatalogCommandPort(
-        UserAgentCatalogProjectionPort projectionPort,
         IActorRuntime actorRuntime,
         IActorDispatchPort actorDispatchPort)
     {
-        _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
     }
 
-    // Refactor (iter5/cluster-012):
-    //   Old pattern: Upsert returned a single-value accepted result wrapper.
-    //   New principle: Upsert completes after projection activation, actor lifecycle ensure, and dispatch.
+    // Refactor (iter23/cluster-002):
+    //   Old pattern: Command ports synchronously activate projection scopes before dispatch and sometimes turn projection lease failure into command admission failure.
+    //   New principle: Command ports dispatch accepted commands; projection activation is owned by committed-state hooks, explicit observation binders, startup activators, or background materializers.
     public async Task UpsertAsync(
         UserAgentCatalogUpsertCommand command,
         CancellationToken ct = default)
@@ -56,7 +53,6 @@ internal sealed class UserAgentCatalogCommandPort : IUserAgentCatalogCommandPort
         if (string.IsNullOrWhiteSpace(command.AgentId))
             throw new ArgumentException("AgentId is required for upsert.", nameof(command));
 
-        await _projectionPort.EnsureProjectionForActorAsync(UserAgentCatalogGAgent.WellKnownId, ct);
         await EnsureCatalogActorAsync(ct);
 
         var envelope = new EventEnvelope
@@ -69,9 +65,9 @@ internal sealed class UserAgentCatalogCommandPort : IUserAgentCatalogCommandPort
         await _actorDispatchPort.DispatchAsync(UserAgentCatalogGAgent.WellKnownId, envelope, ct);
     }
 
-    // Refactor (iter5/cluster-012):
-    //   Old pattern: Tombstone returned a single-value accepted result wrapper.
-    //   New principle: Tombstone completes after projection activation, actor lifecycle ensure, and dispatch.
+    // Refactor (iter23/cluster-002):
+    //   Old pattern: Command ports synchronously activate projection scopes before dispatch and sometimes turn projection lease failure into command admission failure.
+    //   New principle: Command ports dispatch accepted commands; projection activation is owned by committed-state hooks, explicit observation binders, startup activators, or background materializers.
     public async Task TombstoneAsync(
         string agentId,
         CancellationToken ct = default)
@@ -79,7 +75,6 @@ internal sealed class UserAgentCatalogCommandPort : IUserAgentCatalogCommandPort
         if (string.IsNullOrWhiteSpace(agentId))
             throw new ArgumentException("agentId is required.", nameof(agentId));
 
-        await _projectionPort.EnsureProjectionForActorAsync(UserAgentCatalogGAgent.WellKnownId, ct);
         await EnsureCatalogActorAsync(ct);
 
         var envelope = new EventEnvelope

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
 
+// Refactor (iter23/cluster-002):
+//   Old pattern: Command ports synchronously activate projection scopes before dispatch and sometimes turn projection lease failure into command admission failure.
+//   New principle: Command ports dispatch accepted commands; projection activation is owned by committed-state hooks, explicit observation binders, startup activators, or background materializers.
 public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomCommandService
 {
     private const string DefaultRoomName = "Group Chat";
@@ -12,23 +15,17 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
     private readonly IActorRuntime _actorRuntime;
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IGAgentActorRegistryCommandPort _registryCommandPort;
-    private readonly IStreamingProxyRoomSessionProjectionPort _roomSessionProjectionPort;
     private readonly ILogger<StreamingProxyRoomCommandService> _logger;
 
     public StreamingProxyRoomCommandService(
         IActorRuntime actorRuntime,
         IActorDispatchPort actorDispatchPort,
         IGAgentActorRegistryCommandPort registryCommandPort,
-        IStreamingProxyRoomSessionProjectionPort roomSessionProjectionPort,
         ILogger<StreamingProxyRoomCommandService> logger)
     {
-        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
         _registryCommandPort = registryCommandPort ?? throw new ArgumentNullException(nameof(registryCommandPort));
-        _roomSessionProjectionPort = roomSessionProjectionPort ?? throw new ArgumentNullException(nameof(roomSessionProjectionPort));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -50,19 +47,6 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
 
             var envelope = BuildRoomInitializedEnvelope(actor.Id, roomName);
             await DispatchRoomEnvelopeAsync(actor.Id, envelope, cancellationToken);
-
-            var subscriptionLease = await _roomSessionProjectionPort.EnsureSubscriptionProjectionAsync(
-                actor.Id,
-                StreamingProxyRoomSubscriptionObservationPort.RoomSubscriptionSessionId(actor.Id),
-                cancellationToken);
-            if (subscriptionLease == null)
-            {
-                await TryRollbackRoomCreationAsync(scopeId, roomId, CancellationToken.None);
-                return new StreamingProxyRoomCreateResult(
-                    StreamingProxyRoomCreateStatus.AdmissionUnavailable,
-                    roomId,
-                    roomName);
-            }
 
             var receipt = await _registryCommandPort.RegisterActorAsync(
                 new GAgentActorRegistration(scopeId, StreamingProxyDefaults.GAgentTypeName, roomId),

--- a/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
@@ -1,5 +1,4 @@
 using Aevatar.Foundation.Abstractions;
-using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgents.StreamingProxy;
 using Aevatar.GAgents.StreamingProxy.Application.Rooms;
@@ -18,12 +17,10 @@ public sealed class StreamingProxyRoomCommandServiceTests
         var runtime = new RecordingActorRuntime(operations, actor);
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -41,9 +38,6 @@ public sealed class StreamingProxyRoomCommandServiceTests
         runtime.LastCreatedActor.Should().NotBeNull();
         dispatchPort.Dispatches.Should().ContainSingle();
         dispatchPort.Dispatches[0].ActorId.Should().Be(result.RoomId);
-        projectionPort.EnsureSubscriptionCalls.Should().ContainSingle(x =>
-            x.ActorId == result.RoomId &&
-            x.SubscriptionId == $"room:{result.RoomId}:subscription");
         runtime.LastCreatedActor!.ReceivedEnvelopes.Should().ContainSingle();
         var envelope = runtime.LastCreatedActor.ReceivedEnvelopes[0];
         envelope.Route.Direct.TargetActorId.Should().Be(result.RoomId);
@@ -57,7 +51,6 @@ public sealed class StreamingProxyRoomCommandServiceTests
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
-            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:register:{result.RoomId}");
     }
 
@@ -68,12 +61,10 @@ public sealed class StreamingProxyRoomCommandServiceTests
         var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var act = async () => await service.CreateRoomAsync(
@@ -86,7 +77,6 @@ public sealed class StreamingProxyRoomCommandServiceTests
         registry.RegisteredActors.Should().BeEmpty();
         registry.UnregisteredActors.Should().BeEmpty();
         runtime.DestroyedActorIds.Should().BeEmpty();
-        projectionPort.EnsureSubscriptionCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -96,12 +86,10 @@ public sealed class StreamingProxyRoomCommandServiceTests
         var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -116,9 +104,6 @@ public sealed class StreamingProxyRoomCommandServiceTests
             .RoomName
             .Should()
             .Be("Group Chat");
-        projectionPort.EnsureSubscriptionCalls.Should().ContainSingle(x =>
-            x.ActorId == result.RoomId &&
-            x.SubscriptionId == $"room:{result.RoomId}:subscription");
     }
 
     [Fact]
@@ -131,12 +116,10 @@ public sealed class StreamingProxyRoomCommandServiceTests
         {
             RegisterStage = GAgentActorRegistryCommandStage.AcceptedForDispatch,
         };
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -150,48 +133,38 @@ public sealed class StreamingProxyRoomCommandServiceTests
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
-            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:register:{result.RoomId}",
             $"registry:unregister:{result.RoomId}",
             $"runtime:destroy:{result.RoomId}");
     }
 
     [Fact]
-    public async Task CreateRoomAsync_ShouldRollbackCreatedRoom_WhenSubscriptionProjectionIsUnavailable()
+    public async Task CreateRoomAsync_ShouldNotUseSubscriptionProjectionAsCommandAdmission()
     {
         var operations = new List<string>();
         var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-created", operations));
         var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
         var registry = new RecordingGAgentActorRegistryCommandPort(operations);
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations)
-        {
-            EnsureSubscriptionResult = null,
-        };
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
             new StreamingProxyRoomCreateCommand("scope-a", "Incident Room"),
             CancellationToken.None);
 
-        result.Status.Should().Be(StreamingProxyRoomCreateStatus.AdmissionUnavailable);
-        projectionPort.EnsureSubscriptionCalls.Should().ContainSingle(x =>
-            x.ActorId == result.RoomId &&
-            x.SubscriptionId == $"room:{result.RoomId}:subscription");
-        registry.RegisteredActors.Should().BeEmpty();
-        registry.UnregisteredActors.Should().ContainSingle();
-        runtime.DestroyedActorIds.Should().ContainSingle(result.RoomId);
+        result.Status.Should().Be(StreamingProxyRoomCreateStatus.Created);
+        registry.RegisteredActors.Should().ContainSingle();
+        registry.UnregisteredActors.Should().BeEmpty();
+        runtime.DestroyedActorIds.Should().BeEmpty();
         operations.Should().ContainInOrder(
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
-            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
-            $"registry:unregister:{result.RoomId}",
-            $"runtime:destroy:{result.RoomId}");
+            $"registry:register:{result.RoomId}");
+        operations.Should().NotContain(x => x.StartsWith("projection:ensure-subscription:", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -205,12 +178,10 @@ public sealed class StreamingProxyRoomCommandServiceTests
             ThrowOnRegister = new InvalidOperationException("registry unavailable"),
             ThrowOnUnregister = new InvalidOperationException("registry unregister unavailable"),
         };
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var result = await service.CreateRoomAsync(
@@ -224,7 +195,6 @@ public sealed class StreamingProxyRoomCommandServiceTests
             $"runtime:create:{result.RoomId}",
             $"dispatch:{result.RoomId}",
             $"actor:init:{result.RoomId}",
-            $"projection:ensure-subscription:{result.RoomId}:room:{result.RoomId}:subscription",
             $"registry:register:{result.RoomId}",
             $"registry:unregister:{result.RoomId}");
     }
@@ -239,12 +209,10 @@ public sealed class StreamingProxyRoomCommandServiceTests
         {
             ThrowOnRegister = new OperationCanceledException("client disconnected"),
         };
-        var projectionPort = new RecordingRoomSessionProjectionPort(operations);
         var service = new StreamingProxyRoomCommandService(
             runtime,
             dispatchPort,
             registry,
-            projectionPort,
             NullLogger<StreamingProxyRoomCommandService>.Instance);
 
         var act = async () => await service.CreateRoomAsync(
@@ -259,71 +227,6 @@ public sealed class StreamingProxyRoomCommandServiceTests
         unregisterIndex.Should().BeGreaterThanOrEqualTo(0);
         destroyIndex.Should().BeGreaterThan(unregisterIndex);
     }
-
-    private sealed class RecordingRoomSessionProjectionPort(List<string> operations)
-        : IStreamingProxyRoomSessionProjectionPort
-    {
-        public List<(string ActorId, string SubscriptionId)> EnsureSubscriptionCalls { get; } = [];
-        public IStreamingProxyRoomSessionProjectionLease? EnsureSubscriptionResult { get; init; } =
-            new RecordingRoomSessionProjectionLease("pending", "pending");
-        public bool ProjectionEnabled => true;
-
-        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureChatProjectionAsync(
-            string actorId,
-            string sessionId,
-            CancellationToken ct = default)
-        {
-            _ = actorId;
-            _ = sessionId;
-            ct.ThrowIfCancellationRequested();
-            throw new NotSupportedException("Room creation should not ensure chat projections.");
-        }
-
-        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureSubscriptionProjectionAsync(
-            string actorId,
-            string subscriptionId,
-            CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            operations.Add($"projection:ensure-subscription:{actorId}:{subscriptionId}");
-            EnsureSubscriptionCalls.Add((actorId, subscriptionId));
-            return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(EnsureSubscriptionResult is null
-                ? null
-                : new RecordingRoomSessionProjectionLease(actorId, subscriptionId));
-        }
-
-        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
-            IStreamingProxyRoomSessionProjectionLease lease,
-            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
-            CancellationToken ct = default)
-        {
-            _ = lease;
-            _ = sink;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult<IAsyncDisposable?>(null);
-        }
-
-        public Task DetachLiveSinkAsync(
-            IAsyncDisposable? liveSinkLease,
-            CancellationToken ct = default)
-        {
-            _ = liveSinkLease;
-            ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
-        }
-
-        public Task ReleaseActorProjectionAsync(
-            IStreamingProxyRoomSessionProjectionLease lease,
-            CancellationToken ct = default)
-        {
-            _ = lease;
-            ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
-        }
-    }
-
-    private sealed record RecordingRoomSessionProjectionLease(string ActorId, string SessionId)
-        : IStreamingProxyRoomSessionProjectionLease;
 
     private sealed class RecordingGAgentActorRegistryCommandPort(List<string> operations)
         : IGAgentActorRegistryCommandPort

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerCommandPortTests.cs
@@ -13,7 +13,7 @@ public sealed class SkillRunnerCommandPortTests
     private const string ExpectedPublisher = "scheduled.skill-runner";
 
     [Fact]
-    public async Task InitializeAsync_WhenRunImmediatelyFalse_DispatchesSingleEnvelope_AndCreatesActor_AndPrimesProjection()
+    public async Task InitializeAsync_WhenRunImmediatelyFalse_DispatchesSingleEnvelope_AndCreatesActor_WithoutProjectionActivation()
     {
         var fixture = new Fixture();
         fixture.Runtime.GetAsync(AgentId).Returns(Task.FromResult<IActor?>(null));
@@ -30,16 +30,7 @@ public sealed class SkillRunnerCommandPortTests
 
         await fixture.Runtime.Received(1).GetAsync(AgentId);
         await fixture.Runtime.Received(1).CreateAsync<SkillRunnerGAgent>(AgentId, Arg.Any<CancellationToken>());
-        await fixture.Activation.Received(1).EnsureAsync(
-            Arg.Is<ProjectionScopeStartRequest>(r =>
-                r.RootActorId == UserAgentCatalogGAgent.WellKnownId &&
-                r.ProjectionKind == UserAgentCatalogProjectionPort.ProjectionKind),
-            Arg.Any<CancellationToken>());
-        await fixture.Activation.Received(1).EnsureAsync(
-            Arg.Is<ProjectionScopeStartRequest>(r =>
-                r.RootActorId == AgentId &&
-                r.ProjectionKind == UserAgentCatalogProjectionPort.ProjectionKind),
-            Arg.Any<CancellationToken>());
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
 
         fixture.Captured.Should().HaveCount(1);
         var envelope = fixture.Captured[0];
@@ -57,9 +48,7 @@ public sealed class SkillRunnerCommandPortTests
         var command = new InitializeSkillRunnerCommand { SkillName = "demo" };
         await fixture.Port.InitializeAsync(AgentId, command, runImmediately: true, CancellationToken.None);
 
-        await fixture.Activation.Received(1).EnsureAsync(
-            Arg.Is<ProjectionScopeStartRequest>(r => r.RootActorId == AgentId),
-            Arg.Any<CancellationToken>());
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
         fixture.Captured.Should().HaveCount(2);
         fixture.Captured[0].Payload.Is(InitializeSkillRunnerCommand.Descriptor).Should().BeTrue();
         fixture.Captured[1].Payload.Is(TriggerSkillRunnerExecutionCommand.Descriptor).Should().BeTrue();
@@ -79,9 +68,7 @@ public sealed class SkillRunnerCommandPortTests
 
         await fixture.Port.TriggerAsync(AgentId, "manual_run", CancellationToken.None);
 
-        await fixture.Activation.Received(1).EnsureAsync(
-            Arg.Is<ProjectionScopeStartRequest>(r => r.RootActorId == AgentId),
-            Arg.Any<CancellationToken>());
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
         fixture.Captured.Should().ContainSingle();
         var env = fixture.Captured[0];
         env.Payload.Is(TriggerSkillRunnerExecutionCommand.Descriptor).Should().BeTrue();
@@ -110,9 +97,7 @@ public sealed class SkillRunnerCommandPortTests
 
         await fixture.Port.DisableAsync(AgentId, "operator_off", CancellationToken.None);
 
-        await fixture.Activation.Received(1).EnsureAsync(
-            Arg.Is<ProjectionScopeStartRequest>(r => r.RootActorId == AgentId),
-            Arg.Any<CancellationToken>());
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
         fixture.Captured.Should().ContainSingle();
         var env = fixture.Captured[0];
         env.Payload.Is(DisableSkillRunnerCommand.Descriptor).Should().BeTrue();
@@ -129,9 +114,7 @@ public sealed class SkillRunnerCommandPortTests
 
         await fixture.Port.EnableAsync(AgentId, "operator_on", CancellationToken.None);
 
-        await fixture.Activation.Received(1).EnsureAsync(
-            Arg.Is<ProjectionScopeStartRequest>(r => r.RootActorId == AgentId),
-            Arg.Any<CancellationToken>());
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
         fixture.Captured.Should().ContainSingle();
         var env = fixture.Captured[0];
         env.Payload.Is(EnableSkillRunnerCommand.Descriptor).Should().BeTrue();
@@ -200,12 +183,10 @@ public sealed class SkillRunnerCommandPortTests
         var runtime = Substitute.For<IActorRuntime>();
         var projection = Fixture.CreateProjectionPort(out _, out _);
 
-        Action ctor1 = () => new SkillRunnerCommandPort(null!, dispatch, projection);
-        Action ctor2 = () => new SkillRunnerCommandPort(runtime, null!, projection);
-        Action ctor3 = () => new SkillRunnerCommandPort(runtime, dispatch, null!);
+        Action ctor1 = () => new SkillRunnerCommandPort(null!, dispatch);
+        Action ctor2 = () => new SkillRunnerCommandPort(runtime, null!);
         ctor1.Should().Throw<ArgumentNullException>();
         ctor2.Should().Throw<ArgumentNullException>();
-        ctor3.Should().Throw<ArgumentNullException>();
     }
 
     private sealed class Fixture
@@ -225,7 +206,7 @@ public sealed class SkillRunnerCommandPortTests
             Activation = activation;
             Dispatch.DispatchAsync(Arg.Any<string>(), Arg.Do<EventEnvelope>(env => Captured.Add(env)), Arg.Any<CancellationToken>())
                 .Returns(Task.CompletedTask);
-            Port = new SkillRunnerCommandPort(Runtime, Dispatch, Projection);
+            Port = new SkillRunnerCommandPort(Runtime, Dispatch);
         }
 
         public static UserAgentCatalogProjectionPort CreateProjectionPort(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogCommandPortTests.cs
@@ -44,6 +44,7 @@ public sealed class UserAgentCatalogCommandPortTests
         env.Route.Direct.TargetActorId.Should().Be(CatalogActorId);
         await fixture.Dispatch.Received(1).DispatchAsync(CatalogActorId, Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>());
         await fixture.Runtime.Received().GetAsync(CatalogActorId);
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
     }
 
     [Fact]
@@ -87,6 +88,7 @@ public sealed class UserAgentCatalogCommandPortTests
         env.Route.PublisherActorId.Should().Be(ExpectedPublisher);
         env.Route.Direct.TargetActorId.Should().Be(CatalogActorId);
         await fixture.Dispatch.Received(1).DispatchAsync(CatalogActorId, Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>());
+        await fixture.Activation.DidNotReceiveWithAnyArgs().EnsureAsync(default!, default);
     }
 
     [Theory]
@@ -123,6 +125,7 @@ public sealed class UserAgentCatalogCommandPortTests
         source.Should().NotContain(string.Concat("Task", ".Delay"));
         source.Should().NotContain("projectionWait");
         source.Should().NotContain("StateVersion");
+        source.Should().NotContain("EnsureProjectionForActorAsync");
     }
 
     [Fact]
@@ -181,6 +184,7 @@ public sealed class UserAgentCatalogCommandPortTests
     private sealed class Fixture
     {
         public UserAgentCatalogProjectionPort ProjectionPort { get; }
+        public IProjectionScopeActivationService<UserAgentCatalogMaterializationRuntimeLease> Activation { get; }
         public IActorRuntime Runtime { get; }
         public IActorDispatchPort Dispatch { get; }
         public List<EventEnvelope> Captured { get; } = new();
@@ -200,12 +204,12 @@ public sealed class UserAgentCatalogCommandPortTests
                         ProjectionKind = UserAgentCatalogProjectionPort.ProjectionKind,
                     })));
             ProjectionPort = new UserAgentCatalogProjectionPort(activation);
+            Activation = activation;
 
             Dispatch.DispatchAsync(Arg.Any<string>(), Arg.Do<EventEnvelope>(env => Captured.Add(env)), Arg.Any<CancellationToken>())
                 .Returns(Task.CompletedTask);
 
             Port = new UserAgentCatalogCommandPort(
-                ProjectionPort,
                 Runtime,
                 Dispatch);
         }

--- a/tools/ci/query_projection_priming_guard.sh
+++ b/tools/ci/query_projection_priming_guard.sh
@@ -26,13 +26,25 @@ endpoint_lifecycle_hits="$(
     || true
 )"
 
-if [[ -n "${hits}${endpoint_lifecycle_hits}" ]]; then
+command_path_hits="$(
+  rg -n "EnsureProjectionForActorAsync|EnsureChatProjectionAsync|EnsureSubscriptionProjectionAsync|EnsureAndAttachLeaseAsync|ActivateAsync|PrimeAsync" \
+    agents/Aevatar.GAgents.Scheduled/SkillRunnerCommandPort.cs \
+    agents/Aevatar.GAgents.Scheduled/UserAgentCatalogCommandPort.cs \
+    agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs \
+    || true
+)"
+
+if [[ -n "${hits}${endpoint_lifecycle_hits}${command_path_hits}" ]]; then
   if [[ -n "${hits}" ]]; then
     echo "${hits}"
   fi
   if [[ -n "${endpoint_lifecycle_hits}" ]]; then
     echo "${endpoint_lifecycle_hits}"
     echo "Streaming endpoints and runner must use interaction services or attach-only observation ports, not projection lifecycle APIs."
+  fi
+  if [[ -n "${command_path_hits}" ]]; then
+    echo "${command_path_hits}"
+    echo "Command ports must dispatch accepted commands; projection activation belongs to committed-state hooks, observation binders, startup activators, or background materializers."
   fi
   echo "Query/read paths must not trigger projection priming, activation, or lifecycle control."
   exit 1


### PR DESCRIPTION
## Summary / 摘要

### English

iter23 cluster-002-command-path-projection-activation (medium, CLAUDE.md §"权威状态 / ReadModel / Projection").

- **Old**: Command path 同步 ensure projection/session 在 dispatch 前并 use projection availability as admission/completion state.
- **New**: Command paths return accepted receipts after target resolution + dispatch; projection activation owned by explicit binders/startup activation/attach-only observation outside command semantics.

Violated: "Command -> Event;Query -> ReadModel" + "ACK 诚实"。

### 中文

iter23 cluster-002-command-path-projection-activation(中严重度,CLAUDE.md §"权威状态 / ReadModel / Projection")。

- **Old**:command path 同步 ensure projection/session 在 dispatch 之前,把 projection availability 当 admission/completion state。
- **New**:command path 在 target resolution + dispatch 之后返回 accepted receipt;projection activation 由 explicit binder/startup activation/attach-only observation 拥有,不在 command 语义里。

违反:"Command -> Event;Query -> ReadModel" + "ACK 诚实"。

## Scope

9 files changed. Architecture guards green.

See [implement summary](./.refactor-loop/runs/implement-iter23-cluster-002.md), [audit cluster](./.refactor-loop/runs/audit-iter-23.md#cluster-002).

## Stacked-PR

iter23 batch 1. Base = `auto-refact-dev`. Rollup target = `dev`.

🤖 Auto-loop / codex-refactor-loop iter23

⟦AI:AUTO-LOOP⟧
