### PR TITLE
iter34 cluster-006: service artifact projectors 改 state-root overwrite

### DIFF
--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceLifecycleQueryApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceLifecycleQueryApplicationService.cs
@@ -1,6 +1,7 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Services;
 
 namespace Aevatar.GAgentService.Application.Services;
 
@@ -20,16 +21,31 @@ public sealed class ServiceLifecycleQueryApplicationService : IServiceLifecycleQ
         _deploymentQueryReader = deploymentQueryReader ?? throw new ArgumentNullException(nameof(deploymentQueryReader));
     }
 
-    public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-        _catalogQueryReader.GetAsync(identity, ct);
+    public async Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
+    {
+        var service = await _catalogQueryReader.GetAsync(identity, ct);
+        return service == null ? null : await ComposeActiveDeploymentAsync(identity, service, ct);
+    }
 
-    public Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
+    public async Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
         string tenantId,
         string appId,
         string @namespace,
         int take = 200,
-        CancellationToken ct = default) =>
-        _catalogQueryReader.QueryByScopeAsync(tenantId, appId, @namespace, take, ct);
+        CancellationToken ct = default)
+    {
+        var services = await _catalogQueryReader.QueryByScopeAsync(tenantId, appId, @namespace, take, ct);
+        var enriched = new List<ServiceCatalogSnapshot>(services.Count);
+        foreach (var service in services)
+        {
+            enriched.Add(await ComposeActiveDeploymentAsync(
+                BuildIdentity(service),
+                service,
+                ct));
+        }
+
+        return enriched;
+    }
 
     public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(
         ServiceIdentity identity,
@@ -40,4 +56,38 @@ public sealed class ServiceLifecycleQueryApplicationService : IServiceLifecycleQ
         ServiceIdentity identity,
         CancellationToken ct = default) =>
         _deploymentQueryReader.GetAsync(identity, ct);
+
+    private async Task<ServiceCatalogSnapshot> ComposeActiveDeploymentAsync(
+        ServiceIdentity identity,
+        ServiceCatalogSnapshot service,
+        CancellationToken ct)
+    {
+        var deploymentCatalog = await _deploymentQueryReader.GetAsync(identity, ct);
+        var activeDeployment = deploymentCatalog?.Deployments
+            .Where(static x =>
+                string.Equals(x.Status, ServiceDeploymentStatus.Active.ToString(), StringComparison.Ordinal) &&
+                !string.IsNullOrWhiteSpace(x.PrimaryActorId))
+            .OrderByDescending(static x => x.UpdatedAt)
+            .ThenBy(static x => x.DeploymentId, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        return activeDeployment == null
+            ? service
+            : service with
+            {
+                ActiveServingRevisionId = activeDeployment.RevisionId,
+                DeploymentId = activeDeployment.DeploymentId,
+                PrimaryActorId = activeDeployment.PrimaryActorId,
+                DeploymentStatus = activeDeployment.Status,
+            };
+    }
+
+    private static ServiceIdentity BuildIdentity(ServiceCatalogSnapshot service) =>
+        new()
+        {
+            TenantId = service.TenantId,
+            AppId = service.AppId,
+            Namespace = service.Namespace,
+            ServiceId = service.ServiceId,
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceLifecycleQueryApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceLifecycleQueryApplicationService.cs
@@ -1,7 +1,6 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
-using Aevatar.GAgentService.Abstractions.Services;
 
 namespace Aevatar.GAgentService.Application.Services;
 
@@ -23,35 +22,20 @@ public sealed class ServiceLifecycleQueryApplicationService : IServiceLifecycleQ
 
     // Refactor (iter34/cluster-006-artifact-projectors-state-root):
     // Old pattern: ServiceCatalogReadModel carried active deployment fields mutated by the catalog projector.
-    // New principle: catalog queries compose serving facts from deployment readmodels, keeping each readmodel actor-scoped.
-    public async Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
-    {
-        var service = await _catalogQueryReader.GetAsync(identity, ct);
-        return service == null ? null : await ComposeActiveDeploymentAsync(identity, service, ct);
-    }
+    // New principle: service catalog queries return the definition readmodel only; serving facts use serving/deployment readmodels.
+    public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+        _catalogQueryReader.GetAsync(identity, ct);
 
     // Refactor (iter34/cluster-006-artifact-projectors-state-root):
     // Old pattern: list queries returned deployment fields previously stored on each catalog readmodel.
-    // New principle: list queries enrich each definition snapshot from the deployment readmodel for that service.
-    public async Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
+    // New principle: list queries return definition snapshots without query-time aggregate selection.
+    public Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
         string tenantId,
         string appId,
         string @namespace,
         int take = 200,
-        CancellationToken ct = default)
-    {
-        var services = await _catalogQueryReader.QueryByScopeAsync(tenantId, appId, @namespace, take, ct);
-        var enriched = new List<ServiceCatalogSnapshot>(services.Count);
-        foreach (var service in services)
-        {
-            enriched.Add(await ComposeActiveDeploymentAsync(
-                BuildIdentity(service),
-                service,
-                ct));
-        }
-
-        return enriched;
-    }
+        CancellationToken ct = default) =>
+        _catalogQueryReader.QueryByScopeAsync(tenantId, appId, @namespace, take, ct);
 
     public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(
         ServiceIdentity identity,
@@ -62,41 +46,4 @@ public sealed class ServiceLifecycleQueryApplicationService : IServiceLifecycleQ
         ServiceIdentity identity,
         CancellationToken ct = default) =>
         _deploymentQueryReader.GetAsync(identity, ct);
-
-    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
-    // Old pattern: active deployment was a denormalized mutation owned by the service catalog projector.
-    // New principle: active deployment is selected from deployment readmodels during query composition.
-    private async Task<ServiceCatalogSnapshot> ComposeActiveDeploymentAsync(
-        ServiceIdentity identity,
-        ServiceCatalogSnapshot service,
-        CancellationToken ct)
-    {
-        var deploymentCatalog = await _deploymentQueryReader.GetAsync(identity, ct);
-        var activeDeployment = deploymentCatalog?.Deployments
-            .Where(static x =>
-                string.Equals(x.Status, ServiceDeploymentStatus.Active.ToString(), StringComparison.Ordinal) &&
-                !string.IsNullOrWhiteSpace(x.PrimaryActorId))
-            .OrderByDescending(static x => x.UpdatedAt)
-            .ThenBy(static x => x.DeploymentId, StringComparer.Ordinal)
-            .FirstOrDefault();
-
-        return activeDeployment == null
-            ? service
-            : service with
-            {
-                ActiveServingRevisionId = activeDeployment.RevisionId,
-                DeploymentId = activeDeployment.DeploymentId,
-                PrimaryActorId = activeDeployment.PrimaryActorId,
-                DeploymentStatus = activeDeployment.Status,
-            };
-    }
-
-    private static ServiceIdentity BuildIdentity(ServiceCatalogSnapshot service) =>
-        new()
-        {
-            TenantId = service.TenantId,
-            AppId = service.AppId,
-            Namespace = service.Namespace,
-            ServiceId = service.ServiceId,
-        };
 }

--- a/src/platform/Aevatar.GAgentService.Application/Services/ServiceLifecycleQueryApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/ServiceLifecycleQueryApplicationService.cs
@@ -21,12 +21,18 @@ public sealed class ServiceLifecycleQueryApplicationService : IServiceLifecycleQ
         _deploymentQueryReader = deploymentQueryReader ?? throw new ArgumentNullException(nameof(deploymentQueryReader));
     }
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    // Old pattern: ServiceCatalogReadModel carried active deployment fields mutated by the catalog projector.
+    // New principle: catalog queries compose serving facts from deployment readmodels, keeping each readmodel actor-scoped.
     public async Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
     {
         var service = await _catalogQueryReader.GetAsync(identity, ct);
         return service == null ? null : await ComposeActiveDeploymentAsync(identity, service, ct);
     }
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    // Old pattern: list queries returned deployment fields previously stored on each catalog readmodel.
+    // New principle: list queries enrich each definition snapshot from the deployment readmodel for that service.
     public async Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(
         string tenantId,
         string appId,
@@ -57,6 +63,9 @@ public sealed class ServiceLifecycleQueryApplicationService : IServiceLifecycleQ
         CancellationToken ct = default) =>
         _deploymentQueryReader.GetAsync(identity, ct);
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    // Old pattern: active deployment was a denormalized mutation owned by the service catalog projector.
+    // New principle: active deployment is selected from deployment readmodels during query composition.
     private async Task<ServiceCatalogSnapshot> ComposeActiveDeploymentAsync(
         ServiceIdentity identity,
         ServiceCatalogSnapshot service,

--- a/src/platform/Aevatar.GAgentService.Projection/Internal/ServiceProjectionEnvelopeSupport.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Internal/ServiceProjectionEnvelopeSupport.cs
@@ -8,7 +8,9 @@ namespace Aevatar.GAgentService.Projection.Internal;
 
 internal static class ServiceCommittedStateSupport
 {
-    // refactor helper, no behavior change: shared committed state_root extraction for service projectors.
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    // Old pattern: artifact projectors unpacked payloads and then merged changes into prior readmodel documents.
+    // New principle: artifact projectors share state_root extraction and overwrite from the committed actor state.
     public static bool TryGetObservedState<TState>(
         EventEnvelope envelope,
         IProjectionClock clock,
@@ -71,9 +73,4 @@ internal static class ServiceCommittedStateSupport
         return true;
     }
 
-    public static long ResolveNextStateVersion(long currentVersion, long observedStateVersion)
-    {
-        _ = currentVersion;
-        return observedStateVersion;
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Internal/ServiceProjectionEnvelopeSupport.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Internal/ServiceProjectionEnvelopeSupport.cs
@@ -1,12 +1,49 @@
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.Foundation.Abstractions;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Projection.Internal;
 
 internal static class ServiceCommittedStateSupport
 {
+    // refactor helper, no behavior change: shared committed state_root extraction for service projectors.
+    public static bool TryGetObservedState<TState>(
+        EventEnvelope envelope,
+        IProjectionClock clock,
+        out TState? state,
+        out string eventId,
+        out long stateVersion,
+        out DateTimeOffset observedAt)
+        where TState : class, IMessage<TState>, new()
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        state = null;
+        eventId = string.Empty;
+        stateVersion = 0;
+        observedAt = default;
+
+        if (!CommittedStateEventEnvelope.TryUnpackState<TState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out state) ||
+            stateEvent == null ||
+            state == null ||
+            stateEvent.Version <= 0)
+        {
+            return false;
+        }
+
+        eventId = stateEvent.EventId ?? string.Empty;
+        stateVersion = stateEvent.Version;
+        observedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, clock.UtcNow);
+        return true;
+    }
+
     public static bool TryGetObservedPayload(
         EventEnvelope envelope,
         IProjectionClock clock,

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceCatalogProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceCatalogProjector.cs
@@ -14,134 +14,45 @@ public sealed class ServiceCatalogProjector
     : IProjectionArtifactMaterializer<ServiceCatalogProjectionContext>
 {
     private readonly IProjectionWriteDispatcher<ServiceCatalogReadModel> _storeDispatcher;
-    private readonly IProjectionDocumentReader<ServiceCatalogReadModel, string> _documentReader;
     private readonly IProjectionClock _clock;
 
     public ServiceCatalogProjector(
         IProjectionWriteDispatcher<ServiceCatalogReadModel> storeDispatcher,
-        IProjectionDocumentReader<ServiceCatalogReadModel, string> documentReader,
         IProjectionClock clock)
     {
         _storeDispatcher = storeDispatcher ?? throw new ArgumentNullException(nameof(storeDispatcher));
-        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    //   Old pattern: Service artifact projectors injected document reader and incrementally mutated prior readmodel state.
+    //   New principle: 服务投影器仅做 state-root overwrite; catalog definition-only, deployment/serving facts come from their readmodels.
+    //   No new actor, envelope kind, projection phase, layer, or docs/canon change.
     public async ValueTask ProjectAsync(ServiceCatalogProjectionContext context, EventEnvelope envelope, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(envelope);
-        if (!ServiceCommittedStateSupport.TryGetObservedPayload(
+        if (!ServiceCommittedStateSupport.TryGetObservedState<ServiceDefinitionState>(
                 envelope,
                 _clock,
-                out var payload,
+                out var state,
                 out var eventId,
                 out var stateVersion,
                 out var observedAt) ||
-            payload == null)
+            state?.Spec?.Identity == null)
         {
             return;
         }
 
-        if (payload.Is(ServiceDefinitionCreatedEvent.Descriptor))
+        var readModel = new ServiceCatalogReadModel
         {
-            var evt = payload.Unpack<ServiceDefinitionCreatedEvent>();
-            await UpsertDefinitionAsync(context.RootActorId, evt.Spec.Identity, eventId, stateVersion, observedAt, readModel =>
-            {
-                ApplyIdentity(readModel, evt.Spec.Identity);
-                readModel.DisplayName = evt.Spec.DisplayName ?? string.Empty;
-                readModel.Endpoints = evt.Spec.Endpoints.Select(MapEndpoint).ToList();
-                readModel.PolicyIds = [.. evt.Spec.PolicyIds];
-            }, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceDefinitionUpdatedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceDefinitionUpdatedEvent>();
-            await UpsertDefinitionAsync(context.RootActorId, evt.Spec.Identity, eventId, stateVersion, observedAt, readModel =>
-            {
-                ApplyIdentity(readModel, evt.Spec.Identity);
-                readModel.DisplayName = evt.Spec.DisplayName ?? string.Empty;
-                readModel.Endpoints = evt.Spec.Endpoints.Select(MapEndpoint).ToList();
-                readModel.PolicyIds = [.. evt.Spec.PolicyIds];
-            }, ct);
-            return;
-        }
-
-        if (payload.Is(DefaultServingRevisionChangedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<DefaultServingRevisionChangedEvent>();
-            await UpsertDefinitionAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, readModel =>
-            {
-                ApplyIdentity(readModel, evt.Identity);
-                readModel.DefaultServingRevisionId = evt.RevisionId ?? string.Empty;
-            }, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceDeploymentActivatedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceDeploymentActivatedEvent>();
-            await UpsertDefinitionAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, readModel =>
-            {
-                ApplyIdentity(readModel, evt.Identity);
-                readModel.ActiveServingRevisionId = evt.RevisionId ?? string.Empty;
-                readModel.DeploymentId = evt.DeploymentId ?? string.Empty;
-                readModel.PrimaryActorId = evt.PrimaryActorId ?? string.Empty;
-                readModel.DeploymentStatus = evt.Status.ToString();
-            }, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceDeploymentDeactivatedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceDeploymentDeactivatedEvent>();
-            await UpsertDefinitionAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, readModel =>
-            {
-                ApplyIdentity(readModel, evt.Identity);
-                readModel.DeploymentStatus = ServiceDeploymentStatus.Deactivated.ToString();
-            }, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceDeploymentHealthChangedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceDeploymentHealthChangedEvent>();
-            await UpsertDefinitionAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, readModel =>
-            {
-                ApplyIdentity(readModel, evt.Identity);
-                readModel.DeploymentStatus = evt.Status.ToString();
-            }, ct);
-        }
-    }
-
-    private async Task UpsertDefinitionAsync(
-        string actorId,
-        ServiceIdentity identity,
-        string eventId,
-        long stateVersion,
-        DateTimeOffset observedAt,
-        Action<ServiceCatalogReadModel> mutate,
-        CancellationToken ct)
-    {
-        var serviceKey = ServiceKeys.Build(identity);
-        var existing = await _documentReader.GetAsync(serviceKey, ct);
-        if (existing == null)
-        {
-            existing = new ServiceCatalogReadModel
-            {
-                Id = serviceKey,
-            };
-            ApplyIdentity(existing, identity);
-            mutate(existing);
-            ApplyProjectionStamp(existing, actorId, eventId, stateVersion, observedAt);
-            await _storeDispatcher.UpsertAsync(existing, ct);
-            return;
-        }
-
-        mutate(existing);
-        ApplyProjectionStamp(existing, actorId, eventId, stateVersion, observedAt);
-        await _storeDispatcher.UpsertAsync(existing, ct);
+            DisplayName = state.Spec.DisplayName ?? string.Empty,
+            DefaultServingRevisionId = state.DefaultServingRevisionId ?? string.Empty,
+            Endpoints = state.Spec.Endpoints.Select(MapEndpoint).ToList(),
+            PolicyIds = [.. state.Spec.PolicyIds],
+        };
+        ApplyIdentity(readModel, state.Spec.Identity);
+        ApplyProjectionStamp(readModel, context.RootActorId, eventId, stateVersion, observedAt);
+        await _storeDispatcher.UpsertAsync(readModel, ct);
     }
 
     private static void ApplyProjectionStamp(
@@ -152,7 +63,7 @@ public sealed class ServiceCatalogProjector
         DateTimeOffset observedAt)
     {
         readModel.ActorId = actorId;
-        readModel.StateVersion = ServiceCommittedStateSupport.ResolveNextStateVersion(readModel.StateVersion, stateVersion);
+        readModel.StateVersion = stateVersion;
         readModel.LastEventId = eventId;
         readModel.UpdatedAt = observedAt;
     }

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceDeploymentCatalogProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceDeploymentCatalogProjector.cs
@@ -13,110 +13,63 @@ public sealed class ServiceDeploymentCatalogProjector
     : IProjectionArtifactMaterializer<ServiceDeploymentCatalogProjectionContext>
 {
     private readonly IProjectionWriteDispatcher<ServiceDeploymentCatalogReadModel> _storeDispatcher;
-    private readonly IProjectionDocumentReader<ServiceDeploymentCatalogReadModel, string> _documentReader;
     private readonly IProjectionClock _clock;
 
     public ServiceDeploymentCatalogProjector(
         IProjectionWriteDispatcher<ServiceDeploymentCatalogReadModel> storeDispatcher,
-        IProjectionDocumentReader<ServiceDeploymentCatalogReadModel, string> documentReader,
         IProjectionClock clock)
     {
         _storeDispatcher = storeDispatcher ?? throw new ArgumentNullException(nameof(storeDispatcher));
-        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    //   Old pattern: Service artifact projectors injected document reader and incrementally mutated prior readmodel state.
+    //   New principle: 服务投影器仅做 state-root overwrite; catalog definition-only, deployment/serving facts come from their readmodels.
+    //   No new actor, envelope kind, projection phase, layer, or docs/canon change.
     public async ValueTask ProjectAsync(ServiceDeploymentCatalogProjectionContext context, EventEnvelope envelope, CancellationToken ct = default)
     {
-        if (!ServiceCommittedStateSupport.TryGetObservedPayload(
+        if (!ServiceCommittedStateSupport.TryGetObservedState<ServiceDeploymentState>(
                 envelope,
                 _clock,
-                out var payload,
+                out var state,
                 out var eventId,
                 out var stateVersion,
                 out var observedAt) ||
-            payload == null)
+            state?.Identity == null)
         {
             return;
         }
 
-        if (payload.Is(ServiceDeploymentActivatedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceDeploymentActivatedEvent>();
-            await UpsertAsync(context.RootActorId, evt.Identity, evt.DeploymentId, eventId, stateVersion, observedAt, readModel =>
-            {
-                readModel.RevisionId = evt.RevisionId ?? string.Empty;
-                readModel.PrimaryActorId = evt.PrimaryActorId ?? string.Empty;
-                readModel.Status = evt.Status.ToString();
-                readModel.ActivatedAt = evt.ActivatedAt?.ToDateTimeOffset();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.ActivatedAt, _clock.UtcNow);
-            }, ct);
+        var serviceKey = ServiceProjectionMapping.ServiceKey(state.Identity);
+        if (string.IsNullOrWhiteSpace(serviceKey))
             return;
-        }
 
-        if (payload.Is(ServiceDeploymentDeactivatedEvent.Descriptor))
+        var readModel = new ServiceDeploymentCatalogReadModel
         {
-            var evt = payload.Unpack<ServiceDeploymentDeactivatedEvent>();
-            await UpsertAsync(context.RootActorId, evt.Identity, evt.DeploymentId, eventId, stateVersion, observedAt, readModel =>
-            {
-                readModel.RevisionId = evt.RevisionId ?? string.Empty;
-                readModel.Status = ServiceDeploymentStatus.Deactivated.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.DeactivatedAt, _clock.UtcNow);
-            }, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceDeploymentHealthChangedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceDeploymentHealthChangedEvent>();
-            await UpsertAsync(context.RootActorId, evt.Identity, evt.DeploymentId, eventId, stateVersion, observedAt, readModel =>
-            {
-                readModel.Status = evt.Status.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-            }, ct);
-        }
+            Id = serviceKey,
+            ActorId = context.RootActorId,
+            StateVersion = stateVersion,
+            LastEventId = eventId,
+            UpdatedAt = observedAt,
+            Deployments = state.Deployments
+                .Values
+                .Select(MapDeployment)
+                .OrderByDescending(x => x.UpdatedAt)
+                .ThenBy(x => x.DeploymentId, StringComparer.Ordinal)
+                .ToList(),
+        };
+        await _storeDispatcher.UpsertAsync(readModel, ct);
     }
 
-    private async Task UpsertAsync(
-        string actorId,
-        ServiceIdentity? identity,
-        string deploymentId,
-        string eventId,
-        long stateVersion,
-        DateTimeOffset observedAt,
-        Action<ServiceDeploymentReadModel> mutate,
-        CancellationToken ct)
-    {
-        var serviceKey = ServiceProjectionMapping.ServiceKey(identity);
-        if (string.IsNullOrWhiteSpace(serviceKey) || string.IsNullOrWhiteSpace(deploymentId))
-            return;
-
-        var existing = await _documentReader.GetAsync(serviceKey, ct)
-            ?? new ServiceDeploymentCatalogReadModel
-            {
-                Id = serviceKey,
-                UpdatedAt = _clock.UtcNow,
-            };
-        var deployment = existing.Deployments.FirstOrDefault(x => string.Equals(x.DeploymentId, deploymentId, StringComparison.Ordinal));
-        if (deployment == null)
+    private static ServiceDeploymentReadModel MapDeployment(ServiceDeploymentRecord source) =>
+        new()
         {
-            deployment = new ServiceDeploymentReadModel
-            {
-                DeploymentId = deploymentId,
-                UpdatedAt = _clock.UtcNow,
-            };
-            existing.Deployments.Add(deployment);
-        }
-
-        mutate(deployment);
-        existing.ActorId = actorId;
-        existing.StateVersion = ServiceCommittedStateSupport.ResolveNextStateVersion(existing.StateVersion, stateVersion);
-        existing.LastEventId = eventId;
-        existing.UpdatedAt = observedAt;
-        existing.Deployments = existing.Deployments
-            .OrderByDescending(x => x.UpdatedAt)
-            .ThenBy(x => x.DeploymentId, StringComparer.Ordinal)
-            .ToList();
-        await _storeDispatcher.UpsertAsync(existing, ct);
-    }
+            DeploymentId = source.DeploymentId ?? string.Empty,
+            RevisionId = source.RevisionId ?? string.Empty,
+            PrimaryActorId = source.PrimaryActorId ?? string.Empty,
+            Status = source.Status.ToString(),
+            ActivatedAt = source.ActivatedAt?.ToDateTimeOffset(),
+            UpdatedAt = ServiceProjectionMapping.FromTimestamp(source.UpdatedAt, DateTimeOffset.UnixEpoch),
+        };
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRolloutProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRolloutProjector.cs
@@ -13,200 +13,64 @@ public sealed class ServiceRolloutProjector
     : IProjectionArtifactMaterializer<ServiceRolloutProjectionContext>
 {
     private readonly IProjectionWriteDispatcher<ServiceRolloutReadModel> _storeDispatcher;
-    private readonly IProjectionDocumentReader<ServiceRolloutReadModel, string> _documentReader;
     private readonly IProjectionClock _clock;
 
     public ServiceRolloutProjector(
         IProjectionWriteDispatcher<ServiceRolloutReadModel> storeDispatcher,
-        IProjectionDocumentReader<ServiceRolloutReadModel, string> documentReader,
         IProjectionClock clock)
     {
         _storeDispatcher = storeDispatcher ?? throw new ArgumentNullException(nameof(storeDispatcher));
-        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    //   Old pattern: Service artifact projectors injected document reader and incrementally mutated prior readmodel state.
+    //   New principle: 服务投影器仅做 state-root overwrite; catalog definition-only, deployment/serving facts come from their readmodels.
+    //   No new actor, envelope kind, projection phase, layer, or docs/canon change.
     public async ValueTask ProjectAsync(ServiceRolloutProjectionContext context, EventEnvelope envelope, CancellationToken ct = default)
     {
-        if (!ServiceCommittedStateSupport.TryGetObservedPayload(
+        if (!ServiceCommittedStateSupport.TryGetObservedState<ServiceRolloutExecutionState>(
                 envelope,
                 _clock,
-                out var payload,
+                out var state,
                 out var eventId,
                 out var stateVersion,
                 out var observedAt) ||
-            payload == null)
+            state?.Identity == null)
         {
             return;
         }
 
-        if (payload.Is(ServiceRolloutStartedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutStartedEvent>();
-            var serviceKey = ServiceProjectionMapping.ServiceKey(evt.Identity);
-            if (string.IsNullOrWhiteSpace(serviceKey))
-                return;
+        var serviceKey = ServiceProjectionMapping.ServiceKey(state.Identity);
+        if (string.IsNullOrWhiteSpace(serviceKey))
+            return;
 
-            var startedAt = ServiceProjectionMapping.FromTimestamp(evt.StartedAt, _clock.UtcNow);
-            var readModel = await _documentReader.GetAsync(serviceKey, ct)
-                ?? new ServiceRolloutReadModel { Id = serviceKey };
-            readModel.RolloutId = evt.Plan?.RolloutId ?? string.Empty;
-            readModel.DisplayName = evt.Plan?.DisplayName ?? string.Empty;
-            readModel.Status = ServiceRolloutStatus.InProgress.ToString();
-            readModel.CurrentStageIndex = -1;
-            readModel.FailureReason = string.Empty;
-            readModel.StartedAt = startedAt;
-            readModel.ActorId = context.RootActorId;
-            readModel.StateVersion = ServiceCommittedStateSupport.ResolveNextStateVersion(readModel.StateVersion, stateVersion);
-            readModel.LastEventId = eventId;
-            readModel.UpdatedAt = observedAt;
-            readModel.BaselineTargets = evt.BaselineTargets.Select(ServiceProjectionMapping.ToServingTargetReadModel).ToList();
-            readModel.Stages = (evt.Plan?.Stages ?? [])
+        var readModel = new ServiceRolloutReadModel
+        {
+            Id = serviceKey,
+            ActorId = context.RootActorId,
+            StateVersion = stateVersion,
+            LastEventId = eventId,
+            RolloutId = state.RolloutId ?? state.Plan?.RolloutId ?? string.Empty,
+            DisplayName = state.Plan?.DisplayName ?? string.Empty,
+            Status = state.Status.ToString(),
+            CurrentStageIndex = state.CurrentStageIndex,
+            FailureReason = state.FailureReason ?? string.Empty,
+            StartedAt = state.StartedAt?.ToDateTimeOffset(),
+            UpdatedAt = observedAt,
+            BaselineTargets = state.BaselineTargets
+                .Select(ServiceProjectionMapping.ToServingTargetReadModel)
+                .ToList(),
+            Stages = (state.Plan?.Stages ?? [])
                 .Select((stage, index) => new ServiceRolloutStageReadModel
                 {
                     StageId = stage.StageId ?? string.Empty,
                     StageIndex = index,
                     Targets = stage.Targets.Select(ServiceProjectionMapping.ToServingTargetReadModel).ToList(),
                 })
-                .ToList();
-            await _storeDispatcher.UpsertAsync(readModel, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutStageAdvancedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutStageAdvancedEvent>();
-            await MutateAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, ct, readModel =>
-            {
-                readModel.RolloutId = evt.RolloutId ?? readModel.RolloutId;
-                readModel.CurrentStageIndex = evt.StageIndex;
-                readModel.Status = ServiceRolloutStatus.InProgress.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-                var stage = readModel.Stages.FirstOrDefault(x => x.StageIndex == evt.StageIndex);
-                if (stage == null)
-                {
-                    stage = new ServiceRolloutStageReadModel();
-                    readModel.Stages.Add(stage);
-                }
-
-                stage.StageIndex = evt.StageIndex;
-                stage.StageId = evt.StageId ?? string.Empty;
-                stage.Targets = evt.Targets.Select(ServiceProjectionMapping.ToServingTargetReadModel).ToList();
-                readModel.Stages = readModel.Stages.OrderBy(x => x.StageIndex).ToList();
-            });
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutPausedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutPausedEvent>();
-            await MutateAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, ct, readModel =>
-            {
-                readModel.RolloutId = evt.RolloutId ?? readModel.RolloutId;
-                readModel.Status = ServiceRolloutStatus.Paused.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-            });
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutCommandObservedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutCommandObservedEvent>();
-            await StampVersionAsync(context.RootActorId, evt.Identity, eventId, stateVersion, ct);
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutResumedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutResumedEvent>();
-            await MutateAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, ct, readModel =>
-            {
-                readModel.RolloutId = evt.RolloutId ?? readModel.RolloutId;
-                readModel.Status = ServiceRolloutStatus.InProgress.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-            });
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutCompletedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutCompletedEvent>();
-            await MutateAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, ct, readModel =>
-            {
-                readModel.RolloutId = evt.RolloutId ?? readModel.RolloutId;
-                readModel.Status = ServiceRolloutStatus.Completed.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-            });
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutRolledBackEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutRolledBackEvent>();
-            await MutateAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, ct, readModel =>
-            {
-                readModel.RolloutId = evt.RolloutId ?? readModel.RolloutId;
-                readModel.Status = ServiceRolloutStatus.RolledBack.ToString();
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-                readModel.BaselineTargets = evt.Targets.Select(ServiceProjectionMapping.ToServingTargetReadModel).ToList();
-            });
-            return;
-        }
-
-        if (payload.Is(ServiceRolloutFailedEvent.Descriptor))
-        {
-            var evt = payload.Unpack<ServiceRolloutFailedEvent>();
-            await MutateAsync(context.RootActorId, evt.Identity, eventId, stateVersion, observedAt, ct, readModel =>
-            {
-                readModel.RolloutId = evt.RolloutId ?? readModel.RolloutId;
-                readModel.Status = ServiceRolloutStatus.Failed.ToString();
-                readModel.FailureReason = evt.FailureReason ?? string.Empty;
-                readModel.UpdatedAt = ServiceProjectionMapping.FromTimestamp(evt.OccurredAt, _clock.UtcNow);
-            });
-        }
-    }
-
-    private async Task MutateAsync(
-        string actorId,
-        ServiceIdentity? identity,
-        string eventId,
-        long stateVersion,
-        DateTimeOffset observedAt,
-        CancellationToken ct,
-        Action<ServiceRolloutReadModel> mutate)
-    {
-        var serviceKey = ServiceProjectionMapping.ServiceKey(identity);
-        if (string.IsNullOrWhiteSpace(serviceKey))
-            return;
-
-        var readModel = await _documentReader.GetAsync(serviceKey, ct)
-            ?? new ServiceRolloutReadModel { Id = serviceKey, UpdatedAt = _clock.UtcNow };
-        mutate(readModel);
-        readModel.ActorId = actorId;
-        readModel.StateVersion = ServiceCommittedStateSupport.ResolveNextStateVersion(readModel.StateVersion, stateVersion);
-        readModel.LastEventId = eventId;
-        readModel.UpdatedAt = observedAt;
-        await _storeDispatcher.UpsertAsync(readModel, ct);
-    }
-
-    private async Task StampVersionAsync(
-        string actorId,
-        ServiceIdentity? identity,
-        string eventId,
-        long stateVersion,
-        CancellationToken ct)
-    {
-        var serviceKey = ServiceProjectionMapping.ServiceKey(identity);
-        if (string.IsNullOrWhiteSpace(serviceKey))
-            return;
-
-        var readModel = await _documentReader.GetAsync(serviceKey, ct);
-        if (readModel == null)
-            return;
-
-        readModel.ActorId = actorId;
-        readModel.StateVersion = ServiceCommittedStateSupport.ResolveNextStateVersion(readModel.StateVersion, stateVersion);
-        readModel.LastEventId = eventId;
+                .OrderBy(x => x.StageIndex)
+                .ToList(),
+        };
         await _storeDispatcher.UpsertAsync(readModel, ct);
     }
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
@@ -93,6 +93,9 @@ public sealed class ServiceCatalogQueryReader : IServiceCatalogQueryReader
             .ToList();
     }
 
+    // Refactor (iter34/cluster-006-artifact-projectors-state-root):
+    // Old pattern: catalog snapshots echoed active deployment fields stored on the catalog readmodel.
+    // New principle: catalog readmodels expose definition facts only; application queries compose deployment facts separately.
     private static ServiceCatalogSnapshot Map(ServiceCatalogReadModel readModel)
     {
         return new ServiceCatalogSnapshot(

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
@@ -95,7 +95,7 @@ public sealed class ServiceCatalogQueryReader : IServiceCatalogQueryReader
 
     // Refactor (iter34/cluster-006-artifact-projectors-state-root):
     // Old pattern: catalog snapshots echoed active deployment fields stored on the catalog readmodel.
-    // New principle: catalog readmodels expose definition facts only; application queries compose deployment facts separately.
+    // New principle: catalog snapshots expose definition facts only; callers use serving/deployment readmodels for runtime facts.
     private static ServiceCatalogSnapshot Map(ServiceCatalogReadModel readModel)
     {
         return new ServiceCatalogSnapshot(

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceCatalogQueryReader.cs
@@ -103,10 +103,10 @@ public sealed class ServiceCatalogQueryReader : IServiceCatalogQueryReader
             readModel.ServiceId,
             readModel.DisplayName,
             readModel.DefaultServingRevisionId,
-            readModel.ActiveServingRevisionId,
-            readModel.DeploymentId,
-            readModel.PrimaryActorId,
-            readModel.DeploymentStatus,
+            ActiveServingRevisionId: string.Empty,
+            DeploymentId: string.Empty,
+            PrimaryActorId: string.Empty,
+            DeploymentStatus: string.Empty,
             readModel.Endpoints
                 .Select(x => new ServiceEndpointSnapshot(
                     x.EndpointId,

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -20,13 +20,9 @@ message ServiceCatalogReadModel {
   string service_id = 8;
   string display_name = 9;
   string default_serving_revision_id = 10;
-  string active_serving_revision_id = 11;
-  string deployment_id = 12;
-  string primary_actor_id = 13;
-  string deployment_status = 14;
-  google.protobuf.Timestamp updated_at_utc_value = 15;
-  repeated ServiceCatalogEndpointReadModel endpoint_entries = 16;
-  repeated string policy_id_entries = 17;
+  google.protobuf.Timestamp updated_at_utc_value = 11;
+  repeated ServiceCatalogEndpointReadModel endpoint_entries = 12;
+  repeated string policy_id_entries = 13;
 }
 
 message ServiceCatalogEndpointReadModel {

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -20,9 +20,10 @@ message ServiceCatalogReadModel {
   string service_id = 8;
   string display_name = 9;
   string default_serving_revision_id = 10;
-  google.protobuf.Timestamp updated_at_utc_value = 11;
-  repeated ServiceCatalogEndpointReadModel endpoint_entries = 12;
-  repeated string policy_id_entries = 13;
+  reserved 11 to 14;
+  google.protobuf.Timestamp updated_at_utc_value = 15;
+  repeated ServiceCatalogEndpointReadModel endpoint_entries = 16;
+  repeated string policy_id_entries = 17;
 }
 
 message ServiceCatalogEndpointReadModel {

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceQueryApplicationServicesTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceQueryApplicationServicesTests.cs
@@ -79,6 +79,50 @@ public sealed class ServiceQueryApplicationServicesTests
     }
 
     [Fact]
+    public async Task GetServiceAsync_ShouldComposeActiveDeploymentFromDeploymentReadModel()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var catalogReader = new ConfiguredCatalogReader
+        {
+            GetResult = CreateServiceCatalogSnapshot(),
+        };
+        var deploymentReader = new ConfiguredDeploymentReader
+        {
+            GetResult = new ServiceDeploymentCatalogSnapshot(
+                "tenant:app:default:svc",
+                [
+                    new ServiceDeploymentSnapshot(
+                        "dep-old",
+                        "r-old",
+                        "actor-old",
+                        ServiceDeploymentStatus.Deactivated.ToString(),
+                        DateTimeOffset.Parse("2026-03-14T00:00:00+00:00"),
+                        DateTimeOffset.Parse("2026-03-14T00:05:00+00:00")),
+                    new ServiceDeploymentSnapshot(
+                        "dep-active",
+                        "r-active",
+                        "actor-active",
+                        ServiceDeploymentStatus.Active.ToString(),
+                        DateTimeOffset.Parse("2026-03-14T00:10:00+00:00"),
+                        DateTimeOffset.Parse("2026-03-14T00:15:00+00:00")),
+                ],
+                DateTimeOffset.Parse("2026-03-14T00:15:00+00:00")),
+        };
+        var service = new ServiceLifecycleQueryApplicationService(
+            catalogReader,
+            new RecordingRevisionReader(),
+            deploymentReader);
+
+        var result = await service.GetServiceAsync(identity);
+
+        result.Should().NotBeNull();
+        result!.ActiveServingRevisionId.Should().Be("r-active");
+        result.DeploymentId.Should().Be("dep-active");
+        result.PrimaryActorId.Should().Be("actor-active");
+        result.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
+    }
+
+    [Fact]
     public async Task GetServiceRevisionsAsync_ShouldReturnSnapshot_WhenReaderHasData()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
@@ -200,6 +244,25 @@ public sealed class ServiceQueryApplicationServicesTests
             Task.FromResult(GetResult);
     }
 
+    private sealed class ConfiguredCatalogReader : IServiceCatalogQueryReader
+    {
+        public ServiceCatalogSnapshot? GetResult { get; init; }
+
+        public Task<ServiceCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+            Task.FromResult(GetResult);
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryAllAsync(int take = 1000, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryByScopeAsync(
+            string tenantId,
+            string appId,
+            string @namespace,
+            int take = 200,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
+    }
+
     private sealed class ConfiguredDeploymentReader : IServiceDeploymentCatalogQueryReader
     {
         public ServiceDeploymentCatalogSnapshot? GetResult { get; init; }
@@ -301,4 +364,21 @@ public sealed class ServiceQueryApplicationServicesTests
             return Task.FromResult(Snapshot);
         }
     }
+
+    private static ServiceCatalogSnapshot CreateServiceCatalogSnapshot() =>
+        new(
+            ServiceKey: "tenant:app:default:svc",
+            TenantId: "tenant",
+            AppId: "app",
+            Namespace: "default",
+            ServiceId: "svc",
+            DisplayName: "Service",
+            DefaultServingRevisionId: "r-default",
+            ActiveServingRevisionId: string.Empty,
+            DeploymentId: string.Empty,
+            PrimaryActorId: string.Empty,
+            DeploymentStatus: string.Empty,
+            Endpoints: [],
+            PolicyIds: [],
+            UpdatedAt: DateTimeOffset.Parse("2026-03-14T00:00:00+00:00"));
 }

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceQueryApplicationServicesTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceQueryApplicationServicesTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Services;
 using Aevatar.GAgentService.Tests.TestSupport;
 using FluentAssertions;
@@ -61,6 +62,70 @@ public sealed class ServiceQueryApplicationServicesTests
 
         catalogReader.ListCalls.Should().ContainSingle();
         catalogReader.ListCalls[0].Should().Be(("tenant", "app", "ns", 42));
+    }
+
+    [Fact]
+    public async Task ListServicesAsync_ShouldComposeActiveDeploymentFromDeploymentReadModels()
+    {
+        var serviceA = CreateServiceCatalogSnapshot("svc-a");
+        var serviceB = CreateServiceCatalogSnapshot("svc-b");
+        var catalogReader = new ConfiguredCatalogReader
+        {
+            QueryByScopeResult = [serviceA, serviceB],
+        };
+        var deploymentReader = new ConfiguredDeploymentReader
+        {
+            Results =
+            {
+                [serviceA.ServiceKey] = new ServiceDeploymentCatalogSnapshot(
+                    serviceA.ServiceKey,
+                    [
+                        new ServiceDeploymentSnapshot(
+                            "dep-old",
+                            "r-old",
+                            "actor-old",
+                            ServiceDeploymentStatus.Active.ToString(),
+                            DateTimeOffset.Parse("2026-03-14T00:10:00+00:00"),
+                            DateTimeOffset.Parse("2026-03-14T00:11:00+00:00")),
+                        new ServiceDeploymentSnapshot(
+                            "dep-active",
+                            "r-active",
+                            "actor-active",
+                            ServiceDeploymentStatus.Active.ToString(),
+                            DateTimeOffset.Parse("2026-03-14T00:20:00+00:00"),
+                            DateTimeOffset.Parse("2026-03-14T00:21:00+00:00")),
+                    ],
+                    DateTimeOffset.Parse("2026-03-14T00:21:00+00:00")),
+                [serviceB.ServiceKey] = new ServiceDeploymentCatalogSnapshot(
+                    serviceB.ServiceKey,
+                    [
+                        new ServiceDeploymentSnapshot(
+                            "dep-inactive",
+                            "r-inactive",
+                            "actor-inactive",
+                            ServiceDeploymentStatus.Deactivated.ToString(),
+                            DateTimeOffset.Parse("2026-03-14T00:30:00+00:00"),
+                            DateTimeOffset.Parse("2026-03-14T00:31:00+00:00")),
+                    ],
+                    DateTimeOffset.Parse("2026-03-14T00:31:00+00:00")),
+            },
+        };
+        var service = new ServiceLifecycleQueryApplicationService(
+            catalogReader,
+            new RecordingRevisionReader(),
+            deploymentReader);
+
+        var result = await service.ListServicesAsync("tenant", "app", "default", take: 10);
+
+        result.Should().HaveCount(2);
+        var enriched = result.Single(x => x.ServiceId == "svc-a");
+        enriched.ActiveServingRevisionId.Should().Be("r-active");
+        enriched.DeploymentId.Should().Be("dep-active");
+        enriched.PrimaryActorId.Should().Be("actor-active");
+        enriched.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
+        result.Single(x => x.ServiceId == "svc-b")
+            .ActiveServingRevisionId.Should().BeEmpty();
+        deploymentReader.Identities.Select(x => x.ServiceId).Should().Equal("svc-a", "svc-b");
     }
 
     [Fact]
@@ -247,6 +312,7 @@ public sealed class ServiceQueryApplicationServicesTests
     private sealed class ConfiguredCatalogReader : IServiceCatalogQueryReader
     {
         public ServiceCatalogSnapshot? GetResult { get; init; }
+        public IReadOnlyList<ServiceCatalogSnapshot> QueryByScopeResult { get; init; } = [];
 
         public Task<ServiceCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
             Task.FromResult(GetResult);
@@ -260,15 +326,23 @@ public sealed class ServiceQueryApplicationServicesTests
             string @namespace,
             int take = 200,
             CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
+            Task.FromResult(QueryByScopeResult);
     }
 
     private sealed class ConfiguredDeploymentReader : IServiceDeploymentCatalogQueryReader
     {
         public ServiceDeploymentCatalogSnapshot? GetResult { get; init; }
+        public Dictionary<string, ServiceDeploymentCatalogSnapshot> Results { get; } = [];
 
-        public Task<ServiceDeploymentCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
-            Task.FromResult(GetResult);
+        public List<ServiceIdentity> Identities { get; } = [];
+
+        public Task<ServiceDeploymentCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            Identities.Add(identity.Clone());
+            return Task.FromResult(Results.TryGetValue(ServiceKeys.Build(identity), out var result)
+                ? result
+                : GetResult);
+        }
     }
 
     private sealed class RecordingCatalogReader : IServiceCatalogQueryReader
@@ -365,13 +439,13 @@ public sealed class ServiceQueryApplicationServicesTests
         }
     }
 
-    private static ServiceCatalogSnapshot CreateServiceCatalogSnapshot() =>
+    private static ServiceCatalogSnapshot CreateServiceCatalogSnapshot(string serviceId = "svc") =>
         new(
-            ServiceKey: "tenant:app:default:svc",
+            ServiceKey: $"tenant:app:default:{serviceId}",
             TenantId: "tenant",
             AppId: "app",
             Namespace: "default",
-            ServiceId: "svc",
+            ServiceId: serviceId,
             DisplayName: "Service",
             DefaultServingRevisionId: "r-default",
             ActiveServingRevisionId: string.Empty,

--- a/test/Aevatar.GAgentService.Tests/Application/ServiceQueryApplicationServicesTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ServiceQueryApplicationServicesTests.cs
@@ -65,7 +65,7 @@ public sealed class ServiceQueryApplicationServicesTests
     }
 
     [Fact]
-    public async Task ListServicesAsync_ShouldComposeActiveDeploymentFromDeploymentReadModels()
+    public async Task ListServicesAsync_ShouldReturnCatalogSnapshotsWithoutQueryTimeDeploymentSelection()
     {
         var serviceA = CreateServiceCatalogSnapshot("svc-a");
         var serviceB = CreateServiceCatalogSnapshot("svc-b");
@@ -117,15 +117,9 @@ public sealed class ServiceQueryApplicationServicesTests
 
         var result = await service.ListServicesAsync("tenant", "app", "default", take: 10);
 
-        result.Should().HaveCount(2);
-        var enriched = result.Single(x => x.ServiceId == "svc-a");
-        enriched.ActiveServingRevisionId.Should().Be("r-active");
-        enriched.DeploymentId.Should().Be("dep-active");
-        enriched.PrimaryActorId.Should().Be("actor-active");
-        enriched.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
-        result.Single(x => x.ServiceId == "svc-b")
-            .ActiveServingRevisionId.Should().BeEmpty();
-        deploymentReader.Identities.Select(x => x.ServiceId).Should().Equal("svc-a", "svc-b");
+        result.Should().Equal(serviceA, serviceB);
+        result.Select(x => x.ActiveServingRevisionId).Should().OnlyContain(x => string.IsNullOrEmpty(x));
+        deploymentReader.Identities.Should().BeEmpty();
     }
 
     [Fact]
@@ -144,13 +138,11 @@ public sealed class ServiceQueryApplicationServicesTests
     }
 
     [Fact]
-    public async Task GetServiceAsync_ShouldComposeActiveDeploymentFromDeploymentReadModel()
+    public async Task GetServiceAsync_ShouldReturnCatalogSnapshotWithoutQueryTimeDeploymentSelection()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
-        var catalogReader = new ConfiguredCatalogReader
-        {
-            GetResult = CreateServiceCatalogSnapshot(),
-        };
+        var catalogSnapshot = CreateServiceCatalogSnapshot();
+        var catalogReader = new ConfiguredCatalogReader { GetResult = catalogSnapshot };
         var deploymentReader = new ConfiguredDeploymentReader
         {
             GetResult = new ServiceDeploymentCatalogSnapshot(
@@ -180,11 +172,12 @@ public sealed class ServiceQueryApplicationServicesTests
 
         var result = await service.GetServiceAsync(identity);
 
-        result.Should().NotBeNull();
-        result!.ActiveServingRevisionId.Should().Be("r-active");
-        result.DeploymentId.Should().Be("dep-active");
-        result.PrimaryActorId.Should().Be("actor-active");
-        result.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
+        result.Should().Be(catalogSnapshot);
+        result!.ActiveServingRevisionId.Should().BeEmpty();
+        result.DeploymentId.Should().BeEmpty();
+        result.PrimaryActorId.Should().BeEmpty();
+        result.DeploymentStatus.Should().BeEmpty();
+        deploymentReader.Identities.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogProjectorTests.cs
@@ -65,7 +65,7 @@ public sealed class ServiceCatalogProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_ShouldApplyDefinitionMutations_ForExistingReadModel()
+    public async Task ProjectAsync_ShouldOverwriteDefinition_FromLatestStateRoot()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
         var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceCatalogProjectorTests.cs
@@ -14,11 +14,16 @@ namespace Aevatar.GAgentService.Tests.Projection;
 public sealed class ServiceCatalogProjectorTests
 {
     [Fact]
-    public async Task ProjectAsync_ShouldUpsertDefinitionThenMutateDeploymentState()
+    public async Task ProjectAsync_ShouldOverwriteDefinitionOnly_FromCommittedStateRoot()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
+        var state = new ServiceDefinitionState
+        {
+            Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
+            DefaultServingRevisionId = "r-default",
+        };
         var context = new ServiceCatalogProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -27,26 +32,17 @@ public sealed class ServiceCatalogProjectorTests
 
         await projector.ProjectAsync(
             context,
-            BuildEnvelope(new ServiceDefinitionCreatedEvent
-            {
-                Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
-            }));
-        await projector.ProjectAsync(
-            context,
-            BuildEnvelope(new ServiceDeploymentActivatedEvent
-            {
-                Identity = identity.Clone(),
-                DeploymentId = "dep-1",
-                RevisionId = "r1",
-                PrimaryActorId = "actor-1",
-                Status = ServiceDeploymentStatus.Active,
-            }));
+            BuildCommittedEnvelope(
+                new ServiceDefinitionCreatedEvent { Spec = state.Spec.Clone() },
+                state,
+                eventId: "evt-definition-created",
+                stateVersion: 3,
+                observedAt: DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
 
         var readModel = await store.GetAsync("tenant:app:default:svc");
         readModel.Should().NotBeNull();
         readModel!.DisplayName.Should().Be("Service");
-        readModel.ActiveServingRevisionId.Should().Be("r1");
-        readModel.PrimaryActorId.Should().Be("actor-1");
+        readModel.DefaultServingRevisionId.Should().Be("r-default");
         readModel.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
     }
 
@@ -54,7 +50,7 @@ public sealed class ServiceCatalogProjectorTests
     public async Task ProjectAsync_ShouldIgnoreUnrelatedPayload()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
         var context = new ServiceCatalogProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -72,7 +68,7 @@ public sealed class ServiceCatalogProjectorTests
     public async Task ProjectAsync_ShouldApplyDefinitionMutations_ForExistingReadModel()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
         var updatedSpec = GAgentServiceTestKit.CreateDefinitionSpec(
             identity,
@@ -86,45 +82,38 @@ public sealed class ServiceCatalogProjectorTests
 
         await projector.ProjectAsync(
             context,
-            BuildEnvelope(new ServiceDefinitionCreatedEvent
-            {
-                Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
-            }));
+            BuildCommittedEnvelope(
+                new ServiceDefinitionCreatedEvent
+                {
+                    Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
+                },
+                new ServiceDefinitionState
+                {
+                    Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
+                },
+                eventId: "evt-created",
+                stateVersion: 1,
+                observedAt: DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         await projector.ProjectAsync(
             context,
-            BuildEnvelope(new ServiceDefinitionUpdatedEvent
-            {
-                Spec = updatedSpec,
-            }));
-        await projector.ProjectAsync(
-            context,
-            BuildEnvelope(new DefaultServingRevisionChangedEvent
-            {
-                Identity = identity.Clone(),
-                RevisionId = "r2",
-            }));
-        await projector.ProjectAsync(
-            context,
-            BuildEnvelope(new ServiceDeploymentHealthChangedEvent
-            {
-                Identity = identity.Clone(),
-                DeploymentId = "dep-1",
-                Status = ServiceDeploymentStatus.Active,
-            }));
-        await projector.ProjectAsync(
-            context,
-            BuildEnvelope(new ServiceDeploymentDeactivatedEvent
-            {
-                Identity = identity.Clone(),
-                DeploymentId = "dep-1",
-                RevisionId = "r2",
-            }));
+            BuildCommittedEnvelope(
+                new ServiceDefinitionUpdatedEvent
+                {
+                    Spec = updatedSpec,
+                },
+                new ServiceDefinitionState
+                {
+                    Spec = updatedSpec.Clone(),
+                    DefaultServingRevisionId = "r2",
+                },
+                eventId: "evt-updated",
+                stateVersion: 2,
+                observedAt: DateTimeOffset.Parse("2026-03-14T00:01:00+00:00")));
 
         var readModel = await store.GetAsync("tenant:app:default:svc");
         readModel.Should().NotBeNull();
         readModel!.DisplayName.Should().Be("Updated Service");
         readModel.DefaultServingRevisionId.Should().Be("r2");
-        readModel.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Deactivated.ToString());
         readModel.Endpoints.Should().ContainSingle(x => x.EndpointId == "chat" && x.Kind == ServiceEndpointKind.Chat.ToString());
     }
 
@@ -132,7 +121,7 @@ public sealed class ServiceCatalogProjectorTests
     public async Task ProjectAsync_ShouldIgnoreEnvelopeWithoutPayload()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
         var context = new ServiceCatalogProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -151,11 +140,16 @@ public sealed class ServiceCatalogProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_ShouldCreateReadModel_WhenDefaultServingChangesBeforeDefinitionProjection()
+    public async Task ProjectAsync_ShouldMaterializeDefaultServingRevision_FromStateRoot()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
+        var state = new ServiceDefinitionState
+        {
+            Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
+            DefaultServingRevisionId = "r9",
+        };
         var context = new ServiceCatalogProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -164,11 +158,16 @@ public sealed class ServiceCatalogProjectorTests
 
         await projector.ProjectAsync(
             context,
-            BuildEnvelope(new DefaultServingRevisionChangedEvent
-            {
-                Identity = identity.Clone(),
-                RevisionId = "r9",
-            }));
+            BuildCommittedEnvelope(
+                new DefaultServingRevisionChangedEvent
+                {
+                    Identity = identity.Clone(),
+                    RevisionId = "r9",
+                },
+                state,
+                eventId: "evt-default",
+                stateVersion: 5,
+                observedAt: DateTimeOffset.Parse("2026-03-14T00:02:00+00:00")));
 
         var readModel = await store.GetAsync("tenant:app:default:svc");
         readModel.Should().NotBeNull();
@@ -177,10 +176,10 @@ public sealed class ServiceCatalogProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_ShouldCreateReadModel_WhenHealthEventArrivesFirst()
+    public async Task ProjectAsync_ShouldIgnoreDeploymentStateRoot()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
         var context = new ServiceCatalogProjectionContext
         {
@@ -190,16 +189,22 @@ public sealed class ServiceCatalogProjectorTests
 
         await projector.ProjectAsync(
             context,
-            BuildEnvelope(new ServiceDeploymentHealthChangedEvent
-            {
-                Identity = identity.Clone(),
-                DeploymentId = "dep-1",
-                Status = ServiceDeploymentStatus.Active,
-            }));
+            BuildCommittedEnvelope(
+                new ServiceDeploymentHealthChangedEvent
+                {
+                    Identity = identity.Clone(),
+                    DeploymentId = "dep-1",
+                    Status = ServiceDeploymentStatus.Active,
+                },
+                new ServiceDeploymentState
+                {
+                    Identity = identity.Clone(),
+                },
+                eventId: "evt-health",
+                stateVersion: 7,
+                observedAt: DateTimeOffset.Parse("2026-03-14T00:03:00+00:00")));
 
-        var readModel = await store.GetAsync("tenant:app:default:svc");
-        readModel.Should().NotBeNull();
-        readModel!.DeploymentStatus.Should().Be(ServiceDeploymentStatus.Active.ToString());
+        (await store.ReadItemsAsync()).Should().BeEmpty();
     }
 
     [Fact]
@@ -207,7 +212,7 @@ public sealed class ServiceCatalogProjectorTests
     {
         var observedAt = DateTimeOffset.Parse("2026-03-14T09:00:00+00:00");
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
         var context = new ServiceCatalogProjectionContext
         {
@@ -219,6 +224,10 @@ public sealed class ServiceCatalogProjectorTests
             context,
             BuildCommittedEnvelope(
                 new ServiceDefinitionCreatedEvent
+                {
+                    Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
+                },
+                new ServiceDefinitionState
                 {
                     Spec = GAgentServiceTestKit.CreateDefinitionSpec(identity),
                 },
@@ -238,7 +247,7 @@ public sealed class ServiceCatalogProjectorTests
     public async Task ProjectAsync_ShouldIgnoreCommittedEnvelope_WhenEventDataIsMissing()
     {
         var store = new RecordingDocumentStore<ServiceCatalogReadModel>(x => x.Id);
-        var projector = new ServiceCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
+        var projector = new ServiceCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-14T00:00:00+00:00")));
         var context = new ServiceCatalogProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -268,16 +277,19 @@ public sealed class ServiceCatalogProjectorTests
         where T : Google.Protobuf.IMessage =>
         BuildCommittedEnvelope(
             evt,
+            new StringValue { Value = "not-service-definition-state" },
             Guid.NewGuid().ToString("N"),
             1,
             DateTimeOffset.UtcNow);
 
-    private static EventEnvelope BuildCommittedEnvelope<T>(
-        T evt,
+    private static EventEnvelope BuildCommittedEnvelope<TEvent, TState>(
+        TEvent evt,
+        TState state,
         string eventId,
         long stateVersion,
         DateTimeOffset observedAt)
-        where T : Google.Protobuf.IMessage =>
+        where TEvent : Google.Protobuf.IMessage
+        where TState : Google.Protobuf.IMessage =>
         new()
         {
             Id = $"outer-{eventId}",
@@ -291,6 +303,7 @@ public sealed class ServiceCatalogProjectorTests
                     Timestamp = Timestamp.FromDateTimeOffset(observedAt),
                     EventData = Any.Pack(evt),
                 },
+                StateRoot = Any.Pack(state),
             }),
         };
 }

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceConfigurationProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceConfigurationProjectionInfrastructureTests.cs
@@ -172,10 +172,6 @@ public sealed class ServiceConfigurationProjectionInfrastructureTests
         var invalidCommittedResult = (bool)supportType
             .GetMethod("TryGetObservedPayload", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)!
             .Invoke(null, invalidCommittedArgs)!;
-        var resolvedVersion = (long)supportType
-            .GetMethod("ResolveNextStateVersion", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public)!
-            .Invoke(null, [0L, 0L])!;
-
         committedResult.Should().BeTrue();
         ((Any)committedArgs[2]!).Is(StringValue.Descriptor).Should().BeTrue();
         committedArgs[3].Should().Be("evt-1");
@@ -191,7 +187,6 @@ public sealed class ServiceConfigurationProjectionInfrastructureTests
         invalidCommittedArgs[3].Should().Be(string.Empty);
         invalidCommittedArgs[4].Should().Be(0L);
         invalidCommittedArgs[5].Should().Be(default(DateTimeOffset));
-        resolvedVersion.Should().Be(0L);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -473,10 +473,6 @@ public sealed class ServiceProjectionInfrastructureTests
         var plainResult = (bool)supportType
             .GetMethod("TryGetObservedPayload", BindingFlags.Static | BindingFlags.Public)!
             .Invoke(null, plainArgs)!;
-        var resolvedVersion = (long)supportType
-            .GetMethod("ResolveNextStateVersion", BindingFlags.Static | BindingFlags.Public)!
-            .Invoke(null, [3L, 0L])!;
-
         targetSnapshot.EnabledEndpointIds.Should().Equal("run", "chat");
         targetSnapshot.ServingState.Should().Be(ServiceServingState.Active.ToString());
         trafficSnapshot.ServingState.Should().Be(ServiceServingState.Paused.ToString());
@@ -495,7 +491,6 @@ public sealed class ServiceProjectionInfrastructureTests
         plainArgs[3].Should().Be(string.Empty);
         plainArgs[4].Should().Be(0L);
         plainArgs[5].Should().Be(default(DateTimeOffset));
-        resolvedVersion.Should().Be(0L);
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectorAndQueryTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectorAndQueryTests.cs
@@ -1,3 +1,6 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Services;
@@ -366,65 +369,11 @@ public sealed class ServiceServingProjectorAndQueryTests
     public async Task RolloutProjector_ShouldOverwriteStaleStagesAndStatus_FromLatestStateRoot()
     {
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
-        await store.UpsertAsync(new ServiceRolloutReadModel
-        {
-            Id = "tenant:app:default:svc",
-            ActorId = "tenant:app:default:svc",
-            StateVersion = 11,
-            LastEventId = "evt-stale",
-            RolloutId = "rollout-stale",
-            Status = ServiceRolloutStatus.Paused.ToString(),
-            CurrentStageIndex = 99,
-            FailureReason = "stale failure",
-            UpdatedAt = DateTimeOffset.Parse("2026-03-15T00:00:00+00:00"),
-            Stages =
-            {
-                new ServiceRolloutStageReadModel
-                {
-                    StageId = "stage-stale",
-                    StageIndex = 99,
-                    Targets =
-                    {
-                        new ServiceServingTargetReadModel
-                        {
-                            DeploymentId = "dep-stale",
-                            RevisionId = "old-revision",
-                            PrimaryActorId = "old-actor",
-                            AllocationWeight = 100,
-                            ServingState = ServiceServingState.Active.ToString(),
-                            EnabledEndpointIds = { "run" },
-                        },
-                    },
-                },
-            },
-        });
+        await UpsertStaleRolloutReadModelAsync(store);
         var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
         var observedAt = DateTimeOffset.Parse("2026-03-15T10:00:00+00:00");
-        var state = new ServiceRolloutExecutionState
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-fresh",
-            Plan = new ServiceRolloutPlanSpec
-            {
-                RolloutId = "rollout-fresh",
-                DisplayName = "Fresh rollout",
-                Stages =
-                {
-                    new ServiceRolloutStageSpec
-                    {
-                        StageId = "stage-fresh",
-                        Targets =
-                        {
-                            CreateTarget("dep-fresh", "fresh-revision", "fresh-actor", 100, "run"),
-                        },
-                    },
-                },
-            },
-            Status = ServiceRolloutStatus.InProgress,
-            CurrentStageIndex = 0,
-            UpdatedAt = Timestamp.FromDateTimeOffset(observedAt),
-        };
+        var state = CreateFreshRolloutState(identity, observedAt);
 
         await projector.ProjectAsync(
             new ServiceRolloutProjectionContext
@@ -544,19 +493,11 @@ public sealed class ServiceServingProjectorAndQueryTests
     }
 
     [Fact]
-    public void ServiceArtifactProjectorSources_ShouldNotReadPriorProjectionDocuments()
+    public void ServiceArtifactProjectors_ShouldDependOnlyOnWriteDispatcherAndClock()
     {
-        foreach (var sourcePath in new[]
-                 {
-                     SourcePath("src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceCatalogProjector.cs"),
-                     SourcePath("src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceDeploymentCatalogProjector.cs"),
-                     SourcePath("src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRolloutProjector.cs"),
-                 })
-        {
-            var source = File.ReadAllText(sourcePath);
-
-            source.Should().NotContain("IProjectionDocumentReader");
-        }
+        AssertStateRootProjectorConstructor<ServiceCatalogProjector, ServiceCatalogReadModel>();
+        AssertStateRootProjectorConstructor<ServiceDeploymentCatalogProjector, ServiceDeploymentCatalogReadModel>();
+        AssertStateRootProjectorConstructor<ServiceRolloutProjector, ServiceRolloutReadModel>();
     }
 
     [Fact]
@@ -793,18 +734,77 @@ public sealed class ServiceServingProjectorAndQueryTests
         };
     }
 
-    private static string SourcePath(string relativePath)
-    {
-        var directory = AppContext.BaseDirectory;
-        while (!string.IsNullOrEmpty(directory))
+    private static Task UpsertStaleRolloutReadModelAsync(
+        RecordingDocumentStore<ServiceRolloutReadModel> store) =>
+        store.UpsertAsync(new ServiceRolloutReadModel
         {
-            var candidate = Path.Combine(directory, relativePath);
-            if (File.Exists(candidate))
-                return candidate;
+            Id = "tenant:app:default:svc",
+            ActorId = "tenant:app:default:svc",
+            StateVersion = 11,
+            LastEventId = "evt-stale",
+            RolloutId = "rollout-stale",
+            Status = ServiceRolloutStatus.Paused.ToString(),
+            CurrentStageIndex = 99,
+            FailureReason = "stale failure",
+            UpdatedAt = DateTimeOffset.Parse("2026-03-15T00:00:00+00:00"),
+            Stages =
+            {
+                new ServiceRolloutStageReadModel
+                {
+                    StageId = "stage-stale",
+                    StageIndex = 99,
+                    Targets =
+                    {
+                        new ServiceServingTargetReadModel
+                        {
+                            DeploymentId = "dep-stale",
+                            RevisionId = "old-revision",
+                            PrimaryActorId = "old-actor",
+                            AllocationWeight = 100,
+                            ServingState = ServiceServingState.Active.ToString(),
+                            EnabledEndpointIds = { "run" },
+                        },
+                    },
+                },
+            },
+        });
 
-            directory = Directory.GetParent(directory)?.FullName;
-        }
+    private static ServiceRolloutExecutionState CreateFreshRolloutState(
+        ServiceIdentity identity,
+        DateTimeOffset observedAt) =>
+        new()
+        {
+            Identity = identity.Clone(),
+            RolloutId = "rollout-fresh",
+            Plan = new ServiceRolloutPlanSpec
+            {
+                RolloutId = "rollout-fresh",
+                DisplayName = "Fresh rollout",
+                Stages =
+                {
+                    new ServiceRolloutStageSpec
+                    {
+                        StageId = "stage-fresh",
+                        Targets =
+                        {
+                            CreateTarget("dep-fresh", "fresh-revision", "fresh-actor", 100, "run"),
+                        },
+                    },
+                },
+            },
+            Status = ServiceRolloutStatus.InProgress,
+            CurrentStageIndex = 0,
+            UpdatedAt = Timestamp.FromDateTimeOffset(observedAt),
+        };
 
-        throw new FileNotFoundException($"Could not locate source file '{relativePath}'.");
+    private static void AssertStateRootProjectorConstructor<TProjector, TReadModel>()
+        where TReadModel : class, IProjectionReadModel
+    {
+        var constructor = typeof(TProjector).GetConstructors().Should().ContainSingle().Subject;
+
+        constructor.GetParameters()
+            .Select(x => x.ParameterType)
+            .Should()
+            .Equal(typeof(IProjectionWriteDispatcher<TReadModel>), typeof(IProjectionClock));
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectorAndQueryTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectorAndQueryTests.cs
@@ -18,7 +18,7 @@ public sealed class ServiceServingProjectorAndQueryTests
     public async Task DeploymentCatalogProjectorAndQueryReader_ShouldProjectLifecycleAndSortDeployments()
     {
         var store = new RecordingDocumentStore<ServiceDeploymentCatalogReadModel>(x => x.Id);
-        var projector = new ServiceDeploymentCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
+        var projector = new ServiceDeploymentCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
         var reader = new ServiceDeploymentCatalogQueryReader(store);
         var identity = GAgentServiceTestKit.CreateIdentity();
         var context = new ServiceDeploymentCatalogProjectionContext
@@ -26,30 +26,40 @@ public sealed class ServiceServingProjectorAndQueryTests
             RootActorId = "tenant:app:default:svc",
             ProjectionKind = "service-deployments",
         };
-
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceDeploymentHealthChangedEvent
+        var state = new ServiceDeploymentState
         {
             Identity = identity.Clone(),
+        };
+
+        state.Deployments["dep-b"] = new ServiceDeploymentRecord
+        {
             DeploymentId = "dep-b",
             Status = ServiceDeploymentStatus.Active,
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T01:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceDeploymentActivatedEvent
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T01:00:00+00:00")),
+        };
+        state.Deployments["dep-a"] = new ServiceDeploymentRecord
         {
-            Identity = identity.Clone(),
             DeploymentId = "dep-a",
             RevisionId = "r1",
             PrimaryActorId = "actor-a",
-            Status = ServiceDeploymentStatus.Active,
+            Status = ServiceDeploymentStatus.Deactivated,
             ActivatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T02:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceDeploymentDeactivatedEvent
-        {
-            Identity = identity.Clone(),
-            DeploymentId = "dep-a",
-            RevisionId = "r1",
-            DeactivatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T03:00:00+00:00")),
-        }));
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T03:00:00+00:00")),
+        };
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                new ServiceDeploymentDeactivatedEvent
+                {
+                    Identity = identity.Clone(),
+                    DeploymentId = "dep-a",
+                    RevisionId = "r1",
+                    DeactivatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T03:00:00+00:00")),
+                },
+                state,
+                eventId: "evt-deployment-state",
+                stateVersion: 4,
+                observedAt: DateTimeOffset.Parse("2026-03-15T03:00:00+00:00")));
         await projector.ProjectAsync(context, BuildEnvelope(new StringValue { Value = "noop" }));
         await projector.ProjectAsync(context, CreateEnvelopeWithoutPayload());
 
@@ -67,7 +77,7 @@ public sealed class ServiceServingProjectorAndQueryTests
     public async Task DeploymentCatalogProjector_ShouldRespectCancellation_AndReaderShouldReturnNull()
     {
         var store = new RecordingDocumentStore<ServiceDeploymentCatalogReadModel>(x => x.Id);
-        var projector = new ServiceDeploymentCatalogProjector(store, store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var projector = new ServiceDeploymentCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
         var reader = new ServiceDeploymentCatalogQueryReader(store);
         var context = new ServiceDeploymentCatalogProjectionContext
         {
@@ -133,7 +143,7 @@ public sealed class ServiceServingProjectorAndQueryTests
     public async Task RolloutProjectorAndQueryReader_ShouldProjectLifecycleAcrossEvents()
     {
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
-        var projector = new ServiceRolloutProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
+        var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
         var reader = new ServiceRolloutQueryReader(store);
         var identity = GAgentServiceTestKit.CreateIdentity();
         var context = new ServiceRolloutProjectionContext
@@ -142,10 +152,10 @@ public sealed class ServiceServingProjectorAndQueryTests
             ProjectionKind = "service-rollout",
         };
         var baseline = CreateTarget("dep-base", "r0", "actor-base", 100, "run");
-
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutStartedEvent
+        var rolloutState = new ServiceRolloutExecutionState
         {
             Identity = identity.Clone(),
+            RolloutId = "rollout-a",
             Plan = new ServiceRolloutPlanSpec
             {
                 RolloutId = "rollout-a",
@@ -162,54 +172,34 @@ public sealed class ServiceServingProjectorAndQueryTests
                         StageId = "stage-a",
                         Targets = { CreateTarget("dep-a", "r1", "actor-a", 60, "run") },
                     },
+                    new ServiceRolloutStageSpec
+                    {
+                        StageId = "stage-z",
+                        Targets = { CreateTarget("dep-z", "r9", "actor-z", 100, "run") },
+                    },
                 },
             },
-            BaselineTargets = { baseline.Clone() },
-            StartedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T01:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutStageAdvancedEvent
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-a",
-            StageIndex = 5,
-            StageId = "stage-z",
-            Targets = { CreateTarget("dep-z", "r9", "actor-z", 100, "run") },
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T02:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutPausedEvent
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-a",
-            Reason = "pause",
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T03:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutResumedEvent
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-a",
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T04:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutRolledBackEvent
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-a",
-            Targets = { baseline.Clone() },
-            Reason = "rollback",
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T05:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutFailedEvent
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-a",
+            Status = ServiceRolloutStatus.Completed,
+            CurrentStageIndex = 5,
             FailureReason = "boom",
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T06:00:00+00:00")),
-        }));
-        await projector.ProjectAsync(context, BuildEnvelope(new ServiceRolloutCompletedEvent
-        {
-            Identity = identity.Clone(),
-            RolloutId = "rollout-a",
-            OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T07:00:00+00:00")),
-        }));
+            StartedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T01:00:00+00:00")),
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T07:00:00+00:00")),
+            BaselineTargets = { baseline.Clone() },
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                new ServiceRolloutCompletedEvent
+                {
+                    Identity = identity.Clone(),
+                    RolloutId = "rollout-a",
+                    OccurredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T07:00:00+00:00")),
+                },
+                rolloutState,
+                eventId: "evt-rollout-state",
+                stateVersion: 8,
+                observedAt: DateTimeOffset.Parse("2026-03-15T07:00:00+00:00")));
         await projector.ProjectAsync(context, BuildEnvelope(new StringValue { Value = "noop" }));
         await projector.ProjectAsync(context, CreateEnvelopeWithoutPayload());
 
@@ -222,7 +212,7 @@ public sealed class ServiceServingProjectorAndQueryTests
         snapshot.CurrentStageIndex.Should().Be(5);
         snapshot.FailureReason.Should().Be("boom");
         snapshot.BaselineTargets.Select(x => x.DeploymentId).Should().Equal("dep-base");
-        snapshot.Stages.Select(x => x.StageIndex).Should().Equal(0, 1, 5);
+        snapshot.Stages.Select(x => x.StageIndex).Should().Equal(0, 1, 2);
         snapshot.Stages.Last().StageId.Should().Be("stage-z");
     }
 
@@ -230,7 +220,7 @@ public sealed class ServiceServingProjectorAndQueryTests
     public async Task RolloutProjector_ShouldRespectCancellation_AndReaderShouldReturnNull()
     {
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
-        var projector = new ServiceRolloutProjector(store, store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
         var reader = new ServiceRolloutQueryReader(store);
         var context = new ServiceRolloutProjectionContext
         {
@@ -241,11 +231,11 @@ public sealed class ServiceServingProjectorAndQueryTests
     }
 
     [Fact]
-    public async Task RolloutProjector_ShouldCreateReadModelAndStamp_WhenCommittedStageAdvanceArrivesFirst()
+    public async Task RolloutProjector_ShouldCreateReadModelAndStamp_FromCommittedStateRoot()
     {
         var observedAt = DateTimeOffset.Parse("2026-03-15T09:00:00+00:00");
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
-        var projector = new ServiceRolloutProjector(store, store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
+        var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
         var context = new ServiceRolloutProjectionContext
         {
@@ -268,6 +258,28 @@ public sealed class ServiceServingProjectorAndQueryTests
                     },
                     OccurredAt = Timestamp.FromDateTimeOffset(observedAt),
                 },
+                new ServiceRolloutExecutionState
+                {
+                    Identity = identity.Clone(),
+                    RolloutId = "rollout-committed",
+                    Plan = new ServiceRolloutPlanSpec
+                    {
+                        RolloutId = "rollout-committed",
+                        Stages =
+                        {
+                            new ServiceRolloutStageSpec
+                            {
+                                StageId = "stage-2",
+                                Targets =
+                                {
+                                    CreateTarget("dep-2", "rev-2", "actor-2", 100, "run"),
+                                },
+                            },
+                        },
+                    },
+                    Status = ServiceRolloutStatus.InProgress,
+                    CurrentStageIndex = 2,
+                },
                 eventId: "evt-rollout-stage",
                 stateVersion: 17,
                 observedAt: observedAt));
@@ -276,7 +288,7 @@ public sealed class ServiceServingProjectorAndQueryTests
         readModel.Should().NotBeNull();
         readModel!.RolloutId.Should().Be("rollout-committed");
         readModel.CurrentStageIndex.Should().Be(2);
-        readModel.Stages.Should().ContainSingle(x => x.StageIndex == 2 && x.StageId == "stage-2");
+        readModel.Stages.Should().ContainSingle(x => x.StageIndex == 0 && x.StageId == "stage-2");
         readModel.ActorId.Should().Be("tenant:app:default:svc");
         readModel.StateVersion.Should().Be(17);
         readModel.LastEventId.Should().Be("evt-rollout-stage");
@@ -287,7 +299,7 @@ public sealed class ServiceServingProjectorAndQueryTests
     public async Task RolloutProjector_ShouldIgnoreEvents_WhenIdentityIsMissing()
     {
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
-        var projector = new ServiceRolloutProjector(store, store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
         var context = new ServiceRolloutProjectionContext
         {
             RootActorId = "tenant:app:default:svc",
@@ -296,11 +308,19 @@ public sealed class ServiceServingProjectorAndQueryTests
 
         await projector.ProjectAsync(
             context,
-            BuildEnvelope(new ServiceRolloutFailedEvent
-            {
-                RolloutId = "rollout-no-identity",
-                FailureReason = "boom",
-            }));
+            BuildCommittedEnvelope(
+                new ServiceRolloutFailedEvent
+                {
+                    RolloutId = "rollout-no-identity",
+                    FailureReason = "boom",
+                },
+                new ServiceRolloutExecutionState
+                {
+                    RolloutId = "rollout-no-identity",
+                },
+                eventId: "evt-no-identity",
+                stateVersion: 1,
+                observedAt: DateTimeOffset.UtcNow));
         await projector.ProjectAsync(
             context,
             new EventEnvelope
@@ -349,6 +369,7 @@ public sealed class ServiceServingProjectorAndQueryTests
                     WasNoOp = true,
                     ObservedAt = Timestamp.FromDateTimeOffset(observedAt),
                 },
+                new StringValue { Value = "observation-projector-does-not-read-state-root" },
                 eventId: "evt-rollout-observed",
                 stateVersion: 9,
                 observedAt: observedAt));
@@ -371,7 +392,6 @@ public sealed class ServiceServingProjectorAndQueryTests
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
         var projector = new ServiceRolloutProjector(
             store,
-            store,
             new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
         var identity = GAgentServiceTestKit.CreateIdentity();
         var context = new ServiceRolloutProjectionContext
@@ -382,27 +402,38 @@ public sealed class ServiceServingProjectorAndQueryTests
         var startedAt = DateTimeOffset.Parse("2026-03-15T01:00:00+00:00");
         var observedAt = DateTimeOffset.Parse("2026-03-15T02:00:00+00:00");
 
+        var state = new ServiceRolloutExecutionState
+        {
+            Identity = identity.Clone(),
+            RolloutId = "rollout-a",
+            Plan = new ServiceRolloutPlanSpec
+            {
+                RolloutId = "rollout-a",
+                DisplayName = "Primary rollout",
+                Stages =
+                {
+                    new ServiceRolloutStageSpec
+                    {
+                        StageId = "stage-a",
+                        Targets = { CreateTarget("dep-a", "r1", "actor-a", 100, "run") },
+                    },
+                },
+            },
+            Status = ServiceRolloutStatus.InProgress,
+            CurrentStageIndex = -1,
+            StartedAt = Timestamp.FromDateTimeOffset(startedAt),
+            UpdatedAt = Timestamp.FromDateTimeOffset(startedAt),
+        };
         await projector.ProjectAsync(
             context,
             BuildCommittedEnvelope(
                 new ServiceRolloutStartedEvent
                 {
                     Identity = identity.Clone(),
-                    Plan = new ServiceRolloutPlanSpec
-                    {
-                        RolloutId = "rollout-a",
-                        DisplayName = "Primary rollout",
-                        Stages =
-                        {
-                            new ServiceRolloutStageSpec
-                            {
-                                StageId = "stage-a",
-                                Targets = { CreateTarget("dep-a", "r1", "actor-a", 100, "run") },
-                            },
-                        },
-                    },
+                    Plan = state.Plan.Clone(),
                     StartedAt = Timestamp.FromDateTimeOffset(startedAt),
                 },
+                state,
                 eventId: "evt-rollout-start",
                 stateVersion: 3,
                 observedAt: startedAt));
@@ -419,6 +450,7 @@ public sealed class ServiceServingProjectorAndQueryTests
                     WasNoOp = true,
                     ObservedAt = Timestamp.FromDateTimeOffset(observedAt),
                 },
+                state,
                 eventId: "evt-rollout-observed",
                 stateVersion: 5,
                 observedAt: observedAt));
@@ -429,7 +461,7 @@ public sealed class ServiceServingProjectorAndQueryTests
         readModel!.Status.Should().Be(ServiceRolloutStatus.InProgress.ToString());
         readModel.StateVersion.Should().Be(5);
         readModel.LastEventId.Should().Be("evt-rollout-observed");
-        readModel.UpdatedAt.Should().Be(startedAt);
+        readModel.UpdatedAt.Should().Be(observedAt);
     }
 
     [Fact]
@@ -487,16 +519,19 @@ public sealed class ServiceServingProjectorAndQueryTests
         where T : IMessage =>
         BuildCommittedEnvelope(
             evt,
+            new StringValue { Value = "not-target-state-root" },
             Guid.NewGuid().ToString("N"),
             1,
             DateTimeOffset.UtcNow);
 
-    private static EventEnvelope BuildCommittedEnvelope<T>(
-        T evt,
+    private static EventEnvelope BuildCommittedEnvelope<TEvent, TState>(
+        TEvent evt,
+        TState state,
         string eventId,
         long stateVersion,
         DateTimeOffset observedAt)
-        where T : IMessage =>
+        where TEvent : IMessage
+        where TState : IMessage =>
         new()
         {
             Id = $"outer-{eventId}",
@@ -510,6 +545,7 @@ public sealed class ServiceServingProjectorAndQueryTests
                     Timestamp = Timestamp.FromDateTimeOffset(observedAt),
                     EventData = Any.Pack(evt),
                 },
+                StateRoot = Any.Pack(state),
             }),
         };
 

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectorAndQueryTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceServingProjectorAndQueryTests.cs
@@ -74,6 +74,73 @@ public sealed class ServiceServingProjectorAndQueryTests
     }
 
     [Fact]
+    public async Task DeploymentCatalogProjector_ShouldOverwriteStaleDeployments_FromLatestStateRoot()
+    {
+        var store = new RecordingDocumentStore<ServiceDeploymentCatalogReadModel>(x => x.Id);
+        await store.UpsertAsync(new ServiceDeploymentCatalogReadModel
+        {
+            Id = "tenant:app:default:svc",
+            ActorId = "tenant:app:default:svc",
+            StateVersion = 8,
+            LastEventId = "evt-stale",
+            UpdatedAt = DateTimeOffset.Parse("2026-03-15T00:00:00+00:00"),
+            Deployments =
+            {
+                new ServiceDeploymentReadModel
+                {
+                    DeploymentId = "dep-stale",
+                    RevisionId = "old-revision",
+                    PrimaryActorId = "old-actor",
+                    Status = ServiceDeploymentStatus.Active.ToString(),
+                    UpdatedAt = DateTimeOffset.Parse("2026-03-15T00:01:00+00:00"),
+                },
+            },
+        });
+        var projector = new ServiceDeploymentCatalogProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var state = new ServiceDeploymentState
+        {
+            Identity = identity.Clone(),
+        };
+        state.Deployments["dep-fresh"] = new ServiceDeploymentRecord
+        {
+            DeploymentId = "dep-fresh",
+            RevisionId = "fresh-revision",
+            PrimaryActorId = "fresh-actor",
+            Status = ServiceDeploymentStatus.Active,
+            UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-03-15T02:00:00+00:00")),
+        };
+
+        await projector.ProjectAsync(
+            new ServiceDeploymentCatalogProjectionContext
+            {
+                RootActorId = "tenant:app:default:svc",
+                ProjectionKind = "service-deployments",
+            },
+            BuildCommittedEnvelope(
+                new ServiceDeploymentActivatedEvent
+                {
+                    Identity = identity.Clone(),
+                    DeploymentId = "dep-fresh",
+                    RevisionId = "fresh-revision",
+                    PrimaryActorId = "fresh-actor",
+                    Status = ServiceDeploymentStatus.Active,
+                },
+                state,
+                eventId: "evt-fresh",
+                stateVersion: 9,
+                observedAt: DateTimeOffset.Parse("2026-03-15T02:00:00+00:00")));
+
+        var readModel = await store.GetAsync(ServiceKeys.Build(identity));
+
+        readModel.Should().NotBeNull();
+        readModel!.StateVersion.Should().Be(9);
+        readModel.LastEventId.Should().Be("evt-fresh");
+        readModel.Deployments.Select(x => x.DeploymentId).Should().Equal("dep-fresh");
+        readModel.Deployments.Should().NotContain(x => x.DeploymentId == "dep-stale");
+    }
+
+    [Fact]
     public async Task DeploymentCatalogProjector_ShouldRespectCancellation_AndReaderShouldReturnNull()
     {
         var store = new RecordingDocumentStore<ServiceDeploymentCatalogReadModel>(x => x.Id);
@@ -296,6 +363,104 @@ public sealed class ServiceServingProjectorAndQueryTests
     }
 
     [Fact]
+    public async Task RolloutProjector_ShouldOverwriteStaleStagesAndStatus_FromLatestStateRoot()
+    {
+        var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
+        await store.UpsertAsync(new ServiceRolloutReadModel
+        {
+            Id = "tenant:app:default:svc",
+            ActorId = "tenant:app:default:svc",
+            StateVersion = 11,
+            LastEventId = "evt-stale",
+            RolloutId = "rollout-stale",
+            Status = ServiceRolloutStatus.Paused.ToString(),
+            CurrentStageIndex = 99,
+            FailureReason = "stale failure",
+            UpdatedAt = DateTimeOffset.Parse("2026-03-15T00:00:00+00:00"),
+            Stages =
+            {
+                new ServiceRolloutStageReadModel
+                {
+                    StageId = "stage-stale",
+                    StageIndex = 99,
+                    Targets =
+                    {
+                        new ServiceServingTargetReadModel
+                        {
+                            DeploymentId = "dep-stale",
+                            RevisionId = "old-revision",
+                            PrimaryActorId = "old-actor",
+                            AllocationWeight = 100,
+                            ServingState = ServiceServingState.Active.ToString(),
+                            EnabledEndpointIds = { "run" },
+                        },
+                    },
+                },
+            },
+        });
+        var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.Parse("2026-03-15T00:00:00+00:00")));
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var observedAt = DateTimeOffset.Parse("2026-03-15T10:00:00+00:00");
+        var state = new ServiceRolloutExecutionState
+        {
+            Identity = identity.Clone(),
+            RolloutId = "rollout-fresh",
+            Plan = new ServiceRolloutPlanSpec
+            {
+                RolloutId = "rollout-fresh",
+                DisplayName = "Fresh rollout",
+                Stages =
+                {
+                    new ServiceRolloutStageSpec
+                    {
+                        StageId = "stage-fresh",
+                        Targets =
+                        {
+                            CreateTarget("dep-fresh", "fresh-revision", "fresh-actor", 100, "run"),
+                        },
+                    },
+                },
+            },
+            Status = ServiceRolloutStatus.InProgress,
+            CurrentStageIndex = 0,
+            UpdatedAt = Timestamp.FromDateTimeOffset(observedAt),
+        };
+
+        await projector.ProjectAsync(
+            new ServiceRolloutProjectionContext
+            {
+                RootActorId = "tenant:app:default:svc",
+                ProjectionKind = "service-rollout",
+            },
+            BuildCommittedEnvelope(
+                new ServiceRolloutStageAdvancedEvent
+                {
+                    Identity = identity.Clone(),
+                    RolloutId = "rollout-fresh",
+                    StageId = "stage-fresh",
+                    StageIndex = 0,
+                    Targets = { CreateTarget("dep-fresh", "fresh-revision", "fresh-actor", 100, "run") },
+                    OccurredAt = Timestamp.FromDateTimeOffset(observedAt),
+                },
+                state,
+                eventId: "evt-fresh-rollout",
+                stateVersion: 12,
+                observedAt: observedAt));
+
+        var readModel = await store.GetAsync(ServiceKeys.Build(identity));
+
+        readModel.Should().NotBeNull();
+        readModel!.RolloutId.Should().Be("rollout-fresh");
+        readModel.Status.Should().Be(ServiceRolloutStatus.InProgress.ToString());
+        readModel.CurrentStageIndex.Should().Be(0);
+        readModel.FailureReason.Should().BeEmpty();
+        readModel.StateVersion.Should().Be(12);
+        readModel.Stages.Select(x => x.StageId).Should().Equal("stage-fresh");
+        readModel.Stages.Should().NotContain(x => x.StageId == "stage-stale");
+        readModel.Stages.Single().Targets.Select(x => x.DeploymentId).Should().Equal("dep-fresh");
+    }
+
+    [Fact]
     public async Task RolloutProjector_ShouldIgnoreEvents_WhenIdentityIsMissing()
     {
         var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
@@ -338,6 +503,60 @@ public sealed class ServiceServingProjectorAndQueryTests
             });
 
         (await store.ReadItemsAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RolloutProjector_ShouldIgnoreStateRoot_WhenCommittedVersionIsNotPositive()
+    {
+        var store = new RecordingDocumentStore<ServiceRolloutReadModel>(x => x.Id);
+        var projector = new ServiceRolloutProjector(store, new FixedProjectionClock(DateTimeOffset.UtcNow));
+        var identity = GAgentServiceTestKit.CreateIdentity();
+
+        await projector.ProjectAsync(
+            new ServiceRolloutProjectionContext
+            {
+                RootActorId = "tenant:app:default:svc",
+                ProjectionKind = "service-rollout",
+            },
+            BuildCommittedEnvelope(
+                new ServiceRolloutStartedEvent
+                {
+                    Identity = identity.Clone(),
+                    Plan = new ServiceRolloutPlanSpec
+                    {
+                        RolloutId = "rollout-zero-version",
+                    },
+                },
+                new ServiceRolloutExecutionState
+                {
+                    Identity = identity.Clone(),
+                    RolloutId = "rollout-zero-version",
+                    Plan = new ServiceRolloutPlanSpec
+                    {
+                        RolloutId = "rollout-zero-version",
+                    },
+                },
+                eventId: "evt-zero-version",
+                stateVersion: 0,
+                observedAt: DateTimeOffset.Parse("2026-03-15T11:00:00+00:00")));
+
+        (await store.ReadItemsAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ServiceArtifactProjectorSources_ShouldNotReadPriorProjectionDocuments()
+    {
+        foreach (var sourcePath in new[]
+                 {
+                     SourcePath("src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceCatalogProjector.cs"),
+                     SourcePath("src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceDeploymentCatalogProjector.cs"),
+                     SourcePath("src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRolloutProjector.cs"),
+                 })
+        {
+            var source = File.ReadAllText(sourcePath);
+
+            source.Should().NotContain("IProjectionDocumentReader");
+        }
     }
 
     [Fact]
@@ -572,5 +791,20 @@ public sealed class ServiceServingProjectorAndQueryTests
             ServingState = ServiceServingState.Active,
             EnabledEndpointIds = { enabledEndpointIds },
         };
+    }
+
+    private static string SourcePath(string relativePath)
+    {
+        var directory = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(directory))
+        {
+            var candidate = Path.Combine(directory, relativePath);
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+
+        throw new FileNotFoundException($"Could not locate source file '{relativePath}'.");
     }
 }


### PR DESCRIPTION
## 摘要

iter34 cluster-006-artifact-projectors-state-root(中等优先级,Phase 9 r2 consensus)。

- **Old**:Service artifact projectors(`ServiceCatalogProjector` / `ServiceDeploymentCatalogProjector` / `ServiceRolloutProjector`)在投影时读取 prior readmodel 文档进行增量 mutation,让 readmodel 成为第二套状态机(部分业务状态来自 actor,部分来自 projector 对旧文档的增量拼装)。
- **New**:仅做 monotonic state-root overwrite,不读 prior readmodel。Service catalog readmodel 改为 definition-only(unique 服务定义/owner/version),active deployment/serving 字段删除;facts 派生自 existing deployment / serving readmodels(由对应 actor 直接驱动)。
- 不引入新 actor / 新 envelope / 新 projection phase / aggregate actor;不动 top-level CLAUDE.md / docs/canon。

违反:CLAUDE.md「权威状态 / ReadModel / Projection」(覆盖复制优先 + Projection 只负责物化不负责推导 + 不默认保留历史视图)+ 设计完备性(抽象一旦能被滥用即设计未完成)。

## 范围

10 文件改动(+477 / -537 LOC,净 -60 deletion-heavy)。架构 guards 全绿;docs lint 全绿。

## 来源

- Design 共识:[#827](https://github.com/aevatarAI/aevatar/issues/827) Phase 9 r2 unanimous(三 solver propose converge):`META_JUDGE_DONE:consensus:structural:no-new-actor state-root overwrite with definition-only service catalog`

🤖 Auto-loop / codex-refactor-loop iter34

Closes #827

⟦AI:AUTO-LOOP⟧
