### PR TITLE
iter35 cluster-039: observation binder 改为 attach-only

### DIFF
--- a/docs/canon/architecture.md
+++ b/docs/canon/architecture.md
@@ -187,7 +187,7 @@ Agent 收到 `EventEnvelope` 后，会将两类处理器合并执行：
   - `DefaultCommandDispatchService<WorkflowChatRunRequest, WorkflowRunAcceptedCommandTarget, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>` 负责 accepted-only 路径（只返回 accepted receipt，不持有 live sink）
   - `ICommandDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError>` / `ICommandDispatchService<WorkflowSignalCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError>` 负责 run control 命令入口
   - `WorkflowRunCommandTargetResolver` 负责 workflow source 解析与 run target 构建
-  - `WorkflowRunObservationLifecycle` 负责 projection lease/live sink 绑定与清理兜底
+  - `WorkflowRunObservationLifecycle` 负责 attach-only projection lease/live sink 绑定与清理兜底，不在命令 dispatch 前 ensure/activate projection
   - `WorkflowRunAcceptedCommandTargetResolver` 负责 accepted-only target 解析
   - `WorkflowRunAcceptedReceiptFactory` 负责 `actorId + commandId + correlationId` receipt 生成
   - `WorkflowExecutionQueryApplicationService` 提供读侧查询

--- a/docs/canon/cqrs-projection.md
+++ b/docs/canon/cqrs-projection.md
@@ -69,19 +69,19 @@ CQRS 不应只提供零散 helper，而应定义所有 capability 复用的标�
 6. `Create Accepted Receipt`
    统一返回 `Accepted + commandId (+ actorId/correlationId)`，只承诺可追踪，不承诺 committed / observed。
 7. `Observe Result`
-   只有交互式 SSE/WS 等需要实时输出的入口才启动 `ICommandObservationLifecycle<TCommand,TTarget,TReceipt,TError>`。该阶段在 dispatch 前附着 live projection/session sink，以避免错过早期事件；若 observation 启动失败，命令不得进入 actor inbox，也不得发出 accepted receipt。dispatch-only 命令不启动 live observation，后续完成态统一走 read model 或 actor/session stream 观察，而不是在 command API 内私自拼装会话生命周期。
+   只有交互式 SSE/WS 等需要实时输出的入口才启动 `ICommandObservationLifecycle<TCommand,TTarget,TReceipt,TError>`。该阶段在 dispatch 前仅 attach 到已经存在、可确定寻址的 projection session/lease；不得同步 ensure/activate projection。cold session 或 attach 不可用时返回既有 projection pending/unavailable/disabled 类错误，命令不得进入 actor inbox，也不得发出 accepted receipt。dispatch-only 命令不启动 live observation，后续完成态统一走 read model 或 actor/session stream 观察，而不是在 command API 内私自拼装会话生命周期。
 
 职责归属：
 
 1. CQRS Core 应拥有 `Resolve Target / Context / Envelope / Dispatch / Receipt` 的通用抽象与默认实现。
-2. Capability 只提供领域命令模型、目标解析规则、payload 映射、accepted receipt 映射与领域特有的观察模型。命令准备阶段不得启动 projection/read-model activation、live sink attach 或 session lease；这些 live observation 职责必须放在 `ICommandObservationLifecycle`。
+2. Capability 只提供领域命令模型、目标解析规则、payload 映射、accepted receipt 映射与领域特有的观察模型。命令准备阶段不得启动 projection/read-model activation、live sink attach 或 session lease；`ICommandObservationLifecycle` 也只能 attach 已存在 session，不能 ensure/activate projection。
 3. Projection Core 只负责写后传播、读模型与实时观察，不回流承担命令入口语义。
 
 现状映射：
 
 1. `ICommandContextPolicy`、`ICommandEnvelopeFactory<TCommand>` 已经是 CQRS Core 抽象。
 2. `DefaultCommandDispatchPipeline<TCommand, TTarget, TReceipt, TError>` 已把 `Resolve Target -> Context -> Envelope -> Dispatch via IActorDispatchPort -> Accepted Receipt` 串成标准命令骨架；`PrepareAsync` 不做 projection/session attach。
-3. `DefaultCommandInteractionService<TCommand,...>` 已把交互式入口串成 `Prepare -> Observe -> DispatchPrepared -> Accepted callback -> Pump -> Release`。`Observe` 使用 `ICommandObservationLifecycle<,,,>`，失败时返回 start failure 且不 dispatch；dispatch 失败时由 target cleanup 释放已经附着的 observation。
+3. `DefaultCommandInteractionService<TCommand,...>` 已把交互式入口串成 `Prepare -> Observe -> DispatchPrepared -> Accepted callback -> Pump -> Release`。`Observe` 使用 `ICommandObservationLifecycle<,,,>` attach 既有 observation session，失败时返回 start failure 且不 dispatch；dispatch 失败时由 target cleanup 释放已经附着的 observation。
 4. `ActorCommandTargetDispatcher<TTarget>` 通过 `IActorDispatchPort` 落地 runtime-neutral envelope 投递；`IActorRuntime` 继续负责目标 actor 的获取/创建与拓扑语义；对外交互入口统一收敛为 target-erased 的 `ICommandInteractionService<...>`。
 
 ### 4.2 下一阶段蓝图（IActorDispatchPort 投递 + CQRS Core 统一命令骨架）
@@ -123,7 +123,7 @@ CQRS 不应只提供零散 helper，而应定义所有 capability 复用的标�
    `ICommandReceiptFactory<TTarget, TReceipt>`（accepted receipt）。
 2. Workflow 命令侧在此骨架上提供领域特化：
    `WorkflowRunCommandTargetResolver`（workflow source 解析） +
-   `WorkflowRunObservationLifecycle`（materialization activation + projection/live sink 绑定） +
+   `WorkflowRunObservationLifecycle`（attach-only projection/live sink 绑定；不做 pre-dispatch activation） +
    `WorkflowRunAcceptedCommandTargetResolver`（accepted-only receipt 路径） +
    `WorkflowRunAcceptedReceiptFactory`（receipt） +
    `ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus>`（SSE/WS 交互入口） +

--- a/docs/canon/llm-streaming.md
+++ b/docs/canon/llm-streaming.md
@@ -70,8 +70,8 @@ flowchart TB
     CMD --> RES["WorkflowRunCommandTargetResolver"]
     CMD --> BND["WorkflowRunObservationLifecycle"]
     BND --> LIF["IWorkflowExecutionProjectionPort"]
-    LIF --> LEASE["WorkflowExecutionRuntimeLease"]
-    LIF --> SUB["AttachLiveSinkAsync(lease, sink)"]
+    LIF --> LEASE["Deterministic existing lease\nactorId + commandId"]
+    LIF --> SUB["AttachLiveSinkAsync(lease, sink)\n(no ensure/activate)"]
     CMD --> FAC["WorkflowChatRequestEnvelopeFactory"]
     FAC --> DSP["ActorCommandTargetDispatcher / IActorDispatchPort"]
     DSP --> ACT["WorkflowRunGAgent / RoleGAgent"]
@@ -287,7 +287,7 @@ flowchart LR
 
 ### 7.2 运行态约束
 
-1. live sink 订阅通过 `lease + sink` 显式绑定，订阅对象保存在 `WorkflowExecutionRuntimeLease` 的运行态集合。
+1. live sink 订阅通过 `lease + sink` 显式绑定；command binder 只 attach 到 deterministic existing session，不在 dispatch 前 ensure/activate projection。
 2. 会话事件分发按 `scopeId=session actorId` 和 `sessionId=commandId` 二元键，不依赖中间层全局 `actorId->context` 映射。
 3. sink 写入失败会按策略 detach，并尝试发布 run error 遥测事件。
 

--- a/docs/canon/workflow-runtime.md
+++ b/docs/canon/workflow-runtime.md
@@ -206,7 +206,7 @@ POST /api/chat { prompt, workflow?, workflowYaml?, agentId? }
   │
   ├── ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus>.ExecuteAsync
   │     ├── WorkflowRunCommandTargetResolver: workflowYaml 优先；否则按 workflow 名查 registry；仅当 workflow/workflowYaml 同时为空时走默认 workflow（默认 direct，可配置为 auto）
-  │     ├── WorkflowRunObservationLifecycle: 建立 projection lease + live sink；accepted receipt 由 receipt factory 生成
+  │     ├── WorkflowRunObservationLifecycle: attach 到既有 projection session + live sink，不做 pre-dispatch projection activation；accepted receipt 由 receipt factory 生成
   │     └── DefaultCommandDispatchPipeline / ActorCommandTargetDispatcher: 将 `ChatRequestEvent` 包装为 `EventEnvelope`，由 `IActorDispatchPort` 投递到 run actor；目标 actor 的获取/创建仍由 `IActorRuntime` 负责
   │
   ├── WorkflowRunGAgent 收到 `ChatRequestEvent` envelope

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionProjectionPort.cs
@@ -1,4 +1,5 @@
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
 
 namespace Aevatar.Workflow.Application.Abstractions.Projections;
 
@@ -8,5 +9,14 @@ public interface IWorkflowExecutionProjectionPort
     Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
         string rootActorId,
         string commandId,
+        CancellationToken ct = default);
+
+    // Refactor (iter35/cluster-039-observation-binder-attach-only):
+    //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
+    //   New principle: Command observation binders request attach only for an existing projection-owned session; cold sessions return unavailable without command-side ensure/activate.
+    Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+        string rootActorId,
+        string commandId,
+        IEventSink<WorkflowRunEventEnvelope> sink,
         CancellationToken ct = default);
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
@@ -16,7 +16,6 @@ internal sealed class WorkflowRunCommandTarget
       ICommandDispatchCleanupAware
 {
     private readonly IWorkflowExecutionProjectionPort _projectionPort;
-    private readonly IWorkflowExecutionMaterializationActivationPort _materializationActivationPort;
     private readonly IWorkflowRunActorPort _actorPort;
     private readonly WorkflowRunDurableCompletionResolver _durableCompletionResolver;
     private bool _createdActorsDestroyed;
@@ -26,7 +25,6 @@ internal sealed class WorkflowRunCommandTarget
         string workflowName,
         IReadOnlyList<string>? createdActorIds,
         IWorkflowExecutionProjectionPort projectionPort,
-        IWorkflowExecutionMaterializationActivationPort materializationActivationPort,
         IWorkflowRunActorPort actorPort,
         WorkflowRunDurableCompletionResolver durableCompletionResolver)
     {
@@ -39,7 +37,6 @@ internal sealed class WorkflowRunCommandTarget
             : workflowName;
         CreatedActorIds = createdActorIds ?? [];
         _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
-        _materializationActivationPort = materializationActivationPort ?? throw new ArgumentNullException(nameof(materializationActivationPort));
         _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
         _durableCompletionResolver = durableCompletionResolver ?? throw new ArgumentNullException(nameof(durableCompletionResolver));
     }
@@ -59,9 +56,10 @@ internal sealed class WorkflowRunCommandTarget
         IAsyncDisposable? liveSinkLease,
         IEventSink<WorkflowRunEventEnvelope> sink)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: command preparation could attach projection/session leases and mix read-side observation into dispatch admission.
-        //   New principle: live observation is an explicit interaction phase that starts before dispatch; PrepareAsync and dispatch-only callers stay free of read-side lifecycle work
+        // Refactor (iter35/cluster-039-observation-binder-attach-only):
+        //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
+        //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
+        //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。
         ProjectionLease = lease ?? throw new ArgumentNullException(nameof(lease));
         LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
@@ -69,9 +67,6 @@ internal sealed class WorkflowRunCommandTarget
 
     public IEventSink<WorkflowRunEventEnvelope> RequireLiveSink() =>
         LiveSink ?? throw new InvalidOperationException("Workflow run live sink is not bound.");
-
-    public Task<bool> ActivateMaterializationAsync(CancellationToken ct = default) =>
-        _materializationActivationPort.ActivateAsync(ActorId, ct);
 
     public async Task CleanupAfterDispatchFailureAsync(CancellationToken ct = default)
     {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetResolver.cs
@@ -9,20 +9,17 @@ internal sealed class WorkflowRunCommandTargetResolver
 {
     private readonly IWorkflowRunActorResolver _actorResolver;
     private readonly IWorkflowExecutionProjectionPort _projectionPort;
-    private readonly IWorkflowExecutionMaterializationActivationPort _materializationActivationPort;
     private readonly IWorkflowRunActorPort _actorPort;
     private readonly WorkflowRunDurableCompletionResolver _durableCompletionResolver;
 
     public WorkflowRunCommandTargetResolver(
         IWorkflowRunActorResolver actorResolver,
         IWorkflowExecutionProjectionPort projectionPort,
-        IWorkflowExecutionMaterializationActivationPort materializationActivationPort,
         IWorkflowRunActorPort actorPort,
         WorkflowRunDurableCompletionResolver durableCompletionResolver)
     {
         _actorResolver = actorResolver ?? throw new ArgumentNullException(nameof(actorResolver));
         _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
-        _materializationActivationPort = materializationActivationPort ?? throw new ArgumentNullException(nameof(materializationActivationPort));
         _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
         _durableCompletionResolver = durableCompletionResolver ?? throw new ArgumentNullException(nameof(durableCompletionResolver));
     }
@@ -47,7 +44,6 @@ internal sealed class WorkflowRunCommandTargetResolver
                 actorResolution.WorkflowNameForRun,
                 actorResolution.CreatedActorIds,
                 _projectionPort,
-                _materializationActivationPort,
                 _actorPort,
                 _durableCompletionResolver));
     }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
@@ -23,9 +23,10 @@ internal sealed class WorkflowRunObservationLifecycle
         CommandDispatchExecution<WorkflowRunCommandTarget, WorkflowChatRunAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: workflow binder activated materialization and live projections during command preparation.
-        //   New principle: interaction observation lifecycle starts read-side observation before dispatch without affecting dispatch-only command admission.
+        // Refactor (iter35/cluster-039-observation-binder-attach-only):
+        //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
+        //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
+        //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -35,29 +36,19 @@ internal sealed class WorkflowRunObservationLifecycle
 
         try
         {
-            if (!await target.ActivateMaterializationAsync(ct))
-            {
-                await target.RollbackCreatedActorsAsync(CancellationToken.None);
-                return CommandObservationBindingResult<WorkflowChatRunStartError>.Failure(
-                    WorkflowChatRunStartError.ProjectionDisabled);
-            }
+            if (!_projectionPort.ProjectionEnabled)
+                return await FailProjectionUnavailableAsync(target, sink);
 
-            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
-                token => _projectionPort.EnsureActorProjectionAsync(
-                    target.ActorId,
-                    context.CommandId,
-                    token),
+            var lease = new WorkflowExecutionObservationLease(target.ActorId, context.CommandId);
+            var liveSinkLease = await _projectionPort.AttachLiveSinkAsync(
+                lease,
                 sink,
                 ct);
 
-            if (attachment == null)
-            {
-                await target.RollbackCreatedActorsAsync(CancellationToken.None);
-                return CommandObservationBindingResult<WorkflowChatRunStartError>.Failure(
-                    WorkflowChatRunStartError.ProjectionDisabled);
-            }
+            if (liveSinkLease == null)
+                return await FailProjectionUnavailableAsync(target, sink);
 
-            target.BindLiveObservation(attachment.ProjectionLease, attachment.LiveSinkLease, sink);
+            target.BindLiveObservation(lease, liveSinkLease, sink);
             return CommandObservationBindingResult<WorkflowChatRunStartError>.Success();
         }
         catch (Exception ex)
@@ -87,4 +78,22 @@ internal sealed class WorkflowRunObservationLifecycle
             return ex;
         }
     }
+
+    private static async Task<CommandObservationBindingResult<WorkflowChatRunStartError>> FailProjectionUnavailableAsync(
+        WorkflowRunCommandTarget target,
+        IEventSink<WorkflowRunEventEnvelope> sink)
+    {
+        await target.RollbackCreatedActorsAsync(CancellationToken.None);
+        await sink.DisposeAsync();
+        return CommandObservationBindingResult<WorkflowChatRunStartError>.Failure(
+            WorkflowChatRunStartError.ProjectionDisabled);
+    }
+
+    // Refactor (iter35/cluster-039-observation-binder-attach-only):
+    //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
+    //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
+    //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。refactor helper, no behavior change。
+    private sealed record WorkflowExecutionObservationLease(
+        string ActorId,
+        string CommandId) : IWorkflowExecutionProjectionLease;
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
@@ -36,19 +36,16 @@ internal sealed class WorkflowRunObservationLifecycle
 
         try
         {
-            if (!_projectionPort.ProjectionEnabled)
-                return await FailProjectionUnavailableAsync(target, sink);
-
-            var lease = new WorkflowExecutionObservationLease(target.ActorId, context.CommandId);
-            var liveSinkLease = await _projectionPort.AttachLiveSinkAsync(
-                lease,
+            var attachment = await _projectionPort.AttachExistingActorProjectionAsync(
+                target.ActorId,
+                context.CommandId,
                 sink,
                 ct);
 
-            if (liveSinkLease == null)
+            if (attachment == null)
                 return await FailProjectionUnavailableAsync(target, sink);
 
-            target.BindLiveObservation(lease, liveSinkLease, sink);
+            target.BindLiveObservation(attachment.ProjectionLease, attachment.LiveSinkLease, sink);
             return CommandObservationBindingResult<WorkflowChatRunStartError>.Success();
         }
         catch (Exception ex)
@@ -89,11 +86,4 @@ internal sealed class WorkflowRunObservationLifecycle
             WorkflowChatRunStartError.ProjectionDisabled);
     }
 
-    // Refactor (iter35/cluster-039-observation-binder-attach-only):
-    //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
-    //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
-    //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。refactor helper, no behavior change。
-    private sealed record WorkflowExecutionObservationLease(
-        string ActorId,
-        string CommandId) : IWorkflowExecutionProjectionLease;
 }

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
@@ -36,4 +36,21 @@ public sealed class WorkflowExecutionProjectionPort
                 SessionId = commandId,
             },
             ct);
+
+    // Refactor (iter35/cluster-039-observation-binder-attach-only):
+    //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
+    //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
+    //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。
+    protected override WorkflowExecutionRuntimeLease ResolveRuntimeLease(IWorkflowExecutionProjectionLease lease)
+    {
+        if (lease is WorkflowExecutionRuntimeLease runtimeLease)
+            return runtimeLease;
+
+        return new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
+        {
+            RootActorId = lease.ActorId,
+            ProjectionKind = WorkflowProjectionKinds.ExecutionSession,
+            SessionId = lease.CommandId,
+        });
+    }
 }

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
@@ -1,7 +1,9 @@
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Projection.Configuration;
 
 namespace Aevatar.Workflow.Projection.Orchestration;
@@ -10,17 +12,21 @@ public sealed class WorkflowExecutionProjectionPort
     : EventSinkProjectionLifecyclePortBase<IWorkflowExecutionProjectionLease, WorkflowExecutionRuntimeLease, WorkflowRunEventEnvelope>,
       IWorkflowExecutionProjectionPort
 {
+    private readonly IActorRuntime _runtime;
+
     public WorkflowExecutionProjectionPort(
         WorkflowExecutionProjectionOptions options,
         IProjectionScopeActivationService<WorkflowExecutionRuntimeLease> activationService,
         IProjectionScopeReleaseService<WorkflowExecutionRuntimeLease> releaseService,
-        IProjectionSessionEventHub<WorkflowRunEventEnvelope> sessionEventHub)
+        IProjectionSessionEventHub<WorkflowRunEventEnvelope> sessionEventHub,
+        IActorRuntime runtime)
         : base(
             () => options.Enabled,
             activationService,
             releaseService,
             sessionEventHub)
     {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
     public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
@@ -41,16 +47,39 @@ public sealed class WorkflowExecutionProjectionPort
     //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
     //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
     //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。
-    protected override WorkflowExecutionRuntimeLease ResolveRuntimeLease(IWorkflowExecutionProjectionLease lease)
+    public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+        string rootActorId,
+        string commandId,
+        IEventSink<WorkflowRunEventEnvelope> sink,
+        CancellationToken ct = default)
     {
-        if (lease is WorkflowExecutionRuntimeLease runtimeLease)
-            return runtimeLease;
+        ArgumentNullException.ThrowIfNull(sink);
+        ct.ThrowIfCancellationRequested();
 
-        return new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
+        if (!ProjectionEnabled ||
+            string.IsNullOrWhiteSpace(rootActorId) ||
+            string.IsNullOrWhiteSpace(commandId))
         {
-            RootActorId = lease.ActorId,
+            return null;
+        }
+
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            rootActorId,
+            WorkflowProjectionKinds.ExecutionSession,
+            ProjectionRuntimeMode.SessionObservation,
+            commandId);
+        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+            return null;
+
+        var lease = new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
+        {
+            RootActorId = rootActorId,
             ProjectionKind = WorkflowProjectionKinds.ExecutionSession,
-            SessionId = lease.CommandId,
+            SessionId = commandId,
         });
+        var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
+        return liveSinkLease == null
+            ? null
+            : new EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>(lease, liveSinkLease);
     }
 }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -600,6 +600,19 @@ public sealed class WorkflowApplicationLayerTests
             return Task.FromResult<IAsyncDisposable?>(null);
         }
 
+        public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            var lease = new FakeProjectionLease(rootActorId, commandId);
+            var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct);
+            return liveSinkLease == null
+                ? null
+                : new EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>(lease, liveSinkLease);
+        }
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -348,13 +348,11 @@ public sealed class WorkflowApplicationLayerTests
         string commandId,
         IReadOnlyList<string>? createdActorIds = null)
     {
-        var readModelActivationPort = projectionPort;
         var target = new WorkflowRunCommandTarget(
             new FakeActor(actorId),
             workflowName,
             createdActorIds ?? [],
             projectionPort,
-            readModelActivationPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
         var projectionLease = new FakeProjectionLease(actorId, commandId);
@@ -569,8 +567,7 @@ public sealed class WorkflowApplicationLayerTests
     }
 
     private sealed class FakeProjectionPort
-        : IWorkflowExecutionProjectionPort,
-          IWorkflowExecutionMaterializationActivationPort
+        : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled => true;
         public List<IAsyncDisposable?> DetachCalls { get; } = [];
@@ -582,13 +579,6 @@ public sealed class WorkflowApplicationLayerTests
         public int DetachFailureCount { get; set; }
         public int ReleaseFailureCount { get; set; }
         public int ReleaseAttemptCount => ReleaseAttempts.Count;
-
-        public Task<bool> ActivateAsync(string actorId, CancellationToken ct = default)
-        {
-            _ = actorId;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(true);
-        }
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
             string rootActorId,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
@@ -114,6 +114,14 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
             Aevatar.CQRS.Core.Abstractions.Streaming.IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default) =>
             Task.FromResult<IAsyncDisposable?>(null);
+
+        public Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            Aevatar.CQRS.Core.Abstractions.Streaming.IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default) =>
+            Task.FromResult<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?>(null);
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
@@ -63,7 +63,6 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
             "direct",
             createdActorIds: [],
             projectionPort,
-            projectionPort,
             new NoOpWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
         var context = new Aevatar.CQRS.Core.Abstractions.Commands.CommandContext(
@@ -100,17 +99,9 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
     }
 
     private sealed class NoOpProjectionPort
-        : IWorkflowExecutionProjectionPort,
-          IWorkflowExecutionMaterializationActivationPort
+        : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled => true;
-
-        public Task<bool> ActivateAsync(string actorId, CancellationToken ct = default)
-        {
-            _ = actorId;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(true);
-        }
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
             string rootActorId,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -40,7 +40,6 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             "direct",
             [],
             projectionPort,
-            projectionPort,
             new FakeWorkflowRunActorPort(),
             durableCompletionResolver: null!);
 
@@ -384,26 +383,17 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
             "direct",
             createdActorIds ?? [],
             projectionPort,
-            projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(currentStateQueryPort));
     }
 
     private sealed class FakeProjectionPort
-        : IWorkflowExecutionProjectionPort,
-          IWorkflowExecutionMaterializationActivationPort
+        : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled => true;
         public Exception? DetachException { get; set; }
         public Exception? ReleaseException { get; set; }
         public List<string> Events { get; } = [];
-
-        public Task<bool> ActivateAsync(string actorId, CancellationToken ct = default)
-        {
-            _ = actorId;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(true);
-        }
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(string rootActorId, string commandId, CancellationToken ct = default) =>
             throw new NotSupportedException();

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -401,6 +401,13 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(IWorkflowExecutionProjectionLease lease, IEventSink<WorkflowRunEventEnvelope> sink, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
+        public Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
         public Task DetachLiveSinkAsync(IAsyncDisposable? liveSinkLease, CancellationToken ct = default)
         {
             var actorId = liveSinkLease is FakeLiveSinkLease fakeLease ? fakeLease.ActorId : string.Empty;

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -436,19 +436,17 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         var projectionPort = new FakeProjectionPort();
         var actorPort = new FakeWorkflowRunActorPort();
 
-        var actOnActor = () => new WorkflowRunCommandTarget(null!, "workflow-1", [], projectionPort, projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnWorkflowName = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), " ", [], projectionPort, projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnProjectionPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], null!, projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnMaterializationActivationPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, null!, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnActorPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, projectionPort, null!, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnActor = () => new WorkflowRunCommandTarget(null!, "workflow-1", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnWorkflowName = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), " ", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnProjectionPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], null!, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnActorPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, null!, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
         actOnActor.Should().Throw<ArgumentNullException>();
         actOnWorkflowName.Should().Throw<ArgumentException>();
         actOnProjectionPort.Should().Throw<ArgumentNullException>();
-        actOnMaterializationActivationPort.Should().Throw<ArgumentNullException>();
         actOnActorPort.Should().Throw<ArgumentNullException>();
 
-        var target = new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var target = new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
         var lease = new FakeProjectionLease("actor-1", "cmd-1");
         var sink = new FakeEventSink();
 
@@ -474,7 +472,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new FakeActor("actor-1"),
             "workflow-1",
             ["definition-1", "run-1"],
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -508,7 +505,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new FakeActor("actor-1"),
             "workflow-1",
             [],
-            new FakeProjectionPort(),
             new FakeProjectionPort(),
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -580,7 +576,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new FakeWorkflowRunActorResolver(
                 new WorkflowActorResolutionResult(null, "auto", WorkflowChatRunStartError.AgentNotFound)),
             new FakeProjectionPort(),
-            new FakeProjectionPort(),
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
@@ -595,7 +590,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         var projectionPort = new FakeProjectionPort
         {
-            EnsureLease = new FakeProjectionLease("actor-1", "cmd-1"),
             AttachException = new InvalidOperationException("attach failed"),
         };
         var actorPort = new FakeWorkflowRunActorPort
@@ -607,7 +601,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new FakeActor("actor-1"),
             "workflow-1",
             ["actor-1"],
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -627,6 +620,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         var ex = await act.Should().ThrowAsync<AggregateException>();
         ex.Which.Message.Should().Contain("rollback also failed");
         ex.Which.InnerExceptions.Should().HaveCount(2);
+        projectionPort.EnsureCalls.Should().Be(0);
     }
 
     private static WorkflowRunCommandTarget CreateBoundTarget(
@@ -641,7 +635,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             new FakeActor("actor-1"),
             "workflow-1",
             ["definition-1", "run-1"],
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -721,21 +714,14 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     }
 
     private sealed class FakeProjectionPort
-        : IWorkflowExecutionProjectionPort,
-          IWorkflowExecutionMaterializationActivationPort
+        : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled { get; set; } = true;
         public FakeProjectionLease? EnsureLease { get; set; }
         public Exception? AttachException { get; set; }
         public Exception? ReleaseException { get; set; }
+        public int EnsureCalls { get; private set; }
         public List<string> Events { get; } = [];
-
-        public Task<bool> ActivateAsync(string actorId, CancellationToken ct = default)
-        {
-            _ = actorId;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(true);
-        }
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
             string rootActorId,
@@ -745,6 +731,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             _ = rootActorId;
             _ = commandId;
             ct.ThrowIfCancellationRequested();
+            EnsureCalls++;
             return Task.FromResult<IWorkflowExecutionProjectionLease?>(EnsureLease);
         }
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -718,9 +718,11 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         public bool ProjectionEnabled { get; set; } = true;
         public FakeProjectionLease? EnsureLease { get; set; }
+        public FakeProjectionLease ExistingLease { get; set; } = new("actor-1", "cmd-1");
         public Exception? AttachException { get; set; }
         public Exception? ReleaseException { get; set; }
         public int EnsureCalls { get; private set; }
+        public List<(string RootActorId, string CommandId)> AttachExistingCalls { get; } = [];
         public List<string> Events { get; } = [];
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
@@ -749,6 +751,21 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             Events.Add("attach");
             return Task.FromResult<IAsyncDisposable?>(null);
         }
+
+        public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            AttachExistingCalls.Add((rootActorId, commandId));
+            var liveSinkLease = await AttachLiveSinkAsync(ExistingLease, sink, ct);
+            return new EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>(
+                ExistingLease,
+                liveSinkLease);
+        }
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -370,6 +370,14 @@ public sealed class WorkflowRunFallbackCoverageTests
             IEventSink<WorkflowRunEventEnvelope> sink,
             CancellationToken ct = default) =>
             Task.FromResult<IAsyncDisposable?>(null);
+
+        public Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default) =>
+            Task.FromResult<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?>(null);
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -189,7 +189,6 @@ public sealed class WorkflowRunFallbackCoverageTests
             workflowName,
             [actorId],
             projectionPort,
-            projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
         target.BindLiveObservation(
@@ -356,17 +355,9 @@ public sealed class WorkflowRunFallbackCoverageTests
     }
 
     private sealed class FakeProjectionPort
-        : IWorkflowExecutionProjectionPort,
-          IWorkflowExecutionMaterializationActivationPort
+        : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled => true;
-
-        public Task<bool> ActivateAsync(string actorId, CancellationToken ct = default)
-        {
-            _ = actorId;
-            ct.ThrowIfCancellationRequested();
-            return Task.FromResult(true);
-        }
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
             string rootActorId,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -20,7 +20,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var resolver = new WorkflowRunCommandTargetResolver(
             actorResolver,
             new FakeProjectionPort { ProjectionEnabled = false },
-            new FakeProjectionPort { ProjectionEnabled = false },
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
@@ -38,7 +37,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var resolver = new WorkflowRunCommandTargetResolver(
             new FakeWorkflowRunActorResolver(
                 new WorkflowActorResolutionResult(actor, "auto", WorkflowChatRunStartError.None, ["definition-1", "actor-1"])),
-            new FakeProjectionPort(),
             new FakeProjectionPort(),
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -71,7 +69,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
         result.Target.ActorId.Should().Be("actor-accepted");
         result.Target.WorkflowName.Should().Be("direct");
         result.Target.CreatedActorIds.Should().Equal("definition-1", "actor-accepted");
-        projectionPort.ActivateCalls.Should().Be(0);
         projectionPort.AttachCalls.Should().BeEmpty();
     }
 
@@ -196,7 +193,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new FakeWorkflowRunActorResolver(
                 new WorkflowActorResolutionResult(new FakeActor("actor-1"), "direct", WorkflowChatRunStartError.None)),
             projectionPort,
-            projectionPort,
             new FakeWorkflowRunActorPort(),
             durableCompletionResolver: null!);
 
@@ -214,7 +210,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var resolver = new WorkflowRunCommandTargetResolver(
             new FakeWorkflowRunActorResolver(
                 new WorkflowActorResolutionResult(actor, "direct", WorkflowChatRunStartError.None, ["definition-1", "actor-1"])),
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(queryPort));
@@ -239,17 +234,13 @@ public sealed class WorkflowRunOrchestrationComponentTests
     [Fact]
     public async Task WorkflowRunObservationLifecycle_ShouldAttachLeaseAndSink_OnSuccess()
     {
-        var projectionPort = new FakeProjectionPort
-        {
-            EnsureLease = new FakeProjectionLease("actor-1", "cmd-1"),
-        };
+        var projectionPort = new FakeProjectionPort();
         var actorPort = new FakeWorkflowRunActorPort();
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
         var target = new WorkflowRunCommandTarget(
             new FakeActor("actor-1"),
             "direct",
             [],
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -265,18 +256,23 @@ public sealed class WorkflowRunOrchestrationComponentTests
             CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
-        target.ProjectionLease.Should().BeSameAs(projectionPort.EnsureLease);
+        target.ProjectionLease.Should().NotBeNull();
+        target.ProjectionLease!.ActorId.Should().Be("actor-1");
+        target.ProjectionLease.CommandId.Should().Be("cmd-1");
         target.LiveSink.Should().NotBeNull();
         projectionPort.AttachCalls.Should().ContainSingle();
+        projectionPort.AttachCalls[0].Lease.ActorId.Should().Be("actor-1");
+        projectionPort.AttachCalls[0].Lease.CommandId.Should().Be("cmd-1");
+        projectionPort.EnsureCalls.Should().Be(0);
         actorPort.DestroyCalls.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task WorkflowRunObservationLifecycle_ShouldRollbackCreatedActors_WhenProjectionLeaseIsUnavailable()
+    public async Task WorkflowRunObservationLifecycle_ShouldRollbackCreatedActors_WhenProjectionAttachIsUnavailable()
     {
         var projectionPort = new FakeProjectionPort
         {
-            EnsureLease = null,
+            AttachReturnsNull = true,
         };
         var actorPort = new FakeWorkflowRunActorPort();
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
@@ -284,7 +280,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new FakeActor("actor-1"),
             "direct",
             ["definition-1", "actor-1", "definition-1"],
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -301,6 +296,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.ProjectionDisabled);
+        projectionPort.EnsureCalls.Should().Be(0);
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
     }
 
@@ -309,7 +305,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
     {
         var projectionPort = new FakeProjectionPort
         {
-            EnsureLease = new FakeProjectionLease("actor-1", "cmd-1"),
             AttachException = new InvalidOperationException("attach failed"),
         };
         var actorPort = new FakeWorkflowRunActorPort();
@@ -318,7 +313,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
             new FakeActor("actor-1"),
             "direct",
             ["definition-1", "actor-1"],
-            projectionPort,
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -335,6 +329,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("attach failed");
+        projectionPort.EnsureCalls.Should().Be(0);
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
     }
 
@@ -375,22 +370,13 @@ public sealed class WorkflowRunOrchestrationComponentTests
     }
 
     private sealed class FakeProjectionPort
-        : IWorkflowExecutionProjectionPort,
-          IWorkflowExecutionMaterializationActivationPort
+        : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled { get; set; } = true;
-        public FakeProjectionLease? EnsureLease { get; set; }
+        public bool AttachReturnsNull { get; set; }
         public Exception? AttachException { get; set; }
-        public int ActivateCalls { get; private set; }
+        public int EnsureCalls { get; private set; }
         public List<(IWorkflowExecutionProjectionLease Lease, IEventSink<WorkflowRunEventEnvelope> Sink)> AttachCalls { get; } = [];
-
-        public Task<bool> ActivateAsync(string actorId, CancellationToken ct = default)
-        {
-            _ = actorId;
-            ct.ThrowIfCancellationRequested();
-            ActivateCalls++;
-            return Task.FromResult(true);
-        }
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
             string rootActorId,
@@ -400,7 +386,8 @@ public sealed class WorkflowRunOrchestrationComponentTests
             _ = rootActorId;
             _ = commandId;
             ct.ThrowIfCancellationRequested();
-            return Task.FromResult<IWorkflowExecutionProjectionLease?>(EnsureLease);
+            EnsureCalls++;
+            return Task.FromResult<IWorkflowExecutionProjectionLease?>(new FakeProjectionLease(rootActorId, commandId));
         }
 
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
@@ -413,7 +400,8 @@ public sealed class WorkflowRunOrchestrationComponentTests
                 throw AttachException;
 
             AttachCalls.Add((lease, sink));
-            return Task.FromResult<IAsyncDisposable?>(null);
+            return Task.FromResult<IAsyncDisposable?>(
+                AttachReturnsNull ? null : new FakeLiveSinkLease());
         }
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
@@ -424,6 +412,11 @@ public sealed class WorkflowRunOrchestrationComponentTests
             IWorkflowExecutionProjectionLease lease,
             CancellationToken ct = default) =>
             Task.CompletedTask;
+    }
+
+    private sealed class FakeLiveSinkLease : IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -256,13 +256,12 @@ public sealed class WorkflowRunOrchestrationComponentTests
             CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
-        target.ProjectionLease.Should().NotBeNull();
-        target.ProjectionLease!.ActorId.Should().Be("actor-1");
-        target.ProjectionLease.CommandId.Should().Be("cmd-1");
+        target.ProjectionLease.Should().BeSameAs(projectionPort.ExistingLease);
         target.LiveSink.Should().NotBeNull();
-        projectionPort.AttachCalls.Should().ContainSingle();
-        projectionPort.AttachCalls[0].Lease.ActorId.Should().Be("actor-1");
-        projectionPort.AttachCalls[0].Lease.CommandId.Should().Be("cmd-1");
+        projectionPort.AttachExistingCalls.Should().ContainSingle()
+            .Which.Should().Be(("actor-1", "cmd-1"));
+        projectionPort.AttachCalls.Should().ContainSingle()
+            .Which.Lease.Should().BeSameAs(projectionPort.ExistingLease);
         projectionPort.EnsureCalls.Should().Be(0);
         actorPort.DestroyCalls.Should().BeEmpty();
     }
@@ -296,6 +295,8 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.ProjectionDisabled);
+        projectionPort.AttachExistingCalls.Should().ContainSingle()
+            .Which.Should().Be(("actor-1", "cmd-1"));
         projectionPort.EnsureCalls.Should().Be(0);
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
     }
@@ -329,6 +330,8 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("attach failed");
+        projectionPort.AttachExistingCalls.Should().ContainSingle()
+            .Which.Should().Be(("actor-1", "cmd-1"));
         projectionPort.EnsureCalls.Should().Be(0);
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
     }
@@ -376,6 +379,8 @@ public sealed class WorkflowRunOrchestrationComponentTests
         public bool AttachReturnsNull { get; set; }
         public Exception? AttachException { get; set; }
         public int EnsureCalls { get; private set; }
+        public FakeProjectionLease ExistingLease { get; set; } = new("actor-1", "cmd-1");
+        public List<(string RootActorId, string CommandId)> AttachExistingCalls { get; } = [];
         public List<(IWorkflowExecutionProjectionLease Lease, IEventSink<WorkflowRunEventEnvelope> Sink)> AttachCalls { get; } = [];
 
         public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
@@ -403,6 +408,21 @@ public sealed class WorkflowRunOrchestrationComponentTests
             return Task.FromResult<IAsyncDisposable?>(
                 AttachReturnsNull ? null : new FakeLiveSinkLease());
         }
+
+        public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            AttachExistingCalls.Add((rootActorId, commandId));
+            var liveSinkLease = await AttachLiveSinkAsync(ExistingLease, sink, ct);
+            return liveSinkLease == null
+                ? null
+                : new EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>(ExistingLease, liveSinkLease);
+        }
+
         public Task DetachLiveSinkAsync(
             IAsyncDisposable? liveSinkLease,
             CancellationToken ct = default) =>

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Projection;
@@ -20,7 +21,8 @@ public sealed class WorkflowExecutionProjectionPortTests
             new WorkflowExecutionProjectionOptions { Enabled = true },
             activation,
             new RecordingReleaseService(),
-            new RecordingRunEventHub());
+            new RecordingRunEventHub(),
+            new RecordingActorRuntime());
 
         var lease = await port.EnsureActorProjectionAsync("actor-1", "cmd-1");
 
@@ -35,11 +37,14 @@ public sealed class WorkflowExecutionProjectionPortTests
     public async Task AttachAndDetachLiveSinkAsync_ShouldBridgeSessionHubSubscription()
     {
         var hub = new RecordingRunEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.MarkExists("projection.session.scope:workflow-execution-session:actor-1:cmd-1");
         var port = new WorkflowExecutionProjectionPort(
             new WorkflowExecutionProjectionOptions { Enabled = true },
             new RecordingActivationService(),
             new RecordingReleaseService(),
-            hub);
+            hub,
+            runtime);
         var lease = new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
         {
             RootActorId = "actor-1",
@@ -64,6 +69,55 @@ public sealed class WorkflowExecutionProjectionPortTests
     }
 
     [Fact]
+    public async Task AttachExistingActorProjectionAsync_ShouldAttachOnlyWhenProjectionSessionExists()
+    {
+        var hub = new RecordingRunEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.MarkExists("projection.session.scope:workflow-execution-session:actor-1:cmd-1");
+        var port = new WorkflowExecutionProjectionPort(
+            new WorkflowExecutionProjectionOptions { Enabled = true },
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+        var sink = new RecordingRunEventSink();
+
+        var attachment = await port.AttachExistingActorProjectionAsync("actor-1", "cmd-1", sink);
+
+        attachment.Should().NotBeNull();
+        attachment!.ProjectionLease.ActorId.Should().Be("actor-1");
+        attachment.ProjectionLease.CommandId.Should().Be("cmd-1");
+        hub.SubscribeCalls.Should().Be(1);
+        hub.LastScopeId.Should().Be("actor-1");
+        hub.LastSessionId.Should().Be("cmd-1");
+        runtime.ExistsCalls.Should().ContainSingle()
+            .Which.Should().Be("projection.session.scope:workflow-execution-session:actor-1:cmd-1");
+    }
+
+    [Fact]
+    public async Task AttachExistingActorProjectionAsync_ShouldReturnNull_WhenProjectionSessionIsCold()
+    {
+        var hub = new RecordingRunEventHub();
+        var runtime = new RecordingActorRuntime();
+        var port = new WorkflowExecutionProjectionPort(
+            new WorkflowExecutionProjectionOptions { Enabled = true },
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+
+        var attachment = await port.AttachExistingActorProjectionAsync(
+            "actor-1",
+            "cmd-1",
+            new RecordingRunEventSink());
+
+        attachment.Should().BeNull();
+        hub.SubscribeCalls.Should().Be(0);
+        runtime.ExistsCalls.Should().ContainSingle()
+            .Which.Should().Be("projection.session.scope:workflow-execution-session:actor-1:cmd-1");
+    }
+
+    [Fact]
     public async Task ReleaseActorProjectionAsync_ShouldDelegateToReleaseService()
     {
         var release = new RecordingReleaseService();
@@ -71,7 +125,8 @@ public sealed class WorkflowExecutionProjectionPortTests
             new WorkflowExecutionProjectionOptions { Enabled = true },
             new RecordingActivationService(),
             release,
-            new RecordingRunEventHub());
+            new RecordingRunEventHub(),
+            new RecordingActorRuntime());
         var lease = new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
         {
             RootActorId = "actor-1",
@@ -82,6 +137,39 @@ public sealed class WorkflowExecutionProjectionPortTests
         await port.ReleaseActorProjectionAsync(lease);
 
         release.Leases.Should().ContainSingle().Which.Should().BeSameAs(lease);
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        private readonly HashSet<string> _existingActors = new(StringComparer.Ordinal);
+
+        public List<string> ExistsCalls { get; } = [];
+
+        public void MarkExists(string actorId) => _existingActors.Add(actorId);
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default) where TAgent : IAgent =>
+            throw new NotSupportedException();
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IActor?> GetAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string id)
+        {
+            ExistsCalls.Add(id);
+            return Task.FromResult(_existingActors.Contains(id));
+        }
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class RecordingActivationService : IProjectionScopeActivationService<WorkflowExecutionRuntimeLease>


### PR DESCRIPTION
## 摘要

iter35 cluster-039-observation-binder-attach-only(中等优先级,Phase 9 r2 + reflector r2 force-pick `attach-only-B`)。

- **Old**:Command observation binders 同步 ensure + attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
- **New**:Binders 仅 attach pre-existing lease/session(existing deterministic surfaces);**删除** pre-dispatch projection activation。Cold session 用 existing `ProjectionPending` / `ProjectionUnavailable` behavior。Projection activation 移到 projection-owned lifecycle/startup/background path。
- **禁止**新增 top-level CLAUDE 例外(reflector force-pick 排除 A 选项)/ 新 actor / 新 envelope。

违反:CLAUDE.md「Query priming 禁止」+「Command Envelope Dispatch:命令骨架内聚」+「权威状态 / Projection」。

## 范围

14 文件改动(+96 / -137 LOC,净 -41 deletion-heavy)。架构 guards 全绿。

🤖 Auto-loop / codex-refactor-loop iter35

Closes #834

⟦AI:AUTO-LOOP⟧
