### PR TITLE
iter39 cluster-039 public-chatasync-adapter: 删 ChatRuntime 公共 ChatAsync,保留 ChatStreamAsync 唯一实时入口

### DIFF
--- a/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
+++ b/src/Aevatar.AI.Core/Chat/ChatRuntime.cs
@@ -22,6 +22,9 @@ public sealed record ContextCompressionConfig(
     bool EnableSummarization = false);
 
 /// <summary>Chat 执行运行时。调 LLM，管理历史，集成 Middleware。</summary>
+// Refactor (iter39/cluster-039-public-chatasync-adapter):
+//   Old pattern: ChatRuntime 暴露 public ChatAsync 方法作为 non-streaming adapter,callers 可以选 non-streaming conversation API。
+//   New principle: Public runtime surface 仅暴露 ChatStreamAsync;explicit offline aggregation 放到 narrowly named offline/test adapter(明确不能与 realtime chat 混淆)。Provider contract stream-only。
 // Refactor (iter31/cluster-032-chatruntime-taskrun-business-loop):
 //   Old pattern: ChatRuntime.ChatStreamAsync 用 Task.Run + Channel<LLMStreamChunk>/ChannelWriter 在 actor turn 外跑 LLM/tool/hook/history 业务循环,违反 actor execution integrity
 //   New principle: ChatStreamAsync owns the stream flow directly; the Task.Run + Channel owned-stream loop and stream_buffer_capacity config were removed; middleware wrapping stays inside private bridge adapters.
@@ -65,35 +68,6 @@ public sealed class ChatRuntime
         _agentId = string.IsNullOrWhiteSpace(agentId) ? null : agentId;
         _agentName = string.IsNullOrWhiteSpace(agentName) ? null : agentName;
         _compressionConfig = compressionConfig ?? new ContextCompressionConfig();
-    }
-
-    /// <summary>单轮 Chat（含 Tool Calling 循环），显式离线聚合 adapter。</summary>
-    public Task<string?> ChatAsync(string userMessage, int maxToolRounds = DefaultMaxToolRounds, CancellationToken ct = default) =>
-        ChatAsync([ContentPart.TextPart(userMessage)], maxToolRounds, requestId: null, metadata: null, ct);
-
-    /// <summary>单轮 Chat（含 Tool Calling 循环），显式传入稳定 request id 和 metadata（文本快捷方式）。</summary>
-    public Task<string?> ChatAsync(
-        string userMessage,
-        int maxToolRounds,
-        string? requestId,
-        IReadOnlyDictionary<string, string>? metadata,
-        CancellationToken ct = default) =>
-        ChatAsync([ContentPart.TextPart(userMessage)], maxToolRounds, requestId, metadata, ct);
-
-    /// <summary>单轮 Chat（多模态内容），显式传入稳定 request id 和 metadata。</summary>
-    public async Task<string?> ChatAsync(
-        IReadOnlyList<ContentPart> userContent,
-        int maxToolRounds,
-        string? requestId,
-        IReadOnlyDictionary<string, string>? metadata,
-        CancellationToken ct = default)
-    {
-        // Refactor (iter15/cluster-024):
-        //   Old pattern: non-streaming ChatAsync directly called provider.ChatAsync.
-        //   New principle: ChatStreamAsync is the only authoritative AI executor; offline text aggregation consumes the stream as an explicit adapter.
-        return await ChatStreamContentAggregator.AggregateContentAsync(
-            ChatStreamAsync(userContent, maxToolRounds, requestId, metadata, ct),
-            ct: ct);
     }
 
     /// <summary>流式 Chat，包裹 LLM Call Middleware。</summary>

--- a/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
+++ b/test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs
@@ -9,6 +9,9 @@ using FluentAssertions;
 
 namespace Aevatar.AI.Tests;
 
+// Refactor (iter39/cluster-039-public-chatasync-adapter):
+//   Old pattern: ChatRuntime 暴露 public ChatAsync 方法作为 non-streaming adapter,callers 可以选 non-streaming conversation API。
+//   New principle: Public runtime surface 仅暴露 ChatStreamAsync;explicit offline aggregation 放到 narrowly named offline/test adapter(明确不能与 realtime chat 混淆)。Provider contract stream-only。
 public sealed class ChatRuntimeStreamingBufferTests
 {
     [Fact]
@@ -434,7 +437,7 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
-    public async Task ChatAsync_WhenAgentMiddlewareTerminates_ShouldAggregateStreamAdapterWithoutCallingProvider()
+    public async Task ExplicitTestAggregation_WhenAgentMiddlewareTerminates_ShouldConsumeStreamWithoutCallingProvider()
     {
         var provider = new StreamingProvider(["ignored"]);
         var runtime = CreateRuntime(
@@ -449,7 +452,7 @@ public sealed class ChatRuntimeStreamingBufferTests
                 }),
             ]);
 
-        var result = await runtime.ChatAsync("hello");
+        var result = await ChatStreamContentAggregator.AggregateContentAsync(runtime.ChatStreamAsync("hello"));
 
         result.Should().Be("short-circuit");
         provider.StreamCallCount.Should().Be(0);
@@ -488,15 +491,27 @@ public sealed class ChatRuntimeStreamingBufferTests
     }
 
     [Fact]
-    public async Task ChatAsync_WhenProviderStreamsContent_ShouldAggregateWithoutCallingProviderChatAsync()
+    public async Task ExplicitTestAggregation_WhenProviderStreamsContent_ShouldAggregateStreamContent()
     {
         var provider = new StreamingProvider(["stream-", "answer"]);
         var runtime = CreateRuntime(provider);
 
-        var result = await runtime.ChatAsync("hello");
+        var result = await ChatStreamContentAggregator.AggregateContentAsync(runtime.ChatStreamAsync("hello"));
 
         result.Should().Be("stream-answer");
         provider.StreamCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void ChatRuntimePublicSurface_ShouldNotExposeNonStreamingChatAsync()
+    {
+        var chatAsyncMethods = typeof(ChatRuntime)
+            .GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+            .Where(method => method.Name == "ChatAsync")
+            .Select(method => method.ToString())
+            .ToArray();
+
+        chatAsyncMethods.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/ContextCompressorTests.cs
+++ b/test/Aevatar.AI.Tests/ContextCompressorTests.cs
@@ -8,6 +8,9 @@ using FluentAssertions;
 
 namespace Aevatar.AI.Tests;
 
+// Refactor (iter39/cluster-039-public-chatasync-adapter):
+//   Old pattern: ChatRuntime 暴露 public ChatAsync 方法作为 non-streaming adapter,callers 可以选 non-streaming conversation API。
+//   New principle: Public runtime surface 仅暴露 ChatStreamAsync;explicit offline aggregation 放到 narrowly named offline/test adapter(明确不能与 realtime chat 混淆)。Provider contract stream-only。
 public class ContextCompressorTests
 {
     // ═══════════════════════════════════════════════════════════
@@ -373,7 +376,9 @@ public class ContextCompressorTests
             },
             compressionConfig: compressionConfig);
 
-        await chat.ChatAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None);
+        await ChatStreamContentAggregator.AggregateContentAsync(
+            chat.ChatStreamAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None),
+            ct: CancellationToken.None);
 
         hook.CompactStartCount.Should().Be(1);
         hook.CompactEndCount.Should().Be(1);
@@ -674,7 +679,9 @@ public class ContextCompressorTests
             },
             compressionConfig: compressionConfig);
 
-        await chat.ChatAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None);
+        await ChatStreamContentAggregator.AggregateContentAsync(
+            chat.ChatStreamAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None),
+            ct: CancellationToken.None);
 
         hook.CompactStartCount.Should().Be(0);
         hook.CompactEndCount.Should().Be(0);
@@ -705,7 +712,9 @@ public class ContextCompressorTests
             },
             compressionConfig: compressionConfig);
 
-        await chat.ChatAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None);
+        await ChatStreamContentAggregator.AggregateContentAsync(
+            chat.ChatStreamAsync("trigger", maxToolRounds: 1, ct: CancellationToken.None),
+            ct: CancellationToken.None);
 
         hook.CompactStartCount.Should().Be(0);
     }


### PR DESCRIPTION
## 摘要

**Cluster**: iter39 cluster-039-public-chatasync-adapter (direct implement, requires_design:false)

**Old pattern**: `ChatRuntime` 暴露 public `ChatAsync` 方法作为 non-streaming adapter,callers 可以选 non-streaming conversation API。

**New principle**: Public runtime surface 仅暴露 `ChatStreamAsync`;explicit offline aggregation 放到 narrowly named offline/test adapter(明确不能与 realtime chat 混淆)。Provider contract stream-only。

## 改动

- `src/Aevatar.AI.Core/Chat/ChatRuntime.cs`: 删除 public `ChatAsync` (两个重载 — string 和 multimodal)
- `test/Aevatar.AI.Tests/ChatRuntimeStreamingBufferTests.cs`: 改用 `ChatStreamContentAggregator` 显式聚合 `ChatStreamAsync`
- `test/Aevatar.AI.Tests/ContextCompressorTests.cs`: 同上
- 加 public surface regression test 防 `ChatAsync` 重新暴露

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --nologo` ✅ 624 passed
- `bash tools/ci/test_stability_guards.sh` ✅
- `bash tools/ci/architecture_guards.sh` ✅

## 设计依据

CLAUDE.md "AI 对话主链必须流式化":实时会话入口必须使用 `ChatStreamAsync`;`ChatAsync` 仅可用于明确的非交互式离线场景。

audit-iter-39 evidence:
- `src/Aevatar.AI.Core/Chat/ChatRuntime.cs:71` exposes `public Task<string?> ChatAsync(...)`
- `src/Aevatar.AI.Core/Chat/ChatRuntime.cs:84` exposes multimodal `ChatAsync` overload
- `src/Aevatar.AI.Core/Chat/ChatRuntime.cs:94` aggregates stream content to a string

## 测试计划

- [x] AI.Core unit tests pass (624 cases)
- [x] Public surface regression test 防止 ChatAsync 重新暴露
- [x] 架构守卫通过

---

🤖 auto-loop direct implement (Phase 9 跳过 — requires_design:false per audit)

⟦AI:AUTO-LOOP⟧
