### PR TITLE
iter38 cluster-038 streaming-proxy: 复用 IStreamingProxyRoomCommandService

### DIFF
--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -123,19 +123,20 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
 
         var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
         if (actor is null)
-            return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.RoomNotFound, null);
+            return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.RoomNotFound, null, null);
 
         var agentId = NormalizeRequiredValue(command.AgentId, nameof(command.AgentId));
+        var displayName = NormalizeOptionalValue(command.DisplayName) ?? agentId;
         var envelope = BuildRoomEnvelope(
             actor.Id,
             new GroupChatParticipantJoinedEvent
             {
                 AgentId = agentId,
-                DisplayName = NormalizeOptionalValue(command.DisplayName) ?? agentId,
+                DisplayName = displayName,
             });
 
         await DispatchRoomEnvelopeAsync(actor.Id, envelope, cancellationToken);
-        return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.Joined, agentId);
+        return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.Joined, agentId, displayName);
     }
 
     public Task PublishTerminalStateAsync(

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -7,8 +7,8 @@ using Microsoft.Extensions.Logging;
 namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
 
 // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-//   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-//   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+//   Old pattern: endpoints built room envelopes and dispatched post-message, join, and terminal-state events directly.
+//   New principle: the existing room command service owns room command normalization, envelope construction, and dispatch.
 public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomCommandService
 {
     private const string DefaultRoomName = "Group Chat";
@@ -88,9 +88,6 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         StreamingProxyRoomPostMessageCommand command,
         CancellationToken cancellationToken = default)
     {
-        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         ArgumentNullException.ThrowIfNull(command);
 
         var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
@@ -116,9 +113,6 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         StreamingProxyRoomJoinCommand command,
         CancellationToken cancellationToken = default)
     {
-        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         ArgumentNullException.ThrowIfNull(command);
 
         var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
@@ -143,9 +137,6 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         StreamingProxyRoomTerminalStateCommand command,
         CancellationToken cancellationToken = default)
     {
-        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         ArgumentNullException.ThrowIfNull(command);
 
         var roomId = NormalizeRequiredValue(command.RoomId, nameof(command.RoomId));

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -1,13 +1,14 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
 
-// Refactor (iter23/cluster-002):
-//   Old pattern: Command ports synchronously activate projection scopes before dispatch and sometimes turn projection lease failure into command admission failure.
-//   New principle: Command ports dispatch accepted commands; projection activation is owned by committed-state hooks, explicit observation binders, startup activators, or background materializers.
+// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+//   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+//   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
 public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomCommandService
 {
     private const string DefaultRoomName = "Group Chat";
@@ -83,6 +84,83 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         }
     }
 
+    public async Task<StreamingProxyRoomPostMessageResult> PostMessageAsync(
+        StreamingProxyRoomPostMessageCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+        ArgumentNullException.ThrowIfNull(command);
+
+        var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
+        if (actor is null)
+            return new StreamingProxyRoomPostMessageResult(StreamingProxyRoomPostMessageStatus.RoomNotFound);
+
+        var agentId = NormalizeRequiredValue(command.AgentId, nameof(command.AgentId));
+        var envelope = BuildRoomEnvelope(
+            actor.Id,
+            new GroupChatMessageEvent
+            {
+                AgentId = agentId,
+                AgentName = NormalizeOptionalValue(command.AgentName) ?? agentId,
+                Content = NormalizeRequiredValue(command.Content, nameof(command.Content)),
+                SessionId = NormalizeOptionalValue(command.SessionId) ?? Guid.NewGuid().ToString("N"),
+            });
+
+        await DispatchRoomEnvelopeAsync(actor.Id, envelope, cancellationToken);
+        return new StreamingProxyRoomPostMessageResult(StreamingProxyRoomPostMessageStatus.Accepted);
+    }
+
+    public async Task<StreamingProxyRoomJoinResult> JoinAsync(
+        StreamingProxyRoomJoinCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+        ArgumentNullException.ThrowIfNull(command);
+
+        var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
+        if (actor is null)
+            return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.RoomNotFound, null);
+
+        var agentId = NormalizeRequiredValue(command.AgentId, nameof(command.AgentId));
+        var envelope = BuildRoomEnvelope(
+            actor.Id,
+            new GroupChatParticipantJoinedEvent
+            {
+                AgentId = agentId,
+                DisplayName = NormalizeOptionalValue(command.DisplayName) ?? agentId,
+            });
+
+        await DispatchRoomEnvelopeAsync(actor.Id, envelope, cancellationToken);
+        return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.Joined, agentId);
+    }
+
+    public Task PublishTerminalStateAsync(
+        StreamingProxyRoomTerminalStateCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+        ArgumentNullException.ThrowIfNull(command);
+
+        var roomId = NormalizeRequiredValue(command.RoomId, nameof(command.RoomId));
+        var envelope = BuildRoomEnvelope(
+            roomId,
+            new StreamingProxyChatSessionTerminalStateChanged
+            {
+                SessionId = NormalizeRequiredValue(command.SessionId, nameof(command.SessionId)),
+                Status = command.Status,
+                TerminalAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ErrorMessage = command.ErrorMessage ?? string.Empty,
+            });
+
+        return DispatchRoomEnvelopeAsync(roomId, envelope, cancellationToken);
+    }
+
     private static string NormalizeRequiredScopeId(string? scopeId)
     {
         var normalized = scopeId?.Trim();
@@ -98,14 +176,35 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         return string.IsNullOrWhiteSpace(normalized) ? DefaultRoomName : normalized;
     }
 
+    private static string NormalizeRequiredValue(string? value, string parameterName)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+            throw new ArgumentException($"{parameterName} is required.", parameterName);
+
+        return normalized;
+    }
+
+    private static string? NormalizeOptionalValue(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
     private static EventEnvelope BuildRoomInitializedEnvelope(string actorId, string roomName)
     {
         var initEvent = new GroupChatRoomInitializedEvent { RoomName = roomName };
+        return BuildRoomEnvelope(actorId, initEvent);
+    }
+
+    private static EventEnvelope BuildRoomEnvelope(string actorId, IMessage payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
         return new EventEnvelope
         {
             Id = Guid.NewGuid().ToString("N"),
             Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(initEvent),
+            Payload = Any.Pack(payload),
             Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actorId } },
         };
     }

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
@@ -26,7 +26,9 @@ public sealed record StreamingProxyRoomCreateCommand(
     string ScopeId,
     string? RoomName);
 
-// refactor helper, no behavior change
+// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+//   Old pattern: Streaming proxy endpoints built post-message room envelopes directly in Host code.
+//   New principle: The Application command service owns typed message normalization and dispatch.
 public sealed record StreamingProxyRoomPostMessageCommand(
     string RoomId,
     string AgentId,
@@ -34,13 +36,17 @@ public sealed record StreamingProxyRoomPostMessageCommand(
     string Content,
     string? SessionId);
 
-// refactor helper, no behavior change
+// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+//   Old pattern: Streaming proxy endpoints built join room envelopes and duplicated participant normalization in Host code.
+//   New principle: The Application command service owns typed join normalization and returns the normalized participant identity.
 public sealed record StreamingProxyRoomJoinCommand(
     string RoomId,
     string AgentId,
     string? DisplayName);
 
-// refactor helper, no behavior change
+// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+//   Old pattern: Streaming proxy endpoints published terminal state envelopes through raw dispatch helpers.
+//   New principle: The Application command service owns typed terminal-state publication without adding a second room interaction port.
 public sealed record StreamingProxyRoomTerminalStateCommand(
     string RoomId,
     string SessionId,
@@ -57,7 +63,8 @@ public sealed record StreamingProxyRoomPostMessageResult(
 
 public sealed record StreamingProxyRoomJoinResult(
     StreamingProxyRoomJoinStatus Status,
-    string? AgentId);
+    string? AgentId,
+    string? DisplayName);
 
 public enum StreamingProxyRoomCreateStatus
 {

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
@@ -5,20 +5,75 @@ public interface IStreamingProxyRoomCommandService
     Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
         StreamingProxyRoomCreateCommand command,
         CancellationToken cancellationToken = default);
+
+    Task<StreamingProxyRoomPostMessageResult> PostMessageAsync(
+        StreamingProxyRoomPostMessageCommand command,
+        CancellationToken cancellationToken = default);
+
+    Task<StreamingProxyRoomJoinResult> JoinAsync(
+        StreamingProxyRoomJoinCommand command,
+        CancellationToken cancellationToken = default);
+
+    Task PublishTerminalStateAsync(
+        StreamingProxyRoomTerminalStateCommand command,
+        CancellationToken cancellationToken = default);
 }
 
+// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+//   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+//   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
 public sealed record StreamingProxyRoomCreateCommand(
     string ScopeId,
     string? RoomName);
+
+// refactor helper, no behavior change
+public sealed record StreamingProxyRoomPostMessageCommand(
+    string RoomId,
+    string AgentId,
+    string? AgentName,
+    string Content,
+    string? SessionId);
+
+// refactor helper, no behavior change
+public sealed record StreamingProxyRoomJoinCommand(
+    string RoomId,
+    string AgentId,
+    string? DisplayName);
+
+// refactor helper, no behavior change
+public sealed record StreamingProxyRoomTerminalStateCommand(
+    string RoomId,
+    string SessionId,
+    StreamingProxyChatSessionTerminalStatus Status,
+    string? ErrorMessage);
 
 public sealed record StreamingProxyRoomCreateResult(
     StreamingProxyRoomCreateStatus Status,
     string? RoomId,
     string? RoomName);
 
+public sealed record StreamingProxyRoomPostMessageResult(
+    StreamingProxyRoomPostMessageStatus Status);
+
+public sealed record StreamingProxyRoomJoinResult(
+    StreamingProxyRoomJoinStatus Status,
+    string? AgentId);
+
 public enum StreamingProxyRoomCreateStatus
 {
     Created = 0,
     AdmissionUnavailable = 1,
     Failed = 2,
+}
+
+public enum StreamingProxyRoomPostMessageStatus
+{
+    Accepted = 0,
+    RoomNotFound = 1,
+}
+
+public enum StreamingProxyRoomJoinStatus
+{
+    Joined = 0,
+    RoomNotFound = 1,
 }

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
@@ -1,5 +1,8 @@
 namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
 
+// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+//   Old pattern: endpoints exposed room actions by composing actor lookup, raw envelopes, and dispatch locally.
+//   New principle: callers use this existing Application command service for typed room create, post, join, and terminal-state commands.
 public interface IStreamingProxyRoomCommandService
 {
     Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
@@ -20,8 +23,8 @@ public interface IStreamingProxyRoomCommandService
 }
 
 // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-//   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-//   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+//   Old pattern: room create was the only typed command contract while related room actions stayed endpoint-local.
+//   New principle: command, result, and status contracts describe the room command-service boundary explicitly.
 public sealed record StreamingProxyRoomCreateCommand(
     string ScopeId,
     string? RoomName);

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -519,7 +519,7 @@ public static class StreamingProxyEndpoints
             return Results.NotFound(new { error = "Room not found" });
 
         var agentId = result.AgentId ?? request.AgentId.Trim();
-        var displayName = request.DisplayName?.Trim() ?? agentId;
+        var displayName = result.DisplayName ?? agentId;
 
         var logger = loggerFactory.CreateLogger("Aevatar.GAgents.StreamingProxy.Endpoints");
         try

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -21,8 +21,8 @@ namespace Aevatar.GAgents.StreamingProxy;
 public static class StreamingProxyEndpoints
 {
     // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-    //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-    //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+    //   Old pattern: endpoints built post-message, join, and terminal-state room envelopes directly in Host code.
+    //   New principle: endpoints validate HTTP concerns and delegate typed room commands to the existing room command service.
     public static IEndpointRouteBuilder MapStreamingProxyEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/scopes").WithTags("StreamingProxy");
@@ -261,12 +261,12 @@ public static class StreamingProxyEndpoints
                         token,
                         participantStore,
                         roomId));
-                    await PublishTerminalStateAsync(
-                        roomCommandService,
-                        actor.Id,
-                        sessionId,
-                        terminalState.Status,
-                        terminalState.ErrorMessage,
+                    await roomCommandService.PublishTerminalStateAsync(
+                        new StreamingProxyRoomTerminalStateCommand(
+                            actor.Id,
+                            sessionId,
+                            terminalState.Status,
+                            terminalState.ErrorMessage),
                         token);
                 },
                 ct);
@@ -325,9 +325,6 @@ public static class StreamingProxyEndpoints
         [FromServices] IScopeResourceAdmissionPort admissionPort,
         CancellationToken ct)
     {
-        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -494,9 +491,6 @@ public static class StreamingProxyEndpoints
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
-        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -639,22 +633,6 @@ public static class StreamingProxyEndpoints
         out StreamingProxyChatSessionTerminalStateChanged terminalEvent)
         => StreamingProxyRoomInteractionHelpers.TryGetTerminalEvent(envelope, out terminalEvent);
 
-    private static async Task PublishTerminalStateAsync(
-        IStreamingProxyRoomCommandService roomCommandService,
-        string actorId,
-        string sessionId,
-        StreamingProxyChatSessionTerminalStatus status,
-        string? errorMessage,
-        CancellationToken ct)
-    {
-        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
-        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
-        await roomCommandService.PublishTerminalStateAsync(
-            new StreamingProxyRoomTerminalStateCommand(actorId, sessionId, status, errorMessage),
-            ct);
-    }
-
     private static (StreamingProxyChatSessionTerminalStatus Status, string? ErrorMessage) DetermineParticipantTerminalState(
         int successfulReplies) =>
         successfulReplies > 0
@@ -677,12 +655,12 @@ public static class StreamingProxyEndpoints
             if (durableCompletion is StreamingProxyProjectionCompletionStatus.Completed or StreamingProxyProjectionCompletionStatus.Failed)
                 return;
 
-            await PublishTerminalStateAsync(
-                roomCommandService,
-                actor.Id,
-                sessionId,
-                StreamingProxyChatSessionTerminalStatus.Failed,
-                "StreamingProxy chat was cancelled before completion.",
+            await roomCommandService.PublishTerminalStateAsync(
+                new StreamingProxyRoomTerminalStateCommand(
+                    actor.Id,
+                    sessionId,
+                    StreamingProxyChatSessionTerminalStatus.Failed,
+                    "StreamingProxy chat was cancelled before completion."),
                 CancellationToken.None);
         }
         catch (Exception ex)
@@ -712,12 +690,12 @@ public static class StreamingProxyEndpoints
             if (durableCompletion is StreamingProxyProjectionCompletionStatus.Completed or StreamingProxyProjectionCompletionStatus.Failed)
                 return;
 
-            await PublishTerminalStateAsync(
-                roomCommandService,
-                actor.Id,
-                sessionId,
-                StreamingProxyChatSessionTerminalStatus.Failed,
-                errorMessage,
+            await roomCommandService.PublishTerminalStateAsync(
+                new StreamingProxyRoomTerminalStateCommand(
+                    actor.Id,
+                    sessionId,
+                    StreamingProxyChatSessionTerminalStatus.Failed,
+                    errorMessage),
                 CancellationToken.None);
         }
         catch (Exception ex)

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -20,6 +20,9 @@ namespace Aevatar.GAgents.StreamingProxy;
 
 public static class StreamingProxyEndpoints
 {
+    // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+    //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+    //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
     public static IEndpointRouteBuilder MapStreamingProxyEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/scopes").WithTags("StreamingProxy");
@@ -175,7 +178,7 @@ public static class StreamingProxyEndpoints
         string roomId,
         ChatTopicRequest request,
         [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
+        [FromServices] IStreamingProxyRoomCommandService roomCommandService,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
         [FromServices] ICommandInteractionService<StreamingProxyRoomChatCommand, StreamingProxyRoomChatAcceptedReceipt, StreamingProxyRoomChatStartError, StreamingProxyRoomSessionEnvelope, StreamingProxyProjectionCompletionStatus> interactionService,
         [FromServices] StreamingProxyChatDurableCompletionResolver durableCompletionResolver,
@@ -259,7 +262,7 @@ public static class StreamingProxyEndpoints
                         participantStore,
                         roomId));
                     await PublishTerminalStateAsync(
-                        actorDispatchPort,
+                        roomCommandService,
                         actor.Id,
                         sessionId,
                         terminalState.Status,
@@ -290,13 +293,13 @@ public static class StreamingProxyEndpoints
         }
         catch (OperationCanceledException)
         {
-            await TryPublishCanceledTerminalStateAsync(actorDispatchPort, actor, sessionId, durableCompletionResolver, logger);
+            await TryPublishCanceledTerminalStateAsync(roomCommandService, actor, sessionId, durableCompletionResolver, logger);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "StreamingProxy chat failed for room {RoomId}", roomId);
             await TryPublishFailedTerminalStateAsync(
-                actorDispatchPort,
+                roomCommandService,
                 actor,
                 sessionId,
                 "StreamingProxy chat failed before completion.",
@@ -318,11 +321,13 @@ public static class StreamingProxyEndpoints
         string scopeId,
         string roomId,
         PostMessageRequest request,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
+        [FromServices] IStreamingProxyRoomCommandService roomCommandService,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
         CancellationToken ct)
     {
+        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -338,26 +343,16 @@ public static class StreamingProxyEndpoints
         if (admissionError != null)
             return admissionError;
 
-        var actor = await actorRuntime.GetAsync(roomId);
-        if (actor is null)
+        var result = await roomCommandService.PostMessageAsync(
+            new StreamingProxyRoomPostMessageCommand(
+                roomId,
+                request.AgentId,
+                request.AgentName,
+                request.Content,
+                request.SessionId),
+            ct);
+        if (result.Status == StreamingProxyRoomPostMessageStatus.RoomNotFound)
             return Results.NotFound(new { error = "Room not found" });
-
-        var messageEvent = new GroupChatMessageEvent
-        {
-            AgentId = request.AgentId.Trim(),
-            AgentName = request.AgentName?.Trim() ?? request.AgentId.Trim(),
-            Content = request.Content.Trim(),
-            SessionId = request.SessionId ?? Guid.NewGuid().ToString("N"),
-        };
-
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(messageEvent),
-            Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actor.Id } },
-        };
-        await DispatchRoomEnvelopeAsync(actorDispatchPort, actor.Id, envelope, ct);
 
         return Results.Ok(new { status = "accepted" });
     }
@@ -493,13 +488,15 @@ public static class StreamingProxyEndpoints
         string scopeId,
         string roomId,
         JoinRoomRequest request,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort actorDispatchPort,
+        [FromServices] IStreamingProxyRoomCommandService roomCommandService,
         [FromServices] IScopeResourceAdmissionPort admissionPort,
         [FromServices] IStreamingProxyParticipantStore participantStore,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
+        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
         if (AevatarScopeAccessGuard.TryCreateScopeAccessDeniedResult(http, scopeId, out var denied))
             return denied;
 
@@ -515,27 +512,14 @@ public static class StreamingProxyEndpoints
         if (admissionError != null)
             return admissionError;
 
-        var actor = await actorRuntime.GetAsync(roomId);
-        if (actor is null)
+        var result = await roomCommandService.JoinAsync(
+            new StreamingProxyRoomJoinCommand(roomId, request.AgentId, request.DisplayName),
+            ct);
+        if (result.Status == StreamingProxyRoomJoinStatus.RoomNotFound)
             return Results.NotFound(new { error = "Room not found" });
 
-        var agentId = request.AgentId.Trim();
+        var agentId = result.AgentId ?? request.AgentId.Trim();
         var displayName = request.DisplayName?.Trim() ?? agentId;
-
-        var joinEvent = new GroupChatParticipantJoinedEvent
-        {
-            AgentId = agentId,
-            DisplayName = displayName,
-        };
-
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(joinEvent),
-            Route = new EnvelopeRoute { Direct = new DirectRoute { TargetActorId = actor.Id } },
-        };
-        await DispatchRoomEnvelopeAsync(actorDispatchPort, actor.Id, envelope, ct);
 
         var logger = loggerFactory.CreateLogger("Aevatar.GAgents.StreamingProxy.Endpoints");
         try
@@ -656,46 +640,19 @@ public static class StreamingProxyEndpoints
         => StreamingProxyRoomInteractionHelpers.TryGetTerminalEvent(envelope, out terminalEvent);
 
     private static async Task PublishTerminalStateAsync(
-        IActorDispatchPort actorDispatchPort,
+        IStreamingProxyRoomCommandService roomCommandService,
         string actorId,
         string sessionId,
         StreamingProxyChatSessionTerminalStatus status,
         string? errorMessage,
         CancellationToken ct)
     {
-        var terminalEvent = new StreamingProxyChatSessionTerminalStateChanged
-        {
-            SessionId = sessionId,
-            Status = status,
-            TerminalAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            ErrorMessage = errorMessage ?? string.Empty,
-        };
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(terminalEvent),
-            Route = new EnvelopeRoute
-            {
-                Direct = new DirectRoute
-                {
-                    TargetActorId = actorId,
-                },
-            },
-        };
-        await DispatchRoomEnvelopeAsync(actorDispatchPort, actorId, envelope, ct);
-    }
-
-    private static Task DispatchRoomEnvelopeAsync(
-        IActorDispatchPort actorDispatchPort,
-        string actorId,
-        EventEnvelope envelope,
-        CancellationToken ct)
-    {
-        // Refactor (iter1/cluster-004):
-        //   Old pattern: StreamingProxy endpoints invoked actors inline.
-        //   New principle: endpoints publish commands through IActorDispatchPort with runtime-neutral delivery.
-        return actorDispatchPort.DispatchAsync(actorId, envelope, ct);
+        // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
+        //   Old pattern: Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
+        //   New principle: Extend existing IStreamingProxyRoomCommandService with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止** new IStreamingProxyRoomInteractionPort / 新 actor / 新 envelope / full CQRS skeleton。
+        await roomCommandService.PublishTerminalStateAsync(
+            new StreamingProxyRoomTerminalStateCommand(actorId, sessionId, status, errorMessage),
+            ct);
     }
 
     private static (StreamingProxyChatSessionTerminalStatus Status, string? ErrorMessage) DetermineParticipantTerminalState(
@@ -705,7 +662,7 @@ public static class StreamingProxyEndpoints
             : (StreamingProxyChatSessionTerminalStatus.Failed, "StreamingProxy chat completed without any participant replies.");
 
     private static async Task TryPublishCanceledTerminalStateAsync(
-        IActorDispatchPort actorDispatchPort,
+        IStreamingProxyRoomCommandService roomCommandService,
         IActor? actor,
         string? sessionId,
         StreamingProxyChatDurableCompletionResolver durableCompletionResolver,
@@ -721,7 +678,7 @@ public static class StreamingProxyEndpoints
                 return;
 
             await PublishTerminalStateAsync(
-                actorDispatchPort,
+                roomCommandService,
                 actor.Id,
                 sessionId,
                 StreamingProxyChatSessionTerminalStatus.Failed,
@@ -739,7 +696,7 @@ public static class StreamingProxyEndpoints
     }
 
     private static async Task TryPublishFailedTerminalStateAsync(
-        IActorDispatchPort actorDispatchPort,
+        IStreamingProxyRoomCommandService roomCommandService,
         IActor? actor,
         string? sessionId,
         string errorMessage,
@@ -756,7 +713,7 @@ public static class StreamingProxyEndpoints
                 return;
 
             await PublishTerminalStateAsync(
-                actorDispatchPort,
+                roomCommandService,
                 actor.Id,
                 sessionId,
                 StreamingProxyChatSessionTerminalStatus.Failed,

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -244,7 +244,7 @@ public class StreamingProxyCoverageTests
     {
         var context = CreateScopedHttpContext();
         var runtime = new StubActorRuntime();
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var interactionService = new StubStreamingProxyRoomChatInteractionService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
         var participantStore = new StubParticipantStore();
@@ -254,7 +254,7 @@ public class StreamingProxyCoverageTests
         var method = typeof(StreamingProxyEndpoints).GetMethod(
             "HandleChatAsync",
             BindingFlags.NonPublic | BindingFlags.Static)!;
-        var task = method.Invoke(null, [context, "scope-a", "room-a", new ChatTopicRequest(null), runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
+        var task = method.Invoke(null, [context, "scope-a", "room-a", new ChatTopicRequest(null), runtime, roomCommandService, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
         await InvokeTaskAsync(task);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
@@ -267,7 +267,7 @@ public class StreamingProxyCoverageTests
         var context = CreateScopedHttpContext("scope-b");
         context.Response.Body = new MemoryStream();
         var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var interactionService = new StubStreamingProxyRoomChatInteractionService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
         var participantStore = new StubParticipantStore();
@@ -279,7 +279,7 @@ public class StreamingProxyCoverageTests
             BindingFlags.NonPublic | BindingFlags.Static)!;
         var task = method.Invoke(
             null,
-            [context, "scope-a", "room-a", new ChatTopicRequest("hello"), runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
+            [context, "scope-a", "room-a", new ChatTopicRequest("hello"), runtime, roomCommandService, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]);
         await InvokeTaskAsync(task);
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
@@ -486,7 +486,7 @@ public class StreamingProxyCoverageTests
         var context = CreateScopedHttpContext();
         context.Response.Body = new MemoryStream();
         var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var interactionService = new StubStreamingProxyRoomChatInteractionService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(
             new StubTerminalQueryPort(StreamingProxyChatSessionTerminalStatus.Completed));
@@ -577,14 +577,14 @@ public class StreamingProxyCoverageTests
             BindingFlags.NonPublic | BindingFlags.Static)!;
         await InvokeTaskAsync(method.Invoke(
             null,
-            [context, "scope-a", "room-a", request, runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]));
+            [context, "scope-a", "room-a", request, runtime, roomCommandService, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, CancellationToken.None]));
 
         interactionService.Commands.Should().ContainSingle().Which.Should().Be(new StreamingProxyRoomChatCommand(
             "room-a",
             "scope-a",
             "Discuss webhook relay",
             "session-123"));
-        dispatchPort.Dispatches.Should().BeEmpty();
+        roomCommandService.TerminalCommands.Should().BeEmpty();
 
         context.Response.Body.Position = 0;
         var body = await new StreamReader(context.Response.Body).ReadToEndAsync();
@@ -600,7 +600,7 @@ public class StreamingProxyCoverageTests
         context.Response.Body = new MemoryStream();
         var actor = new StubActor("room-a");
         var runtime = new StubActorRuntime(new List<IActor> { actor });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var interactionService = new StubStreamingProxyRoomChatInteractionService
         {
             WaitForCancellation = true,
@@ -616,17 +616,16 @@ public class StreamingProxyCoverageTests
             BindingFlags.NonPublic | BindingFlags.Static)!;
         var task = InvokeTaskAsync(method.Invoke(
             null,
-            [context, "scope-a", "room-a", new ChatTopicRequest("Cancel me", "session-cancel"), runtime, dispatchPort, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, cts.Token]));
+            [context, "scope-a", "room-a", new ChatTopicRequest("Cancel me", "session-cancel"), runtime, roomCommandService, actorStore, interactionService, durableCompletionResolver, participantStore, coordinator, NullLoggerFactory.Instance, cts.Token]));
 
         await interactionService.Started.Task;
         cts.Cancel();
         await task;
 
-        dispatchPort.Dispatches.Select(x => x.Envelope).Should().Contain(envelope =>
-            envelope.Payload.Is(StreamingProxyChatSessionTerminalStateChanged.Descriptor) &&
-            envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().SessionId == "session-cancel" &&
-            envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().Status == StreamingProxyChatSessionTerminalStatus.Failed &&
-            envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().ErrorMessage == "StreamingProxy chat was cancelled before completion.");
+        roomCommandService.TerminalCommands.Should().ContainSingle(command =>
+            command.SessionId == "session-cancel" &&
+            command.Status == StreamingProxyChatSessionTerminalStatus.Failed &&
+            command.ErrorMessage == "StreamingProxy chat was cancelled before completion.");
     }
 
     [Fact]
@@ -893,8 +892,7 @@ public class StreamingProxyCoverageTests
     public async Task TryPublishFailedTerminalStateAsync_ShouldEmitFailedTerminalEvent_WhenCompletionIsUnknown()
     {
         var actor = new StubActor("room-a");
-        var runtime = new StubActorRuntime(new List<IActor> { actor });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(new StubTerminalQueryPort());
         var logger = NullLogger.Instance;
         var method = typeof(StreamingProxyEndpoints).GetMethod(
@@ -903,21 +901,19 @@ public class StreamingProxyCoverageTests
 
         await InvokeTaskAsync(method.Invoke(
             null,
-            [dispatchPort, actor, "session-123", "StreamingProxy chat failed before completion.", durableCompletionResolver, logger]));
+            [roomCommandService, actor, "session-123", "StreamingProxy chat failed before completion.", durableCompletionResolver, logger]));
 
-        dispatchPort.Dispatches.Select(x => x.Envelope).Should().Contain(envelope =>
-            envelope.Payload.Is(StreamingProxyChatSessionTerminalStateChanged.Descriptor) &&
-            envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().SessionId == "session-123" &&
-            envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().Status == StreamingProxyChatSessionTerminalStatus.Failed &&
-            envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>().ErrorMessage == "StreamingProxy chat failed before completion.");
+        roomCommandService.TerminalCommands.Should().ContainSingle(command =>
+            command.SessionId == "session-123" &&
+            command.Status == StreamingProxyChatSessionTerminalStatus.Failed &&
+            command.ErrorMessage == "StreamingProxy chat failed before completion.");
     }
 
     [Fact]
     public async Task TryPublishFailedTerminalStateAsync_ShouldNotEmitTerminalEvent_WhenCompletionAlreadyVisible()
     {
         var actor = new StubActor("room-a");
-        var runtime = new StubActorRuntime(new List<IActor> { actor });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var durableCompletionResolver = new StreamingProxyChatDurableCompletionResolver(
             new StubTerminalQueryPort(StreamingProxyChatSessionTerminalStatus.Completed));
         var logger = NullLogger.Instance;
@@ -927,10 +923,9 @@ public class StreamingProxyCoverageTests
 
         await InvokeTaskAsync(method.Invoke(
             null,
-            [dispatchPort, actor, "session-123", "StreamingProxy chat failed before completion.", durableCompletionResolver, logger]));
+            [roomCommandService, actor, "session-123", "StreamingProxy chat failed before completion.", durableCompletionResolver, logger]));
 
-        dispatchPort.Dispatches.Select(x => x.Envelope).Should().NotContain(envelope =>
-            envelope.Payload.Is(StreamingProxyChatSessionTerminalStateChanged.Descriptor));
+        roomCommandService.TerminalCommands.Should().BeEmpty();
     }
 
     [Fact]
@@ -1063,13 +1058,17 @@ public class StreamingProxyCoverageTests
     [Fact]
     public async Task HandlePostMessageAsync_ShouldRejectMissingFieldsAndReturnAccepted()
     {
+        var roomCommandService = new StubRoomCommandService
+        {
+            PostMessageResult = new StreamingProxyRoomPostMessageResult(StreamingProxyRoomPostMessageStatus.RoomNotFound),
+        };
         var result = await InvokeResultAsync(
             "HandlePostMessageAsync",
             CreateScopedHttpContext(),
             "scope-a",
             "room-a",
             new PostMessageRequest(null, "name", "content"),
-            new StubActorRuntime(),
+            roomCommandService,
             new StubGAgentActorStore(),
             CancellationToken.None);
 
@@ -1082,37 +1081,34 @@ public class StreamingProxyCoverageTests
             "scope-a",
             "missing-room",
             new PostMessageRequest("agent", null, "content"),
-            new StubActorRuntime(),
+            roomCommandService,
             new StubGAgentActorStore(),
             CancellationToken.None);
 
         response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
 
-        var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        roomCommandService = new StubRoomCommandService();
         result = await InvokeResultAsync(
             "HandlePostMessageAsync",
             CreateScopedHttpContext(),
             "scope-a",
             "room-a",
             new PostMessageRequest("agent", null, "content"),
-            runtime,
-            dispatchPort,
+            roomCommandService,
             new StubGAgentActorStore(),
             CancellationToken.None);
 
         response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
-        dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
+        roomCommandService.PostMessageCommands.Should().ContainSingle(x => x.RoomId == "room-a");
     }
 
     [Fact]
     public async Task HandleJoinAsync_ShouldRejectMissingAgentIdAndAddParticipant()
     {
         var participantStore = new StubParticipantStore();
-        var runtime = new StubActorRuntime(new List<IActor> { new StubActor("room-a") });
-        var dispatchPort = new StubActorDispatchPort(runtime);
+        var roomCommandService = new StubRoomCommandService();
         var actorStore = new StubGAgentActorStore();
 
         var result = await InvokeResultAsync(
@@ -1121,7 +1117,7 @@ public class StreamingProxyCoverageTests
             "scope-a",
             "room-a",
             new JoinRoomRequest(null, null),
-            runtime,
+            roomCommandService,
             actorStore,
             participantStore,
             NullLoggerFactory.Instance,
@@ -1137,8 +1133,7 @@ public class StreamingProxyCoverageTests
             "scope-a",
             "room-a",
             joinRequest,
-            runtime,
-            dispatchPort,
+            roomCommandService,
             actorStore,
             participantStore,
             NullLoggerFactory.Instance,
@@ -1148,7 +1143,7 @@ public class StreamingProxyCoverageTests
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         participantStore.AddedParticipants.Should().ContainSingle(x =>
             x.roomId == "room-a" && x.agentId == "agent-1" && x.displayName == "Alice");
-        dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
+        roomCommandService.JoinCommands.Should().ContainSingle(x => x.RoomId == "room-a");
     }
 
     [Fact]
@@ -2032,10 +2027,17 @@ public class StreamingProxyCoverageTests
             => Task.FromResult(ScopeResourceAdmissionResult.Allowed());
     }
 
-    private sealed class StubRoomCommandService(StreamingProxyRoomCreateResult result)
+    private sealed class StubRoomCommandService(
+        StreamingProxyRoomCreateResult? result = null)
         : IStreamingProxyRoomCommandService
     {
         public List<StreamingProxyRoomCreateCommand> Commands { get; } = [];
+        public List<StreamingProxyRoomPostMessageCommand> PostMessageCommands { get; } = [];
+        public List<StreamingProxyRoomJoinCommand> JoinCommands { get; } = [];
+        public List<StreamingProxyRoomTerminalStateCommand> TerminalCommands { get; } = [];
+        public StreamingProxyRoomPostMessageResult PostMessageResult { get; init; } =
+            new(StreamingProxyRoomPostMessageStatus.Accepted);
+        public StreamingProxyRoomJoinResult? JoinResult { get; init; }
 
         public Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
             StreamingProxyRoomCreateCommand command,
@@ -2043,7 +2045,39 @@ public class StreamingProxyCoverageTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             Commands.Add(command);
-            return Task.FromResult(result);
+            return Task.FromResult(result ?? new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Created,
+                "room-a",
+                "Room A"));
+        }
+
+        public Task<StreamingProxyRoomPostMessageResult> PostMessageAsync(
+            StreamingProxyRoomPostMessageCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            PostMessageCommands.Add(command);
+            return Task.FromResult(PostMessageResult);
+        }
+
+        public Task<StreamingProxyRoomJoinResult> JoinAsync(
+            StreamingProxyRoomJoinCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            JoinCommands.Add(command);
+            return Task.FromResult(JoinResult ?? new StreamingProxyRoomJoinResult(
+                StreamingProxyRoomJoinStatus.Joined,
+                command.AgentId?.Trim()));
+        }
+
+        public Task PublishTerminalStateAsync(
+            StreamingProxyRoomTerminalStateCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TerminalCommands.Add(command);
+            return Task.CompletedTask;
         }
     }
 

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -1126,6 +1126,30 @@ public class StreamingProxyCoverageTests
         var response = await ExecuteResultAsync(result);
         response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
 
+        roomCommandService = new StubRoomCommandService
+        {
+            JoinResult = new StreamingProxyRoomJoinResult(
+                StreamingProxyRoomJoinStatus.RoomNotFound,
+                null,
+                null),
+        };
+        result = await InvokeResultAsync(
+            "HandleJoinAsync",
+            CreateScopedHttpContext(),
+            "scope-a",
+            "missing-room",
+            new JoinRoomRequest("agent-1", "Alice"),
+            roomCommandService,
+            actorStore,
+            participantStore,
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+
+        response = await ExecuteResultAsync(result);
+        response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        participantStore.AddedParticipants.Should().BeEmpty();
+
+        roomCommandService = new StubRoomCommandService();
         var joinRequest = new JoinRoomRequest("agent-1", "Alice");
         result = await InvokeResultAsync(
             "HandleJoinAsync",
@@ -2068,7 +2092,8 @@ public class StreamingProxyCoverageTests
             JoinCommands.Add(command);
             return Task.FromResult(JoinResult ?? new StreamingProxyRoomJoinResult(
                 StreamingProxyRoomJoinStatus.Joined,
-                command.AgentId?.Trim()));
+                command.AgentId?.Trim(),
+                command.DisplayName?.Trim()));
         }
 
         public Task PublishTerminalStateAsync(

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -126,6 +126,42 @@ public class StreamingProxyCoverageTests
     }
 
     [Fact]
+    public void StreamingProxyEndpointSource_ShouldDelegateRoomCommandsToRoomCommandService()
+    {
+        var root = GetRepositoryRoot();
+        var endpoints = File.ReadAllText(Path.Combine(
+            root,
+            "agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs"));
+
+        endpoints.Should().NotContain("IActorDispatchPort");
+        endpoints.Should().NotContain("DispatchRoomEnvelopeAsync");
+        endpoints.Should().NotContain("Any.Pack");
+        endpoints.Should().Contain("IStreamingProxyRoomCommandService");
+        endpoints.Should().Contain("StreamingProxyRoomPostMessageCommand");
+        endpoints.Should().Contain("StreamingProxyRoomJoinCommand");
+        endpoints.Should().Contain("StreamingProxyRoomTerminalStateCommand");
+    }
+
+    [Fact]
+    public void StreamingProxyRoomSources_ShouldNotIntroduceParallelRoomInteractionPort()
+    {
+        var root = GetRepositoryRoot();
+        var roomSources = Directory
+            .EnumerateFiles(
+                Path.Combine(root, "agents/Aevatar.GAgents.StreamingProxy"),
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => path.Contains($"{Path.DirectorySeparatorChar}Application{Path.DirectorySeparatorChar}Rooms{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                           Path.GetFileName(path).Equals("StreamingProxyEndpoints.cs", StringComparison.Ordinal))
+            .Select(File.ReadAllText);
+
+        roomSources.Should().OnlyContain(source =>
+            !source.Contains("IStreamingProxyRoomInteractionPort", StringComparison.Ordinal));
+        roomSources.Should().OnlyContain(source =>
+            !source.Contains("RoomInteractionPort", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void StreamingProxyRoomAndCoordinatorSource_ShouldNotInlineDispatchActorEvents()
     {
         var root = GetRepositoryRoot();

--- a/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
@@ -335,7 +335,8 @@ public sealed class StreamingProxyEndpointsCoverageTests
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(new StreamingProxyRoomJoinResult(
                 StreamingProxyRoomJoinStatus.Joined,
-                command.AgentId?.Trim()));
+                command.AgentId?.Trim(),
+                command.DisplayName?.Trim()));
         }
 
         public Task PublishTerminalStateAsync(

--- a/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
@@ -317,6 +317,35 @@ public sealed class StreamingProxyEndpointsCoverageTests
             Commands.Add(command);
             return Task.FromResult(result);
         }
+
+        public Task<StreamingProxyRoomPostMessageResult> PostMessageAsync(
+            StreamingProxyRoomPostMessageCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            _ = command;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new StreamingProxyRoomPostMessageResult(
+                StreamingProxyRoomPostMessageStatus.Accepted));
+        }
+
+        public Task<StreamingProxyRoomJoinResult> JoinAsync(
+            StreamingProxyRoomJoinCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new StreamingProxyRoomJoinResult(
+                StreamingProxyRoomJoinStatus.Joined,
+                command.AgentId?.Trim()));
+        }
+
+        public Task PublishTerminalStateAsync(
+            StreamingProxyRoomTerminalStateCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            _ = command;
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class RecordingParticipantStore : IStreamingProxyParticipantStore

--- a/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
@@ -228,6 +228,110 @@ public sealed class StreamingProxyRoomCommandServiceTests
         destroyIndex.Should().BeGreaterThan(unregisterIndex);
     }
 
+    [Fact]
+    public async Task PostMessageAsync_ShouldLookupRoomAndDispatchTypedMessage()
+    {
+        var operations = new List<string>();
+        var actor = new RecordingActor("room-a", operations);
+        var runtime = new RecordingActorRuntime(operations, actor);
+        await runtime.CreateAsync<StreamingProxyGAgent>("room-a");
+        operations.Clear();
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.PostMessageAsync(
+            new StreamingProxyRoomPostMessageCommand("room-a", " agent-1 ", null, " hello ", null),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomPostMessageStatus.Accepted);
+        dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
+        var message = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<GroupChatMessageEvent>();
+        message.AgentId.Should().Be("agent-1");
+        message.AgentName.Should().Be("agent-1");
+        message.Content.Should().Be("hello");
+        message.SessionId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task PostMessageAsync_ShouldReturnRoomNotFound_WhenRoomIsMissing()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-a", operations));
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.PostMessageAsync(
+            new StreamingProxyRoomPostMessageCommand("missing-room", "agent-1", null, "hello", null),
+            CancellationToken.None);
+
+        result.Status.Should().Be(StreamingProxyRoomPostMessageStatus.RoomNotFound);
+        dispatchPort.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task JoinAsync_ShouldLookupRoomAndDispatchTypedJoin()
+    {
+        var operations = new List<string>();
+        var actor = new RecordingActor("room-a", operations);
+        var runtime = new RecordingActorRuntime(operations, actor);
+        await runtime.CreateAsync<StreamingProxyGAgent>("room-a");
+        operations.Clear();
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.JoinAsync(
+            new StreamingProxyRoomJoinCommand("room-a", " agent-1 ", " Alice "),
+            CancellationToken.None);
+
+        result.Should().Be(new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.Joined, "agent-1"));
+        dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
+        var joined = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<GroupChatParticipantJoinedEvent>();
+        joined.AgentId.Should().Be("agent-1");
+        joined.DisplayName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task PublishTerminalStateAsync_ShouldDispatchTypedTerminalStateWithoutRuntimeLookup()
+    {
+        var operations = new List<string>();
+        var actor = new RecordingActor("room-a", operations);
+        var runtime = new RecordingActorRuntime(operations, actor);
+        await runtime.CreateAsync<StreamingProxyGAgent>("room-a");
+        operations.Clear();
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        await service.PublishTerminalStateAsync(
+            new StreamingProxyRoomTerminalStateCommand(
+                " room-a ",
+                " session-1 ",
+                StreamingProxyChatSessionTerminalStatus.Failed,
+                "failed"),
+            CancellationToken.None);
+
+        dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
+        var terminal = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>();
+        terminal.SessionId.Should().Be("session-1");
+        terminal.Status.Should().Be(StreamingProxyChatSessionTerminalStatus.Failed);
+        terminal.ErrorMessage.Should().Be("failed");
+    }
+
     private sealed class RecordingGAgentActorRegistryCommandPort(List<string> operations)
         : IGAgentActorRegistryCommandPort
     {

--- a/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
@@ -295,11 +295,37 @@ public sealed class StreamingProxyRoomCommandServiceTests
             new StreamingProxyRoomJoinCommand("room-a", " agent-1 ", " Alice "),
             CancellationToken.None);
 
-        result.Should().Be(new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.Joined, "agent-1"));
+        result.Should().Be(new StreamingProxyRoomJoinResult(
+            StreamingProxyRoomJoinStatus.Joined,
+            "agent-1",
+            "Alice"));
         dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
         var joined = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<GroupChatParticipantJoinedEvent>();
         joined.AgentId.Should().Be("agent-1");
         joined.DisplayName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task JoinAsync_ShouldReturnRoomNotFound_WhenRoomIsMissing()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-a", operations));
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.JoinAsync(
+            new StreamingProxyRoomJoinCommand("missing-room", "agent-1", "Alice"),
+            CancellationToken.None);
+
+        result.Should().Be(new StreamingProxyRoomJoinResult(
+            StreamingProxyRoomJoinStatus.RoomNotFound,
+            null,
+            null));
+        dispatchPort.Dispatches.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

iter38 cluster-038-streaming-proxy-reuse-existing(高优先级,Phase 9 r2 + reflector r2 force-pick reuse-existing-room-command-service)。

- **Old**:Streaming proxy endpoint orchestration:Host endpoints do platform selection / scope resolution / post-message / join / terminal directly with raw runtime/dispatch helpers + 无 typed Application port。
- **New**:Extend existing `IStreamingProxyRoomCommandService` with narrow typed post-message/join/terminal-state publication methods。Preserve command lifecycle semantics internally。**禁止**new `IStreamingProxyRoomInteractionPort` / 新 actor / 新 envelope / full CQRS skeleton。

违反:CLAUDE.md「顶级架构约束:严格分层」+「命令骨架内聚」。

## 范围

6 文件改动(+407 / -129 LOC,净 +278)。

🤖 Auto-loop / codex-refactor-loop iter38

Closes #848

⟦AI:AUTO-LOOP⟧
