### PR TITLE
iter34 cluster-003: projection session 删除 legacy string payload 路径

### DIFF
--- a/src/Aevatar.CQRS.Projection.Core.Abstractions/Abstractions/Streaming/IProjectionSessionEventCodec.cs
+++ b/src/Aevatar.CQRS.Projection.Core.Abstractions/Abstractions/Streaming/IProjectionSessionEventCodec.cs
@@ -5,6 +5,9 @@ namespace Aevatar.CQRS.Projection.Core.Abstractions;
 /// <summary>
 /// Encodes and decodes projection session events for stream transport.
 /// </summary>
+// Refactor (iter34/cluster-003-projection-session-legacy-payload):
+//   Old pattern: Projection session event transport carries both protobuf bytes and legacy string payload compatibility (legacy_payload string field in proto + legacy codec interface + legacy payload write path).
+//   New principle: Projection session event transport carries protobuf payload only; obsolete legacy codec surface is deleted; tests/docs updated; protobuf legacy_payload field reserved per protobuf evolution rules; no concrete codec depended on the legacy interface.
 public interface IProjectionSessionEventCodec<TEvent>
     where TEvent : class
 {
@@ -18,15 +21,4 @@ public interface IProjectionSessionEventCodec<TEvent>
     ByteString Serialize(TEvent evt);
 
     TEvent? Deserialize(string eventType, ByteString payload);
-}
-
-/// <summary>
-/// Optional compatibility contract for codecs that must keep legacy string transport readable during mixed-version rollout.
-/// </summary>
-public interface ILegacyProjectionSessionEventCodec<TEvent>
-    where TEvent : class
-{
-    string? SerializeLegacy(TEvent evt);
-
-    TEvent? DeserializeLegacy(string eventType, string payload);
 }

--- a/src/Aevatar.CQRS.Projection.Core/Streaming/ProjectionSessionEventHub.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Streaming/ProjectionSessionEventHub.cs
@@ -7,6 +7,9 @@ namespace Aevatar.CQRS.Projection.Core.Streaming;
 /// <summary>
 /// Generic stream-backed session event hub keyed by scope/session.
 /// </summary>
+// Refactor (iter34/cluster-003-projection-session-legacy-payload):
+//   Old pattern: Projection session event transport carries both protobuf bytes and legacy string payload compatibility (legacy_payload string field in proto + legacy codec interface + legacy payload write path).
+//   New principle: Projection session event transport carries protobuf payload only; obsolete legacy codec surface is deleted; tests/docs updated; protobuf legacy_payload field reserved per protobuf evolution rules; no concrete codec depended on the legacy interface.
 public sealed class ProjectionSessionEventHub<TEvent> : IProjectionSessionEventHub<TEvent>
     where TEvent : class
 {
@@ -44,7 +47,6 @@ public sealed class ProjectionSessionEventHub<TEvent> : IProjectionSessionEventH
             ScopeId = scopeId,
             SessionId = sessionId,
             EventType = _codec.GetEventType(evt),
-            LegacyPayload = (_codec as ILegacyProjectionSessionEventCodec<TEvent>)?.SerializeLegacy(evt) ?? string.Empty,
             Payload = _codec.Serialize(evt),
         };
         return stream.ProduceAsync(message, ct);
@@ -73,11 +75,10 @@ public sealed class ProjectionSessionEventHub<TEvent> : IProjectionSessionEventH
                 return;
             }
 
-            if ((message.Payload == null || message.Payload.IsEmpty) &&
-                string.IsNullOrWhiteSpace(message.LegacyPayload))
+            if (message.Payload == null || message.Payload.IsEmpty)
             {
                 _logger.LogWarning(
-                    "Dropping projection session event with empty payloads. channel={Channel} scopeId={ScopeId} sessionId={SessionId} eventType={EventType}",
+                    "Dropping projection session event with empty protobuf payload. channel={Channel} scopeId={ScopeId} sessionId={SessionId} eventType={EventType}",
                     _codec.Channel,
                     scopeId,
                     sessionId,
@@ -85,27 +86,17 @@ public sealed class ProjectionSessionEventHub<TEvent> : IProjectionSessionEventH
                 return;
             }
 
-            TEvent? evt = default;
-            if (message.Payload != null && !message.Payload.IsEmpty)
-                evt = _codec.Deserialize(message.EventType, message.Payload);
-
-            if (evt == null &&
-                !string.IsNullOrWhiteSpace(message.LegacyPayload) &&
-                _codec is ILegacyProjectionSessionEventCodec<TEvent> legacyCodec)
-            {
-                evt = legacyCodec.DeserializeLegacy(message.EventType, message.LegacyPayload);
-            }
+            var evt = _codec.Deserialize(message.EventType, message.Payload);
 
             if (evt == null)
             {
                 _logger.LogWarning(
-                    "Dropping undecodable projection session event. channel={Channel} scopeId={ScopeId} sessionId={SessionId} eventType={EventType} payloadBytes={PayloadBytes} legacyPayloadLength={LegacyPayloadLength}",
+                    "Dropping undecodable projection session event. channel={Channel} scopeId={ScopeId} sessionId={SessionId} eventType={EventType} payloadBytes={PayloadBytes}",
                     _codec.Channel,
                     scopeId,
                     sessionId,
                     message.EventType,
-                    message.Payload?.Length ?? 0,
-                    message.LegacyPayload?.Length ?? 0);
+                    message.Payload.Length);
                 return;
             }
 

--- a/src/Aevatar.CQRS.Projection.Core/projection_session_event_transport.proto
+++ b/src/Aevatar.CQRS.Projection.Core/projection_session_event_transport.proto
@@ -2,10 +2,15 @@ syntax = "proto3";
 
 option csharp_namespace = "Aevatar.CQRS.Projection.Core.Streaming";
 
+// Refactor (iter34/cluster-003-projection-session-legacy-payload):
+//   Old pattern: Projection session event transport carries both protobuf bytes and legacy string payload compatibility (legacy_payload string field in proto + legacy codec interface + legacy payload write path).
+//   New principle: Projection session event transport carries protobuf payload only; obsolete legacy codec surface is deleted; tests/docs updated; protobuf legacy_payload field reserved per protobuf evolution rules; no concrete codec depended on the legacy interface.
 message ProjectionSessionEventTransportMessage {
+  reserved 4;
+  reserved "legacy_payload";
+
   string scope_id = 1;
   string session_id = 2;
   string event_type = 3;
-  string legacy_payload = 4;
   bytes payload = 5;
 }

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionHotspotCoverageTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionHotspotCoverageTests.cs
@@ -40,7 +40,6 @@ public sealed class ProjectionHotspotCoverageTests
         message.ScopeId.Should().Be("scope-1");
         message.SessionId.Should().Be("session-1");
         message.EventType.Should().Be("native");
-        message.LegacyPayload.Should().Be("legacy:native:ok");
         message.Payload.Should().NotBeNull();
         message.Payload.IsEmpty.Should().BeFalse();
 
@@ -52,8 +51,11 @@ public sealed class ProjectionHotspotCoverageTests
         await invalidSubscribe.Should().ThrowAsync<InvalidOperationException>();
     }
 
+    // Refactor (iter34/cluster-003-projection-session-legacy-payload):
+    //   Old pattern: Projection session event transport carries both protobuf bytes and legacy string payload compatibility (legacy_payload string field in proto + legacy codec interface + legacy payload write path).
+    //   New principle: Projection session event transport carries protobuf payload only; obsolete legacy codec surface is deleted; tests/docs updated; protobuf legacy_payload field reserved per protobuf evolution rules; no concrete codec depended on the legacy interface.
     [Fact]
-    public async Task ProjectionSessionEventHub_ShouldHandleNativeLegacyAndUndecodableMessages()
+    public async Task ProjectionSessionEventHub_ShouldHandleNativeAndUndecodableProtobufMessages()
     {
         var streamProvider = new RecordingStreamProvider();
         var stream = streamProvider.GetOrAdd("projection-run:scope-1:session-1");
@@ -99,7 +101,6 @@ public sealed class ProjectionHotspotCoverageTests
                 SessionId = "session-1",
                 EventType = "legacy",
                 Payload = ByteString.CopyFromUtf8("broken"),
-                LegacyPayload = "legacy:fallback",
             });
         await stream.ProduceAsync(
             new ProjectionSessionEventTransportMessage
@@ -108,10 +109,9 @@ public sealed class ProjectionHotspotCoverageTests
                 SessionId = "session-1",
                 EventType = "legacy",
                 Payload = ByteString.CopyFromUtf8("broken"),
-                LegacyPayload = "broken",
             });
 
-        received.Should().Equal("native:ok", "fallback");
+        received.Should().Equal("native:ok");
     }
 
     [Fact]
@@ -305,9 +305,7 @@ public sealed class ProjectionHotspotCoverageTests
         await nullLease.Should().ThrowAsync<ArgumentNullException>().WithParameterName("runtimeLease");
     }
 
-    private sealed class TestSessionCodec
-        : IProjectionSessionEventCodec<StringValue>,
-          ILegacyProjectionSessionEventCodec<StringValue>
+    private sealed class TestSessionCodec : IProjectionSessionEventCodec<StringValue>
     {
         public TestSessionCodec(string channel)
         {
@@ -339,23 +337,6 @@ public sealed class ProjectionHotspotCoverageTests
                 : null;
         }
 
-        public string SerializeLegacy(StringValue evt)
-        {
-            ArgumentNullException.ThrowIfNull(evt);
-            return "legacy:" + evt.Value;
-        }
-
-        public StringValue? DeserializeLegacy(string eventType, string payload)
-        {
-            if (!string.Equals(eventType, "legacy", StringComparison.Ordinal) ||
-                string.IsNullOrWhiteSpace(payload) ||
-                !payload.StartsWith("legacy:", StringComparison.Ordinal))
-            {
-                return null;
-            }
-
-            return new StringValue { Value = payload["legacy:".Length..] };
-        }
     }
 
     private sealed class RecordingStreamProvider : IStreamProvider


### PR DESCRIPTION
## 摘要

iter34 cluster-003-projection-session-legacy-payload(中等优先级,direct implement)。

- **Old**:projection session event transport 同时携带 protobuf bytes 和 legacy string payload 兼容路径(`legacy_payload` proto string field + `IProjectionSessionEventCodec` 的 legacy compat interface + ProjectionSessionEventHub 的 legacy write path);经审计无 concrete codec 实现 legacy interface。
- **New**:仅保留 protobuf payload bytes 路径;删除 legacy codec compatibility interface;proto `legacy_payload` field reserved per protobuf evolution rules;ProjectionSessionEventHub 同步删 legacy write path;相关 tests/docs 对齐。

违反:CLAUDE.md「序列化」(`State`、领域事件、命令、回调载荷、快照、缓存载荷、跨 Actor/跨节点内部传输对象全部使用 Protobuf;禁止 JSON/XML/自定义字符串格式 used internally as 事实存储 / fact source)。

## 范围

4 文件改动(+23 / -54 LOC,净 -31 行 deletion-heavy)。架构 guards 全绿;docs lint 全绿;test stability guards 全绿。

🤖 Auto-loop / codex-refactor-loop iter34

⟦AI:AUTO-LOOP⟧
