### PR TITLE
iter25 cluster-027: TelegramWaitReplyGAgent task-scoped actor (lark stream architecture unified)

### DIFF
--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/Aevatar.Workflow.Extensions.Bridge.csproj
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/Aevatar.Workflow.Extensions.Bridge.csproj
@@ -13,6 +13,14 @@
     <ProjectReference Include="..\..\..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="telegram_wait_reply.proto" GrpcServices="None" />
   </ItemGroup>
 </Project>

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramBridgeGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramBridgeGAgent.cs
@@ -9,18 +9,21 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 
 /// <summary>
 /// Telegram channel bridge agent.
-/// Handles ChatRequestEvent -> Telegram sendMessage and waitReply polling.
+/// Handles ChatRequestEvent -> Telegram sendMessage and waitReply dispatch.
 /// </summary>
+// Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
+//   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
+//   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
 public class TelegramBridgeGAgent : GAgentBase
 {
     private const string LlmFailureContentPrefix = "[[AEVATAR_LLM_ERROR]]";
     private const string WaitReplyOperation = "/waitReply";
     private const int DefaultWaitReplyTimeoutMs = 120_000;
-    private const int DefaultConnectorExecutionWatchdogMs = 20_000;
     private const int DefaultPollTimeoutSeconds = 8;
     private const int DefaultSettlePollsAfterMatch = 1;
     private const int MaxSettlePollsAfterMatch = 5;
     private const int MaxPollTimeoutSeconds = 25;
+    private readonly IActorRuntime _runtime;
     private readonly IConnectorRegistry _connectorRegistry;
 
     protected virtual string DefaultConnectorName => "telegram";
@@ -29,7 +32,7 @@ public class TelegramBridgeGAgent : GAgentBase
         IActorRuntime runtime,
         IConnectorRegistry connectorRegistry)
     {
-        _ = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _connectorRegistry = connectorRegistry ?? throw new ArgumentNullException(nameof(connectorRegistry));
         InitializeId();
     }
@@ -42,12 +45,6 @@ public class TelegramBridgeGAgent : GAgentBase
         var connectorName = ReadMetadata(request.Headers, "telegram.connector", "connector", "connector_name");
         if (string.IsNullOrWhiteSpace(connectorName))
             connectorName = DefaultConnectorName;
-
-        if (!_connectorRegistry.TryGet(connectorName, out var connector) || connector == null)
-        {
-            await PublishFailureAsync(request, $"telegram connector '{connectorName}' not found");
-            return;
-        }
 
         var chatId = ReadMetadata(request.Headers, "telegram.chat_id", "chat_id");
         if (string.IsNullOrWhiteSpace(chatId))
@@ -63,7 +60,13 @@ public class TelegramBridgeGAgent : GAgentBase
         if (string.Equals(operation, WaitReplyOperation, StringComparison.OrdinalIgnoreCase) ||
             string.Equals(operation, "wait_reply", StringComparison.OrdinalIgnoreCase))
         {
-            await HandleWaitReplyAsync(request, connectorName, connector);
+            await HandleWaitReplyAsync(request, connectorName);
+            return;
+        }
+
+        if (!_connectorRegistry.TryGet(connectorName, out var connector) || connector == null)
+        {
+            await PublishFailureAsync(request, $"telegram connector '{connectorName}' not found");
             return;
         }
 
@@ -99,8 +102,7 @@ public class TelegramBridgeGAgent : GAgentBase
 
     private async Task HandleWaitReplyAsync(
         ChatRequestEvent request,
-        string connectorName,
-        IConnector connector)
+        string connectorName)
     {
         var expectedChatId = ReadMetadata(request.Headers, "telegram.chat_id", "chat_id").Trim();
         if (string.IsNullOrWhiteSpace(expectedChatId))
@@ -131,515 +133,87 @@ public class TelegramBridgeGAgent : GAgentBase
         var settlePollsAfterMatch = ResolveSettlePollsAfterMatch(request.Headers);
         var collectAllReplies = ResolveCollectAllReplies(request.Headers);
         var startFromLatest = ResolveStartFromLatest(request.Headers);
-        var bootstrapRecentCutoffUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-            - Math.Max(30, Math.Min(600, waitTimeoutMs / 1000 + 10));
-
         var connectorParameters = BuildConnectorParameters(request.Headers);
-        long? offset = TryReadInt64(
+        var offset = TryReadInt64(
             ReadMetadata(request.Headers, "telegram.offset", "offset"),
             minimum: 0);
-        var collectedByIdentity = collectAllReplies
-            ? new Dictionary<string, TelegramInboundUpdate>(StringComparer.Ordinal)
-            : null;
-        var collectedIdentityOrder = collectAllReplies
-            ? new List<string>()
-            : null;
-        TelegramInboundUpdate? pendingMatchedUpdate = null;
-        var pollsSinceLastMatch = 0;
 
-        if (startFromLatest && offset == null)
+        var commandId = BuildWaitReplyCommandId(request);
+        var waitActorId = BuildWaitReplyActorId(commandId);
+        var waitActor = await _runtime.CreateAsync<TelegramWaitReplyGAgent>(waitActorId);
+        await _runtime.LinkAsync(Id, waitActor.Id);
+        var command = new TelegramWaitForReplyCommand
         {
-            var bootstrap = await ExecuteGetUpdatesAsync(
-                request,
-                connectorName,
-                connector,
-                connectorParameters,
-                offset: null,
-                pollTimeoutSeconds: 0,
-                perCallTimeoutMs: 5_000);
-            if (!bootstrap.Success)
-            {
-                await PublishFailureAsync(
-                    request,
-                    string.IsNullOrWhiteSpace(bootstrap.Error)
-                        ? "telegram bootstrap getUpdates failed"
-                        : bootstrap.Error.Trim());
-                return;
-            }
-
-            if (!TryParseTelegramUpdates(
-                bootstrap.Output,
-                out var bootstrapUpdates,
-                out var bootstrapMaxUpdateId,
-                out var bootstrapError))
-            {
-                await PublishFailureAsync(request, $"telegram bootstrap parse failed: {bootstrapError}");
-                return;
-            }
-
-            var bootstrapMatchedUpdates = SelectMatchedUpdates(
-                bootstrapUpdates,
-                expectedChatId,
-                expectedFromUserId,
-                expectedFromUsername,
-                correlationContains,
-                minimumUpdateId: null,
-                minimumDateUnixExclusive: bootstrapRecentCutoffUnix);
-            if (bootstrapMatchedUpdates.Count > 0)
-            {
-                pendingMatchedUpdate = bootstrapMatchedUpdates[^1];
-                pollsSinceLastMatch = 0;
-                if (collectAllReplies)
-                {
-                    MergeMatchedUpdates(
-                        bootstrapMatchedUpdates,
-                        collectedByIdentity!,
-                        collectedIdentityOrder!);
-                    if (settlePollsAfterMatch <= 0)
-                    {
-                        await PublishSuccessAsync(
-                            request,
-                            BuildMatchedReplyContent(
-                                collectedByIdentity!,
-                                collectedIdentityOrder!,
-                                pendingMatchedUpdate));
-                        return;
-                    }
-                }
-                else
-                {
-                    await PublishSuccessAsync(request, pendingMatchedUpdate.Content);
-                    return;
-                }
-            }
-
-            if (bootstrapMaxUpdateId.HasValue)
-                offset = bootstrapMaxUpdateId.Value + 1;
-        }
-
-        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(waitTimeoutMs);
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            var remaining = deadline - DateTimeOffset.UtcNow;
-            var currentPollMaxSeconds = pendingMatchedUpdate != null ? 1 : pollTimeoutSeconds;
-            var currentPollSeconds = Math.Clamp(
-                (int)Math.Ceiling(Math.Max(1, remaining.TotalSeconds)),
-                1,
-                currentPollMaxSeconds);
-            var perCallTimeoutMs = (currentPollSeconds + 3) * 1_000;
-            var requestedOffset = offset;
-
-            var poll = await ExecuteGetUpdatesAsync(
-                request,
-                connectorName,
-                connector,
-                connectorParameters,
-                offset,
-                currentPollSeconds,
-                perCallTimeoutMs);
-            if (!poll.Success)
-            {
-                await PublishFailureAsync(
-                    request,
-                    string.IsNullOrWhiteSpace(poll.Error)
-                        ? "telegram getUpdates failed"
-                        : poll.Error.Trim());
-                return;
-            }
-
-            if (!TryParseTelegramUpdates(poll.Output, out var updates, out var maxUpdateId, out var parseError))
-            {
-                await PublishFailureAsync(request, $"telegram getUpdates parse failed: {parseError}");
-                return;
-            }
-
-            if (maxUpdateId.HasValue)
-                offset = maxUpdateId.Value + 1;
-
-            var matchedUpdatesInBatch = SelectMatchedUpdates(
-                updates,
-                expectedChatId,
-                expectedFromUserId,
-                expectedFromUsername,
-                correlationContains,
-                minimumUpdateId: requestedOffset,
-                minimumDateUnixExclusive: null);
-            if (matchedUpdatesInBatch.Count > 0)
-            {
-                var latestMatchedInBatch = matchedUpdatesInBatch[^1];
-                pendingMatchedUpdate = latestMatchedInBatch;
-                pollsSinceLastMatch = 0;
-                if (collectAllReplies)
-                {
-                    MergeMatchedUpdates(
-                        matchedUpdatesInBatch,
-                        collectedByIdentity!,
-                        collectedIdentityOrder!);
-                }
-                if (settlePollsAfterMatch <= 0)
-                {
-                    await PublishSuccessAsync(
-                        request,
-                        collectAllReplies
-                            ? BuildMatchedReplyContent(
-                                collectedByIdentity!,
-                                collectedIdentityOrder!,
-                                pendingMatchedUpdate)
-                            : pendingMatchedUpdate.Content);
-                    return;
-                }
-
-                continue;
-            }
-
-            if (pendingMatchedUpdate != null)
-            {
-                pollsSinceLastMatch++;
-                if (pollsSinceLastMatch >= settlePollsAfterMatch)
-                {
-                    await PublishSuccessAsync(
-                        request,
-                        collectAllReplies
-                            ? BuildMatchedReplyContent(
-                                collectedByIdentity!,
-                                collectedIdentityOrder!,
-                                pendingMatchedUpdate)
-                            : pendingMatchedUpdate.Content);
-                    return;
-                }
-            }
-        }
-
-        if (pendingMatchedUpdate != null)
-        {
-            await PublishSuccessAsync(
-                request,
-                collectAllReplies
-                    ? BuildMatchedReplyContent(
-                        collectedByIdentity!,
-                        collectedIdentityOrder!,
-                        pendingMatchedUpdate)
-                    : pendingMatchedUpdate.Content);
-            return;
-        }
-
-        await PublishFailureAsync(
-            request,
-            $"telegram group stream timeout after {waitTimeoutMs}ms without matched reply");
-    }
-
-    private static List<TelegramInboundUpdate> SelectMatchedUpdates(
-        IEnumerable<TelegramInboundUpdate> updates,
-        string expectedChatId,
-        string expectedFromUserId,
-        string expectedFromUsername,
-        string correlationContains,
-        long? minimumUpdateId,
-        long? minimumDateUnixExclusive)
-    {
-        var matches = new List<TelegramInboundUpdate>();
-        foreach (var update in updates)
-        {
-            if (minimumUpdateId.HasValue &&
-                update.UpdateId >= 0 &&
-                update.UpdateId < minimumUpdateId.Value)
-            {
-                continue;
-            }
-
-            if (minimumDateUnixExclusive.HasValue &&
-                update.DateUnix > 0 &&
-                update.DateUnix < minimumDateUnixExclusive.Value)
-            {
-                continue;
-            }
-
-            if (!IsMatchedUpdate(
-                    update,
-                    expectedChatId,
-                    expectedFromUserId,
-                    expectedFromUsername,
-                    correlationContains))
-            {
-                continue;
-            }
-
-            matches.Add(update);
-        }
-
-        return matches;
-    }
-
-    private static void MergeMatchedUpdates(
-        IEnumerable<TelegramInboundUpdate> matchedUpdates,
-        IDictionary<string, TelegramInboundUpdate> latestByIdentity,
-        IList<string> identityOrder)
-    {
-        foreach (var update in matchedUpdates)
-        {
-            var identity = BuildMatchedReplyIdentity(update);
-            if (!latestByIdentity.ContainsKey(identity))
-                identityOrder.Add(identity);
-            latestByIdentity[identity] = update;
-        }
-    }
-
-    private static string BuildMatchedReplyContent(
-        IReadOnlyDictionary<string, TelegramInboundUpdate> latestByIdentity,
-        IReadOnlyList<string> identityOrder,
-        TelegramInboundUpdate? fallback)
-    {
-        if (latestByIdentity.Count == 0 || identityOrder.Count == 0)
-            return fallback?.Content ?? string.Empty;
-
-        var orderedReplies = new List<string>(identityOrder.Count);
-        foreach (var identity in identityOrder)
-        {
-            if (!latestByIdentity.TryGetValue(identity, out var update))
-                continue;
-            if (string.IsNullOrWhiteSpace(update.Content))
-                continue;
-
-            orderedReplies.Add(update.Content);
-        }
-
-        if (orderedReplies.Count == 0)
-            return fallback?.Content ?? string.Empty;
-        if (orderedReplies.Count == 1)
-            return orderedReplies[0];
-
-        return string.Join("\n\n---\n\n", orderedReplies);
-    }
-
-    private static string BuildMatchedReplyIdentity(TelegramInboundUpdate update)
-    {
-        if (update.MessageId > 0)
-            return $"msg:{update.ChatId}:{update.MessageId}";
-        if (update.UpdateId >= 0)
-            return $"update:{update.UpdateId}";
-
-        return $"raw:{update.ChatId}:{update.FromUserId}:{update.DateUnix}:{update.Content}";
-    }
-
-    private async Task<ConnectorResponse> ExecuteGetUpdatesAsync(
-        ChatRequestEvent request,
-        string connectorName,
-        IConnector connector,
-        IReadOnlyDictionary<string, string> baseParameters,
-        long? offset,
-        int pollTimeoutSeconds,
-        int perCallTimeoutMs)
-    {
-        var parameters = new Dictionary<string, string>(baseParameters, StringComparer.OrdinalIgnoreCase)
-        {
-            ["method"] = "POST",
-            ["content_type"] = "application/json",
-            ["timeout_ms"] = perCallTimeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            CommandId = commandId,
+            SessionId = request.SessionId,
+            ConnectorName = connectorName,
+            ExpectedChatId = expectedChatId,
+            ExpectedFromUserId = expectedFromUserId,
+            ExpectedFromUsername = expectedFromUsername,
+            CorrelationContains = correlationContains,
+            WaitTimeoutMs = waitTimeoutMs,
+            PollTimeoutSeconds = pollTimeoutSeconds,
+            SettlePollsAfterMatch = settlePollsAfterMatch,
+            CollectAllReplies = collectAllReplies,
+            StartFromLatest = startFromLatest,
+            EmitChatResponse = ShouldEmitChatResponse(request.Headers),
         };
+        command.ConnectorParameters.Add(connectorParameters);
+        if (offset.HasValue)
+            command.Offset = offset.Value;
 
-        var connectorRequest = new ConnectorRequest
-        {
-            RunId = ReadMetadata(request.Headers, "run_id", "workflow.run_id", "workflow_run_id", "session_id"),
-            StepId = ReadMetadata(request.Headers, "step_id", "workflow.step_id", "workflow_step_id"),
-            Connector = connectorName,
-            Operation = "/getUpdates",
-            Payload = BuildGetUpdatesPayload(offset, pollTimeoutSeconds),
-            Parameters = parameters,
-        };
-
-        return await ExecuteConnectorWithWatchdogAsync(
-            connector,
-            connectorRequest,
-            ResolveConnectorExecutionWatchdogMs(parameters));
+        await SendToAsync(waitActor.Id, command);
     }
 
-    private static string BuildGetUpdatesPayload(long? offset, int pollTimeoutSeconds)
+    [EventHandler]
+    public async Task HandleWaitReplyCompleted(TelegramWaitReplyCompletedEvent evt)
     {
-        var payload = new Dictionary<string, object?>
-        {
-            ["timeout"] = Math.Clamp(pollTimeoutSeconds, 0, MaxPollTimeoutSeconds),
-            ["allowed_updates"] = new[] { "message", "channel_post" },
-        };
-        if (offset.HasValue && offset.Value >= 0)
-            payload["offset"] = offset.Value;
-
-        return JsonSerializer.Serialize(payload);
+        // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
+        //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
+        //   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
+        ArgumentNullException.ThrowIfNull(evt);
+        await PublishSuccessAsync(evt.SessionId, evt.Content, evt.EmitChatResponse);
     }
 
-    private static bool TryParseTelegramUpdates(
-        string output,
-        out List<TelegramInboundUpdate> updates,
-        out long? maxUpdateId,
-        out string error)
+    [EventHandler]
+    public async Task HandleWaitReplyFailed(TelegramWaitReplyFailedEvent evt)
     {
-        updates = [];
-        maxUpdateId = null;
-        error = string.Empty;
-
-        if (string.IsNullOrWhiteSpace(output))
-            return true;
-
-        try
-        {
-            using var doc = JsonDocument.Parse(output);
-            var root = doc.RootElement;
-            if (root.ValueKind != JsonValueKind.Object)
-            {
-                error = "root is not a JSON object";
-                return false;
-            }
-
-            if (root.TryGetProperty("ok", out var okElement) &&
-                okElement.ValueKind is JsonValueKind.False)
-            {
-                var description = root.TryGetProperty("description", out var desc)
-                    ? desc.GetString()
-                    : null;
-                error = string.IsNullOrWhiteSpace(description)
-                    ? "telegram api returned ok=false"
-                    : description;
-                return false;
-            }
-
-            if (!root.TryGetProperty("result", out var result) ||
-                result.ValueKind != JsonValueKind.Array)
-            {
-                return true;
-            }
-
-            foreach (var item in result.EnumerateArray())
-            {
-                if (item.ValueKind != JsonValueKind.Object)
-                    continue;
-
-                var updateId = TryGetInt64(item, "update_id");
-                if (updateId.HasValue)
-                    maxUpdateId = !maxUpdateId.HasValue ? updateId : Math.Max(maxUpdateId.Value, updateId.Value);
-
-                JsonElement message;
-                if (item.TryGetProperty("message", out var messageValue) && messageValue.ValueKind == JsonValueKind.Object)
-                {
-                    message = messageValue;
-                }
-                else if (item.TryGetProperty("channel_post", out var channelPost) && channelPost.ValueKind == JsonValueKind.Object)
-                {
-                    message = channelPost;
-                }
-                else
-                {
-                    continue;
-                }
-
-                var chatId = TryGetNestedStringOrNumber(message, "chat", "id");
-                if (string.IsNullOrWhiteSpace(chatId))
-                    continue;
-
-                var text = TryGetString(message, "text");
-                if (string.IsNullOrWhiteSpace(text))
-                    text = TryGetString(message, "caption");
-
-                var messageId = TryGetInt64(message, "message_id") ?? 0;
-                var dateUnix = TryGetInt64(message, "date") ?? 0;
-                var fromUserId = TryGetNestedStringOrNumber(message, "from", "id");
-                var fromUsername = TryGetNestedStringOrNumber(message, "from", "username");
-
-                updates.Add(new TelegramInboundUpdate(
-                    UpdateId: updateId ?? -1,
-                    MessageId: messageId,
-                    DateUnix: dateUnix,
-                    ChatId: chatId,
-                    FromUserId: fromUserId,
-                    FromUsername: fromUsername,
-                    Content: text ?? string.Empty));
-            }
-
-            return true;
-        }
-        catch (Exception ex)
-        {
-            error = ex.Message;
-            return false;
-        }
+        // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
+        //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
+        //   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
+        ArgumentNullException.ThrowIfNull(evt);
+        await PublishFailureAsync(evt.SessionId, evt.Error);
     }
 
-    private static bool IsMatchedUpdate(
-        TelegramInboundUpdate update,
-        string expectedChatId,
-        string expectedFromUserId,
-        string expectedFromUsername,
-        string correlationContains)
+    private static string BuildWaitReplyCommandId(ChatRequestEvent request)
     {
-        if (!string.Equals(update.ChatId, expectedChatId, StringComparison.Ordinal))
-            return false;
+        var runId = ReadMetadata(request.Headers, "run_id", "workflow.run_id", "workflow_run_id", "session_id");
+        var stepId = ReadMetadata(request.Headers, "step_id", "workflow.step_id", "workflow_step_id");
+        if (!string.IsNullOrWhiteSpace(runId) && !string.IsNullOrWhiteSpace(stepId))
+            return $"telegram-wait-reply-{NormalizeActorIdSegment(runId)}-{NormalizeActorIdSegment(stepId)}";
 
-        if (!string.IsNullOrWhiteSpace(expectedFromUserId) &&
-            !string.Equals(update.FromUserId, expectedFromUserId, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        // Some Telegram update variants may omit username in from{}.
-        // When username is present we enforce an exact match; otherwise we
-        // continue with other guards (chat_id / from_user_id / correlation).
-        if (!string.IsNullOrWhiteSpace(expectedFromUsername))
-        {
-            var actualUsername = NormalizeUsername(update.FromUsername);
-            if (!string.IsNullOrWhiteSpace(actualUsername) &&
-                !string.Equals(actualUsername, expectedFromUsername, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-        }
-
-        if (string.IsNullOrWhiteSpace(update.Content))
-            return false;
-
-        if (!string.IsNullOrWhiteSpace(correlationContains) &&
-            update.Content.IndexOf(correlationContains, StringComparison.OrdinalIgnoreCase) < 0)
-        {
-            return false;
-        }
-
-        return true;
+        var seed = string.IsNullOrWhiteSpace(request.SessionId)
+            ? Guid.NewGuid().ToString("N")
+            : request.SessionId;
+        return $"telegram-wait-reply-{NormalizeActorIdSegment(seed)}";
     }
 
-    private static long? TryGetInt64(JsonElement element, string name)
+    private static string BuildWaitReplyActorId(string commandId) =>
+        NormalizeActorIdSegment(commandId);
+
+    private static string NormalizeActorIdSegment(string value)
     {
-        if (!element.TryGetProperty(name, out var value))
-            return null;
-        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var number))
-            return number;
-        if (value.ValueKind == JsonValueKind.String &&
-            long.TryParse(value.GetString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out number))
+        var trimmed = string.IsNullOrWhiteSpace(value) ? Guid.NewGuid().ToString("N") : value.Trim();
+        Span<char> buffer = stackalloc char[Math.Min(trimmed.Length, 96)];
+        var count = 0;
+        foreach (var ch in trimmed)
         {
-            return number;
+            if (count >= buffer.Length)
+                break;
+            buffer[count++] = char.IsLetterOrDigit(ch) || ch is '-' or '_' ? char.ToLowerInvariant(ch) : '-';
         }
 
-        return null;
-    }
-
-    private static string TryGetString(JsonElement element, string name)
-    {
-        if (!element.TryGetProperty(name, out var value))
-            return string.Empty;
-        return value.ValueKind == JsonValueKind.String ? value.GetString() ?? string.Empty : string.Empty;
-    }
-
-    private static string TryGetNestedStringOrNumber(JsonElement element, string nested, string name)
-    {
-        if (!element.TryGetProperty(nested, out var nestedElement) ||
-            nestedElement.ValueKind != JsonValueKind.Object ||
-            !nestedElement.TryGetProperty(name, out var value))
-        {
-            return string.Empty;
-        }
-
-        return value.ValueKind switch
-        {
-            JsonValueKind.String => value.GetString() ?? string.Empty,
-            JsonValueKind.Number => value.GetRawText(),
-            _ => string.Empty,
-        };
+        return new string(buffer[..count]).Trim('-');
     }
 
     private static int ResolveWaitReplyTimeoutMs(Google.Protobuf.Collections.MapField<string, string> metadata)
@@ -806,7 +380,7 @@ public class TelegramBridgeGAgent : GAgentBase
         return parsed > 0 ? parsed : null;
     }
 
-    private static int ResolveConnectorExecutionWatchdogMs(IReadOnlyDictionary<string, string> parameters)
+    internal static int ResolveConnectorExecutionWatchdogMs(IReadOnlyDictionary<string, string> parameters)
     {
         if (parameters.TryGetValue("timeout_ms", out var timeoutRaw) &&
             int.TryParse(timeoutRaw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed) &&
@@ -815,10 +389,10 @@ public class TelegramBridgeGAgent : GAgentBase
             return Math.Clamp(parsed, 100, 300_000);
         }
 
-        return DefaultConnectorExecutionWatchdogMs;
+        return 20_000;
     }
 
-    private static async Task<ConnectorResponse> ExecuteConnectorWithWatchdogAsync(
+    internal static async Task<ConnectorResponse> ExecuteConnectorWithWatchdogAsync(
         IConnector connector,
         ConnectorRequest connectorRequest,
         int watchdogTimeoutMs)
@@ -941,12 +515,17 @@ public class TelegramBridgeGAgent : GAgentBase
 
     private async Task PublishSuccessAsync(ChatRequestEvent request, string content)
     {
-        if (ShouldEmitChatResponse(request.Headers))
+        await PublishSuccessAsync(request.SessionId, content, ShouldEmitChatResponse(request.Headers));
+    }
+
+    private async Task PublishSuccessAsync(string sessionId, string content, bool emitChatResponse)
+    {
+        if (emitChatResponse)
         {
             await PublishAsync(
                 new ChatResponseEvent
                 {
-                    SessionId = request.SessionId,
+                    SessionId = sessionId,
                     Content = content,
                 },
                 TopologyAudience.Parent);
@@ -955,7 +534,7 @@ public class TelegramBridgeGAgent : GAgentBase
         await PublishAsync(
             new TextMessageEndEvent
             {
-                SessionId = request.SessionId,
+                SessionId = sessionId,
                 Content = content,
             },
             TopologyAudience.Parent);
@@ -963,11 +542,16 @@ public class TelegramBridgeGAgent : GAgentBase
 
     private async Task PublishFailureAsync(ChatRequestEvent request, string error)
     {
+        await PublishFailureAsync(request.SessionId, error);
+    }
+
+    private async Task PublishFailureAsync(string sessionId, string error)
+    {
         var safeError = string.IsNullOrWhiteSpace(error) ? "telegram bridge call failed" : error.Trim();
         await PublishAsync(
             new TextMessageEndEvent
             {
-                SessionId = request.SessionId,
+                SessionId = sessionId,
                 Content = $"{LlmFailureContentPrefix} {safeError}",
             },
             TopologyAudience.Parent);
@@ -1027,12 +611,4 @@ public class TelegramBridgeGAgent : GAgentBase
         return string.Empty;
     }
 
-    private sealed record TelegramInboundUpdate(
-        long UpdateId,
-        long MessageId,
-        long DateUnix,
-        string ChatId,
-        string FromUserId,
-        string FromUsername,
-        string Content);
 }

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
@@ -3,6 +3,8 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Core;
+using Aevatar.Foundation.Core.EventSourcing;
+using Google.Protobuf;
 
 namespace Aevatar.Workflow.Extensions.Bridge;
 
@@ -11,18 +13,28 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 /// </summary>
 // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
 //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
-//   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
-public sealed class TelegramWaitReplyGAgent : GAgentBase
+//   New principle: New task-scoped TelegramWaitReplyGAgent owns protobuf wait state; typed self-events advance one bounded poll per actor turn and resume bridge via WaitReplyCompleted/Failed.
+public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 {
     private const int MaxPollTimeoutSeconds = 25;
     private readonly IConnectorRegistry _connectorRegistry;
+    private readonly TimeProvider _timeProvider;
 
     public TelegramWaitReplyGAgent(
         IActorRuntime runtime,
         IConnectorRegistry connectorRegistry)
+        : this(runtime, connectorRegistry, TimeProvider.System)
+    {
+    }
+
+    public TelegramWaitReplyGAgent(
+        IActorRuntime runtime,
+        IConnectorRegistry connectorRegistry,
+        TimeProvider timeProvider)
     {
         _ = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _connectorRegistry = connectorRegistry ?? throw new ArgumentNullException(nameof(connectorRegistry));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         InitializeId();
     }
 
@@ -31,88 +43,56 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
     {
         // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
         //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
-        //   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
+        //   New principle: New task-scoped TelegramWaitReplyGAgent owns protobuf wait state; typed self-events advance one bounded poll per actor turn and resume bridge via WaitReplyCompleted/Failed.
         ArgumentNullException.ThrowIfNull(command);
+
+        var generation = State.Generation + 1;
+        var state = BuildStartedState(command, generation);
+        await PersistDomainEventAsync(new TelegramWaitReplyStartedEvent { State = state });
 
         if (!_connectorRegistry.TryGet(command.ConnectorName, out var connector) || connector == null)
         {
-            await PublishFailedAsync(command, $"telegram connector '{command.ConnectorName}' not found");
+            await CompleteFailureAsync($"telegram connector '{command.ConnectorName}' not found");
             return;
         }
 
-        var result = await WaitForReplyAsync(command, connector);
-        if (result.Success)
+        if (State.StartFromLatest && !State.HasNextOffset)
         {
-            await PublishAsync(
-                new TelegramWaitReplyCompletedEvent
-                {
-                    CommandId = command.CommandId,
-                    SessionId = command.SessionId,
-                    Content = result.Content,
-                    EmitChatResponse = command.EmitChatResponse,
-                    WaitActorId = Id,
-                },
-                TopologyAudience.Parent);
-            return;
-        }
-
-        await PublishFailedAsync(command, result.Error);
-    }
-
-    private Task PublishFailedAsync(TelegramWaitForReplyCommand command, string error)
-    {
-        return PublishAsync(
-            new TelegramWaitReplyFailedEvent
+            await SendToAsync(Id, new TelegramWaitReplyBootstrapDueEvent
             {
-                CommandId = command.CommandId,
-                SessionId = command.SessionId,
-                Error = error,
-                EmitChatResponse = command.EmitChatResponse,
-                WaitActorId = Id,
-            },
-            TopologyAudience.Parent);
-    }
-
-    private static async Task<TelegramWaitReplyResult> WaitForReplyAsync(
-        TelegramWaitForReplyCommand command,
-        IConnector connector)
-    {
-        var context = new TelegramWaitReplyRuntimeContext(command);
-
-        if (command.StartFromLatest && context.Offset == null)
-        {
-            var bootstrapResult = await BootstrapFromLatestAsync(command, connector, context);
-            if (!bootstrapResult.ShouldContinue)
-                return bootstrapResult.Result;
+                CommandId = State.CommandId,
+                Generation = State.Generation,
+            });
+            return;
         }
 
-        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(command.WaitTimeoutMs);
-        while (DateTimeOffset.UtcNow < deadline)
+        await SendToAsync(Id, new TelegramWaitReplyPollDueEvent
         {
-            var pollResult = await PollOnceAsync(command, connector, context, deadline);
-            if (!pollResult.ShouldContinue)
-                return pollResult.Result;
-        }
-
-        return context.ToTerminalResult(command.WaitTimeoutMs);
+            CommandId = State.CommandId,
+            Generation = State.Generation,
+        });
     }
 
-    private static async Task<TelegramWaitReplyStepResult> BootstrapFromLatestAsync(
-        TelegramWaitForReplyCommand command,
-        IConnector connector,
-        TelegramWaitReplyRuntimeContext context)
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleBootstrapDue(TelegramWaitReplyBootstrapDueEvent evt)
     {
-        var bootstrap = await ExecuteGetUpdatesAsync(
-            command,
-            connector,
-            offset: null,
-            pollTimeoutSeconds: 0,
-            perCallTimeoutMs: 5_000);
+        ArgumentNullException.ThrowIfNull(evt);
+        if (!IsActiveContinuation(evt.CommandId, evt.Generation))
+            return;
+
+        if (!_connectorRegistry.TryGet(State.ConnectorName, out var connector) || connector == null)
+        {
+            await CompleteFailureAsync($"telegram connector '{State.ConnectorName}' not found");
+            return;
+        }
+
+        var bootstrap = await ExecuteGetUpdatesAsync(offset: null, pollTimeoutSeconds: 0, perCallTimeoutMs: 5_000, connector);
         if (!bootstrap.Success)
         {
-            return TelegramWaitReplyStepResult.Done(TelegramWaitReplyResult.Fail(string.IsNullOrWhiteSpace(bootstrap.Error)
+            await CompleteFailureAsync(string.IsNullOrWhiteSpace(bootstrap.Error)
                 ? "telegram bootstrap getUpdates failed"
-                : bootstrap.Error.Trim()));
+                : bootstrap.Error.Trim());
+            return;
         }
 
         if (!TryParseTelegramUpdates(
@@ -121,84 +101,248 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
                 out var bootstrapMaxUpdateId,
                 out var bootstrapError))
         {
-            return TelegramWaitReplyStepResult.Done(
-                TelegramWaitReplyResult.Fail($"telegram bootstrap parse failed: {bootstrapError}"));
+            await CompleteFailureAsync($"telegram bootstrap parse failed: {bootstrapError}");
+            return;
         }
 
-        var bootstrapRecentCutoffUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
-            - Math.Max(30, Math.Min(600, command.WaitTimeoutMs / 1000 + 10));
-        var bootstrapMatchedUpdates = SelectMatchedUpdates(
+        var bootstrapRecentCutoffUnix = _timeProvider.GetUtcNow().ToUnixTimeSeconds()
+            - Math.Max(30, Math.Min(600, State.WaitTimeoutMs / 1000 + 10));
+        var matchedUpdates = SelectMatchedUpdates(
             bootstrapUpdates,
-            command,
             minimumUpdateId: null,
             minimumDateUnixExclusive: bootstrapRecentCutoffUnix);
-        if (bootstrapMatchedUpdates.Count > 0 && !command.CollectAllReplies)
+
+        if (matchedUpdates.Count > 0 && !State.CollectAllReplies)
         {
-            return TelegramWaitReplyStepResult.Done(
-                TelegramWaitReplyResult.Ok(bootstrapMatchedUpdates[^1].Content));
+            await CompleteSuccessAsync(matchedUpdates[^1].Content);
+            return;
         }
 
-        var matchedResult = context.ApplyMatches(command, bootstrapMatchedUpdates);
-        if (matchedResult.HasValue)
-            return TelegramWaitReplyStepResult.Done(matchedResult.Value);
-
+        var next = State.Clone();
         if (bootstrapMaxUpdateId.HasValue)
-            context.Offset = bootstrapMaxUpdateId.Value + 1;
-        return TelegramWaitReplyStepResult.Continue();
+            next.NextOffset = bootstrapMaxUpdateId.Value + 1;
+        ApplyMatches(next, matchedUpdates);
+
+        var result = ResolveCurrentResult(next, emptyPoll: matchedUpdates.Count == 0);
+        if (result.HasValue)
+        {
+            await CompleteResultAsync(result.Value);
+            return;
+        }
+
+        await PersistAndContinuePollAsync(next);
     }
 
-    private static async Task<TelegramWaitReplyStepResult> PollOnceAsync(
-        TelegramWaitForReplyCommand command,
-        IConnector connector,
-        TelegramWaitReplyRuntimeContext context,
-        DateTimeOffset deadline)
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandlePollDue(TelegramWaitReplyPollDueEvent evt)
     {
-        var remaining = deadline - DateTimeOffset.UtcNow;
-        var currentPollMaxSeconds = context.HasPendingMatch ? 1 : command.PollTimeoutSeconds;
-        var currentPollSeconds = Math.Clamp(
-            (int)Math.Ceiling(Math.Max(1, remaining.TotalSeconds)),
-            1,
-            currentPollMaxSeconds);
-        var perCallTimeoutMs = (currentPollSeconds + 3) * 1_000;
-        var requestedOffset = context.Offset;
+        ArgumentNullException.ThrowIfNull(evt);
+        if (!IsActiveContinuation(evt.CommandId, evt.Generation))
+            return;
 
+        if (!_connectorRegistry.TryGet(State.ConnectorName, out var connector) || connector == null)
+        {
+            await CompleteFailureAsync($"telegram connector '{State.ConnectorName}' not found");
+            return;
+        }
+
+        if (_timeProvider.GetUtcNow().ToUnixTimeMilliseconds() >= State.DeadlineUnixMs)
+        {
+            await CompleteTimeoutAsync();
+            return;
+        }
+
+        var currentPollSeconds = ResolveCurrentPollSeconds();
+        long? requestedOffset = State.HasNextOffset ? State.NextOffset : null;
         var poll = await ExecuteGetUpdatesAsync(
-            command,
-            connector,
-            context.Offset,
+            requestedOffset,
             currentPollSeconds,
-            perCallTimeoutMs);
+            perCallTimeoutMs: (currentPollSeconds + 3) * 1_000,
+            connector);
         if (!poll.Success)
         {
-            return TelegramWaitReplyStepResult.Done(TelegramWaitReplyResult.Fail(string.IsNullOrWhiteSpace(poll.Error)
+            await CompleteFailureAsync(string.IsNullOrWhiteSpace(poll.Error)
                 ? "telegram getUpdates failed"
-                : poll.Error.Trim()));
+                : poll.Error.Trim());
+            return;
         }
 
         if (!TryParseTelegramUpdates(poll.Output, out var updates, out var maxUpdateId, out var parseError))
         {
-            return TelegramWaitReplyStepResult.Done(
-                TelegramWaitReplyResult.Fail($"telegram getUpdates parse failed: {parseError}"));
+            await CompleteFailureAsync($"telegram getUpdates parse failed: {parseError}");
+            return;
         }
 
-        if (maxUpdateId.HasValue)
-            context.Offset = maxUpdateId.Value + 1;
-
-        var matchedUpdatesInBatch = SelectMatchedUpdates(
+        var matchedUpdates = SelectMatchedUpdates(
             updates,
-            command,
             minimumUpdateId: requestedOffset,
             minimumDateUnixExclusive: null);
-        var matchedResult = context.ApplyMatches(command, matchedUpdatesInBatch);
-        if (matchedResult.HasValue)
-            return TelegramWaitReplyStepResult.Done(matchedResult.Value);
+        var next = State.Clone();
+        if (maxUpdateId.HasValue)
+            next.NextOffset = maxUpdateId.Value + 1;
+        ApplyMatches(next, matchedUpdates);
 
-        return TelegramWaitReplyStepResult.Continue();
+        var result = ResolveCurrentResult(next, emptyPoll: matchedUpdates.Count == 0);
+        if (result.HasValue)
+        {
+            await CompleteResultAsync(result.Value);
+            return;
+        }
+
+        await PersistAndContinuePollAsync(next);
     }
 
-    private static List<TelegramInboundUpdate> SelectMatchedUpdates(
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleTimeoutDue(TelegramWaitReplyTimeoutDueEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        if (!IsActiveContinuation(evt.CommandId, evt.Generation))
+            return;
+
+        await CompleteTimeoutAsync();
+    }
+
+    protected override TelegramWaitReplyState TransitionState(TelegramWaitReplyState current, IMessage evt)
+    {
+        return StateTransitionMatcher
+            .Match(current, evt)
+            .On<TelegramWaitReplyStartedEvent>((_, started) => started.State.Clone())
+            .On<TelegramWaitReplyProgressedEvent>((_, progressed) => progressed.State.Clone())
+            .On<TelegramWaitReplyClearedEvent>((state, cleared) =>
+            {
+                if (string.Equals(state.CommandId, cleared.CommandId, StringComparison.Ordinal) &&
+                    state.Generation == cleared.Generation)
+                {
+                    var next = state.Clone();
+                    next.Active = false;
+                    next.PendingMatchedUpdate = null;
+                    next.CollectedReplies.Clear();
+                    next.CollectedReplyOrder.Clear();
+                    return next;
+                }
+
+                return state;
+            })
+            .OrCurrent();
+    }
+
+    private TelegramWaitReplyState BuildStartedState(TelegramWaitForReplyCommand command, long generation)
+    {
+        var state = new TelegramWaitReplyState
+        {
+            Active = true,
+            Generation = generation,
+            CommandId = command.CommandId,
+            SessionId = command.SessionId,
+            ConnectorName = command.ConnectorName,
+            ExpectedChatId = command.ExpectedChatId,
+            ExpectedFromUserId = command.ExpectedFromUserId,
+            ExpectedFromUsername = command.ExpectedFromUsername,
+            CorrelationContains = command.CorrelationContains,
+            WaitTimeoutMs = command.WaitTimeoutMs,
+            PollTimeoutSeconds = command.PollTimeoutSeconds,
+            SettlePollsAfterMatch = command.SettlePollsAfterMatch,
+            CollectAllReplies = command.CollectAllReplies,
+            StartFromLatest = command.StartFromLatest,
+            EmitChatResponse = command.EmitChatResponse,
+            DeadlineUnixMs = _timeProvider.GetUtcNow().AddMilliseconds(command.WaitTimeoutMs).ToUnixTimeMilliseconds(),
+        };
+        state.ConnectorParameters.Add(command.ConnectorParameters);
+        if (command.HasOffset)
+            state.NextOffset = command.Offset;
+        return state;
+    }
+
+    private bool IsActiveContinuation(string commandId, long generation) =>
+        State.Active &&
+        State.Generation == generation &&
+        string.Equals(State.CommandId, commandId, StringComparison.Ordinal);
+
+    private async Task PersistAndContinuePollAsync(TelegramWaitReplyState next)
+    {
+        await PersistDomainEventAsync(new TelegramWaitReplyProgressedEvent { State = next });
+        if (_timeProvider.GetUtcNow().ToUnixTimeMilliseconds() >= State.DeadlineUnixMs)
+        {
+            await CompleteTimeoutAsync();
+            return;
+        }
+
+        await SendToAsync(Id, new TelegramWaitReplyPollDueEvent
+        {
+            CommandId = State.CommandId,
+            Generation = State.Generation,
+        });
+    }
+
+    private async Task CompleteTimeoutAsync()
+    {
+        if (State.PendingMatchedUpdate != null)
+        {
+            await CompleteSuccessAsync(State.CollectAllReplies
+                ? BuildMatchedReplyContent()
+                : State.PendingMatchedUpdate.Content);
+            return;
+        }
+
+        await CompleteFailureAsync(
+            $"telegram group stream timeout after {State.WaitTimeoutMs}ms without matched reply");
+    }
+
+    private Task CompleteResultAsync(TelegramWaitReplyResult result) =>
+        result.Success ? CompleteSuccessAsync(result.Content) : CompleteFailureAsync(result.Error);
+
+    private async Task CompleteSuccessAsync(string content)
+    {
+        await PublishAsync(
+            new TelegramWaitReplyCompletedEvent
+            {
+                CommandId = State.CommandId,
+                SessionId = State.SessionId,
+                Content = content,
+                EmitChatResponse = State.EmitChatResponse,
+                WaitActorId = Id,
+            },
+            TopologyAudience.Parent);
+        await ClearActiveStateAsync();
+    }
+
+    private async Task CompleteFailureAsync(string error)
+    {
+        await PublishAsync(
+            new TelegramWaitReplyFailedEvent
+            {
+                CommandId = State.CommandId,
+                SessionId = State.SessionId,
+                Error = error,
+                EmitChatResponse = State.EmitChatResponse,
+                WaitActorId = Id,
+            },
+            TopologyAudience.Parent);
+        await ClearActiveStateAsync();
+    }
+
+    private Task ClearActiveStateAsync()
+    {
+        if (!State.Active)
+            return Task.CompletedTask;
+
+        return PersistDomainEventAsync(new TelegramWaitReplyClearedEvent
+        {
+            CommandId = State.CommandId,
+            Generation = State.Generation,
+        });
+    }
+
+    private int ResolveCurrentPollSeconds()
+    {
+        var remainingMs = State.DeadlineUnixMs - _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        var remainingSeconds = (int)Math.Ceiling(Math.Max(1, remainingMs / 1000.0));
+        var currentPollMaxSeconds = State.PendingMatchedUpdate != null ? 1 : State.PollTimeoutSeconds;
+        return Math.Clamp(remainingSeconds, 1, currentPollMaxSeconds);
+    }
+
+    private List<TelegramInboundUpdate> SelectMatchedUpdates(
         IEnumerable<TelegramInboundUpdate> updates,
-        TelegramWaitForReplyCommand command,
         long? minimumUpdateId,
         long? minimumDateUnixExclusive)
     {
@@ -219,7 +363,7 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
                 continue;
             }
 
-            if (!IsMatchedUpdate(update, command))
+            if (!IsMatchedUpdate(update))
                 continue;
 
             matches.Add(update);
@@ -228,23 +372,23 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
         return matches;
     }
 
-    private static bool IsMatchedUpdate(TelegramInboundUpdate update, TelegramWaitForReplyCommand command)
+    private bool IsMatchedUpdate(TelegramInboundUpdate update)
     {
-        if (!string.Equals(update.ChatId, command.ExpectedChatId, StringComparison.Ordinal))
+        if (!string.Equals(update.ChatId, State.ExpectedChatId, StringComparison.Ordinal))
             return false;
 
-        if (!string.IsNullOrWhiteSpace(command.ExpectedFromUserId) &&
-            !string.Equals(update.FromUserId, command.ExpectedFromUserId, StringComparison.Ordinal))
+        if (!string.IsNullOrWhiteSpace(State.ExpectedFromUserId) &&
+            !string.Equals(update.FromUserId, State.ExpectedFromUserId, StringComparison.Ordinal))
         {
             return false;
         }
 
         // Some Telegram update variants omit username; keep other guards authoritative.
-        if (!string.IsNullOrWhiteSpace(command.ExpectedFromUsername))
+        if (!string.IsNullOrWhiteSpace(State.ExpectedFromUsername))
         {
             var actualUsername = NormalizeUsername(update.FromUsername);
             if (!string.IsNullOrWhiteSpace(actualUsername) &&
-                !string.Equals(actualUsername, command.ExpectedFromUsername, StringComparison.OrdinalIgnoreCase))
+                !string.Equals(actualUsername, State.ExpectedFromUsername, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -253,36 +397,62 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
         if (string.IsNullOrWhiteSpace(update.Content))
             return false;
 
-        return string.IsNullOrWhiteSpace(command.CorrelationContains) ||
-               update.Content.IndexOf(command.CorrelationContains, StringComparison.OrdinalIgnoreCase) >= 0;
+        return string.IsNullOrWhiteSpace(State.CorrelationContains) ||
+               update.Content.IndexOf(State.CorrelationContains, StringComparison.OrdinalIgnoreCase) >= 0;
     }
 
-    private static void MergeMatchedUpdates(
-        IEnumerable<TelegramInboundUpdate> matchedUpdates,
-        IDictionary<string, TelegramInboundUpdate> latestByIdentity,
-        IList<string> identityOrder)
+    private static void ApplyMatches(TelegramWaitReplyState state, IReadOnlyList<TelegramInboundUpdate> matchedUpdates)
     {
+        if (matchedUpdates.Count == 0)
+            return;
+
+        state.PendingMatchedUpdate = ToState(matchedUpdates[^1]);
+        state.PollsSinceLastMatch = 0;
+        if (!state.CollectAllReplies)
+            return;
+
         foreach (var update in matchedUpdates)
         {
             var identity = BuildMatchedReplyIdentity(update);
-            if (!latestByIdentity.ContainsKey(identity))
-                identityOrder.Add(identity);
-            latestByIdentity[identity] = update;
+            if (!state.CollectedReplies.ContainsKey(identity))
+                state.CollectedReplyOrder.Add(identity);
+            state.CollectedReplies[identity] = ToState(update);
         }
     }
 
-    private static string BuildMatchedReplyContent(
-        IReadOnlyDictionary<string, TelegramInboundUpdate> latestByIdentity,
-        IReadOnlyList<string> identityOrder,
-        TelegramInboundUpdate? fallback)
+    private TelegramWaitReplyResult? ResolveCurrentResult(TelegramWaitReplyState state, bool emptyPoll)
     {
-        if (latestByIdentity.Count == 0 || identityOrder.Count == 0)
-            return fallback?.Content ?? string.Empty;
+        if (state.PendingMatchedUpdate == null)
+            return null;
 
-        var orderedReplies = new List<string>(identityOrder.Count);
-        foreach (var identity in identityOrder)
+        if (emptyPoll)
+            state.PollsSinceLastMatch++;
+
+        if (!emptyPoll || state.PollsSinceLastMatch < state.SettlePollsAfterMatch)
+            return state.SettlePollsAfterMatch <= 0 ? BuildCurrentSuccess(state) : null;
+
+        return BuildCurrentSuccess(state);
+    }
+
+    private TelegramWaitReplyResult BuildCurrentSuccess(TelegramWaitReplyState state)
+    {
+        if (!state.CollectAllReplies)
+            return TelegramWaitReplyResult.Ok(state.PendingMatchedUpdate?.Content ?? string.Empty);
+
+        return TelegramWaitReplyResult.Ok(BuildMatchedReplyContent(state));
+    }
+
+    private string BuildMatchedReplyContent() => BuildMatchedReplyContent(State);
+
+    private static string BuildMatchedReplyContent(TelegramWaitReplyState state)
+    {
+        if (state.CollectedReplies.Count == 0 || state.CollectedReplyOrder.Count == 0)
+            return state.PendingMatchedUpdate?.Content ?? string.Empty;
+
+        var orderedReplies = new List<string>(state.CollectedReplyOrder.Count);
+        foreach (var identity in state.CollectedReplyOrder)
         {
-            if (!latestByIdentity.TryGetValue(identity, out var update))
+            if (!state.CollectedReplies.TryGetValue(identity, out var update))
                 continue;
             if (string.IsNullOrWhiteSpace(update.Content))
                 continue;
@@ -291,7 +461,7 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
         }
 
         if (orderedReplies.Count == 0)
-            return fallback?.Content ?? string.Empty;
+            return state.PendingMatchedUpdate?.Content ?? string.Empty;
         if (orderedReplies.Count == 1)
             return orderedReplies[0];
 
@@ -308,14 +478,13 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
         return $"raw:{update.ChatId}:{update.FromUserId}:{update.DateUnix}:{update.Content}";
     }
 
-    private static async Task<ConnectorResponse> ExecuteGetUpdatesAsync(
-        TelegramWaitForReplyCommand command,
-        IConnector connector,
+    private async Task<ConnectorResponse> ExecuteGetUpdatesAsync(
         long? offset,
         int pollTimeoutSeconds,
-        int perCallTimeoutMs)
+        int perCallTimeoutMs,
+        IConnector connector)
     {
-        var parameters = new Dictionary<string, string>(command.ConnectorParameters, StringComparer.OrdinalIgnoreCase)
+        var parameters = new Dictionary<string, string>(State.ConnectorParameters, StringComparer.OrdinalIgnoreCase)
         {
             ["method"] = "POST",
             ["content_type"] = "application/json",
@@ -324,9 +493,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
 
         var connectorRequest = new ConnectorRequest
         {
-            RunId = command.CommandId,
-            StepId = command.SessionId,
-            Connector = command.ConnectorName,
+            RunId = State.CommandId,
+            StepId = State.SessionId,
+            Connector = State.ConnectorName,
             Operation = "/getUpdates",
             Payload = BuildGetUpdatesPayload(offset, pollTimeoutSeconds),
             Parameters = parameters,
@@ -499,82 +668,17 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase
         return normalized.StartsWith('@') ? normalized[1..] : normalized;
     }
 
-    private sealed class TelegramWaitReplyRuntimeContext
-    {
-        private readonly Dictionary<string, TelegramInboundUpdate>? _collectedByIdentity;
-        private readonly List<string>? _collectedIdentityOrder;
-        private TelegramInboundUpdate? _pendingMatchedUpdate;
-        private int _pollsSinceLastMatch;
-
-        public TelegramWaitReplyRuntimeContext(TelegramWaitForReplyCommand command)
+    private static TelegramInboundUpdateState ToState(TelegramInboundUpdate update) =>
+        new()
         {
-            Offset = command.HasOffset ? command.Offset : null;
-            if (!command.CollectAllReplies)
-                return;
-
-            _collectedByIdentity = new Dictionary<string, TelegramInboundUpdate>(StringComparer.Ordinal);
-            _collectedIdentityOrder = [];
-        }
-
-        public long? Offset { get; set; }
-        public bool HasPendingMatch => _pendingMatchedUpdate != null;
-
-        public TelegramWaitReplyResult? ApplyMatches(
-            TelegramWaitForReplyCommand command,
-            IReadOnlyList<TelegramInboundUpdate> matchedUpdates)
-        {
-            if (matchedUpdates.Count == 0)
-                return ApplyEmptyPoll(command);
-
-            _pendingMatchedUpdate = matchedUpdates[^1];
-            _pollsSinceLastMatch = 0;
-            if (command.CollectAllReplies)
-                MergeMatchedUpdates(matchedUpdates, _collectedByIdentity!, _collectedIdentityOrder!);
-
-            return command.SettlePollsAfterMatch <= 0
-                ? BuildCurrentSuccess(command)
-                : null;
-        }
-
-        public TelegramWaitReplyResult ToTerminalResult(int waitTimeoutMs)
-        {
-            if (_pendingMatchedUpdate == null)
-                return TelegramWaitReplyResult.Fail(
-                    $"telegram group stream timeout after {waitTimeoutMs}ms without matched reply");
-
-            return TelegramWaitReplyResult.Ok(_pendingMatchedUpdate.Content);
-        }
-
-        private TelegramWaitReplyResult? ApplyEmptyPoll(TelegramWaitForReplyCommand command)
-        {
-            if (_pendingMatchedUpdate == null)
-                return null;
-
-            _pollsSinceLastMatch++;
-            return _pollsSinceLastMatch >= command.SettlePollsAfterMatch
-                ? BuildCurrentSuccess(command)
-                : null;
-        }
-
-        private TelegramWaitReplyResult BuildCurrentSuccess(TelegramWaitForReplyCommand command)
-        {
-            if (!command.CollectAllReplies)
-                return TelegramWaitReplyResult.Ok(_pendingMatchedUpdate?.Content ?? string.Empty);
-
-            return TelegramWaitReplyResult.Ok(BuildMatchedReplyContent(
-                _collectedByIdentity!,
-                _collectedIdentityOrder!,
-                _pendingMatchedUpdate));
-        }
-    }
-
-    private readonly record struct TelegramWaitReplyStepResult(
-        bool ShouldContinue,
-        TelegramWaitReplyResult Result)
-    {
-        public static TelegramWaitReplyStepResult Continue() => new(true, default);
-        public static TelegramWaitReplyStepResult Done(TelegramWaitReplyResult result) => new(false, result);
-    }
+            UpdateId = update.UpdateId,
+            MessageId = update.MessageId,
+            DateUnix = update.DateUnix,
+            ChatId = update.ChatId,
+            FromUserId = update.FromUserId,
+            FromUsername = update.FromUsername,
+            Content = update.Content,
+        };
 
     private readonly record struct TelegramWaitReplyResult(bool Success, string Content, string Error)
     {

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
@@ -1,0 +1,593 @@
+using System.Text.Json;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Core;
+
+namespace Aevatar.Workflow.Extensions.Bridge;
+
+/// <summary>
+/// Task-scoped Telegram wait-reply agent.
+/// </summary>
+// Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
+//   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
+//   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
+public sealed class TelegramWaitReplyGAgent : GAgentBase
+{
+    private const int MaxPollTimeoutSeconds = 25;
+    private readonly IConnectorRegistry _connectorRegistry;
+
+    public TelegramWaitReplyGAgent(
+        IActorRuntime runtime,
+        IConnectorRegistry connectorRegistry)
+    {
+        _ = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _connectorRegistry = connectorRegistry ?? throw new ArgumentNullException(nameof(connectorRegistry));
+        InitializeId();
+    }
+
+    [EventHandler]
+    public async Task HandleWaitForReply(TelegramWaitForReplyCommand command)
+    {
+        // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
+        //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
+        //   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (!_connectorRegistry.TryGet(command.ConnectorName, out var connector) || connector == null)
+        {
+            await PublishFailedAsync(command, $"telegram connector '{command.ConnectorName}' not found");
+            return;
+        }
+
+        var result = await WaitForReplyAsync(command, connector);
+        if (result.Success)
+        {
+            await PublishAsync(
+                new TelegramWaitReplyCompletedEvent
+                {
+                    CommandId = command.CommandId,
+                    SessionId = command.SessionId,
+                    Content = result.Content,
+                    EmitChatResponse = command.EmitChatResponse,
+                    WaitActorId = Id,
+                },
+                TopologyAudience.Parent);
+            return;
+        }
+
+        await PublishFailedAsync(command, result.Error);
+    }
+
+    private Task PublishFailedAsync(TelegramWaitForReplyCommand command, string error)
+    {
+        return PublishAsync(
+            new TelegramWaitReplyFailedEvent
+            {
+                CommandId = command.CommandId,
+                SessionId = command.SessionId,
+                Error = error,
+                EmitChatResponse = command.EmitChatResponse,
+                WaitActorId = Id,
+            },
+            TopologyAudience.Parent);
+    }
+
+    private static async Task<TelegramWaitReplyResult> WaitForReplyAsync(
+        TelegramWaitForReplyCommand command,
+        IConnector connector)
+    {
+        var context = new TelegramWaitReplyRuntimeContext(command);
+
+        if (command.StartFromLatest && context.Offset == null)
+        {
+            var bootstrapResult = await BootstrapFromLatestAsync(command, connector, context);
+            if (!bootstrapResult.ShouldContinue)
+                return bootstrapResult.Result;
+        }
+
+        var deadline = DateTimeOffset.UtcNow.AddMilliseconds(command.WaitTimeoutMs);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var pollResult = await PollOnceAsync(command, connector, context, deadline);
+            if (!pollResult.ShouldContinue)
+                return pollResult.Result;
+        }
+
+        return context.ToTerminalResult(command.WaitTimeoutMs);
+    }
+
+    private static async Task<TelegramWaitReplyStepResult> BootstrapFromLatestAsync(
+        TelegramWaitForReplyCommand command,
+        IConnector connector,
+        TelegramWaitReplyRuntimeContext context)
+    {
+        var bootstrap = await ExecuteGetUpdatesAsync(
+            command,
+            connector,
+            offset: null,
+            pollTimeoutSeconds: 0,
+            perCallTimeoutMs: 5_000);
+        if (!bootstrap.Success)
+        {
+            return TelegramWaitReplyStepResult.Done(TelegramWaitReplyResult.Fail(string.IsNullOrWhiteSpace(bootstrap.Error)
+                ? "telegram bootstrap getUpdates failed"
+                : bootstrap.Error.Trim()));
+        }
+
+        if (!TryParseTelegramUpdates(
+                bootstrap.Output,
+                out var bootstrapUpdates,
+                out var bootstrapMaxUpdateId,
+                out var bootstrapError))
+        {
+            return TelegramWaitReplyStepResult.Done(
+                TelegramWaitReplyResult.Fail($"telegram bootstrap parse failed: {bootstrapError}"));
+        }
+
+        var bootstrapRecentCutoffUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+            - Math.Max(30, Math.Min(600, command.WaitTimeoutMs / 1000 + 10));
+        var bootstrapMatchedUpdates = SelectMatchedUpdates(
+            bootstrapUpdates,
+            command,
+            minimumUpdateId: null,
+            minimumDateUnixExclusive: bootstrapRecentCutoffUnix);
+        if (bootstrapMatchedUpdates.Count > 0 && !command.CollectAllReplies)
+        {
+            return TelegramWaitReplyStepResult.Done(
+                TelegramWaitReplyResult.Ok(bootstrapMatchedUpdates[^1].Content));
+        }
+
+        var matchedResult = context.ApplyMatches(command, bootstrapMatchedUpdates);
+        if (matchedResult.HasValue)
+            return TelegramWaitReplyStepResult.Done(matchedResult.Value);
+
+        if (bootstrapMaxUpdateId.HasValue)
+            context.Offset = bootstrapMaxUpdateId.Value + 1;
+        return TelegramWaitReplyStepResult.Continue();
+    }
+
+    private static async Task<TelegramWaitReplyStepResult> PollOnceAsync(
+        TelegramWaitForReplyCommand command,
+        IConnector connector,
+        TelegramWaitReplyRuntimeContext context,
+        DateTimeOffset deadline)
+    {
+        var remaining = deadline - DateTimeOffset.UtcNow;
+        var currentPollMaxSeconds = context.HasPendingMatch ? 1 : command.PollTimeoutSeconds;
+        var currentPollSeconds = Math.Clamp(
+            (int)Math.Ceiling(Math.Max(1, remaining.TotalSeconds)),
+            1,
+            currentPollMaxSeconds);
+        var perCallTimeoutMs = (currentPollSeconds + 3) * 1_000;
+        var requestedOffset = context.Offset;
+
+        var poll = await ExecuteGetUpdatesAsync(
+            command,
+            connector,
+            context.Offset,
+            currentPollSeconds,
+            perCallTimeoutMs);
+        if (!poll.Success)
+        {
+            return TelegramWaitReplyStepResult.Done(TelegramWaitReplyResult.Fail(string.IsNullOrWhiteSpace(poll.Error)
+                ? "telegram getUpdates failed"
+                : poll.Error.Trim()));
+        }
+
+        if (!TryParseTelegramUpdates(poll.Output, out var updates, out var maxUpdateId, out var parseError))
+        {
+            return TelegramWaitReplyStepResult.Done(
+                TelegramWaitReplyResult.Fail($"telegram getUpdates parse failed: {parseError}"));
+        }
+
+        if (maxUpdateId.HasValue)
+            context.Offset = maxUpdateId.Value + 1;
+
+        var matchedUpdatesInBatch = SelectMatchedUpdates(
+            updates,
+            command,
+            minimumUpdateId: requestedOffset,
+            minimumDateUnixExclusive: null);
+        var matchedResult = context.ApplyMatches(command, matchedUpdatesInBatch);
+        if (matchedResult.HasValue)
+            return TelegramWaitReplyStepResult.Done(matchedResult.Value);
+
+        return TelegramWaitReplyStepResult.Continue();
+    }
+
+    private static List<TelegramInboundUpdate> SelectMatchedUpdates(
+        IEnumerable<TelegramInboundUpdate> updates,
+        TelegramWaitForReplyCommand command,
+        long? minimumUpdateId,
+        long? minimumDateUnixExclusive)
+    {
+        var matches = new List<TelegramInboundUpdate>();
+        foreach (var update in updates)
+        {
+            if (minimumUpdateId.HasValue &&
+                update.UpdateId >= 0 &&
+                update.UpdateId < minimumUpdateId.Value)
+            {
+                continue;
+            }
+
+            if (minimumDateUnixExclusive.HasValue &&
+                update.DateUnix > 0 &&
+                update.DateUnix < minimumDateUnixExclusive.Value)
+            {
+                continue;
+            }
+
+            if (!IsMatchedUpdate(update, command))
+                continue;
+
+            matches.Add(update);
+        }
+
+        return matches;
+    }
+
+    private static bool IsMatchedUpdate(TelegramInboundUpdate update, TelegramWaitForReplyCommand command)
+    {
+        if (!string.Equals(update.ChatId, command.ExpectedChatId, StringComparison.Ordinal))
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(command.ExpectedFromUserId) &&
+            !string.Equals(update.FromUserId, command.ExpectedFromUserId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Some Telegram update variants omit username; keep other guards authoritative.
+        if (!string.IsNullOrWhiteSpace(command.ExpectedFromUsername))
+        {
+            var actualUsername = NormalizeUsername(update.FromUsername);
+            if (!string.IsNullOrWhiteSpace(actualUsername) &&
+                !string.Equals(actualUsername, command.ExpectedFromUsername, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(update.Content))
+            return false;
+
+        return string.IsNullOrWhiteSpace(command.CorrelationContains) ||
+               update.Content.IndexOf(command.CorrelationContains, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static void MergeMatchedUpdates(
+        IEnumerable<TelegramInboundUpdate> matchedUpdates,
+        IDictionary<string, TelegramInboundUpdate> latestByIdentity,
+        IList<string> identityOrder)
+    {
+        foreach (var update in matchedUpdates)
+        {
+            var identity = BuildMatchedReplyIdentity(update);
+            if (!latestByIdentity.ContainsKey(identity))
+                identityOrder.Add(identity);
+            latestByIdentity[identity] = update;
+        }
+    }
+
+    private static string BuildMatchedReplyContent(
+        IReadOnlyDictionary<string, TelegramInboundUpdate> latestByIdentity,
+        IReadOnlyList<string> identityOrder,
+        TelegramInboundUpdate? fallback)
+    {
+        if (latestByIdentity.Count == 0 || identityOrder.Count == 0)
+            return fallback?.Content ?? string.Empty;
+
+        var orderedReplies = new List<string>(identityOrder.Count);
+        foreach (var identity in identityOrder)
+        {
+            if (!latestByIdentity.TryGetValue(identity, out var update))
+                continue;
+            if (string.IsNullOrWhiteSpace(update.Content))
+                continue;
+
+            orderedReplies.Add(update.Content);
+        }
+
+        if (orderedReplies.Count == 0)
+            return fallback?.Content ?? string.Empty;
+        if (orderedReplies.Count == 1)
+            return orderedReplies[0];
+
+        return string.Join("\n\n---\n\n", orderedReplies);
+    }
+
+    private static string BuildMatchedReplyIdentity(TelegramInboundUpdate update)
+    {
+        if (update.MessageId > 0)
+            return $"msg:{update.ChatId}:{update.MessageId}";
+        if (update.UpdateId >= 0)
+            return $"update:{update.UpdateId}";
+
+        return $"raw:{update.ChatId}:{update.FromUserId}:{update.DateUnix}:{update.Content}";
+    }
+
+    private static async Task<ConnectorResponse> ExecuteGetUpdatesAsync(
+        TelegramWaitForReplyCommand command,
+        IConnector connector,
+        long? offset,
+        int pollTimeoutSeconds,
+        int perCallTimeoutMs)
+    {
+        var parameters = new Dictionary<string, string>(command.ConnectorParameters, StringComparer.OrdinalIgnoreCase)
+        {
+            ["method"] = "POST",
+            ["content_type"] = "application/json",
+            ["timeout_ms"] = perCallTimeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+
+        var connectorRequest = new ConnectorRequest
+        {
+            RunId = command.CommandId,
+            StepId = command.SessionId,
+            Connector = command.ConnectorName,
+            Operation = "/getUpdates",
+            Payload = BuildGetUpdatesPayload(offset, pollTimeoutSeconds),
+            Parameters = parameters,
+        };
+
+        return await TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync(
+            connector,
+            connectorRequest,
+            TelegramBridgeGAgent.ResolveConnectorExecutionWatchdogMs(parameters));
+    }
+
+    private static string BuildGetUpdatesPayload(long? offset, int pollTimeoutSeconds)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["timeout"] = Math.Clamp(pollTimeoutSeconds, 0, MaxPollTimeoutSeconds),
+            ["allowed_updates"] = new[] { "message", "channel_post" },
+        };
+        if (offset.HasValue && offset.Value >= 0)
+            payload["offset"] = offset.Value;
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static bool TryParseTelegramUpdates(
+        string output,
+        out List<TelegramInboundUpdate> updates,
+        out long? maxUpdateId,
+        out string error)
+    {
+        updates = [];
+        maxUpdateId = null;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(output))
+            return true;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(output);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                error = "root is not a JSON object";
+                return false;
+            }
+
+            if (root.TryGetProperty("ok", out var okElement) &&
+                okElement.ValueKind is JsonValueKind.False)
+            {
+                var description = root.TryGetProperty("description", out var desc)
+                    ? desc.GetString()
+                    : null;
+                error = string.IsNullOrWhiteSpace(description)
+                    ? "telegram api returned ok=false"
+                    : description;
+                return false;
+            }
+
+            if (!root.TryGetProperty("result", out var result) ||
+                result.ValueKind != JsonValueKind.Array)
+            {
+                return true;
+            }
+
+            foreach (var item in result.EnumerateArray())
+                AddTelegramUpdate(item, updates, ref maxUpdateId);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    private static void AddTelegramUpdate(JsonElement item, List<TelegramInboundUpdate> updates, ref long? maxUpdateId)
+    {
+        if (item.ValueKind != JsonValueKind.Object)
+            return;
+
+        var updateId = TryGetInt64(item, "update_id");
+        if (updateId.HasValue)
+            maxUpdateId = !maxUpdateId.HasValue ? updateId : Math.Max(maxUpdateId.Value, updateId.Value);
+
+        if (!TryGetMessageElement(item, out var message))
+            return;
+
+        var chatId = TryGetNestedStringOrNumber(message, "chat", "id");
+        if (string.IsNullOrWhiteSpace(chatId))
+            return;
+
+        var text = TryGetString(message, "text");
+        if (string.IsNullOrWhiteSpace(text))
+            text = TryGetString(message, "caption");
+
+        updates.Add(new TelegramInboundUpdate(
+            UpdateId: updateId ?? -1,
+            MessageId: TryGetInt64(message, "message_id") ?? 0,
+            DateUnix: TryGetInt64(message, "date") ?? 0,
+            ChatId: chatId,
+            FromUserId: TryGetNestedStringOrNumber(message, "from", "id"),
+            FromUsername: TryGetNestedStringOrNumber(message, "from", "username"),
+            Content: text ?? string.Empty));
+    }
+
+    private static bool TryGetMessageElement(JsonElement item, out JsonElement message)
+    {
+        if (item.TryGetProperty("message", out var messageValue) && messageValue.ValueKind == JsonValueKind.Object)
+        {
+            message = messageValue;
+            return true;
+        }
+
+        if (item.TryGetProperty("channel_post", out var channelPost) && channelPost.ValueKind == JsonValueKind.Object)
+        {
+            message = channelPost;
+            return true;
+        }
+
+        message = default;
+        return false;
+    }
+
+    private static long? TryGetInt64(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var value))
+            return null;
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var number))
+            return number;
+        if (value.ValueKind == JsonValueKind.String &&
+            long.TryParse(value.GetString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out number))
+        {
+            return number;
+        }
+
+        return null;
+    }
+
+    private static string TryGetString(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var value))
+            return string.Empty;
+        return value.ValueKind == JsonValueKind.String ? value.GetString() ?? string.Empty : string.Empty;
+    }
+
+    private static string TryGetNestedStringOrNumber(JsonElement element, string nested, string name)
+    {
+        if (!element.TryGetProperty(nested, out var nestedElement) ||
+            nestedElement.ValueKind != JsonValueKind.Object ||
+            !nestedElement.TryGetProperty(name, out var value))
+        {
+            return string.Empty;
+        }
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? string.Empty,
+            JsonValueKind.Number => value.GetRawText(),
+            _ => string.Empty,
+        };
+    }
+
+    private static string NormalizeUsername(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return string.Empty;
+        var normalized = raw.Trim();
+        return normalized.StartsWith('@') ? normalized[1..] : normalized;
+    }
+
+    private sealed class TelegramWaitReplyRuntimeContext
+    {
+        private readonly Dictionary<string, TelegramInboundUpdate>? _collectedByIdentity;
+        private readonly List<string>? _collectedIdentityOrder;
+        private TelegramInboundUpdate? _pendingMatchedUpdate;
+        private int _pollsSinceLastMatch;
+
+        public TelegramWaitReplyRuntimeContext(TelegramWaitForReplyCommand command)
+        {
+            Offset = command.HasOffset ? command.Offset : null;
+            if (!command.CollectAllReplies)
+                return;
+
+            _collectedByIdentity = new Dictionary<string, TelegramInboundUpdate>(StringComparer.Ordinal);
+            _collectedIdentityOrder = [];
+        }
+
+        public long? Offset { get; set; }
+        public bool HasPendingMatch => _pendingMatchedUpdate != null;
+
+        public TelegramWaitReplyResult? ApplyMatches(
+            TelegramWaitForReplyCommand command,
+            IReadOnlyList<TelegramInboundUpdate> matchedUpdates)
+        {
+            if (matchedUpdates.Count == 0)
+                return ApplyEmptyPoll(command);
+
+            _pendingMatchedUpdate = matchedUpdates[^1];
+            _pollsSinceLastMatch = 0;
+            if (command.CollectAllReplies)
+                MergeMatchedUpdates(matchedUpdates, _collectedByIdentity!, _collectedIdentityOrder!);
+
+            return command.SettlePollsAfterMatch <= 0
+                ? BuildCurrentSuccess(command)
+                : null;
+        }
+
+        public TelegramWaitReplyResult ToTerminalResult(int waitTimeoutMs)
+        {
+            if (_pendingMatchedUpdate == null)
+                return TelegramWaitReplyResult.Fail(
+                    $"telegram group stream timeout after {waitTimeoutMs}ms without matched reply");
+
+            return TelegramWaitReplyResult.Ok(_pendingMatchedUpdate.Content);
+        }
+
+        private TelegramWaitReplyResult? ApplyEmptyPoll(TelegramWaitForReplyCommand command)
+        {
+            if (_pendingMatchedUpdate == null)
+                return null;
+
+            _pollsSinceLastMatch++;
+            return _pollsSinceLastMatch >= command.SettlePollsAfterMatch
+                ? BuildCurrentSuccess(command)
+                : null;
+        }
+
+        private TelegramWaitReplyResult BuildCurrentSuccess(TelegramWaitForReplyCommand command)
+        {
+            if (!command.CollectAllReplies)
+                return TelegramWaitReplyResult.Ok(_pendingMatchedUpdate?.Content ?? string.Empty);
+
+            return TelegramWaitReplyResult.Ok(BuildMatchedReplyContent(
+                _collectedByIdentity!,
+                _collectedIdentityOrder!,
+                _pendingMatchedUpdate));
+        }
+    }
+
+    private readonly record struct TelegramWaitReplyStepResult(
+        bool ShouldContinue,
+        TelegramWaitReplyResult Result)
+    {
+        public static TelegramWaitReplyStepResult Continue() => new(true, default);
+        public static TelegramWaitReplyStepResult Done(TelegramWaitReplyResult result) => new(false, result);
+    }
+
+    private readonly record struct TelegramWaitReplyResult(bool Success, string Content, string Error)
+    {
+        public static TelegramWaitReplyResult Ok(string content) => new(true, content, string.Empty);
+        public static TelegramWaitReplyResult Fail(string error) => new(false, string.Empty, error);
+    }
+
+    private sealed record TelegramInboundUpdate(
+        long UpdateId,
+        long MessageId,
+        long DateUnix,
+        string ChatId,
+        string FromUserId,
+        string FromUsername,
+        string Content);
+}

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+package aevatar.workflow.extensions.bridge;
+option csharp_namespace = "Aevatar.Workflow.Extensions.Bridge";
+
+message TelegramWaitForReplyCommand {
+  string command_id = 1;
+  string session_id = 2;
+  string connector_name = 3;
+  string expected_chat_id = 4;
+  string expected_from_user_id = 5;
+  string expected_from_username = 6;
+  string correlation_contains = 7;
+  int32 wait_timeout_ms = 8;
+  int32 poll_timeout_seconds = 9;
+  int32 settle_polls_after_match = 10;
+  bool collect_all_replies = 11;
+  bool start_from_latest = 12;
+  optional int64 offset = 13;
+  map<string, string> connector_parameters = 14;
+  bool emit_chat_response = 15;
+}
+
+message TelegramWaitReplyCompletedEvent {
+  string command_id = 1;
+  string session_id = 2;
+  string content = 3;
+  bool emit_chat_response = 4;
+  string wait_actor_id = 5;
+}
+
+message TelegramWaitReplyFailedEvent {
+  string command_id = 1;
+  string session_id = 2;
+  string error = 3;
+  bool emit_chat_response = 4;
+  string wait_actor_id = 5;
+}

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
@@ -2,6 +2,10 @@ syntax = "proto3";
 package aevatar.workflow.extensions.bridge;
 option csharp_namespace = "Aevatar.Workflow.Extensions.Bridge";
 
+// Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
+//   Old pattern: Telegram bridge owned wait-reply polling and stack-local progress inside one actor turn.
+//   New principle: a task-scoped wait actor owns protobuf wait state and advances by typed self-continuation events.
+
 message TelegramWaitForReplyCommand {
   string command_id = 1;
   string session_id = 2;
@@ -18,6 +22,70 @@ message TelegramWaitForReplyCommand {
   optional int64 offset = 13;
   map<string, string> connector_parameters = 14;
   bool emit_chat_response = 15;
+}
+
+message TelegramInboundUpdateState {
+  int64 update_id = 1;
+  int64 message_id = 2;
+  int64 date_unix = 3;
+  string chat_id = 4;
+  string from_user_id = 5;
+  string from_username = 6;
+  string content = 7;
+}
+
+message TelegramWaitReplyState {
+  bool active = 1;
+  int64 generation = 2;
+  string command_id = 3;
+  string session_id = 4;
+  string connector_name = 5;
+  string expected_chat_id = 6;
+  string expected_from_user_id = 7;
+  string expected_from_username = 8;
+  string correlation_contains = 9;
+  int32 wait_timeout_ms = 10;
+  int32 poll_timeout_seconds = 11;
+  int32 settle_polls_after_match = 12;
+  bool collect_all_replies = 13;
+  bool start_from_latest = 14;
+  bool emit_chat_response = 15;
+  optional int64 next_offset = 16;
+  map<string, string> connector_parameters = 17;
+  int64 deadline_unix_ms = 18;
+  TelegramInboundUpdateState pending_matched_update = 19;
+  int32 polls_since_last_match = 20;
+  map<string, TelegramInboundUpdateState> collected_replies = 21;
+  repeated string collected_reply_order = 22;
+}
+
+message TelegramWaitReplyStartedEvent {
+  TelegramWaitReplyState state = 1;
+}
+
+message TelegramWaitReplyProgressedEvent {
+  TelegramWaitReplyState state = 1;
+}
+
+message TelegramWaitReplyClearedEvent {
+  string command_id = 1;
+  int64 generation = 2;
+}
+
+message TelegramWaitReplyBootstrapDueEvent {
+  string command_id = 1;
+  int64 generation = 2;
+}
+
+message TelegramWaitReplyPollDueEvent {
+  string command_id = 1;
+  int64 generation = 2;
+}
+
+message TelegramWaitReplyTimeoutDueEvent {
+  string command_id = 1;
+  int64 generation = 2;
+  int32 timeout_ms = 3;
 }
 
 message TelegramWaitReplyCompletedEvent {

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -154,26 +154,15 @@ public sealed class TelegramBridgeGAgentTests
     }
 
     [Fact]
-    public async Task HandleChatRequest_WhenWaitReplyOperation_ShouldPollTelegramGroupStream()
+    public async Task HandleChatRequest_WhenWaitReplyOperation_ShouldDispatchTaskScopedWaitActor()
     {
-        var connector = new RecordingConnector(
-            new ConnectorResponse
-            {
-                Success = true,
-                Output =
-                    """{"ok":true,"result":[{"update_id":100,"message":{"chat":{"id":"10001"},"from":{"id":"1000","username":"aevatar_bot"},"text":"old-message"}}]}""",
-            },
-            new ConnectorResponse
-            {
-                Success = true,
-                Output =
-                    """{"ok":true,"result":[{"update_id":101,"message":{"chat":{"id":"10001"},"from":{"id":"2002","username":"openclaw_bot"},"text":"openclaw-reply"}}]}""",
-            });
+        var connector = new RecordingConnector();
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
+        var runtime = new NoopActorRuntime();
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramBridgeGAgent(
-            new NoopActorRuntime(),
+            runtime,
             registry)
         {
             EventPublisher = publisher,
@@ -193,19 +182,22 @@ public sealed class TelegramBridgeGAgentTests
 
         await agent.HandleEventAsync(Envelope(request), CancellationToken.None);
 
-        connector.Received.Count.Should().BeGreaterThanOrEqualTo(2);
-        connector.Received.Should().OnlyContain(x => x.Operation == "/getUpdates");
+        connector.Received.Should().BeEmpty();
+        runtime.CreatedActorTypes.Should().ContainSingle().Which.Should().Be(typeof(TelegramWaitReplyGAgent));
+        publisher.Sent.Should().ContainSingle();
+        publisher.Sent[0].targetActorId.Should().StartWith("telegram-wait-reply-session-wait");
 
-        var secondPayload = JsonDocument.Parse(connector.Received[1].Payload).RootElement;
-        secondPayload.GetProperty("offset").GetInt64().Should().Be(101);
-
-        var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
-        textEnd.SessionId.Should().Be("session-wait");
-        textEnd.Content.Should().Be("openclaw-reply");
+        var command = publisher.Sent[0].evt.Should().BeOfType<TelegramWaitForReplyCommand>().Subject;
+        command.SessionId.Should().Be("session-wait");
+        command.ConnectorName.Should().Be("telegram");
+        command.ExpectedChatId.Should().Be("10001");
+        command.ExpectedFromUsername.Should().Be("openclaw_bot");
+        command.WaitTimeoutMs.Should().Be(5000);
+        command.PollTimeoutSeconds.Should().Be(1);
     }
 
     [Fact]
-    public async Task HandleChatRequest_WhenWaitReplyGetsEditedMessage_ShouldReturnLatestMatchedContent()
+    public async Task TelegramWaitReplyGAgent_WhenWaitReplyGetsEditedMessage_ShouldReturnLatestMatchedContent()
     {
         var connector = new RecordingConnector(
             new ConnectorResponse
@@ -234,7 +226,7 @@ public sealed class TelegramBridgeGAgentTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
         var publisher = new RecordingEventPublisher();
-        var agent = new TelegramBridgeGAgent(
+        var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
             registry)
         {
@@ -242,19 +234,12 @@ public sealed class TelegramBridgeGAgentTests
             Services = CreateAgentServices(),
         };
 
-        var request = new ChatRequestEvent
-        {
-            Prompt = "wait-edited",
-            SessionId = "session-wait-edited",
-        };
-        request.Headers["chat_id"] = "10001";
-        request.Headers["operation"] = "/waitReply";
-        request.Headers["expected_from_username"] = "openclaw_bot";
-        request.Headers["wait_timeout_ms"] = "5000";
-        request.Headers["poll_timeout_sec"] = "1";
-        request.Headers["start_from_latest"] = "true";
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-wait-edited",
+            expectedUsername: "openclaw_bot");
+        command.StartFromLatest = true;
 
-        await agent.HandleEventAsync(Envelope(request), CancellationToken.None);
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
 
         connector.Received.Count.Should().BeGreaterThanOrEqualTo(4);
         connector.Received.Should().OnlyContain(x => x.Operation == "/getUpdates");
@@ -264,13 +249,38 @@ public sealed class TelegramBridgeGAgentTests
         var thirdPayload = JsonDocument.Parse(connector.Received[2].Payload).RootElement;
         thirdPayload.GetProperty("offset").GetInt64().Should().Be(402);
 
+        var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
+        completed.SessionId.Should().Be("session-wait-edited");
+        completed.Content.Should().Be("openclaw-reply-final");
+    }
+
+    [Fact]
+    public async Task TelegramBridgeGAgent_WhenWaitReplyCompleted_ShouldPublishTextMessageEnd()
+    {
+        var publisher = new RecordingEventPublisher();
+        var agent = new TelegramBridgeGAgent(
+            new NoopActorRuntime(),
+            new InMemoryConnectorRegistry())
+        {
+            EventPublisher = publisher,
+            Services = CreateAgentServices(),
+        };
+
+        await agent.HandleEventAsync(
+            Envelope(new TelegramWaitReplyCompletedEvent
+            {
+                SessionId = "session-wait-edited",
+                Content = "openclaw-reply-final",
+            }),
+            CancellationToken.None);
+
         var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
         textEnd.SessionId.Should().Be("session-wait-edited");
         textEnd.Content.Should().Be("openclaw-reply-final");
     }
 
     [Fact]
-    public async Task HandleChatRequest_WhenCollectAllRepliesEnabled_ShouldReturnMergedReplies()
+    public async Task TelegramWaitReplyGAgent_WhenCollectAllRepliesEnabled_ShouldReturnMergedReplies()
     {
         var connector = new RecordingConnector(
             new ConnectorResponse
@@ -310,7 +320,7 @@ public sealed class TelegramBridgeGAgentTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
         var publisher = new RecordingEventPublisher();
-        var agent = new TelegramBridgeGAgent(
+        var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
             registry)
         {
@@ -318,29 +328,22 @@ public sealed class TelegramBridgeGAgentTests
             Services = CreateAgentServices(),
         };
 
-        var request = new ChatRequestEvent
-        {
-            Prompt = "wait-collect-all",
-            SessionId = "session-wait-collect-all",
-        };
-        request.Headers["chat_id"] = "10001";
-        request.Headers["operation"] = "/waitReply";
-        request.Headers["expected_from_username"] = "openclaw_bot";
-        request.Headers["wait_timeout_ms"] = "5000";
-        request.Headers["poll_timeout_sec"] = "1";
-        request.Headers["start_from_latest"] = "true";
-        request.Headers["collect_all_replies"] = "true";
-        request.Headers["settle_polls_after_match"] = "2";
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-wait-collect-all",
+            expectedUsername: "openclaw_bot");
+        command.StartFromLatest = true;
+        command.CollectAllReplies = true;
+        command.SettlePollsAfterMatch = 2;
 
-        await agent.HandleEventAsync(Envelope(request), CancellationToken.None);
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
 
-        var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
-        textEnd.SessionId.Should().Be("session-wait-collect-all");
-        textEnd.Content.Should().Be("openclaw-reply-part-1\n\n---\n\nopenclaw-reply-part-2-final");
+        var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
+        completed.SessionId.Should().Be("session-wait-collect-all");
+        completed.Content.Should().Be("openclaw-reply-part-1\n\n---\n\nopenclaw-reply-part-2-final");
     }
 
     [Fact]
-    public async Task HandleChatRequest_WhenWaitReplyMatchAppearsInBootstrapBatch_ShouldReturnImmediately()
+    public async Task TelegramWaitReplyGAgent_WhenWaitReplyMatchAppearsInBootstrapBatch_ShouldReturnImmediately()
     {
         var connector = new RecordingConnector(
             new ConnectorResponse
@@ -352,7 +355,7 @@ public sealed class TelegramBridgeGAgentTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
         var publisher = new RecordingEventPublisher();
-        var agent = new TelegramBridgeGAgent(
+        var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
             registry)
         {
@@ -360,31 +363,24 @@ public sealed class TelegramBridgeGAgentTests
             Services = CreateAgentServices(),
         };
 
-        var request = new ChatRequestEvent
-        {
-            Prompt = "wait-bootstrap",
-            SessionId = "session-wait-bootstrap",
-        };
-        request.Headers["chat_id"] = "10001";
-        request.Headers["operation"] = "/waitReply";
-        request.Headers["expected_from_username"] = "openclaw_bot";
-        request.Headers["correlation_contains"] = "[AEVATAR_STREAM_REPLY]";
-        request.Headers["wait_timeout_ms"] = "5000";
-        request.Headers["poll_timeout_sec"] = "1";
-        request.Headers["start_from_latest"] = "true";
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-wait-bootstrap",
+            expectedUsername: "openclaw_bot",
+            correlationContains: "[AEVATAR_STREAM_REPLY]");
+        command.StartFromLatest = true;
 
-        await agent.HandleEventAsync(Envelope(request), CancellationToken.None);
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
 
         connector.Received.Should().ContainSingle();
         connector.Received[0].Operation.Should().Be("/getUpdates");
 
-        var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
-        textEnd.SessionId.Should().Be("session-wait-bootstrap");
-        textEnd.Content.Should().Be("[AEVATAR_STREAM_REPLY] bootstrap-reply");
+        var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
+        completed.SessionId.Should().Be("session-wait-bootstrap");
+        completed.Content.Should().Be("[AEVATAR_STREAM_REPLY] bootstrap-reply");
     }
 
     [Fact]
-    public async Task HandleChatRequest_WhenWaitReplyUsernameMissing_ShouldFallbackToCorrelationMatch()
+    public async Task TelegramWaitReplyGAgent_WhenWaitReplyUsernameMissing_ShouldFallbackToCorrelationMatch()
     {
         var connector = new RecordingConnector(
             new ConnectorResponse
@@ -396,7 +392,7 @@ public sealed class TelegramBridgeGAgentTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
         var publisher = new RecordingEventPublisher();
-        var agent = new TelegramBridgeGAgent(
+        var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
             registry)
         {
@@ -404,24 +400,17 @@ public sealed class TelegramBridgeGAgentTests
             Services = CreateAgentServices(),
         };
 
-        var request = new ChatRequestEvent
-        {
-            Prompt = "wait-username-missing",
-            SessionId = "session-wait-username-missing",
-        };
-        request.Headers["chat_id"] = "10001";
-        request.Headers["operation"] = "/waitReply";
-        request.Headers["expected_from_username"] = "openclaw_bot";
-        request.Headers["correlation_contains"] = "[AEVATAR_STREAM_REPLY]";
-        request.Headers["wait_timeout_ms"] = "5000";
-        request.Headers["poll_timeout_sec"] = "1";
-        request.Headers["start_from_latest"] = "true";
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-wait-username-missing",
+            expectedUsername: "openclaw_bot",
+            correlationContains: "[AEVATAR_STREAM_REPLY]");
+        command.StartFromLatest = true;
 
-        await agent.HandleEventAsync(Envelope(request), CancellationToken.None);
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
 
-        var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
-        textEnd.SessionId.Should().Be("session-wait-username-missing");
-        textEnd.Content.Should().Be("[AEVATAR_STREAM_REPLY] no-username-reply");
+        var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
+        completed.SessionId.Should().Be("session-wait-username-missing");
+        completed.Content.Should().Be("[AEVATAR_STREAM_REPLY] no-username-reply");
     }
 
     [Fact]
@@ -507,6 +496,29 @@ public sealed class TelegramBridgeGAgentTests
         };
     }
 
+    private static TelegramWaitForReplyCommand BuildWaitReplyCommand(
+        string sessionId,
+        string expectedUsername,
+        string correlationContains = "")
+    {
+        var command = new TelegramWaitForReplyCommand
+        {
+            CommandId = $"cmd-{sessionId}",
+            SessionId = sessionId,
+            ConnectorName = "telegram",
+            ExpectedChatId = "10001",
+            ExpectedFromUsername = expectedUsername,
+            CorrelationContains = correlationContains,
+            WaitTimeoutMs = 5000,
+            PollTimeoutSeconds = 1,
+            SettlePollsAfterMatch = 1,
+            StartFromLatest = false,
+        };
+        command.ConnectorParameters["method"] = "POST";
+        command.ConnectorParameters["content_type"] = "application/json";
+        return command;
+    }
+
     private sealed class RecordingConnector : IConnector
     {
         private readonly IReadOnlyList<ConnectorResponse> _responses;
@@ -574,6 +586,7 @@ public sealed class TelegramBridgeGAgentTests
     private sealed class RecordingEventPublisher : IEventPublisher
     {
         public List<(IMessage evt, TopologyAudience direction)> Published { get; } = [];
+        public List<(string targetActorId, IMessage evt)> Sent { get; } = [];
 
         public Task PublishAsync<TEvent>(
             TEvent evt,
@@ -594,8 +607,14 @@ public sealed class TelegramBridgeGAgentTests
             CancellationToken ct = default,
             EventEnvelope? sourceEnvelope = null,
             EventEnvelopePublishOptions? options = null)
-            where TEvent : IMessage =>
-            Task.CompletedTask;
+            where TEvent : IMessage
+        {
+            _ = ct;
+            _ = sourceEnvelope;
+            _ = options;
+            Sent.Add((targetActorId, evt));
+            return Task.CompletedTask;
+        }
     }
 
     private static IServiceProvider CreateAgentServices()
@@ -634,12 +653,18 @@ public sealed class TelegramBridgeGAgentTests
 
     private sealed class NoopActorRuntime : IActorRuntime
     {
+        public List<System.Type> CreatedActorTypes { get; } = [];
+
         public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
             where TAgent : IAgent =>
-            Task.FromResult<IActor>(new NoopActor(id ?? Guid.NewGuid().ToString("N")));
+            CreateAsync(typeof(TAgent), id, ct);
 
-        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
-            Task.FromResult<IActor>(new NoopActor(id ?? Guid.NewGuid().ToString("N")));
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default)
+        {
+            _ = ct;
+            CreatedActorTypes.Add(agentType);
+            return Task.FromResult<IActor>(new NoopActor(id ?? Guid.NewGuid().ToString("N")));
+        }
 
         public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
         public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(null);

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Workflow.Extensions.Bridge;
 using FluentAssertions;
 using Google.Protobuf;
@@ -230,6 +231,8 @@ public sealed class TelegramBridgeGAgentTests
             new NoopActorRuntime(),
             registry)
         {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
             Services = CreateAgentServices(),
         };
@@ -241,7 +244,12 @@ public sealed class TelegramBridgeGAgentTests
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
 
-        connector.Received.Count.Should().BeGreaterThanOrEqualTo(4);
+        connector.Received.Should().BeEmpty();
+        publisher.Sent.Select(x => x.evt).Should().ContainSingle(x => x is TelegramWaitReplyBootstrapDueEvent);
+
+        await DrainWaitReplySelfEventsAsync(agent, publisher);
+
+        connector.Received.Count.Should().Be(4);
         connector.Received.Should().OnlyContain(x => x.Operation == "/getUpdates");
 
         var secondPayload = JsonDocument.Parse(connector.Received[1].Payload).RootElement;
@@ -324,6 +332,8 @@ public sealed class TelegramBridgeGAgentTests
             new NoopActorRuntime(),
             registry)
         {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
             Services = CreateAgentServices(),
         };
@@ -336,6 +346,7 @@ public sealed class TelegramBridgeGAgentTests
         command.SettlePollsAfterMatch = 2;
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher);
 
         var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
         completed.SessionId.Should().Be("session-wait-collect-all");
@@ -359,6 +370,8 @@ public sealed class TelegramBridgeGAgentTests
             new NoopActorRuntime(),
             registry)
         {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
             Services = CreateAgentServices(),
         };
@@ -370,6 +383,9 @@ public sealed class TelegramBridgeGAgentTests
         command.StartFromLatest = true;
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
+        connector.Received.Should().BeEmpty();
+
+        await DrainWaitReplySelfEventsAsync(agent, publisher);
 
         connector.Received.Should().ContainSingle();
         connector.Received[0].Operation.Should().Be("/getUpdates");
@@ -396,6 +412,8 @@ public sealed class TelegramBridgeGAgentTests
             new NoopActorRuntime(),
             registry)
         {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
             Services = CreateAgentServices(),
         };
@@ -407,10 +425,72 @@ public sealed class TelegramBridgeGAgentTests
         command.StartFromLatest = true;
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher);
 
         var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
         completed.SessionId.Should().Be("session-wait-username-missing");
         completed.Content.Should().Be("[AEVATAR_STREAM_REPLY] no-username-reply");
+    }
+
+    [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenConnectorReturnsOkFalse_ShouldPublishFailedEvent()
+    {
+        var connector = new RecordingConnector(new ConnectorResponse
+        {
+            Success = true,
+            Output = """{"ok":false,"description":"telegram denied getUpdates"}""",
+        });
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var agent = new TelegramWaitReplyGAgent(
+            new NoopActorRuntime(),
+            registry)
+        {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
+            EventPublisher = publisher,
+            Services = CreateAgentServices(),
+        };
+
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-wait-failed",
+            expectedUsername: "openclaw_bot");
+
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher);
+
+        var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
+        failed.SessionId.Should().Be("session-wait-failed");
+        failed.CommandId.Should().Be("cmd-session-wait-failed");
+        failed.Error.Should().Be("telegram getUpdates parse failed: telegram denied getUpdates");
+        failed.WaitActorId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task TelegramBridgeGAgent_WhenWaitReplyFailed_ShouldPublishFailureMarker()
+    {
+        var publisher = new RecordingEventPublisher();
+        var agent = new TelegramBridgeGAgent(
+            new NoopActorRuntime(),
+            new InMemoryConnectorRegistry())
+        {
+            EventPublisher = publisher,
+            Services = CreateAgentServices(),
+        };
+
+        await agent.HandleEventAsync(
+            Envelope(new TelegramWaitReplyFailedEvent
+            {
+                SessionId = "session-wait-failed",
+                Error = "telegram denied getUpdates",
+            }),
+            CancellationToken.None);
+
+        var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
+        textEnd.SessionId.Should().Be("session-wait-failed");
+        textEnd.Content.Should().StartWith("[[AEVATAR_LLM_ERROR]]");
+        textEnd.Content.Should().Contain("telegram denied getUpdates");
     }
 
     [Fact]
@@ -494,6 +574,27 @@ public sealed class TelegramBridgeGAgentTests
             Payload = Any.Pack(evt),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication("test", TopologyAudience.Self),
         };
+    }
+
+    private static async Task DrainWaitReplySelfEventsAsync(
+        TelegramWaitReplyGAgent agent,
+        RecordingEventPublisher publisher,
+        int maxTurns = 16)
+    {
+        for (var i = 0; i < maxTurns; i++)
+        {
+            var nextIndex = publisher.Sent.FindIndex(x =>
+                x.targetActorId == agent.Id &&
+                x.evt is TelegramWaitReplyBootstrapDueEvent or TelegramWaitReplyPollDueEvent or TelegramWaitReplyTimeoutDueEvent);
+            if (nextIndex < 0)
+                return;
+
+            var next = publisher.Sent[nextIndex];
+            publisher.Sent.RemoveAt(nextIndex);
+            await agent.HandleEventAsync(Envelope(next.evt), CancellationToken.None);
+        }
+
+        throw new InvalidOperationException("wait-reply self event drain exceeded max turns");
     }
 
     private static TelegramWaitForReplyCommand BuildWaitReplyCommand(
@@ -614,6 +715,76 @@ public sealed class TelegramBridgeGAgentTests
             _ = options;
             Sent.Add((targetActorId, evt));
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingEventSourcing<TState>(Func<TState, IMessage, TState> transition)
+        : IEventSourcingBehavior<TState>
+        where TState : class, IMessage<TState>, new()
+    {
+        private readonly List<IMessage> _pending = [];
+
+        public long CurrentVersion { get; private set; }
+
+        public void RaiseEvent<TEvent>(TEvent evt) where TEvent : IMessage
+        {
+            _pending.Add(evt);
+        }
+
+        public Task<EventStoreCommitResult> ConfirmEventsAsync(CancellationToken ct = default)
+        {
+            CurrentVersion += _pending.Count;
+            _pending.Clear();
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = "test-agent",
+                LatestVersion = CurrentVersion,
+            });
+        }
+
+        public Task PersistSnapshotAsync(TState currentState, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task<TState?> ReplayAsync(string agentId, CancellationToken ct = default) =>
+            Task.FromResult<TState?>(null);
+
+        public void DiscardPendingEvents()
+        {
+            _pending.Clear();
+        }
+
+        public TState TransitionState(TState current, IMessage evt) => transition(current, evt);
+    }
+
+    private static class TelegramWaitReplyStateTransitions
+    {
+        public static TelegramWaitReplyState Apply(TelegramWaitReplyState current, IMessage evt)
+        {
+            return evt switch
+            {
+                TelegramWaitReplyStartedEvent started => started.State.Clone(),
+                TelegramWaitReplyProgressedEvent progressed => progressed.State.Clone(),
+                TelegramWaitReplyClearedEvent cleared => ApplyCleared(current, cleared),
+                _ => current,
+            };
+        }
+
+        private static TelegramWaitReplyState ApplyCleared(
+            TelegramWaitReplyState current,
+            TelegramWaitReplyClearedEvent cleared)
+        {
+            if (!string.Equals(current.CommandId, cleared.CommandId, StringComparison.Ordinal) ||
+                current.Generation != cleared.Generation)
+            {
+                return current;
+            }
+
+            var next = current.Clone();
+            next.Active = false;
+            next.PendingMatchedUpdate = null;
+            next.CollectedReplies.Clear();
+            next.CollectedReplyOrder.Clear();
+            return next;
         }
     }
 


### PR DESCRIPTION
## Summary / 摘要

### English

iter25 cluster-027-telegram-wait-reply-actor-turn (high, CLAUDE.md §"Actor 即业务实体" §"Actor 生命周期").

- **Old**: `TelegramBridgeGAgent` owned wait state in an in-process dict; bridge inline orchestrated wait + reply lifecycle.
- **New**: New task-scoped `TelegramWaitReplyGAgent` owns wait state per request; bridge dispatches `TelegramWaitForReplyCommand` + resumes via typed `TelegramWaitReplyCompletedEvent` / `TelegramWaitReplyFailedEvent`(consistent with lark stream actor architecture)。

Per #777 maintainer directive "跟 lark 架构上统一. 最顶层 actor 持有 stream 模式的统一"。

### 中文

iter25 cluster-027-telegram-wait-reply-actor-turn(高严重度,CLAUDE.md §"Actor 即业务实体" §"Actor 生命周期")。

- **Old**:`TelegramBridgeGAgent` 在 in-process dict 持 wait state;bridge 内联编排 wait + reply lifecycle。
- **New**:新 task-scoped `TelegramWaitReplyGAgent` per request 持 wait state;bridge 发 `TelegramWaitForReplyCommand` + resume via typed `TelegramWaitReplyCompletedEvent` / `TelegramWaitReplyFailedEvent`(与 lark stream actor 架构一致)。

违反:"Actor 即业务实体" + 顶层 actor 持有 stream 模式统一。

## Scope

5 files changed(新 proto + 新 actor + bridge 改 + tests)。Architecture guards green;build pass;test pass。

See [Phase 9 r2 structural solver framing](./.refactor-loop/runs/phase9-issue777-r2-structural.md), [implement summary](./.refactor-loop/runs/implement-iter25-cluster-027.md).

## Stacked-PR

iter25 batch 1. Base = `auto-refact-dev`. Rollup target = `dev`.

Closes #777.

🤖 Auto-loop / codex-refactor-loop iter25

⟦AI:AUTO-LOOP⟧
