### PR TITLE
iter34 cluster-005: Mainnet Host endpoints 改走 Application command ports

### DIFF
--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCommandPort.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCommandPort.cs
@@ -29,10 +29,6 @@ internal sealed class ChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
     }
 
-    // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-    //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-    //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-    //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
     public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
         string scopeId,
         UpsertChatRoutePolicyRequested command,
@@ -42,10 +38,6 @@ internal sealed class ChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
         return DispatchAsync(scopeId, command, ct);
     }
 
-    // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-    //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-    //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-    //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
     public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
         string scopeId,
         RemoveChatRouteRuleRequested command,

--- a/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCommandPort.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/ChatRoutePolicyCommandPort.cs
@@ -1,0 +1,91 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
+using Aevatar.Foundation.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.ChatRouting;
+
+/// <summary>
+/// Runtime-backed command port for <see cref="ChatRoutePolicyGAgent"/>.
+/// </summary>
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+internal sealed class ChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
+{
+    private const string ActorIdPrefix = "chat-route-policy:";
+    private const string PublisherActorId = "chat-route-policy-admin";
+
+    private readonly IActorRuntime _actorRuntime;
+    private readonly IActorDispatchPort _actorDispatchPort;
+
+    public ChatRoutePolicyCommandPort(
+        IActorRuntime actorRuntime,
+        IActorDispatchPort actorDispatchPort)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+    }
+
+    // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+    //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+    //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+    //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+    public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
+        string scopeId,
+        UpsertChatRoutePolicyRequested command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        return DispatchAsync(scopeId, command, ct);
+    }
+
+    // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+    //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+    //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+    //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+    public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
+        string scopeId,
+        RemoveChatRouteRuleRequested command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        return DispatchAsync(scopeId, command, ct);
+    }
+
+    private async Task<ChatRoutePolicyCommandAcceptedReceipt> DispatchAsync(
+        string scopeId,
+        IMessage command,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(scopeId))
+            throw new ArgumentException("scopeId is required.", nameof(scopeId));
+
+        var actorId = $"{ActorIdPrefix}{scopeId.Trim()}";
+        var actor = await _actorRuntime.CreateAsync<ChatRoutePolicyGAgent>(actorId, ct);
+        var commandId = Guid.NewGuid().ToString("N");
+        var envelope = new EventEnvelope
+        {
+            Id = commandId,
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(command),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, actor.Id),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = commandId,
+            },
+            Runtime = new EnvelopeRuntime
+            {
+                Deduplication = new DeliveryDeduplication
+                {
+                    OperationId = commandId,
+                },
+            },
+        };
+
+        await _actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
+        return new ChatRoutePolicyCommandAcceptedReceipt(actor.Id, commandId, commandId);
+    }
+}

--- a/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
@@ -40,9 +40,9 @@ public static class ChatRoutingServiceCollectionExtensions
     public static IServiceCollection AddChatRoutingAgents(
         this IServiceCollection services, IConfiguration? configuration = null)
     {
-        // Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-        //   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-        //   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
+        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+        //   Old pattern: Mainnet Host endpoints registered actor runtime/dispatch and performed command envelope assembly in request handlers.
+        //   New principle: DI exposes the chat route policy Application command port so Host composes the port instead of runtime internals.
         ArgumentNullException.ThrowIfNull(services);
 
         // Shared projection plumbing used by the projector (write dispatcher +

--- a/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChatRouting/DependencyInjection/ChatRoutingServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ public static class ChatRoutingServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionActivationPlanProvider,
             ChatRoutePolicyCommittedStateProjectionActivationPlanProvider>());
+        services.TryAddSingleton<IChatRoutePolicyCommandPort, ChatRoutePolicyCommandPort>();
 
         var useElasticsearch = ElasticsearchProjectionConfiguration.IsEnabled(
             configuration,

--- a/agents/Aevatar.GAgents.NyxidChat/IVoiceDemoAgentCommandPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IVoiceDemoAgentCommandPort.cs
@@ -10,7 +10,7 @@ namespace Aevatar.GAgents.NyxidChat;
 public interface IVoiceDemoAgentCommandPort
 {
     Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
-        string actorId,
+        string scopeId,
         string voiceModuleName,
         CancellationToken ct = default);
 }

--- a/agents/Aevatar.GAgents.NyxidChat/IVoiceDemoAgentCommandPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IVoiceDemoAgentCommandPort.cs
@@ -1,0 +1,21 @@
+namespace Aevatar.GAgents.NyxidChat;
+
+/// <summary>
+/// Command surface for admitting voice demo agent initialization.
+/// </summary>
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+public interface IVoiceDemoAgentCommandPort
+{
+    Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
+        string actorId,
+        string voiceModuleName,
+        CancellationToken ct = default);
+}
+
+public sealed record VoiceDemoAgentCommandAcceptedReceipt(
+    string ActorId,
+    string CommandId,
+    string CorrelationId);

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -74,6 +74,7 @@ public static class ServiceCollectionExtensions
             }));
         }
         services.TryAddSingleton<IConversationReplyGenerator, NyxIdConversationReplyGenerator>();
+        services.TryAddSingleton<IVoiceDemoAgentCommandPort, VoiceDemoAgentCommandPort>();
 
         // ─── LLM-call middleware that injects channel context into LLM requests ───
         // Lives here (not in Channel.Runtime) because it implements ILLMCallMiddleware

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -29,11 +29,11 @@ namespace Aevatar.GAgents.NyxidChat;
 
 public static class ServiceCollectionExtensions
 {
-    // Refactor (iter17/cluster-038):
-    //   Old pattern: Nyx relay replay/idempotency 和 reply 累积在 process-local ConcurrentDictionary/lock(NyxRelayBridgeIdempotencyGuard / NyxIdRelayReplayGuard / NyxIdRelayReplyAccumulator)。
-    //   New principle: ConversationGAgent persist callback_jti admission 为 typed event 优先于 business work;删除 process-local replay guards + dead accumulator。
     public static IServiceCollection AddNyxIdChat(this IServiceCollection services, IConfiguration? configuration = null)
     {
+        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+        //   Old pattern: Mainnet Host voice bootstrap injected actor runtime/dispatch and built initialization envelopes in the endpoint.
+        //   New principle: DI exposes the voice demo Application command port so Host composes the port instead of runtime internals.
         ArgumentNullException.ThrowIfNull(services);
         RuntimeHelpers.RunClassConstructor(typeof(NyxIdChatGAgent).TypeHandle);
         RuntimeHelpers.RunClassConstructor(typeof(AgentRunGAgent).TypeHandle);

--- a/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Google.Protobuf;
@@ -28,16 +30,17 @@ internal sealed class VoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
     }
 
     public async Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
-        string actorId,
+        string scopeId,
         string voiceModuleName,
         CancellationToken ct = default)
     {
-        if (string.IsNullOrWhiteSpace(actorId))
-            throw new ArgumentException("actorId is required.", nameof(actorId));
+        if (string.IsNullOrWhiteSpace(scopeId))
+            throw new ArgumentException("scopeId is required.", nameof(scopeId));
         if (string.IsNullOrWhiteSpace(voiceModuleName))
             throw new ArgumentException("voiceModuleName is required.", nameof(voiceModuleName));
 
-        var actor = await _actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId.Trim(), ct);
+        var actorId = BuildDemoActorId(scopeId);
+        var actor = await _actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
         var initialize = new InitializeRoleAgentEvent
         {
             RoleId = "voice-demo",
@@ -69,5 +72,12 @@ internal sealed class VoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
 
         await _actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
         return new VoiceDemoAgentCommandAcceptedReceipt(actor.Id, commandId, commandId);
+    }
+
+    private static string BuildDemoActorId(string scopeId)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim()));
+        var hash = Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+        return $"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-{hash}";
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
@@ -27,10 +27,6 @@ internal sealed class VoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
     }
 
-    // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-    //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-    //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-    //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
     public async Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
         string actorId,
         string voiceModuleName,

--- a/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/VoiceDemoAgentCommandPort.cs
@@ -1,0 +1,77 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+/// <summary>
+/// Runtime-backed command port for voice demo NyxID chat agent initialization.
+/// </summary>
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+internal sealed class VoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
+{
+    private const string PublisherActorId = "voice-demo-bootstrap";
+
+    private readonly IActorRuntime _actorRuntime;
+    private readonly IActorDispatchPort _actorDispatchPort;
+
+    public VoiceDemoAgentCommandPort(
+        IActorRuntime actorRuntime,
+        IActorDispatchPort actorDispatchPort)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+    }
+
+    // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+    //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+    //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+    //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+    public async Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
+        string actorId,
+        string voiceModuleName,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(actorId))
+            throw new ArgumentException("actorId is required.", nameof(actorId));
+        if (string.IsNullOrWhiteSpace(voiceModuleName))
+            throw new ArgumentException("voiceModuleName is required.", nameof(voiceModuleName));
+
+        var actor = await _actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId.Trim(), ct);
+        var initialize = new InitializeRoleAgentEvent
+        {
+            RoleId = "voice-demo",
+            RoleName = "Voice Demo Agent",
+            ProviderName = NyxIdChatServiceDefaults.ProviderName,
+            SystemPrompt = "You are the Aevatar voice demo agent. Reply conversationally and keep spoken answers concise.",
+            MaxHistoryMessages = 16,
+            EventModules = voiceModuleName.Trim(),
+        };
+        var commandId = Guid.NewGuid().ToString("N");
+        var envelope = new EventEnvelope
+        {
+            Id = commandId,
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(initialize),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, actor.Id),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = commandId,
+            },
+            Runtime = new EnvelopeRuntime
+            {
+                Deduplication = new DeliveryDeduplication
+                {
+                    OperationId = commandId,
+                },
+            },
+        };
+
+        await _actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
+        return new VoiceDemoAgentCommandAcceptedReceipt(actor.Id, commandId, commandId);
+    }
+}

--- a/src/Aevatar.ChatRouting.Core/IChatRoutePolicyCommandPort.cs
+++ b/src/Aevatar.ChatRouting.Core/IChatRoutePolicyCommandPort.cs
@@ -1,0 +1,28 @@
+using Aevatar.ChatRouting.Abstractions;
+
+namespace Aevatar.ChatRouting.Core;
+
+/// <summary>
+/// Application command surface for chat route policy mutations.
+/// </summary>
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
+public interface IChatRoutePolicyCommandPort
+{
+    Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
+        string scopeId,
+        UpsertChatRoutePolicyRequested command,
+        CancellationToken ct = default);
+
+    Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
+        string scopeId,
+        RemoveChatRouteRuleRequested command,
+        CancellationToken ct = default);
+}
+
+public sealed record ChatRoutePolicyCommandAcceptedReceipt(
+    string ActorId,
+    string CommandId,
+    string CorrelationId);

--- a/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
@@ -71,10 +71,6 @@ internal static class ChatRoutePolicyAdminEndpoints
         [FromServices] IChatRoutePolicyCommandPort commandPort,
         CancellationToken ct)
     {
-        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -133,10 +129,6 @@ internal static class ChatRoutePolicyAdminEndpoints
         [FromServices] IChatRoutePolicyCommandPort commandPort,
         CancellationToken ct)
     {
-        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 

--- a/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/ChatRouting/ChatRoutePolicyAdminEndpoints.cs
@@ -1,10 +1,8 @@
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.ChatRouting;
 using Aevatar.Hosting;
 using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,8 +19,8 @@ namespace Aevatar.Mainnet.Host.Api.ChatRouting;
 /// service), so the generic <c>/api/scopes/{scopeId}/invoke/{endpointId}</c>
 /// surface can't address it. This endpoint dispatches
 /// <see cref="UpsertChatRoutePolicyRequested"/> /
-/// <see cref="RemoveChatRouteRuleRequested"/> directly via
-/// <see cref="IActorDispatchPort"/>.
+/// <see cref="RemoveChatRouteRuleRequested"/> through the chat route policy
+/// application command port.
 ///
 /// Authorization model: the same scope-access guard the other
 /// scope-bound endpoints use — caller's scope claim must match the URL
@@ -30,13 +28,12 @@ namespace Aevatar.Mainnet.Host.Api.ChatRouting;
 /// scopeId so callers cannot write a policy targeting someone else's caller
 /// scope by accident or by intent.
 /// </summary>
-// Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-//   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-//   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
 internal static class ChatRoutePolicyAdminEndpoints
 {
-    private const string ProjectionKindActorIdPrefix = "chat-route-policy:";
-
     private static readonly JsonParser BodyParser = new(
         JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
 
@@ -71,13 +68,13 @@ internal static class ChatRoutePolicyAdminEndpoints
     private static async Task<IResult> HandleUpsertAsync(
         HttpContext http,
         string scopeId,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
+        [FromServices] IChatRoutePolicyCommandPort commandPort,
         CancellationToken ct)
     {
-        // Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-        //   Old pattern: write endpoint injected ChatRoutePolicyProjectionPort and primed projection before dispatch.
-        //   New principle: endpoint only builds/dispatches the command; committed-state hook activates projection.
+        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -117,11 +114,11 @@ internal static class ChatRoutePolicyAdminEndpoints
             SenderId = string.Empty,
         };
 
-        var (actorId, commandId) = await DispatchAsync(command, scopeId, actorRuntime, actorDispatchPort, ct);
+        var receipt = await commandPort.UpsertAsync(scopeId, command, ct);
         return Results.Accepted(value: new
         {
-            actor_id = actorId,
-            command_id = commandId,
+            actor_id = receipt.ActorId,
+            command_id = receipt.CommandId,
             note = "Upsert dispatched. Re-query GET to observe materialized state.",
         });
     }
@@ -133,13 +130,13 @@ internal static class ChatRoutePolicyAdminEndpoints
         HttpContext http,
         string scopeId,
         string ruleId,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
+        [FromServices] IChatRoutePolicyCommandPort commandPort,
         CancellationToken ct)
     {
-        // Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-        //   Old pattern: delete endpoint injected ChatRoutePolicyProjectionPort and primed projection before dispatch.
-        //   New principle: endpoint only builds/dispatches the command; committed-state hook activates projection.
+        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -147,11 +144,11 @@ internal static class ChatRoutePolicyAdminEndpoints
             return JsonError(StatusCodes.Status400BadRequest, "rule_id_required", "rule_id path segment is required.");
 
         var command = new RemoveChatRouteRuleRequested { RuleId = ruleId.Trim() };
-        var (actorId, commandId) = await DispatchAsync(command, scopeId, actorRuntime, actorDispatchPort, ct);
+        var receipt = await commandPort.RemoveRuleAsync(scopeId, command, ct);
         return Results.Accepted(value: new
         {
-            actor_id = actorId,
-            command_id = commandId,
+            actor_id = receipt.ActorId,
+            command_id = receipt.CommandId,
             note = "Rule removal dispatched. Re-query GET to observe materialized state.",
         });
     }
@@ -195,41 +192,6 @@ internal static class ChatRoutePolicyAdminEndpoints
             view.Rules.Add(rule.Clone());
 
         return Results.Content(ResponseFormatter.Format(view), "application/json");
-    }
-
-    private static async Task<(string ActorId, string CommandId)> DispatchAsync(
-        IMessage command,
-        string scopeId,
-        IActorRuntime actorRuntime,
-        IActorDispatchPort actorDispatchPort,
-        CancellationToken ct)
-    {
-        // Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-        //   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-        //   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
-        var actorId = $"{ProjectionKindActorIdPrefix}{scopeId}";
-        var actor = await actorRuntime.CreateAsync<ChatRoutePolicyGAgent>(actorId, ct);
-        var commandId = Guid.NewGuid().ToString("N");
-        var envelope = new EventEnvelope
-        {
-            Id = commandId,
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(command),
-            Route = EnvelopeRouteSemantics.CreateDirect("chat-route-policy-admin", actor.Id),
-            Propagation = new EnvelopePropagation
-            {
-                CorrelationId = commandId,
-            },
-            Runtime = new EnvelopeRuntime
-            {
-                Deduplication = new DeliveryDeduplication
-                {
-                    OperationId = commandId,
-                },
-            },
-        };
-        await actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
-        return (actor.Id, commandId);
     }
 
     private static IResult JsonError(int status, string error, string detail) =>

--- a/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
@@ -48,10 +48,6 @@ internal static class VoiceDemoBootstrapEndpoints
         [FromServices] IVoicePresenceSessionResolver voiceSessionResolver,
         CancellationToken ct)
     {
-        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         if (!TryResolveScopeId(http.User, out var scopeId))
         {
             return Results.Json(
@@ -134,10 +130,6 @@ internal static class VoiceDemoBootstrapEndpoints
         IChatRoutePolicyQueryPort routePolicyQueryPort,
         CancellationToken ct)
     {
-        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
-        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
-        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
-        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         var existing = await routePolicyQueryPort.LookupForCallerAsync(routingScope, ct);
         var command = new UpsertChatRoutePolicyRequested
         {

--- a/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
@@ -5,13 +5,9 @@ using Aevatar.AI.Abstractions;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.VoicePresence.Hosting;
-using Aevatar.GAgents.ChatRouting;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.GAgents.Scheduled;
-using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -20,15 +16,14 @@ using ScheduledOwnerScope = Aevatar.GAgents.Scheduled.OwnerScope;
 
 namespace Aevatar.Mainnet.Host.Api.Voice;
 
-// Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-//   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-//   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
 internal static class VoiceDemoBootstrapEndpoints
 {
     private const string VoiceModuleName = "voice_presence_openai";
     private const string RouteRuleId = "voice-demo";
-    private const string ChatRoutePolicyActorIdPrefix = "chat-route-policy:";
-    private const string PublisherActorId = "voice-demo-bootstrap";
     private static readonly TimeSpan ObservationTimeout = TimeSpan.FromSeconds(12);
     private static readonly TimeSpan ObservationPollInterval = TimeSpan.FromMilliseconds(150);
 
@@ -44,18 +39,19 @@ internal static class VoiceDemoBootstrapEndpoints
 
     private static async Task<IResult> HandleBootstrapAsync(
         HttpContext http,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
+        [FromServices] IVoiceDemoAgentCommandPort voiceDemoAgentCommandPort,
         [FromServices] IUserAgentCatalogCommandPort catalogCommandPort,
         [FromServices] IUserAgentCatalogQueryPort catalogQueryPort,
+        [FromServices] IChatRoutePolicyCommandPort routePolicyCommandPort,
         [FromServices] IChatRoutePolicyQueryPort routePolicyQueryPort,
         [FromServices] ChatRouteResolver routeResolver,
         [FromServices] IVoicePresenceSessionResolver voiceSessionResolver,
         CancellationToken ct)
     {
-        // Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-        //   Old pattern: bootstrap request path injected ChatRoutePolicyProjectionPort and primed projection.
-        //   New principle: bootstrap dispatches accepted commands; committed-state hook activates route-policy projection.
+        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         if (!TryResolveScopeId(http.User, out var scopeId))
         {
             return Results.Json(
@@ -67,7 +63,7 @@ internal static class VoiceDemoBootstrapEndpoints
         var scheduledScope = ScheduledOwnerScope.ForNyxIdNative(scopeId);
         var actorId = BuildDemoActorId(scopeId);
 
-        await EnsureDemoAgentAsync(actorId, actorRuntime, actorDispatchPort, ct);
+        await voiceDemoAgentCommandPort.EnsureAsync(actorId, VoiceModuleName, ct);
         await catalogCommandPort.UpsertAsync(new UserAgentCatalogUpsertCommand
         {
             AgentId = actorId,
@@ -76,14 +72,11 @@ internal static class VoiceDemoBootstrapEndpoints
             OwnerScope = scheduledScope.Clone(),
         }, ct);
 
-        var routePolicyActorId = $"{ChatRoutePolicyActorIdPrefix}{scopeId}";
         await EnsureVoiceRoutePolicyAsync(
-            routePolicyActorId,
             scopeId,
             actorId,
             routingScope,
-            actorRuntime,
-            actorDispatchPort,
+            routePolicyCommandPort,
             routePolicyQueryPort,
             ct);
 
@@ -133,39 +126,18 @@ internal static class VoiceDemoBootstrapEndpoints
         });
     }
 
-    private static async Task EnsureDemoAgentAsync(
-        string actorId,
-        IActorRuntime actorRuntime,
-        IActorDispatchPort actorDispatchPort,
-        CancellationToken ct)
-    {
-        var actor = await actorRuntime.CreateAsync<NyxIdChatGAgent>(actorId, ct);
-        var initialize = new InitializeRoleAgentEvent
-        {
-            RoleId = "voice-demo",
-            RoleName = "Voice Demo Agent",
-            ProviderName = NyxIdChatServiceDefaults.ProviderName,
-            SystemPrompt = "You are the Aevatar voice demo agent. Reply conversationally and keep spoken answers concise.",
-            MaxHistoryMessages = 16,
-            EventModules = VoiceModuleName,
-        };
-
-        await DispatchAsync(actor.Id, initialize, actorDispatchPort, ct);
-    }
-
     private static async Task EnsureVoiceRoutePolicyAsync(
-        string routePolicyActorId,
         string scopeId,
         string actorId,
         RoutingOwnerScope routingScope,
-        IActorRuntime actorRuntime,
-        IActorDispatchPort actorDispatchPort,
+        IChatRoutePolicyCommandPort routePolicyCommandPort,
         IChatRoutePolicyQueryPort routePolicyQueryPort,
         CancellationToken ct)
     {
-        // Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-        //   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-        //   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
+        // Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+        //   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+        //   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+        //   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
         var existing = await routePolicyQueryPort.LookupForCallerAsync(routingScope, ct);
         var command = new UpsertChatRoutePolicyRequested
         {
@@ -196,8 +168,7 @@ internal static class VoiceDemoBootstrapEndpoints
             Description = "route browser voice demo to the current user's mainnet agent",
         });
 
-        var actor = await actorRuntime.CreateAsync<ChatRoutePolicyGAgent>(routePolicyActorId, ct);
-        await DispatchAsync(actor.Id, command, actorDispatchPort, ct);
+        await routePolicyCommandPort.UpsertAsync(scopeId, command, ct);
     }
 
     private static bool RouteResolvesToDemoActor(
@@ -243,35 +214,6 @@ internal static class VoiceDemoBootstrapEndpoints
                 VoiceModuleName = VoiceModuleName,
             },
         };
-
-    private static async Task DispatchAsync(
-        string actorId,
-        IMessage command,
-        IActorDispatchPort actorDispatchPort,
-        CancellationToken ct)
-    {
-        var commandId = Guid.NewGuid().ToString("N");
-        var envelope = new EventEnvelope
-        {
-            Id = commandId,
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(command),
-            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, actorId),
-            Propagation = new EnvelopePropagation
-            {
-                CorrelationId = commandId,
-            },
-            Runtime = new EnvelopeRuntime
-            {
-                Deduplication = new DeliveryDeduplication
-                {
-                    OperationId = commandId,
-                },
-            },
-        };
-
-        await actorDispatchPort.DispatchAsync(actorId, envelope, ct);
-    }
 
     private static async Task<bool> WaitUntilAsync(
         Func<Task<bool>> predicate,

--- a/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/VoiceDemoBootstrapEndpoints.cs
@@ -1,6 +1,4 @@
 using System.Security.Claims;
-using System.Security.Cryptography;
-using System.Text;
 using Aevatar.AI.Abstractions;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
@@ -57,9 +55,9 @@ internal static class VoiceDemoBootstrapEndpoints
 
         var routingScope = RoutingOwnerScope.ForNyxIdNative(scopeId);
         var scheduledScope = ScheduledOwnerScope.ForNyxIdNative(scopeId);
-        var actorId = BuildDemoActorId(scopeId);
 
-        await voiceDemoAgentCommandPort.EnsureAsync(actorId, VoiceModuleName, ct);
+        var voiceDemoReceipt = await voiceDemoAgentCommandPort.EnsureAsync(scopeId, VoiceModuleName, ct);
+        var actorId = voiceDemoReceipt.ActorId;
         await catalogCommandPort.UpsertAsync(new UserAgentCatalogUpsertCommand
         {
             AgentId = actorId,
@@ -233,13 +231,6 @@ internal static class VoiceDemoBootstrapEndpoints
             user.FindFirst(ClaimTypes.NameIdentifier)?.Value) ?? string.Empty;
 
         return !string.IsNullOrWhiteSpace(scopeId);
-    }
-
-    private static string BuildDemoActorId(string scopeId)
-    {
-        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim()));
-        var hash = Convert.ToHexString(bytes)[..16].ToLowerInvariant();
-        return $"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-{hash}";
     }
 
     private static string? FirstNonEmpty(params string?[] values)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/VoiceDemoAgentCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/VoiceDemoAgentCommandPortTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Aevatar.AI.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.NyxidChat;
@@ -21,17 +23,18 @@ public sealed class VoiceDemoAgentCommandPortTests
         var dispatchPort = new RecordingActorDispatchPort();
         using var provider = CreateProvider(actorRuntime, dispatchPort);
         var commandPort = provider.GetRequiredService<IVoiceDemoAgentCommandPort>();
+        var expectedActorId = BuildExpectedDemoActorId("scope-1");
 
-        var receipt = await commandPort.EnsureAsync(" demo-actor ", " voice_presence_openai ");
+        var receipt = await commandPort.EnsureAsync(" scope-1 ", " voice_presence_openai ");
 
         actorRuntime.CreatedActors.Should().ContainSingle()
-            .Which.Should().Be(("demo-actor", typeof(NyxIdChatGAgent)));
+            .Which.Should().Be((expectedActorId, typeof(NyxIdChatGAgent)));
         dispatchPort.Dispatches.Should().ContainSingle();
         var (actorId, envelope) = dispatchPort.Dispatches[0];
-        actorId.Should().Be("demo-actor");
+        actorId.Should().Be(expectedActorId);
         envelope.Id.Should().NotBeNullOrWhiteSpace();
         envelope.Route.PublisherActorId.Should().Be("voice-demo-bootstrap");
-        envelope.Route.Direct.TargetActorId.Should().Be("demo-actor");
+        envelope.Route.Direct.TargetActorId.Should().Be(expectedActorId);
         envelope.Propagation.CorrelationId.Should().Be(envelope.Id);
         envelope.Runtime.Deduplication.OperationId.Should().Be(envelope.Id);
 
@@ -43,30 +46,37 @@ public sealed class VoiceDemoAgentCommandPortTests
         initialize.MaxHistoryMessages.Should().Be(16);
         initialize.EventModules.Should().Be("voice_presence_openai");
         receipt.Should().Be(new VoiceDemoAgentCommandAcceptedReceipt(
-            "demo-actor",
+            expectedActorId,
             envelope.Id,
             envelope.Id));
     }
 
     [Theory]
-    [InlineData(null, "voice_presence_openai", "actorId")]
-    [InlineData("", "voice_presence_openai", "actorId")]
-    [InlineData("   ", "voice_presence_openai", "actorId")]
-    [InlineData("demo-actor", null, "voiceModuleName")]
-    [InlineData("demo-actor", "", "voiceModuleName")]
-    [InlineData("demo-actor", "   ", "voiceModuleName")]
+    [InlineData(null, "voice_presence_openai", "scopeId")]
+    [InlineData("", "voice_presence_openai", "scopeId")]
+    [InlineData("   ", "voice_presence_openai", "scopeId")]
+    [InlineData("scope-1", null, "voiceModuleName")]
+    [InlineData("scope-1", "", "voiceModuleName")]
+    [InlineData("scope-1", "   ", "voiceModuleName")]
     public async Task EnsureAsync_RejectsMissingCommandInputs(
-        string? actorId,
+        string? scopeId,
         string? voiceModuleName,
         string expectedParameterName)
     {
         using var provider = CreateProvider(new RecordingActorRuntime(), new RecordingActorDispatchPort());
         var commandPort = provider.GetRequiredService<IVoiceDemoAgentCommandPort>();
 
-        var act = () => commandPort.EnsureAsync(actorId!, voiceModuleName!);
+        var act = () => commandPort.EnsureAsync(scopeId!, voiceModuleName!);
 
         await act.Should().ThrowAsync<ArgumentException>()
             .WithParameterName(expectedParameterName);
+    }
+
+    private static string BuildExpectedDemoActorId(string scopeId)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(scopeId.Trim()));
+        var hash = Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+        return $"{NyxIdChatServiceDefaults.ActorIdPrefix}-voice-demo-{hash}";
     }
 
     private static ServiceProvider CreateProvider(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/VoiceDemoAgentCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/VoiceDemoAgentCommandPortTests.cs
@@ -1,0 +1,127 @@
+using Aevatar.AI.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.NyxidChat;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+/// <summary>
+/// Direct coverage for the voice demo command port used by Mainnet bootstrap.
+/// </summary>
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Voice bootstrap endpoint built InitializeRoleAgentEvent envelopes with runtime dependencies in Host.
+//   New principle: command-port tests own initialization envelope assertions; Host endpoint tests only verify admission into the port.
+public sealed class VoiceDemoAgentCommandPortTests
+{
+    [Fact]
+    public async Task EnsureAsync_DispatchesInitializationEnvelopeAndReturnsAcceptedReceipt()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IVoiceDemoAgentCommandPort>();
+
+        var receipt = await commandPort.EnsureAsync(" demo-actor ", " voice_presence_openai ");
+
+        actorRuntime.CreatedActors.Should().ContainSingle()
+            .Which.Should().Be(("demo-actor", typeof(NyxIdChatGAgent)));
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var (actorId, envelope) = dispatchPort.Dispatches[0];
+        actorId.Should().Be("demo-actor");
+        envelope.Id.Should().NotBeNullOrWhiteSpace();
+        envelope.Route.PublisherActorId.Should().Be("voice-demo-bootstrap");
+        envelope.Route.Direct.TargetActorId.Should().Be("demo-actor");
+        envelope.Propagation.CorrelationId.Should().Be(envelope.Id);
+        envelope.Runtime.Deduplication.OperationId.Should().Be(envelope.Id);
+
+        var initialize = envelope.Payload.Unpack<InitializeRoleAgentEvent>();
+        initialize.RoleId.Should().Be("voice-demo");
+        initialize.RoleName.Should().Be("Voice Demo Agent");
+        initialize.ProviderName.Should().Be(NyxIdChatServiceDefaults.ProviderName);
+        initialize.SystemPrompt.Should().Contain("Aevatar voice demo agent");
+        initialize.MaxHistoryMessages.Should().Be(16);
+        initialize.EventModules.Should().Be("voice_presence_openai");
+        receipt.Should().Be(new VoiceDemoAgentCommandAcceptedReceipt(
+            "demo-actor",
+            envelope.Id,
+            envelope.Id));
+    }
+
+    [Theory]
+    [InlineData(null, "voice_presence_openai", "actorId")]
+    [InlineData("", "voice_presence_openai", "actorId")]
+    [InlineData("   ", "voice_presence_openai", "actorId")]
+    [InlineData("demo-actor", null, "voiceModuleName")]
+    [InlineData("demo-actor", "", "voiceModuleName")]
+    [InlineData("demo-actor", "   ", "voiceModuleName")]
+    public async Task EnsureAsync_RejectsMissingCommandInputs(
+        string? actorId,
+        string? voiceModuleName,
+        string expectedParameterName)
+    {
+        using var provider = CreateProvider(new RecordingActorRuntime(), new RecordingActorDispatchPort());
+        var commandPort = provider.GetRequiredService<IVoiceDemoAgentCommandPort>();
+
+        var act = () => commandPort.EnsureAsync(actorId!, voiceModuleName!);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName(expectedParameterName);
+    }
+
+    private static ServiceProvider CreateProvider(
+        RecordingActorRuntime actorRuntime,
+        RecordingActorDispatchPort dispatchPort)
+    {
+        return new ServiceCollection()
+            .AddSingleton<IActorRuntime>(actorRuntime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddNyxIdChat()
+            .BuildServiceProvider();
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        public List<(string ActorId, Type AgentType)> CreatedActors { get; } = [];
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            CreateAsync(typeof(TAgent), id, ct);
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            CreatedActors.Add((id, agentType));
+            return Task.FromResult<IActor>(new StubActor(id));
+        }
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(new StubActor(id));
+        public Task<bool> ExistsAsync(string id) => Task.FromResult(false);
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Dispatches.Add((actorId, envelope));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+    }
+}

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCommandPortTests.cs
@@ -84,6 +84,38 @@ public sealed class ChatRoutePolicyCommandPortTests
             .WithParameterName("scopeId");
     }
 
+    [Fact]
+    public async Task UpsertAsync_RejectsNullCommand()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+
+        var act = () => commandPort.UpsertAsync("scope-1", null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("command");
+        actorRuntime.CreatedActors.Should().BeEmpty();
+        dispatchPort.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveRuleAsync_RejectsNullCommand()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+
+        var act = () => commandPort.RemoveRuleAsync("scope-1", null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>()
+            .WithParameterName("command");
+        actorRuntime.CreatedActors.Should().BeEmpty();
+        dispatchPort.Dispatches.Should().BeEmpty();
+    }
+
     private static ServiceProvider CreateProvider(
         RecordingActorRuntime actorRuntime,
         RecordingActorDispatchPort dispatchPort)

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCommandPortTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutePolicyCommandPortTests.cs
@@ -1,0 +1,142 @@
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.ChatRouting.Core;
+using Aevatar.Foundation.Abstractions;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.GAgents.ChatRouting.Tests;
+
+/// <summary>
+/// Direct coverage for the chat route policy command port that Mainnet Host composes.
+/// </summary>
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Host endpoint tests inspected Host-local EventEnvelope construction directly.
+//   New principle: command-port tests own envelope/dispatch assertions; Host endpoint tests only verify admission into the port.
+public sealed class ChatRoutePolicyCommandPortTests
+{
+    [Fact]
+    public async Task UpsertAsync_DispatchesDirectEnvelopeAndReturnsAcceptedReceipt()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+        var command = new UpsertChatRoutePolicyRequested
+        {
+            DefaultTarget = new ChatRouteAction
+            {
+                ForwardToModel = new ForwardToModel { ModelName = "chrono-llm/gpt-5.5" },
+            },
+        };
+
+        var receipt = await commandPort.UpsertAsync(" scope-1 ", command);
+
+        actorRuntime.CreatedActors.Should().ContainSingle()
+            .Which.Should().Be(("chat-route-policy:scope-1", typeof(ChatRoutePolicyGAgent)));
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var (actorId, envelope) = dispatchPort.Dispatches[0];
+        actorId.Should().Be("chat-route-policy:scope-1");
+        envelope.Id.Should().NotBeNullOrWhiteSpace();
+        envelope.Payload.Unpack<UpsertChatRoutePolicyRequested>()
+            .DefaultTarget.ForwardToModel.ModelName.Should().Be("chrono-llm/gpt-5.5");
+        envelope.Route.PublisherActorId.Should().Be("chat-route-policy-admin");
+        envelope.Route.Direct.TargetActorId.Should().Be("chat-route-policy:scope-1");
+        envelope.Propagation.CorrelationId.Should().Be(envelope.Id);
+        envelope.Runtime.Deduplication.OperationId.Should().Be(envelope.Id);
+        receipt.Should().Be(new ChatRoutePolicyCommandAcceptedReceipt(
+            "chat-route-policy:scope-1",
+            envelope.Id,
+            envelope.Id));
+    }
+
+    [Fact]
+    public async Task RemoveRuleAsync_DispatchesRemovePayloadToScopeActor()
+    {
+        var actorRuntime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        using var provider = CreateProvider(actorRuntime, dispatchPort);
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+
+        await commandPort.RemoveRuleAsync("scope-1", new RemoveChatRouteRuleRequested { RuleId = "drop-me" });
+
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var (actorId, envelope) = dispatchPort.Dispatches[0];
+        actorId.Should().Be("chat-route-policy:scope-1");
+        envelope.Payload.Unpack<RemoveChatRouteRuleRequested>().RuleId.Should().Be("drop-me");
+        envelope.Route.PublisherActorId.Should().Be("chat-route-policy-admin");
+        envelope.Route.Direct.TargetActorId.Should().Be("chat-route-policy:scope-1");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task UpsertAsync_RejectsMissingScopeId(string? scopeId)
+    {
+        using var provider = CreateProvider(new RecordingActorRuntime(), new RecordingActorDispatchPort());
+        var commandPort = provider.GetRequiredService<IChatRoutePolicyCommandPort>();
+        var command = new UpsertChatRoutePolicyRequested();
+
+        var act = () => commandPort.UpsertAsync(scopeId!, command);
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("scopeId");
+    }
+
+    private static ServiceProvider CreateProvider(
+        RecordingActorRuntime actorRuntime,
+        RecordingActorDispatchPort dispatchPort)
+    {
+        return new ServiceCollection()
+            .AddSingleton<IActorRuntime>(actorRuntime)
+            .AddSingleton<IActorDispatchPort>(dispatchPort)
+            .AddChatRoutingAgents()
+            .BuildServiceProvider();
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        public List<(string ActorId, System.Type AgentType)> CreatedActors { get; } = [];
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            CreateAsync(typeof(TAgent), id, ct);
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(id);
+            CreatedActors.Add((id, agentType));
+            return Task.FromResult<IActor>(new StubActor(id));
+        }
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(new StubActor(id));
+        public Task<bool> ExistsAsync(string id) => Task.FromResult(false);
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Dispatches.Add((actorId, envelope));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+    }
+}

--- a/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChatRouting.Tests/ChatRoutingServiceCollectionExtensionsTests.cs
@@ -16,9 +16,10 @@ namespace Aevatar.GAgents.ChatRouting.Tests;
 /// These assertions lock in the full materialization-runtime + materializer +
 /// document-store triple so the readmodel actually populates.
 /// </summary>
-// Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-//   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-//   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
 public sealed class ChatRoutingServiceCollectionExtensionsTests
 {
     [Fact]
@@ -65,6 +66,17 @@ public sealed class ChatRoutingServiceCollectionExtensionsTests
         provider.GetServices<IProjectionActivationPlanProvider>()
             .Should().ContainSingle(planProvider =>
                 planProvider is ChatRoutePolicyCommittedStateProjectionActivationPlanProvider);
+    }
+
+    [Fact]
+    public void AddChatRoutingAgents_RegistersChatRoutePolicyCommandPort()
+    {
+        var services = new ServiceCollection()
+            .AddChatRoutingAgents();
+
+        services.Should().ContainSingle(
+            descriptor => descriptor.ServiceType == typeof(IChatRoutePolicyCommandPort),
+                "Mainnet Host endpoint must call the feature command port instead of actor runtime/dispatch directly");
     }
 
     [Fact]

--- a/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using System.Text;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.ChatRouting;
 using Aevatar.Hosting;
 using Aevatar.Mainnet.Host.Api.ChatRouting;
@@ -29,9 +28,10 @@ namespace Aevatar.Hosting.Tests;
 /// (validated by ChatRoutePolicyGAgentTests) is fire-and-forget on the
 /// stream, so an endpoint bug surfaces only in operator pain.
 /// </summary>
-// Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-//   Old pattern: Chat route policy admin endpoints + voice demo bootstrap 在 request path 调 EnsureProjectionForActorAsync 同步 priming projection,违反 query-time priming forbidden + 命令骨架内聚
-//   New principle: 加 ChatRoutePolicyCommittedStateProjectionActivationPlanProvider(committed-state hook 触发);删 ChatRoutePolicyProjectionPort + request-path activation;DI 注册 dispatcher + hook + provider;query_projection_priming_guard 加 chat route policy endpoint 扫描
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
 public sealed class MainnetChatRoutePolicyAdminEndpointsTests
 {
     private const string Scope = "5d0d7b72-acff-49af-bb1b-9f30bbb7c102";
@@ -39,9 +39,8 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
     [Fact]
     public async Task PutPolicy_StampsOwnerScopeAndDispatchesUpsertCommandToScopeActor()
     {
-        var actorRuntime = new RecordingActorRuntime();
-        var dispatchPort = new RecordingActorDispatchPort();
-        await using var app = await CreateAppAsync(actorRuntime, dispatchPort);
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
+        await using var app = await CreateAppAsync(commandPort);
         var client = app.GetTestClient();
 
         var body = """
@@ -64,14 +63,9 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
         var response = await client.SendAsync(request);
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted, await response.Content.ReadAsStringAsync());
-        actorRuntime.CreatedActors.Should().ContainSingle()
-            .Which.Should().Be($"chat-route-policy:{Scope}");
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var (dispatchedActorId, envelope) = dispatchPort.Dispatches[0];
-        dispatchedActorId.Should().Be($"chat-route-policy:{Scope}");
-        envelope.Route.RouteCase.Should().Be(EnvelopeRoute.RouteOneofCase.Direct);
-        envelope.Payload.Is(UpsertChatRoutePolicyRequested.Descriptor).Should().BeTrue();
-        var command = envelope.Payload.Unpack<UpsertChatRoutePolicyRequested>();
+        commandPort.Upserts.Should().ContainSingle();
+        var (acceptedScope, command) = commandPort.Upserts[0];
+        acceptedScope.Should().Be(Scope);
         command.OwnerScope.NyxUserId.Should().Be(Scope,
             "server must stamp owner_scope from the URL, ignoring whatever the client sent");
         command.OwnerScope.Platform.Should().Be(OwnerScope.NyxIdPlatform);
@@ -87,9 +81,8 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
         // default_target; catch the error synchronously at the REST boundary
         // so operators see a 400 + reason instead of a silent fire-and-forget
         // dispatch that drops on the actor side.
-        var actorRuntime = new RecordingActorRuntime();
-        var dispatchPort = new RecordingActorDispatchPort();
-        await using var app = await CreateAppAsync(actorRuntime, dispatchPort);
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
+        await using var app = await CreateAppAsync(commandPort);
         var client = app.GetTestClient();
 
         using var request = new HttpRequestMessage(HttpMethod.Put, $"/api/scopes/{Scope}/chat-route-policy")
@@ -102,33 +95,31 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest, body);
         body.Should().Contain("default_target_required");
-        dispatchPort.Dispatches.Should().BeEmpty(
+        commandPort.Upserts.Should().BeEmpty(
             "REST validation must short-circuit before fire-and-forget dispatch when the body is invalid");
     }
 
     [Fact]
     public async Task DeleteRule_DispatchesRemoveCommandWithTrimmedRuleId()
     {
-        var actorRuntime = new RecordingActorRuntime();
-        var dispatchPort = new RecordingActorDispatchPort();
-        await using var app = await CreateAppAsync(actorRuntime, dispatchPort);
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
+        await using var app = await CreateAppAsync(commandPort);
         var client = app.GetTestClient();
 
         var response = await client.DeleteAsync($"/api/scopes/{Scope}/chat-route-policy/rules/  claude-for-responses  ");
 
         response.StatusCode.Should().Be(HttpStatusCode.Accepted, await response.Content.ReadAsStringAsync());
-        dispatchPort.Dispatches.Should().ContainSingle();
-        var command = dispatchPort.Dispatches[0].Envelope.Payload.Unpack<RemoveChatRouteRuleRequested>();
+        commandPort.Removals.Should().ContainSingle();
+        var (_, command) = commandPort.Removals[0];
         command.RuleId.Should().Be("claude-for-responses");
     }
 
     [Fact]
     public async Task GetPolicy_ReturnsNotFoundWhenSnapshotMissing()
     {
-        var actorRuntime = new RecordingActorRuntime();
-        var dispatchPort = new RecordingActorDispatchPort();
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
         var queryPort = new StaticPolicyQueryPort(snapshot: null);
-        await using var app = await CreateAppAsync(actorRuntime, dispatchPort, queryPort);
+        await using var app = await CreateAppAsync(commandPort, queryPort);
         var client = app.GetTestClient();
 
         var response = await client.GetAsync($"/api/scopes/{Scope}/chat-route-policy");
@@ -155,10 +146,9 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
                     Description = "test rule",
                 },
             ]);
-        var actorRuntime = new RecordingActorRuntime();
-        var dispatchPort = new RecordingActorDispatchPort();
+        var commandPort = new RecordingChatRoutePolicyCommandPort();
         var queryPort = new StaticPolicyQueryPort(snapshot);
-        await using var app = await CreateAppAsync(actorRuntime, dispatchPort, queryPort);
+        await using var app = await CreateAppAsync(commandPort, queryPort);
         var client = app.GetTestClient();
 
         var response = await client.GetAsync($"/api/scopes/{Scope}/chat-route-policy");
@@ -193,11 +183,31 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
         requestPathSource.Should().NotContain("EnsureProjectionForActorAsync");
     }
 
+    [Fact]
+    public void MainnetHostEndpoints_ShouldNotInjectActorRuntimeOrDispatchPortOutsideRefactorComments()
+    {
+        var adminSource = StripLineComments(File.ReadAllText(GetSourcePath(
+            "src",
+            "Aevatar.Mainnet.Host.Api",
+            "ChatRouting",
+            "ChatRoutePolicyAdminEndpoints.cs")));
+        var voiceSource = StripLineComments(File.ReadAllText(GetSourcePath(
+            "src",
+            "Aevatar.Mainnet.Host.Api",
+            "Voice",
+            "VoiceDemoBootstrapEndpoints.cs")));
+        var requestPathSource = adminSource + voiceSource;
+
+        requestPathSource.Should().NotContain("IActorRuntime");
+        requestPathSource.Should().NotContain("IActorDispatchPort");
+        requestPathSource.Should().NotContain("EventEnvelope");
+        requestPathSource.Should().NotContain("CreateDirect");
+    }
+
     // ----- Test fixtures -------------------------------------------------------
 
     private static async Task<WebApplication> CreateAppAsync(
-        RecordingActorRuntime actorRuntime,
-        RecordingActorDispatchPort dispatchPort,
+        RecordingChatRoutePolicyCommandPort commandPort,
         IChatRoutePolicyQueryPort? queryPort = null)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
@@ -214,8 +224,7 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
         builder.Services.AddAuthentication("test")
             .AddScheme<AuthenticationSchemeOptions, AlwaysSucceedAuthHandler>("test", _ => { });
         builder.Services.AddAuthorization();
-        builder.Services.AddSingleton<IActorRuntime>(actorRuntime);
-        builder.Services.AddSingleton<IActorDispatchPort>(dispatchPort);
+        builder.Services.AddSingleton<IChatRoutePolicyCommandPort>(commandPort);
         builder.Services.AddSingleton(queryPort ?? new StaticPolicyQueryPort(snapshot: null));
 
         var app = builder.Build();
@@ -242,52 +251,33 @@ public sealed class MainnetChatRoutePolicyAdminEndpointsTests
         throw new FileNotFoundException($"Could not locate {Path.Combine(relativePath)} from test output directory.");
     }
 
-    private sealed class RecordingActorRuntime : IActorRuntime
+    private sealed class RecordingChatRoutePolicyCommandPort : IChatRoutePolicyCommandPort
     {
-        public List<string> CreatedActors { get; } = [];
+        public List<(string ScopeId, UpsertChatRoutePolicyRequested Command)> Upserts { get; } = [];
+        public List<(string ScopeId, RemoveChatRouteRuleRequested Command)> Removals { get; } = [];
 
-        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
-            where TAgent : IAgent
+        public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
+            string scopeId,
+            UpsertChatRoutePolicyRequested command,
+            CancellationToken ct = default)
         {
-            ArgumentNullException.ThrowIfNull(id);
-            CreatedActors.Add(id);
-            return Task.FromResult<IActor>(new StubActor(id));
+            Upserts.Add((scopeId, command.Clone()));
+            return Task.FromResult(new ChatRoutePolicyCommandAcceptedReceipt(
+                $"chat-route-policy:{scopeId}",
+                "accepted-upsert",
+                "accepted-upsert"));
         }
 
-        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default) =>
-            CreateAsync<IAgent>(id, ct);
-
-        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(new StubActor(id));
-
-        public Task<bool> ExistsAsync(string id) => Task.FromResult(false);
-
-        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
-    }
-
-    private sealed class StubActor(string id) : IActor
-    {
-        public string Id { get; } = id;
-        public IAgent Agent => throw new NotSupportedException();
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
-            Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
-    }
-
-    private sealed class RecordingActorDispatchPort : IActorDispatchPort
-    {
-        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
-
-        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
+            string scopeId,
+            RemoveChatRouteRuleRequested command,
+            CancellationToken ct = default)
         {
-            Dispatches.Add((actorId, envelope));
-            return Task.CompletedTask;
+            Removals.Add((scopeId, command.Clone()));
+            return Task.FromResult(new ChatRoutePolicyCommandAcceptedReceipt(
+                $"chat-route-policy:{scopeId}",
+                "accepted-remove",
+                "accepted-remove"));
         }
     }
 

--- a/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetChatRoutePolicyAdminEndpointsTests.cs
@@ -23,8 +23,8 @@ namespace Aevatar.Hosting.Tests;
 
 /// <summary>
 /// REST admin surface for ChatRoutePolicyGAgent. Without these tests it is
-/// easy to regress the JSON parsing, scope-stamp behavior, or the dispatch
-/// shape (commandId / actor id / envelope route) — the actor itself
+/// easy to regress the JSON parsing, scope-stamp behavior, or the command-port
+/// admission shape (accepted scope / stamped owner scope / rule command) — the actor itself
 /// (validated by ChatRoutePolicyGAgentTests) is fire-and-forget on the
 /// stream, so an endpoint bug surfaces only in operator pain.
 /// </summary>

--- a/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
@@ -73,7 +73,8 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         body.Should().ContainKey("actor_id");
         var demoActorId = body!["actor_id"].ToString()!;
         voiceDemoCommandPort.Commands.Should().ContainSingle()
-            .Which.Should().Be((demoActorId, "voice_presence_openai"));
+            .Which.Should().Be((Scope, "voice_presence_openai"));
+        demoActorId.Should().Be(RecordingVoiceDemoAgentCommandPort.DemoActorId);
         catalogCommandPort.Commands.Should().ContainSingle()
             .Which.AgentId.Should().Be(demoActorId);
 
@@ -128,16 +129,18 @@ public sealed class VoiceDemoBootstrapEndpointsTests
 
     private sealed class RecordingVoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
     {
-        public List<(string ActorId, string VoiceModuleName)> Commands { get; } = [];
+        public const string DemoActorId = "nyxid-chat-voice-demo-test-scope";
+
+        public List<(string ScopeId, string VoiceModuleName)> Commands { get; } = [];
 
         public Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
-            string actorId,
+            string scopeId,
             string voiceModuleName,
             CancellationToken ct = default)
         {
-            Commands.Add((actorId, voiceModuleName));
+            Commands.Add((scopeId, voiceModuleName));
             return Task.FromResult(new VoiceDemoAgentCommandAcceptedReceipt(
-                actorId,
+                DemoActorId,
                 "voice-demo-command",
                 "voice-demo-command"));
         }

--- a/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/VoiceDemoBootstrapEndpointsTests.cs
@@ -5,15 +5,12 @@ using Aevatar.AI.Abstractions;
 using Aevatar.Authentication.Abstractions;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.ChatRouting.Core;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.VoicePresence.Hosting;
-using Aevatar.GAgents.ChatRouting;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.GAgents.Scheduled;
 using Aevatar.Hosting;
 using Aevatar.Mainnet.Host.Api.Voice;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -25,9 +22,10 @@ using ScheduledOwnerScope = Aevatar.GAgents.Scheduled.OwnerScope;
 
 namespace Aevatar.Hosting.Tests;
 
-// Refactor (iter32/cluster-034-chat-route-policy-request-path-projection-activation):
-//   Old pattern: voice bootstrap removed request-path projection priming without endpoint behavior coverage.
-//   New principle: test the route-policy upsert command shape and dispatch-only request path.
+// Refactor (iter34/cluster-005-mainnet-host-direct-actor-runtime):
+//   Old pattern: Mainnet Host endpoints inject IActorRuntime/IActorDispatchPort and build EventEnvelope + dispatch directly in Host code.
+//   New principle: Host calls Application command ports that normalize, resolve target, build envelope, dispatch, return honest accepted receipt.
+//   Host endpoint stays minimal (auth + body parsing). NO direct dependency on IActorRuntime/IActorDispatchPort in Host.
 public sealed class VoiceDemoBootstrapEndpointsTests
 {
     private const string Scope = "voice-scope-1";
@@ -35,7 +33,7 @@ public sealed class VoiceDemoBootstrapEndpointsTests
     [Fact]
     public async Task Bootstrap_UpsertsVoiceRoutePolicyWithoutProjectionPriming()
     {
-        var actorRuntime = new RecordingActorRuntime();
+        var voiceDemoCommandPort = new RecordingVoiceDemoAgentCommandPort();
         var catalogCommandPort = new RecordingCatalogCommandPort();
         var existing = new ChatRoutePolicySnapshot(
             new ChatRouteAction { ForwardToModel = new ForwardToModel { ModelName = "existing-default" } },
@@ -58,12 +56,12 @@ public sealed class VoiceDemoBootstrapEndpointsTests
                 },
             ]);
         var routePolicyQueryPort = new UpdatingRoutePolicyQueryPort(existing);
-        var dispatchPort = new RecordingActorDispatchPort(routePolicyQueryPort);
+        var routePolicyCommandPort = new RecordingChatRoutePolicyCommandPort(routePolicyQueryPort);
         await using var app = await CreateAppAsync(
-            actorRuntime,
-            dispatchPort,
+            voiceDemoCommandPort,
             catalogCommandPort,
             new RecordingCatalogQueryPort(),
+            routePolicyCommandPort,
             routePolicyQueryPort,
             new ReadyVoiceSessionResolver());
         var client = app.GetTestClient();
@@ -74,16 +72,14 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
         body.Should().ContainKey("actor_id");
         var demoActorId = body!["actor_id"].ToString()!;
-        actorRuntime.CreatedActors.Should().Equal(demoActorId, $"chat-route-policy:{Scope}");
+        voiceDemoCommandPort.Commands.Should().ContainSingle()
+            .Which.Should().Be((demoActorId, "voice_presence_openai"));
         catalogCommandPort.Commands.Should().ContainSingle()
             .Which.AgentId.Should().Be(demoActorId);
 
-        dispatchPort.Dispatches.Should().HaveCount(2);
-        dispatchPort.Dispatches.Should().ContainSingle(dispatch => dispatch.ActorId == demoActorId)
-            .Which.Envelope.Payload.Is(InitializeRoleAgentEvent.Descriptor).Should().BeTrue();
-        dispatchPort.Dispatches.Should().ContainSingle(dispatch => dispatch.ActorId == $"chat-route-policy:{Scope}");
-        var routeDispatch = dispatchPort.Dispatches.Single(dispatch => dispatch.ActorId == $"chat-route-policy:{Scope}");
-        var command = routeDispatch.Envelope.Payload.Unpack<UpsertChatRoutePolicyRequested>();
+        routePolicyCommandPort.Upserts.Should().ContainSingle();
+        var (policyScope, command) = routePolicyCommandPort.Upserts[0];
+        policyScope.Should().Be(Scope);
         command.OwnerScope.NyxUserId.Should().Be(Scope);
         command.OwnerScope.Platform.Should().Be(RoutingOwnerScope.NyxIdPlatform);
         command.DefaultTarget.ForwardToModel.ModelName.Should().Be("existing-default");
@@ -97,10 +93,10 @@ public sealed class VoiceDemoBootstrapEndpointsTests
     }
 
     private static async Task<WebApplication> CreateAppAsync(
-        RecordingActorRuntime actorRuntime,
-        RecordingActorDispatchPort dispatchPort,
+        RecordingVoiceDemoAgentCommandPort voiceDemoCommandPort,
         RecordingCatalogCommandPort catalogCommandPort,
         RecordingCatalogQueryPort catalogQueryPort,
+        RecordingChatRoutePolicyCommandPort routePolicyCommandPort,
         UpdatingRoutePolicyQueryPort routePolicyQueryPort,
         ReadyVoiceSessionResolver voiceSessionResolver)
     {
@@ -109,10 +105,10 @@ public sealed class VoiceDemoBootstrapEndpointsTests
             EnvironmentName = Environments.Development,
         });
         builder.WebHost.UseTestServer();
-        builder.Services.AddSingleton<IActorRuntime>(actorRuntime);
-        builder.Services.AddSingleton<IActorDispatchPort>(dispatchPort);
+        builder.Services.AddSingleton<IVoiceDemoAgentCommandPort>(voiceDemoCommandPort);
         builder.Services.AddSingleton<IUserAgentCatalogCommandPort>(catalogCommandPort);
         builder.Services.AddSingleton<IUserAgentCatalogQueryPort>(catalogQueryPort);
+        builder.Services.AddSingleton<IChatRoutePolicyCommandPort>(routePolicyCommandPort);
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(routePolicyQueryPort);
         builder.Services.AddSingleton(new ChatRouteResolver(new StaticFallbackProvider()));
         builder.Services.AddSingleton<IVoicePresenceSessionResolver>(voiceSessionResolver);
@@ -130,58 +126,49 @@ public sealed class VoiceDemoBootstrapEndpointsTests
         return app;
     }
 
-    private sealed class RecordingActorRuntime : IActorRuntime
+    private sealed class RecordingVoiceDemoAgentCommandPort : IVoiceDemoAgentCommandPort
     {
-        public List<string> CreatedActors { get; } = [];
+        public List<(string ActorId, string VoiceModuleName)> Commands { get; } = [];
 
-        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
-            where TAgent : IAgent
+        public Task<VoiceDemoAgentCommandAcceptedReceipt> EnsureAsync(
+            string actorId,
+            string voiceModuleName,
+            CancellationToken ct = default)
         {
-            ArgumentNullException.ThrowIfNull(id);
-            CreatedActors.Add(id);
-            return Task.FromResult<IActor>(new StubActor(id));
+            Commands.Add((actorId, voiceModuleName));
+            return Task.FromResult(new VoiceDemoAgentCommandAcceptedReceipt(
+                actorId,
+                "voice-demo-command",
+                "voice-demo-command"));
         }
-
-        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default) =>
-            CreateAsync<IAgent>(id, ct);
-
-        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(new StubActor(id));
-
-        public Task<bool> ExistsAsync(string id) => Task.FromResult(false);
-
-        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
     }
 
-    private sealed class StubActor(string id) : IActor
+    private sealed class RecordingChatRoutePolicyCommandPort(
+        UpdatingRoutePolicyQueryPort routePolicyQueryPort) : IChatRoutePolicyCommandPort
     {
-        public string Id { get; } = id;
-        public IAgent Agent => throw new NotSupportedException();
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
-            Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
-    }
+        public List<(string ScopeId, UpsertChatRoutePolicyRequested Command)> Upserts { get; } = [];
 
-    private sealed class RecordingActorDispatchPort(UpdatingRoutePolicyQueryPort routePolicyQueryPort) : IActorDispatchPort
-    {
-        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
-
-        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        public Task<ChatRoutePolicyCommandAcceptedReceipt> UpsertAsync(
+            string scopeId,
+            UpsertChatRoutePolicyRequested command,
+            CancellationToken ct = default)
         {
-            Dispatches.Add((actorId, envelope));
-            if (envelope.Payload.Is(UpsertChatRoutePolicyRequested.Descriptor))
-            {
-                routePolicyQueryPort.Observe(envelope.Payload.Unpack<UpsertChatRoutePolicyRequested>());
-            }
-
-            return Task.CompletedTask;
+            Upserts.Add((scopeId, command.Clone()));
+            routePolicyQueryPort.Observe(command);
+            return Task.FromResult(new ChatRoutePolicyCommandAcceptedReceipt(
+                $"chat-route-policy:{scopeId}",
+                "route-policy-command",
+                "route-policy-command"));
         }
+
+        public Task<ChatRoutePolicyCommandAcceptedReceipt> RemoveRuleAsync(
+            string scopeId,
+            RemoveChatRouteRuleRequested command,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ChatRoutePolicyCommandAcceptedReceipt(
+                $"chat-route-policy:{scopeId}",
+                "route-policy-remove",
+                "route-policy-remove"));
     }
 
     private sealed class RecordingCatalogCommandPort : IUserAgentCatalogCommandPort


### PR DESCRIPTION
## 摘要

iter34 cluster-005-mainnet-host-direct-actor-runtime(中等优先级,direct implement)。

- **Old**:Mainnet Host endpoints(`ChatRoutePolicyAdminEndpoints` / `VoiceDemoBootstrapEndpoints`)直接 inject `IActorRuntime` / `IActorDispatchPort`,build `EventEnvelope` + dispatch 在 Host 内做。违反 CLAUDE「Actor 即业务实体」+「应用层契约以业务命名:endpoint 不直接依赖 IActorRuntime 或 IProjectionDocumentReader」。
- **New**:Host 仅调 Application 层 command port(`IChatRoutePolicyCommandPort` / `IVoiceDemoAgentCommandPort`),port normalize + resolve target + build envelope + dispatch + return honest accepted receipt。Host endpoint 保持最小(auth + body parsing)。

引入 `IChatRoutePolicyCommandPort` + `ChatRoutePolicyCommandPort` + `IVoiceDemoAgentCommandPort` + `VoiceDemoAgentCommandPort` + DI 接线 + endpoints/handlers 同步测试更新。

## 范围

11 文件改动(+388 / -276 LOC,净 +112)。架构 guards 全绿;docs lint 全绿。

🤖 Auto-loop / codex-refactor-loop iter34

⟦AI:AUTO-LOOP⟧
