### PR TITLE
iter37 cluster-037 gagentservice-binders: 改为 attach-existing

### DIFF
--- a/.refactor-loop/runs/implement-cluster-037-gagentservice-binders-attach-existing.md
+++ b/.refactor-loop/runs/implement-cluster-037-gagentservice-binders-attach-existing.md
@@ -1,0 +1,61 @@
+# implement-cluster-037-gagentservice-binders-attach-existing
+
+## Modified files
+
+- `src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs` (40 lines)
+- `src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs` (97 lines)
+- `src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunProjectionContracts.cs` (30 lines)
+- `src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentRunTerminalModels.cs` (73 lines)
+- `src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs` (439 lines)
+- `src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs` (602 lines)
+- `src/platform/Aevatar.GAgentService.Application/Scripts/ScriptServiceRunInteraction.cs` (435 lines)
+- `src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs` (85 lines)
+- `src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs` (133 lines)
+- `src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs` (90 lines)
+- `test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs` (1659 lines)
+- `test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs` (650 lines)
+- `test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs` (797 lines)
+- `test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionTests.cs` (201 lines)
+- `test/Aevatar.GAgentService.Tests/Application/ScriptServiceRunInteractionTests.cs` (563 lines)
+- `test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs` (170 lines)
+- `test/Aevatar.GAgentService.Tests/Projection/ProjectionTestDoubles.cs` (196 lines)
+- `test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs` (200 lines)
+- `test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs` (562 lines)
+
+## Summary
+
+- Replaced GAgentService script-run, draft-run, and approval observation binders with attach-existing calls.
+- Added capability-specific attach-existing methods on existing GAgentService projection ports; no new core abstraction was introduced.
+- Implemented attach-existing by checking existing projection scope actor ids and constructing typed leases without invoking activation services.
+- Cold live/terminal projection sessions now return typed `ProjectionUnavailable` before dispatch.
+
+## Test results
+
+- PASS: `dotnet build aevatar.slnx --nologo`
+- PASS: `dotnet test test/Aevatar.GAgentService.Tests/Aevatar.GAgentService.Tests.csproj --nologo --filter "FullyQualifiedName~ScriptServiceRunInteractionTests|FullyQualifiedName~GAgentDraftRunInteraction|FullyQualifiedName~GAgentApprovalInteraction"`
+- PASS: `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter FullyQualifiedName~ScopeServiceEndpointsStreamTests`
+- PASS: `bash tools/ci/test_stability_guards.sh`
+- PASS: `bash tools/ci/query_projection_priming_guard.sh`
+- PASS: `bash tools/ci/architecture_guards.sh`
+- PASS: `git diff --check`
+
+## Deviations
+
+- The repository has no `src/platform/Aevatar.GAgentService.*/Binders/*` directory. The actual GAgentService interaction binder implementations live in Application interaction lifecycle classes, matching the audit evidence.
+- Added `ProjectionUnavailable` enum values for GAgent draft-run and approval start errors so cold attach-existing sessions can fail as typed results instead of exceptions.
+- Did not add any top-level `CLAUDE.md` live-observation exception.
+- Did not modify any external repositories.
+
+## SCOPE_EXTEND records
+
+- `src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs` add capability-specific attach-existing method required by audit fix boundary; no new core abstraction
+- `src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunProjectionContracts.cs` add capability-specific attach-existing method required by audit fix boundary; no new core abstraction
+- `src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentRunTerminalModels.cs` add capability-specific attach-existing materialization lease method required by audit fix boundary; no new core abstraction
+- `src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs` implement existing-session attach by actor runtime existence check; no request-path activation
+- `src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs` implement existing-session attach by actor runtime existence check; no request-path activation
+- `src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs` implement existing-materialization lease by actor runtime existence check; no request-path activation
+- `src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs` add ProjectionUnavailable enum values so cold attach-existing sessions return typed start errors before dispatch
+- `test/Aevatar.GAgentService.Tests/Projection/*` update projection port constructor tests for attach-existing runtime dependency and assertions
+- `test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs` update integration stubs for attach-existing ports
+
+⟦AI:AUTO-LOOP⟧

--- a/.refactor-loop/runs/scope-extend-cluster-037-gagentservice-binders-attach-existing.log
+++ b/.refactor-loop/runs/scope-extend-cluster-037-gagentservice-binders-attach-existing.log
@@ -1,0 +1,9 @@
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs add capability-specific attach-existing method required by audit fix boundary; no new core abstraction
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunProjectionContracts.cs add capability-specific attach-existing method required by audit fix boundary; no new core abstraction
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentRunTerminalModels.cs add capability-specific attach-existing materialization lease method required by audit fix boundary; no new core abstraction
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs implement existing-session attach by actor runtime existence check; no request-path activation
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs implement existing-session attach by actor runtime existence check; no request-path activation
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs implement existing-materialization lease by actor runtime existence check; no request-path activation
+SCOPE_EXTEND: src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs add ProjectionUnavailable enum values so cold attach-existing sessions return typed start errors before dispatch
+SCOPE_EXTEND: test/Aevatar.GAgentService.Tests/Projection/* update projection port constructor tests for attach-existing runtime dependency and assertions
+SCOPE_EXTEND: test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs update integration stubs for attach-existing ports

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs
@@ -27,4 +27,14 @@ public interface IScriptServiceAguiProjectionPort
         string actorId,
         string runId,
         CancellationToken ct = default);
+
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
+        string actorId,
+        string runId,
+        IEventSink<AGUIEvent> sink,
+        CancellationToken ct = default);
 }

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs
@@ -44,6 +44,7 @@ public enum GAgentDraftRunStartError
     None = 0,
     UnknownActorType = 1,
     ActorTypeMismatch = 2,
+    ProjectionUnavailable = 3,
 }
 
 public enum GAgentDraftRunCompletionStatus
@@ -78,6 +79,7 @@ public enum GAgentApprovalStartError
 {
     None = 0,
     ActorNotFound = 1,
+    ProjectionUnavailable = 2,
 }
 
 public enum GAgentApprovalCompletionStatus

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunProjectionContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunProjectionContracts.cs
@@ -17,4 +17,14 @@ public interface IGAgentDraftRunProjectionPort
         string actorId,
         string commandId,
         CancellationToken ct = default);
+
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
+        string actorId,
+        string commandId,
+        IEventSink<AGUIEvent> sink,
+        CancellationToken ct = default);
 }

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentRunTerminalModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentRunTerminalModels.cs
@@ -57,6 +57,16 @@ public interface IGAgentRunTerminalProjectionPort
         GAgentRunTerminalInteractionKind interactionKind,
         CancellationToken ct = default);
 
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
+        string actorId,
+        string correlationId,
+        GAgentRunTerminalInteractionKind interactionKind,
+        CancellationToken ct = default);
+
     Task ReleaseProjectionAsync(
         IGAgentRunTerminalProjectionLease lease,
         CancellationToken ct = default);

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentApprovalInteraction.cs
@@ -205,9 +205,10 @@ internal sealed class GAgentApprovalObservationLifecycle
         CommandDispatchExecution<GAgentApprovalCommandTarget, GAgentApprovalAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: approval binder attached terminal/live projections during command preparation.
-        //   New principle: interaction observation lifecycle starts read-side observation before dispatch without affecting dispatch-only command admission.
+        // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+        //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+        //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+        //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -218,26 +219,27 @@ internal sealed class GAgentApprovalObservationLifecycle
 
         try
         {
-            terminalProjectionLease = await _terminalProjectionPort.EnsureProjectionAsync(
+            terminalProjectionLease = await _terminalProjectionPort.AttachExistingProjectionAsync(
                 target.ActorId,
                 context.CorrelationId,
                 GAgentRunTerminalInteractionKind.Approval,
                 ct);
+            if (terminalProjectionLease == null)
+                return await FailProjectionUnavailableAsync(sink);
+
             target.BindTerminalProjection(terminalProjectionLease);
 
-            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
-                token => _projectionPort.EnsureActorProjectionAsync(
-                    target.ActorId,
-                    context.CorrelationId,
-                    token),
+            var attachment = await _projectionPort.AttachExistingActorProjectionAsync(
+                target.ActorId,
+                context.CorrelationId,
                 sink,
                 ct);
 
             if (attachment == null)
             {
-                sink.Complete();
-                await sink.DisposeAsync();
-                throw new InvalidOperationException("GAgent approval projection pipeline is unavailable.");
+                await _terminalProjectionPort.ReleaseProjectionAsync(terminalProjectionLease, ct);
+                target.BindTerminalProjection(null);
+                return await FailProjectionUnavailableAsync(sink);
             }
 
             target.BindLiveObservation(
@@ -259,6 +261,15 @@ internal sealed class GAgentApprovalObservationLifecycle
             await sink.DisposeAsync();
             throw;
         }
+    }
+
+    private static async Task<CommandObservationBindingResult<GAgentApprovalStartError>> FailProjectionUnavailableAsync(
+        IEventSink<AGUIEvent> sink)
+    {
+        sink.Complete();
+        await sink.DisposeAsync();
+        return CommandObservationBindingResult<GAgentApprovalStartError>.Failure(
+            GAgentApprovalStartError.ProjectionUnavailable);
     }
 }
 

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
@@ -307,9 +307,10 @@ internal sealed class GAgentDraftRunObservationLifecycle
         CommandDispatchExecution<GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Refactor (iter25/cluster-002-observation-lifecycle-core):
-        //   Old pattern: draft-run binder attached terminal/live projections during command preparation.
-        //   New principle: interaction observation lifecycle starts read-side observation before dispatch without affecting dispatch-only command admission.
+        // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+        //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+        //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+        //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -320,26 +321,27 @@ internal sealed class GAgentDraftRunObservationLifecycle
 
         try
         {
-            terminalProjectionLease = await _terminalProjectionPort.EnsureProjectionAsync(
+            terminalProjectionLease = await _terminalProjectionPort.AttachExistingProjectionAsync(
                 target.ActorId,
                 context.CorrelationId,
                 GAgentRunTerminalInteractionKind.DraftRun,
                 ct);
+            if (terminalProjectionLease == null)
+                return await FailProjectionUnavailableAsync(sink);
+
             target.BindTerminalProjection(terminalProjectionLease);
 
-            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
-                token => _projectionPort.EnsureActorProjectionAsync(
-                    target.ActorId,
-                    context.CommandId,
-                    token),
+            var attachment = await _projectionPort.AttachExistingActorProjectionAsync(
+                target.ActorId,
+                context.CommandId,
                 sink,
                 ct);
 
             if (attachment == null)
             {
-                sink.Complete();
-                await sink.DisposeAsync();
-                throw new InvalidOperationException("GAgent draft-run projection pipeline is unavailable.");
+                await _terminalProjectionPort.ReleaseProjectionAsync(terminalProjectionLease, ct);
+                target.BindTerminalProjection(null);
+                return await FailProjectionUnavailableAsync(sink);
             }
 
             target.BindLiveObservation(
@@ -361,6 +363,15 @@ internal sealed class GAgentDraftRunObservationLifecycle
             await sink.DisposeAsync();
             throw;
         }
+    }
+
+    private static async Task<CommandObservationBindingResult<GAgentDraftRunStartError>> FailProjectionUnavailableAsync(
+        IEventSink<AGUIEvent> sink)
+    {
+        sink.Complete();
+        await sink.DisposeAsync();
+        return CommandObservationBindingResult<GAgentDraftRunStartError>.Failure(
+            GAgentDraftRunStartError.ProjectionUnavailable);
     }
 
     private static string ResolveSessionId(

--- a/src/platform/Aevatar.GAgentService.Application/Scripts/ScriptServiceRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Scripts/ScriptServiceRunInteraction.cs
@@ -209,9 +209,10 @@ internal sealed class ScriptServiceRunCommandTargetResolver
     }
 }
 
-// Refactor (iter25/cluster-026-scope-service-script-stream-inline-orchestration):
-//   Old pattern: Scope service script stream inline orchestration in endpoints
-//   New principle: use existing ICommandInteractionService skeleton with ScriptServiceRunCommand and Application-owned service-run registration decorator
+// Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+//   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+//   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+//   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
 internal sealed class ScriptServiceRunCommandTargetBinder
     : ICommandObservationLifecycle<ScriptServiceRunCommand, ScriptServiceRunCommandTarget, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError>
 {
@@ -222,9 +223,10 @@ internal sealed class ScriptServiceRunCommandTargetBinder
         _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
     }
 
-    // Refactor (iter25/cluster-026-scope-service-script-stream-inline-orchestration):
-    //   Old pattern: Host endpoint built script runtime payload and attached projection leases inline
-    //   New principle: Application binder owns payload construction, projection attachment, and target binding
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
     public async Task<CommandObservationBindingResult<ScriptServiceRunStartError>> BindAsync(
         ScriptServiceRunCommand command,
         CommandDispatchExecution<ScriptServiceRunCommandTarget, ScriptServiceRunAcceptedReceipt> execution,
@@ -246,8 +248,9 @@ internal sealed class ScriptServiceRunCommandTargetBinder
         var inputPayload = Any.Pack(chatRequest);
         var eventChannel = new EventChannel<AGUIEvent>();
 
-        var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
-            token => _projectionPort.EnsureRunProjectionAsync(target.ActorId, command.RunId, token),
+        var attachment = await _projectionPort.AttachExistingRunProjectionAsync(
+            target.ActorId,
+            command.RunId,
             eventChannel,
             ct);
         if (attachment == null)

--- a/src/platform/Aevatar.GAgentService.Application/Scripts/ScriptServiceRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Scripts/ScriptServiceRunInteraction.cs
@@ -209,10 +209,6 @@ internal sealed class ScriptServiceRunCommandTargetResolver
     }
 }
 
-// Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
-//   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
-//   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
-//   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
 internal sealed class ScriptServiceRunCommandTargetBinder
     : ICommandObservationLifecycle<ScriptServiceRunCommand, ScriptServiceRunCommandTarget, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError>
 {

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs
@@ -1,5 +1,7 @@
+using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.Presentation.AGUI;
@@ -10,17 +12,21 @@ public sealed class GAgentDraftRunProjectionPort
     : EventSinkProjectionLifecyclePortBase<IGAgentDraftRunProjectionLease, GAgentDraftRunRuntimeLease, AGUIEvent>,
       IGAgentDraftRunProjectionPort
 {
+    private readonly IActorRuntime _runtime;
+
     public GAgentDraftRunProjectionPort(
         ServiceProjectionOptions options,
         IProjectionScopeActivationService<GAgentDraftRunRuntimeLease> activationService,
         IProjectionScopeReleaseService<GAgentDraftRunRuntimeLease> releaseService,
-        IProjectionSessionEventHub<AGUIEvent> sessionEventHub)
+        IProjectionSessionEventHub<AGUIEvent> sessionEventHub,
+        IActorRuntime runtime)
         : base(
             () => options.Enabled,
             activationService,
             releaseService,
             sessionEventHub)
     {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
     public Task<IGAgentDraftRunProjectionLease?> EnsureActorProjectionAsync(
@@ -36,4 +42,44 @@ public sealed class GAgentDraftRunProjectionPort
                 SessionId = commandId,
             },
             ct);
+
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    public async Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
+        string actorId,
+        string commandId,
+        IEventSink<AGUIEvent> sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        ct.ThrowIfCancellationRequested();
+
+        if (!ProjectionEnabled ||
+            string.IsNullOrWhiteSpace(actorId) ||
+            string.IsNullOrWhiteSpace(commandId))
+        {
+            return null;
+        }
+
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            actorId,
+            ServiceProjectionKinds.DraftRunSession,
+            ProjectionRuntimeMode.SessionObservation,
+            commandId);
+        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+            return null;
+
+        var lease = new GAgentDraftRunRuntimeLease(new GAgentDraftRunProjectionContext
+        {
+            RootActorId = actorId,
+            ProjectionKind = ServiceProjectionKinds.DraftRunSession,
+            SessionId = commandId,
+        });
+        var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
+        return liveSinkLease == null
+            ? null
+            : new EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>(lease, liveSinkLease);
+    }
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs
@@ -1,3 +1,6 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.GAgentService.Projection.Contexts;
@@ -8,12 +11,16 @@ public sealed class GAgentRunTerminalProjectionPort
     : ServiceProjectionPortBase<GAgentRunTerminalProjectionContext>,
       IGAgentRunTerminalProjectionPort
 {
+    private readonly IActorRuntime _runtime;
+
     public GAgentRunTerminalProjectionPort(
         ServiceProjectionOptions options,
         IProjectionScopeActivationService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> activationService,
-        IProjectionScopeReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> releaseService)
+        IProjectionScopeReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> releaseService,
+        IActorRuntime runtime)
         : base(options, activationService, releaseService, ServiceProjectionKinds.GAgentRunTerminalDraftRun)
     {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
     public async Task<IGAgentRunTerminalProjectionLease?> EnsureProjectionAsync(
@@ -38,6 +45,45 @@ public sealed class GAgentRunTerminalProjectionPort
         return runtimeLease == null
             ? null
             : new GAgentRunTerminalProjectionLease(runtimeLease);
+    }
+
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    public async Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
+        string actorId,
+        string correlationId,
+        GAgentRunTerminalInteractionKind interactionKind,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (!ProjectionEnabled ||
+            string.IsNullOrWhiteSpace(actorId) ||
+            string.IsNullOrWhiteSpace(correlationId))
+        {
+            return null;
+        }
+
+        var projectionKind = ResolveProjectionKind(interactionKind);
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            actorId,
+            projectionKind,
+            ProjectionRuntimeMode.DurableMaterialization,
+            correlationId);
+        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+            return null;
+
+        var context = new GAgentRunTerminalProjectionContext
+        {
+            RootActorId = actorId,
+            ProjectionKind = projectionKind,
+            CorrelationId = correlationId.Trim(),
+            InteractionKind = interactionKind,
+        };
+        return new GAgentRunTerminalProjectionLease(
+            new ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>(context.RootActorId, context));
     }
 
     public Task ReleaseProjectionAsync(

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs
@@ -1,5 +1,7 @@
+using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.Presentation.AGUI;
@@ -15,17 +17,21 @@ public sealed class ScriptServiceAguiProjectionPort
     : EventSinkProjectionLifecyclePortBase<IScriptServiceAguiProjectionLease, ScriptServiceAguiRuntimeLease, AGUIEvent>,
       IScriptServiceAguiProjectionPort
 {
+    private readonly IActorRuntime _runtime;
+
     public ScriptServiceAguiProjectionPort(
         ServiceProjectionOptions options,
         IProjectionScopeActivationService<ScriptServiceAguiRuntimeLease> activationService,
         IProjectionScopeReleaseService<ScriptServiceAguiRuntimeLease> releaseService,
-        IProjectionSessionEventHub<AGUIEvent> sessionEventHub)
+        IProjectionSessionEventHub<AGUIEvent> sessionEventHub,
+        IActorRuntime runtime)
         : base(
             () => options.Enabled,
             activationService,
             releaseService,
             sessionEventHub)
     {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
     public Task<IScriptServiceAguiProjectionLease?> EnsureRunProjectionAsync(
@@ -41,4 +47,44 @@ public sealed class ScriptServiceAguiProjectionPort
                 SessionId = runId,
             },
             ct);
+
+    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
+    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
+    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
+    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    public async Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
+        string actorId,
+        string runId,
+        IEventSink<AGUIEvent> sink,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        ct.ThrowIfCancellationRequested();
+
+        if (!ProjectionEnabled ||
+            string.IsNullOrWhiteSpace(actorId) ||
+            string.IsNullOrWhiteSpace(runId))
+        {
+            return null;
+        }
+
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            actorId,
+            ServiceProjectionKinds.ScriptServiceAguiSession,
+            ProjectionRuntimeMode.SessionObservation,
+            runId);
+        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+            return null;
+
+        var lease = new ScriptServiceAguiRuntimeLease(new ScriptServiceAguiProjectionContext
+        {
+            RootActorId = actorId,
+            ProjectionKind = ServiceProjectionKinds.ScriptServiceAguiSession,
+            SessionId = runId,
+        });
+        var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
+        return liveSinkLease == null
+            ? null
+            : new EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>(lease, liveSinkLease);
+    }
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -1325,6 +1325,17 @@ public sealed class ScopeServiceEndpointsStreamTests
             return Task.FromResult<IGAgentDraftRunProjectionLease?>(new StubDraftRunProjectionLease(actorId, commandId));
         }
 
+        public async Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
+            string actorId,
+            string commandId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            var lease = new StubDraftRunProjectionLease(actorId, commandId);
+            var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct);
+            return new EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>(lease, liveSinkLease);
+        }
+
         public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
@@ -1387,6 +1398,13 @@ public sealed class ScopeServiceEndpointsStreamTests
                 new StubGAgentRunTerminalProjectionLease(actorId, correlationId, interactionKind));
         }
 
+        public Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
+            string actorId,
+            string correlationId,
+            GAgentRunTerminalInteractionKind interactionKind,
+            CancellationToken ct = default) =>
+            EnsureProjectionAsync(actorId, correlationId, interactionKind, ct);
+
         public Task ReleaseProjectionAsync(
             IGAgentRunTerminalProjectionLease lease,
             CancellationToken ct = default)
@@ -1442,6 +1460,17 @@ public sealed class ScopeServiceEndpointsStreamTests
             _ = ct;
             EnsureCalls.Add((actorId, runId));
             return Task.FromResult<IScriptServiceAguiProjectionLease?>(new StubScriptServiceAguiProjectionLease(actorId, runId));
+        }
+
+        public async Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
+            string actorId,
+            string runId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            var lease = new StubScriptServiceAguiProjectionLease(actorId, runId);
+            var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct);
+            return new EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>(lease, liveSinkLease);
         }
 
         public async Task<IAsyncDisposable?> AttachLiveSinkAsync(

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentApprovalInteractionTests.cs
@@ -76,7 +76,7 @@ public sealed class GAgentApprovalInteractionTests
         target.ProjectionLease.Should().BeSameAs(projectionPort.LeaseToReturn);
         target.LiveSinkLease.Should().BeSameAs(projectionPort.LiveSinkLeaseToReturn);
         target.LiveSink.Should().NotBeNull();
-        projectionPort.EnsureCalls.Should().ContainSingle(x => x.actorId == "actor-1" && x.commandId == "corr-1");
+        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().ContainSingle();
         terminalPort.Calls.Should().ContainSingle(x =>
             x.actorId == "actor-1" &&
@@ -85,7 +85,7 @@ public sealed class GAgentApprovalInteractionTests
     }
 
     [Fact]
-    public async Task ObservationLifecycle_ShouldThrow_WhenProjectionPipelineIsUnavailable()
+    public async Task ObservationLifecycle_ShouldReturnProjectionUnavailable_WhenProjectionPipelineIsUnavailable()
     {
         var projectionPort = new ApprovalProjectionPort
         {
@@ -99,13 +99,13 @@ public sealed class GAgentApprovalInteractionTests
             terminalPort);
         var context = new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>());
 
-        var act = async () => await lifecycle.BindAsync(
+        var result = await lifecycle.BindAsync(
             new GAgentApprovalCommand("actor-1", "req-1"),
             CreateExecution(target, context),
             CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("GAgent approval projection pipeline is unavailable.");
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(GAgentApprovalStartError.ProjectionUnavailable);
         projectionPort.AttachCalls.Should().BeEmpty();
         terminalPort.Calls.Should().ContainSingle(x =>
             x.actorId == "actor-1" &&
@@ -448,6 +448,19 @@ public sealed class GAgentApprovalInteractionTests
             return Task.FromResult<IGAgentDraftRunProjectionLease?>(LeaseToReturn);
         }
 
+        public async Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
+            string actorId,
+            string commandId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            if (LeaseToReturn == null)
+                return null;
+
+            var liveSinkLease = await AttachLiveSinkAsync(LeaseToReturn, sink, ct);
+            return new EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>(LeaseToReturn, liveSinkLease);
+        }
+
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
@@ -507,6 +520,13 @@ public sealed class GAgentApprovalInteractionTests
             return Task.FromResult<IGAgentRunTerminalProjectionLease?>(
                 new ApprovalTerminalProjectionLease(actorId, correlationId, interactionKind));
         }
+
+        public Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
+            string actorId,
+            string correlationId,
+            GAgentRunTerminalInteractionKind interactionKind,
+            CancellationToken ct = default) =>
+            EnsureProjectionAsync(actorId, correlationId, interactionKind, ct);
 
         public Task ReleaseProjectionAsync(
             IGAgentRunTerminalProjectionLease lease,

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
@@ -3,6 +3,9 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.CQRS.Core.Interactions;
+using Aevatar.CQRS.Core.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
@@ -300,6 +303,37 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             x.correlationId == "corr-1" &&
             x.interactionKind == GAgentRunTerminalInteractionKind.DraftRun);
         terminalPort.ReleaseCalls.Should().ContainSingle();
+        target.TerminalProjectionLease.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ObservationLifecycle_ShouldReturnProjectionUnavailable_WhenTerminalProjectionIsUnavailable()
+    {
+        var projectionPort = new DraftRunProjectionPort();
+        var terminalPort = new RecordingGAgentRunTerminalProjectionPort { ReturnNullLease = true };
+        var lifecycle = new GAgentDraftRunObservationLifecycle(projectionPort, terminalPort);
+        var target = new GAgentDraftRunCommandTarget(
+            new DraftRunStubActor("actor-1", new DraftRunExpectedAgent()),
+            typeof(DraftRunExpectedAgent).AssemblyQualifiedName!,
+            projectionPort,
+            terminalPort);
+        var context = new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>());
+
+        var result = await lifecycle.BindAsync(
+            new GAgentDraftRunCommand("scope-a", typeof(DraftRunExpectedAgent).AssemblyQualifiedName!, "hello"),
+            CreateExecution(target, context),
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(GAgentDraftRunStartError.ProjectionUnavailable);
+        terminalPort.Calls.Should().ContainSingle(x =>
+            x.actorId == "actor-1" &&
+            x.correlationId == "corr-1" &&
+            x.interactionKind == GAgentRunTerminalInteractionKind.DraftRun);
+        terminalPort.ReleaseCalls.Should().BeEmpty();
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachCalls.Should().BeEmpty();
+        target.TerminalProjectionLease.Should().BeNull();
     }
 
     [Fact]
@@ -551,6 +585,54 @@ public sealed class GAgentDraftRunInteractionCoverageTests
         projectionPort.AttachCalls.Should().ContainSingle();
     }
 
+    [Fact]
+    public async Task Interaction_ShouldFailWithProjectionUnavailable_AndNotDispatch_WhenTerminalProjectionAttachFails()
+    {
+        var projectionPort = new DraftRunProjectionPort();
+        var terminalPort = new RecordingGAgentRunTerminalProjectionPort { ReturnNullLease = true };
+        var dispatchPort = new RecordingActorDispatchPort();
+        var interaction = CreateInteraction(projectionPort, terminalPort, dispatchPort);
+
+        var result = await interaction.ExecuteAsync(
+            CreateCommand(),
+            (_, _) => ValueTask.CompletedTask,
+            null,
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(GAgentDraftRunStartError.ProjectionUnavailable);
+        dispatchPort.Dispatches.Should().BeEmpty();
+        terminalPort.Calls.Should().ContainSingle(x =>
+            x.interactionKind == GAgentRunTerminalInteractionKind.DraftRun);
+        terminalPort.ReleaseCalls.Should().BeEmpty();
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachCalls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Interaction_ShouldFailWithProjectionUnavailable_AndNotDispatch_WhenLiveProjectionAttachFails()
+    {
+        var projectionPort = new DraftRunProjectionPort { LeaseToReturn = null };
+        var terminalPort = new RecordingGAgentRunTerminalProjectionPort();
+        var dispatchPort = new RecordingActorDispatchPort();
+        var interaction = CreateInteraction(projectionPort, terminalPort, dispatchPort);
+
+        var result = await interaction.ExecuteAsync(
+            CreateCommand(),
+            (_, _) => ValueTask.CompletedTask,
+            null,
+            CancellationToken.None);
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(GAgentDraftRunStartError.ProjectionUnavailable);
+        dispatchPort.Dispatches.Should().BeEmpty();
+        terminalPort.Calls.Should().ContainSingle(x =>
+            x.interactionKind == GAgentRunTerminalInteractionKind.DraftRun);
+        terminalPort.ReleaseCalls.Should().ContainSingle();
+        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachCalls.Should().BeEmpty();
+    }
+
     private static CommandDispatchExecution<GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt> CreateExecution(
         GAgentDraftRunCommandTarget target,
         CommandContext context) =>
@@ -566,6 +648,33 @@ public sealed class GAgentDraftRunInteractionCoverageTests
                 context.CorrelationId,
                 string.Empty),
         };
+
+    private static ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> CreateInteraction(
+        DraftRunProjectionPort projectionPort,
+        RecordingGAgentRunTerminalProjectionPort terminalPort,
+        RecordingActorDispatchPort dispatchPort)
+    {
+        var pipeline = new DefaultCommandDispatchPipeline<GAgentDraftRunCommand, GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError>(
+            new GAgentDraftRunCommandTargetResolver(
+                new DraftRunStubActorRuntime(),
+                projectionPort,
+                terminalPort),
+            new DefaultCommandContextPolicy(),
+            new GAgentDraftRunCommandEnvelopeFactory(),
+            new ActorCommandTargetDispatcher<GAgentDraftRunCommandTarget>(dispatchPort),
+            new GAgentDraftRunAcceptedReceiptFactory());
+
+        return new DefaultCommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, AGUIEvent, GAgentDraftRunCompletionStatus>(
+            pipeline,
+            new DefaultEventOutputStream<AGUIEvent, AGUIEvent>(new IdentityEventFrameMapper<AGUIEvent>()),
+            new GAgentDraftRunCompletionPolicy(),
+            new GAgentDraftRunFinalizeEmitter(),
+            new GAgentDraftRunDurableCompletionResolver(new RecordingGAgentRunTerminalQueryPort()),
+            observationLifecycle: new GAgentDraftRunObservationLifecycle(projectionPort, terminalPort));
+    }
+
+    private static GAgentDraftRunCommand CreateCommand() =>
+        new("scope-a", typeof(DraftRunExpectedAgent).AssemblyQualifiedName!, "hello");
 
     private sealed class DraftRunProjectionPort : IGAgentDraftRunProjectionPort
     {
@@ -647,6 +756,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
     {
         public List<(string actorId, string correlationId, GAgentRunTerminalInteractionKind interactionKind)> Calls { get; } = [];
         public List<IGAgentRunTerminalProjectionLease> ReleaseCalls { get; } = [];
+        public bool ReturnNullLease { get; init; }
 
         public Task<IGAgentRunTerminalProjectionLease?> EnsureProjectionAsync(
             string actorId,
@@ -655,6 +765,9 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             CancellationToken ct = default)
         {
             Calls.Add((actorId, correlationId, interactionKind));
+            if (ReturnNullLease)
+                return Task.FromResult<IGAgentRunTerminalProjectionLease?>(null);
+
             return Task.FromResult<IGAgentRunTerminalProjectionLease?>(
                 new RecordingGAgentRunTerminalProjectionLease(actorId, correlationId, interactionKind));
         }
@@ -731,6 +844,17 @@ public sealed class GAgentDraftRunInteractionCoverageTests
         public Task<bool> ExistsAsync(string id) => Task.FromResult(_actors.ContainsKey(id));
         public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
         public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string actorId, EventEnvelope envelope)> Dispatches { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Dispatches.Add((actorId, envelope));
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class DraftRunStubActor(string id, IAgent agent) : IActor

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
@@ -276,7 +276,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
     }
 
     [Fact]
-    public async Task ObservationLifecycle_ShouldThrow_WhenProjectionPipelineIsUnavailable()
+    public async Task ObservationLifecycle_ShouldReturnProjectionUnavailable_WhenProjectionPipelineIsUnavailable()
     {
         var projectionPort = new DraftRunProjectionPort { LeaseToReturn = null };
         var terminalPort = new RecordingGAgentRunTerminalProjectionPort();
@@ -288,13 +288,13 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             terminalPort);
         var context = new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>());
 
-        var act = async () => await lifecycle.BindAsync(
+        var result = await lifecycle.BindAsync(
             new GAgentDraftRunCommand("scope-a", typeof(DraftRunExpectedAgent).AssemblyQualifiedName!, "hello"),
             CreateExecution(target, context),
             CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("GAgent draft-run projection pipeline is unavailable.");
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(GAgentDraftRunStartError.ProjectionUnavailable);
         terminalPort.Calls.Should().ContainSingle(x =>
             x.actorId == "actor-1" &&
             x.correlationId == "corr-1" &&
@@ -525,7 +525,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
     }
 
     [Fact]
-    public async Task ObservationLifecycle_ShouldActivateTerminalMaterialization_BeforeLiveObservation()
+    public async Task ObservationLifecycle_ShouldAttachExistingTerminalMaterialization_BeforeLiveObservation()
     {
         var projectionPort = new DraftRunProjectionPort();
         var terminalPort = new RecordingGAgentRunTerminalProjectionPort();
@@ -547,7 +547,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             x.actorId == "actor-1" &&
             x.correlationId == "corr-1" &&
             x.interactionKind == GAgentRunTerminalInteractionKind.DraftRun);
-        projectionPort.EnsureCalls.Should().ContainSingle(x => x.actorId == "actor-1" && x.commandId == "cmd-1");
+        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().ContainSingle();
     }
 
@@ -584,6 +584,19 @@ public sealed class GAgentDraftRunInteractionCoverageTests
         {
             EnsureCalls.Add((actorId, commandId));
             return Task.FromResult<IGAgentDraftRunProjectionLease?>(LeaseToReturn);
+        }
+
+        public async Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
+            string actorId,
+            string commandId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            if (LeaseToReturn == null)
+                return null;
+
+            var liveSinkLease = await AttachLiveSinkAsync(LeaseToReturn, sink, ct);
+            return new EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>(LeaseToReturn, liveSinkLease);
         }
 
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
@@ -645,6 +658,13 @@ public sealed class GAgentDraftRunInteractionCoverageTests
             return Task.FromResult<IGAgentRunTerminalProjectionLease?>(
                 new RecordingGAgentRunTerminalProjectionLease(actorId, correlationId, interactionKind));
         }
+
+        public Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
+            string actorId,
+            string correlationId,
+            GAgentRunTerminalInteractionKind interactionKind,
+            CancellationToken ct = default) =>
+            EnsureProjectionAsync(actorId, correlationId, interactionKind, ct);
 
         public Task ReleaseProjectionAsync(
             IGAgentRunTerminalProjectionLease lease,

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionTests.cs
@@ -105,6 +105,13 @@ public sealed class GAgentDraftRunInteractionTests
             CancellationToken ct = default) =>
             Task.FromResult<IGAgentDraftRunProjectionLease?>(null);
 
+        public Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
+            string actorId,
+            string commandId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default) =>
+            Task.FromResult<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?>(null);
+
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IGAgentDraftRunProjectionLease lease,
             IEventSink<AGUIEvent> sink,
@@ -125,6 +132,14 @@ public sealed class GAgentDraftRunInteractionTests
     private sealed class NoOpGAgentRunTerminalProjectionPort : IGAgentRunTerminalProjectionPort
     {
         public Task<IGAgentRunTerminalProjectionLease?> EnsureProjectionAsync(
+            string actorId,
+            string correlationId,
+            GAgentRunTerminalInteractionKind interactionKind,
+            CancellationToken ct = default) =>
+            Task.FromResult<IGAgentRunTerminalProjectionLease?>(
+                new NoOpGAgentRunTerminalProjectionLease(actorId, correlationId, interactionKind));
+
+        public Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
             string actorId,
             string correlationId,
             GAgentRunTerminalInteractionKind interactionKind,

--- a/test/Aevatar.GAgentService.Tests/Application/ScriptServiceRunInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScriptServiceRunInteractionTests.cs
@@ -67,8 +67,7 @@ public sealed class ScriptServiceRunInteractionTests
         runtimeRequest.ScopeId.Should().Be("scope-a");
         runtimeRequest.Metadata.Should().ContainKey("trace-id")
             .WhoseValue.Should().Be("trace-1");
-        projectionPort.EnsureCalls.Should().ContainSingle(call =>
-            call.ActorId == "runtime-1" && call.RunId == "run-1");
+        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.ReleaseCalls.Should().ContainSingle(call =>
             call.ActorId == "runtime-1" && call.RunId == "run-1");
         emitted.Should().ContainSingle(evt => evt.EventCase == AGUIEvent.EventOneofCase.RunFinished);
@@ -129,8 +128,7 @@ public sealed class ScriptServiceRunInteractionTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Code.Should().Be(ScriptServiceRunStartErrorCode.ProjectionUnavailable);
-        projectionPort.EnsureCalls.Should().ContainSingle(call =>
-            call.ActorId == "runtime-1" && call.RunId == "run-1");
+        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().BeEmpty();
         projectionPort.ReleaseCalls.Should().BeEmpty();
         runtimePort.Invocations.Should().BeEmpty();
@@ -157,8 +155,7 @@ public sealed class ScriptServiceRunInteractionTests
         runtimePort.Invocations.Should().ContainSingle(invocation =>
             invocation.RuntimeActorId == "runtime-1" &&
             invocation.RunId == "run-1");
-        projectionPort.EnsureCalls.Should().ContainSingle(call =>
-            call.ActorId == "runtime-1" && call.RunId == "run-1");
+        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().ContainSingle(call =>
             call.ActorId == "runtime-1" && call.RunId == "run-1");
         projectionPort.ReleaseCalls.Should().ContainSingle(call =>
@@ -392,6 +389,20 @@ public sealed class ScriptServiceRunInteractionTests
             EnsureCalls.Add((actorId, runId));
             return Task.FromResult<IScriptServiceAguiProjectionLease?>(
                 ReturnNullLease ? null : new Lease(actorId, runId));
+        }
+
+        public async Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
+            string actorId,
+            string runId,
+            IEventSink<AGUIEvent> sink,
+            CancellationToken ct = default)
+        {
+            if (ReturnNullLease)
+                return null;
+
+            var lease = new Lease(actorId, runId);
+            var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct);
+            return new EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>(lease, liveSinkLease);
         }
 
         public async Task<IAsyncDisposable?> AttachLiveSinkAsync(

--- a/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.GAgentService.Projection.Orchestration;
 using Aevatar.Presentation.AGUI;
@@ -46,7 +47,8 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
             new ServiceProjectionOptions { Enabled = true },
             activation,
             release,
-            hub);
+            hub,
+            new RecordingActorRuntime());
         var lease = await port.EnsureActorProjectionAsync("actor-1", "cmd-1", CancellationToken.None);
         var sink = new RecordingEventSink();
 

--- a/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.GAgentService.Projection.Orchestration;
@@ -75,6 +76,96 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
         hub.LastSessionId.Should().Be("cmd-1");
         sink.Events.Should().ContainSingle();
         release.Leases.Should().ContainSingle().Which.Should().BeSameAs(lease);
+    }
+
+    [Fact]
+    public async Task ProjectionPort_ShouldAttachExistingDraftRunSession_WhenScopeActorExists()
+    {
+        var activation = new RecordingActivationService();
+        var hub = new RecordingSessionEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+            "actor-1",
+            "service-draft-run-session",
+            ProjectionRuntimeMode.SessionObservation,
+            "cmd-1")));
+        var port = new GAgentDraftRunProjectionPort(
+            new ServiceProjectionOptions { Enabled = true },
+            activation,
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+        var sink = new RecordingEventSink();
+
+        var attachment = await port.AttachExistingActorProjectionAsync(
+            "actor-1",
+            "cmd-1",
+            sink,
+            CancellationToken.None);
+
+        attachment.Should().NotBeNull();
+        activation.Requests.Should().BeEmpty();
+        var lease = attachment!.ProjectionLease.Should().BeOfType<GAgentDraftRunRuntimeLease>().Subject;
+        lease.ActorId.Should().Be("actor-1");
+        lease.CommandId.Should().Be("cmd-1");
+        hub.SubscribeCalls.Should().Be(1);
+        hub.LastScopeId.Should().Be("actor-1");
+        hub.LastSessionId.Should().Be("cmd-1");
+
+        await hub.Handler!(new AGUIEvent
+        {
+            RunFinished = new RunFinishedEvent
+            {
+                ThreadId = "actor-1",
+                RunId = "cmd-1",
+            },
+        });
+        sink.Events.Should().ContainSingle().Which.RunFinished.RunId.Should().Be("cmd-1");
+    }
+
+    [Fact]
+    public async Task ProjectionPort_ShouldReturnNullForAttachExisting_WhenScopeActorIsMissingOrInvalid()
+    {
+        var activation = new RecordingActivationService();
+        var hub = new RecordingSessionEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.ExistingActorIds.Add("different-scope");
+        var disabledPort = new GAgentDraftRunProjectionPort(
+            new ServiceProjectionOptions { Enabled = false },
+            activation,
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+        var enabledPort = new GAgentDraftRunProjectionPort(
+            new ServiceProjectionOptions { Enabled = true },
+            activation,
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+
+        (await disabledPort.AttachExistingActorProjectionAsync(
+            "actor-1",
+            "cmd-1",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+        (await enabledPort.AttachExistingActorProjectionAsync(
+            "actor-1",
+            "cmd-1",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+        (await enabledPort.AttachExistingActorProjectionAsync(
+            "",
+            "cmd-1",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+        (await enabledPort.AttachExistingActorProjectionAsync(
+            "actor-1",
+            " ",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+
+        activation.Requests.Should().BeEmpty();
+        hub.SubscribeCalls.Should().Be(0);
     }
 
     private sealed class RecordingActivationService : IProjectionScopeActivationService<GAgentDraftRunRuntimeLease>

--- a/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
@@ -84,7 +84,7 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
         var activation = new RecordingActivationService();
         var hub = new RecordingSessionEventHub();
         var runtime = new RecordingActorRuntime();
-        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+        runtime.KnownActorIds.Add(ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
             "actor-1",
             "service-draft-run-session",
             ProjectionRuntimeMode.SessionObservation,
@@ -129,7 +129,7 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
         var activation = new RecordingActivationService();
         var hub = new RecordingSessionEventHub();
         var runtime = new RecordingActorRuntime();
-        runtime.ExistingActorIds.Add("different-scope");
+        runtime.KnownActorIds.Add("different-scope");
         var disabledPort = new GAgentDraftRunProjectionPort(
             new ServiceProjectionOptions { Enabled = false },
             activation,

--- a/test/Aevatar.GAgentService.Tests/Projection/ProjectionTestDoubles.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ProjectionTestDoubles.cs
@@ -171,3 +171,26 @@ internal sealed class NoOpServiceConfigurationReleaseService
         return Task.CompletedTask;
     }
 }
+
+internal sealed class RecordingActorRuntime : IActorRuntime
+{
+    public HashSet<string> ExistingActorIds { get; } = [];
+
+    public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+        where TAgent : IAgent =>
+        throw new NotSupportedException();
+
+    public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(null);
+
+    public Task<bool> ExistsAsync(string id) =>
+        Task.FromResult(ExistingActorIds.Count == 0 || ExistingActorIds.Contains(id));
+
+    public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+}

--- a/test/Aevatar.GAgentService.Tests/Projection/ProjectionTestDoubles.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ProjectionTestDoubles.cs
@@ -174,7 +174,7 @@ internal sealed class NoOpServiceConfigurationReleaseService
 
 internal sealed class RecordingActorRuntime : IActorRuntime
 {
-    public HashSet<string> ExistingActorIds { get; } = [];
+    public HashSet<string> KnownActorIds { get; } = [];
 
     public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
         where TAgent : IAgent =>
@@ -188,7 +188,7 @@ internal sealed class RecordingActorRuntime : IActorRuntime
     public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(null);
 
     public Task<bool> ExistsAsync(string id) =>
-        Task.FromResult(ExistingActorIds.Count == 0 || ExistingActorIds.Contains(id));
+        Task.FromResult(KnownActorIds.Contains(id));
 
     public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
 

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -106,7 +106,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
         var activation = new RecordingActivationService();
         var hub = new RecordingSessionEventHub();
         var runtime = new RecordingActorRuntime();
-        runtime.ExistingActorIds.Add(BuildScopeActorId(
+        runtime.KnownActorIds.Add(BuildScopeActorId(
             "script-actor-1",
             ScriptServiceAguiProjectionKind,
             ProjectionRuntimeMode.SessionObservation,
@@ -154,7 +154,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
         var activation = new RecordingActivationService();
         var hub = new RecordingSessionEventHub();
         var runtime = new RecordingActorRuntime();
-        runtime.ExistingActorIds.Add("different-scope");
+        runtime.KnownActorIds.Add("different-scope");
         var disabledPort = new ScriptServiceAguiProjectionPort(
             new ServiceProjectionOptions { Enabled = false },
             activation,

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -100,6 +100,106 @@ public sealed class ScriptServiceAguiProjectionPortTests
         release.Leases.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task AttachExistingRunProjection_ShouldAttachSink_WhenProjectionScopeActorExists()
+    {
+        var activation = new RecordingActivationService();
+        var hub = new RecordingSessionEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.ExistingActorIds.Add(BuildScopeActorId(
+            "script-actor-1",
+            ScriptServiceAguiProjectionKind,
+            ProjectionRuntimeMode.SessionObservation,
+            "run-1"));
+        var port = new ScriptServiceAguiProjectionPort(
+            new ServiceProjectionOptions { Enabled = true },
+            activation,
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+        var sink = new RecordingEventSink();
+
+        var attachment = await port.AttachExistingRunProjectionAsync(
+            "script-actor-1",
+            "run-1",
+            sink,
+            CancellationToken.None);
+
+        attachment.Should().NotBeNull();
+        activation.Requests.Should().BeEmpty();
+        var lease = attachment!.ProjectionLease.Should().BeOfType<ScriptServiceAguiRuntimeLease>().Subject;
+        lease.ActorId.Should().Be("script-actor-1");
+        lease.RunId.Should().Be("run-1");
+        hub.SubscribeCalls.Should().Be(1);
+        hub.LastScopeId.Should().Be("script-actor-1");
+        hub.LastSessionId.Should().Be("run-1");
+
+        await hub.Handler!(new AGUIEvent
+        {
+            RunFinished = new RunFinishedEvent
+            {
+                ThreadId = "script-actor-1",
+                RunId = "run-1",
+            },
+        });
+        sink.Events.Should().ContainSingle().Which.RunFinished.RunId.Should().Be("run-1");
+        attachment.LiveSinkLease.Should().NotBeNull();
+        await attachment.LiveSinkLease!.DisposeAsync();
+        hub.DisposedSubscriptions.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AttachExistingRunProjection_ShouldReturnNull_WhenProjectionIsColdOrInvalid()
+    {
+        var activation = new RecordingActivationService();
+        var hub = new RecordingSessionEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.ExistingActorIds.Add("different-scope");
+        var disabledPort = new ScriptServiceAguiProjectionPort(
+            new ServiceProjectionOptions { Enabled = false },
+            activation,
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+        var enabledPort = new ScriptServiceAguiProjectionPort(
+            new ServiceProjectionOptions { Enabled = true },
+            activation,
+            new RecordingReleaseService(),
+            hub,
+            runtime);
+
+        (await disabledPort.AttachExistingRunProjectionAsync(
+            "script-actor-1",
+            "run-1",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+        (await enabledPort.AttachExistingRunProjectionAsync(
+            "script-actor-1",
+            "run-1",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+        (await enabledPort.AttachExistingRunProjectionAsync(
+            "",
+            "run-1",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+        (await enabledPort.AttachExistingRunProjectionAsync(
+            "script-actor-1",
+            " ",
+            new RecordingEventSink(),
+            CancellationToken.None)).Should().BeNull();
+
+        activation.Requests.Should().BeEmpty();
+        hub.SubscribeCalls.Should().Be(0);
+    }
+
+    private static string BuildScopeActorId(
+        string actorId,
+        string projectionKind,
+        ProjectionRuntimeMode mode,
+        string sessionId) =>
+        ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(actorId, projectionKind, mode, sessionId));
+
     private sealed class RecordingActivationService : IProjectionScopeActivationService<ScriptServiceAguiRuntimeLease>
     {
         public List<ProjectionScopeStartRequest> Requests { get; } = [];

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.GAgentService.Projection.Orchestration;
@@ -27,7 +28,8 @@ public sealed class ScriptServiceAguiProjectionPortTests
             new ServiceProjectionOptions { Enabled = true },
             activation,
             release,
-            hub);
+            hub,
+            new RecordingActorRuntime());
         var sink = new RecordingEventSink();
 
         var lease = await port.EnsureRunProjectionAsync("script-actor-1", "run-1", CancellationToken.None);
@@ -75,7 +77,8 @@ public sealed class ScriptServiceAguiProjectionPortTests
             new ServiceProjectionOptions { Enabled = false },
             activation,
             release,
-            hub);
+            hub,
+            new RecordingActorRuntime());
 
         var lease = await port.EnsureRunProjectionAsync("script-actor-1", "run-1", CancellationToken.None);
         await port.AttachLiveSinkAsync(new ScriptServiceAguiRuntimeLease(new ScriptServiceAguiProjectionContext

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -196,7 +196,7 @@ public sealed class ServiceProjectionInfrastructureTests
                 InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(projectionName),
             });
         var runtime = new RecordingActorRuntime();
-        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+        runtime.KnownActorIds.Add(ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
             "actor-1",
             "gagent-run-terminal-draft-run",
             ProjectionRuntimeMode.DurableMaterialization,
@@ -232,7 +232,7 @@ public sealed class ServiceProjectionInfrastructureTests
                 InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(projectionName),
             });
         var runtime = new RecordingActorRuntime();
-        runtime.ExistingActorIds.Add("different-scope");
+        runtime.KnownActorIds.Add("different-scope");
         IGAgentRunTerminalProjectionPort disabledService = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions { Enabled = false },
             activationService,

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -114,7 +114,8 @@ public sealed class ServiceProjectionInfrastructureTests
         IGAgentRunTerminalProjectionPort service = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions(),
             activationService,
-            releaseService);
+            releaseService,
+            new RecordingActorRuntime());
 
         var draftLease = await service.EnsureProjectionAsync(
             "actor-1",
@@ -159,11 +160,13 @@ public sealed class ServiceProjectionInfrastructureTests
         IGAgentRunTerminalProjectionPort disabledService = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions { Enabled = false },
             activationService,
-            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>());
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            new RecordingActorRuntime());
         IGAgentRunTerminalProjectionPort enabledService = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions(),
             activationService,
-            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>());
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            new RecordingActorRuntime());
 
         (await disabledService.EnsureProjectionAsync(
             "actor-1",
@@ -195,7 +198,8 @@ public sealed class ServiceProjectionInfrastructureTests
         IGAgentRunTerminalProjectionPort service = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions(),
             activationService,
-            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>());
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            new RecordingActorRuntime());
 
         Func<Task> releaseNull = () => service.ReleaseProjectionAsync(null!);
         Func<Task> releaseForeignLease = () => service.ReleaseProjectionAsync(new ForeignGAgentRunTerminalProjectionLease());

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -185,6 +185,87 @@ public sealed class ServiceProjectionInfrastructureTests
     }
 
     [Fact]
+    public async Task GAgentRunTerminalProjectionPort_ShouldAttachExistingProjection_WhenScopeActorExists()
+    {
+        var activationService = new RecordingProjectionActivationService<GAgentRunTerminalProjectionContext>(
+            static (rootActorId, projectionName) => new GAgentRunTerminalProjectionContext
+            {
+                RootActorId = rootActorId,
+                ProjectionKind = projectionName,
+                CorrelationId = "corr-1",
+                InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(projectionName),
+            });
+        var runtime = new RecordingActorRuntime();
+        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+            "actor-1",
+            "gagent-run-terminal-draft-run",
+            ProjectionRuntimeMode.DurableMaterialization,
+            "corr-1")));
+        IGAgentRunTerminalProjectionPort service = new GAgentRunTerminalProjectionPort(
+            new ServiceProjectionOptions(),
+            activationService,
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            runtime);
+
+        var lease = await service.AttachExistingProjectionAsync(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.DraftRun);
+
+        lease.Should().NotBeNull();
+        lease!.ActorId.Should().Be("actor-1");
+        lease.CorrelationId.Should().Be("corr-1");
+        lease.InteractionKind.Should().Be(GAgentRunTerminalInteractionKind.DraftRun);
+        activationService.Requests.Should().BeEmpty();
+        activationService.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GAgentRunTerminalProjectionPort_ShouldReturnNullForAttachExisting_WhenScopeActorIsMissingOrInvalid()
+    {
+        var activationService = new RecordingProjectionActivationService<GAgentRunTerminalProjectionContext>(
+            static (rootActorId, projectionName) => new GAgentRunTerminalProjectionContext
+            {
+                RootActorId = rootActorId,
+                ProjectionKind = projectionName,
+                CorrelationId = "corr-1",
+                InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(projectionName),
+            });
+        var runtime = new RecordingActorRuntime();
+        runtime.ExistingActorIds.Add("different-scope");
+        IGAgentRunTerminalProjectionPort disabledService = new GAgentRunTerminalProjectionPort(
+            new ServiceProjectionOptions { Enabled = false },
+            activationService,
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            runtime);
+        IGAgentRunTerminalProjectionPort enabledService = new GAgentRunTerminalProjectionPort(
+            new ServiceProjectionOptions(),
+            activationService,
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            runtime);
+
+        (await disabledService.AttachExistingProjectionAsync(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.DraftRun)).Should().BeNull();
+        (await enabledService.AttachExistingProjectionAsync(
+            "actor-1",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.DraftRun)).Should().BeNull();
+        (await enabledService.AttachExistingProjectionAsync(
+            "",
+            "corr-1",
+            GAgentRunTerminalInteractionKind.DraftRun)).Should().BeNull();
+        (await enabledService.AttachExistingProjectionAsync(
+            "actor-1",
+            " ",
+            GAgentRunTerminalInteractionKind.DraftRun)).Should().BeNull();
+
+        activationService.Requests.Should().BeEmpty();
+        activationService.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GAgentRunTerminalProjectionPort_ShouldGuardReleaseAndUnknownKinds()
     {
         var activationService = new RecordingProjectionActivationService<GAgentRunTerminalProjectionContext>(


### PR DESCRIPTION
## 摘要

iter37 cluster-037-gagentservice-binders-attach-existing(高优先级,Phase 9 r1 + reflector r1 force-pick attach-existing)。

- **Old**:GAgentService interaction binders 同步 prime projection sessions before dispatch(request-path projection activation in BindAsync)。
- **New**:Attach-existing only(capability-specific ports);删 request-path projection activation;cold sessions return `ProjectionUnavailable` / pending;**禁止**top-level CLAUDE.md live-observation exception。

违反:CLAUDE.md「Query priming 禁止」+「权威状态 / Projection」(同 #834/#842/#844 attach-existing pattern)。

## 范围

21 文件改动(+451 / -59 LOC,净 +392)。

🤖 Auto-loop / codex-refactor-loop iter37

Closes #843

⟦AI:AUTO-LOOP⟧
