### PR TITLE
Fix draft-run projection session activation

### DIFF
--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
@@ -23,10 +23,12 @@ internal sealed class WorkflowRunObservationLifecycle
         CommandDispatchExecution<WorkflowRunCommandTarget, WorkflowChatRunAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Projection activation belongs to the explicit observation lifecycle, after
-        // target resolution/context creation and before dispatch. PrepareAsync stays
-        // free of read-side lifecycle work, while first-run streaming has a session
-        // to attach before the command enters the actor inbox.
+        // Refactor (iter39/cluster-039-draft-run-projection-session-activation):
+        //   Old pattern: BindAsync only attached to an already-active projection session, so a cold
+        //   draft-run stream could fail before the command reached the workflow actor.
+        //   New principle: Live workflow observation may create/lease the actorized projection
+        //   session inside this explicit observation lifecycle before dispatch; PrepareAsync,
+        //   Host endpoints, and query/read paths remain free of projection lifecycle work.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -87,5 +89,4 @@ internal sealed class WorkflowRunObservationLifecycle
         return CommandObservationBindingResult<WorkflowChatRunStartError>.Failure(
             WorkflowChatRunStartError.ProjectionDisabled);
     }
-
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunObservationLifecycle.cs
@@ -23,10 +23,10 @@ internal sealed class WorkflowRunObservationLifecycle
         CommandDispatchExecution<WorkflowRunCommandTarget, WorkflowChatRunAcceptedReceipt> execution,
         CancellationToken ct = default)
     {
-        // Refactor (iter35/cluster-039-observation-binder-attach-only):
-        //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
-        //   New principle: Command observation binders 仅 attach 到 pre-existing lease/session;cold session 返回 ProjectionPending / ProjectionUnavailable;projection activation 移到 projection-owned startup / background lifecycle。
-        //   删除 pre-dispatch projection activation from command binders。不新增 top-level CLAUDE.md exception。
+        // Projection activation belongs to the explicit observation lifecycle, after
+        // target resolution/context creation and before dispatch. PrepareAsync stays
+        // free of read-side lifecycle work, while first-run streaming has a session
+        // to attach before the command enters the actor inbox.
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(execution);
 
@@ -36,9 +36,11 @@ internal sealed class WorkflowRunObservationLifecycle
 
         try
         {
-            var attachment = await _projectionPort.AttachExistingActorProjectionAsync(
-                target.ActorId,
-                context.CommandId,
+            var attachment = await _projectionPort.EnsureAndAttachLeaseAsync(
+                token => _projectionPort.EnsureActorProjectionAsync(
+                    target.ActorId,
+                    context.CommandId,
+                    token),
                 sink,
                 ct);
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -590,6 +590,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         var projectionPort = new FakeProjectionPort
         {
+            EnsureLease = new FakeProjectionLease("actor-1", "cmd-1"),
             AttachException = new InvalidOperationException("attach failed"),
         };
         var actorPort = new FakeWorkflowRunActorPort
@@ -620,7 +621,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         var ex = await act.Should().ThrowAsync<AggregateException>();
         ex.Which.Message.Should().Contain("rollback also failed");
         ex.Which.InnerExceptions.Should().HaveCount(2);
-        projectionPort.EnsureCalls.Should().Be(0);
+        projectionPort.EnsureCalls.Should().Be(1);
     }
 
     private static WorkflowRunCommandTarget CreateBoundTarget(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -258,20 +258,20 @@ public sealed class WorkflowRunOrchestrationComponentTests
         result.Succeeded.Should().BeTrue();
         target.ProjectionLease.Should().BeSameAs(projectionPort.ExistingLease);
         target.LiveSink.Should().NotBeNull();
-        projectionPort.AttachExistingCalls.Should().ContainSingle()
-            .Which.Should().Be(("actor-1", "cmd-1"));
         projectionPort.AttachCalls.Should().ContainSingle()
             .Which.Lease.Should().BeSameAs(projectionPort.ExistingLease);
-        projectionPort.EnsureCalls.Should().Be(0);
+        projectionPort.EnsureCalls.Should().ContainSingle()
+            .Which.Should().Be(("actor-1", "cmd-1"));
+        projectionPort.AttachExistingCalls.Should().BeEmpty();
         actorPort.DestroyCalls.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task WorkflowRunObservationLifecycle_ShouldRollbackCreatedActors_WhenProjectionAttachIsUnavailable()
+    public async Task WorkflowRunObservationLifecycle_ShouldRollbackCreatedActors_WhenProjectionEnsureIsUnavailable()
     {
         var projectionPort = new FakeProjectionPort
         {
-            AttachReturnsNull = true,
+            EnsureReturnsNull = true,
         };
         var actorPort = new FakeWorkflowRunActorPort();
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
@@ -295,9 +295,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.ProjectionDisabled);
-        projectionPort.AttachExistingCalls.Should().ContainSingle()
+        projectionPort.EnsureCalls.Should().ContainSingle()
             .Which.Should().Be(("actor-1", "cmd-1"));
-        projectionPort.EnsureCalls.Should().Be(0);
+        projectionPort.AttachCalls.Should().BeEmpty();
+        projectionPort.AttachExistingCalls.Should().BeEmpty();
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
     }
 
@@ -330,9 +331,9 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("attach failed");
-        projectionPort.AttachExistingCalls.Should().ContainSingle()
+        projectionPort.EnsureCalls.Should().ContainSingle()
             .Which.Should().Be(("actor-1", "cmd-1"));
-        projectionPort.EnsureCalls.Should().Be(0);
+        projectionPort.AttachExistingCalls.Should().BeEmpty();
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
     }
 
@@ -376,9 +377,10 @@ public sealed class WorkflowRunOrchestrationComponentTests
         : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled { get; set; } = true;
+        public bool EnsureReturnsNull { get; set; }
         public bool AttachReturnsNull { get; set; }
         public Exception? AttachException { get; set; }
-        public int EnsureCalls { get; private set; }
+        public List<(string RootActorId, string CommandId)> EnsureCalls { get; } = [];
         public FakeProjectionLease ExistingLease { get; set; } = new("actor-1", "cmd-1");
         public List<(string RootActorId, string CommandId)> AttachExistingCalls { get; } = [];
         public List<(IWorkflowExecutionProjectionLease Lease, IEventSink<WorkflowRunEventEnvelope> Sink)> AttachCalls { get; } = [];
@@ -391,8 +393,12 @@ public sealed class WorkflowRunOrchestrationComponentTests
             _ = rootActorId;
             _ = commandId;
             ct.ThrowIfCancellationRequested();
-            EnsureCalls++;
-            return Task.FromResult<IWorkflowExecutionProjectionLease?>(new FakeProjectionLease(rootActorId, commandId));
+            EnsureCalls.Add((rootActorId, commandId));
+            if (EnsureReturnsNull)
+                return Task.FromResult<IWorkflowExecutionProjectionLease?>(null);
+
+            ExistingLease = new FakeProjectionLease(rootActorId, commandId);
+            return Task.FromResult<IWorkflowExecutionProjectionLease?>(ExistingLease);
         }
 
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -378,7 +378,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
     {
         public bool ProjectionEnabled { get; set; } = true;
         public bool EnsureReturnsNull { get; set; }
-        public bool AttachReturnsNull { get; set; }
         public Exception? AttachException { get; set; }
         public List<(string RootActorId, string CommandId)> EnsureCalls { get; } = [];
         public FakeProjectionLease ExistingLease { get; set; } = new("actor-1", "cmd-1");
@@ -411,8 +410,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
                 throw AttachException;
 
             AttachCalls.Add((lease, sink));
-            return Task.FromResult<IAsyncDisposable?>(
-                AttachReturnsNull ? null : new FakeLiveSinkLease());
+            return Task.FromResult<IAsyncDisposable?>(new FakeLiveSinkLease());
         }
 
         public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(


### PR DESCRIPTION
## Problem
`ScopeDraftRunActorQueryIntegrationTests.DraftRunEndpoint_ShouldExposeCompletedActorSnapshotViaActorQuery` failed on `coverage-quality` because `/api/scopes/{scopeId}/workflow/draft-run` returned 503 `PROJECTION_DISABLED`.

## Root Cause
The attach-only observation refactor made `WorkflowRunObservationLifecycle` attach only to an already-existing projection session. A cold draft-run request has no prior workflow execution session to attach, so the interaction failed before dispatch even though projection providers were enabled.

## Fix
Activate the workflow execution projection session in the explicit observation lifecycle after target/context resolution and before dispatch, then attach the live sink through the existing lifecycle helper. `PrepareAsync` remains free of projection lifecycle work, while first-run streaming has the required projection-owned session before the command enters the actor inbox.

## Validation
- `dotnet test test/Aevatar.GAgentService.Integration.Tests/Aevatar.GAgentService.Integration.Tests.csproj --nologo --filter "DraftRunEndpoint_ShouldExposeCompletedActorSnapshotViaActorQuery"`
- `dotnet test test/Aevatar.Workflow.Application.Tests/Aevatar.Workflow.Application.Tests.csproj --nologo --filter "WorkflowRunObservationLifecycle"`
- `bash tools/ci/test_stability_guards.sh`
- `bash tools/ci/architecture_guards.sh`

⟦AI:AUTO-LOOP⟧
