### PR TITLE
iter27 cluster-029: delete raw script-facing actor lifecycle API

### DIFF
--- a/docs/canon/scripting.md
+++ b/docs/canon/scripting.md
@@ -58,7 +58,9 @@ owner: eanzhao
 
 1. `IScriptBehaviorRuntimeCapabilities` 不再暴露 `GetReadModelSnapshotAsync(...)` 这类跨 actor readmodel 侧读能力。
 2. scripting behavior 在 actor turn 内只能发布消息、调度 self continuation、调用 AI/definition/provisioning/evolution 等显式应用端口。
-3. 读取其他 actor 的已提交事实必须回到正式 query/readmodel 入口，不能通过 runtime capability 在脚本内部侧读。
+3. `IScriptBehaviorRuntimeCapabilities` 不暴露 raw actor lifecycle/topology 能力：脚本不能用 assembly-qualified type name 和调用方提供的 actor id 直接 create/destroy/link/unlink actor。
+4. 需要定义、provision runtime、执行 runtime、catalog promotion/rollback 时，只能使用现有 typed scripting ports；普通业务交互使用 `PublishAsync` / `SendToAsync` / self durable signal。
+5. 读取其他 actor 的已提交事实必须回到正式 query/readmodel 入口，不能通过 runtime capability 在脚本内部侧读。
 
 当前 runtime semantics 也已经明确收紧：
 

--- a/src/Aevatar.Scripting.Abstractions/Behaviors/IScriptBehaviorRuntimeCapabilities.cs
+++ b/src/Aevatar.Scripting.Abstractions/Behaviors/IScriptBehaviorRuntimeCapabilities.cs
@@ -5,6 +5,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Scripting.Abstractions.Behaviors;
 
+// Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
+//   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
+//   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
 public interface IScriptBehaviorRuntimeCapabilities
 {
     Task<string> AskAIAsync(string prompt, CancellationToken ct);
@@ -22,14 +25,6 @@ public interface IScriptBehaviorRuntimeCapabilities
         CancellationToken ct);
 
     Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct);
-
-    Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct);
-
-    Task DestroyAgentAsync(string actorId, CancellationToken ct);
-
-    Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct);
-
-    Task UnlinkAgentAsync(string childActorId, CancellationToken ct);
 
     Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct);
 

--- a/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilities.cs
+++ b/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilities.cs
@@ -10,6 +10,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Scripting.Application.Runtime;
 
+// Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
+//   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
+//   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
 public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCapabilities
 {
     private readonly Func<IMessage, TopologyAudience, CancellationToken, Task> _publishAsync;
@@ -18,7 +21,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
     private readonly Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> _scheduleSelfSignalAsync;
     private readonly Func<RuntimeCallbackLease, CancellationToken, Task> _cancelCallbackAsync;
     private readonly IAICapability _aiCapability;
-    private readonly IActorRuntime _runtime;
     private readonly IScriptDefinitionSnapshotPort _definitionSnapshotPort;
     private readonly IScriptEvolutionProposalPort _proposalPort;
     private readonly IScriptDefinitionCommandPort _definitionCommandPort;
@@ -43,7 +45,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
         Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> scheduleSelfSignalAsync,
         Func<RuntimeCallbackLease, CancellationToken, Task> cancelCallbackAsync,
         IAICapability aiCapability,
-        IActorRuntime runtime,
         IScriptDefinitionSnapshotPort definitionSnapshotPort,
         IScriptEvolutionProposalPort proposalPort,
         IScriptDefinitionCommandPort definitionCommandPort,
@@ -60,7 +61,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
             scheduleSelfSignalAsync,
             cancelCallbackAsync,
             aiCapability,
-            runtime,
             definitionSnapshotPort,
             proposalPort,
             definitionCommandPort,
@@ -80,7 +80,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
         Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> scheduleSelfSignalAsync,
         Func<RuntimeCallbackLease, CancellationToken, Task> cancelCallbackAsync,
         IAICapability aiCapability,
-        IActorRuntime runtime,
         IScriptDefinitionSnapshotPort definitionSnapshotPort,
         IScriptEvolutionProposalPort proposalPort,
         IScriptDefinitionCommandPort definitionCommandPort,
@@ -97,7 +96,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
         _scheduleSelfSignalAsync = scheduleSelfSignalAsync ?? throw new ArgumentNullException(nameof(scheduleSelfSignalAsync));
         _cancelCallbackAsync = cancelCallbackAsync ?? throw new ArgumentNullException(nameof(cancelCallbackAsync));
         _aiCapability = aiCapability ?? throw new ArgumentNullException(nameof(aiCapability));
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _definitionSnapshotPort = definitionSnapshotPort ?? throw new ArgumentNullException(nameof(definitionSnapshotPort));
         _proposalPort = proposalPort ?? throw new ArgumentNullException(nameof(proposalPort));
         _definitionCommandPort = definitionCommandPort ?? throw new ArgumentNullException(nameof(definitionCommandPort));
@@ -127,26 +125,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
 
     public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) =>
         _cancelCallbackAsync(lease, ct);
-
-    public async Task<string> CreateAgentAsync(
-        string agentTypeAssemblyQualifiedName,
-        string? actorId,
-        CancellationToken ct)
-    {
-        var agentType = System.Type.GetType(agentTypeAssemblyQualifiedName, throwOnError: true)
-            ?? throw new InvalidOperationException($"Agent type `{agentTypeAssemblyQualifiedName}` could not be resolved.");
-        var actor = await _runtime.CreateAsync(agentType, actorId, ct);
-        return actor.Id;
-    }
-
-    public Task DestroyAgentAsync(string actorId, CancellationToken ct) =>
-        _runtime.DestroyAsync(actorId, ct);
-
-    public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) =>
-        _runtime.LinkAsync(parentActorId, childActorId, ct);
-
-    public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) =>
-        _runtime.UnlinkAsync(childActorId, ct);
 
     public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(
         ScriptEvolutionProposal proposal,

--- a/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilityFactory.cs
+++ b/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilityFactory.cs
@@ -9,10 +9,12 @@ using Google.Protobuf;
 
 namespace Aevatar.Scripting.Application.Runtime;
 
+// Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
+//   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
+//   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
 public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRuntimeCapabilityFactory
 {
     private readonly IAICapability _aiCapability;
-    private readonly IActorRuntime _runtime;
     private readonly IScriptDefinitionSnapshotPort _definitionSnapshotPort;
     private readonly IScriptEvolutionProposalPort _proposalPort;
     private readonly IScriptDefinitionCommandPort _definitionCommandPort;
@@ -22,7 +24,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRunt
 
     public ScriptBehaviorRuntimeCapabilityFactory(
         IAICapability aiCapability,
-        IActorRuntime runtime,
         IScriptDefinitionSnapshotPort definitionSnapshotPort,
         IScriptEvolutionProposalPort proposalPort,
         IScriptDefinitionCommandPort definitionCommandPort,
@@ -31,7 +32,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRunt
         IScriptCatalogCommandPort catalogCommandPort)
     {
         _aiCapability = aiCapability ?? throw new ArgumentNullException(nameof(aiCapability));
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _definitionSnapshotPort = definitionSnapshotPort ?? throw new ArgumentNullException(nameof(definitionSnapshotPort));
         _proposalPort = proposalPort ?? throw new ArgumentNullException(nameof(proposalPort));
         _definitionCommandPort = definitionCommandPort ?? throw new ArgumentNullException(nameof(definitionCommandPort));
@@ -60,7 +60,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRunt
             scheduleSelfSignalAsync,
             cancelCallbackAsync,
             _aiCapability,
-            _runtime,
             _definitionSnapshotPort,
             _proposalPort,
             _definitionCommandPort,

--- a/src/Aevatar.Scripting.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Scripting.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,9 @@ using Aevatar.Scripting.Projection.DependencyInjection;
 
 namespace Aevatar.Scripting.Hosting.DependencyInjection;
 
+// Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
+//   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
+//   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
 public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddScriptCapability(

--- a/test/Aevatar.Integration.Tests/ClaimComplexBusinessScenarioTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimComplexBusinessScenarioTests.cs
@@ -35,6 +35,10 @@ public class ClaimComplexBusinessScenarioTests
             var analystActor = await ClaimIntegrationTestKit.CreateFreshSinkActorAsync(runtime, "role-claim-analyst-" + runId);
             var fraudActor = await ClaimIntegrationTestKit.CreateFreshSinkActorAsync(runtime, "fraud-risk-agent-" + runId);
             var complianceActor = await ClaimIntegrationTestKit.CreateFreshSinkActorAsync(runtime, "compliance-rule-agent-" + runId);
+            var manualReviewActorId = "human-review-" + runId;
+            var manualReviewActor = claimCase.ManualReviewRequired
+                ? await ClaimIntegrationTestKit.CreateFreshSinkActorAsync(runtime, manualReviewActorId)
+                : null;
             var runtimeActorId = "claim-complex-runtime-" + claimCase.CaseId.ToLowerInvariant();
             var aiCountBefore = aiCapability.Calls.Count;
 
@@ -104,11 +108,9 @@ public class ClaimComplexBusinessScenarioTests
             ClaimIntegrationTestKit.ReadMessages(fraudActor).Should().ContainSingle(x => x == nameof(ClaimFraudScoringRequested));
             ClaimIntegrationTestKit.ReadMessages(complianceActor).Should().ContainSingle(x => x == nameof(ClaimComplianceCheckRequested));
 
-            var manualReviewActorId = "human-review-" + runId;
             if (claimCase.ManualReviewRequired)
             {
                 (await runtime.ExistsAsync(manualReviewActorId)).Should().BeTrue();
-                var manualReviewActor = await runtime.GetAsync(manualReviewActorId);
                 manualReviewActor.Should().NotBeNull();
                 await ClaimIntegrationTestKit.WaitForMessageAsync(
                     runtime,

--- a/test/Aevatar.Integration.Tests/ClaimOrchestrationIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimOrchestrationIntegrationTests.cs
@@ -68,8 +68,9 @@ public class ClaimOrchestrationIntegrationTests
             nameof(ClaimFraudScoringRequested),
             nameof(ClaimComplianceCheckRequested),
             nameof(ClaimManualReviewRequested));
-        capabilities.CreateCalls.Should().ContainSingle();
-        capabilities.CreateCalls[0].ActorId.Should().Be("human-review-run-claim-b");
+        capabilities.SendCalls.Should().ContainSingle(x =>
+            x.TargetActorId == "human-review-run-claim-b" &&
+            x.MessageType == nameof(ClaimManualReviewRequested));
         emitted.Should().ContainSingle();
         emitted[0].Should().BeOfType<ClaimDecisionRecorded>()
             .Which.Current.DecisionStatus.Should().Be("ManualReview");
@@ -114,7 +115,6 @@ public class ClaimOrchestrationIntegrationTests
                 RuntimeCapabilities: capabilities),
             CancellationToken.None);
 
-        capabilities.CreateCalls.Should().BeEmpty();
         capabilities.SendCalls.Select(static x => x.MessageType).Should().ContainInOrder(
             nameof(ClaimAnalystReviewRequested),
             nameof(ClaimFraudScoringRequested),
@@ -126,7 +126,6 @@ public class ClaimOrchestrationIntegrationTests
     private sealed class RecordingCapabilities(string aiOutput) : IScriptBehaviorRuntimeCapabilities
     {
         public List<(string TargetActorId, string MessageType)> SendCalls { get; } = [];
-        public List<(string AgentType, string? ActorId)> CreateCalls { get; } = [];
 
         public Task<string> AskAIAsync(string prompt, CancellationToken ct)
         {
@@ -152,19 +151,6 @@ public class ClaimOrchestrationIntegrationTests
             Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease("runtime-1", callbackId, 0, Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
 
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-            CreateCalls.Add((agentTypeAssemblyQualifiedName, actorId));
-            return Task.FromResult(actorId ?? "created");
-        }
-
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) => Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) => Task.FromResult(definitionActorId ?? string.Empty);
         public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) => Task.FromResult(runtimeActorId ?? string.Empty);

--- a/test/Aevatar.Integration.Tests/ClaimScriptDocumentDrivenFlexibilityTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimScriptDocumentDrivenFlexibilityTests.cs
@@ -196,12 +196,6 @@ public class ClaimScriptDocumentDrivenFlexibilityTests
             Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease("runtime", callbackId, 0, Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
 
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? "created");
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) => Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) => Task.FromResult(definitionActorId ?? string.Empty);
         public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) => Task.FromResult(runtimeActorId ?? string.Empty);

--- a/test/Aevatar.Integration.Tests/Fixtures/ScriptDocuments/ClaimScriptScenarioDocument.cs
+++ b/test/Aevatar.Integration.Tests/Fixtures/ScriptDocuments/ClaimScriptScenarioDocument.cs
@@ -138,12 +138,8 @@ public sealed class ClaimScriptScenarioDocument
                 {
                     decisionStatus = "ManualReview";
                     manualReviewRequired = true;
-                    var manualReviewActorId = await context.RuntimeCapabilities.CreateAgentAsync(
-                        "Aevatar.Integration.Tests.ClaimMessageSinkGAgent, Aevatar.Integration.Tests",
-                        "human-review-" + context.RunId,
-                        ct);
                     await context.RuntimeCapabilities.SendToAsync(
-                        manualReviewActorId,
+                        "human-review-" + context.RunId,
                         new ClaimManualReviewRequested { CaseId = command.CaseId ?? string.Empty },
                         ct);
                 }

--- a/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationSources.cs
+++ b/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationSources.cs
@@ -232,14 +232,7 @@ internal static class ScriptEvolutionIntegrationSources
                 var workerBV3Source = input.WorkerBV3Source ?? string.Empty;
                 var generatedSource1 = input.GeneratedSource1 ?? string.Empty;
                 var generatedSource2 = input.GeneratedSource2 ?? string.Empty;
-                var runtimeAgentType = input.RuntimeAgentType ?? string.Empty;
-
-                var lifecycleActorId = await context.RuntimeCapabilities.CreateAgentAsync(
-                    runtimeAgentType,
-                    "script-created-runtime-" + context.RunId,
-                    ct);
-                await context.RuntimeCapabilities.LinkAgentsAsync(context.ActorId, lifecycleActorId, ct);
-                await context.RuntimeCapabilities.UnlinkAgentAsync(lifecycleActorId, ct);
+                var lifecycleActorId = "raw-lifecycle-api-deleted-" + context.RunId;
 
                 var tempARuntimeId = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
                     "multi-worker-a-definition",
@@ -411,8 +404,6 @@ internal static class ScriptEvolutionIntegrationSources
                     generatedDefinitionActorId2,
                     "generated.script.2.run",
                     ct);
-
-                await context.RuntimeCapabilities.DestroyAgentAsync(lifecycleActorId, ct);
 
                 context.Emit(new MultiScriptEvolutionCompleted
                 {
@@ -767,18 +758,19 @@ internal static class ScriptEvolutionIntegrationSources
                 ScriptCommandContext<InteractionUpsertState> context,
                 CancellationToken ct)
             {
-                var definitionType = input.DefinitionAgentType ?? string.Empty;
                 var publishSource = input.PublishSource ?? string.Empty;
                 var sendToSource = input.SendtoSource ?? string.Empty;
                 var invokeSource = input.InvokeSource ?? string.Empty;
 
                 var aiResponse = await context.RuntimeCapabilities.AskAIAsync("health-check", ct);
 
-                var publishedDefinitionActorId = await context.RuntimeCapabilities.CreateAgentAsync(
-                    definitionType,
+                var publishedDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                    "interaction-published-script",
+                    "rev-published-1",
+                    publishSource,
+                    ComputeHash(publishSource),
                     "published-definition-" + context.RunId,
                     ct);
-                await context.RuntimeCapabilities.LinkAgentsAsync(context.ActorId, publishedDefinitionActorId, ct);
                 await context.RuntimeCapabilities.PublishAsync(
                     new InteractionPublishSignal
                     {
@@ -786,10 +778,12 @@ internal static class ScriptEvolutionIntegrationSources
                     },
                     TopologyAudience.Children,
                     ct);
-                await context.RuntimeCapabilities.UnlinkAgentAsync(publishedDefinitionActorId, ct);
 
-                var sendToDefinitionActorId = await context.RuntimeCapabilities.CreateAgentAsync(
-                    definitionType,
+                var sendToDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                    "interaction-sendto-script",
+                    "rev-sendto-1",
+                    sendToSource,
+                    ComputeHash(sendToSource),
                     "sendto-definition-" + context.RunId,
                     ct);
                 await context.RuntimeCapabilities.SendToAsync(
@@ -803,19 +797,13 @@ internal static class ScriptEvolutionIntegrationSources
                     },
                     ct);
 
-                var upsertDefinitionActorId = await context.RuntimeCapabilities.CreateAgentAsync(
-                    definitionType,
-                    "upsert-definition-" + context.RunId,
-                    ct);
-                upsertDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var upsertDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "interaction-invoke-script",
                     "rev-invoke-1",
                     invokeSource,
                     ComputeHash(invokeSource),
-                    upsertDefinitionActorId,
+                    "upsert-definition-" + context.RunId,
                     ct);
-
-                _ = publishSource;
 
                 context.Emit(new InteractionUpsertCompleted
                 {

--- a/test/Aevatar.Scripting.Core.Tests/AI/ClaimRoleIntegrationTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/AI/ClaimRoleIntegrationTests.cs
@@ -122,12 +122,6 @@ public class ClaimRoleIntegrationTests
             Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 0, RuntimeCallbackBackend.InMemory));
 
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? "created");
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
 
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(
             ScriptEvolutionProposal proposal,

--- a/test/Aevatar.Scripting.Core.Tests/Behaviors/ScriptBehaviorAbstractionsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Behaviors/ScriptBehaviorAbstractionsTests.cs
@@ -449,12 +449,6 @@ public sealed class ScriptBehaviorAbstractionsTests
         public Task<RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 0, RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Business/ClaimScriptDecisionTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Business/ClaimScriptDecisionTests.cs
@@ -136,12 +136,6 @@ public class ClaimScriptDecisionTests
             Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 0, RuntimeCallbackBackend.InMemory));
 
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? "created");
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
 
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));

--- a/test/Aevatar.Scripting.Core.Tests/Compilation/RoslynScriptExecutionEngineTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Compilation/RoslynScriptExecutionEngineTests.cs
@@ -125,12 +125,6 @@ public sealed class RoslynScriptExecutionEngineTests
         public Task<Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease("runtime-1", callbackId, 0, Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Contract/ScriptDefinitionContractsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Contract/ScriptDefinitionContractsTests.cs
@@ -60,13 +60,6 @@ public sealed class ScriptDefinitionContractsTests
         public Task<Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease("runtime-1", callbackId, 0, Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<Aevatar.Scripting.Abstractions.Queries.ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) =>
-            Task.FromResult<Aevatar.Scripting.Abstractions.Queries.ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Contract/ScriptPackageRuntimeContractTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Contract/ScriptPackageRuntimeContractTests.cs
@@ -239,12 +239,6 @@ public sealed class ScriptPackageRuntimeContractTests
         public Task<Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease("runtime-1", callbackId, 0, Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
@@ -10,35 +10,11 @@ using Aevatar.Scripting.Core.Tests.Messages;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
-using SystemType = System.Type;
 
 namespace Aevatar.Scripting.Core.Tests.Runtime;
 
 public sealed class ScriptAgentLifecycleCapabilitiesTests
 {
-    [Fact]
-    public async Task CreateDestroyLinkAndUnlink_ShouldDelegateToRuntime()
-    {
-        var runtime = new RecordingRuntime();
-        var capabilities = CreateCapabilities(runtime: runtime);
-
-        var actorId = await capabilities.CreateAgentAsync(
-            typeof(FakeTestAgent).AssemblyQualifiedName!,
-            "agent-x",
-            CancellationToken.None);
-        await capabilities.LinkAgentsAsync("parent-1", "child-1", CancellationToken.None);
-        await capabilities.UnlinkAgentAsync("child-1", CancellationToken.None);
-        await capabilities.DestroyAgentAsync("child-1", CancellationToken.None);
-
-        actorId.Should().Be("agent-x");
-        runtime.CreatedType.Should().Be(typeof(FakeTestAgent));
-        runtime.CreatedActorId.Should().Be("agent-x");
-        runtime.LinkedParentId.Should().Be("parent-1");
-        runtime.LinkedChildId.Should().Be("child-1");
-        runtime.UnlinkedChildId.Should().Be("child-1");
-        runtime.DestroyedActorId.Should().Be("child-1");
-    }
-
     [Fact]
     public async Task MessagingAndCallbackApis_ShouldDelegateToInjectedHandlers()
     {
@@ -177,16 +153,6 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
         runtimeCommandPort.RunCalls.Should().ContainSingle(x => x.RunId == "run-1");
         catalogCommandPort.PromoteCalls.Should().ContainSingle(x => x.Revision == "rev-2");
         catalogCommandPort.RollbackCalls.Should().ContainSingle(x => x.TargetRevision == "rev-1");
-    }
-
-    [Fact]
-    public async Task CreateAgentAsync_ShouldThrow_WhenAgentTypeCannotBeResolved()
-    {
-        var capabilities = CreateCapabilities();
-
-        var act = () => capabilities.CreateAgentAsync("Not.A.Real.Type", "agent-x", CancellationToken.None);
-
-        await act.Should().ThrowAsync<TypeLoadException>();
     }
 
     [Fact]
@@ -492,19 +458,18 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     {
         var cases = new (string Name, Func<ScriptBehaviorRuntimeCapabilities> Create)[]
         {
-            ("publishAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", null!, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("sendToAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("publishToSelfAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, null!, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("scheduleSelfSignalAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("cancelCallbackAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), null!, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, null!, new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtime", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), null!, new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionSnapshotPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
-            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
+            ("publishAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", null!, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("sendToAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("publishToSelfAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, null!, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("scheduleSelfSignalAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("cancelCallbackAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), null!, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, null!, new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("definitionSnapshotPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
+            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
         };
 
         foreach (var testCase in cases)
@@ -515,7 +480,6 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     private static ScriptBehaviorRuntimeCapabilities CreateCapabilities(
-        IActorRuntime? runtime = null,
         IAICapability? aiCapability = null,
         IScriptDefinitionSnapshotPort? definitionSnapshotPort = null,
         IScriptEvolutionProposalPort? proposalPort = null,
@@ -539,7 +503,6 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
                 Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory))),
             cancelCallbackAsync: cancelCallbackAsync ?? ((_, _) => Task.CompletedTask),
             aiCapability: aiCapability ?? new RecordingAICapability(),
-            runtime: runtime ?? new RecordingRuntime(),
             definitionSnapshotPort: definitionSnapshotPort ?? new RecordingDefinitionSnapshotPort(),
             proposalPort: proposalPort ?? new RecordingProposalPort(),
             definitionCommandPort: definitionCommandPort ?? new RecordingDefinitionCommandPort(),
@@ -616,61 +579,6 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
         }
 
         private sealed record RecordingLease(string ActorId) : IScriptExecutionProjectionLease;
-    }
-
-    private sealed class RecordingRuntime : IActorRuntime
-    {
-        public SystemType? CreatedType { get; private set; }
-        public string? CreatedActorId { get; private set; }
-        public string? DestroyedActorId { get; private set; }
-        public string? LinkedParentId { get; private set; }
-        public string? LinkedChildId { get; private set; }
-        public string? UnlinkedChildId { get; private set; }
-
-        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default) where TAgent : IAgent =>
-            CreateAsync(typeof(TAgent), id, ct);
-
-        public Task<IActor> CreateAsync(SystemType agentType, string? id = null, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            CreatedType = agentType;
-            CreatedActorId = id ?? string.Empty;
-            return Task.FromResult<IActor>(new FakeActor(id ?? string.Empty, new FakeTestAgent(id ?? string.Empty)));
-        }
-
-        public Task DestroyAsync(string id, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            DestroyedActorId = id;
-            return Task.CompletedTask;
-        }
-
-        public Task<IActor?> GetAsync(string id)
-        {
-            _ = id;
-            return Task.FromResult<IActor?>(null);
-        }
-
-        public Task<bool> ExistsAsync(string id)
-        {
-            _ = id;
-            return Task.FromResult(false);
-        }
-
-        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            LinkedParentId = parentId;
-            LinkedChildId = childId;
-            return Task.CompletedTask;
-        }
-
-        public Task UnlinkAsync(string childId, CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            UnlinkedChildId = childId;
-            return Task.CompletedTask;
-        }
     }
 
     private sealed class RecordingReadModelQueryPort : IScriptReadModelQueryPort
@@ -930,44 +838,4 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
         }
     }
 
-    private sealed class FakeActor(string id, IAgent agent) : IActor
-    {
-        public string Id { get; } = id;
-        public IAgent Agent { get; } = agent;
-
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
-        {
-            _ = envelope;
-            ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
-        }
-
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
-    }
-
-    private sealed class FakeTestAgent(string id) : IAgent
-    {
-        public string Id { get; } = id;
-
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
-        {
-            _ = envelope;
-            ct.ThrowIfCancellationRequested();
-            return Task.CompletedTask;
-        }
-
-        public Task<string> GetDescriptionAsync() => Task.FromResult("fake");
-
-        public Task<IReadOnlyList<SystemType>> GetSubscribedEventTypesAsync() => Task.FromResult<IReadOnlyList<SystemType>>([]);
-    }
 }

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptBehaviorDispatcherTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptBehaviorDispatcherTests.cs
@@ -1103,12 +1103,6 @@ public sealed class ScriptBehaviorDispatcherTests
         public Task<RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 0, RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(
                 false,

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeExecutionOrchestratorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeExecutionOrchestratorTests.cs
@@ -144,12 +144,6 @@ public sealed class ScriptRuntimeExecutionOrchestratorTests
         public Task<RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 0, RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
@@ -618,13 +618,6 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         public Task<RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 0, RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<Aevatar.Scripting.Abstractions.Queries.ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) =>
-            Task.FromResult<Aevatar.Scripting.Abstractions.Queries.ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
@@ -187,12 +187,6 @@ public class ScriptBehaviorGAgentReplayContractTests
         public Task<Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease> ScheduleSelfDurableSignalAsync(string callbackId, TimeSpan dueTime, IMessage eventPayload, CancellationToken ct) =>
             Task.FromResult(new Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease("runtime-1", callbackId, 0, Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
         public Task CancelDurableCallbackAsync(Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
-        public Task<string> CreateAgentAsync(string agentTypeAssemblyQualifiedName, string? actorId, CancellationToken ct) => Task.FromResult(actorId ?? string.Empty);
-        public Task DestroyAgentAsync(string actorId, CancellationToken ct) => Task.CompletedTask;
-        public Task LinkAgentsAsync(string parentActorId, string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task UnlinkAgentAsync(string childActorId, CancellationToken ct) => Task.CompletedTask;
-        public Task<ScriptReadModelSnapshot?> GetReadModelSnapshotAsync(string actorId, CancellationToken ct) => Task.FromResult<ScriptReadModelSnapshot?>(null);
-        public Task<Any?> ExecuteReadModelQueryAsync(string actorId, Any queryPayload, CancellationToken ct) => Task.FromResult<Any?>(null);
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
         public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
@@ -430,7 +430,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactoryTests
         var ai = new RecordingAICapability();
         var factory = new ScriptBehaviorRuntimeCapabilityFactory(
             ai,
-            new RecordingActorRuntime(),
             new RecordingDefinitionSnapshotPort(),
             new RecordingProposalPort(),
             new RecordingDefinitionCommandPort(),
@@ -462,14 +461,13 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactoryTests
     {
         var cases = new (string Name, Func<ScriptBehaviorRuntimeCapabilityFactory> Create)[]
         {
-            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilityFactory(null!, new RecordingActorRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtime", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), null!, new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionSnapshotPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingActorRuntime(), null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingActorRuntime(), new RecordingDefinitionSnapshotPort(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingActorRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingActorRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingActorRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
-            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingActorRuntime(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
+            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilityFactory(null!, new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("definitionSnapshotPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
+            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
         };
 
         foreach (var testCase in cases)


### PR DESCRIPTION
## Summary

iter27 cluster-029 (high, C-SCRIPT-RUNTIME-PORT/C-RUNTIME-DISPATCH-SPLIT/C-ID-SEPARATION/C-LOCAL-DISTRIBUTED)。

- **Old**:`IScriptBehaviorRuntimeCapabilities` 暴露 4 个 raw actor lifecycle 方法(CreateAgentAsync 用 assembly-qualified type name + DestroyAgentAsync/LinkAgentsAsync/UnlinkAgentAsync 按 actorId 操作 actor 拓扑),脚本层拿到底层 actor runtime 控制面而非业务能力。
- **New**:删除 4 个 raw lifecycle 方法,`ScriptBehaviorRuntimeCapabilities/Factory` 不再依赖 `IActorRuntime`;脚本只能通过现有 typed scripting ports(provisioning/command/definition/catalog/evolution)操作。

违反 CLAUDE.md:"Runtime 负责 actor 的 lifecycle/topology/lookup,Dispatch Port 负责消息投递;禁止把创建、查询、投递、观察等职责揉进一个全能接口" + "actorId 对调用方不透明地址:不得解析前缀/类型名/实现来源"。

## Scope

22 files changed (+55/-308 net -253)。388 scripting tests pass, architecture+test_stability+docs lint guards green。

设计共识:[issue #799 r2 judge consensus](https://github.com/aevatarAI/aevatar/issues/799)

🤖 Auto-loop / codex-refactor-loop iter27

⟦AI:AUTO-LOOP⟧
