### PR TITLE
iter26 cluster-026: responses route user catalog cache cleanup

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -92,7 +92,10 @@ public static class MainnetHostBuilderExtensions
         builder.Services.AddScheduledAgents(builder.Configuration);
         builder.Services.TryAddSingleton<IResponsesCallerScopeResolver, NyxIdResponsesCallerScopeResolver>();
         builder.Services.TryAddSingleton<IResponsesModelsAggregator, NyxIdResponsesModelsAggregator>();
-        builder.Services.TryAddSingleton<IResponsesRouteResolver, CachingResponsesRouteResolver>();
+        // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):
+        //   Old pattern: Responses/Messages routes resolve `vendor/model` by reading a singleton per-bearer in-process cache of NyxID user LLM service catalog facts.
+        //   New principle: Resolve model route from the current catalog read in the request flow; do not store user route facts in singleton process memory.
+        builder.Services.TryAddSingleton<IResponsesRouteResolver, ResponsesRouteResolver>();
         builder.Services.Configure<ResponsesModelMetadataFallbackOptions>(options =>
         {
             // Bind a flat slug-or-slug/model → fallback dictionary from

--- a/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
@@ -123,6 +123,9 @@ internal static class MessagesApiEndpoints
             logger,
             ct);
 
+        // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):
+        //   Old pattern: Responses/Messages routes resolve `vendor/model` by reading a singleton per-bearer in-process cache of NyxID user LLM service catalog facts.
+        //   New principle: Resolve model route from the current catalog read in the request flow; do not store user route facts in singleton process memory.
         // OpenRouter-style vendor prefix routing (same as Path A). If the
         // model is `vendor/name`, resolve the route value through the catalog;
         // unknown slugs fall through to gateway default.

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -155,6 +155,9 @@ internal static class ResponsesApiEndpoints
             toolProviderContext,
             logger,
             ct);
+        // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):
+        //   Old pattern: Responses/Messages routes resolve `vendor/model` by reading a singleton per-bearer in-process cache of NyxID user LLM service catalog facts.
+        //   New principle: Resolve model route from the current catalog read in the request flow; do not store user route facts in singleton process memory.
         // OpenRouter-style vendor prefix: the catalog advertises every model as
         // `{slug}/{model}` regardless of route shape (gateway provider, user
         // service, proxy service). When the slug resolves to a known catalog

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesRouteResolver.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesRouteResolver.cs
@@ -1,6 +1,3 @@
-using System.Collections.Concurrent;
-using System.Security.Cryptography;
-using System.Text;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Microsoft.Extensions.Logging;
 
@@ -20,27 +17,20 @@ internal interface IResponsesRouteResolver
         CancellationToken ct);
 }
 
-internal sealed class CachingResponsesRouteResolver : IResponsesRouteResolver
+internal sealed class ResponsesRouteResolver : IResponsesRouteResolver
 {
-    /// <summary>Catalog HTTP fetches are expensive (2 NyxID round-trips). Cache per caller
-    /// (bearer-keyed because the catalog is per-user-filtered) with a short TTL so revocations
-    /// and new service bindings surface within a few minutes. Bearer is hashed before keying
-    /// to keep raw tokens out of in-memory state.</summary>
-    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
-
+    // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):
+    //   Old pattern: Responses/Messages routes resolve `vendor/model` by reading a singleton per-bearer in-process cache of NyxID user LLM service catalog facts.
+    //   New principle: Resolve model route from the current catalog read in the request flow; do not store user route facts in singleton process memory.
     private readonly IUserLlmCatalogPort _catalog;
-    private readonly ILogger<CachingResponsesRouteResolver> _logger;
-    private readonly TimeProvider _timeProvider;
-    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
+    private readonly ILogger<ResponsesRouteResolver> _logger;
 
-    public CachingResponsesRouteResolver(
+    public ResponsesRouteResolver(
         IUserLlmCatalogPort catalog,
-        ILogger<CachingResponsesRouteResolver> logger,
-        TimeProvider? timeProvider = null)
+        ILogger<ResponsesRouteResolver> logger)
     {
         _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     public async Task<string?> ResolveRouteValueAsync(
@@ -52,19 +42,14 @@ internal sealed class CachingResponsesRouteResolver : IResponsesRouteResolver
         ArgumentException.ThrowIfNullOrWhiteSpace(bearerToken);
 
         var normalizedSlug = slug.Trim();
-        var routes = await GetRoutesAsync(bearerToken, ct).ConfigureAwait(false);
+        var routes = await ReadCurrentRoutesAsync(bearerToken, ct).ConfigureAwait(false);
         return routes.TryGetValue(normalizedSlug, out var routeValue) ? routeValue : null;
     }
 
-    private async Task<IReadOnlyDictionary<string, string>> GetRoutesAsync(
+    private async Task<IReadOnlyDictionary<string, string>> ReadCurrentRoutesAsync(
         string bearerToken,
         CancellationToken ct)
     {
-        var key = HashBearer(bearerToken);
-        var now = _timeProvider.GetUtcNow();
-        if (_cache.TryGetValue(key, out var cached) && cached.ExpiresAt > now)
-            return cached.Routes;
-
         NyxIdLlmServicesResult result;
         try
         {
@@ -80,9 +65,7 @@ internal sealed class CachingResponsesRouteResolver : IResponsesRouteResolver
             return EmptyRoutes;
         }
 
-        var routes = BuildRouteMap(result);
-        _cache[key] = new CacheEntry(routes, now + CacheTtl);
-        return routes;
+        return BuildRouteMap(result);
     }
 
     private static Dictionary<string, string> BuildRouteMap(NyxIdLlmServicesResult result)
@@ -106,16 +89,6 @@ internal sealed class CachingResponsesRouteResolver : IResponsesRouteResolver
         return routes;
     }
 
-    private static string HashBearer(string bearerToken)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(bearerToken));
-        return Convert.ToHexString(bytes);
-    }
-
     private static readonly IReadOnlyDictionary<string, string> EmptyRoutes =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-    private readonly record struct CacheEntry(
-        IReadOnlyDictionary<string, string> Routes,
-        DateTimeOffset ExpiresAt);
 }

--- a/test/Aevatar.Hosting.Tests/CachingResponsesRouteResolverTests.cs
+++ b/test/Aevatar.Hosting.Tests/CachingResponsesRouteResolverTests.cs
@@ -2,11 +2,10 @@ using Aevatar.Mainnet.Host.Api.Responses;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Time.Testing;
 
 namespace Aevatar.Hosting.Tests;
 
-public sealed class CachingResponsesRouteResolverTests
+public sealed class ResponsesRouteResolverTests
 {
     [Fact]
     public async Task ResolveRouteValueAsync_ShouldReturnSlugRouteValue_FromCatalog()
@@ -16,7 +15,7 @@ public sealed class CachingResponsesRouteResolverTests
             MakeService("anthropic", "/api/v1/llm/anthropic/v1", allowed: true),
             MakeService("chrono-llm", "/api/v1/proxy/s/chrono-llm", allowed: true),
         ], null));
-        var resolver = new CachingResponsesRouteResolver(catalog, NullLogger<CachingResponsesRouteResolver>.Instance);
+        var resolver = new ResponsesRouteResolver(catalog, NullLogger<ResponsesRouteResolver>.Instance);
 
         (await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None))
             .Should().Be("/api/v1/llm/anthropic/v1");
@@ -31,7 +30,7 @@ public sealed class CachingResponsesRouteResolverTests
         [
             MakeService("anthropic", "/api/v1/llm/anthropic/v1", allowed: true),
         ], null));
-        var resolver = new CachingResponsesRouteResolver(catalog, NullLogger<CachingResponsesRouteResolver>.Instance);
+        var resolver = new ResponsesRouteResolver(catalog, NullLogger<ResponsesRouteResolver>.Instance);
 
         (await resolver.ResolveRouteValueAsync("mistralai", "bearer-1", CancellationToken.None))
             .Should().BeNull();
@@ -50,52 +49,50 @@ public sealed class CachingResponsesRouteResolverTests
         [
             MakeService("chrono-llm", "/api/v1/proxy/s/chrono-llm", allowed: false),
         ], null));
-        var resolver = new CachingResponsesRouteResolver(catalog, NullLogger<CachingResponsesRouteResolver>.Instance);
+        var resolver = new ResponsesRouteResolver(catalog, NullLogger<ResponsesRouteResolver>.Instance);
 
         (await resolver.ResolveRouteValueAsync("chrono-llm", "bearer-1", CancellationToken.None))
             .Should().Be("/api/v1/proxy/s/chrono-llm");
     }
 
     [Fact]
-    public async Task ResolveRouteValueAsync_ShouldHitCacheWithinTtlAndRefetchAfter()
+    public async Task ResolveRouteValueAsync_ShouldReadCurrentCatalogOnEachCall()
     {
-        // Catalog HTTP fetches are expensive (~2 NyxID round-trips); the resolver
-        // sits on the /v1/responses hot path. Cache must keep repeated lookups
-        // for the same bearer in-memory, and naturally refresh after the TTL.
-        var catalog = new RecordingCatalogPort(new NyxIdLlmServicesResult(
+        // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):
+        //   Old pattern: Responses/Messages routes resolve `vendor/model` by reading a singleton per-bearer in-process cache of NyxID user LLM service catalog facts.
+        //   New principle: Resolve model route from the current catalog read in the request flow; do not store user route facts in singleton process memory.
+        var catalog = new MutableCatalogPort(new NyxIdLlmServicesResult(
         [
             MakeService("anthropic", "/api/v1/llm/anthropic/v1", allowed: true),
         ], null));
-        var time = new FakeTimeProvider(DateTimeOffset.UtcNow);
-        var resolver = new CachingResponsesRouteResolver(
-            catalog,
-            NullLogger<CachingResponsesRouteResolver>.Instance,
-            time);
+        var resolver = new ResponsesRouteResolver(catalog, NullLogger<ResponsesRouteResolver>.Instance);
 
-        await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None);
-        await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None);
-        catalog.FetchCount.Should().Be(1, "second lookup within TTL is a cache hit");
+        (await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None))
+            .Should().Be("/api/v1/llm/anthropic/v1");
 
-        time.Advance(TimeSpan.FromMinutes(6));
-        await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None);
-        catalog.FetchCount.Should().Be(2, "TTL has passed → refetch");
+        catalog.Result = new NyxIdLlmServicesResult(
+        [
+            MakeService("anthropic", "/api/v1/llm/anthropic/v2", allowed: true),
+        ], null);
+
+        (await resolver.ResolveRouteValueAsync("anthropic", "bearer-1", CancellationToken.None))
+            .Should().Be("/api/v1/llm/anthropic/v2");
+        catalog.FetchCount.Should().Be(2, "route facts are read from the current request catalog, not singleton memory");
     }
 
     [Fact]
-    public async Task ResolveRouteValueAsync_ShouldKeepPerBearerCacheSeparate()
+    public async Task ResolveRouteValueAsync_ShouldReadCatalogForEachBearer()
     {
-        // Different bearers can see different services (per-user proxy connections).
-        // Cache must key by bearer hash so user A's view doesn't leak to user B.
         var catalog = new RecordingCatalogPort(new NyxIdLlmServicesResult(
         [
             MakeService("anthropic", "/api/v1/llm/anthropic/v1", allowed: true),
         ], null));
-        var resolver = new CachingResponsesRouteResolver(catalog, NullLogger<CachingResponsesRouteResolver>.Instance);
+        var resolver = new ResponsesRouteResolver(catalog, NullLogger<ResponsesRouteResolver>.Instance);
 
         await resolver.ResolveRouteValueAsync("anthropic", "bearer-A", CancellationToken.None);
         await resolver.ResolveRouteValueAsync("anthropic", "bearer-B", CancellationToken.None);
 
-        catalog.FetchCount.Should().Be(2, "distinct bearers must each warm their own cache slot");
+        catalog.FetchCount.Should().Be(2, "each request bearer is resolved against its current catalog");
     }
 
     private static NyxIdLlmService MakeService(string slug, string routeValue, bool allowed) =>
@@ -122,6 +119,23 @@ public sealed class CachingResponsesRouteResolverTests
         {
             FetchCount++;
             return Task.FromResult(_result);
+        }
+
+        public Task<NyxIdLlmService> ProvisionAsync(string bearerToken, string provisionEndpointId, CancellationToken ct) =>
+            throw new NotSupportedException("Provision not used by route resolver.");
+    }
+
+    private sealed class MutableCatalogPort : IUserLlmCatalogPort
+    {
+        public int FetchCount { get; private set; }
+        public NyxIdLlmServicesResult Result { get; set; }
+
+        public MutableCatalogPort(NyxIdLlmServicesResult result) => Result = result;
+
+        public Task<NyxIdLlmServicesResult> GetServicesAsync(string bearerToken, CancellationToken ct)
+        {
+            FetchCount++;
+            return Task.FromResult(Result);
         }
 
         public Task<NyxIdLlmService> ProvisionAsync(string bearerToken, string provisionEndpointId, CancellationToken ct) =>


### PR DESCRIPTION
## Summary / 摘要

### English
iter26 cluster-026-responses-route-user-catalog-cache (medium, CLAUDE.md §"事实源唯一" §"中间层状态约束").

### 中文
iter26 cluster-026 — responses route 内的 user catalog 缓存清理。

详见 [audit cluster](./.refactor-loop/runs/audit-iter-26.md#cluster-026), [implement summary](./.refactor-loop/runs/implement-iter26-cluster-026.md).

## Stacked-PR

iter26 batch 1. Base = `auto-refact-dev`. Rollup target = `dev`.

🤖 Auto-loop / codex-refactor-loop iter26

⟦AI:AUTO-LOOP⟧
