### PR TITLE
iter26 cluster-030: Telegram /getUpdates actor-owned ExternalLink stream + delete watchdog race

### DIFF
--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/ServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Core.TypeSystem;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.Workflow.Extensions.Bridge;
@@ -8,6 +9,9 @@ public static class ServiceCollectionExtensions
     // Refactor (iter30/cluster-030-workflow-step-raw-actor-lifecycle):
     //   Old pattern: WorkflowStepTargetAgentResolver 用 agent_type/agent_id 通过 Type.GetType + AppDomain scan + IRoleAgentTypeResolver 直接 create/link actors,workflow step parameter 暴露 raw CLR lifecycle
     //   New principle: role-level agent_kind 配合 WorkflowRunGAgent runtime lifecycle;step 只用 target_role;删 agent_type/agent_id raw lifecycle 参数 + IWorkflowAgentTypeAliasProvider;Foundation 加 CreateByKindAsync;Bridge 注册 stable kind token
+    // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+    //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+    //   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
     public static IServiceCollection AddWorkflowBridgeExtensions(this IServiceCollection services)
     {
         services.AddAevatarAgentKindRegistry(builder =>
@@ -16,6 +20,7 @@ public static class ServiceCollectionExtensions
             builder.Register<TelegramUserBridgeGAgent>();
             builder.Register<TelegramWaitReplyGAgent>();
         });
+        services.AddSingleton<IExternalLinkTransportFactory, TelegramGetUpdatesExternalLinkTransportFactory>();
         return services;
     }
 }

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/ServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
     //   New principle: role-level agent_kind 配合 WorkflowRunGAgent runtime lifecycle;step 只用 target_role;删 agent_type/agent_id raw lifecycle 参数 + IWorkflowAgentTypeAliasProvider;Foundation 加 CreateByKindAsync;Bridge 注册 stable kind token
     // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
     //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-    //   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+    //   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
     public static IServiceCollection AddWorkflowBridgeExtensions(this IServiceCollection services)
     {
         services.AddAevatarAgentKindRegistry(builder =>

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramBridgeGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramBridgeGAgent.cs
@@ -21,7 +21,7 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 //   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
 // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
 //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+//   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
 public class TelegramBridgeGAgent : GAgentBase
 {
     private const string LlmFailureContentPrefix = "[[AEVATAR_LLM_ERROR]]";

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramBridgeGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramBridgeGAgent.cs
@@ -19,6 +19,9 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
 //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
 //   New principle: New task-scoped TelegramWaitReplyGAgent owns wait state; bridge sends WaitForReplyCommand and resumes via WaitReplyCompleted/Failed event(reference lark stream actor architecture for unification)
+// Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+//   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
 public class TelegramBridgeGAgent : GAgentBase
 {
     private const string LlmFailureContentPrefix = "[[AEVATAR_LLM_ERROR]]";
@@ -87,10 +90,19 @@ public class TelegramBridgeGAgent : GAgentBase
             Parameters = connectorParameters,
         };
 
-        var response = await ExecuteConnectorWithWatchdogAsync(
-            connector,
-            connectorRequest,
-            ResolveConnectorExecutionWatchdogMs(connectorParameters));
+        ConnectorResponse response;
+        try
+        {
+            response = await connector.ExecuteAsync(connectorRequest, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            response = new ConnectorResponse
+            {
+                Success = false,
+                Error = $"telegram connector execution failed: {ex.Message}",
+            };
+        }
 
         if (!response.Success)
         {
@@ -383,83 +395,6 @@ public class TelegramBridgeGAgent : GAgentBase
         if (!int.TryParse(raw.Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
             return null;
         return parsed > 0 ? parsed : null;
-    }
-
-    internal static int ResolveConnectorExecutionWatchdogMs(IReadOnlyDictionary<string, string> parameters)
-    {
-        if (parameters.TryGetValue("timeout_ms", out var timeoutRaw) &&
-            int.TryParse(timeoutRaw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed) &&
-            parsed > 0)
-        {
-            return Math.Clamp(parsed, 100, 300_000);
-        }
-
-        return 20_000;
-    }
-
-    internal static async Task<ConnectorResponse> ExecuteConnectorWithWatchdogAsync(
-        IConnector connector,
-        ConnectorRequest connectorRequest,
-        int watchdogTimeoutMs)
-    {
-        var timeoutMs = Math.Clamp(watchdogTimeoutMs, 100, 300_000);
-        using var timeoutCts = new CancellationTokenSource();
-
-        Task<ConnectorResponse> executeTask;
-        try
-        {
-            executeTask = connector.ExecuteAsync(connectorRequest, timeoutCts.Token);
-        }
-        catch (Exception ex)
-        {
-            return new ConnectorResponse
-            {
-                Success = false,
-                Error = $"telegram connector execution failed: {ex.Message}",
-            };
-        }
-
-        var timeoutTask = Task.Delay(timeoutMs);
-        var completedTask = await Task.WhenAny(executeTask, timeoutTask);
-        if (completedTask != executeTask)
-        {
-            timeoutCts.Cancel();
-            _ = executeTask.ContinueWith(
-                static completed =>
-                {
-                    _ = completed.Exception;
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted,
-                TaskScheduler.Default);
-            return new ConnectorResponse
-            {
-                Success = false,
-                Error = $"telegram connector watchdog timeout after {timeoutMs}ms",
-            };
-        }
-
-        try
-        {
-            timeoutCts.Cancel();
-            return await executeTask;
-        }
-        catch (OperationCanceledException)
-        {
-            return new ConnectorResponse
-            {
-                Success = false,
-                Error = $"telegram connector execution canceled after {timeoutMs}ms",
-            };
-        }
-        catch (Exception ex)
-        {
-            return new ConnectorResponse
-            {
-                Success = false,
-                Error = $"telegram connector execution failed: {ex.Message}",
-            };
-        }
     }
 
     private static string BuildTelegramPayload(ChatRequestEvent request, string chatId)

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
@@ -1,5 +1,6 @@
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.ExternalLinks;
+using System.Text.Json;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging;
 
@@ -7,7 +8,7 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 
 // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
 //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+//   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
 public sealed class TelegramGetUpdatesExternalLinkTransport(
     IConnectorRegistry connectorRegistry,
     ILogger<TelegramGetUpdatesExternalLinkTransport> logger) : IExternalLinkTransport
@@ -100,15 +101,37 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     private static ConnectorRequest BuildConnectorRequest(TelegramGetUpdatesRequest request)
     {
+        var parameters = new Dictionary<string, string>(request.Parameters, StringComparer.OrdinalIgnoreCase)
+        {
+            ["method"] = string.IsNullOrWhiteSpace(request.HttpMethod) ? "POST" : request.HttpMethod,
+            ["content_type"] = string.IsNullOrWhiteSpace(request.ContentType) ? "application/json" : request.ContentType,
+            ["timeout_ms"] = Math.Max(1, request.PerCallTimeoutMs).ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+
         return new ConnectorRequest
         {
             RunId = request.RunId,
             StepId = request.StepId,
             Connector = request.ConnectorName,
             Operation = "/getUpdates",
-            Payload = request.Payload,
-            Parameters = new Dictionary<string, string>(request.Parameters, StringComparer.OrdinalIgnoreCase),
+            Payload = BuildGetUpdatesPayload(request),
+            Parameters = parameters,
         };
+    }
+
+    private static string BuildGetUpdatesPayload(TelegramGetUpdatesRequest request)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["timeout"] = Math.Max(0, request.PollTimeoutSeconds),
+            ["allowed_updates"] = request.AllowedUpdates.Count > 0
+                ? request.AllowedUpdates.ToArray()
+                : ["message", "channel_post"],
+        };
+        if (request.HasRequestedOffset && request.RequestedOffset >= 0)
+            payload["offset"] = request.RequestedOffset;
+
+        return JsonSerializer.Serialize(payload);
     }
 
     private static TelegramGetUpdatesResult BuildResult(TelegramGetUpdatesRequest request, ConnectorResponse response)
@@ -134,7 +157,7 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
 // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
 //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+//   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
 public sealed class TelegramGetUpdatesExternalLinkTransportFactory(
     IConnectorRegistry connectorRegistry,
     ILogger<TelegramGetUpdatesExternalLinkTransport> logger) : IExternalLinkTransportFactory

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
@@ -1,0 +1,153 @@
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.Workflow.Extensions.Bridge;
+
+// Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+//   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+public sealed class TelegramGetUpdatesExternalLinkTransport(
+    IConnectorRegistry connectorRegistry,
+    ILogger<TelegramGetUpdatesExternalLinkTransport> logger) : IExternalLinkTransport
+{
+    public const string TransportTypeName = "telegram-get-updates";
+
+    public string TransportType => TransportTypeName;
+
+    public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { private get; set; }
+    public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { private get; set; }
+
+    public async Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
+    {
+        _ = descriptor;
+        await NotifyStateChangedAsync(ExternalLinkStateChange.Connected, null, ct);
+    }
+
+    // refactor helper, no behavior change: bridges connector completion back to the existing ExternalLink callback path.
+    public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
+    {
+        var request = TelegramGetUpdatesRequest.Parser.ParseFrom(payload.Span);
+        var connectorTask = StartConnectorExecution(request);
+        if (connectorTask.IsCompleted)
+            return PublishCompletedConnectorTaskAsync(request, connectorTask, CancellationToken.None);
+
+        _ = AwaitAndPublishAsync(request, connectorTask, CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisconnectAsync(CancellationToken ct)
+    {
+        await NotifyStateChangedAsync(ExternalLinkStateChange.Closed, "closed", ct);
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    private Task<ConnectorResponse> StartConnectorExecution(TelegramGetUpdatesRequest request)
+    {
+        if (!connectorRegistry.TryGet(request.ConnectorName, out var connector) || connector == null)
+            return Task.FromResult(new ConnectorResponse
+            {
+                Success = false,
+                Error = $"telegram connector '{request.ConnectorName}' not found",
+            });
+
+        var connectorRequest = BuildConnectorRequest(request);
+        try
+        {
+            return connector.ExecuteAsync(connectorRequest, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(new ConnectorResponse
+            {
+                Success = false,
+                Error = $"telegram getUpdates execution failed: {ex.Message}",
+            });
+        }
+    }
+
+    private async Task AwaitAndPublishAsync(
+        TelegramGetUpdatesRequest request,
+        Task<ConnectorResponse> connectorTask,
+        CancellationToken ct)
+    {
+        await PublishCompletedConnectorTaskAsync(request, connectorTask, ct);
+    }
+
+    private async Task PublishCompletedConnectorTaskAsync(
+        TelegramGetUpdatesRequest request,
+        Task<ConnectorResponse> connectorTask,
+        CancellationToken ct)
+    {
+        TelegramGetUpdatesResult result;
+        try
+        {
+            result = BuildResult(request, await connectorTask);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Telegram getUpdates external-link execution failed for request {RequestId}", request.RequestId);
+            result = new TelegramGetUpdatesResult
+            {
+                CommandId = request.CommandId,
+                Generation = request.Generation,
+                RequestId = request.RequestId,
+                Bootstrap = request.Bootstrap,
+                Success = false,
+                Error = $"telegram getUpdates execution failed: {ex.Message}",
+            };
+            if (request.HasRequestedOffset)
+                result.RequestedOffset = request.RequestedOffset;
+        }
+
+        if (OnMessageReceived != null)
+            await OnMessageReceived(result.ToByteArray(), ct);
+    }
+
+    private static ConnectorRequest BuildConnectorRequest(TelegramGetUpdatesRequest request)
+    {
+        return new ConnectorRequest
+        {
+            RunId = request.RunId,
+            StepId = request.StepId,
+            Connector = request.ConnectorName,
+            Operation = "/getUpdates",
+            Payload = request.Payload,
+            Parameters = new Dictionary<string, string>(request.Parameters, StringComparer.OrdinalIgnoreCase),
+        };
+    }
+
+    private static TelegramGetUpdatesResult BuildResult(TelegramGetUpdatesRequest request, ConnectorResponse response)
+    {
+        var result = new TelegramGetUpdatesResult
+        {
+            CommandId = request.CommandId,
+            Generation = request.Generation,
+            RequestId = request.RequestId,
+            Bootstrap = request.Bootstrap,
+            Success = response.Success,
+            Output = response.Output ?? string.Empty,
+            Error = response.Error ?? string.Empty,
+        };
+        if (request.HasRequestedOffset)
+            result.RequestedOffset = request.RequestedOffset;
+        return result;
+    }
+
+    private Task NotifyStateChangedAsync(ExternalLinkStateChange state, string? reason, CancellationToken ct) =>
+        OnStateChanged?.Invoke(state, reason, ct) ?? Task.CompletedTask;
+}
+
+// refactor helper, no behavior change
+public sealed class TelegramGetUpdatesExternalLinkTransportFactory(
+    IConnectorRegistry connectorRegistry,
+    ILogger<TelegramGetUpdatesExternalLinkTransport> logger) : IExternalLinkTransportFactory
+{
+    public bool CanCreate(string transportType) =>
+        string.Equals(transportType, TelegramGetUpdatesExternalLinkTransport.TransportTypeName, StringComparison.OrdinalIgnoreCase);
+
+    public IExternalLinkTransport Create() =>
+        new TelegramGetUpdatesExternalLinkTransport(connectorRegistry, logger);
+}

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
@@ -132,6 +132,9 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
         OnStateChanged?.Invoke(state, reason, ct) ?? Task.CompletedTask;
 }
 
+// Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+//   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
 public sealed class TelegramGetUpdatesExternalLinkTransportFactory(
     IConnectorRegistry connectorRegistry,
     ILogger<TelegramGetUpdatesExternalLinkTransport> logger) : IExternalLinkTransportFactory

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
@@ -25,7 +25,6 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
         await NotifyStateChangedAsync(ExternalLinkStateChange.Connected, null, ct);
     }
 
-    // refactor helper, no behavior change: bridges connector completion back to the existing ExternalLink callback path.
     public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
     {
         var request = TelegramGetUpdatesRequest.Parser.ParseFrom(payload.Span);
@@ -33,7 +32,8 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
         if (connectorTask.IsCompleted)
             return PublishCompletedConnectorTaskAsync(request, connectorTask, CancellationToken.None);
 
-        _ = AwaitAndPublishAsync(request, connectorTask, CancellationToken.None);
+        // Long polling must finish outside the actor turn; the result re-enters through ExternalLink callbacks.
+        _ = PublishCompletedConnectorTaskAsync(request, connectorTask, CancellationToken.None);
         return Task.CompletedTask;
     }
 
@@ -66,14 +66,6 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
                 Error = $"telegram getUpdates execution failed: {ex.Message}",
             });
         }
-    }
-
-    private async Task AwaitAndPublishAsync(
-        TelegramGetUpdatesRequest request,
-        Task<ConnectorResponse> connectorTask,
-        CancellationToken ct)
-    {
-        await PublishCompletedConnectorTaskAsync(request, connectorTask, ct);
     }
 
     private async Task PublishCompletedConnectorTaskAsync(
@@ -140,7 +132,6 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
         OnStateChanged?.Invoke(state, reason, ct) ?? Task.CompletedTask;
 }
 
-// refactor helper, no behavior change
 public sealed class TelegramGetUpdatesExternalLinkTransportFactory(
     IConnectorRegistry connectorRegistry,
     ILogger<TelegramGetUpdatesExternalLinkTransport> logger) : IExternalLinkTransportFactory

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
@@ -22,12 +22,18 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     public async Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: Telegram wait reply had no actor-owned ExternalLink session for /getUpdates.
+        //   New principle: transport participates in the existing ExternalLink lifecycle and reports readiness.
         _ = descriptor;
         await NotifyStateChangedAsync(ExternalLinkStateChange.Connected, null, ct);
     }
 
     public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: /getUpdates connector execution could block the Telegram wait actor turn.
+        //   New principle: SendAsync starts the connector and publishes completion back through callbacks.
         var request = TelegramGetUpdatesRequest.Parser.ParseFrom(payload.Span);
         var connectorTask = StartConnectorExecution(request);
         if (connectorTask.IsCompleted)
@@ -47,6 +53,9 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     private Task<ConnectorResponse> StartConnectorExecution(TelegramGetUpdatesRequest request)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: TelegramBridgeGAgent owned connector lookup and watchdog execution inline.
+        //   New principle: transport adapts the existing connector as replaceable ExternalLink I/O.
         if (!connectorRegistry.TryGet(request.ConnectorName, out var connector) || connector == null)
             return Task.FromResult(new ConnectorResponse
             {
@@ -74,6 +83,9 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
         Task<ConnectorResponse> connectorTask,
         CancellationToken ct)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: connector result raced in-turn watchdog code.
+        //   New principle: every result is serialized as a typed TelegramGetUpdatesResult callback.
         TelegramGetUpdatesResult result;
         try
         {
@@ -101,6 +113,9 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     private static ConnectorRequest BuildConnectorRequest(TelegramGetUpdatesRequest request)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: wait actor assembled Telegram connector calls inside the actor turn.
+        //   New principle: transport maps typed getUpdates requests to the connector boundary.
         var parameters = new Dictionary<string, string>(request.Parameters, StringComparer.OrdinalIgnoreCase)
         {
             ["method"] = string.IsNullOrWhiteSpace(request.HttpMethod) ? "POST" : request.HttpMethod,
@@ -121,6 +136,9 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     private static string BuildGetUpdatesPayload(TelegramGetUpdatesRequest request)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: /getUpdates payload construction was coupled to actor polling control flow.
+        //   New principle: transport owns Telegram HTTP payload adaptation from the typed request.
         var payload = new Dictionary<string, object?>
         {
             ["timeout"] = Math.Max(0, request.PollTimeoutSeconds),
@@ -136,6 +154,9 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     private static TelegramGetUpdatesResult BuildResult(TelegramGetUpdatesRequest request, ConnectorResponse response)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: connector response was consumed directly by the blocked actor call stack.
+        //   New principle: response becomes a typed callback that carries command/generation/request identity.
         var result = new TelegramGetUpdatesResult
         {
             CommandId = request.CommandId,
@@ -165,6 +186,11 @@ public sealed class TelegramGetUpdatesExternalLinkTransportFactory(
     public bool CanCreate(string transportType) =>
         string.Equals(transportType, TelegramGetUpdatesExternalLinkTransport.TransportTypeName, StringComparison.OrdinalIgnoreCase);
 
-    public IExternalLinkTransport Create() =>
-        new TelegramGetUpdatesExternalLinkTransport(connectorRegistry, logger);
+    public IExternalLinkTransport Create()
+    {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: wait-reply /getUpdates used no ExternalLink transport factory.
+        //   New principle: DI creates the Telegram getUpdates transport through the standard factory contract.
+        return new TelegramGetUpdatesExternalLinkTransport(connectorRegistry, logger);
+    }
 }

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
@@ -4,6 +4,7 @@ using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Google.Protobuf;
@@ -26,6 +27,7 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>, IExternalLinkAware
 {
     private const string GetUpdatesLinkId = "telegram-get-updates";
+    private const string GetUpdatesTimeoutCallbackPrefix = "telegram-get-updates-timeout";
     private const int MaxPollTimeoutSeconds = 25;
     private readonly IConnectorRegistry _connectorRegistry;
     private readonly TimeProvider _timeProvider;
@@ -159,6 +161,12 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         ArgumentNullException.ThrowIfNull(evt);
         if (!IsActiveContinuation(evt.CommandId, evt.Generation))
             return;
+        if (!string.IsNullOrWhiteSpace(evt.RequestId) &&
+            (State.PendingGetUpdates == null ||
+             !string.Equals(State.PendingGetUpdates.RequestId, evt.RequestId, StringComparison.Ordinal)))
+        {
+            return;
+        }
 
         await CompleteTimeoutAsync();
     }
@@ -176,6 +184,7 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
                 {
                     var next = state.Clone();
                     next.Active = false;
+                    next.PendingGetUpdates = null;
                     next.PendingMatchedUpdate = null;
                     next.CollectedReplies.Clear();
                     next.CollectedReplyOrder.Clear();
@@ -248,6 +257,7 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         var next = State.Clone();
         next.PendingGetUpdates = request.Clone();
         await PersistDomainEventAsync(new TelegramWaitReplyProgressedEvent { State = next });
+        await SchedulePendingGetUpdatesTimeoutAsync(request, perCallTimeoutMs);
 
         if (ExternalLinkPort == null)
         {
@@ -263,6 +273,23 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         {
             await CompleteFailureAsync($"telegram getUpdates dispatch failed: {ex.Message}");
         }
+    }
+
+    private async Task SchedulePendingGetUpdatesTimeoutAsync(
+        TelegramGetUpdatesRequest request,
+        int perCallTimeoutMs)
+    {
+        var dueMs = Math.Max(1, perCallTimeoutMs);
+        await ScheduleSelfDurableTimeoutAsync(
+            BuildGetUpdatesTimeoutCallbackId(request),
+            TimeSpan.FromMilliseconds(dueMs),
+            new TelegramWaitReplyTimeoutDueEvent
+            {
+                CommandId = request.CommandId,
+                Generation = request.Generation,
+                TimeoutMs = dueMs,
+                RequestId = request.RequestId,
+            });
     }
 
     private TelegramGetUpdatesRequest BuildGetUpdatesRequest(
@@ -397,6 +424,13 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
     private async Task CompleteTimeoutAsync()
     {
+        if (State.PendingGetUpdates != null)
+        {
+            await CompleteFailureAsync(
+                $"telegram getUpdates timeout after {ResolvePendingGetUpdatesTimeoutMs(State.PendingGetUpdates)}ms");
+            return;
+        }
+
         if (State.PendingMatchedUpdate != null)
         {
             await CompleteSuccessAsync(State.CollectAllReplies
@@ -610,6 +644,22 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
             payload["offset"] = offset.Value;
 
         return JsonSerializer.Serialize(payload);
+    }
+
+    private static string BuildGetUpdatesTimeoutCallbackId(TelegramGetUpdatesRequest request) =>
+        RuntimeCallbackKeyComposer.BuildCallbackId(
+            GetUpdatesTimeoutCallbackPrefix,
+            request.CommandId,
+            request.Generation.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            request.RequestId);
+
+    private static int ResolvePendingGetUpdatesTimeoutMs(TelegramGetUpdatesRequest request)
+    {
+        return request.Parameters.TryGetValue("timeout_ms", out var raw) &&
+               int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed) &&
+               parsed > 0
+            ? parsed
+            : 1;
     }
 
     private static bool TryParseTelegramUpdates(

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
@@ -158,6 +158,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
     [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
     public async Task HandleTimeoutDue(TelegramWaitReplyTimeoutDueEvent evt)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: watchdog timeout raced outside the actor-owned getUpdates request identity.
+        //   New principle: timeout is a self-continuation and stale RequestId callbacks cannot complete state.
         ArgumentNullException.ThrowIfNull(evt);
         if (!IsActiveContinuation(evt.CommandId, evt.Generation))
             return;
@@ -250,6 +253,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         int perCallTimeoutMs,
         bool bootstrap)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: actor turn awaited Telegram /getUpdates connector work behind a Task.Delay watchdog.
+        //   New principle: persist pending request, schedule durable timeout, then hand off to ExternalLink stream.
         if (State.PendingGetUpdates != null)
             return;
 
@@ -322,6 +328,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
     private async Task HandleGetUpdatesResultAsync(TelegramGetUpdatesResult result)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: connector completion raced in-turn watchdog callbacks with no request identity guard.
+        //   New principle: only the actor-owned pending RequestId may advance the getUpdates continuation.
         if (!IsActiveContinuation(result.CommandId, result.Generation))
             return;
 
@@ -352,6 +361,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
     private async Task HandleBootstrapGetUpdatesResultAsync(TelegramGetUpdatesResult result)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: bootstrap /getUpdates ran inline before the actor turn could yield.
+        //   New principle: bootstrap is a normal ExternalLink result continuation that updates actor state.
         if (!TryParseTelegramUpdates(
                 result.Output,
                 out var bootstrapUpdates,
@@ -393,6 +405,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
     private async Task HandlePollGetUpdatesResultAsync(TelegramGetUpdatesResult result)
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: long-poll results returned directly to the blocked actor turn.
+        //   New principle: poll results enter as event continuations and either complete or schedule the next turn.
         if (!TryParseTelegramUpdates(result.Output, out var updates, out var maxUpdateId, out var parseError))
         {
             await CompleteFailureAsync($"telegram getUpdates parse failed: {parseError}");
@@ -422,6 +437,9 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
     private async Task CompleteTimeoutAsync()
     {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: Task.Delay watchdog raced connector completion outside actor state.
+        //   New principle: timeout is an actor event reconciled against PendingGetUpdates or matched reply state.
         if (State.PendingGetUpdates != null)
         {
             await CompleteFailureAsync(

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
@@ -3,6 +3,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Google.Protobuf;
@@ -15,12 +16,16 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 // Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
 //   Old pattern: Telegram bridge maintains in-process wait-reply state in dict; bridge owns wait + reply lifecycle inline
 //   New principle: New task-scoped TelegramWaitReplyGAgent owns protobuf wait state; typed self-events advance one bounded poll per actor turn and resume bridge via WaitReplyCompleted/Failed.
+// Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+//   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
 [GAgent("workflow.telegram-wait-reply")]
 // Refactor (iter30/cluster-030-workflow-step-raw-actor-lifecycle):
 //   Old pattern: WorkflowStepTargetAgentResolver 用 agent_type/agent_id 通过 Type.GetType + AppDomain scan + IRoleAgentTypeResolver 直接 create/link actors,workflow step parameter 暴露 raw CLR lifecycle
 //   New principle: role-level agent_kind 配合 WorkflowRunGAgent runtime lifecycle;step 只用 target_role;删 agent_type/agent_id raw lifecycle 参数 + IWorkflowAgentTypeAliasProvider;Foundation 加 CreateByKindAsync;Bridge 注册 stable kind token
-public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
+public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>, IExternalLinkAware
 {
+    private const string GetUpdatesLinkId = "telegram-get-updates";
     private const int MaxPollTimeoutSeconds = 25;
     private readonly IConnectorRegistry _connectorRegistry;
     private readonly TimeProvider _timeProvider;
@@ -42,6 +47,14 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         InitializeId();
     }
+
+    public IReadOnlyList<ExternalLinkDescriptor> GetLinkDescriptors() =>
+        [
+            new(
+                GetUpdatesLinkId,
+                TelegramGetUpdatesExternalLinkTransport.TransportTypeName,
+                "telegram://get-updates")
+        ];
 
     [EventHandler]
     public async Task HandleWaitForReply(TelegramWaitForReplyCommand command)
@@ -85,57 +98,11 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         if (!IsActiveContinuation(evt.CommandId, evt.Generation))
             return;
 
-        if (!_connectorRegistry.TryGet(State.ConnectorName, out var connector) || connector == null)
-        {
-            await CompleteFailureAsync($"telegram connector '{State.ConnectorName}' not found");
-            return;
-        }
-
-        var bootstrap = await ExecuteGetUpdatesAsync(offset: null, pollTimeoutSeconds: 0, perCallTimeoutMs: 5_000, connector);
-        if (!bootstrap.Success)
-        {
-            await CompleteFailureAsync(string.IsNullOrWhiteSpace(bootstrap.Error)
-                ? "telegram bootstrap getUpdates failed"
-                : bootstrap.Error.Trim());
-            return;
-        }
-
-        if (!TryParseTelegramUpdates(
-                bootstrap.Output,
-                out var bootstrapUpdates,
-                out var bootstrapMaxUpdateId,
-                out var bootstrapError))
-        {
-            await CompleteFailureAsync($"telegram bootstrap parse failed: {bootstrapError}");
-            return;
-        }
-
-        var bootstrapRecentCutoffUnix = _timeProvider.GetUtcNow().ToUnixTimeSeconds()
-            - Math.Max(30, Math.Min(600, State.WaitTimeoutMs / 1000 + 10));
-        var matchedUpdates = SelectMatchedUpdates(
-            bootstrapUpdates,
-            minimumUpdateId: null,
-            minimumDateUnixExclusive: bootstrapRecentCutoffUnix);
-
-        if (matchedUpdates.Count > 0 && !State.CollectAllReplies)
-        {
-            await CompleteSuccessAsync(matchedUpdates[^1].Content);
-            return;
-        }
-
-        var next = State.Clone();
-        if (bootstrapMaxUpdateId.HasValue)
-            next.NextOffset = bootstrapMaxUpdateId.Value + 1;
-        ApplyMatches(next, matchedUpdates);
-
-        var result = ResolveCurrentResult(next, emptyPoll: matchedUpdates.Count == 0);
-        if (result.HasValue)
-        {
-            await CompleteResultAsync(result.Value);
-            return;
-        }
-
-        await PersistAndContinuePollAsync(next);
+        await SendGetUpdatesAsync(
+            offset: null,
+            pollTimeoutSeconds: 0,
+            perCallTimeoutMs: 5_000,
+            bootstrap: true);
     }
 
     [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
@@ -145,12 +112,6 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         if (!IsActiveContinuation(evt.CommandId, evt.Generation))
             return;
 
-        if (!_connectorRegistry.TryGet(State.ConnectorName, out var connector) || connector == null)
-        {
-            await CompleteFailureAsync($"telegram connector '{State.ConnectorName}' not found");
-            return;
-        }
-
         if (_timeProvider.GetUtcNow().ToUnixTimeMilliseconds() >= State.DeadlineUnixMs)
         {
             await CompleteTimeoutAsync();
@@ -159,42 +120,37 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
         var currentPollSeconds = ResolveCurrentPollSeconds();
         long? requestedOffset = State.HasNextOffset ? State.NextOffset : null;
-        var poll = await ExecuteGetUpdatesAsync(
+        await SendGetUpdatesAsync(
             requestedOffset,
             currentPollSeconds,
             perCallTimeoutMs: (currentPollSeconds + 3) * 1_000,
-            connector);
-        if (!poll.Success)
+            bootstrap: false);
+    }
+
+    [EventHandler(AllowSelfHandling = true)]
+    public async Task HandleExternalLinkMessageReceived(ExternalLinkMessageReceivedEvent evt)
+    {
+        // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+        //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+        //   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+        ArgumentNullException.ThrowIfNull(evt);
+        if (!string.Equals(evt.LinkId, GetUpdatesLinkId, StringComparison.Ordinal))
+            return;
+
+        TelegramGetUpdatesResult result;
+        try
         {
-            await CompleteFailureAsync(string.IsNullOrWhiteSpace(poll.Error)
-                ? "telegram getUpdates failed"
-                : poll.Error.Trim());
+            result = evt.Payload != null && evt.Payload.Is(TelegramGetUpdatesResult.Descriptor)
+                ? evt.Payload.Unpack<TelegramGetUpdatesResult>()
+                : TelegramGetUpdatesResult.Parser.ParseFrom(evt.RawPayload);
+        }
+        catch (Exception ex)
+        {
+            await CompleteFailureAsync($"telegram getUpdates result parse failed: {ex.Message}");
             return;
         }
 
-        if (!TryParseTelegramUpdates(poll.Output, out var updates, out var maxUpdateId, out var parseError))
-        {
-            await CompleteFailureAsync($"telegram getUpdates parse failed: {parseError}");
-            return;
-        }
-
-        var matchedUpdates = SelectMatchedUpdates(
-            updates,
-            minimumUpdateId: requestedOffset,
-            minimumDateUnixExclusive: null);
-        var next = State.Clone();
-        if (maxUpdateId.HasValue)
-            next.NextOffset = maxUpdateId.Value + 1;
-        ApplyMatches(next, matchedUpdates);
-
-        var result = ResolveCurrentResult(next, emptyPoll: matchedUpdates.Count == 0);
-        if (result.HasValue)
-        {
-            await CompleteResultAsync(result.Value);
-            return;
-        }
-
-        await PersistAndContinuePollAsync(next);
+        await HandleGetUpdatesResultAsync(result);
     }
 
     [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
@@ -277,6 +233,166 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
             CommandId = State.CommandId,
             Generation = State.Generation,
         });
+    }
+
+    private async Task SendGetUpdatesAsync(
+        long? offset,
+        int pollTimeoutSeconds,
+        int perCallTimeoutMs,
+        bool bootstrap)
+    {
+        if (State.PendingGetUpdates != null)
+            return;
+
+        var request = BuildGetUpdatesRequest(offset, pollTimeoutSeconds, perCallTimeoutMs, bootstrap);
+        var next = State.Clone();
+        next.PendingGetUpdates = request.Clone();
+        await PersistDomainEventAsync(new TelegramWaitReplyProgressedEvent { State = next });
+
+        if (ExternalLinkPort == null)
+        {
+            await CompleteFailureAsync("telegram getUpdates external link is not active");
+            return;
+        }
+
+        try
+        {
+            await ExternalLinkPort.SendAsync(GetUpdatesLinkId, request);
+        }
+        catch (Exception ex)
+        {
+            await CompleteFailureAsync($"telegram getUpdates dispatch failed: {ex.Message}");
+        }
+    }
+
+    private TelegramGetUpdatesRequest BuildGetUpdatesRequest(
+        long? offset,
+        int pollTimeoutSeconds,
+        int perCallTimeoutMs,
+        bool bootstrap)
+    {
+        var parameters = new Dictionary<string, string>(State.ConnectorParameters, StringComparer.OrdinalIgnoreCase)
+        {
+            ["method"] = "POST",
+            ["content_type"] = "application/json",
+            ["timeout_ms"] = perCallTimeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+
+        var request = new TelegramGetUpdatesRequest
+        {
+            CommandId = State.CommandId,
+            Generation = State.Generation,
+            RequestId = Guid.NewGuid().ToString("N"),
+            ConnectorName = State.ConnectorName,
+            RunId = State.CommandId,
+            StepId = State.SessionId,
+            Payload = BuildGetUpdatesPayload(offset, pollTimeoutSeconds),
+            Bootstrap = bootstrap,
+        };
+        request.Parameters.Add(parameters);
+        if (offset.HasValue)
+            request.RequestedOffset = offset.Value;
+        return request;
+    }
+
+    private async Task HandleGetUpdatesResultAsync(TelegramGetUpdatesResult result)
+    {
+        if (!IsActiveContinuation(result.CommandId, result.Generation))
+            return;
+
+        if (State.PendingGetUpdates == null ||
+            string.IsNullOrWhiteSpace(State.PendingGetUpdates.RequestId) ||
+            !string.Equals(State.PendingGetUpdates.RequestId, result.RequestId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (!result.Success)
+        {
+            var fallback = result.Bootstrap
+                ? "telegram bootstrap getUpdates failed"
+                : "telegram getUpdates failed";
+            await CompleteFailureAsync(string.IsNullOrWhiteSpace(result.Error) ? fallback : result.Error.Trim());
+            return;
+        }
+
+        if (result.Bootstrap)
+        {
+            await HandleBootstrapGetUpdatesResultAsync(result);
+            return;
+        }
+
+        await HandlePollGetUpdatesResultAsync(result);
+    }
+
+    private async Task HandleBootstrapGetUpdatesResultAsync(TelegramGetUpdatesResult result)
+    {
+        if (!TryParseTelegramUpdates(
+                result.Output,
+                out var bootstrapUpdates,
+                out var bootstrapMaxUpdateId,
+                out var bootstrapError))
+        {
+            await CompleteFailureAsync($"telegram bootstrap parse failed: {bootstrapError}");
+            return;
+        }
+
+        var bootstrapRecentCutoffUnix = _timeProvider.GetUtcNow().ToUnixTimeSeconds()
+            - Math.Max(30, Math.Min(600, State.WaitTimeoutMs / 1000 + 10));
+        var matchedUpdates = SelectMatchedUpdates(
+            bootstrapUpdates,
+            minimumUpdateId: null,
+            minimumDateUnixExclusive: bootstrapRecentCutoffUnix);
+
+        if (matchedUpdates.Count > 0 && !State.CollectAllReplies)
+        {
+            await CompleteSuccessAsync(matchedUpdates[^1].Content);
+            return;
+        }
+
+        var next = State.Clone();
+        next.PendingGetUpdates = null;
+        if (bootstrapMaxUpdateId.HasValue)
+            next.NextOffset = bootstrapMaxUpdateId.Value + 1;
+        ApplyMatches(next, matchedUpdates);
+
+        var resolved = ResolveCurrentResult(next, emptyPoll: matchedUpdates.Count == 0);
+        if (resolved.HasValue)
+        {
+            await CompleteResultAsync(resolved.Value);
+            return;
+        }
+
+        await PersistAndContinuePollAsync(next);
+    }
+
+    private async Task HandlePollGetUpdatesResultAsync(TelegramGetUpdatesResult result)
+    {
+        if (!TryParseTelegramUpdates(result.Output, out var updates, out var maxUpdateId, out var parseError))
+        {
+            await CompleteFailureAsync($"telegram getUpdates parse failed: {parseError}");
+            return;
+        }
+
+        var requestedOffset = result.HasRequestedOffset ? result.RequestedOffset : (long?)null;
+        var matchedUpdates = SelectMatchedUpdates(
+            updates,
+            minimumUpdateId: requestedOffset,
+            minimumDateUnixExclusive: null);
+        var next = State.Clone();
+        next.PendingGetUpdates = null;
+        if (maxUpdateId.HasValue)
+            next.NextOffset = maxUpdateId.Value + 1;
+        ApplyMatches(next, matchedUpdates);
+
+        var resolved = ResolveCurrentResult(next, emptyPoll: matchedUpdates.Count == 0);
+        if (resolved.HasValue)
+        {
+            await CompleteResultAsync(resolved.Value);
+            return;
+        }
+
+        await PersistAndContinuePollAsync(next);
     }
 
     private async Task CompleteTimeoutAsync()
@@ -481,35 +597,6 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
             return $"update:{update.UpdateId}";
 
         return $"raw:{update.ChatId}:{update.FromUserId}:{update.DateUnix}:{update.Content}";
-    }
-
-    private async Task<ConnectorResponse> ExecuteGetUpdatesAsync(
-        long? offset,
-        int pollTimeoutSeconds,
-        int perCallTimeoutMs,
-        IConnector connector)
-    {
-        var parameters = new Dictionary<string, string>(State.ConnectorParameters, StringComparer.OrdinalIgnoreCase)
-        {
-            ["method"] = "POST",
-            ["content_type"] = "application/json",
-            ["timeout_ms"] = perCallTimeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
-        };
-
-        var connectorRequest = new ConnectorRequest
-        {
-            RunId = State.CommandId,
-            StepId = State.SessionId,
-            Connector = State.ConnectorName,
-            Operation = "/getUpdates",
-            Payload = BuildGetUpdatesPayload(offset, pollTimeoutSeconds),
-            Parameters = parameters,
-        };
-
-        return await TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync(
-            connector,
-            connectorRequest,
-            TelegramBridgeGAgent.ResolveConnectorExecutionWatchdogMs(parameters));
     }
 
     private static string BuildGetUpdatesPayload(long? offset, int pollTimeoutSeconds)

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs
@@ -19,7 +19,7 @@ namespace Aevatar.Workflow.Extensions.Bridge;
 //   New principle: New task-scoped TelegramWaitReplyGAgent owns protobuf wait state; typed self-events advance one bounded poll per actor turn and resume bridge via WaitReplyCompleted/Failed.
 // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
 //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+//   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
 [GAgent("workflow.telegram-wait-reply")]
 // Refactor (iter30/cluster-030-workflow-step-raw-actor-lifecycle):
 //   Old pattern: WorkflowStepTargetAgentResolver 用 agent_type/agent_id 通过 Type.GetType + AppDomain scan + IRoleAgentTypeResolver 直接 create/link actors,workflow step parameter 暴露 raw CLR lifecycle
@@ -134,7 +134,7 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
     {
         // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
         //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-        //   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+        //   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
         ArgumentNullException.ThrowIfNull(evt);
         if (!string.Equals(evt.LinkId, GetUpdatesLinkId, StringComparison.Ordinal))
             return;
@@ -298,13 +298,6 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         int perCallTimeoutMs,
         bool bootstrap)
     {
-        var parameters = new Dictionary<string, string>(State.ConnectorParameters, StringComparer.OrdinalIgnoreCase)
-        {
-            ["method"] = "POST",
-            ["content_type"] = "application/json",
-            ["timeout_ms"] = perCallTimeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture),
-        };
-
         var request = new TelegramGetUpdatesRequest
         {
             CommandId = State.CommandId,
@@ -313,10 +306,15 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
             ConnectorName = State.ConnectorName,
             RunId = State.CommandId,
             StepId = State.SessionId,
-            Payload = BuildGetUpdatesPayload(offset, pollTimeoutSeconds),
+            PollTimeoutSeconds = Math.Clamp(pollTimeoutSeconds, 0, MaxPollTimeoutSeconds),
+            PerCallTimeoutMs = perCallTimeoutMs,
+            HttpMethod = "POST",
+            ContentType = "application/json",
             Bootstrap = bootstrap,
         };
-        request.Parameters.Add(parameters);
+        request.AllowedUpdates.Add("message");
+        request.AllowedUpdates.Add("channel_post");
+        request.Parameters.Add(State.ConnectorParameters);
         if (offset.HasValue)
             request.RequestedOffset = offset.Value;
         return request;
@@ -633,19 +631,6 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
         return $"raw:{update.ChatId}:{update.FromUserId}:{update.DateUnix}:{update.Content}";
     }
 
-    private static string BuildGetUpdatesPayload(long? offset, int pollTimeoutSeconds)
-    {
-        var payload = new Dictionary<string, object?>
-        {
-            ["timeout"] = Math.Clamp(pollTimeoutSeconds, 0, MaxPollTimeoutSeconds),
-            ["allowed_updates"] = new[] { "message", "channel_post" },
-        };
-        if (offset.HasValue && offset.Value >= 0)
-            payload["offset"] = offset.Value;
-
-        return JsonSerializer.Serialize(payload);
-    }
-
     private static string BuildGetUpdatesTimeoutCallbackId(TelegramGetUpdatesRequest request) =>
         RuntimeCallbackKeyComposer.BuildCallbackId(
             GetUpdatesTimeoutCallbackPrefix,
@@ -655,11 +640,7 @@ public sealed class TelegramWaitReplyGAgent : GAgentBase<TelegramWaitReplyState>
 
     private static int ResolvePendingGetUpdatesTimeoutMs(TelegramGetUpdatesRequest request)
     {
-        return request.Parameters.TryGetValue("timeout_ms", out var raw) &&
-               int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsed) &&
-               parsed > 0
-            ? parsed
-            : 1;
+        return request.PerCallTimeoutMs > 0 ? request.PerCallTimeoutMs : 1;
     }
 
     private static bool TryParseTelegramUpdates(

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
@@ -4,7 +4,7 @@ option csharp_namespace = "Aevatar.Workflow.Extensions.Bridge";
 
 // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
 //   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
-//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
+//   New principle: TelegramWaitReplyGAgent owns /getUpdates polling through the existing ExternalLink stream; it sends getUpdates requests via IExternalLinkPort and handles ExternalLinkMessageReceivedEvent continuations, so long polling no longer blocks an actor turn and no new actor type is introduced.
 
 message TelegramWaitForReplyCommand {
   string command_id = 1;
@@ -67,10 +67,14 @@ message TelegramGetUpdatesRequest {
   string connector_name = 4;
   string run_id = 5;
   string step_id = 6;
-  string payload = 7;
   map<string, string> parameters = 8;
   bool bootstrap = 9;
   optional int64 requested_offset = 10;
+  int32 poll_timeout_seconds = 11;
+  int32 per_call_timeout_ms = 12;
+  repeated string allowed_updates = 13;
+  string http_method = 14;
+  string content_type = 15;
 }
 
 message TelegramGetUpdatesResult {

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 package aevatar.workflow.extensions.bridge;
 option csharp_namespace = "Aevatar.Workflow.Extensions.Bridge";
 
-// Refactor (iter25/cluster-027-telegram-wait-reply-actor-turn):
-//   Old pattern: Telegram bridge owned wait-reply polling and stack-local progress inside one actor turn.
-//   New principle: a task-scoped wait actor owns protobuf wait state and advances by typed self-continuation events.
+// Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):
+//   Old pattern: TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync 用 Task.Delay 兜底超时 + ContinueWith race + actor turn 内同步 await /getUpdates 长轮询
+//   New principle: 复用现有 ExternalLink actor-owned stream pattern(reflector force-pick):TelegramWaitReplyGAgent 实现 IExternalLinkAware + 加 TelegramGetUpdatesExternalLinkTransport;/getUpdates 走 IExternalLinkPort.SendAsync,result 经 ExternalLinkMessageReceivedEvent 回 actor;删 ExecuteConnectorWithWatchdogAsync/Task.Delay/ContinueWith race。**不新增 actor 类型**
 
 message TelegramWaitForReplyCommand {
   string command_id = 1;
@@ -57,6 +57,31 @@ message TelegramWaitReplyState {
   int32 polls_since_last_match = 20;
   map<string, TelegramInboundUpdateState> collected_replies = 21;
   repeated string collected_reply_order = 22;
+  TelegramGetUpdatesRequest pending_get_updates = 23;
+}
+
+message TelegramGetUpdatesRequest {
+  string command_id = 1;
+  int64 generation = 2;
+  string request_id = 3;
+  string connector_name = 4;
+  string run_id = 5;
+  string step_id = 6;
+  string payload = 7;
+  map<string, string> parameters = 8;
+  bool bootstrap = 9;
+  optional int64 requested_offset = 10;
+}
+
+message TelegramGetUpdatesResult {
+  string command_id = 1;
+  int64 generation = 2;
+  string request_id = 3;
+  bool bootstrap = 4;
+  bool success = 5;
+  string output = 6;
+  string error = 7;
+  optional int64 requested_offset = 8;
 }
 
 message TelegramWaitReplyStartedEvent {

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/telegram_wait_reply.proto
@@ -111,6 +111,7 @@ message TelegramWaitReplyTimeoutDueEvent {
   string command_id = 1;
   int64 generation = 2;
   int32 timeout_ms = 3;
+  string request_id = 4;
 }
 
 message TelegramWaitReplyCompletedEvent {

--- a/test/Aevatar.Workflow.Core.Tests/Extensions/WorkflowBridgeExtensionRegistrationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Extensions/WorkflowBridgeExtensionRegistrationTests.cs
@@ -1,7 +1,11 @@
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
 using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Workflow.Extensions.Bridge;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.Workflow.Core.Tests.Extensions;
 
@@ -26,5 +30,41 @@ public sealed class WorkflowBridgeExtensionRegistrationTests
 
         implementation.Metadata.Kind.Should().Be(agentKind);
         implementation.Metadata.ImplementationClrTypeName.Should().Be(expectedImplementationType.FullName);
+    }
+
+    [Fact]
+    public void AddWorkflowBridgeExtensions_ShouldRegisterTelegramGetUpdatesExternalLinkTransportFactory()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConnectorRegistry, EmptyConnectorRegistry>();
+        services.AddSingleton<ILogger<TelegramGetUpdatesExternalLinkTransport>>(
+            NullLogger<TelegramGetUpdatesExternalLinkTransport>.Instance);
+
+        services.AddWorkflowBridgeExtensions();
+
+        using var provider = services.BuildServiceProvider();
+
+        var factories = provider.GetServices<IExternalLinkTransportFactory>();
+        var factory = factories.Should().ContainSingle(x =>
+            x.CanCreate(TelegramGetUpdatesExternalLinkTransport.TransportTypeName)).Subject;
+        factory.CanCreate("TELEGRAM-GET-UPDATES").Should().BeTrue();
+        factory.Create().Should().BeOfType<TelegramGetUpdatesExternalLinkTransport>();
+    }
+
+    private sealed class EmptyConnectorRegistry : IConnectorRegistry
+    {
+        public void Register(IConnector connector)
+        {
+            _ = connector;
+        }
+
+        public bool TryGet(string name, out IConnector? connector)
+        {
+            _ = name;
+            connector = null;
+            return false;
+        }
+
+        public IReadOnlyList<string> ListNames() => [];
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -3,12 +3,15 @@ using System.Text.Json;
 using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Workflow.Extensions.Bridge;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
@@ -234,8 +237,10 @@ public sealed class TelegramBridgeGAgentTests
             EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
                 (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
-            Services = CreateAgentServices(),
         };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry);
+        await agent.ActivateAsync();
 
         var command = BuildWaitReplyCommand(
             sessionId: "session-wait-edited",
@@ -247,7 +252,7 @@ public sealed class TelegramBridgeGAgentTests
         connector.Received.Should().BeEmpty();
         publisher.Sent.Select(x => x.evt).Should().ContainSingle(x => x is TelegramWaitReplyBootstrapDueEvent);
 
-        await DrainWaitReplySelfEventsAsync(agent, publisher);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch);
 
         connector.Received.Count.Should().Be(4);
         connector.Received.Should().OnlyContain(x => x.Operation == "/getUpdates");
@@ -335,8 +340,10 @@ public sealed class TelegramBridgeGAgentTests
             EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
                 (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
-            Services = CreateAgentServices(),
         };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry);
+        await agent.ActivateAsync();
 
         var command = BuildWaitReplyCommand(
             sessionId: "session-wait-collect-all",
@@ -346,7 +353,7 @@ public sealed class TelegramBridgeGAgentTests
         command.SettlePollsAfterMatch = 2;
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
-        await DrainWaitReplySelfEventsAsync(agent, publisher);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch);
 
         var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
         completed.SessionId.Should().Be("session-wait-collect-all");
@@ -373,8 +380,10 @@ public sealed class TelegramBridgeGAgentTests
             EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
                 (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
-            Services = CreateAgentServices(),
         };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry);
+        await agent.ActivateAsync();
 
         var command = BuildWaitReplyCommand(
             sessionId: "session-wait-bootstrap",
@@ -385,7 +394,7 @@ public sealed class TelegramBridgeGAgentTests
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
         connector.Received.Should().BeEmpty();
 
-        await DrainWaitReplySelfEventsAsync(agent, publisher);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch);
 
         connector.Received.Should().ContainSingle();
         connector.Received[0].Operation.Should().Be("/getUpdates");
@@ -415,8 +424,10 @@ public sealed class TelegramBridgeGAgentTests
             EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
                 (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
-            Services = CreateAgentServices(),
         };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry);
+        await agent.ActivateAsync();
 
         var command = BuildWaitReplyCommand(
             sessionId: "session-wait-username-missing",
@@ -425,7 +436,7 @@ public sealed class TelegramBridgeGAgentTests
         command.StartFromLatest = true;
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
-        await DrainWaitReplySelfEventsAsync(agent, publisher);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch);
 
         var completed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Single();
         completed.SessionId.Should().Be("session-wait-username-missing");
@@ -450,15 +461,17 @@ public sealed class TelegramBridgeGAgentTests
             EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
                 (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
-            Services = CreateAgentServices(),
         };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry);
+        await agent.ActivateAsync();
 
         var command = BuildWaitReplyCommand(
             sessionId: "session-wait-failed",
             expectedUsername: "openclaw_bot");
 
         await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
-        await DrainWaitReplySelfEventsAsync(agent, publisher);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch);
 
         var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
         failed.SessionId.Should().Be("session-wait-failed");
@@ -494,38 +507,35 @@ public sealed class TelegramBridgeGAgentTests
     }
 
     [Fact]
-    public async Task HandleChatRequest_WhenConnectorHangs_ShouldFailByWatchdogBeforeLlmTimeout()
+    public async Task TelegramWaitReplyGAgent_WhenGetUpdatesConnectorHangs_ShouldNotBlockActorTurn()
     {
         var connector = new HangingConnector();
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
         var publisher = new RecordingEventPublisher();
-        var agent = new TelegramBridgeGAgent(
+        var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
             registry)
         {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
             EventPublisher = publisher,
-            Services = CreateAgentServices(),
         };
-
-        var request = new ChatRequestEvent
-        {
-            Prompt = "hello telegram",
-            SessionId = "session-watchdog-timeout",
-        };
-        request.Headers["chat_id"] = "10001";
-        request.Headers["telegram.timeout_ms"] = "100";
-        request.Headers["aevatar.llm_timeout_ms"] = "30000";
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry);
+        await agent.ActivateAsync();
 
         var stopwatch = Stopwatch.StartNew();
-        await agent.HandleEventAsync(Envelope(request), CancellationToken.None);
+        await agent.HandleEventAsync(Envelope(BuildWaitReplyCommand(
+            sessionId: "session-hanging-getupdates",
+            expectedUsername: "openclaw_bot")), CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch, maxTurns: 1);
         stopwatch.Stop();
 
-        stopwatch.ElapsedMilliseconds.Should().BeLessThan(2_000);
-
-        var textEnd = publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>().Single();
-        textEnd.Content.Should().StartWith("[[AEVATAR_LLM_ERROR]]");
-        textEnd.Content.Should().Contain("watchdog timeout");
+        stopwatch.ElapsedMilliseconds.Should().BeLessThan(500);
+        connector.Received.Should().ContainSingle(x => x.Operation == "/getUpdates");
+        publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Should().BeEmpty();
+        publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Should().BeEmpty();
     }
 
     [Fact]
@@ -579,10 +589,13 @@ public sealed class TelegramBridgeGAgentTests
     private static async Task DrainWaitReplySelfEventsAsync(
         TelegramWaitReplyGAgent agent,
         RecordingEventPublisher publisher,
+        RecordingActorDispatchPort dispatch,
         int maxTurns = 16)
     {
         for (var i = 0; i < maxTurns; i++)
         {
+            await dispatch.DrainAsync();
+
             var nextIndex = publisher.Sent.FindIndex(x =>
                 x.targetActorId == agent.Id &&
                 x.evt is TelegramWaitReplyBootstrapDueEvent or TelegramWaitReplyPollDueEvent or TelegramWaitReplyTimeoutDueEvent);
@@ -592,9 +605,16 @@ public sealed class TelegramBridgeGAgentTests
             var next = publisher.Sent[nextIndex];
             publisher.Sent.RemoveAt(nextIndex);
             await agent.HandleEventAsync(Envelope(next.evt), CancellationToken.None);
+            await dispatch.DrainAsync();
         }
 
-        throw new InvalidOperationException("wait-reply self event drain exceeded max turns");
+        await dispatch.DrainAsync();
+        if (publisher.Sent.Any(x =>
+                x.targetActorId == agent.Id &&
+                x.evt is TelegramWaitReplyBootstrapDueEvent or TelegramWaitReplyPollDueEvent or TelegramWaitReplyTimeoutDueEvent))
+        {
+            throw new InvalidOperationException("wait-reply self event drain exceeded max turns");
+        }
     }
 
     private static TelegramWaitForReplyCommand BuildWaitReplyCommand(
@@ -662,12 +682,13 @@ public sealed class TelegramBridgeGAgentTests
 
     private sealed class HangingConnector : IConnector
     {
+        public List<ConnectorRequest> Received { get; } = [];
         public string Name { get; } = "telegram";
         public string Type { get; } = "http";
 
         public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
         {
-            _ = request;
+            Received.Add(request);
             _ = ct;
             return new TaskCompletionSource<ConnectorResponse>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
         }
@@ -733,12 +754,22 @@ public sealed class TelegramBridgeGAgentTests
 
         public Task<EventStoreCommitResult> ConfirmEventsAsync(CancellationToken ct = default)
         {
+            var committedEvents = _pending.Select((evt, index) => new StateEvent
+            {
+                AgentId = "test-agent",
+                EventId = Guid.NewGuid().ToString("N"),
+                EventType = evt.Descriptor.FullName,
+                EventData = Any.Pack(evt),
+                Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                Version = CurrentVersion + index + 1,
+            }).ToList();
             CurrentVersion += _pending.Count;
             _pending.Clear();
             return Task.FromResult(new EventStoreCommitResult
             {
                 AgentId = "test-agent",
                 LatestVersion = CurrentVersion,
+                CommittedEvents = { committedEvents },
             });
         }
 
@@ -788,34 +819,63 @@ public sealed class TelegramBridgeGAgentTests
         }
     }
 
-    private static IServiceProvider CreateAgentServices()
+    private static IServiceProvider CreateAgentServices(
+        RecordingActorDispatchPort? dispatchPort = null,
+        IConnectorRegistry? connectorRegistry = null)
     {
-        return new Microsoft.Extensions.DependencyInjection.ServiceCollection()
-            .AddSingleton<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler, NoopRuntimeCallbackScheduler>()
-            .BuildServiceProvider();
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection()
+            .AddSingleton<IActorRuntimeCallbackScheduler, NoopRuntimeCallbackScheduler>()
+            .AddSingleton<IExternalLinkTransportFactory, TelegramGetUpdatesExternalLinkTransportFactory>()
+            .AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        if (dispatchPort != null)
+            services.AddSingleton<IActorDispatchPort>(dispatchPort);
+        if (connectorRegistry != null)
+            services.AddSingleton(connectorRegistry);
+        return services.BuildServiceProvider();
     }
 
-    private sealed class NoopRuntimeCallbackScheduler : Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler
+    private sealed class RecordingActorDispatchPort(TelegramWaitReplyGAgent agent) : IActorDispatchPort
     {
-        public Task<Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease> ScheduleTimeoutAsync(
-            Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackTimeoutRequest request,
+        private readonly Queue<EventEnvelope> _pending = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            actorId.Should().Be(agent.Id);
+            _pending.Enqueue(envelope);
+            return Task.CompletedTask;
+        }
+
+        public async Task DrainAsync()
+        {
+            while (_pending.Count > 0)
+            {
+                var envelope = _pending.Dequeue();
+                await agent.HandleEventAsync(envelope, CancellationToken.None);
+            }
+        }
+    }
+
+    private sealed class NoopRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
             CancellationToken ct = default) =>
-            Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease(
+            Task.FromResult(new RuntimeCallbackLease(
                 request.ActorId,
                 request.CallbackId,
                 1,
-                Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
+                RuntimeCallbackBackend.InMemory));
 
-        public Task<Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease> ScheduleTimerAsync(
-            Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackTimerRequest request,
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
             CancellationToken ct = default) =>
-            Task.FromResult(new Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease(
+            Task.FromResult(new RuntimeCallbackLease(
                 request.ActorId,
                 request.CallbackId,
                 1,
-                Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackBackend.InMemory));
+                RuntimeCallbackBackend.InMemory));
 
-        public Task CancelAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct = default) =>
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
             Task.CompletedTask;
 
         public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -17,11 +17,6 @@ namespace Aevatar.Workflow.Host.Api.Tests;
 
 public sealed class TelegramBridgeGAgentTests
 {
-    private const string WaitReplyProductionPath =
-        "src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs";
-    private const string GetUpdatesTransportProductionPath =
-        "src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs";
-
     [Fact]
     public async Task HandleChatRequest_WhenConnectorSucceeds_ShouldPublishTextMessageEnd()
     {
@@ -576,6 +571,40 @@ public sealed class TelegramBridgeGAgentTests
     }
 
     [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenGetUpdatesTimeoutRequestIdIsStale_ShouldIgnoreTimeout()
+    {
+        var connector = new HangingConnector();
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
+
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-stale-timeout",
+            expectedUsername: "openclaw_bot");
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch, maxTurns: 1);
+
+        agent.State.PendingGetUpdates.Should().NotBeNull();
+        var pendingRequest = agent.State.PendingGetUpdates.Clone();
+
+        await agent.HandleEventAsync(
+            Envelope(new TelegramWaitReplyTimeoutDueEvent
+            {
+                CommandId = command.CommandId,
+                Generation = agent.State.Generation,
+                RequestId = "stale-request",
+                TimeoutMs = 4000,
+            }),
+            CancellationToken.None);
+
+        agent.State.Active.Should().BeTrue();
+        agent.State.PendingGetUpdates.Should().BeEquivalentTo(pendingRequest);
+        publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Should().BeEmpty();
+        publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task TelegramWaitReplyGAgent_WhenExternalLinkInactive_ShouldPublishFailedEvent()
     {
         var connector = new RecordingConnector();
@@ -727,14 +756,14 @@ public sealed class TelegramBridgeGAgentTests
     [Fact]
     public void TelegramWaitReplyProductionPath_ShouldNotReintroduceInTurnWatchdogRace()
     {
-        var root = FindRepositoryRoot();
-        var waitReplySource = File.ReadAllText(Path.Combine(root, WaitReplyProductionPath));
-        var transportSource = File.ReadAllText(Path.Combine(root, GetUpdatesTransportProductionPath));
-        var source = RemoveLineComments(waitReplySource) + "\n" + RemoveLineComments(transportSource);
-
-        source.Should().NotContain("ExecuteConnectorWithWatchdogAsync");
-        source.Should().NotContain("Task.Delay");
-        source.Should().NotContain("ContinueWith");
+        typeof(TelegramBridgeGAgent)
+            .GetMethod(
+                "ExecuteConnectorWithWatchdogAsync",
+                System.Reflection.BindingFlags.Static |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public)
+            .Should()
+            .BeNull();
     }
 
     [Fact]
@@ -1085,11 +1114,11 @@ public sealed class TelegramBridgeGAgentTests
             }
 
             var next = current.Clone();
-                next.Active = false;
-                next.PendingGetUpdates = null;
-                next.PendingMatchedUpdate = null;
-                next.CollectedReplies.Clear();
-                next.CollectedReplyOrder.Clear();
+            next.Active = false;
+            next.PendingGetUpdates = null;
+            next.PendingMatchedUpdate = null;
+            next.CollectedReplies.Clear();
+            next.CollectedReplyOrder.Clear();
             return next;
         }
     }
@@ -1112,26 +1141,6 @@ public sealed class TelegramBridgeGAgentTests
         if (connectorRegistry != null)
             services.AddSingleton(connectorRegistry);
         return services.BuildServiceProvider();
-    }
-
-    private static string FindRepositoryRoot()
-    {
-        var current = new DirectoryInfo(AppContext.BaseDirectory);
-        while (current != null)
-        {
-            if (File.Exists(Path.Combine(current.FullName, "aevatar.slnx")))
-                return current.FullName;
-            current = current.Parent;
-        }
-
-        throw new InvalidOperationException("repository root not found");
-    }
-
-    private static string RemoveLineComments(string source)
-    {
-        return string.Join(
-            '\n',
-            source.Split('\n').Where(line => !line.TrimStart().StartsWith("//", StringComparison.Ordinal)));
     }
 
     private sealed class RecordingActorDispatchPort(TelegramWaitReplyGAgent agent) : IActorDispatchPort

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -17,6 +17,11 @@ namespace Aevatar.Workflow.Host.Api.Tests;
 
 public sealed class TelegramBridgeGAgentTests
 {
+    private const string WaitReplyProductionPath =
+        "src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramWaitReplyGAgent.cs";
+    private const string GetUpdatesTransportProductionPath =
+        "src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs";
+
     [Fact]
     public async Task HandleChatRequest_WhenConnectorSucceeds_ShouldPublishTextMessageEnd()
     {
@@ -539,6 +544,200 @@ public sealed class TelegramBridgeGAgentTests
     }
 
     [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenGetUpdatesConnectorHangs_ShouldFailFromRequestTimeoutContinuation()
+    {
+        var connector = new HangingConnector();
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var scheduler = new RecordingRuntimeCallbackScheduler();
+        var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher, scheduler);
+
+        var command = BuildWaitReplyCommand(
+            sessionId: "session-hanging-getupdates-timeout",
+            expectedUsername: "openclaw_bot");
+        await agent.HandleEventAsync(Envelope(command), CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch, maxTurns: 1);
+
+        var timeout = scheduler.Timeouts.Should().ContainSingle().Subject;
+        var timeoutDue = timeout.TriggerEnvelope.Payload.Unpack<TelegramWaitReplyTimeoutDueEvent>();
+        timeoutDue.CommandId.Should().Be(command.CommandId);
+        timeoutDue.Generation.Should().Be(agent.State.Generation);
+        timeoutDue.RequestId.Should().Be(agent.State.PendingGetUpdates.RequestId);
+        timeoutDue.TimeoutMs.Should().Be(4000);
+
+        await agent.HandleEventAsync(timeout.TriggerEnvelope, CancellationToken.None);
+
+        var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
+        failed.SessionId.Should().Be("session-hanging-getupdates-timeout");
+        failed.Error.Should().Be("telegram getUpdates timeout after 4000ms");
+        agent.State.Active.Should().BeFalse();
+        agent.State.PendingGetUpdates.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenExternalLinkInactive_ShouldPublishFailedEvent()
+    {
+        var connector = new RecordingConnector();
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var agent = new TelegramWaitReplyGAgent(
+            new NoopActorRuntime(),
+            registry)
+        {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
+            EventPublisher = publisher,
+            Services = CreateAgentServices(),
+        };
+
+        await agent.HandleEventAsync(
+            Envelope(BuildWaitReplyCommand("session-inactive-link", "openclaw_bot")),
+            CancellationToken.None);
+        await DrainWaitReplySelfEventsWithoutExternalLinksAsync(agent, publisher, maxTurns: 1);
+
+        var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
+        failed.SessionId.Should().Be("session-inactive-link");
+        failed.Error.Should().Be("telegram getUpdates external link is not active");
+        agent.State.Active.Should().BeFalse();
+        agent.State.PendingGetUpdates.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenExternalLinkDispatchFails_ShouldPublishFailedEvent()
+    {
+        var connector = new RecordingConnector();
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var agent = new TelegramWaitReplyGAgent(
+            new NoopActorRuntime(),
+            registry)
+        {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
+            EventPublisher = publisher,
+        };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(
+            dispatch,
+            registry,
+            new RecordingRuntimeCallbackScheduler(),
+            new ThrowingSendTransportFactory("dispatch offline"));
+        await agent.ActivateAsync();
+
+        await agent.HandleEventAsync(
+            Envelope(BuildWaitReplyCommand("session-dispatch-fails", "openclaw_bot")),
+            CancellationToken.None);
+        await agent.HandleEventAsync(
+            Envelope(publisher.PopSentSelfEvent<TelegramWaitReplyPollDueEvent>(agent.Id)),
+            CancellationToken.None);
+
+        var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
+        failed.SessionId.Should().Be("session-dispatch-fails");
+        failed.Error.Should().Be("telegram getUpdates dispatch failed: dispatch offline");
+        agent.State.Active.Should().BeFalse();
+        agent.State.PendingGetUpdates.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenExternalLinkPayloadInvalid_ShouldPublishFailedEvent()
+    {
+        var connector = new HangingConnector();
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
+
+        await agent.HandleEventAsync(
+            Envelope(BuildWaitReplyCommand("session-invalid-payload", "openclaw_bot")),
+            CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch, maxTurns: 1);
+
+        await agent.HandleEventAsync(Envelope(new ExternalLinkMessageReceivedEvent
+        {
+            LinkId = "telegram-get-updates",
+            RawPayload = ByteString.CopyFrom([0xFF]),
+            ReceivedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+        }), CancellationToken.None);
+
+        var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
+        failed.SessionId.Should().Be("session-invalid-payload");
+        failed.Error.Should().StartWith("telegram getUpdates result parse failed:");
+        agent.State.Active.Should().BeFalse();
+        agent.State.PendingGetUpdates.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenGetUpdatesResultRequestIdIsStale_ShouldIgnoreResult()
+    {
+        var connector = new HangingConnector();
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
+
+        await agent.HandleEventAsync(
+            Envelope(BuildWaitReplyCommand("session-stale-result", "openclaw_bot")),
+            CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch, maxTurns: 1);
+
+        await agent.HandleEventAsync(Envelope(new ExternalLinkMessageReceivedEvent
+        {
+            LinkId = "telegram-get-updates",
+            RawPayload = new TelegramGetUpdatesResult
+            {
+                CommandId = agent.State.CommandId,
+                Generation = agent.State.Generation,
+                RequestId = "stale-request",
+                Success = true,
+                Output = """{"ok":true,"result":[]}""",
+            }.ToByteString(),
+            ReceivedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+        }), CancellationToken.None);
+
+        agent.State.Active.Should().BeTrue();
+        agent.State.PendingGetUpdates.Should().NotBeNull();
+        publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyCompletedEvent>().Should().BeEmpty();
+        publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task TelegramWaitReplyGAgent_WhenGetUpdatesResultIsUnsuccessful_ShouldPublishFailedEvent()
+    {
+        var connector = new AsyncFaultingConnector(new InvalidOperationException("remote fault"));
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var publisher = new RecordingEventPublisher();
+        var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
+
+        await agent.HandleEventAsync(
+            Envelope(BuildWaitReplyCommand("session-unsuccessful-result", "openclaw_bot")),
+            CancellationToken.None);
+        await DrainWaitReplySelfEventsAsync(agent, publisher, dispatch, maxTurns: 1);
+
+        var failed = publisher.Published.Select(x => x.evt).OfType<TelegramWaitReplyFailedEvent>().Single();
+        failed.SessionId.Should().Be("session-unsuccessful-result");
+        failed.Error.Should().Be("telegram getUpdates execution failed: remote fault");
+        agent.State.Active.Should().BeFalse();
+        agent.State.PendingGetUpdates.Should().BeNull();
+    }
+
+    [Fact]
+    public void TelegramWaitReplyProductionPath_ShouldNotReintroduceInTurnWatchdogRace()
+    {
+        var root = FindRepositoryRoot();
+        var waitReplySource = File.ReadAllText(Path.Combine(root, WaitReplyProductionPath));
+        var transportSource = File.ReadAllText(Path.Combine(root, GetUpdatesTransportProductionPath));
+        var source = RemoveLineComments(waitReplySource) + "\n" + RemoveLineComments(transportSource);
+
+        source.Should().NotContain("ExecuteConnectorWithWatchdogAsync");
+        source.Should().NotContain("Task.Delay");
+        source.Should().NotContain("ContinueWith");
+    }
+
+    [Fact]
     public async Task TelegramUserBridgeGAgent_WhenConnectorNotSpecified_ShouldUseTelegramUserConnectorByDefault()
     {
         var connector = new RecordingConnector(
@@ -615,6 +814,58 @@ public sealed class TelegramBridgeGAgentTests
         {
             throw new InvalidOperationException("wait-reply self event drain exceeded max turns");
         }
+    }
+
+    private static async Task DrainWaitReplySelfEventsWithoutExternalLinksAsync(
+        TelegramWaitReplyGAgent agent,
+        RecordingEventPublisher publisher,
+        int maxTurns = 16)
+    {
+        for (var i = 0; i < maxTurns; i++)
+        {
+            var nextIndex = publisher.Sent.FindIndex(x =>
+                x.targetActorId == agent.Id &&
+                x.evt is TelegramWaitReplyBootstrapDueEvent or TelegramWaitReplyPollDueEvent or TelegramWaitReplyTimeoutDueEvent);
+            if (nextIndex < 0)
+                return;
+
+            var next = publisher.Sent[nextIndex];
+            publisher.Sent.RemoveAt(nextIndex);
+            await agent.HandleEventAsync(Envelope(next.evt), CancellationToken.None);
+        }
+
+        if (publisher.Sent.Any(x =>
+                x.targetActorId == agent.Id &&
+                x.evt is TelegramWaitReplyBootstrapDueEvent or TelegramWaitReplyPollDueEvent or TelegramWaitReplyTimeoutDueEvent))
+        {
+            throw new InvalidOperationException("wait-reply self event drain exceeded max turns");
+        }
+    }
+
+    private static Task<(TelegramWaitReplyGAgent Agent, RecordingActorDispatchPort Dispatch)> CreateActivatedWaitReplyAgentAsync(
+        IConnectorRegistry registry,
+        RecordingEventPublisher publisher)
+    {
+        return CreateActivatedWaitReplyAgentAsync(registry, publisher, new RecordingRuntimeCallbackScheduler());
+    }
+
+    private static async Task<(TelegramWaitReplyGAgent Agent, RecordingActorDispatchPort Dispatch)> CreateActivatedWaitReplyAgentAsync(
+        IConnectorRegistry registry,
+        RecordingEventPublisher publisher,
+        RecordingRuntimeCallbackScheduler scheduler)
+    {
+        var agent = new TelegramWaitReplyGAgent(
+            new NoopActorRuntime(),
+            registry)
+        {
+            EventSourcing = new RecordingEventSourcing<TelegramWaitReplyState>(
+                (state, evt) => TelegramWaitReplyStateTransitions.Apply(state, evt)),
+            EventPublisher = publisher,
+        };
+        var dispatch = new RecordingActorDispatchPort(agent);
+        agent.Services = CreateAgentServices(dispatch, registry, scheduler);
+        await agent.ActivateAsync();
+        return (agent, dispatch);
     }
 
     private static TelegramWaitForReplyCommand BuildWaitReplyCommand(
@@ -694,6 +945,19 @@ public sealed class TelegramBridgeGAgentTests
         }
     }
 
+    private sealed class AsyncFaultingConnector(Exception exception) : IConnector
+    {
+        public string Name { get; } = "telegram";
+        public string Type { get; } = "http";
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            return Task.FromException<ConnectorResponse>(exception);
+        }
+    }
+
     private sealed class InMemoryConnectorRegistry : IConnectorRegistry
     {
         private readonly Dictionary<string, IConnector> _connectors = new(StringComparer.OrdinalIgnoreCase);
@@ -736,6 +1000,16 @@ public sealed class TelegramBridgeGAgentTests
             _ = options;
             Sent.Add((targetActorId, evt));
             return Task.CompletedTask;
+        }
+
+        public TEvent PopSentSelfEvent<TEvent>(string targetActorId)
+            where TEvent : IMessage
+        {
+            var index = Sent.FindIndex(x => x.targetActorId == targetActorId && x.evt is TEvent);
+            index.Should().BeGreaterThanOrEqualTo(0);
+            var evt = Sent[index].evt.Should().BeOfType<TEvent>().Subject;
+            Sent.RemoveAt(index);
+            return evt;
         }
     }
 
@@ -811,27 +1085,53 @@ public sealed class TelegramBridgeGAgentTests
             }
 
             var next = current.Clone();
-            next.Active = false;
-            next.PendingMatchedUpdate = null;
-            next.CollectedReplies.Clear();
-            next.CollectedReplyOrder.Clear();
+                next.Active = false;
+                next.PendingGetUpdates = null;
+                next.PendingMatchedUpdate = null;
+                next.CollectedReplies.Clear();
+                next.CollectedReplyOrder.Clear();
             return next;
         }
     }
 
     private static IServiceProvider CreateAgentServices(
         RecordingActorDispatchPort? dispatchPort = null,
-        IConnectorRegistry? connectorRegistry = null)
+        IConnectorRegistry? connectorRegistry = null,
+        IActorRuntimeCallbackScheduler? callbackScheduler = null,
+        IExternalLinkTransportFactory? externalLinkTransportFactory = null)
     {
         var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection()
-            .AddSingleton<IActorRuntimeCallbackScheduler, NoopRuntimeCallbackScheduler>()
-            .AddSingleton<IExternalLinkTransportFactory, TelegramGetUpdatesExternalLinkTransportFactory>()
             .AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton(callbackScheduler ?? new NoopRuntimeCallbackScheduler());
+        if (externalLinkTransportFactory != null)
+            services.AddSingleton(externalLinkTransportFactory);
+        else
+            services.AddSingleton<IExternalLinkTransportFactory, TelegramGetUpdatesExternalLinkTransportFactory>();
         if (dispatchPort != null)
             services.AddSingleton<IActorDispatchPort>(dispatchPort);
         if (connectorRegistry != null)
             services.AddSingleton(connectorRegistry);
         return services.BuildServiceProvider();
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "aevatar.slnx")))
+                return current.FullName;
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("repository root not found");
+    }
+
+    private static string RemoveLineComments(string source)
+    {
+        return string.Join(
+            '\n',
+            source.Split('\n').Where(line => !line.TrimStart().StartsWith("//", StringComparison.Ordinal)));
     }
 
     private sealed class RecordingActorDispatchPort(TelegramWaitReplyGAgent agent) : IActorDispatchPort
@@ -853,6 +1153,80 @@ public sealed class TelegramBridgeGAgentTests
                 await agent.HandleEventAsync(envelope, CancellationToken.None);
             }
         }
+    }
+
+    private sealed class ThrowingSendTransportFactory(string message) : IExternalLinkTransportFactory
+    {
+        public bool CanCreate(string transportType) =>
+            string.Equals(transportType, TelegramGetUpdatesExternalLinkTransport.TransportTypeName, StringComparison.OrdinalIgnoreCase);
+
+        public IExternalLinkTransport Create() => new ThrowingSendTransport(message);
+    }
+
+    private sealed class ThrowingSendTransport(string message) : IExternalLinkTransport
+    {
+        public string TransportType => TelegramGetUpdatesExternalLinkTransport.TransportTypeName;
+
+        public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived
+        {
+            private get;
+            set;
+        }
+
+        public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged
+        {
+            private get;
+            set;
+        }
+
+        public Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
+        {
+            _ = descriptor;
+            return OnStateChanged?.Invoke(ExternalLinkStateChange.Connected, null, ct) ?? Task.CompletedTask;
+        }
+
+        public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
+        {
+            _ = payload;
+            _ = ct;
+            throw new InvalidOperationException(message);
+        }
+
+        public Task DisconnectAsync(CancellationToken ct) => Task.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RecordingRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            Timeouts.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) =>
+            Task.CompletedTask;
     }
 
     private sealed class NoopRuntimeCallbackScheduler : IActorRuntimeCallbackScheduler

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
@@ -1,0 +1,213 @@
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
+using Aevatar.Workflow.Extensions.Bridge;
+using FluentAssertions;
+using Google.Protobuf;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.Workflow.Host.Api.Tests;
+
+public sealed class TelegramGetUpdatesExternalLinkTransportTests
+{
+    [Fact]
+    public async Task SendAsync_WhenConnectorSucceeds_ShouldMapRequestAndPublishResult()
+    {
+        var connector = new RecordingConnector(new ConnectorResponse
+        {
+            Success = true,
+            Output = """{"ok":true,"result":[]}""",
+        });
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(connector);
+        var transport = CreateTransport(registry);
+        var received = new List<TelegramGetUpdatesResult>();
+        transport.OnMessageReceived = (payload, ct) =>
+        {
+            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
+            return Task.CompletedTask;
+        };
+        var request = BuildRequest();
+
+        await transport.SendAsync(request.ToByteArray(), CancellationToken.None);
+
+        connector.Received.Should().ContainSingle();
+        connector.Received[0].RunId.Should().Be("cmd-1");
+        connector.Received[0].StepId.Should().Be("session-1");
+        connector.Received[0].Connector.Should().Be("telegram");
+        connector.Received[0].Operation.Should().Be("/getUpdates");
+        connector.Received[0].Payload.Should().Be("""{"timeout":1}""");
+        connector.Received[0].Parameters["method"].Should().Be("POST");
+        received.Should().ContainSingle();
+        received[0].CommandId.Should().Be("cmd-1");
+        received[0].Generation.Should().Be(7);
+        received[0].RequestId.Should().Be("request-1");
+        received[0].Success.Should().BeTrue();
+        received[0].Output.Should().Be("""{"ok":true,"result":[]}""");
+        received[0].RequestedOffset.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenConnectorMissing_ShouldPublishFailureResult()
+    {
+        var transport = CreateTransport(new InMemoryConnectorRegistry());
+        var received = new List<TelegramGetUpdatesResult>();
+        transport.OnMessageReceived = (payload, ct) =>
+        {
+            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
+            return Task.CompletedTask;
+        };
+
+        await transport.SendAsync(BuildRequest().ToByteArray(), CancellationToken.None);
+
+        var result = received.Should().ContainSingle().Subject;
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("telegram connector 'telegram' not found");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenConnectorThrowsSynchronously_ShouldPublishFailureResult()
+    {
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(new ThrowingConnector(new InvalidOperationException("sync broke")));
+        var transport = CreateTransport(registry);
+        var received = new List<TelegramGetUpdatesResult>();
+        transport.OnMessageReceived = (payload, ct) =>
+        {
+            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
+            return Task.CompletedTask;
+        };
+
+        await transport.SendAsync(BuildRequest().ToByteArray(), CancellationToken.None);
+
+        var result = received.Should().ContainSingle().Subject;
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("telegram getUpdates execution failed: sync broke");
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenConnectorFaultsAsynchronously_ShouldPublishFailureResult()
+    {
+        var registry = new InMemoryConnectorRegistry();
+        registry.Register(new FaultingConnector(new InvalidOperationException("async broke")));
+        var transport = CreateTransport(registry);
+        var received = new List<TelegramGetUpdatesResult>();
+        transport.OnMessageReceived = (payload, ct) =>
+        {
+            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
+            return Task.CompletedTask;
+        };
+
+        await transport.SendAsync(BuildRequest().ToByteArray(), CancellationToken.None);
+
+        var result = received.Should().ContainSingle().Subject;
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("telegram getUpdates execution failed: async broke");
+    }
+
+    [Fact]
+    public async Task ConnectAndDisconnect_ShouldPublishStateCallbacks()
+    {
+        var transport = CreateTransport(new InMemoryConnectorRegistry());
+        var states = new List<(ExternalLinkStateChange State, string? Reason)>();
+        transport.OnStateChanged = (state, reason, ct) =>
+        {
+            states.Add((state, reason));
+            return Task.CompletedTask;
+        };
+
+        await transport.ConnectAsync(
+            new ExternalLinkDescriptor("telegram-get-updates", "telegram-get-updates", "telegram://get-updates"),
+            CancellationToken.None);
+        await transport.DisconnectAsync(CancellationToken.None);
+
+        states.Should().Equal(
+            (ExternalLinkStateChange.Connected, null),
+            (ExternalLinkStateChange.Closed, "closed"));
+    }
+
+    [Fact]
+    public void Factory_ShouldMatchTransportTypeCaseInsensitivelyAndCreateTransport()
+    {
+        var factory = new TelegramGetUpdatesExternalLinkTransportFactory(
+            new InMemoryConnectorRegistry(),
+            NullLogger<TelegramGetUpdatesExternalLinkTransport>.Instance);
+
+        factory.CanCreate("telegram-get-updates").Should().BeTrue();
+        factory.CanCreate("TELEGRAM-GET-UPDATES").Should().BeTrue();
+        factory.CanCreate("websocket").Should().BeFalse();
+        factory.Create().Should().BeOfType<TelegramGetUpdatesExternalLinkTransport>();
+    }
+
+    private static TelegramGetUpdatesExternalLinkTransport CreateTransport(IConnectorRegistry registry) =>
+        new(registry, NullLogger<TelegramGetUpdatesExternalLinkTransport>.Instance);
+
+    private static TelegramGetUpdatesRequest BuildRequest()
+    {
+        var request = new TelegramGetUpdatesRequest
+        {
+            CommandId = "cmd-1",
+            Generation = 7,
+            RequestId = "request-1",
+            ConnectorName = "telegram",
+            RunId = "cmd-1",
+            StepId = "session-1",
+            Payload = """{"timeout":1}""",
+            Bootstrap = true,
+            RequestedOffset = 42,
+        };
+        request.Parameters["method"] = "POST";
+        return request;
+    }
+
+    private sealed class RecordingConnector(params ConnectorResponse[] responses) : IConnector
+    {
+        private int _responseIndex;
+
+        public List<ConnectorRequest> Received { get; } = [];
+        public string Name { get; } = "telegram";
+        public string Type { get; } = "http";
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            Received.Add(request);
+            var index = Math.Min(_responseIndex, responses.Length - 1);
+            _responseIndex++;
+            return Task.FromResult(responses[index]);
+        }
+    }
+
+    private sealed class ThrowingConnector(Exception exception) : IConnector
+    {
+        public string Name { get; } = "telegram";
+        public string Type { get; } = "http";
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            throw exception;
+        }
+    }
+
+    private sealed class FaultingConnector(Exception exception) : IConnector
+    {
+        public string Name { get; } = "telegram";
+        public string Type { get; } = "http";
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            return Task.FromException<ConnectorResponse>(exception);
+        }
+    }
+
+    private sealed class InMemoryConnectorRegistry : IConnectorRegistry
+    {
+        private readonly Dictionary<string, IConnector> _connectors = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Register(IConnector connector) => _connectors[connector.Name] = connector;
+        public bool TryGet(string name, out IConnector? connector) => _connectors.TryGetValue(name, out connector);
+        public IReadOnlyList<string> ListNames() => _connectors.Keys.ToList();
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
@@ -4,6 +4,7 @@ using Aevatar.Workflow.Extensions.Bridge;
 using FluentAssertions;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
@@ -35,8 +36,15 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
         connector.Received[0].StepId.Should().Be("session-1");
         connector.Received[0].Connector.Should().Be("telegram");
         connector.Received[0].Operation.Should().Be("/getUpdates");
-        connector.Received[0].Payload.Should().Be("""{"timeout":1}""");
+        var payload = JsonDocument.Parse(connector.Received[0].Payload).RootElement;
+        payload.GetProperty("timeout").GetInt32().Should().Be(1);
+        payload.GetProperty("offset").GetInt64().Should().Be(42);
+        payload.GetProperty("allowed_updates").EnumerateArray()
+            .Select(x => x.GetString())
+            .Should().Equal("message", "channel_post");
         connector.Received[0].Parameters["method"].Should().Be("POST");
+        connector.Received[0].Parameters["content_type"].Should().Be("application/json");
+        connector.Received[0].Parameters["timeout_ms"].Should().Be("4000");
         received.Should().ContainSingle();
         received[0].CommandId.Should().Be("cmd-1");
         received[0].Generation.Should().Be(7);
@@ -151,11 +159,15 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
             ConnectorName = "telegram",
             RunId = "cmd-1",
             StepId = "session-1",
-            Payload = """{"timeout":1}""",
+            PollTimeoutSeconds = 1,
+            PerCallTimeoutMs = 4000,
+            HttpMethod = "POST",
+            ContentType = "application/json",
             Bootstrap = true,
             RequestedOffset = 42,
         };
-        request.Parameters["method"] = "POST";
+        request.AllowedUpdates.Add("message");
+        request.AllowedUpdates.Add("channel_post");
         return request;
     }
 


### PR DESCRIPTION
## Summary

iter26 cluster-030 (medium)。Auric narrowing: "这跟 actor 持有 stream 是一类问题吧?"

- **Old**:`TelegramBridgeGAgent.ExecuteConnectorWithWatchdogAsync` 用 `Task.Delay` 兜底超时 + `ContinueWith` race + actor turn 内同步 await `/getUpdates` 长轮询。违反 "延迟/超时事件化" + "跨 actor 等待 continuation 化"。
- **New**:复用现有 `IExternalLinkAware/IExternalLinkPort/IExternalLinkTransport` actor-owned stream pattern(reflector#2 force-pick)。`TelegramWaitReplyGAgent` 实现 `IExternalLinkAware`,声明 Telegram get-updates link;`TelegramGetUpdatesExternalLinkTransport` 跑 `/getUpdates` 在 actor turn 外;result 经 `ExternalLinkMessageReceivedEvent` 回 actor inbox。

**无新 actor type**(reflector 已明示:actor 持有 stream 是已 CLAUDE.md 规则方向,非 new core abstraction)。

违反 CLAUDE.md:`延迟/超时事件化` + `跨 actor 等待 continuation 化`。

## Scope

6 files changed (+505/-240)。334 Host.Api tests pass。

设计共识:[issue #800 reflector#2 force-pick existing-externallink-stream](https://github.com/aevatarAI/aevatar/issues/800)(Auric narrowing 后)

🤖 Auto-loop / codex-refactor-loop iter26

⟦AI:AUTO-LOOP⟧
