### PR TITLE
iter39 cluster-039 gagent-reflection-catalog: ScopeGAgentEndpoints 改源 registered service revision catalog readmodel,删 AppDomain reflection

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeGAgentEndpoints.cs
@@ -1,26 +1,17 @@
-using System.Reflection;
-using System.Text;
 using System.Text.Json;
-using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.ScopeGAgents;
 using Aevatar.Hosting;
 using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Application.Studio.Abstractions;
-using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
-using Type = System.Type;
-// AI Abstractions types (published by RoleGAgent) — aliased to avoid conflict with AGUI types
-using AiTextStart = Aevatar.AI.Abstractions.TextMessageStartEvent;
-using AiTextContent = Aevatar.AI.Abstractions.TextMessageContentEvent;
-using AiTextReasoning = Aevatar.AI.Abstractions.TextMessageReasoningEvent;
-using AiTextEnd = Aevatar.AI.Abstractions.TextMessageEndEvent;
-using AiToolCall = Aevatar.AI.Abstractions.ToolCallEvent;
-using AiToolResult = Aevatar.AI.Abstractions.ToolResultEvent;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -43,222 +34,103 @@ public static class ScopeGAgentEndpoints
         return app;
     }
 
-    // ─── List GAgent Types (reflection) ───
-
-    private static IResult HandleListGAgentTypesAsync()
+    // Refactor (iter39/cluster-039-gagent-reflection-catalog):
+    //   Old pattern: ScopeGAgentEndpoints 通过 AppDomain reflection + AIGAgentBase + [EventHandler] + protobuf descriptors 发现 GAgent 类型,把进程内加载的 CLR class 当成业务事实源。
+    //   New principle: GAgent type 列表必须来自 registered service revision catalog readmodel,不是反射偶然加载的 CLR class。保留 endpoint 路由,换实现为读 readmodel。
+    private static async Task<IResult> HandleListGAgentTypesAsync(
+        [FromServices] IServiceCatalogQueryReader catalogReader,
+        [FromServices] IServiceRevisionCatalogQueryReader revisionCatalogReader,
+        CancellationToken ct)
     {
-        var aiGAgentBaseType = FindOpenGenericBaseType("Aevatar.AI.Core.AIGAgentBase`1");
-        if (aiGAgentBaseType is null)
-        {
-            return Results.Ok(Array.Empty<object>());
-        }
+        var services = await catalogReader.QueryAllAsync(ct: ct);
+        var gAgentTypes = new Dictionary<string, GAgentTypeCatalogHttpResponse>(StringComparer.Ordinal);
 
-        var types = new List<object>();
-
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        foreach (var service in services)
         {
-            if (assembly.IsDynamic)
+            var identity = BuildServiceIdentity(service);
+            var revisions = await revisionCatalogReader.GetAsync(identity, ct);
+            if (revisions == null)
                 continue;
 
-            Type[] exportedTypes;
-            try
+            foreach (var revision in revisions.Revisions)
             {
-                exportedTypes = assembly.GetTypes();
-            }
-            catch (ReflectionTypeLoadException ex)
-            {
-                exportedTypes = ex.Types.Where(t => t is not null).ToArray()!;
-            }
-            catch
-            {
-                continue;
-            }
+                var actorTypeName = revision.Implementation?.Static?.ActorTypeName?.Trim() ?? string.Empty;
+                if (actorTypeName.Length == 0)
+                    continue;
 
-            foreach (var type in exportedTypes)
-            {
-                try
+                var endpoints = revision.Endpoints.Select(MapGAgentEndpoint).ToList();
+                if (gAgentTypes.TryGetValue(actorTypeName, out var existing))
                 {
-                    if (!type.IsClass || type.IsAbstract)
-                        continue;
-
-                    if (!DerivesFromOpenGeneric(type, aiGAgentBaseType))
-                        continue;
-
-                    types.Add(new
-                    {
-                        typeName = type.Name,
-                        fullName = type.FullName ?? type.Name,
-                        assemblyName = assembly.GetName().Name ?? assembly.FullName ?? string.Empty,
-                        endpoints = DiscoverEndpoints(type),
-                    });
+                    MergeEndpoints(existing.Endpoints, endpoints);
+                    continue;
                 }
-                catch
-                {
-                    // Skip individual types that fail to inspect — don't let one broken
-                    // GAgent type prevent the rest from being listed.
-                }
+
+                gAgentTypes[actorTypeName] = new GAgentTypeCatalogHttpResponse(
+                    ResolveTypeDisplayName(actorTypeName),
+                    actorTypeName,
+                    ResolveAssemblyName(actorTypeName),
+                    endpoints);
             }
         }
 
-        return Results.Ok(types);
+        return Results.Ok(gAgentTypes.Values
+            .OrderBy(x => x.TypeName, StringComparer.Ordinal)
+            .ThenBy(x => x.FullName, StringComparer.Ordinal)
+            .ToList());
     }
 
-    /// <summary>
-    /// Discovers available endpoints from a GAgent type by reflecting over [EventHandler] methods.
-    /// Any AIGAgentBase subclass always has a "chat" endpoint (ChatRequestEvent).
-    /// Additional endpoints are discovered from [EventHandler] methods whose parameter type
-    /// is NOT a base framework event (TextMessageStart/End/Content, ToolCall, etc.).
-    /// </summary>
-    private static object[] DiscoverEndpoints(Type gAgentType)
-    {
-        // Well-known base event types that are internal framework plumbing,
-        // not user-facing endpoints.
-        var frameworkEventTypes = new HashSet<Type>
+    private static ServiceIdentity BuildServiceIdentity(ServiceCatalogSnapshot service) =>
+        new()
         {
-            typeof(ChatRequestEvent),
-            typeof(ChatResponseEvent),
-            typeof(AiTextStart),
-            typeof(AiTextContent),
-            typeof(AiTextReasoning),
-            typeof(AiTextEnd),
-            typeof(AiToolCall),
-            typeof(ToolResultEvent),
-            typeof(InitializeRoleAgentEvent),
-            typeof(RoleChatSessionStartedEvent),
-            typeof(RoleChatSessionCompletedEvent),
+            TenantId = service.TenantId,
+            AppId = service.AppId,
+            Namespace = service.Namespace,
+            ServiceId = service.ServiceId,
         };
 
-        var endpoints = new List<object>();
+    private static GAgentEndpointCatalogHttpResponse MapGAgentEndpoint(ServiceEndpointSnapshot endpoint) =>
+        new(
+            endpoint.EndpointId,
+            string.IsNullOrWhiteSpace(endpoint.DisplayName) ? endpoint.EndpointId : endpoint.DisplayName,
+            NormalizeEndpointKind(endpoint.Kind),
+            endpoint.RequestTypeUrl,
+            endpoint.ResponseTypeUrl,
+            endpoint.Description,
+            Auto: false);
 
-        // Chat endpoint is always present for AIGAgentBase subclasses.
-        endpoints.Add(new
+    private static void MergeEndpoints(
+        List<GAgentEndpointCatalogHttpResponse> target,
+        IReadOnlyList<GAgentEndpointCatalogHttpResponse> source)
+    {
+        foreach (var endpoint in source)
         {
-            endpointId = "chat",
-            displayName = "chat",
-            kind = "chat",
-            requestTypeUrl = GetProtoTypeUrl(ChatRequestEvent.Descriptor),
-            description = "Default chat endpoint.",
-            auto = true,
-        });
-
-        // Walk the type hierarchy and discover [EventHandler] methods.
-        var seen = new HashSet<string>(StringComparer.Ordinal);
-        for (var current = gAgentType; current != null && current != typeof(object); current = current.BaseType)
-        {
-            MethodInfo[] methods;
-            try
-            {
-                methods = current.GetMethods(
-                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
-            }
-            catch
-            {
-                // Type hierarchy reflection failed — skip this level.
+            if (target.Any(x => string.Equals(x.EndpointId, endpoint.EndpointId, StringComparison.Ordinal)))
                 continue;
-            }
 
-            foreach (var method in methods)
-            {
-                try
-                {
-                    var ehAttr = method.GetCustomAttribute<EventHandlerAttribute>();
-                    if (ehAttr is null)
-                        continue;
-
-                    var parameters = method.GetParameters();
-                    if (parameters.Length != 1)
-                        continue;
-
-                    var paramType = parameters[0].ParameterType;
-                    if (!typeof(IMessage).IsAssignableFrom(paramType) || paramType.IsAbstract)
-                        continue;
-
-                    // Skip framework/internal event types — they're not user-facing endpoints.
-                    if (frameworkEventTypes.Contains(paramType))
-                        continue;
-
-                    var typeUrl = TryGetProtoTypeUrl(paramType);
-                    var customName = ehAttr.EndpointName;
-                    var endpointId = !string.IsNullOrWhiteSpace(customName)
-                        ? customName
-                        : ToCamelCase(StripEventSuffix(paramType.Name));
-
-                    if (!seen.Add(endpointId))
-                        continue;
-
-                    endpoints.Add(new
-                    {
-                        endpointId,
-                        displayName = endpointId,
-                        kind = "command",
-                        requestTypeUrl = typeUrl ?? paramType.FullName ?? paramType.Name,
-                        description = $"Handles {paramType.Name}",
-                        auto = true,
-                    });
-                }
-                catch
-                {
-                    // Skip individual methods that fail — don't let one broken
-                    // handler prevent other endpoints from being discovered.
-                }
-            }
+            target.Add(endpoint);
         }
-
-        return endpoints.ToArray();
     }
 
-    private static string GetProtoTypeUrl(Google.Protobuf.Reflection.MessageDescriptor descriptor) =>
-        $"type.googleapis.com/{descriptor.FullName}";
-
-    private static string? TryGetProtoTypeUrl(Type messageType)
+    private static string ResolveTypeDisplayName(string actorTypeName)
     {
-        // Try to get the Protobuf Descriptor property to build the proper TypeUrl.
-        var descriptorProp = messageType.GetProperty(
-            "Descriptor",
-            BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-        if (descriptorProp?.GetValue(null) is Google.Protobuf.Reflection.MessageDescriptor desc)
-            return $"type.googleapis.com/{desc.FullName}";
-        return null;
+        var typeName = actorTypeName.Split(',', 2)[0].Trim();
+        var lastDot = typeName.LastIndexOf('.');
+        return lastDot < 0 ? typeName : typeName[(lastDot + 1)..];
     }
 
-    private static string StripEventSuffix(string name) =>
-        name.EndsWith("Event", StringComparison.Ordinal) ? name[..^5] : name;
-
-    private static string ToCamelCase(string name) =>
-        string.IsNullOrEmpty(name) ? name : char.ToLowerInvariant(name[0]) + name[1..];
-
-    private static Type? FindOpenGenericBaseType(string fullName)
+    private static string ResolveAssemblyName(string actorTypeName)
     {
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        var separator = actorTypeName.IndexOf(',');
+        return separator < 0 ? string.Empty : actorTypeName[(separator + 1)..].Trim();
+    }
+
+    private static string NormalizeEndpointKind(string kind) =>
+        kind switch
         {
-            if (assembly.IsDynamic) continue;
-            try
-            {
-                var type = assembly.GetType(fullName);
-                if (type is not null)
-                    return type;
-            }
-            catch
-            {
-                // ignored
-            }
-        }
-
-        return null;
-    }
-
-    private static bool DerivesFromOpenGeneric(Type type, Type openGenericBase)
-    {
-        var current = type.BaseType;
-        while (current is not null)
-        {
-            if (current.IsGenericType && current.GetGenericTypeDefinition() == openGenericBase)
-                return true;
-            current = current.BaseType;
-        }
-
-        return false;
-    }
+            nameof(ServiceEndpointKind.Chat) => "chat",
+            nameof(ServiceEndpointKind.Command) => "command",
+            _ => kind?.Trim().ToLowerInvariant() ?? string.Empty,
+        };
 
     // ─── Draft Run ───
 
@@ -728,6 +600,21 @@ public static class ScopeGAgentEndpoints
     }
 
     // ─── Request models ───
+
+    public sealed record GAgentTypeCatalogHttpResponse(
+        string TypeName,
+        string FullName,
+        string AssemblyName,
+        List<GAgentEndpointCatalogHttpResponse> Endpoints);
+
+    public sealed record GAgentEndpointCatalogHttpResponse(
+        string EndpointId,
+        string DisplayName,
+        string Kind,
+        string RequestTypeUrl,
+        string ResponseTypeUrl,
+        string Description,
+        bool Auto);
 
     public sealed record GAgentDraftRunHttpRequest(
         string ActorTypeName,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
@@ -779,6 +779,8 @@ public sealed class ScopeGAgentEndpointsTests
     public async Task HandleListGAgentTypesAsync_ShouldReadRegisteredStaticServiceRevisionFacts()
     {
         var staticActorTypeName = "Tests.RegisteredStaticGAgent, Tests.Assembly";
+        var requestTypeUrl = "type.googleapis.com/aevatar.ai.ChatRequestEvent";
+        var responseTypeUrl = "type.googleapis.com/aevatar.ai.ChatResponseEvent";
         var catalogReader = new FakeServiceCatalogQueryReader
         {
             Services =
@@ -804,8 +806,8 @@ public sealed class ScopeGAgentEndpointsTests
                                     "chat",
                                     "Chat",
                                     ServiceEndpointKind.Chat.ToString(),
-                                    "type.googleapis.com/aevatar.ai.ChatRequestEvent",
-                                    string.Empty,
+                                    requestTypeUrl,
+                                    responseTypeUrl,
                                     "Registered chat endpoint."),
                             ],
                             DateTimeOffset.UtcNow,
@@ -823,10 +825,20 @@ public sealed class ScopeGAgentEndpointsTests
 
         var (statusCode, body) = await ExecuteResultAsync(result);
         statusCode.Should().Be((int)HttpStatusCode.OK);
-        body.Should().Contain("RegisteredStaticGAgent");
-        body.Should().Contain(staticActorTypeName);
-        body.Should().Contain("Tests.Assembly");
-        body.Should().Contain("chat");
+        using var document = JsonDocument.Parse(body);
+        var gAgentType = document.RootElement.EnumerateArray().Should().ContainSingle().Subject;
+        gAgentType.GetProperty("typeName").GetString().Should().Be("RegisteredStaticGAgent");
+        gAgentType.GetProperty("fullName").GetString().Should().Be(staticActorTypeName);
+        gAgentType.GetProperty("assemblyName").GetString().Should().Be("Tests.Assembly");
+        var endpoint = gAgentType.GetProperty("endpoints").EnumerateArray().Should().ContainSingle().Subject;
+        AssertEndpointContract(
+            endpoint,
+            endpointId: "chat",
+            displayName: "Chat",
+            kind: "chat",
+            requestTypeUrl: requestTypeUrl,
+            responseTypeUrl: responseTypeUrl,
+            description: "Registered chat endpoint.");
         revisionReader.RequestedIdentities.Should().ContainSingle(identity =>
             identity.ServiceId == "svc-a" &&
             identity.TenantId == "scope-a");
@@ -889,6 +901,62 @@ public sealed class ScopeGAgentEndpointsTests
         revisionReader.RequestedIdentities.Should().ContainSingle(identity =>
             identity.ServiceId == "svc-filtered-revisions" &&
             identity.TenantId == "scope-a");
+    }
+
+    [Fact]
+    public async Task HandleListGAgentTypesAsync_ShouldMapBlankDisplayNameAndCustomEndpointKind()
+    {
+        var staticActorTypeName = "Tests.CustomEndpointGAgent, Tests.Assembly";
+        var catalogReader = new FakeServiceCatalogQueryReader
+        {
+            Services =
+            [
+                CreateServiceCatalogSnapshot("svc-custom-endpoint"),
+            ],
+        };
+        var identity = CreateServiceIdentity("svc-custom-endpoint");
+        var requestTypeUrl = "type.googleapis.com/tests.CustomRequest";
+        var responseTypeUrl = "type.googleapis.com/tests.CustomResponse";
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader
+        {
+            Revisions =
+            {
+                [ServiceKeys.Build(identity)] = new ServiceRevisionCatalogSnapshot(
+                    ServiceKeys.Build(identity),
+                    [
+                        CreateStaticRevisionSnapshot(
+                            "rev-custom",
+                            staticActorTypeName,
+                            new ServiceEndpointSnapshot(
+                                "custom-action",
+                                " ",
+                                "  BatchCommand  ",
+                                requestTypeUrl,
+                                responseTypeUrl,
+                                "Runs a custom action.")),
+                    ],
+                    DateTimeOffset.UtcNow),
+            },
+        };
+
+        var result = await InvokeHandleListGAgentTypesAsync(catalogReader, revisionReader);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+        statusCode.Should().Be((int)HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(body);
+        var gAgentType = document.RootElement.EnumerateArray().Should().ContainSingle().Subject;
+        gAgentType.GetProperty("typeName").GetString().Should().Be("CustomEndpointGAgent");
+        gAgentType.GetProperty("fullName").GetString().Should().Be(staticActorTypeName);
+        gAgentType.GetProperty("assemblyName").GetString().Should().Be("Tests.Assembly");
+        var endpoint = gAgentType.GetProperty("endpoints").EnumerateArray().Should().ContainSingle().Subject;
+        AssertEndpointContract(
+            endpoint,
+            endpointId: "custom-action",
+            displayName: "custom-action",
+            kind: "batchcommand",
+            requestTypeUrl: requestTypeUrl,
+            responseTypeUrl: responseTypeUrl,
+            description: "Runs a custom action.");
     }
 
     [Fact]
@@ -1164,13 +1232,22 @@ public sealed class ScopeGAgentEndpointsTests
         string revisionId,
         string actorTypeName,
         params string[] endpointIds) =>
+        CreateStaticRevisionSnapshot(
+            revisionId,
+            actorTypeName,
+            endpointIds.Select(CreateEndpointSnapshot).ToArray());
+
+    private static ServiceRevisionSnapshot CreateStaticRevisionSnapshot(
+        string revisionId,
+        string actorTypeName,
+        params ServiceEndpointSnapshot[] endpoints) =>
         new(
             revisionId,
             ServiceImplementationKind.Static.ToString(),
             ServiceRevisionStatus.Published.ToString(),
             $"{revisionId}-hash",
             string.Empty,
-            endpointIds.Select(CreateEndpointSnapshot).ToList(),
+            endpoints.ToList(),
             DateTimeOffset.UtcNow,
             DateTimeOffset.UtcNow,
             DateTimeOffset.UtcNow,
@@ -1205,6 +1282,24 @@ public sealed class ScopeGAgentEndpointsTests
             $"type.googleapis.com/tests.{endpointId}",
             string.Empty,
             $"{endpointId} endpoint.");
+
+    private static void AssertEndpointContract(
+        JsonElement endpoint,
+        string endpointId,
+        string displayName,
+        string kind,
+        string requestTypeUrl,
+        string responseTypeUrl,
+        string description)
+    {
+        endpoint.GetProperty("endpointId").GetString().Should().Be(endpointId);
+        endpoint.GetProperty("displayName").GetString().Should().Be(displayName);
+        endpoint.GetProperty("kind").GetString().Should().Be(kind);
+        endpoint.GetProperty("requestTypeUrl").GetString().Should().Be(requestTypeUrl);
+        endpoint.GetProperty("responseTypeUrl").GetString().Should().Be(responseTypeUrl);
+        endpoint.GetProperty("description").GetString().Should().Be(description);
+        endpoint.GetProperty("auto").GetBoolean().Should().BeFalse();
+    }
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
@@ -833,6 +833,112 @@ public sealed class ScopeGAgentEndpointsTests
     }
 
     [Fact]
+    public async Task HandleListGAgentTypesAsync_ShouldSkipServicesWithoutRevisionCatalog()
+    {
+        var catalogReader = new FakeServiceCatalogQueryReader
+        {
+            Services =
+            [
+                CreateServiceCatalogSnapshot("svc-missing-revisions"),
+            ],
+        };
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader();
+
+        var result = await InvokeHandleListGAgentTypesAsync(catalogReader, revisionReader);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+        statusCode.Should().Be((int)HttpStatusCode.OK);
+        body.Should().Be("[]");
+        revisionReader.RequestedIdentities.Should().ContainSingle(identity =>
+            identity.ServiceId == "svc-missing-revisions" &&
+            identity.TenantId == "scope-a");
+    }
+
+    [Fact]
+    public async Task HandleListGAgentTypesAsync_ShouldIgnoreNonStaticAndBlankStaticRevisionFacts()
+    {
+        var catalogReader = new FakeServiceCatalogQueryReader
+        {
+            Services =
+            [
+                CreateServiceCatalogSnapshot("svc-filtered-revisions"),
+            ],
+        };
+        var identity = CreateServiceIdentity("svc-filtered-revisions");
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader
+        {
+            Revisions =
+            {
+                [ServiceKeys.Build(identity)] = new ServiceRevisionCatalogSnapshot(
+                    ServiceKeys.Build(identity),
+                    [
+                        CreateWorkflowRevisionSnapshot("rev-workflow", "workflow-endpoint"),
+                        CreateStaticRevisionSnapshot("rev-blank-static", " ", "blank-static-endpoint"),
+                    ],
+                    DateTimeOffset.UtcNow),
+            },
+        };
+
+        var result = await InvokeHandleListGAgentTypesAsync(catalogReader, revisionReader);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+        statusCode.Should().Be((int)HttpStatusCode.OK);
+        body.Should().Be("[]");
+        body.Should().NotContain("workflow-endpoint");
+        body.Should().NotContain("blank-static-endpoint");
+        revisionReader.RequestedIdentities.Should().ContainSingle(identity =>
+            identity.ServiceId == "svc-filtered-revisions" &&
+            identity.TenantId == "scope-a");
+    }
+
+    [Fact]
+    public async Task HandleListGAgentTypesAsync_ShouldMergeDuplicateStaticActorTypeEndpoints()
+    {
+        var staticActorTypeName = "Tests.SharedStaticGAgent, Tests.Assembly";
+        var catalogReader = new FakeServiceCatalogQueryReader
+        {
+            Services =
+            [
+                CreateServiceCatalogSnapshot("svc-duplicate-actor-type"),
+            ],
+        };
+        var identity = CreateServiceIdentity("svc-duplicate-actor-type");
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader
+        {
+            Revisions =
+            {
+                [ServiceKeys.Build(identity)] = new ServiceRevisionCatalogSnapshot(
+                    ServiceKeys.Build(identity),
+                    [
+                        CreateStaticRevisionSnapshot("rev-a", staticActorTypeName, "chat", "run"),
+                        CreateStaticRevisionSnapshot("rev-b", staticActorTypeName, "chat", "status"),
+                    ],
+                    DateTimeOffset.UtcNow),
+            },
+        };
+
+        var result = await InvokeHandleListGAgentTypesAsync(catalogReader, revisionReader);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+        statusCode.Should().Be((int)HttpStatusCode.OK);
+        using var document = JsonDocument.Parse(body);
+        var gAgentType = document.RootElement.EnumerateArray().Should().ContainSingle().Subject;
+        gAgentType.GetProperty("typeName").GetString().Should().Be("SharedStaticGAgent");
+        gAgentType.GetProperty("fullName").GetString().Should().Be(staticActorTypeName);
+        gAgentType.GetProperty("assemblyName").GetString().Should().Be("Tests.Assembly");
+        gAgentType.GetProperty("endpoints")
+            .EnumerateArray()
+            .Select(endpoint => endpoint.GetProperty("endpointId").GetString())
+            .Should()
+            .BeEquivalentTo(["chat", "run", "status"]);
+        gAgentType.GetProperty("endpoints")
+            .EnumerateArray()
+            .Count(endpoint => endpoint.GetProperty("endpointId").GetString() == "chat")
+            .Should()
+            .Be(1);
+    }
+
+    [Fact]
     public async Task HandleListGAgentTypesAsync_ShouldNotDiscoverLoadedClrAgentClasses()
     {
         var catalogReader = new FakeServiceCatalogQueryReader();
@@ -1053,6 +1159,52 @@ public sealed class ScopeGAgentEndpointsTests
             Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
             ServiceId = serviceId,
         };
+
+    private static ServiceRevisionSnapshot CreateStaticRevisionSnapshot(
+        string revisionId,
+        string actorTypeName,
+        params string[] endpointIds) =>
+        new(
+            revisionId,
+            ServiceImplementationKind.Static.ToString(),
+            ServiceRevisionStatus.Published.ToString(),
+            $"{revisionId}-hash",
+            string.Empty,
+            endpointIds.Select(CreateEndpointSnapshot).ToList(),
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            null,
+            new ServiceRevisionImplementationSnapshot(
+                Static: new ServiceRevisionStaticSnapshot(actorTypeName, "preferred-actor")));
+
+    private static ServiceRevisionSnapshot CreateWorkflowRevisionSnapshot(
+        string revisionId,
+        params string[] endpointIds) =>
+        new(
+            revisionId,
+            ServiceImplementationKind.Workflow.ToString(),
+            ServiceRevisionStatus.Published.ToString(),
+            $"{revisionId}-hash",
+            string.Empty,
+            endpointIds.Select(CreateEndpointSnapshot).ToList(),
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            null,
+            new ServiceRevisionImplementationSnapshot(
+                Workflow: new ServiceRevisionWorkflowSnapshot("workflow-a", "definition-actor", 1)));
+
+    private static ServiceEndpointSnapshot CreateEndpointSnapshot(string endpointId) =>
+        new(
+            endpointId,
+            endpointId,
+            endpointId == "chat"
+                ? ServiceEndpointKind.Chat.ToString()
+                : ServiceEndpointKind.Command.ToString(),
+            $"type.googleapis.com/tests.{endpointId}",
+            string.Empty,
+            $"{endpointId} endpoint.");
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeGAgentEndpointsTests.cs
@@ -8,7 +8,11 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.ScopeGAgents;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Presentation.AGUI;
@@ -772,22 +776,75 @@ public sealed class ScopeGAgentEndpointsTests
     }
 
     [Fact]
-    public void ToCamelCaseAndStripEventSuffix_ShouldTransformWords()
+    public async Task HandleListGAgentTypesAsync_ShouldReadRegisteredStaticServiceRevisionFacts()
     {
-        InvokeToCamelCase("").Should().BeEmpty();
-        InvokeToCamelCase("TextEvent").Should().Be("textEvent");
+        var staticActorTypeName = "Tests.RegisteredStaticGAgent, Tests.Assembly";
+        var catalogReader = new FakeServiceCatalogQueryReader
+        {
+            Services =
+            [
+                CreateServiceCatalogSnapshot("svc-a"),
+            ],
+        };
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader
+        {
+            Revisions =
+            {
+                [ServiceKeys.Build(CreateServiceIdentity("svc-a"))] = new ServiceRevisionCatalogSnapshot(
+                    ServiceKeys.Build(CreateServiceIdentity("svc-a")),
+                    [
+                        new ServiceRevisionSnapshot(
+                            "rev-static",
+                            ServiceImplementationKind.Static.ToString(),
+                            ServiceRevisionStatus.Published.ToString(),
+                            "hash-a",
+                            string.Empty,
+                            [
+                                new ServiceEndpointSnapshot(
+                                    "chat",
+                                    "Chat",
+                                    ServiceEndpointKind.Chat.ToString(),
+                                    "type.googleapis.com/aevatar.ai.ChatRequestEvent",
+                                    string.Empty,
+                                    "Registered chat endpoint."),
+                            ],
+                            DateTimeOffset.UtcNow,
+                            DateTimeOffset.UtcNow,
+                            DateTimeOffset.UtcNow,
+                            null,
+                            new ServiceRevisionImplementationSnapshot(
+                                Static: new ServiceRevisionStaticSnapshot(staticActorTypeName, "preferred-actor"))),
+                    ],
+                    DateTimeOffset.UtcNow),
+            },
+        };
 
-        InvokeStripEventSuffix("ToolResultEvent").Should().Be("ToolResult");
-        InvokeStripEventSuffix("NoSuffix").Should().Be("NoSuffix");
+        var result = await InvokeHandleListGAgentTypesAsync(catalogReader, revisionReader);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+        statusCode.Should().Be((int)HttpStatusCode.OK);
+        body.Should().Contain("RegisteredStaticGAgent");
+        body.Should().Contain(staticActorTypeName);
+        body.Should().Contain("Tests.Assembly");
+        body.Should().Contain("chat");
+        revisionReader.RequestedIdentities.Should().ContainSingle(identity =>
+            identity.ServiceId == "svc-a" &&
+            identity.TenantId == "scope-a");
     }
 
     [Fact]
-    public void HandleListGAgentTypesAsync_ShouldReturnOkResult()
+    public async Task HandleListGAgentTypesAsync_ShouldNotDiscoverLoadedClrAgentClasses()
     {
-        var result = InvokeHandleListGAgentTypesAsync();
-        result.Should().NotBeNull();
-        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
-        ((IStatusCodeHttpResult)result).StatusCode.Should().Be((int)HttpStatusCode.OK);
+        var catalogReader = new FakeServiceCatalogQueryReader();
+        var revisionReader = new FakeServiceRevisionCatalogQueryReader();
+
+        var result = await InvokeHandleListGAgentTypesAsync(catalogReader, revisionReader);
+
+        var (statusCode, body) = await ExecuteResultAsync(result);
+        statusCode.Should().Be((int)HttpStatusCode.OK);
+        body.Should().NotContain(nameof(FakeAgent));
+        body.Should().Be("[]");
+        revisionReader.RequestedIdentities.Should().BeEmpty();
     }
 
     [Fact]
@@ -801,6 +858,19 @@ public sealed class ScopeGAgentEndpointsTests
         source.Should().NotContain("TryMapEnvelopeToAguiEvent");
         source.Should().NotContain("BuildToolApprovalStruct");
         source.Should().NotContain("ScopeGAgentAguiEventMapper.TryMap");
+    }
+
+    [Fact]
+    public void ScopeGAgentEndpointsSource_ShouldNotUseReflectionAsGAgentTypeCatalog()
+    {
+        var source = File.ReadAllText(GetScopeGAgentEndpointsSourcePath());
+
+        source.Should().NotContain("AppDomain.CurrentDomain.GetAssemblies()");
+        source.Should().NotContain("FindOpenGenericBaseType");
+        source.Should().NotContain("DerivesFromOpenGeneric");
+        source.Should().NotContain("EventHandlerAttribute");
+        source.Should().NotContain("TryGetProtoTypeUrl");
+        source.Should().Contain("IServiceRevisionCatalogQueryReader");
     }
 
     private static string? InvokeExtractBearerToken(HttpContext context)
@@ -817,22 +887,6 @@ public sealed class ScopeGAgentEndpointsTests
             "IsNyxIdAuthenticationRequired",
             BindingFlags.NonPublic | BindingFlags.Static);
         return (bool)method!.Invoke(null, new object[] { ex })!;
-    }
-
-    private static string InvokeToCamelCase(string value)
-    {
-        var method = typeof(ScopeGAgentEndpoints).GetMethod(
-            "ToCamelCase",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        return (string)method!.Invoke(null, new object[] { value })!;
-    }
-
-    private static string InvokeStripEventSuffix(string value)
-    {
-        var method = typeof(ScopeGAgentEndpoints).GetMethod(
-            "StripEventSuffix",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        return (string)method!.Invoke(null, new object[] { value })!;
     }
 
     private static async Task<IResult> InvokeHandleListActorsAsync(
@@ -855,12 +909,19 @@ public sealed class ScopeGAgentEndpointsTests
         })!;
     }
 
-    private static IResult InvokeHandleListGAgentTypesAsync()
+    private static async Task<IResult> InvokeHandleListGAgentTypesAsync(
+        IServiceCatalogQueryReader catalogReader,
+        IServiceRevisionCatalogQueryReader revisionCatalogReader)
     {
         var method = typeof(ScopeGAgentEndpoints).GetMethod(
             "HandleListGAgentTypesAsync",
             BindingFlags.NonPublic | BindingFlags.Static);
-        return (IResult)method!.Invoke(null, [])!;
+        return await (Task<IResult>)method!.Invoke(null, new object[]
+        {
+            catalogReader,
+            revisionCatalogReader,
+            CancellationToken.None,
+        })!;
     }
 
     private static async Task<IResult> InvokeHandleAddActorAsync(
@@ -963,6 +1024,35 @@ public sealed class ScopeGAgentEndpointsTests
             ], "test")),
         };
     }
+
+    private static ServiceCatalogSnapshot CreateServiceCatalogSnapshot(string serviceId)
+    {
+        var identity = CreateServiceIdentity(serviceId);
+        return new ServiceCatalogSnapshot(
+            ServiceKeys.Build(identity),
+            identity.TenantId,
+            identity.AppId,
+            identity.Namespace,
+            identity.ServiceId,
+            DisplayName: serviceId,
+            DefaultServingRevisionId: string.Empty,
+            ActiveServingRevisionId: string.Empty,
+            DeploymentId: string.Empty,
+            PrimaryActorId: string.Empty,
+            DeploymentStatus: string.Empty,
+            Endpoints: [],
+            PolicyIds: [],
+            UpdatedAt: DateTimeOffset.UtcNow);
+    }
+
+    private static ServiceIdentity CreateServiceIdentity(string serviceId) =>
+        new()
+        {
+            TenantId = "scope-a",
+            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
+            ServiceId = serviceId,
+        };
 
     private sealed class TestHostEnvironment : IHostEnvironment
     {
@@ -1214,6 +1304,47 @@ public sealed class ScopeGAgentEndpointsTests
             ScopeResourceTarget target,
             CancellationToken cancellationToken = default)
             => Task.FromResult(ScopeResourceAdmissionResult.Allowed());
+    }
+
+    private sealed class FakeServiceCatalogQueryReader : IServiceCatalogQueryReader
+    {
+        public IReadOnlyList<ServiceCatalogSnapshot> Services { get; set; } = [];
+
+        public Task<ServiceCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default) =>
+            Task.FromResult(Services.FirstOrDefault(x =>
+                string.Equals(x.ServiceKey, ServiceKeys.Build(identity), StringComparison.Ordinal)));
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryAllAsync(
+            int take = 1000,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>(Services.Take(take).ToList());
+
+        public Task<IReadOnlyList<ServiceCatalogSnapshot>> QueryByScopeAsync(
+            string tenantId,
+            string appId,
+            string @namespace,
+            int take = 200,
+            CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>(Services
+                .Where(x =>
+                    string.Equals(x.TenantId, tenantId, StringComparison.Ordinal) &&
+                    string.Equals(x.AppId, appId, StringComparison.Ordinal) &&
+                    string.Equals(x.Namespace, @namespace, StringComparison.Ordinal))
+                .Take(take)
+                .ToList());
+    }
+
+    private sealed class FakeServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQueryReader
+    {
+        public Dictionary<string, ServiceRevisionCatalogSnapshot> Revisions { get; } = new(StringComparer.Ordinal);
+
+        public List<ServiceIdentity> RequestedIdentities { get; } = [];
+
+        public Task<ServiceRevisionCatalogSnapshot?> GetAsync(ServiceIdentity identity, CancellationToken ct = default)
+        {
+            RequestedIdentities.Add(identity.Clone());
+            return Task.FromResult(Revisions.GetValueOrDefault(ServiceKeys.Build(identity)));
+        }
     }
 
     private sealed class FakeActorRuntime : IActorRuntime


### PR DESCRIPTION
## 摘要

**Cluster**: iter39 cluster-039-gagent-reflection-catalog
**Issue**: Closes #852
**Design**: Phase 9 r2 reflector `force-pick:minimal`(`.refactor-loop/runs/meta-reflect-issue852-r2.md`)

**Old pattern**: `ScopeGAgentEndpoints` 通过 AppDomain reflection + AIGAgentBase + [EventHandler] + protobuf descriptors 发现 GAgent 类型,把进程内加载的 CLR class 当成业务事实源。

**New principle**: GAgent type 列表必须来自 registered service revision catalog readmodel,不是反射偶然加载的 CLR class。保留 `/api/scopes/gagent-types` 路由(console-web 依赖),换实现为读 readmodel。

## 改动

- `ScopeGAgentEndpoints`: keeps `/api/scopes/gagent-types`,改为读 existing service catalog + revision catalog readmodel facts(不再 reflect loaded CLR types)
- 删除 AppDomain/AIGAgentBase/EventHandler/protobuf descriptor discovery 路径
- 加 integration tests proving registered static service revision facts 被返回,arbitrary loaded CLR-only agents 不再 discovered

## 不允许(reflector r2 strict)

- ❌ GAgentCapabilityCatalogGAgent / 任何 new actor type(structural solver 提议被 reflector 拒绝)
- ❌ 新 proto / new readmodel catalog / new projection phase
- ❌ docs/canon edit
- ❌ AgentKind migration(本 cluster 不做)

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test test/Aevatar.GAgentService.Tests` ✅
- `ScopeGAgentEndpointsTests` targeted ✅
- `bash tools/ci/test_stability_guards.sh` ✅
- `bash tools/ci/architecture_guards.sh` ✅

## 已知 unrelated CI deviation

Full `Aevatar.GAgentService.Integration.Tests` 有 dev-wide pre-existing `PROJECTION_DISABLED` failure in `ScopeDraftRunActorQueryIntegrationTests`(从 2026-05-22T19:32 dev 开始 fail)— 不是本 PR 引入。**已在 PR #855 修复**。

## 测试计划

- [x] GAgentService unit tests pass
- [x] ScopeGAgentEndpointsTests pass(targeted)
- [x] 架构守卫通过
- [x] 删反射后,/api/scopes/gagent-types 仍返回 console-web 需要的 types(基于 service catalog readmodel)

---

🤖 auto-loop Phase 9 reflector force-pick:minimal

⟦AI:AUTO-LOOP⟧
