### PR TITLE
[codex] Add tool-driven Aevatar core invocation sources

### DIFF
--- a/aevatar.slnx
+++ b/aevatar.slnx
@@ -52,6 +52,7 @@
     <Project Path="src/Aevatar.AI.ToolProviders.Binding/Aevatar.AI.ToolProviders.Binding.csproj" />
     <Project Path="src/Aevatar.AI.ToolProviders.ChronoStorage/Aevatar.AI.ToolProviders.ChronoStorage.csproj" />
     <Project Path="src/Aevatar.AI.ToolProviders.AgentCatalog/Aevatar.AI.ToolProviders.AgentCatalog.csproj" />
+    <Project Path="src/Aevatar.AI.ToolProviders.AevatarInvocation/Aevatar.AI.ToolProviders.AevatarInvocation.csproj" />
     <Project Path="src/Aevatar.AI.ToolProviders.Channel/Aevatar.AI.ToolProviders.Channel.csproj" />
     <Project Path="src/Aevatar.AI.ToolProviders.ChannelAdmin/Aevatar.AI.ToolProviders.ChannelAdmin.csproj" />
     <Project Path="src/Aevatar.AI.ToolProviders.Lark/Aevatar.AI.ToolProviders.Lark.csproj" />
@@ -166,6 +167,7 @@
     <Project Path="test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Core.Tests\Aevatar.AI.Core.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Tests\Aevatar.AI.Tests.csproj" />
+    <Project Path="test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj" />
     <Project Path="test\Aevatar.AI.ToolProviders.Ornn.Tests\Aevatar.AI.ToolProviders.Ornn.Tests.csproj" />
     <Project Path="test\Aevatar.AI.ToolProviders.ServiceInvoke.Tests\Aevatar.AI.ToolProviders.ServiceInvoke.Tests.csproj" />
     <Project Path="test\Aevatar.AI.ToolProviders.Lark.Tests\Aevatar.AI.ToolProviders.Lark.Tests.csproj" />

--- a/docs/adr/0026-tool-first-chat-ingress.md
+++ b/docs/adr/0026-tool-first-chat-ingress.md
@@ -1,0 +1,294 @@
+---
+title: Tool-First Chat Ingress — Collapse Forward Actions to Model + Tools
+status: Proposed
+owner: eanzhao
+---
+
+# ADR-0026: Tool-First Chat Ingress — Collapse Forward Actions to Model + Tools
+
+## Context
+
+ADR-0024 introduced `ChatRoutePolicy` with five `ChatRouteAction` oneof
+variants — `ForwardToModel`, `ForwardToGAgent`, `ForwardToTeam`,
+`ForwardToWorkflow`, `Reject` — and shipped `ForwardToModel`,
+`ForwardToGAgent`, and `ForwardToTeam` in v1. ADR-0025 extended the policy
+to voice using `ForwardToGAgent(actor_id, voice_module_name)` because voice
+v1 was framed as "pick a voice-enabled actor and attach a module".
+
+Two facts make the v1 shape no longer the right shape:
+
+1. **The tool-calling backbone is already present and load-bearing.**
+   `ToolCallLoop` in `src/Aevatar.AI.Core/Tools/ToolCallLoop.cs` plus
+   `IAgentToolSource` (30+ live implementations covering Scripting, Skills,
+   NyxID, Lark, ChronoStorage, …) already drives "LLM decides which tool to
+   call, dispatcher executes, result flows back". `/v1/responses` already
+   composes this on top of caller scope: substitute tools (`TodoWrite`,
+   `WebFetch`, `WebSearch`, `Task`) and additive tools (`use_skill`,
+   `ornn_search_skills`) are routed through the same caller's NyxID bearer
+   via NyxID proxy (see `nyxid-responses-direct.md` §5 and
+   `ResponsesAevatarToolProvider`). This is the architecture the policy was
+   incidentally working around, not a future state.
+
+2. **The remaining forward variants are a parallel routing dialect, not a
+   distinct capability.** `ForwardToGAgent` and `ForwardToTeam` on
+   `/v1/responses` (`ResponsesEndpoints.cs:779-927`) ultimately fan
+   `IStaticGAgentStreamInvocationPort<AGUIEvent>` and adapt back to SSE.
+   `ForwardToGAgent` on NyxIdChat (`AgentRunGAgent.cs:1108-1141`) is
+   implemented by mutating `NeedsLlmReplyEvent.TargetActorId`. Both shapes
+   could equally well be expressed as the LLM choosing to call a tool
+   `aevatar_invoke_gagent(actor_id, payload)` or
+   `aevatar_invoke_team(team_id, endpoint_id, payload)` that performs the
+   same dispatch.
+
+The status quo violates CLAUDE.md §"顶级架构约束 — 统一投影链路，禁止双轨实现"
+and §"单一主干，插件扩展". The cost is paid in three places: a parallel
+adapter chain on `/v1/responses` and `/ws/voice`, `TargetActorId` override
+plumbing in `NyxidChat`, and `/v1/messages` returning HTTP 501 because it
+cannot host the parallel dialect.
+
+## Decision
+
+### D1 — Collapse `ChatRouteAction` to two variants
+
+`ChatRoutePolicy` actions reduce to:
+
+- `Reject` (governance boundary, unchanged from ADR-0024)
+- `ForwardToModel` (extended; see D2)
+
+Removed actions:
+
+- `ForwardToGAgent` — replaced by tool `aevatar_invoke_gagent`
+- `ForwardToTeam` — replaced by tool `aevatar_invoke_team`
+- `ForwardToWorkflow` — replaced by tool `aevatar_start_workflow`
+  (the reserved wire slot becomes deprecated rather than realized)
+
+The "config actor + boundary resolver + readmodel" three-part form from
+ADR-0024 D1 is preserved. Only the action set narrows.
+
+### D2 — `ForwardToModel` carries tool injection
+
+`ForwardToModel` gains two typed fields:
+
+- `tool_set_ref` — a typed reference to a tool set the resolver should
+  inject for this ingress turn. Tool sets are named compositions (e.g.
+  `"workspace.default"`, `"lark.self_notify"`, `"voice.realtime"`) maintained
+  outside the policy proto so the action stays small.
+- `tool_choice_hint` — optional pinning of a particular tool plus
+  pre-filled named arguments. This is how a policy rule replaces the
+  semantics of "this caller's traffic should always reach GAgent X": it
+  ships `tool_set_ref=...; tool_choice_hint={name: "aevatar_invoke_gagent",
+  prefilled: {actor_id: "X"}}` instead of `ForwardToGAgent(X)`.
+
+Per CLAUDE.md §"字段命名与 Metadata 决策树" step 1, both fields are typed
+sub-messages, not `map<string, string>` bags.
+
+### D3 — New tool sources expose orchestration
+
+The following `IAgentToolSource` implementations are introduced in this
+repository (no external repo changes — CLAUDE.md §"外部仓库无改动权"):
+
+| Tool | Input | Output | Default `wait` |
+|---|---|---|---|
+| `aevatar_invoke_gagent` | `actor_id`/`actor_name`, typed `payload` | `{run_id, status, stream_topic?, result?}` | `stream` |
+| `aevatar_invoke_team` | `team_id`, `endpoint_id`, typed `payload` | same | `stream` |
+| `aevatar_start_workflow` | `workflow_id`, typed `inputs` | same | `stream` |
+| `aevatar_observe_run` | `run_id` | `{status, recent_events, partial_output}` | — |
+| `aevatar_query_readmodel` | `readmodel_name`, typed `query` | typed result | — |
+
+Payloads are typed proto, not free-form JSON. The dispatcher validates the
+proto schema before executing; a malformed call returns a structured error
+back to the LLM so it can self-correct rather than fail the turn.
+
+The existing additive-tool pattern from `/v1/responses` is the model: tools
+execute under the caller's scope through `AgentToolRequestContext`, never
+accepting credentials as arguments (CLAUDE.md §"NyxID credential isolation"
+memory).
+
+### D4 — Long-running work uses continuation events, not synchronous waits
+
+LLM tool-call protocol is request/response, but a GAgent run can take
+seconds to minutes. The default `wait=stream` returns `{run_id,
+stream_topic}` immediately; the session actor (D5) subscribes to the
+stream and folds events back into the LLM context for the next turn. The
+LLM can then continue with `aevatar_observe_run`, cancel, or proceed on
+the partial.
+
+This applies CLAUDE.md §"Actor 执行模型 — self continuation 事件化" and
+§"跨 actor 等待 continuation 化" at the chat-session layer: there is no
+synchronous await across actor boundaries.
+
+### D5 — `ChatRunActor` and `VoiceSessionActor` own session state as actors
+
+Two new session-scoped actors are introduced:
+
+- **`ChatRunActor`** for `/v1/responses` and `/v1/messages` SSE sessions.
+- **`VoiceSessionActor`** for `/ws/voice` Realtime sessions.
+
+Both own:
+
+- LLM context for the session
+- Tool-call history
+- Active sub-run subscriptions as a typed list in `State` (not a
+  middle-layer `Dictionary<runId, context>` — see CLAUDE.md §"中间层状态约束")
+- The state machine that folds sub-run committed events into the next
+  LLM turn
+
+Per CLAUDE.md §"Actor 即业务实体", these are named for the business entity
+(chat run, voice session), not the technical role.
+
+### D6 — Voice converges on the same ingress shape
+
+`/ws/voice` no longer binds to an actor at WebSocket upgrade time.
+`ChatRouteResolver` runs once at session establishment, returns
+`ForwardToModel(tool_set_ref=..., tool_choice_hint=...)`, and the
+`VoiceSessionActor` issues `session.update` to the OpenAI Realtime provider
+declaring the resolved tool set. Function calls from the model
+(`response.function_call_arguments.done` events) feed the same
+`ToolCallLoop`. Tool results flow back via server-initiated
+`conversation.item.create` + `response.create`, which is the documented
+OpenAI Realtime backchannel for asynchronous tool output.
+
+`/ws/voice/{actorId}` (dev/admin bypass from ADR-0024 D4) stays. It
+short-circuits the resolver, so its semantics are unaffected.
+
+This supersedes ADR-0025's "voice v1 supports `ForwardToGAgent` only;
+`ForwardToModel` returns HTTP 501". Voice v2 supports `ForwardToModel`
+exclusively; `ForwardToGAgent` ceases to be a wire-level concept for voice.
+
+**Prerequisite, not in this ADR:** `Aevatar.Foundation.VoicePresence.OpenAI`
+must complete its migration from beta-shape `session.update` to GA shape
+before voice can drive tool calls end-to-end (per the
+`reference_openai_realtime_beta_ga_shape_mismatch` operational record).
+This migration is tracked as an independent prerequisite issue.
+
+### D7 — Caller-scoped tools enable the "NyxID-direct user routes Lark to
+self" use case
+
+Because the additive-tool pattern from `nyxid-responses-direct.md` §5
+already executes tools under the caller's NyxID bearer (`use_skill` and
+`ornn_search_skills` work this way today), exposing Lark outbound as an
+`IAgentToolSource` lets a user calling `/v1/responses` directly through
+NyxID — without ever opening the Aevatar UI — say "push this to my Lark"
+and have the LLM call `lark_message_send`. The tool dispatcher reads
+`AgentToolRequestContext.NyxIdUserId`, calls NyxID's user-scoped Lark
+relay outbound endpoint with the caller's credentials, and the message
+lands in the caller's Lark account.
+
+This is not a new capability added by this ADR; it is the natural
+consequence of the unified shape. Two implementation details must be
+verified in Phase 1 and tracked as Phase 1 sub-tasks rather than
+deferred:
+
+1. NyxID's Lark relay outbound endpoint supports user-scoped push (not
+   only service-bot push). If it does not, CLAUDE.md §"外部仓库无改动权"
+   forbids us patching NyxID; the use case is then deferred until NyxID
+   ships it independently.
+2. Aevatar's Lark outbound tool (if any) propagates caller scope through
+   `AgentToolRequestContext` rather than using a service-level Lark
+   identity.
+
+## Boundaries
+
+- `IActorDispatchPort`, `IActorRuntime`, and internal actor-to-actor
+  dispatch surfaces are **not affected**. Only user-facing ingress
+  collapses. Internal system code that invokes a GAgent directly keeps its
+  direct path.
+- `ChatRoutePolicy` three-part form from ADR-0024 D1 is preserved.
+  `ChatRouteDecision` remains transient per ADR-0024 D2.
+- Workflow definition / editing endpoints
+  (`/api/scopes/{scopeId}/workflows`, `IWorkflowDraftStore`, etc.) are
+  unaffected. Only workflow *triggering* moves to the tool path. The
+  Studio member invoke surface
+  (`POST /api/scopes/{scopeId}/members/{memberId}/invoke/{endpointId}`)
+  remains as a direct system-to-system surface for callers that explicitly
+  do not want LLM mediation.
+- The existing `/v1/responses` Aevatar substitute and additive tool model
+  (`nyxid-responses-direct.md` §5) is extended, not replaced. The new
+  invocation tools join the additive-tool category.
+- `/ws/voice/{actorId}` dev bypass is preserved.
+- This ADR does not redesign the read-path for sub-run state observation;
+  `aevatar_observe_run` reads through the existing readmodel projection
+  surfaces. No new readmodel is introduced.
+
+## Verification
+
+Static checks (CI guards):
+
+- `chat_route_policy.proto`: new policy snapshots MUST NOT emit
+  `ForwardToGAgent`, `ForwardToTeam`, or `ForwardToWorkflow` after Phase 4.
+  A guard script asserts emission paths only produce `ForwardToModel` or
+  `Reject`.
+- `ResponsesEndpoints.cs` lines 779-927 deleted after Phase 4. A guard
+  script asserts the file does not contain `IStaticGAgentStreamInvocationPort`
+  references in `/v1/responses` handler bodies.
+- `AgentRunGAgent.cs:1108-1141` `TargetActorId` override deleted after
+  Phase 4. A guard script asserts `NeedsLlmReplyEvent.TargetActorId` is no
+  longer mutated outside the actor that owns the field's authoritative
+  state.
+- `ChatRunActor` and `VoiceSessionActor` substate that tracks sub-run IDs
+  is a typed proto `repeated` field on actor State, not a
+  `Dictionary<,>` field. Existing middleware-state guard (`tools/ci/`)
+  scope extends to the new actors.
+
+Runtime checks:
+
+- `/v1/responses` policy resolves `ForwardToModel(tool_set_ref=...)`,
+  injects the resolved tool set, ToolCallLoop dispatches
+  `aevatar_invoke_gagent(actor_id=X)`, sub-run starts, stream events fold
+  back into the response SSE — observed end-to-end without the legacy
+  `ForwardToGAgent` adapter.
+- `/v1/messages` no longer returns HTTP 501 for any case the legacy
+  policy would have routed to `ForwardToGAgent` / `ForwardToTeam`. The
+  Anthropic facade can host the same orchestration because the
+  orchestration lives in the tool layer, not the wire shape.
+- `/ws/voice` resolves a policy, declares tools to the Realtime provider,
+  and the model can call `aevatar_invoke_gagent` mid-conversation; the
+  result lands as a backchannel `conversation.item.create` + `response.create`
+  and the model speaks it aloud.
+- NyxID-direct caller (no Aevatar UI session) hits `/v1/responses` with
+  a NyxID bearer that has a Lark connection in NyxID; says "push X to
+  my Lark"; the Lark tool dispatches under caller scope; the message
+  appears in the caller's Lark account.
+
+Behavior preserved:
+
+- Caller scope semantics from `nyxid-responses-direct.md` §2 (scope
+  resolution, response session visibility) unchanged.
+- Per-user NyxID binding from ADR-0018 unchanged.
+- ADR-0024 D1/D2/D3/D4/D6 unchanged. Only D5 (action set in v1) is
+  superseded.
+
+## Stage Plan
+
+Each stage ships independently. Stages 1 and 5 can run in parallel after
+Stage 1's tool sources are merged.
+
+| Stage | Scope | Breaking? |
+|---|---|---|
+| **1** | Implement `aevatar_invoke_gagent` / `_team` / `_workflow` / `_observe_run` / `_query_readmodel` as `IAgentToolSource`. Wire into existing ToolCallLoop. Verify Lark outbound user-scoped path (D7 prerequisite). | No |
+| **2** | Extend `ForwardToModel` proto with `tool_set_ref` + `tool_choice_hint`. `ChatRouteResolver` translates legacy `ForwardToGAgent/Team` rules to `ForwardToModel + tool_choice_hint`. `ChatRunActor` introduced for SSE sessions. | No |
+| **3** | Deprecation: legacy `ForwardToGAgent` / `ForwardToTeam` / `ForwardToWorkflow` rules emit warning headers + structured logs. Provide policy-migration tool. Hold at least one release cycle. | No |
+| **4** | Remove code paths: `ResponsesEndpoints.cs:779-927`, `AgentRunGAgent.cs:1108-1141`, resolver branches for the three actions. Proto enum values marked deprecated (kept on the wire to avoid tag re-use); next major proto bump removes them. `/v1/messages` 501 fallback for these actions deleted. | Yes (clients still using legacy actions) |
+| **5** | `VoiceSessionActor` implementation. `/ws/voice` switches to `ForwardToModel + tool_set_ref`. `/ws/voice/{actorId}` dev bypass unaffected. **Blocked by:** VoicePresence.OpenAI GA migration. | Yes (voice clients) |
+
+## Supersedes
+
+- **ADR-0024 §D5** (v1 action set: `ForwardToGAgent`, `ForwardToModel`,
+  `ForwardToTeam` all implemented) — superseded by D1 of this ADR. The
+  rest of ADR-0024 (D1/D2/D3/D4/D6) stands.
+- **ADR-0025** (voice v1 routes to `ForwardToGAgent` only;
+  `ForwardToModel` returns 501) — superseded by D6 of this ADR. The
+  boundary constraints in ADR-0025 §"Boundaries" stand.
+
+## References
+
+- ADR-0018: Per-user NyxID binding via OAuth broker
+- ADR-0024: Chat Route Policy — Config Actor + Boundary Resolver
+- ADR-0025: Voice Router Integration — Policy-Aware WebSocket Boundary
+- `docs/canon/nyxid-responses-direct.md` — additive tools and caller
+  scope contract
+- `docs/canon/chat-api.md`
+- `docs/canon/llm-streaming.md`
+- Issue #672, #674, #588 — preceding routing work
+- `reference_openai_realtime_beta_ga_shape_mismatch` (operational memory)
+  — Voice Stage 5 prerequisite signal

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/Aevatar.AI.ToolProviders.AevatarInvocation.csproj
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/Aevatar.AI.ToolProviders.AevatarInvocation.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Aevatar.AI.ToolProviders.AevatarInvocation</AssemblyName>
+    <RootNamespace>Aevatar.AI.ToolProviders.AevatarInvocation</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aevatar.AI.ToolProviders.AevatarInvocation.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Aevatar.AI.Abstractions\Aevatar.AI.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\Aevatar.Presentation.AGUI\Aevatar.Presentation.AGUI.csproj" />
+    <ProjectReference Include="..\platform\Aevatar.GAgentService.Abstractions\Aevatar.GAgentService.Abstractions.csproj" />
+    <ProjectReference Include="..\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" />
+    <PackageReference Include="Grpc.Tools">
+      <PrivateAssets>All</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="aevatar_invocation_tools.proto" GrpcServices="None" />
+  </ItemGroup>
+</Project>

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationDispatcher.cs
@@ -1,0 +1,989 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.Presentation.AGUI;
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+public sealed class AevatarInvocationDispatcher
+{
+    private const string DirectGAgentPublisherId = "aevatar.tools.invoke_gagent";
+    private static readonly string[] ProtectedCallerMetadataKeys =
+    [
+        LLMRequestMetadataKeys.ScopeId,
+        LLMRequestMetadataKeys.OwnerSubject,
+        LLMRequestMetadataKeys.ResponseId,
+        LLMRequestMetadataKeys.RequestId,
+        LLMRequestMetadataKeys.CallId,
+        LLMRequestMetadataKeys.NyxIdAccessToken,
+        LLMRequestMetadataKeys.NyxIdOrgToken,
+        LLMRequestMetadataKeys.SenderNyxIdAccessToken,
+        LLMRequestMetadataKeys.SenderBindingId,
+        LLMRequestMetadataKeys.ModelOverride,
+        LLMRequestMetadataKeys.NyxIdRoutePreference,
+        LLMRequestMetadataKeys.MaxToolRoundsOverride,
+        LLMRequestMetadataKeys.ConnectedServicesContext,
+        "scope_id",
+    ];
+
+    private static readonly JsonFormatter ProtoJsonFormatter = new(
+        JsonFormatter.Settings.Default
+            .WithFormatDefaultValues(false)
+            .WithTypeRegistry(TypeRegistry.FromFiles(
+                AGUIEvent.Descriptor.File,
+                AnyReflection.Descriptor,
+                StructReflection.Descriptor,
+                WrappersReflection.Descriptor)));
+
+    private readonly IActorDispatchPort _actorDispatchPort;
+    private readonly IGAgentActorRegistryQueryPort _actorRegistryQueryPort;
+    private readonly ITeamEntryMemberResolver _teamEntryMemberResolver;
+    private readonly IStaticGAgentStreamInvocationPort<AGUIEvent> _teamInvocationPort;
+    private readonly ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> _workflowDispatchService;
+    private readonly IServiceRunQueryPort _serviceRunQueryPort;
+    private readonly IGAgentRunTerminalQueryPort _terminalQueryPort;
+    private readonly IWorkflowExecutionQueryApplicationService _workflowQueryService;
+    private readonly ILogger<AevatarInvocationDispatcher> _logger;
+
+    public AevatarInvocationDispatcher(
+        IActorDispatchPort actorDispatchPort,
+        IGAgentActorRegistryQueryPort actorRegistryQueryPort,
+        ITeamEntryMemberResolver teamEntryMemberResolver,
+        IStaticGAgentStreamInvocationPort<AGUIEvent> teamInvocationPort,
+        ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> workflowDispatchService,
+        IServiceRunQueryPort serviceRunQueryPort,
+        IGAgentRunTerminalQueryPort terminalQueryPort,
+        IWorkflowExecutionQueryApplicationService workflowQueryService,
+        ILogger<AevatarInvocationDispatcher>? logger = null)
+    {
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _actorRegistryQueryPort = actorRegistryQueryPort ?? throw new ArgumentNullException(nameof(actorRegistryQueryPort));
+        _teamEntryMemberResolver = teamEntryMemberResolver ?? throw new ArgumentNullException(nameof(teamEntryMemberResolver));
+        _teamInvocationPort = teamInvocationPort ?? throw new ArgumentNullException(nameof(teamInvocationPort));
+        _workflowDispatchService = workflowDispatchService ?? throw new ArgumentNullException(nameof(workflowDispatchService));
+        _serviceRunQueryPort = serviceRunQueryPort ?? throw new ArgumentNullException(nameof(serviceRunQueryPort));
+        _terminalQueryPort = terminalQueryPort ?? throw new ArgumentNullException(nameof(terminalQueryPort));
+        _workflowQueryService = workflowQueryService ?? throw new ArgumentNullException(nameof(workflowQueryService));
+        _logger = logger ?? NullLogger<AevatarInvocationDispatcher>.Instance;
+    }
+
+    public async Task<string> InvokeGAgentAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var parsed = ProtoToolArguments.Parse<InvokeGAgentToolRequest>(argumentsJson);
+        if (parsed.Error != null)
+            return AevatarInvocationJson.Error(parsed.Error);
+
+        var request = parsed.Value!;
+        var error = ProtoToolArguments.RequirePayload(request.Payload, "payload") ??
+                    ValidateWaitIsDispatchable(ResolveWait(request.Wait), "aevatar_invoke_gagent");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
+
+        var scope = ResolveCallerScope();
+        if (scope.Error != null)
+            return AevatarInvocationJson.Error(scope.Error);
+
+        var target = await ResolveGAgentActorIdAsync(request, scope.Value!, ct);
+        if (target.Error != null)
+            return AevatarInvocationJson.Error(target.Error);
+
+        var wait = ResolveWait(request.Wait);
+        var commandId = ResolveCommandId();
+        var chatRequest = BuildChatRequest(request.Payload, commandId, scope.Value!);
+        var envelope = new EventEnvelope
+        {
+            Id = commandId,
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(chatRequest),
+            Route = EnvelopeRouteSemantics.CreateDirect(DirectGAgentPublisherId, target.ActorId),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = commandId,
+            },
+        };
+
+        try
+        {
+            await _actorDispatchPort.DispatchAsync(target.ActorId, envelope, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return AevatarInvocationJson.Error(Error(
+                "dispatch_failed",
+                $"GAgent dispatch failed: {ex.Message}"));
+        }
+
+        return AevatarInvocationJson.Serialize(new InvocationToolResult
+        {
+            RunId = commandId,
+            Status = wait == InvocationWaitMode.Ack ? "accepted" : "streaming",
+            StreamTopic = wait == InvocationWaitMode.Stream
+                ? AevatarInvocationStreamTopics.ForActorRun(target.ActorId, commandId)
+                : string.Empty,
+            ActorId = target.ActorId,
+            CommandId = commandId,
+            CorrelationId = commandId,
+            Wait = wait,
+        });
+    }
+
+    public async Task<string> InvokeTeamAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var parsed = ProtoToolArguments.Parse<InvokeTeamToolRequest>(argumentsJson);
+        if (parsed.Error != null)
+            return AevatarInvocationJson.Error(parsed.Error);
+
+        var request = parsed.Value!;
+        var error = ProtoToolArguments.Require(request.TeamId, "team_id", "team_id is required.") ??
+                    ProtoToolArguments.Require(request.EndpointId, "endpoint_id", "endpoint_id is required.") ??
+                    ProtoToolArguments.RequirePayload(request.Payload, "payload");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
+
+        var scope = ResolveCallerScope();
+        if (scope.Error != null)
+            return AevatarInvocationJson.Error(scope.Error);
+
+        var wait = ResolveWait(request.Wait);
+        try
+        {
+            var resolution = await _teamEntryMemberResolver.ResolveAsync(
+                scope.Value!.ScopeId,
+                request.TeamId.Trim(),
+                ct);
+            var invocation = BuildStaticInvocationRequest(resolution, request, scope.Value!);
+            return wait == InvocationWaitMode.Complete
+                ? await InvokeTeamToCompletionAsync(invocation, resolution, request.EndpointId, wait, ct)
+                : await InvokeTeamToAcceptanceAsync(invocation, resolution, request.EndpointId, wait, ct);
+        }
+        catch (TeamEntryMemberResolutionException ex)
+        {
+            return AevatarInvocationJson.Error(Error(ex.Code, ex.Message));
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            return AevatarInvocationJson.Error(Error(
+                "dispatch_failed",
+                $"Team invocation failed: {ex.Message}"));
+        }
+    }
+
+    public async Task<string> StartWorkflowAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var parsed = ProtoToolArguments.Parse<StartWorkflowToolRequest>(argumentsJson);
+        if (parsed.Error != null)
+            return AevatarInvocationJson.Error(parsed.Error);
+
+        var request = parsed.Value!;
+        var wait = ResolveWait(request.Wait);
+        var error = ProtoToolArguments.Require(request.WorkflowId, "workflow_id", "workflow_id is required.") ??
+                    ProtoToolArguments.RequirePayload(request.Inputs, "inputs") ??
+                    ValidateWaitIsDispatchable(wait, "aevatar_start_workflow");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
+
+        var scope = ResolveCallerScope();
+        if (scope.Error != null)
+            return AevatarInvocationJson.Error(scope.Error);
+
+        var metadata = BuildLegacyMetadata(scope.Value!, request.Inputs.Headers);
+        metadata[WorkflowRunCommandMetadataKeys.ScopeId] = scope.Value!.ScopeId;
+        var command = new WorkflowChatRunRequest(
+            Prompt: request.Inputs.Prompt,
+            WorkflowName: request.WorkflowId.Trim(),
+            ActorId: string.IsNullOrWhiteSpace(request.ActorId) ? null : request.ActorId.Trim(),
+            SessionId: ResolveSessionId(),
+            InputParts: ToWorkflowInputParts(request.Inputs),
+            WorkflowYamls: request.WorkflowYamls.Count == 0
+                ? null
+                : request.WorkflowYamls
+                    .Where(static item => !string.IsNullOrWhiteSpace(item))
+                    .Select(static item => item.Trim())
+                    .ToArray(),
+            Metadata: metadata,
+            ScopeId: scope.Value.ScopeId);
+
+        var result = await _workflowDispatchService.DispatchAsync(command, ct);
+        if (!result.Succeeded || result.Receipt == null)
+        {
+            return AevatarInvocationJson.Error(Error(
+                result.Error.ToString(),
+                $"Workflow start failed: {result.Error}"));
+        }
+
+        var receipt = result.Receipt;
+        return AevatarInvocationJson.Serialize(new InvocationToolResult
+        {
+            RunId = receipt.CommandId,
+            Status = wait == InvocationWaitMode.Ack ? "accepted" : "streaming",
+            StreamTopic = wait == InvocationWaitMode.Stream
+                ? AevatarInvocationStreamTopics.ForActorRun(receipt.ActorId, receipt.CommandId)
+                : string.Empty,
+            ActorId = receipt.ActorId,
+            CommandId = receipt.CommandId,
+            CorrelationId = receipt.CorrelationId,
+            Wait = wait,
+        });
+    }
+
+    public async Task<string> ObserveRunAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var parsed = ProtoToolArguments.Parse<ObserveRunToolRequest>(argumentsJson);
+        if (parsed.Error != null)
+            return AevatarInvocationJson.Error(parsed.Error);
+
+        var request = parsed.Value!;
+        var error = ProtoToolArguments.Require(request.RunId, "run_id", "run_id is required.");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
+
+        var runId = request.RunId.Trim();
+        var scope = ResolveCallerScope(requireOwner: false);
+        if (scope.Error != null)
+            return AevatarInvocationJson.Error(scope.Error);
+
+        ServiceRunSnapshot? serviceRun = null;
+        if (!string.IsNullOrWhiteSpace(request.ServiceId))
+        {
+            serviceRun = await _serviceRunQueryPort.GetByRunIdAsync(
+                scope.Value!.ScopeId,
+                request.ServiceId.Trim(),
+                runId,
+                ct);
+        }
+
+        var actorId = FirstNonEmpty(request.ActorId, serviceRun?.TargetActorId, serviceRun?.ActorId);
+        if (!string.IsNullOrWhiteSpace(actorId))
+        {
+            var terminal = await _terminalQueryPort.GetByCorrelationIdAsync(actorId!, runId, ct)
+                           ?? await _terminalQueryPort.GetBySessionIdAsync(actorId!, runId, ct);
+            if (terminal != null)
+                return AevatarInvocationJson.Serialize(MapTerminal(terminal, runId));
+
+            var workflow = await _workflowQueryService.GetActorSnapshotAsync(actorId!, ct);
+            if (workflow != null &&
+                (string.IsNullOrWhiteSpace(workflow.LastCommandId) ||
+                 string.Equals(workflow.LastCommandId, runId, StringComparison.Ordinal)))
+            {
+                return AevatarInvocationJson.Serialize(MapWorkflowSnapshot(workflow, runId, request.Take));
+            }
+        }
+
+        if (serviceRun != null)
+            return AevatarInvocationJson.Serialize(MapServiceRun(serviceRun));
+
+        return AevatarInvocationJson.Serialize(new ObserveRunResult
+        {
+            RunId = runId,
+            Error = Error(
+                "run_not_found",
+                "No registered service run, terminal GAgent snapshot, or workflow snapshot matched the requested run_id."),
+        });
+    }
+
+    public async Task<string> QueryReadModelAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        var parsed = ProtoToolArguments.Parse<QueryReadModelToolRequest>(argumentsJson);
+        if (parsed.Error != null)
+            return AevatarInvocationJson.Error(parsed.Error);
+
+        var request = parsed.Value!;
+        var error = ProtoToolArguments.Require(request.ReadmodelName, "readmodel_name", "readmodel_name is required.") ??
+                    ProtoToolArguments.RequireMessage(request.Query, "query");
+        if (error != null)
+            return AevatarInvocationJson.Error(error);
+
+        return request.ReadmodelName.Trim() switch
+        {
+            AevatarInvocationReadModels.ServiceRunCurrentState => await QueryServiceRunAsync(request.Query, ct),
+            AevatarInvocationReadModels.GAgentRunTerminal => await QueryGAgentRunTerminalAsync(request.Query, ct),
+            AevatarInvocationReadModels.WorkflowActorCurrentState => await QueryWorkflowActorSnapshotAsync(request.Query, ct),
+            AevatarInvocationReadModels.WorkflowActorTimeline => await QueryWorkflowActorTimelineAsync(request.Query, ct),
+            _ => AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = request.ReadmodelName,
+                Error = Error(
+                    "readmodel_not_registered",
+                    $"readmodel_name must be one of: {string.Join(", ", AevatarInvocationToolSchemas.ReadModelNames)}",
+                    "readmodel_name"),
+            }),
+        };
+    }
+
+    private static InvocationToolError? ValidateWaitIsDispatchable(InvocationWaitMode wait, string toolName) =>
+        wait == InvocationWaitMode.Complete
+            ? Error(
+                "wait_complete_unavailable",
+                $"{toolName} supports wait=ack and wait=stream in Unit 1. wait=complete requires a completion observer.",
+                "wait")
+            : null;
+
+    private async Task<string> InvokeTeamToAcceptanceAsync(
+        StaticGAgentStreamInvocationRequest invocation,
+        TeamEntryMemberResolution resolution,
+        string endpointId,
+        InvocationWaitMode wait,
+        CancellationToken ct)
+    {
+        var acceptedSource = new TaskCompletionSource<StaticGAgentStreamAcceptedReceipt>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var invocationTask = _teamInvocationPort.InvokeAsync(
+            invocation,
+            static (_, _) => ValueTask.CompletedTask,
+            (receipt, _) =>
+            {
+                acceptedSource.TrySetResult(receipt);
+                return ValueTask.CompletedTask;
+            },
+            ct);
+
+        _ = ObserveDetachedInvocationAsync(invocationTask);
+
+        var accepted = await acceptedSource.Task.WaitAsync(ct);
+        return AevatarInvocationJson.Serialize(BuildTeamAcceptedResult(
+            resolution,
+            endpointId,
+            accepted,
+            wait));
+    }
+
+    private async Task<string> InvokeTeamToCompletionAsync(
+        StaticGAgentStreamInvocationRequest invocation,
+        TeamEntryMemberResolution resolution,
+        string endpointId,
+        InvocationWaitMode wait,
+        CancellationToken ct)
+    {
+        var frames = new List<AGUIEvent>();
+        var result = await _teamInvocationPort.InvokeAsync(
+            invocation,
+            (frame, _) =>
+            {
+                frames.Add(frame.Clone());
+                return ValueTask.CompletedTask;
+            },
+            null,
+            ct);
+
+        if (!result.Succeeded || result.Accepted == null)
+        {
+            return AevatarInvocationJson.Error(Error(
+                result.StartError.ToString(),
+                $"Team invocation was not accepted: {result.StartError}"));
+        }
+
+        var accepted = BuildTeamAcceptedResult(resolution, endpointId, result.Accepted, wait);
+        accepted.Status = result.CompletionObserved ? result.CompletionStatus.ToString() : "accepted";
+        accepted.ResultJson = AevatarInvocationJson.ToJson(new
+        {
+            completion_status = result.CompletionStatus.ToString(),
+            completion_observed = result.CompletionObserved,
+            events = frames.Select(static frame => AevatarInvocationToolSchemas.ParseObject(ProtoJsonFormatter.Format(frame))).ToArray(),
+        });
+        return AevatarInvocationJson.Serialize(accepted);
+    }
+
+    private InvocationToolResult BuildTeamAcceptedResult(
+        TeamEntryMemberResolution resolution,
+        string endpointId,
+        StaticGAgentStreamAcceptedReceipt accepted,
+        InvocationWaitMode wait)
+    {
+        var runId = accepted.ServiceReceipt.CommandId;
+        return new InvocationToolResult
+        {
+            RunId = runId,
+            Status = wait == InvocationWaitMode.Ack ? "accepted" : "streaming",
+            StreamTopic = wait == InvocationWaitMode.Stream
+                ? AevatarInvocationStreamTopics.ForServiceRun(resolution.ScopeId, resolution.PublishedServiceId, runId)
+                : string.Empty,
+            ActorId = accepted.ServiceReceipt.TargetActorId,
+            CommandId = accepted.ServiceReceipt.CommandId,
+            CorrelationId = accepted.ServiceReceipt.CorrelationId,
+            ServiceId = resolution.PublishedServiceId,
+            EndpointId = endpointId.Trim(),
+            Wait = wait,
+        };
+    }
+
+    private async Task ObserveDetachedInvocationAsync(Task invocationTask)
+    {
+        try
+        {
+            await invocationTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // The caller's token can cancel after the accepted receipt has already been returned.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Detached team invocation failed after accepted receipt was returned.");
+        }
+    }
+
+    private StaticGAgentStreamInvocationRequest BuildStaticInvocationRequest(
+        TeamEntryMemberResolution resolution,
+        InvokeTeamToolRequest request,
+        InvocationCallerScope scope)
+    {
+        var headers = BuildLegacyMetadata(scope, request.Payload.Headers);
+        var identity = new ServiceIdentity
+        {
+            TenantId = resolution.ScopeId,
+            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
+            ServiceId = resolution.PublishedServiceId,
+        };
+
+        var input = new StaticGAgentStreamInvocationInput(
+            Prompt: request.Payload.Prompt,
+            SessionId: ResolveSessionId(),
+            Headers: headers,
+            InputParts: ToGAgentInputParts(request.Payload),
+            Caller: new ServiceInvocationCaller
+            {
+                TenantId = resolution.ScopeId,
+                AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+                ServiceKey = string.Empty,
+            });
+        return new StaticGAgentStreamInvocationRequest(identity, request.EndpointId.Trim(), input);
+    }
+
+    private async Task<ActorTargetResolution> ResolveGAgentActorIdAsync(
+        InvokeGAgentToolRequest request,
+        InvocationCallerScope scope,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(request.ActorId))
+            return ActorTargetResolution.Success(request.ActorId.Trim());
+
+        if (string.IsNullOrWhiteSpace(request.ActorName))
+        {
+            return ActorTargetResolution.Failed(Error(
+                "invalid_arguments",
+                "actor_id or actor_name is required.",
+                "actor_id"));
+        }
+
+        var actorName = request.ActorName.Trim();
+        var snapshot = await _actorRegistryQueryPort.ListActorsAsync(scope.ScopeId, ct);
+        var group = snapshot.Groups.FirstOrDefault(g =>
+            string.Equals(g.GAgentType, actorName, StringComparison.OrdinalIgnoreCase));
+        if (group == null || group.ActorIds.Count == 0)
+        {
+            return ActorTargetResolution.Failed(Error(
+                "actor_not_found",
+                $"No actor_name '{actorName}' is registered in caller scope '{scope.ScopeId}'.",
+                "actor_name"));
+        }
+
+        if (group.ActorIds.Count > 1)
+        {
+            return ActorTargetResolution.Failed(Error(
+                "actor_name_ambiguous",
+                $"actor_name '{actorName}' resolved to {group.ActorIds.Count} actors. Use actor_id.",
+                "actor_name"));
+        }
+
+        return ActorTargetResolution.Success(group.ActorIds[0]);
+    }
+
+    private async Task<string> QueryServiceRunAsync(ReadModelQuery query, CancellationToken ct)
+    {
+        var scope = ResolveCallerScope(requireOwner: false);
+        if (scope.Error != null)
+            return AevatarInvocationJson.Error(scope.Error);
+
+        if (string.IsNullOrWhiteSpace(query.ServiceId))
+        {
+            return AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = AevatarInvocationReadModels.ServiceRunCurrentState,
+                Error = Error("invalid_arguments", "query.service_id is required.", "query.service_id"),
+            });
+        }
+
+        ServiceRunSnapshot? one = null;
+        if (!string.IsNullOrWhiteSpace(query.RunId))
+        {
+            one = await _serviceRunQueryPort.GetByRunIdAsync(
+                scope.Value!.ScopeId,
+                query.ServiceId.Trim(),
+                query.RunId.Trim(),
+                ct);
+        }
+        else if (!string.IsNullOrWhiteSpace(query.CommandId))
+        {
+            one = await _serviceRunQueryPort.GetByCommandIdAsync(
+                scope.Value!.ScopeId,
+                query.ServiceId.Trim(),
+                query.CommandId.Trim(),
+                ct);
+        }
+
+        if (one != null)
+        {
+            return AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = AevatarInvocationReadModels.ServiceRunCurrentState,
+                ResultJson = AevatarInvocationJson.ToJson(one),
+                Count = 1,
+            });
+        }
+
+        var items = await _serviceRunQueryPort.ListAsync(
+            new ServiceRunQuery(
+                scope.Value!.ScopeId,
+                query.ServiceId.Trim(),
+                BoundTake(query.Take)),
+            ct);
+        return AevatarInvocationJson.Serialize(new QueryReadModelResult
+        {
+            ReadmodelName = AevatarInvocationReadModels.ServiceRunCurrentState,
+            ResultJson = AevatarInvocationJson.ToJson(items),
+            Count = items.Count,
+        });
+    }
+
+    private async Task<string> QueryGAgentRunTerminalAsync(ReadModelQuery query, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query.ActorId))
+        {
+            return AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = AevatarInvocationReadModels.GAgentRunTerminal,
+                Error = Error("invalid_arguments", "query.actor_id is required.", "query.actor_id"),
+            });
+        }
+
+        var correlationId = FirstNonEmpty(query.CommandId, query.RunId, query.Id);
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            return AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = AevatarInvocationReadModels.GAgentRunTerminal,
+                Error = Error("invalid_arguments", "query.command_id, query.run_id, or query.id is required.", "query.run_id"),
+            });
+        }
+
+        var snapshot = await _terminalQueryPort.GetByCorrelationIdAsync(
+            query.ActorId.Trim(),
+            correlationId!,
+            ct);
+        return AevatarInvocationJson.Serialize(new QueryReadModelResult
+        {
+            ReadmodelName = AevatarInvocationReadModels.GAgentRunTerminal,
+            ResultJson = snapshot == null ? "null" : AevatarInvocationJson.ToJson(snapshot),
+            Count = snapshot == null ? 0 : 1,
+        });
+    }
+
+    private async Task<string> QueryWorkflowActorSnapshotAsync(ReadModelQuery query, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query.ActorId))
+        {
+            return AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = AevatarInvocationReadModels.WorkflowActorCurrentState,
+                Error = Error("invalid_arguments", "query.actor_id is required.", "query.actor_id"),
+            });
+        }
+
+        var snapshot = await _workflowQueryService.GetActorSnapshotAsync(query.ActorId.Trim(), ct);
+        return AevatarInvocationJson.Serialize(new QueryReadModelResult
+        {
+            ReadmodelName = AevatarInvocationReadModels.WorkflowActorCurrentState,
+            ResultJson = snapshot == null ? "null" : ProtoJsonFormatter.Format(snapshot),
+            Count = snapshot == null ? 0 : 1,
+        });
+    }
+
+    private async Task<string> QueryWorkflowActorTimelineAsync(ReadModelQuery query, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query.ActorId))
+        {
+            return AevatarInvocationJson.Serialize(new QueryReadModelResult
+            {
+                ReadmodelName = AevatarInvocationReadModels.WorkflowActorTimeline,
+                Error = Error("invalid_arguments", "query.actor_id is required.", "query.actor_id"),
+            });
+        }
+
+        var items = await _workflowQueryService.ListActorTimelineAsync(
+            query.ActorId.Trim(),
+            BoundTake(query.Take),
+            ct);
+        return AevatarInvocationJson.Serialize(new QueryReadModelResult
+        {
+            ReadmodelName = AevatarInvocationReadModels.WorkflowActorTimeline,
+            ResultJson = ProtoJsonFormatter.Format(new ListValue
+            {
+                Values =
+                {
+                    items.Select(item => Value.ForStruct(JsonParser.Default.Parse<Struct>(
+                        ProtoJsonFormatter.Format(item)))),
+                },
+            }),
+            Count = items.Count,
+        });
+    }
+
+    private static ObserveRunResult MapTerminal(GAgentRunTerminalSnapshot terminal, string runId) =>
+        new()
+        {
+            RunId = runId,
+            Status = terminal.Status.ToString(),
+            ActorId = terminal.ActorId,
+            CommandId = terminal.CorrelationId,
+            StateVersion = terminal.StateVersion,
+            RecentEvents =
+            {
+                new RunEventSummary
+                {
+                    EventType = terminal.InteractionKind.ToString(),
+                    Message = FirstNonEmpty(terminal.ReasonMessage, terminal.ReasonCode, terminal.Status.ToString()) ?? string.Empty,
+                    TimestampUtc = terminal.ObservedAt.UtcDateTime.ToString("O"),
+                },
+            },
+        };
+
+    private static ObserveRunResult MapWorkflowSnapshot(
+        WorkflowActorSnapshot snapshot,
+        string runId,
+        int take)
+    {
+        var result = new ObserveRunResult
+        {
+            RunId = runId,
+            Status = snapshot.CompletionStatusValue.ToString(),
+            PartialOutput = snapshot.LastOutput,
+            ActorId = snapshot.ActorId,
+            CommandId = snapshot.LastCommandId,
+            StateVersion = snapshot.StateVersion,
+        };
+        result.RecentEvents.Add(new RunEventSummary
+        {
+            EventType = "workflow_actor_snapshot",
+            Message = string.IsNullOrWhiteSpace(snapshot.LastError) ? snapshot.LastOutput : snapshot.LastError,
+            TimestampUtc = snapshot.LastUpdatedAtUtc?.ToDateTime().ToUniversalTime().ToString("O") ?? string.Empty,
+        });
+        return result;
+    }
+
+    private static ObserveRunResult MapServiceRun(ServiceRunSnapshot snapshot) =>
+        new()
+        {
+            RunId = snapshot.RunId,
+            Status = snapshot.Status.ToString(),
+            ActorId = FirstNonEmpty(snapshot.TargetActorId, snapshot.ActorId) ?? string.Empty,
+            CommandId = snapshot.CommandId,
+            StateVersion = snapshot.StateVersion,
+            RecentEvents =
+            {
+                new RunEventSummary
+                {
+                    EventType = "service_run_current_state",
+                    Message = snapshot.Status.ToString(),
+                    TimestampUtc = snapshot.UpdatedAt.UtcDateTime.ToString("O"),
+                },
+            },
+        };
+
+    private static ChatRequestEvent BuildChatRequest(
+        InvocationPayload payload,
+        string commandId,
+        InvocationCallerScope scope)
+    {
+        var metadata = BuildLegacyMetadata(scope, payload.Headers);
+        var request = new ChatRequestEvent
+        {
+            Prompt = payload.Prompt,
+            SessionId = commandId,
+            ScopeId = scope.ScopeId,
+            ToolContext = ToPayload(AgentToolRequestContext.Current),
+        };
+        request.Headers[LLMRequestMetadataKeys.RequestId] = commandId;
+        AppendMetadata(request.Headers, metadata);
+        AppendMetadata(request.Metadata, metadata);
+        request.InputParts.Add(ToChatInputParts(payload));
+        return request;
+    }
+
+    private static Dictionary<string, string> BuildLegacyMetadata(
+        InvocationCallerScope scope,
+        Google.Protobuf.Collections.MapField<string, string>? headers = null)
+    {
+        var metadata = AgentToolRequestContext.Current?.ToLegacyMetadata() is { } current
+            ? new Dictionary<string, string>(current, StringComparer.Ordinal)
+            : new Dictionary<string, string>(StringComparer.Ordinal);
+        RemoveProtectedCallerMetadata(metadata);
+        if (headers != null)
+        {
+            foreach (var (key, value) in headers)
+            {
+                var normalizedKey = Normalize(key);
+                if (normalizedKey != null && !IsProtectedCallerMetadataKey(normalizedKey))
+                    metadata[normalizedKey] = value ?? string.Empty;
+            }
+        }
+
+        StampTrustedCallerMetadata(metadata, scope);
+        return metadata;
+    }
+
+    private static void RemoveProtectedCallerMetadata(IDictionary<string, string> metadata)
+    {
+        foreach (var key in ProtectedCallerMetadataKeys)
+            metadata.Remove(key);
+    }
+
+    private static bool IsProtectedCallerMetadataKey(string key) =>
+        ProtectedCallerMetadataKeys.Any(protectedKey =>
+            string.Equals(protectedKey, key, StringComparison.Ordinal));
+
+    private static void StampTrustedCallerMetadata(
+        IDictionary<string, string> metadata,
+        InvocationCallerScope scope)
+    {
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ScopeId, scope.ScopeId);
+        SetTrustedMetadata(metadata, "scope_id", scope.ScopeId);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.OwnerSubject, scope.OwnerSubject);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ResponseId, scope.ResponseId);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.RequestId, AgentToolRequestContext.RequestId);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.CallId, AgentToolRequestContext.CallId);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.NyxIdAccessToken, AgentToolRequestContext.NyxIdAccessToken);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.NyxIdOrgToken, AgentToolRequestContext.NyxIdOrgToken);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.SenderNyxIdAccessToken, AgentToolRequestContext.SenderNyxIdAccessToken);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.SenderBindingId, AgentToolRequestContext.SenderBindingId);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ModelOverride, AgentToolRequestContext.ModelOverride);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.NyxIdRoutePreference, AgentToolRequestContext.NyxIdRoutePreference);
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.MaxToolRoundsOverride, AgentToolRequestContext.MaxToolRoundsOverride?.ToString());
+        SetTrustedMetadata(metadata, LLMRequestMetadataKeys.ConnectedServicesContext, AgentToolRequestContext.ConnectedServicesContext);
+    }
+
+    private static void SetTrustedMetadata(
+        IDictionary<string, string> metadata,
+        string key,
+        string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            metadata[key] = value.Trim();
+    }
+
+    private static void AppendMetadata(
+        Google.Protobuf.Collections.MapField<string, string> destination,
+        IReadOnlyDictionary<string, string> source)
+    {
+        foreach (var (key, value) in source)
+        {
+            if (!string.IsNullOrWhiteSpace(key) && !string.IsNullOrWhiteSpace(value))
+                destination[key.Trim()] = value.Trim();
+        }
+    }
+
+    private static AgentToolExecutionContextPayload ToPayload(AgentToolExecutionContext? context)
+    {
+        context ??= AgentToolExecutionContext.Empty;
+        var payload = new AgentToolExecutionContextPayload
+        {
+            Request = new AgentToolRequestIdentityPayload
+            {
+                RequestId = context.Request.RequestId ?? string.Empty,
+                CallId = context.Request.CallId ?? string.Empty,
+            },
+            Credentials = new AgentToolCredentialsPayload
+            {
+                NyxIdAccessToken = context.Credentials.NyxIdAccessToken ?? string.Empty,
+                NyxIdOrgToken = context.Credentials.NyxIdOrgToken ?? string.Empty,
+                SenderNyxIdAccessToken = context.Credentials.SenderNyxIdAccessToken ?? string.Empty,
+            },
+            Caller = new AgentToolCallerContextPayload
+            {
+                ScopeId = context.Caller.ScopeId ?? string.Empty,
+                OwnerSubject = context.Caller.OwnerSubject ?? string.Empty,
+                ResponseId = context.Caller.ResponseId ?? string.Empty,
+            },
+            Channel = new AgentToolChannelContextPayload
+            {
+                Platform = context.Channel.Platform ?? string.Empty,
+                SenderId = context.Channel.SenderId ?? string.Empty,
+                RegistrationScopeId = context.Channel.RegistrationScopeId ?? string.Empty,
+                MessageId = context.Channel.MessageId ?? string.Empty,
+                PlatformMessageId = context.Channel.PlatformMessageId ?? string.Empty,
+            },
+            SenderBinding = new AgentToolSenderBindingContextPayload
+            {
+                BindingId = context.SenderBinding.BindingId ?? string.Empty,
+            },
+            Routing = new LLMRequestRoutingContextPayload
+            {
+                ModelOverride = context.Routing.ModelOverride ?? string.Empty,
+                NyxIdRoutePreference = context.Routing.NyxIdRoutePreference ?? string.Empty,
+                UserMemoryPrompt = context.Routing.UserMemoryPrompt ?? string.Empty,
+            },
+            ConnectedServices = new AgentToolConnectedServicesContextPayload
+            {
+                ContextJson = context.ConnectedServices.ContextJson ?? string.Empty,
+            },
+        };
+        if (context.Routing.MaxToolRoundsOverride.HasValue)
+            payload.Routing.MaxToolRoundsOverride = context.Routing.MaxToolRoundsOverride.Value;
+        foreach (var (key, value) in context.ExternalMetadata)
+            payload.ExternalMetadata[key] = value;
+        return payload;
+    }
+
+    private CallerScopeResolution ResolveCallerScope(bool requireOwner = true)
+    {
+        var scopeId = Normalize(AgentToolRequestContext.ScopeId);
+        var ownerSubject = Normalize(AgentToolRequestContext.OwnerSubject);
+        var responseId = Normalize(AgentToolRequestContext.ResponseId)
+                         ?? Normalize(AgentToolRequestContext.RequestId)
+                         ?? Normalize(AgentToolRequestContext.CallId);
+        if (scopeId == null || responseId == null || (requireOwner && ownerSubject == null))
+        {
+            return CallerScopeResolution.Failed(Error(
+                "caller_scope_unavailable",
+                requireOwner
+                    ? "scope_id, owner_subject, and response_id/request_id are required in AgentToolRequestContext."
+                    : "scope_id and response_id/request_id are required in AgentToolRequestContext."));
+        }
+
+        return CallerScopeResolution.Success(new InvocationCallerScope(
+            scopeId,
+            ownerSubject ?? string.Empty,
+            responseId));
+    }
+
+    private static IReadOnlyList<ChatContentPart> ToChatInputParts(InvocationPayload payload) =>
+        payload.InputParts.Select(static part => new ChatContentPart
+        {
+            Kind = part.Kind switch
+            {
+                InvocationContentPartKind.Text => ChatContentPartKind.Text,
+                InvocationContentPartKind.Image => ChatContentPartKind.Image,
+                InvocationContentPartKind.Audio => ChatContentPartKind.Audio,
+                InvocationContentPartKind.Video => ChatContentPartKind.Video,
+                _ => ChatContentPartKind.Unspecified,
+            },
+            Text = part.Text,
+            DataBase64 = part.DataBase64,
+            MediaType = part.MediaType,
+            Uri = part.Uri,
+            Name = part.Name,
+        }).ToArray();
+
+    private static IReadOnlyList<GAgentDraftRunInputPart>? ToGAgentInputParts(InvocationPayload payload)
+    {
+        if (payload.InputParts.Count == 0)
+            return null;
+
+        return payload.InputParts.Select(static part => new GAgentDraftRunInputPart
+        {
+            Kind = part.Kind switch
+            {
+                InvocationContentPartKind.Text => GAgentDraftRunInputPartKind.Text,
+                InvocationContentPartKind.Image => GAgentDraftRunInputPartKind.Image,
+                InvocationContentPartKind.Audio => GAgentDraftRunInputPartKind.Audio,
+                InvocationContentPartKind.Video => GAgentDraftRunInputPartKind.Video,
+                _ => GAgentDraftRunInputPartKind.Unspecified,
+            },
+            Text = EmptyToNull(part.Text),
+            DataBase64 = EmptyToNull(part.DataBase64),
+            MediaType = EmptyToNull(part.MediaType),
+            Uri = EmptyToNull(part.Uri),
+            Name = EmptyToNull(part.Name),
+        }).ToArray();
+    }
+
+    private static IReadOnlyList<WorkflowChatInputPart>? ToWorkflowInputParts(InvocationPayload payload)
+    {
+        if (payload.InputParts.Count == 0)
+            return null;
+
+        return payload.InputParts.Select(static part => new WorkflowChatInputPart
+        {
+            Kind = part.Kind switch
+            {
+                InvocationContentPartKind.Text => WorkflowChatInputPartKind.Text,
+                InvocationContentPartKind.Image => WorkflowChatInputPartKind.Image,
+                InvocationContentPartKind.Audio => WorkflowChatInputPartKind.Audio,
+                InvocationContentPartKind.Video => WorkflowChatInputPartKind.Video,
+                _ => WorkflowChatInputPartKind.Unspecified,
+            },
+            Text = EmptyToNull(part.Text),
+            DataBase64 = EmptyToNull(part.DataBase64),
+            MediaType = EmptyToNull(part.MediaType),
+            Uri = EmptyToNull(part.Uri),
+            Name = EmptyToNull(part.Name),
+        }).ToArray();
+    }
+
+    private static InvocationWaitMode ResolveWait(InvocationWaitMode wait) =>
+        wait == InvocationWaitMode.Unspecified
+            ? InvocationWaitMode.Stream
+            : wait;
+
+    private static int BoundTake(int take) => take <= 0 ? 50 : Math.Clamp(take, 1, 200);
+
+    private static string ResolveCommandId() =>
+        Normalize(AgentToolRequestContext.CallId)
+        ?? Normalize(AgentToolRequestContext.RequestId)
+        ?? Guid.NewGuid().ToString("N");
+
+    private static string ResolveSessionId() =>
+        Normalize(AgentToolRequestContext.ResponseId)
+        ?? Normalize(AgentToolRequestContext.RequestId)
+        ?? Normalize(AgentToolRequestContext.CallId)
+        ?? Guid.NewGuid().ToString("N");
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? EmptyToNull(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.Select(Normalize).FirstOrDefault(static value => value != null);
+
+    private static InvocationToolError Error(string code, string message, string? field = null) =>
+        new()
+        {
+            Code = string.IsNullOrWhiteSpace(code) ? "invocation_error" : code.Trim().ToLowerInvariant(),
+            Message = message,
+            Field = field ?? string.Empty,
+        };
+
+    private sealed record InvocationCallerScope(string ScopeId, string OwnerSubject, string ResponseId);
+
+    private sealed record CallerScopeResolution(InvocationCallerScope? Value, InvocationToolError? Error)
+    {
+        public static CallerScopeResolution Success(InvocationCallerScope scope) => new(scope, null);
+
+        public static CallerScopeResolution Failed(InvocationToolError error) => new(null, error);
+    }
+
+    private sealed record ActorTargetResolution(string ActorId, InvocationToolError? Error)
+    {
+        public static ActorTargetResolution Success(string actorId) => new(actorId, null);
+
+        public static ActorTargetResolution Failed(InvocationToolError error) => new(string.Empty, error);
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationJson.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationJson.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+using Google.Protobuf.Collections;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+internal static class AevatarInvocationJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = false,
+    };
+
+    public static string Error(InvocationToolError error) =>
+        JsonSerializer.Serialize(new
+        {
+            error = new
+            {
+                code = error.Code,
+                message = error.Message,
+                field = string.IsNullOrWhiteSpace(error.Field) ? null : error.Field,
+            },
+        }, Options);
+
+    public static string Serialize(InvocationToolResult result) =>
+        result.Error == null
+            ? JsonSerializer.Serialize(new
+            {
+                run_id = EmptyToNull(result.RunId),
+                status = EmptyToNull(result.Status),
+                stream_topic = EmptyToNull(result.StreamTopic),
+                result = TryParseJson(result.ResultJson),
+                actor_id = EmptyToNull(result.ActorId),
+                command_id = EmptyToNull(result.CommandId),
+                correlation_id = EmptyToNull(result.CorrelationId),
+                service_id = EmptyToNull(result.ServiceId),
+                endpoint_id = EmptyToNull(result.EndpointId),
+                wait = ToWaitText(result.Wait),
+            }, Options)
+            : Error(result.Error);
+
+    public static string Serialize(ObserveRunResult result) =>
+        result.Error == null
+            ? JsonSerializer.Serialize(new
+            {
+                run_id = EmptyToNull(result.RunId),
+                status = EmptyToNull(result.Status),
+                recent_events = result.RecentEvents.Select(static evt => new
+                {
+                    event_type = EmptyToNull(evt.EventType),
+                    message = EmptyToNull(evt.Message),
+                    step_id = EmptyToNull(evt.StepId),
+                    timestamp_utc = EmptyToNull(evt.TimestampUtc),
+                }).ToArray(),
+                partial_output = EmptyToNull(result.PartialOutput),
+                actor_id = EmptyToNull(result.ActorId),
+                command_id = EmptyToNull(result.CommandId),
+                state_version = result.StateVersion,
+            }, Options)
+            : Error(result.Error);
+
+    public static string Serialize(QueryReadModelResult result) =>
+        result.Error == null
+            ? JsonSerializer.Serialize(new
+            {
+                readmodel_name = result.ReadmodelName,
+                result = TryParseJson(result.ResultJson),
+                count = result.Count,
+            }, Options)
+            : Error(result.Error);
+
+    public static Dictionary<string, string> ToDictionary(MapField<string, string> source)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var pair in source)
+        {
+            var key = pair.Key?.Trim() ?? string.Empty;
+            if (key.Length == 0)
+                continue;
+            result[key] = pair.Value ?? string.Empty;
+        }
+
+        return result;
+    }
+
+    public static string ToJson<T>(T value) =>
+        JsonSerializer.Serialize(value, Options);
+
+    private static string? EmptyToNull(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static string ToWaitText(InvocationWaitMode wait) =>
+        wait switch
+        {
+            InvocationWaitMode.Ack => "ack",
+            InvocationWaitMode.Complete => "complete",
+            _ => "stream",
+        };
+
+    private static object? TryParseJson(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(value);
+        }
+        catch
+        {
+            return value;
+        }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationReadModels.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationReadModels.cs
@@ -1,0 +1,9 @@
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+internal static class AevatarInvocationReadModels
+{
+    public const string ServiceRunCurrentState = "service_run_current_state";
+    public const string GAgentRunTerminal = "gagent_run_terminal";
+    public const string WorkflowActorCurrentState = "workflow_actor_current_state";
+    public const string WorkflowActorTimeline = "workflow_actor_timeline";
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationStreamTopics.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationStreamTopics.cs
@@ -1,0 +1,10 @@
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+internal static class AevatarInvocationStreamTopics
+{
+    public static string ForActorRun(string actorId, string runId) =>
+        $"aevatar://actors/{Uri.EscapeDataString(actorId)}/runs/{Uri.EscapeDataString(runId)}";
+
+    public static string ForServiceRun(string scopeId, string serviceId, string runId) =>
+        $"aevatar://scopes/{Uri.EscapeDataString(scopeId)}/services/{Uri.EscapeDataString(serviceId)}/runs/{Uri.EscapeDataString(runId)}";
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSchemas.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+internal static class AevatarInvocationToolSchemas
+{
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> WaitValues =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            ["wait"] = ["ack", "stream", "complete"],
+            ["kind"] = ["text", "image", "audio", "video"],
+        };
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ReadModelValues =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            ["readmodel_name"] =
+            [
+                AevatarInvocationReadModels.ServiceRunCurrentState,
+                AevatarInvocationReadModels.GAgentRunTerminal,
+                AevatarInvocationReadModels.WorkflowActorCurrentState,
+                AevatarInvocationReadModels.WorkflowActorTimeline,
+            ],
+        };
+
+    public static readonly string InvokeGAgent = ProtoToolSchema.Build(
+        InvokeGAgentToolRequest.Descriptor,
+        requiredFields: new HashSet<string>(StringComparer.Ordinal) { "payload" },
+        stringEnums: WaitValues,
+        oneOfRequiredGroups:
+        [
+            ["actor_id"],
+            ["actor_name"],
+        ]);
+
+    public static readonly string InvokeTeam = ProtoToolSchema.Build(
+        InvokeTeamToolRequest.Descriptor,
+        requiredFields: new HashSet<string>(StringComparer.Ordinal)
+        {
+            "team_id",
+            "endpoint_id",
+            "payload",
+        },
+        stringEnums: WaitValues);
+
+    public static readonly string StartWorkflow = ProtoToolSchema.Build(
+        StartWorkflowToolRequest.Descriptor,
+        requiredFields: new HashSet<string>(StringComparer.Ordinal)
+        {
+            "workflow_id",
+            "inputs",
+        },
+        stringEnums: WaitValues);
+
+    public static readonly string ObserveRun = ProtoToolSchema.Build(
+        ObserveRunToolRequest.Descriptor,
+        requiredFields: new HashSet<string>(StringComparer.Ordinal) { "run_id" });
+
+    public static readonly string QueryReadModel = ProtoToolSchema.Build(
+        QueryReadModelToolRequest.Descriptor,
+        requiredFields: new HashSet<string>(StringComparer.Ordinal)
+        {
+            "readmodel_name",
+            "query",
+        },
+        stringEnums: ReadModelValues);
+
+    public static IReadOnlyList<string> ReadModelNames => ReadModelValues["readmodel_name"];
+
+    public static JsonElement ParseObject(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolSources.cs
@@ -1,0 +1,172 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+public sealed class InvokeGAgentToolSource : IAgentToolSource
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public InvokeGAgentToolSource(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IAgentTool>>([new InvokeGAgentTool(_dispatcher)]);
+}
+
+public sealed class InvokeTeamToolSource : IAgentToolSource
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public InvokeTeamToolSource(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IAgentTool>>([new InvokeTeamTool(_dispatcher)]);
+}
+
+public sealed class StartWorkflowToolSource : IAgentToolSource
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public StartWorkflowToolSource(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IAgentTool>>([new StartWorkflowTool(_dispatcher)]);
+}
+
+public sealed class ObserveRunToolSource : IAgentToolSource
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public ObserveRunToolSource(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IAgentTool>>([new ObserveRunTool(_dispatcher)]);
+}
+
+public sealed class QueryReadModelToolSource : IAgentToolSource
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public QueryReadModelToolSource(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+    }
+
+    public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<IAgentTool>>([new QueryReadModelTool(_dispatcher)]);
+}
+
+internal sealed class InvokeGAgentTool : IAevatarInvocationTool
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public InvokeGAgentTool(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public string Name => "aevatar_invoke_gagent";
+
+    public string Description =>
+        "Invoke a single Aevatar GAgent by actor_id or caller-scoped actor_name with a typed chat payload.";
+
+    public string ParametersSchema => AevatarInvocationToolSchemas.InvokeGAgent;
+
+    public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+        _dispatcher.InvokeGAgentAsync(argumentsJson, ct);
+}
+
+internal sealed class InvokeTeamTool : IAevatarInvocationTool
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public InvokeTeamTool(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public string Name => "aevatar_invoke_team";
+
+    public string Description =>
+        "Invoke a Studio team entry endpoint by team_id and endpoint_id with a typed chat payload.";
+
+    public string ParametersSchema => AevatarInvocationToolSchemas.InvokeTeam;
+
+    public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+        _dispatcher.InvokeTeamAsync(argumentsJson, ct);
+}
+
+internal sealed class StartWorkflowTool : IAevatarInvocationTool
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public StartWorkflowTool(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public string Name => "aevatar_start_workflow";
+
+    public string Description =>
+        "Start an Aevatar workflow by workflow_id with typed inputs.";
+
+    public string ParametersSchema => AevatarInvocationToolSchemas.StartWorkflow;
+
+    public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+        _dispatcher.StartWorkflowAsync(argumentsJson, ct);
+}
+
+internal sealed class ObserveRunTool : IAevatarInvocationTool
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public ObserveRunTool(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public string Name => "aevatar_observe_run";
+
+    public string Description =>
+        "Observe a previously accepted Aevatar run by run_id through existing run and projection read models.";
+
+    public string ParametersSchema => AevatarInvocationToolSchemas.ObserveRun;
+
+    public bool IsReadOnly => true;
+
+    public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+        _dispatcher.ObserveRunAsync(argumentsJson, ct);
+}
+
+internal sealed class QueryReadModelTool : IAevatarInvocationTool
+{
+    private readonly AevatarInvocationDispatcher _dispatcher;
+
+    public QueryReadModelTool(AevatarInvocationDispatcher dispatcher)
+    {
+        _dispatcher = dispatcher;
+    }
+
+    public string Name => "aevatar_query_readmodel";
+
+    public string Description =>
+        "Read one of the closed-set Aevatar current-state read models by name and typed query.";
+
+    public string ParametersSchema => AevatarInvocationToolSchemas.QueryReadModel;
+
+    public bool IsReadOnly => true;
+
+    public Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default) =>
+        _dispatcher.QueryReadModelAsync(argumentsJson, ct);
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/AevatarInvocationToolTags.cs
@@ -1,0 +1,13 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+public static class AevatarInvocationToolTags
+{
+    public const string ToolSet = "aevatar.invocation";
+}
+
+public interface IAevatarInvocationTool : IAgentTool
+{
+    string ToolSetTag => AevatarInvocationToolTags.ToolSet;
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolArguments.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Google.Protobuf;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+internal sealed record ToolArgumentParseResult<T>(
+    T? Value,
+    InvocationToolError? Error)
+    where T : class, IMessage<T>;
+
+internal static class ProtoToolArguments
+{
+    public static ToolArgumentParseResult<T> Parse<T>(string argumentsJson)
+        where T : class, IMessage<T>, new()
+    {
+        var normalized = string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson;
+        try
+        {
+            var node = JsonNode.Parse(normalized) ?? new JsonObject();
+            NormalizeToolEnums(node);
+            normalized = node.ToJsonString(new JsonSerializerOptions { WriteIndented = false });
+            var value = JsonParser.Default.Parse<T>(normalized);
+            return new ToolArgumentParseResult<T>(value, null);
+        }
+        catch (JsonException ex)
+        {
+            return Invalid<T>($"Arguments must be a JSON object: {ex.Message}");
+        }
+        catch (InvalidProtocolBufferException ex)
+        {
+            return Invalid<T>(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return Invalid<T>(ex.Message);
+        }
+    }
+
+    public static InvocationToolError? Require(
+        string? value,
+        string field,
+        string message)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? new InvocationToolError
+            {
+                Code = "invalid_arguments",
+                Message = message,
+                Field = field,
+            }
+            : null;
+    }
+
+    public static InvocationToolError? RequirePayload(InvocationPayload? payload, string field)
+    {
+        if (payload == null)
+        {
+            return new InvocationToolError
+            {
+                Code = "invalid_arguments",
+                Message = $"{field} is required.",
+                Field = field,
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(payload.Prompt) && payload.InputParts.Count == 0)
+        {
+            return new InvocationToolError
+            {
+                Code = "invalid_arguments",
+                Message = $"{field}.prompt or {field}.input_parts is required.",
+                Field = field,
+            };
+        }
+
+        return null;
+    }
+
+    public static InvocationToolError? RequireMessage(IMessage? value, string field) =>
+        value == null
+            ? new InvocationToolError
+            {
+                Code = "invalid_arguments",
+                Message = $"{field} is required.",
+                Field = field,
+            }
+            : null;
+
+    private static ToolArgumentParseResult<T> Invalid<T>(string message)
+        where T : class, IMessage<T>, new() =>
+        new(null, new InvocationToolError
+        {
+            Code = "invalid_arguments",
+            Message = message,
+        });
+
+    private static void NormalizeToolEnums(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                NormalizeEnumProperty(obj, "wait", NormalizeWaitEnum);
+                NormalizeEnumProperty(obj, "kind", NormalizeContentPartKind);
+                foreach (var (_, child) in obj)
+                    NormalizeToolEnums(child);
+                break;
+            case JsonArray array:
+                foreach (var child in array)
+                    NormalizeToolEnums(child);
+                break;
+        }
+    }
+
+    private static void NormalizeEnumProperty(
+        JsonObject obj,
+        string propertyName,
+        Func<string, string> normalize)
+    {
+        if (obj[propertyName] is not JsonValue value)
+            return;
+
+        var raw = value.GetValue<string?>()?.Trim();
+        if (string.IsNullOrWhiteSpace(raw))
+            return;
+
+        obj[propertyName] = normalize(raw);
+    }
+
+    private static string NormalizeWaitEnum(string raw) =>
+        raw.ToLowerInvariant() switch
+        {
+            "ack" => "INVOCATION_WAIT_MODE_ACK",
+            "stream" => "INVOCATION_WAIT_MODE_STREAM",
+            "complete" => "INVOCATION_WAIT_MODE_COMPLETE",
+            "invocation_wait_mode_ack" => "INVOCATION_WAIT_MODE_ACK",
+            "invocation_wait_mode_stream" => "INVOCATION_WAIT_MODE_STREAM",
+            "invocation_wait_mode_complete" => "INVOCATION_WAIT_MODE_COMPLETE",
+            _ => raw,
+        };
+
+    private static string NormalizeContentPartKind(string raw) =>
+        raw.ToLowerInvariant() switch
+        {
+            "text" => "INVOCATION_CONTENT_PART_KIND_TEXT",
+            "image" => "INVOCATION_CONTENT_PART_KIND_IMAGE",
+            "audio" => "INVOCATION_CONTENT_PART_KIND_AUDIO",
+            "video" => "INVOCATION_CONTENT_PART_KIND_VIDEO",
+            "invocation_content_part_kind_text" => "INVOCATION_CONTENT_PART_KIND_TEXT",
+            "invocation_content_part_kind_image" => "INVOCATION_CONTENT_PART_KIND_IMAGE",
+            "invocation_content_part_kind_audio" => "INVOCATION_CONTENT_PART_KIND_AUDIO",
+            "invocation_content_part_kind_video" => "INVOCATION_CONTENT_PART_KIND_VIDEO",
+            _ => raw,
+        };
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolSchema.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ProtoToolSchema.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Google.Protobuf.Reflection;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+internal static class ProtoToolSchema
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new() { WriteIndented = false };
+
+    public static string Build(
+        MessageDescriptor descriptor,
+        IReadOnlySet<string>? requiredFields = null,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? stringEnums = null,
+        IReadOnlyList<IReadOnlyList<string>>? oneOfRequiredGroups = null)
+    {
+        var schema = BuildMessageSchema(descriptor, requiredFields, stringEnums, depth: 0);
+        if (oneOfRequiredGroups is { Count: > 0 })
+        {
+            schema["oneOf"] = oneOfRequiredGroups
+                .Select(group => new Dictionary<string, object>
+                {
+                    ["required"] = group,
+                })
+                .ToArray();
+        }
+
+        return JsonSerializer.Serialize(schema, SerializerOptions);
+    }
+
+    private static Dictionary<string, object> BuildMessageSchema(
+        MessageDescriptor descriptor,
+        IReadOnlySet<string>? requiredFields,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? stringEnums,
+        int depth)
+    {
+        if (depth > 8)
+        {
+            return new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["additionalProperties"] = false,
+            };
+        }
+
+        var properties = new Dictionary<string, object>(StringComparer.Ordinal);
+        foreach (var field in descriptor.Fields.InDeclarationOrder())
+        {
+            if (field.ContainingOneof != null && !field.ContainingOneof.IsSynthetic)
+                continue;
+
+            properties[field.Name] = BuildFieldSchema(field, stringEnums, depth);
+        }
+
+        foreach (var oneof in descriptor.Oneofs)
+        {
+            if (oneof.IsSynthetic)
+                continue;
+
+            foreach (var field in oneof.Fields)
+                properties[field.Name] = BuildFieldSchema(field, stringEnums, depth);
+        }
+
+        var schema = new Dictionary<string, object>
+        {
+            ["type"] = "object",
+            ["properties"] = properties,
+            ["additionalProperties"] = false,
+        };
+
+        if (requiredFields is { Count: > 0 })
+            schema["required"] = requiredFields.ToArray();
+
+        return schema;
+    }
+
+    private static Dictionary<string, object> BuildFieldSchema(
+        FieldDescriptor field,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? stringEnums,
+        int depth)
+    {
+        if (stringEnums != null && stringEnums.TryGetValue(field.Name, out var values))
+        {
+            return new Dictionary<string, object>
+            {
+                ["type"] = "string",
+                ["enum"] = values,
+            };
+        }
+
+        if (field.IsMap)
+        {
+            var valueField = field.MessageType.FindFieldByName("value");
+            return new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["additionalProperties"] = BuildSingleFieldTypeSchema(valueField, stringEnums, depth + 1),
+            };
+        }
+
+        if (field.IsRepeated)
+        {
+            return new Dictionary<string, object>
+            {
+                ["type"] = "array",
+                ["items"] = BuildSingleFieldTypeSchema(field, stringEnums, depth + 1),
+            };
+        }
+
+        return BuildSingleFieldTypeSchema(field, stringEnums, depth);
+    }
+
+    private static Dictionary<string, object> BuildSingleFieldTypeSchema(
+        FieldDescriptor field,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? stringEnums,
+        int depth)
+    {
+        return field.FieldType switch
+        {
+            FieldType.String => new Dictionary<string, object> { ["type"] = "string" },
+            FieldType.Bool => new Dictionary<string, object> { ["type"] = "boolean" },
+            FieldType.Int32 or FieldType.SInt32 or FieldType.UInt32 or FieldType.Fixed32 or FieldType.SFixed32 =>
+                new Dictionary<string, object> { ["type"] = "integer" },
+            FieldType.Int64 or FieldType.SInt64 or FieldType.UInt64 or FieldType.Fixed64 or FieldType.SFixed64 =>
+                new Dictionary<string, object> { ["type"] = "integer" },
+            FieldType.Float or FieldType.Double => new Dictionary<string, object> { ["type"] = "number" },
+            FieldType.Bytes => new Dictionary<string, object> { ["type"] = "string", ["format"] = "byte" },
+            FieldType.Enum => BuildEnumSchema(field),
+            FieldType.Message => BuildMessageSchema(field.MessageType, null, stringEnums, depth + 1),
+            _ => new Dictionary<string, object> { ["type"] = "string" },
+        };
+    }
+
+    private static Dictionary<string, object> BuildEnumSchema(FieldDescriptor field)
+    {
+        var values = field.EnumType.Values
+            .Where(static value => value.Number != 0)
+            .Select(static value => value.Name.ToLowerInvariant())
+            .ToArray();
+        return new Dictionary<string, object>
+        {
+            ["type"] = "string",
+            ["enum"] = values,
+        };
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/ServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Aevatar.AI.Abstractions.ToolProviders;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddAevatarInvocationTools(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<AevatarInvocationDispatcher>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, InvokeGAgentToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, InvokeTeamToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, StartWorkflowToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, ObserveRunToolSource>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IAgentToolSource, QueryReadModelToolSource>());
+        return services;
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto
+++ b/src/Aevatar.AI.ToolProviders.AevatarInvocation/aevatar_invocation_tools.proto
@@ -1,0 +1,125 @@
+syntax = "proto3";
+
+package aevatar.ai.toolproviders.aevatar_invocation.v1;
+
+option csharp_namespace = "Aevatar.AI.ToolProviders.AevatarInvocation";
+
+enum InvocationWaitMode {
+  INVOCATION_WAIT_MODE_UNSPECIFIED = 0;
+  INVOCATION_WAIT_MODE_ACK = 1;
+  INVOCATION_WAIT_MODE_STREAM = 2;
+  INVOCATION_WAIT_MODE_COMPLETE = 3;
+}
+
+enum InvocationContentPartKind {
+  INVOCATION_CONTENT_PART_KIND_UNSPECIFIED = 0;
+  INVOCATION_CONTENT_PART_KIND_TEXT = 1;
+  INVOCATION_CONTENT_PART_KIND_IMAGE = 2;
+  INVOCATION_CONTENT_PART_KIND_AUDIO = 3;
+  INVOCATION_CONTENT_PART_KIND_VIDEO = 4;
+}
+
+message InvocationContentPart {
+  InvocationContentPartKind kind = 1;
+  string text = 2;
+  string data_base64 = 3;
+  string media_type = 4;
+  string uri = 5;
+  string name = 6;
+}
+
+message InvocationPayload {
+  string prompt = 1;
+  repeated InvocationContentPart input_parts = 2;
+  map<string, string> headers = 3;
+}
+
+message InvokeGAgentToolRequest {
+  oneof target {
+    string actor_id = 1;
+    string actor_name = 2;
+  }
+  InvocationPayload payload = 3;
+  InvocationWaitMode wait = 4;
+}
+
+message InvokeTeamToolRequest {
+  string team_id = 1;
+  string endpoint_id = 2;
+  InvocationPayload payload = 3;
+  InvocationWaitMode wait = 4;
+}
+
+message StartWorkflowToolRequest {
+  string workflow_id = 1;
+  InvocationPayload inputs = 2;
+  InvocationWaitMode wait = 3;
+  string actor_id = 4;
+  repeated string workflow_yamls = 5;
+}
+
+message ObserveRunToolRequest {
+  string run_id = 1;
+  string actor_id = 2;
+  string service_id = 3;
+  int32 take = 4;
+}
+
+message ReadModelQuery {
+  string id = 1;
+  string actor_id = 2;
+  string run_id = 3;
+  string service_id = 4;
+  string command_id = 5;
+  int32 take = 6;
+}
+
+message QueryReadModelToolRequest {
+  string readmodel_name = 1;
+  ReadModelQuery query = 2;
+}
+
+message InvocationToolError {
+  string code = 1;
+  string message = 2;
+  string field = 3;
+}
+
+message InvocationToolResult {
+  string run_id = 1;
+  string status = 2;
+  string stream_topic = 3;
+  string result_json = 4;
+  InvocationToolError error = 5;
+  string actor_id = 6;
+  string command_id = 7;
+  string correlation_id = 8;
+  string service_id = 9;
+  string endpoint_id = 10;
+  InvocationWaitMode wait = 11;
+}
+
+message RunEventSummary {
+  string event_type = 1;
+  string message = 2;
+  string step_id = 3;
+  string timestamp_utc = 4;
+}
+
+message ObserveRunResult {
+  string run_id = 1;
+  string status = 2;
+  repeated RunEventSummary recent_events = 3;
+  string partial_output = 4;
+  InvocationToolError error = 5;
+  string actor_id = 6;
+  string command_id = 7;
+  int64 state_version = 8;
+}
+
+message QueryReadModelResult {
+  string readmodel_name = 1;
+  string result_json = 2;
+  InvocationToolError error = 3;
+  int32 count = 4;
+}

--- a/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
+++ b/src/Aevatar.Mainnet.Host.Api/Aevatar.Mainnet.Host.Api.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Telegram\Aevatar.AI.ToolProviders.Telegram.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.NyxId\Aevatar.AI.ToolProviders.NyxId.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.ChronoStorage\Aevatar.AI.ToolProviders.ChronoStorage.csproj" />
+    <ProjectReference Include="..\Aevatar.AI.ToolProviders.AevatarInvocation\Aevatar.AI.ToolProviders.AevatarInvocation.csproj" />
     <ProjectReference Include="..\Aevatar.AI.ToolProviders.Web\Aevatar.AI.ToolProviders.Web.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.ToolProviders.AgentCatalog;
+using Aevatar.AI.ToolProviders.AevatarInvocation;
 using Aevatar.AI.ToolProviders.Channel;
 using Aevatar.AI.ToolProviders.ChannelAdmin;
 using Aevatar.AI.ToolProviders.ChronoStorage;
@@ -155,6 +156,7 @@ public static class MainnetHostBuilderExtensions
         builder.Services.AddChannelInteractiveReplyTools();
         builder.Services.AddChannelAdminTools();
         builder.Services.AddAgentCatalogTools();
+        builder.Services.AddAevatarInvocationTools();
         builder.Services.Configure<DeviceEventOptions>(
             builder.Configuration.GetSection("Aevatar:DeviceEvents"));
         builder.Services.AddNyxIdTools(o =>

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Aevatar.AI.ToolProviders.AevatarInvocation.Tests</AssemblyName>
+    <RootNamespace>Aevatar.AI.ToolProviders.AevatarInvocation.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Aevatar.AI.ToolProviders.AevatarInvocation\Aevatar.AI.ToolProviders.AevatarInvocation.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+</Project>

--- a/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
+++ b/test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/AevatarInvocationToolSourceTests.cs
@@ -1,0 +1,854 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.Presentation.AGUI;
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using Aevatar.Workflow.Application.Abstractions.Runs;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aevatar.AI.ToolProviders.AevatarInvocation.Tests;
+
+public sealed class AevatarInvocationToolSourceTests
+{
+    [Fact]
+    public async Task AddAevatarInvocationTools_ShouldRegisterFiveTaggedToolSources()
+    {
+        var services = new ServiceCollection();
+        var harness = new Harness();
+        harness.RegisterDependencies(services);
+
+        services.AddAevatarInvocationTools();
+        services.AddAevatarInvocationTools();
+
+        await using var provider = services.BuildServiceProvider();
+        var sources = provider.GetServices<IAgentToolSource>().ToList();
+
+        sources.OfType<InvokeGAgentToolSource>().Should().ContainSingle();
+        sources.OfType<InvokeTeamToolSource>().Should().ContainSingle();
+        sources.OfType<StartWorkflowToolSource>().Should().ContainSingle();
+        sources.OfType<ObserveRunToolSource>().Should().ContainSingle();
+        sources.OfType<QueryReadModelToolSource>().Should().ContainSingle();
+
+        var tools = new List<IAgentTool>();
+        foreach (var source in sources)
+            tools.AddRange(await source.DiscoverToolsAsync());
+
+        tools.Select(static tool => tool.Name).Should().BeEquivalentTo(
+            "aevatar_invoke_gagent",
+            "aevatar_invoke_team",
+            "aevatar_start_workflow",
+            "aevatar_observe_run",
+            "aevatar_query_readmodel");
+        tools.All(static tool => tool is IAevatarInvocationTool invocationTool &&
+                                 invocationTool.ToolSetTag == AevatarInvocationToolTags.ToolSet)
+            .Should()
+            .BeTrue();
+        tools.Should().OnlyContain(static tool => HasStrictObjectSchema(tool.ParametersSchema));
+    }
+
+    [Fact]
+    public async Task QueryReadModelSchema_ShouldExposeClosedReadModelSet()
+    {
+        var tool = await DiscoverSingleAsync(new QueryReadModelToolSource(new Harness().CreateDispatcher()));
+        using var doc = JsonDocument.Parse(tool.ParametersSchema);
+
+        var values = doc.RootElement
+            .GetProperty("properties")
+            .GetProperty("readmodel_name")
+            .GetProperty("enum")
+            .EnumerateArray()
+            .Select(static item => item.GetString())
+            .ToArray();
+
+        values.Should().BeEquivalentTo(
+            "service_run_current_state",
+            "gagent_run_terminal",
+            "workflow_actor_current_state",
+            "workflow_actor_timeline");
+    }
+
+    [Theory]
+    [InlineData("aevatar_invoke_gagent", "{}")]
+    [InlineData("aevatar_invoke_team", """{"team_id":"team"}""")]
+    [InlineData("aevatar_start_workflow", """{"workflow_id":"wf"}""")]
+    [InlineData("aevatar_observe_run", "{}")]
+    [InlineData("aevatar_query_readmodel", """{"readmodel_name":"service_run_current_state"}""")]
+    public async Task Tools_ShouldReturnStructuredValidationError(string toolName, string argumentsJson)
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync(toolName);
+
+        using var _ = PushContext(callId: $"call-{toolName}");
+        var output = await tool.ExecuteAsync(argumentsJson);
+
+        ErrorCode(output).Should().Be("invalid_arguments");
+    }
+
+    [Fact]
+    public async Task InvokeGAgent_ShouldResolveActorNameAndDispatchEnvelopeThroughPort()
+    {
+        var harness = new Harness();
+        harness.ActorRegistry.Snapshot = new GAgentActorRegistrySnapshot(
+            "scope-1",
+            [new GAgentActorGroup("RoleGAgent", ["actor-1"])],
+            7,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(callId: "call-gagent");
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_name": "RoleGAgent",
+              "payload": {
+                "prompt": "hello",
+                "input_parts": [
+                  { "kind": "text", "text": "typed part" }
+                ],
+                "headers": { "x-test": "yes" }
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ActorRegistry.LastScopeId.Should().Be("scope-1");
+        harness.ActorDispatch.Calls.Should().ContainSingle();
+        var call = harness.ActorDispatch.Calls.Single();
+        call.ActorId.Should().Be("actor-1");
+        call.Envelope.Route.GetTargetActorId().Should().Be("actor-1");
+        call.Envelope.Propagation.CorrelationId.Should().Be("call-gagent");
+
+        var payload = call.Envelope.Payload.Unpack<ChatRequestEvent>();
+        payload.Prompt.Should().Be("hello");
+        payload.SessionId.Should().Be("call-gagent");
+        payload.ScopeId.Should().Be("scope-1");
+        payload.Headers["x-test"].Should().Be("yes");
+        payload.Headers[LLMRequestMetadataKeys.ScopeId].Should().Be("scope-1");
+        payload.InputParts.Should().ContainSingle();
+        payload.InputParts[0].Kind.Should().Be(ChatContentPartKind.Text);
+        payload.InputParts[0].Text.Should().Be("typed part");
+        payload.ToolContext.Caller.OwnerSubject.Should().Be("owner-1");
+        payload.ToolContext.Credentials.NyxIdAccessToken.Should().Be("access-token");
+
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be("call-gagent");
+        result.GetProperty("stream_topic").GetString().Should().Be("aevatar://actors/actor-1/runs/call-gagent");
+        result.GetProperty("wait").GetString().Should().Be("stream");
+    }
+
+    [Fact]
+    public async Task InvokeGAgent_ShouldRejectPayloadHeaderCredentialOverrides()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(callId: "call-gagent-credentials");
+        var output = await tool.ExecuteAsync($$"""
+            {
+              "actor_id": "actor-1",
+              "payload": {
+                "prompt": "hello",
+                "headers": {
+                  "{{LLMRequestMetadataKeys.OwnerSubject}}": "evil-owner",
+                  "{{LLMRequestMetadataKeys.NyxIdAccessToken}}": "evil-access-token",
+                  "{{LLMRequestMetadataKeys.SenderNyxIdAccessToken}}": "evil-sender-token",
+                  "{{LLMRequestMetadataKeys.ScopeId}}": "evil-scope",
+                  "scope_id": "evil-legacy-scope"
+                }
+              },
+              "wait": "ack"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        var payload = harness.ActorDispatch.Calls.Single().Envelope.Payload.Unpack<ChatRequestEvent>();
+        ShouldCarryTrustedCallerValues(payload.Headers);
+        ShouldCarryTrustedCallerValues(payload.Metadata);
+    }
+
+    [Fact]
+    public async Task InvokeGAgent_WhenDispatchFails_ShouldReturnStructuredError()
+    {
+        var harness = new Harness();
+        harness.ActorDispatch.Failure = new InvalidOperationException("dispatch broke");
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_gagent");
+
+        using var _ = PushContext(callId: "call-fail");
+        var output = await tool.ExecuteAsync("""
+            {
+              "actor_id": "actor-1",
+              "payload": { "prompt": "hello" },
+              "wait": "ack"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("dispatch_failed");
+    }
+
+    [Fact]
+    public async Task InvokeTeam_ShouldResolveMemberAndReturnStreamTopic()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_team");
+
+        using var _ = PushContext(callId: "call-team");
+        var output = await tool.ExecuteAsync("""
+            {
+              "team_id": "team-1",
+              "endpoint_id": "entry",
+              "payload": {
+                "prompt": "go",
+                "headers": { "h": "v" }
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.TeamResolver.LastScopeId.Should().Be("scope-1");
+        harness.TeamResolver.LastTeamId.Should().Be("team-1");
+        harness.TeamInvocation.Request.Should().NotBeNull();
+        harness.TeamInvocation.Request!.Identity.TenantId.Should().Be("scope-1");
+        harness.TeamInvocation.Request.Identity.ServiceId.Should().Be("service-1");
+        harness.TeamInvocation.Request.EndpointId.Should().Be("entry");
+        harness.TeamInvocation.Request.Input.Prompt.Should().Be("go");
+        harness.TeamInvocation.Request.Input.Headers.Should().Contain("scope_id", "scope-1");
+        harness.TeamInvocation.Request.Input.Headers.Should().Contain("h", "v");
+        harness.TeamInvocation.Request.Input.Caller!.TenantId.Should().Be("scope-1");
+
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be("team-command");
+        result.GetProperty("service_id").GetString().Should().Be("service-1");
+        result.GetProperty("stream_topic").GetString().Should().Be("aevatar://scopes/scope-1/services/service-1/runs/team-command");
+    }
+
+    [Fact]
+    public async Task InvokeTeam_ShouldRejectPayloadHeaderCredentialOverrides()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_team");
+
+        using var _ = PushContext(callId: "call-team-credentials");
+        var output = await tool.ExecuteAsync($$"""
+            {
+              "team_id": "team-1",
+              "endpoint_id": "entry",
+              "payload": {
+                "prompt": "go",
+                "headers": {
+                  "{{LLMRequestMetadataKeys.OwnerSubject}}": "evil-owner",
+                  "{{LLMRequestMetadataKeys.NyxIdAccessToken}}": "evil-access-token",
+                  "{{LLMRequestMetadataKeys.SenderNyxIdAccessToken}}": "evil-sender-token",
+                  "{{LLMRequestMetadataKeys.ScopeId}}": "evil-scope",
+                  "scope_id": "evil-legacy-scope"
+                }
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        ShouldCarryTrustedCallerValues(harness.TeamInvocation.Request!.Input.Headers);
+    }
+
+    [Fact]
+    public async Task InvokeTeam_WhenResolverFails_ShouldReturnStructuredError()
+    {
+        var harness = new Harness();
+        harness.TeamResolver.Failure = new TeamEntryMemberResolutionException(
+            TeamEntryMemberErrorCodes.TeamNotFound,
+            "scope-1",
+            "team-missing",
+            "team missing");
+        var tool = await harness.DiscoverToolAsync("aevatar_invoke_team");
+
+        using var _ = PushContext(callId: "call-team-fail");
+        var output = await tool.ExecuteAsync("""
+            {
+              "team_id": "team-missing",
+              "endpoint_id": "entry",
+              "payload": { "prompt": "go" }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("team_not_found");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_ShouldPropagateScopeAndReturnStreamReceipt()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "wf-main",
+              "inputs": {
+                "prompt": "run workflow",
+                "headers": { "x-workflow": "yes" }
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.WorkflowDispatch.Command.Should().NotBeNull();
+        harness.WorkflowDispatch.Command!.WorkflowName.Should().Be("wf-main");
+        harness.WorkflowDispatch.Command.Prompt.Should().Be("run workflow");
+        harness.WorkflowDispatch.Command.ScopeId.Should().Be("scope-1");
+        harness.WorkflowDispatch.Command.Metadata.Should().Contain("scope_id", "scope-1");
+        harness.WorkflowDispatch.Command.Metadata.Should().Contain("x-workflow", "yes");
+
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be("wf-command");
+        result.GetProperty("actor_id").GetString().Should().Be("workflow-actor");
+        result.GetProperty("stream_topic").GetString().Should().Be("aevatar://actors/workflow-actor/runs/wf-command");
+    }
+
+    [Fact]
+    public async Task StartWorkflow_ShouldRejectPayloadHeaderCredentialOverrides()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "wf-main", "wf-command", "wf-correlation"));
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow-credentials");
+        var output = await tool.ExecuteAsync($$"""
+            {
+              "workflow_id": "wf-main",
+              "inputs": {
+                "prompt": "run workflow",
+                "headers": {
+                  "{{LLMRequestMetadataKeys.OwnerSubject}}": "evil-owner",
+                  "{{LLMRequestMetadataKeys.NyxIdAccessToken}}": "evil-access-token",
+                  "{{LLMRequestMetadataKeys.SenderNyxIdAccessToken}}": "evil-sender-token",
+                  "{{LLMRequestMetadataKeys.ScopeId}}": "evil-scope",
+                  "scope_id": "evil-legacy-scope"
+                }
+              },
+              "wait": "stream"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        ShouldCarryTrustedCallerValues(harness.WorkflowDispatch.Command!.Metadata);
+    }
+
+    [Fact]
+    public async Task StartWorkflow_WhenDispatchRejects_ShouldReturnStructuredError()
+    {
+        var harness = new Harness();
+        harness.WorkflowDispatch.Result = CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+            .Failure(WorkflowChatRunStartError.WorkflowNotFound);
+        var tool = await harness.DiscoverToolAsync("aevatar_start_workflow");
+
+        using var _ = PushContext(callId: "call-workflow-fail");
+        var output = await tool.ExecuteAsync("""
+            {
+              "workflow_id": "missing",
+              "inputs": { "prompt": "run workflow" }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("workflownotfound");
+    }
+
+    [Fact]
+    public async Task ObserveRun_ShouldReadExistingTerminalSnapshot()
+    {
+        var harness = new Harness();
+        harness.TerminalQuery.ByCorrelationId = new GAgentRunTerminalSnapshot(
+            "actor-1",
+            "session-1",
+            "run-1",
+            GAgentRunTerminalInteractionKind.DraftRun,
+            GAgentRunTerminalStatus.RunFinished,
+            "done",
+            "finished",
+            3,
+            "event-3",
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe");
+        var output = await tool.ExecuteAsync("""
+            {
+              "run_id": "run-1",
+              "actor_id": "actor-1"
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.TerminalQuery.LastActorId.Should().Be("actor-1");
+        harness.TerminalQuery.LastCorrelationId.Should().Be("run-1");
+        var result = Read(output);
+        result.GetProperty("run_id").GetString().Should().Be("run-1");
+        result.GetProperty("status").GetString().Should().Be(nameof(GAgentRunTerminalStatus.RunFinished));
+        result.GetProperty("recent_events").GetArrayLength().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ObserveRun_WhenCallerScopeIsUnavailable_ShouldFastFail()
+    {
+        var harness = new Harness();
+        harness.TerminalQuery.ByCorrelationId = new GAgentRunTerminalSnapshot(
+            "actor-1",
+            "session-1",
+            "run-1",
+            GAgentRunTerminalInteractionKind.DraftRun,
+            GAgentRunTerminalStatus.RunFinished,
+            "done",
+            "finished",
+            3,
+            "event-3",
+            DateTimeOffset.UtcNow);
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-no-scope", scopeId: null);
+        var output = await tool.ExecuteAsync("""
+            {
+              "run_id": "run-1",
+              "actor_id": "actor-1"
+            }
+            """);
+
+        ErrorCode(output).Should().Be("caller_scope_unavailable");
+        harness.TerminalQuery.LastActorId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ObserveRun_WhenNoReadModelMatches_ShouldReturnStructuredError()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_observe_run");
+
+        using var _ = PushContext(callId: "call-observe-missing");
+        var output = await tool.ExecuteAsync("""{"run_id":"missing","actor_id":"actor-1"}""");
+
+        ErrorCode(output).Should().Be("run_not_found");
+    }
+
+    [Fact]
+    public async Task QueryReadModel_ShouldUseClosedServiceRunReaderWithCallerScope()
+    {
+        var harness = new Harness();
+        harness.ServiceRunQuery.ListResult =
+        [
+            BuildServiceRun("scope-1", "service-1", "run-1", "command-1"),
+        ];
+        var tool = await harness.DiscoverToolAsync("aevatar_query_readmodel");
+
+        using var _ = PushContext(callId: "call-query");
+        var output = await tool.ExecuteAsync("""
+            {
+              "readmodel_name": "service_run_current_state",
+              "query": {
+                "service_id": "service-1",
+                "take": 10
+              }
+            }
+            """);
+
+        ErrorCodeOrNull(output).Should().BeNull(output);
+        harness.ServiceRunQuery.LastQuery.Should().Be(new ServiceRunQuery("scope-1", "service-1", 10));
+        var result = Read(output);
+        result.GetProperty("readmodel_name").GetString().Should().Be("service_run_current_state");
+        result.GetProperty("count").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task QueryReadModel_WhenNameIsNotRegistered_ShouldReturnStructuredError()
+    {
+        var harness = new Harness();
+        var tool = await harness.DiscoverToolAsync("aevatar_query_readmodel");
+
+        using var _ = PushContext(callId: "call-query-missing");
+        var output = await tool.ExecuteAsync("""
+            {
+              "readmodel_name": "arbitrary_collection",
+              "query": { "id": "1" }
+            }
+            """);
+
+        ErrorCode(output).Should().Be("readmodel_not_registered");
+    }
+
+    private static bool HasStrictObjectSchema(string schema)
+    {
+        using var doc = JsonDocument.Parse(schema);
+        return doc.RootElement.GetProperty("type").GetString() == "object" &&
+               doc.RootElement.GetProperty("additionalProperties").ValueKind == JsonValueKind.False;
+    }
+
+    private static async Task<IAgentTool> DiscoverSingleAsync(IAgentToolSource source)
+    {
+        var tools = await source.DiscoverToolsAsync();
+        return tools.Should().ContainSingle().Subject;
+    }
+
+    private static JsonElement Read(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private static string ErrorCode(string json) =>
+        ErrorCodeOrNull(json) ?? throw new InvalidOperationException($"Expected an error result: {json}");
+
+    private static string? ErrorCodeOrNull(string json)
+    {
+        var root = Read(json);
+        return root.TryGetProperty("error", out var error) &&
+               error.TryGetProperty("code", out var code)
+            ? code.GetString()
+            : null;
+    }
+
+    private static void ShouldCarryTrustedCallerValues(IEnumerable<KeyValuePair<string, string>>? metadata)
+    {
+        metadata.Should().NotBeNull();
+        var values = metadata!.ToDictionary(static item => item.Key, static item => item.Value, StringComparer.Ordinal);
+        values.Should().Contain(LLMRequestMetadataKeys.OwnerSubject, "owner-1");
+        values.Should().Contain(LLMRequestMetadataKeys.NyxIdAccessToken, "access-token");
+        values.Should().Contain(LLMRequestMetadataKeys.SenderNyxIdAccessToken, "sender-token");
+        values.Should().Contain(LLMRequestMetadataKeys.ScopeId, "scope-1");
+        values.Should().Contain("scope_id", "scope-1");
+    }
+
+    private static AgentToolContextScope PushContext(string callId, string? scopeId = "scope-1") =>
+        AgentToolContextScope.Push(new AgentToolExecutionContext(
+            new AgentToolRequestIdentity("request-1", callId),
+            new AgentToolCredentials("access-token", "org-token", "sender-token"),
+            new AgentToolCallerContext(scopeId, "owner-1", "response-1"),
+            new AgentToolChannelContext("telegram", "sender-1", "registration-scope-1", "message-1", "platform-message-1"),
+            new AgentToolSenderBindingContext("binding-1"),
+            new LLMRequestRoutingContext("model-1", "route-1", 4, "memory"),
+            new AgentToolConnectedServicesContext("""{"service":"ctx"}"""),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["external"] = "value",
+            }));
+
+    private static ServiceRunSnapshot BuildServiceRun(
+        string scopeId,
+        string serviceId,
+        string runId,
+        string commandId) =>
+        new(
+            scopeId,
+            serviceId,
+            "service-key",
+            runId,
+            commandId,
+            commandId,
+            "entry",
+            ServiceImplementationKind.Static,
+            "target-actor",
+            "revision-1",
+            "deployment-1",
+            ServiceRunStatus.Accepted,
+            "actor-1",
+            scopeId,
+            ScopeServiceIdentityDefaults.ServiceAppId,
+            ScopeServiceIdentityDefaults.ServiceNamespace,
+            1,
+            "event-1",
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+    private sealed class Harness
+    {
+        public RecordingActorDispatchPort ActorDispatch { get; } = new();
+        public RecordingActorRegistryQueryPort ActorRegistry { get; } = new();
+        public RecordingTeamEntryMemberResolver TeamResolver { get; } = new();
+        public RecordingStaticGAgentInvocationPort TeamInvocation { get; } = new();
+        public RecordingWorkflowDispatchService WorkflowDispatch { get; } = new();
+        public RecordingServiceRunQueryPort ServiceRunQuery { get; } = new();
+        public RecordingTerminalQueryPort TerminalQuery { get; } = new();
+        public StubWorkflowExecutionQueryService WorkflowQuery { get; } = new();
+
+        public AevatarInvocationDispatcher CreateDispatcher() =>
+            new(
+                ActorDispatch,
+                ActorRegistry,
+                TeamResolver,
+                TeamInvocation,
+                WorkflowDispatch,
+                ServiceRunQuery,
+                TerminalQuery,
+                WorkflowQuery);
+
+        public void RegisterDependencies(IServiceCollection services)
+        {
+            services.AddSingleton<IActorDispatchPort>(ActorDispatch);
+            services.AddSingleton<IGAgentActorRegistryQueryPort>(ActorRegistry);
+            services.AddSingleton<ITeamEntryMemberResolver>(TeamResolver);
+            services.AddSingleton<IStaticGAgentStreamInvocationPort<AGUIEvent>>(TeamInvocation);
+            services.AddSingleton<ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>>(WorkflowDispatch);
+            services.AddSingleton<IServiceRunQueryPort>(ServiceRunQuery);
+            services.AddSingleton<IGAgentRunTerminalQueryPort>(TerminalQuery);
+            services.AddSingleton<IWorkflowExecutionQueryApplicationService>(WorkflowQuery);
+        }
+
+        public async Task<IAgentTool> DiscoverToolAsync(string toolName)
+        {
+            IAgentToolSource source = toolName switch
+            {
+                "aevatar_invoke_gagent" => new InvokeGAgentToolSource(CreateDispatcher()),
+                "aevatar_invoke_team" => new InvokeTeamToolSource(CreateDispatcher()),
+                "aevatar_start_workflow" => new StartWorkflowToolSource(CreateDispatcher()),
+                "aevatar_observe_run" => new ObserveRunToolSource(CreateDispatcher()),
+                "aevatar_query_readmodel" => new QueryReadModelToolSource(CreateDispatcher()),
+                _ => throw new ArgumentOutOfRangeException(nameof(toolName), toolName, null),
+            };
+            var tools = await source.DiscoverToolsAsync();
+            return tools.Single(tool => tool.Name == toolName);
+        }
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Calls { get; } = [];
+        public Exception? Failure { get; set; }
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            if (Failure != null)
+                throw Failure;
+
+            Calls.Add((actorId, envelope.Clone()));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingActorRegistryQueryPort : IGAgentActorRegistryQueryPort
+    {
+        public string? LastScopeId { get; private set; }
+        public GAgentActorRegistrySnapshot Snapshot { get; set; } = new(
+            "scope-1",
+            [],
+            0,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        public Task<GAgentActorRegistrySnapshot> ListActorsAsync(
+            string scopeId,
+            CancellationToken cancellationToken = default)
+        {
+            LastScopeId = scopeId;
+            return Task.FromResult(Snapshot);
+        }
+    }
+
+    private sealed class RecordingTeamEntryMemberResolver : ITeamEntryMemberResolver
+    {
+        public string? LastScopeId { get; private set; }
+        public string? LastTeamId { get; private set; }
+        public TeamEntryMemberResolution Resolution { get; set; } = new("scope-1", "team-1", "member-1", "service-1");
+        public TeamEntryMemberResolutionException? Failure { get; set; }
+
+        public Task<TeamEntryMemberResolution> ResolveAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default)
+        {
+            LastScopeId = scopeId;
+            LastTeamId = teamId;
+            if (Failure != null)
+                throw Failure;
+
+            return Task.FromResult(Resolution);
+        }
+    }
+
+    private sealed class RecordingStaticGAgentInvocationPort : IStaticGAgentStreamInvocationPort<AGUIEvent>
+    {
+        public StaticGAgentStreamInvocationRequest? Request { get; private set; }
+        public StaticGAgentStreamInvocationResult? Result { get; set; }
+        public Exception? Failure { get; set; }
+
+        public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+            StaticGAgentStreamInvocationRequest request,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            if (Failure != null)
+                throw Failure;
+
+            Request = request;
+            var accepted = new StaticGAgentStreamAcceptedReceipt(
+                new ServiceInvocationAcceptedReceipt
+                {
+                    RequestId = "request-team",
+                    ServiceKey = "service-key",
+                    DeploymentId = "deployment-1",
+                    TargetActorId = "team-actor",
+                    EndpointId = request.EndpointId,
+                    CommandId = "team-command",
+                    CorrelationId = "team-correlation",
+                },
+                new GAgentDraftRunAcceptedReceipt(
+                    "team-actor",
+                    "RoleGAgent",
+                    "team-command",
+                    "team-correlation",
+                    request.Input.SessionId ?? string.Empty));
+
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(accepted, ct);
+
+            return Result ?? new StaticGAgentStreamInvocationResult(
+                accepted,
+                GAgentDraftRunStartError.None,
+                GAgentDraftRunCompletionStatus.RunFinished,
+                true);
+        }
+    }
+
+    private sealed class RecordingWorkflowDispatchService
+        : ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+    {
+        public WorkflowChatRunRequest? Command { get; private set; }
+
+        public CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError> Result { get; set; } =
+            CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>
+                .Success(new WorkflowChatRunAcceptedReceipt("workflow-actor", "workflow", "workflow-command", "workflow-correlation"));
+
+        public Task<CommandDispatchResult<WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>> DispatchAsync(
+            WorkflowChatRunRequest command,
+            CancellationToken ct = default)
+        {
+            Command = command;
+            return Task.FromResult(Result);
+        }
+    }
+
+    private sealed class RecordingServiceRunQueryPort : IServiceRunQueryPort
+    {
+        public ServiceRunQuery? LastQuery { get; private set; }
+        public string? LastScopeId { get; private set; }
+        public string? LastServiceId { get; private set; }
+        public string? LastRunId { get; private set; }
+        public IReadOnlyList<ServiceRunSnapshot> ListResult { get; set; } = [];
+        public ServiceRunSnapshot? ByRunId { get; set; }
+        public ServiceRunSnapshot? ByCommandId { get; set; }
+
+        public Task<IReadOnlyList<ServiceRunSnapshot>> ListAsync(
+            ServiceRunQuery query,
+            CancellationToken ct = default)
+        {
+            LastQuery = query;
+            return Task.FromResult(ListResult);
+        }
+
+        public Task<ServiceRunSnapshot?> GetByRunIdAsync(
+            string scopeId,
+            string serviceId,
+            string runId,
+            CancellationToken ct = default)
+        {
+            LastScopeId = scopeId;
+            LastServiceId = serviceId;
+            LastRunId = runId;
+            return Task.FromResult(ByRunId);
+        }
+
+        public Task<ServiceRunSnapshot?> GetByCommandIdAsync(
+            string scopeId,
+            string serviceId,
+            string commandId,
+            CancellationToken ct = default) =>
+            Task.FromResult(ByCommandId);
+    }
+
+    private sealed class RecordingTerminalQueryPort : IGAgentRunTerminalQueryPort
+    {
+        public string? LastActorId { get; private set; }
+        public string? LastCorrelationId { get; private set; }
+        public string? LastSessionId { get; private set; }
+        public GAgentRunTerminalSnapshot? ByCorrelationId { get; set; }
+        public GAgentRunTerminalSnapshot? BySessionId { get; set; }
+
+        public Task<GAgentRunTerminalSnapshot?> GetByCorrelationIdAsync(
+            string actorId,
+            string correlationId,
+            CancellationToken ct = default)
+        {
+            LastActorId = actorId;
+            LastCorrelationId = correlationId;
+            return Task.FromResult(ByCorrelationId);
+        }
+
+        public Task<GAgentRunTerminalSnapshot?> GetBySessionIdAsync(
+            string actorId,
+            string sessionId,
+            CancellationToken ct = default)
+        {
+            LastActorId = actorId;
+            LastSessionId = sessionId;
+            return Task.FromResult(BySessionId);
+        }
+    }
+
+    private sealed class StubWorkflowExecutionQueryService : IWorkflowExecutionQueryApplicationService
+    {
+        public bool ActorQueryEnabled => true;
+        public WorkflowActorSnapshot? Snapshot { get; set; }
+        public IReadOnlyList<WorkflowActorTimelineItem> Timeline { get; set; } = [];
+
+        public Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<WorkflowAgentSummary>>([]);
+
+        public IReadOnlyList<string> ListWorkflows() => [];
+
+        public IReadOnlyList<WorkflowCatalogItem> ListWorkflowCatalog() => [];
+
+        public WorkflowCatalogItemDetail? GetWorkflowDetail(string workflowName) => null;
+
+        public WorkflowCapabilitiesDocument GetCapabilities() => new();
+
+        public Task<WorkflowActorSnapshot?> GetActorSnapshotAsync(string actorId, CancellationToken ct = default) =>
+            Task.FromResult(Snapshot);
+
+        public Task<WorkflowRunReport?> GetActorReportAsync(string actorId, CancellationToken ct = default) =>
+            Task.FromResult<WorkflowRunReport?>(null);
+
+        public Task<IReadOnlyList<WorkflowActorTimelineItem>> ListActorTimelineAsync(
+            string actorId,
+            int take = 200,
+            CancellationToken ct = default) =>
+            Task.FromResult(Timeline);
+
+        public Task<IReadOnlyList<WorkflowActorGraphEdge>> ListActorGraphEdgesAsync(
+            string actorId,
+            int take = 200,
+            WorkflowActorGraphQueryOptions? options = null,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<WorkflowActorGraphEdge>>([]);
+
+        public Task<WorkflowActorGraphSubgraph> GetActorGraphSubgraphAsync(
+            string actorId,
+            int depth = 2,
+            int take = 200,
+            WorkflowActorGraphQueryOptions? options = null,
+            CancellationToken ct = default) =>
+            Task.FromResult(new WorkflowActorGraphSubgraph());
+    }
+}

--- a/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Lark.Tests/LarkToolsTests.cs
@@ -34,6 +34,7 @@ public class LarkToolsTests
             document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
             document.RootElement.GetProperty("message_id").GetString().Should().Be("om_123");
             document.RootElement.GetProperty("target_type").GetString().Should().Be("chat_id");
+            client.LastSendToken.Should().Be("token-123");
             client.LastSendRequest.Should().NotBeNull();
             client.LastSendRequest!.MessageType.Should().Be("text");
         }
@@ -41,6 +42,74 @@ public class LarkToolsTests
         {
             AgentToolRequestContext.CurrentMetadata = null;
         }
+    }
+
+    [Fact]
+    public async Task LarkMessagesSendTool_PropagatesTypedCallerScope()
+    {
+        var client = new StubLarkNyxClient
+        {
+            SendResponse = """{"code":0,"data":{"message_id":"om_123"}}""",
+        };
+        var tool = new LarkMessagesSendTool(client);
+        using var _ = new AgentToolRequestContextScope(new AgentToolExecutionContext(
+            AgentToolRequestIdentity.Empty,
+            new AgentToolCredentials("caller-token", null, null),
+            AgentToolCallerContext.Empty,
+            AgentToolChannelContext.Empty,
+            AgentToolSenderBindingContext.Empty,
+            LLMRequestRoutingContext.Empty,
+            AgentToolConnectedServicesContext.Empty,
+            new Dictionary<string, string>(StringComparer.Ordinal)));
+
+        var result = await tool.ExecuteAsync(
+            """{"target_type":"chat_id","target_id":"oc_456","message_type":"text","text":"Hello from caller scope"}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        client.LastSendToken.Should().Be("caller-token");
+        client.LastSendRequest.Should().NotBeNull();
+        client.LastSendRequest!.TargetId.Should().Be("oc_456");
+    }
+
+    [Fact]
+    public async Task LarkMessagesSendTool_DoesNotLetPayloadOrExternalMetadataOverrideCallerScope()
+    {
+        var client = new StubLarkNyxClient
+        {
+            SendResponse = """{"code":0,"data":{"message_id":"om_123"}}""",
+        };
+        var tool = new LarkMessagesSendTool(client);
+        using var _ = new AgentToolRequestContextScope(new AgentToolExecutionContext(
+            AgentToolRequestIdentity.Empty,
+            new AgentToolCredentials("trusted-caller-token", null, null),
+            AgentToolCallerContext.Empty,
+            AgentToolChannelContext.Empty,
+            AgentToolSenderBindingContext.Empty,
+            LLMRequestRoutingContext.Empty,
+            AgentToolConnectedServicesContext.Empty,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [LLMRequestMetadataKeys.NyxIdAccessToken] = "external-metadata-token",
+            }));
+
+        var result = await tool.ExecuteAsync(
+            """
+            {
+              "target_type": "chat_id",
+              "target_id": "oc_456",
+              "message_type": "text",
+              "text": "Hello from caller scope",
+              "nyx_id_access_token": "payload-token",
+              "headers": {
+                "x-nyxid-access-token": "payload-header-token"
+              }
+            }
+            """);
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+        client.LastSendToken.Should().Be("trusted-caller-token");
     }
 
     [Fact]
@@ -1328,6 +1397,7 @@ public class LarkToolsTests
         public string ApprovalListResponse { get; set; } = """{"code":0,"data":{"tasks":[],"count":0}}""";
         public string ApprovalActionResponse { get; set; } = """{"code":0,"data":{}}""";
 
+        public string? LastSendToken { get; private set; }
         public LarkSendMessageRequest? LastSendRequest { get; private set; }
         public LarkReplyMessageRequest? LastReplyRequest { get; private set; }
         public LarkMessageReactionRequest? LastReactionRequest { get; private set; }
@@ -1342,6 +1412,7 @@ public class LarkToolsTests
 
         public Task<string> SendMessageAsync(string token, LarkSendMessageRequest request, CancellationToken ct)
         {
+            LastSendToken = token;
             LastSendRequest = request;
             return Task.FromResult(SendResponse);
         }
@@ -1426,6 +1497,22 @@ public class LarkToolsTests
                 ? null
                 : await request.Content.ReadAsStringAsync(cancellationToken);
             return _responder(request);
+        }
+    }
+
+    private sealed class AgentToolRequestContextScope : IDisposable
+    {
+        private readonly AgentToolExecutionContext? _previous;
+
+        public AgentToolRequestContextScope(AgentToolExecutionContext context)
+        {
+            _previous = AgentToolRequestContext.Current;
+            AgentToolRequestContext.Current = context;
+        }
+
+        public void Dispose()
+        {
+            AgentToolRequestContext.Current = _previous;
         }
     }
 


### PR DESCRIPTION
## 背景

这个 PR 是 ADR-0026 的 Stage 1：把 aevatar 的核心能力重新定位为 LLM tool source，让模型通过 function call 主动选择何时使用 workflow、GAgent、team、readmodel observation 等能力，而不是继续在入口层维护 `ForwardToGAgent` / `ForwardToTeam` 这类并行路由方言。

## 改动

- 新增 ADR：`docs/adr/0026-tool-first-chat-ingress.md`，明确 tool-first chat ingress 的目标、边界和后续阶段。
- 新增 `Aevatar.AI.ToolProviders.AevatarInvocation`：提供 5 个 invocation tools：
  - `aevatar_invoke_gagent`
  - `aevatar_invoke_team`
  - `aevatar_start_workflow`
  - `aevatar_observe_run`
  - `aevatar_query_readmodel`
- 新增共享 `AevatarInvocationDispatcher`，统一做 proto 参数解析、caller scope 注入、调度、readmodel 查询与结构化错误返回。
- 通过 proto descriptor 生成严格 JSON schema，避免把核心语义塞进无约束 JSON bag。
- 接入 Mainnet Host DI，让这些 tool sources 能进入现有 `IAgentToolSource` 发现链路。
- 补 Lark caller-scope 回归测试，证明 Lark send tool 使用可信的 `AgentToolRequestContext.NyxIdAccessToken`，payload/外部 metadata 不能覆盖调用者凭据。

## 影响

- 这是 tool-driven core loop 的第一步，不删除现有 legacy forward path。
- GAgent / workflow 的 `wait=complete` 仍返回结构化 `wait_complete_unavailable`；当前阶段支持 `ack` / `stream`，后续由 session actor/观察链路承接长任务 continuation。
- `aevatar_query_readmodel` 只允许查询封闭集合 readmodel，不开放任意 document collection。
- 没有修改 NyxID、chrono-* 等外部仓库。

## 验证

- `dotnet test test/Aevatar.AI.ToolProviders.AevatarInvocation.Tests/Aevatar.AI.ToolProviders.AevatarInvocation.Tests.csproj --nologo`：通过，21 passed。
- `dotnet test test/Aevatar.AI.ToolProviders.Lark.Tests/Aevatar.AI.ToolProviders.Lark.Tests.csproj --nologo`：通过，61 passed。
- `bash tools/ci/test_stability_guards.sh`：通过。
- `bash tools/ci/architecture_guards.sh`：通过。
- `git diff --check origin/dev..HEAD`：通过。

备注：本地测试仍有既有 NuGet source mapping / analyzer warnings，没有测试失败。
