### PR TITLE
iter37 cluster-037 agent-session: NyxID/StreamingProxy observation 改为 attach-existing

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatInteraction.cs
@@ -102,9 +102,9 @@ internal sealed class NyxIdChatCommandTarget
         IEventSink<AGUIEvent> sink,
         string sessionId)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: command preparation could attach projection/session leases and mix read-side observation into dispatch admission.
-        //   New principle: live observation is an explicit interaction phase that starts before dispatch; PrepareAsync and dispatch-only callers stay free of read-side lifecycle work
+        // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+        //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+        //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
         ProjectionLease = projectionLease ?? throw new ArgumentNullException(nameof(projectionLease));
         LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
@@ -212,6 +212,9 @@ internal sealed class NyxIdChatCommandTargetResolver<TCommand>
 internal sealed class NyxIdChatObservationLifecycle<TCommand>
     : ICommandObservationLifecycle<TCommand, NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt, NyxIdChatStartError>
 {
+    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
     private readonly INyxIdChatSessionProjectionPort _projectionPort;
     private readonly Func<TCommand, string> _sessionIdResolver;
 
@@ -228,9 +231,9 @@ internal sealed class NyxIdChatObservationLifecycle<TCommand>
         CommandDispatchExecution<NyxIdChatCommandTarget, NyxIdChatAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: target binder attached projection/session leases during command preparation.
-        //   New principle: interaction observation lifecycle attaches live sinks before dispatch and keeps dispatch-only PrepareAsync free of read-side work.
+        // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+        //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+        //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -239,11 +242,9 @@ internal sealed class NyxIdChatObservationLifecycle<TCommand>
         var sink = new EventChannel<AGUIEvent>();
         try
         {
-            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
-                token => _projectionPort.EnsureChatProjectionAsync(
-                    target.ActorId,
-                    sessionId,
-                    token),
+            var attachment = await _projectionPort.AttachExistingChatProjectionAsync(
+                target.ActorId,
+                sessionId,
                 sink,
                 ct);
             if (attachment == null)

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
@@ -29,6 +29,15 @@ public interface INyxIdChatSessionProjectionPort
         string actorId,
         string sessionId,
         CancellationToken ct = default);
+
+    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+        string actorId,
+        string sessionId,
+        IEventSink<AGUIEvent> sink,
+        CancellationToken ct = default);
 }
 
 /// <summary>
@@ -69,16 +78,23 @@ public sealed class NyxIdChatSessionRuntimeLease
 /// Lifecycle adapter for NyxID chat Projection Pipeline sessions. It attaches
 /// typed AGUIEvent sinks to sessions whose projector input is EventEnvelope.
 /// </summary>
+// Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+//   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+//   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
 public sealed class NyxIdChatSessionProjectionPort
     : EventSinkProjectionLifecyclePortBase<INyxIdChatSessionProjectionLease, NyxIdChatSessionRuntimeLease, AGUIEvent>,
       INyxIdChatSessionProjectionPort
 {
+    private readonly IActorRuntime _runtime;
+
     public NyxIdChatSessionProjectionPort(
         IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease> activationService,
         IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease> releaseService,
-        IProjectionSessionEventHub<AGUIEvent> sessionEventHub)
+        IProjectionSessionEventHub<AGUIEvent> sessionEventHub,
+        IActorRuntime runtime)
         : base(static () => true, activationService, releaseService, sessionEventHub)
     {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
     public Task<INyxIdChatSessionProjectionLease?> EnsureChatProjectionAsync(
@@ -94,6 +110,45 @@ public sealed class NyxIdChatSessionProjectionPort
                 SessionId = sessionId,
             },
             ct);
+
+    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    public async Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+        string actorId,
+        string sessionId,
+        IEventSink<AGUIEvent> sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        ct.ThrowIfCancellationRequested();
+
+        if (!ProjectionEnabled ||
+            string.IsNullOrWhiteSpace(actorId) ||
+            string.IsNullOrWhiteSpace(sessionId))
+        {
+            return null;
+        }
+
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            actorId,
+            NyxIdChatProjectionKinds.ChatSession,
+            ProjectionRuntimeMode.SessionObservation,
+            sessionId);
+        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+            return null;
+
+        var lease = new NyxIdChatSessionRuntimeLease(new NyxIdChatSessionProjectionContext
+        {
+            RootActorId = actorId,
+            ProjectionKind = NyxIdChatProjectionKinds.ChatSession,
+            SessionId = sessionId,
+        });
+        var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
+        return liveSinkLease == null
+            ? null
+            : new EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>(lease, liveSinkLease);
+    }
 }
 
 /// <summary>

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomInteraction.cs
@@ -73,9 +73,9 @@ internal sealed class StreamingProxyRoomChatCommandTarget
         IEventSink<StreamingProxyRoomSessionEnvelope> sink,
         string sessionId)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: command preparation could attach projection/session leases and mix read-side observation into dispatch admission.
-        //   New principle: live observation is an explicit interaction phase that starts before dispatch; PrepareAsync and dispatch-only callers stay free of read-side lifecycle work
+        // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+        //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+        //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
         ProjectionLease = projectionLease ?? throw new ArgumentNullException(nameof(projectionLease));
         LiveSinkLease = liveSinkLease;
         LiveSink = sink ?? throw new ArgumentNullException(nameof(sink));
@@ -181,6 +181,9 @@ internal sealed class StreamingProxyRoomChatCommandTargetResolver
 internal sealed class StreamingProxyRoomObservationLifecycle
     : ICommandObservationLifecycle<StreamingProxyRoomChatCommand, StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError>
 {
+    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
     private readonly IStreamingProxyRoomSessionProjectionPort _projectionPort;
 
     public StreamingProxyRoomObservationLifecycle(
@@ -194,9 +197,9 @@ internal sealed class StreamingProxyRoomObservationLifecycle
         CommandDispatchExecution<StreamingProxyRoomChatCommandTarget, StreamingProxyRoomChatAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: target binder attached projection/session leases during command preparation.
-        //   New principle: interaction observation lifecycle attaches live sinks before dispatch and keeps dispatch-only PrepareAsync free of read-side work.
+        // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+        //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+        //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -204,11 +207,9 @@ internal sealed class StreamingProxyRoomObservationLifecycle
         var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
         try
         {
-            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
-                token => _projectionPort.EnsureChatProjectionAsync(
-                    target.ActorId,
-                    command.SessionId,
-                    token),
+            var attachment = await _projectionPort.AttachExistingChatProjectionAsync(
+                target.ActorId,
+                command.SessionId,
                 sink,
                 ct);
             if (attachment == null)

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionContracts.cs
@@ -27,4 +27,13 @@ public interface IStreamingProxyRoomSessionProjectionPort
         string actorId,
         string subscriptionId,
         CancellationToken ct = default);
+
+    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+        string actorId,
+        string sessionId,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default);
 }

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionPort.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionPort.cs
@@ -1,27 +1,31 @@
+using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
 
 namespace Aevatar.GAgents.StreamingProxy;
 
+// Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+//   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+//   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
 public sealed class StreamingProxyRoomSessionProjectionPort
     : EventSinkProjectionLifecyclePortBase<IStreamingProxyRoomSessionProjectionLease, StreamingProxyRoomSessionRuntimeLease, StreamingProxyRoomSessionEnvelope>,
       IStreamingProxyRoomSessionProjectionPort
 {
-    private readonly StreamingProxyCurrentStateProjectionPort _currentStateProjectionPort;
+    private readonly IActorRuntime _runtime;
 
     public StreamingProxyRoomSessionProjectionPort(
         IProjectionScopeActivationService<StreamingProxyRoomSessionRuntimeLease> activationService,
         IProjectionScopeReleaseService<StreamingProxyRoomSessionRuntimeLease> releaseService,
         IProjectionSessionEventHub<StreamingProxyRoomSessionEnvelope> sessionEventHub,
-        StreamingProxyCurrentStateProjectionPort currentStateProjectionPort)
+        IActorRuntime runtime)
         : base(
             static () => true,
             activationService,
             releaseService,
             sessionEventHub)
     {
-        _currentStateProjectionPort = currentStateProjectionPort ??
-                                      throw new ArgumentNullException(nameof(currentStateProjectionPort));
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
     public async Task<IStreamingProxyRoomSessionProjectionLease?> EnsureRoomProjectionAsync(
@@ -54,8 +58,6 @@ public sealed class StreamingProxyRoomSessionProjectionPort
         string projectionKind,
         CancellationToken ct)
     {
-        await _currentStateProjectionPort.EnsureProjectionForActorAsync(actorId, ct);
-
         return await EnsureProjectionAsync(
             new ProjectionScopeStartRequest
             {
@@ -65,5 +67,44 @@ public sealed class StreamingProxyRoomSessionProjectionPort
                 SessionId = sessionId,
             },
             ct);
+    }
+
+    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
+    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
+    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    public async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+        string actorId,
+        string sessionId,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        ct.ThrowIfCancellationRequested();
+
+        if (!ProjectionEnabled ||
+            string.IsNullOrWhiteSpace(actorId) ||
+            string.IsNullOrWhiteSpace(sessionId))
+        {
+            return null;
+        }
+
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            actorId,
+            StreamingProxyProjectionKinds.RoomChatSession,
+            ProjectionRuntimeMode.SessionObservation,
+            sessionId);
+        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+            return null;
+
+        var lease = new StreamingProxyRoomSessionRuntimeLease(new StreamingProxyRoomSessionProjectionContext
+        {
+            RootActorId = actorId,
+            ProjectionKind = StreamingProxyProjectionKinds.RoomChatSession,
+            SessionId = sessionId,
+        });
+        var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
+        return liveSinkLease == null
+            ? null
+            : new EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>(lease, liveSinkLease);
     }
 }

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -1146,7 +1146,8 @@ public class NyxIdChatEndpointsCoverageTests
         result.FinalizeResult.Should().NotBeNull();
         result.FinalizeResult!.Completed.Should().BeTrue();
         result.FinalizeResult.Completion.Should().Be(NyxIdChatCompletionStatus.Completed);
-        projectionPort.EnsureCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
         projectionPort.ReleaseCount.Should().Be(1);
@@ -1189,6 +1190,8 @@ public class NyxIdChatEndpointsCoverageTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(NyxIdChatStartError.ProjectionUnavailable);
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
         projectionPort.AttachCount.Should().Be(0);
         projectionPort.DetachCount.Should().Be(0);
         projectionPort.ReleaseCount.Should().Be(0);
@@ -1217,6 +1220,8 @@ public class NyxIdChatEndpointsCoverageTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("dispatch failed");
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
         projectionPort.ReleaseCount.Should().Be(1);
@@ -2851,6 +2856,7 @@ public class NyxIdChatEndpointsCoverageTests
 
         public List<AGUIEvent> Messages { get; } = [];
         public List<(string ActorId, string SessionId)> EnsureCalls { get; } = [];
+        public List<(string ActorId, string SessionId)> AttachExistingCalls { get; } = [];
         public bool ProjectionEnabled => true;
         public bool ReturnNullLease { get; init; }
         public int AttachCount { get; private set; }
@@ -2869,6 +2875,22 @@ public class NyxIdChatEndpointsCoverageTests
 
             _lease = new StubNyxIdChatSessionProjectionLease(actorId, sessionId);
             return _lease;
+        }
+
+        public async Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+            string actorId,
+            string sessionId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            AttachExistingCalls.Add((actorId, sessionId));
+            if (ReturnNullLease)
+                return null;
+
+            _lease = new StubNyxIdChatSessionProjectionLease(actorId, sessionId);
+            var liveSinkLease = await AttachLiveSinkAsync(_lease, sink, ct);
+            return new EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>(_lease, liveSinkLease);
         }
 
         public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
@@ -2956,6 +2978,19 @@ public class NyxIdChatEndpointsCoverageTests
         {
             _ = actorId;
             _ = sessionId;
+            _ = ct;
+            throw exception;
+        }
+
+        public Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+            string actorId,
+            string sessionId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            _ = actorId;
+            _ = sessionId;
+            _ = sink;
             _ = ct;
             throw exception;
         }

--- a/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
@@ -26,7 +26,7 @@ public sealed class NyxIdChatProjectionSessionTests
         var activation = new RecordingActivationService();
         var release = new RecordingReleaseService();
         var hub = new RecordingSessionEventHub();
-        var port = new NyxIdChatSessionProjectionPort(activation, release, hub);
+        var port = new NyxIdChatSessionProjectionPort(activation, release, hub, new RecordingActorRuntime());
         var sink = new RecordingEventSink();
 
         var lease = await port.EnsureChatProjectionAsync("chat-actor-1", "session-1", CancellationToken.None);
@@ -61,6 +61,58 @@ public sealed class NyxIdChatProjectionSessionTests
         sink.Events.Should().ContainSingle().Which.TextMessageContent.Delta.Should().Be("hello");
         hub.DisposedSubscriptions.Should().Be(1);
         release.Leases.Should().ContainSingle().Which.Should().BeSameAs(lease);
+    }
+
+    [Fact]
+    public async Task AttachExistingChatProjectionAsync_ShouldAttachOnlyWhenProjectionSessionExists()
+    {
+        var runtime = new RecordingActorRuntime();
+        runtime.MarkExists("projection.session.scope:nyxid-chat-session:chat-actor-1:session-1");
+        var hub = new RecordingSessionEventHub();
+        var port = new NyxIdChatSessionProjectionPort(
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+        var sink = new RecordingEventSink();
+
+        var attachment = await port.AttachExistingChatProjectionAsync(
+            "chat-actor-1",
+            "session-1",
+            sink,
+            CancellationToken.None);
+
+        attachment.Should().NotBeNull();
+        attachment!.ProjectionLease.ActorId.Should().Be("chat-actor-1");
+        attachment.ProjectionLease.SessionId.Should().Be("session-1");
+        hub.SubscribeCalls.Should().Be(1);
+        hub.LastScopeId.Should().Be("chat-actor-1");
+        hub.LastSessionId.Should().Be("session-1");
+        runtime.ExistsCalls.Should().ContainSingle()
+            .Which.Should().Be("projection.session.scope:nyxid-chat-session:chat-actor-1:session-1");
+    }
+
+    [Fact]
+    public async Task AttachExistingChatProjectionAsync_ShouldReturnNull_WhenProjectionSessionIsCold()
+    {
+        var runtime = new RecordingActorRuntime();
+        var hub = new RecordingSessionEventHub();
+        var port = new NyxIdChatSessionProjectionPort(
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+
+        var attachment = await port.AttachExistingChatProjectionAsync(
+            "chat-actor-1",
+            "session-1",
+            new RecordingEventSink(),
+            CancellationToken.None);
+
+        attachment.Should().BeNull();
+        hub.SubscribeCalls.Should().Be(0);
+        runtime.ExistsCalls.Should().ContainSingle()
+            .Which.Should().Be("projection.session.scope:nyxid-chat-session:chat-actor-1:session-1");
     }
 
     [Fact]
@@ -197,6 +249,40 @@ public sealed class NyxIdChatProjectionSessionTests
             Leases.Add(lease);
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        private readonly HashSet<string> _existingActors = new(StringComparer.Ordinal);
+
+        public List<string> ExistsCalls { get; } = [];
+
+        public void MarkExists(string actorId) => _existingActors.Add(actorId);
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            throw new NotSupportedException();
+
+        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IActor?> GetAsync(string id) =>
+            throw new NotSupportedException();
+
+        public Task<bool> ExistsAsync(string id)
+        {
+            ExistsCalls.Add(id);
+            return Task.FromResult(_existingActors.Contains(id));
+        }
+
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class RecordingSessionEventHub : IProjectionSessionEventHub<AGUIEvent>

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -385,6 +385,47 @@ public class StreamingProxyCoverageTests
     }
 
     [Fact]
+    public async Task StreamingProxyRoomSessionProjectionPort_ShouldAttachOnlyWhenProjectionSessionExists()
+    {
+        var runtime = new StubActorRuntime();
+        runtime.Actors["projection.session.scope:streaming-proxy-room-chat-session:room-a:session-123"] =
+            new StubActor("projection.session.scope:streaming-proxy-room-chat-session:room-a:session-123");
+        var hub = new RecordingRoomSessionEventHub();
+        var port = new StreamingProxyRoomSessionProjectionPort(
+            new RecordingRoomSessionActivationService(),
+            new RecordingRoomSessionReleaseService(),
+            hub,
+            runtime);
+        await using var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
+
+        var attachment = await port.AttachExistingChatProjectionAsync("room-a", "session-123", sink, CancellationToken.None);
+
+        attachment.Should().NotBeNull();
+        attachment!.ProjectionLease.ActorId.Should().Be("room-a");
+        attachment.ProjectionLease.SessionId.Should().Be("session-123");
+        hub.SubscribeCalls.Should().Be(1);
+        hub.LastScopeId.Should().Be("room-a");
+        hub.LastSessionId.Should().Be("session-123");
+    }
+
+    [Fact]
+    public async Task StreamingProxyRoomSessionProjectionPort_ShouldReturnNull_WhenProjectionSessionIsCold()
+    {
+        var hub = new RecordingRoomSessionEventHub();
+        var port = new StreamingProxyRoomSessionProjectionPort(
+            new RecordingRoomSessionActivationService(),
+            new RecordingRoomSessionReleaseService(),
+            hub,
+            new StubActorRuntime());
+        await using var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
+
+        var attachment = await port.AttachExistingChatProjectionAsync("room-a", "session-123", sink, CancellationToken.None);
+
+        attachment.Should().BeNull();
+        hub.SubscribeCalls.Should().Be(0);
+    }
+
+    [Fact]
     public async Task StreamingProxyRoomSessionEventProjector_ShouldIgnoreDifferentChatSessionEvents()
     {
         var sessionHub = new RecordingRoomSessionEventHub();
@@ -641,10 +682,10 @@ public class StreamingProxyCoverageTests
         result.FinalizeResult.Should().NotBeNull();
         result.FinalizeResult!.Completed.Should().BeTrue();
         result.FinalizeResult.Completion.Should().Be(StreamingProxyProjectionCompletionStatus.Completed);
-        projectionPort.EnsureCalls.Should().ContainSingle(x =>
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
             x.actorId == actor.Id &&
-            x.sessionId == "session-123" &&
-            x.projectionKind == StreamingProxyProjectionKinds.RoomChatSession);
+            x.sessionId == "session-123");
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
         projectionPort.ReleaseCount.Should().Be(1);
@@ -681,6 +722,10 @@ public class StreamingProxyCoverageTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(StreamingProxyRoomChatStartError.ProjectionUnavailable);
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
+            x.actorId == actor.Id &&
+            x.sessionId == "session-123");
         projectionPort.AttachCount.Should().Be(0);
         projectionPort.DetachCount.Should().Be(0);
         projectionPort.ReleaseCount.Should().Be(0);
@@ -709,6 +754,10 @@ public class StreamingProxyCoverageTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("dispatch failed");
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
+            x.actorId == actor.Id &&
+            x.sessionId == "session-123");
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
         projectionPort.ReleaseCount.Should().Be(1);
@@ -1742,6 +1791,7 @@ public class StreamingProxyCoverageTests
         public bool ReturnNullLease { get; init; }
 
         public List<(string actorId, string sessionId, string projectionKind)> EnsureCalls { get; } = [];
+        public List<(string actorId, string sessionId)> AttachExistingCalls { get; } = [];
         public List<StreamingProxyRoomSessionEnvelope> Messages { get; } = [];
         public List<IStreamingProxyRoomSessionProjectionLease> AttachedLeases { get; } = [];
         public int AttachCount { get; private set; }
@@ -1789,6 +1839,22 @@ public class StreamingProxyCoverageTests
 
             _lease = new StubRoomSessionProjectionLease(actorId, sessionId);
             return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(_lease);
+        }
+
+        public async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingChatProjectionAsync(
+            string actorId,
+            string sessionId,
+            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            AttachExistingCalls.Add((actorId, sessionId));
+            if (ReturnNullLease)
+                return null;
+
+            _lease = new StubRoomSessionProjectionLease(actorId, sessionId);
+            var liveSinkLease = await AttachLiveSinkAsync(_lease, sink, ct);
+            return new EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>(_lease, liveSinkLease);
         }
 
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
@@ -1846,6 +1912,9 @@ public class StreamingProxyCoverageTests
         : IProjectionSessionEventHub<StreamingProxyRoomSessionEnvelope>
     {
         public List<(string ScopeId, string SessionId, StreamingProxyRoomSessionEnvelope Event)> Published { get; } = [];
+        public int SubscribeCalls { get; private set; }
+        public string? LastScopeId { get; private set; }
+        public string? LastSessionId { get; private set; }
 
         public Task PublishAsync(
             string scopeId,
@@ -1864,11 +1933,45 @@ public class StreamingProxyCoverageTests
             Func<StreamingProxyRoomSessionEnvelope, ValueTask> handler,
             CancellationToken ct = default)
         {
-            _ = scopeId;
-            _ = sessionId;
+            SubscribeCalls++;
+            LastScopeId = scopeId;
+            LastSessionId = sessionId;
             _ = handler;
             _ = ct;
             return Task.FromResult<IAsyncDisposable>(new NoopAsyncDisposable());
+        }
+    }
+
+    private sealed class RecordingRoomSessionActivationService
+        : IProjectionScopeActivationService<StreamingProxyRoomSessionRuntimeLease>
+    {
+        public List<ProjectionScopeStartRequest> Requests { get; } = [];
+
+        public Task<StreamingProxyRoomSessionRuntimeLease> EnsureAsync(
+            ProjectionScopeStartRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(new StreamingProxyRoomSessionRuntimeLease(new StreamingProxyRoomSessionProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            }));
+        }
+    }
+
+    private sealed class RecordingRoomSessionReleaseService
+        : IProjectionScopeReleaseService<StreamingProxyRoomSessionRuntimeLease>
+    {
+        public List<StreamingProxyRoomSessionRuntimeLease> Leases { get; } = [];
+
+        public Task ReleaseIfIdleAsync(StreamingProxyRoomSessionRuntimeLease lease, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Leases.Add(lease);
+            return Task.CompletedTask;
         }
     }
 


### PR DESCRIPTION
## 摘要

iter37 cluster-037-agent-session-observation-attach-only(高优先级,Phase 9 r1 consensus)。

- **Old**:Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
- **New**:Attach-existing NyxID/StreamingProxy observation ports;cold sessions return `ProjectionUnavailable`;projection activation 移 projection-owned lifecycle。

违反:CLAUDE.md「Query priming 禁止」+「权威状态 / Projection」(同 #834 cluster-039 attach-only-B 模式)。

## 范围

8 文件改动(+367 / -36 LOC,净 +331)。

🤖 Auto-loop / codex-refactor-loop iter37

Closes #842

⟦AI:AUTO-LOOP⟧
