### PR TITLE
iter39 cluster-039 scope-service-host-orchestration: 删除 Host inline default-chat fallback,保留 bound 路由

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -1608,8 +1608,8 @@ public static class ScopeServiceEndpoints
         CancellationToken ct)
     {
         // Refactor (iter39/cluster-039-scope-service-host-orchestration):
-        //   Old pattern: ScopeServiceEndpoints.HandleInvokeDefaultChatStreamAsync 在 unbound default service 情况下 launch Host-inline DefaultChatWorkflowYaml 作为 hidden fallback,把 Host 当成 business orchestrator。
-        //   New principle: Host endpoint 仅做 routing + bound service stream;unbound case 返回 explicit error;stream registration / static orchestration 归 Application owner。
+        //   Old pattern: Host built the static GAgent draft-run command, registered service-run state from the endpoint callback, and owned timeout/SSE lifecycle around that orchestration.
+        //   New principle: Host only adapts HTTP/SSE callbacks; Application-owned IStaticGAgentStreamInvocationPort<AGUIEvent> owns static invocation and service-run registration semantics.
         var writer = new AGUISseWriter(http.Response);
         var responseStarted = false;
 

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -575,93 +575,31 @@ public static class ScopeServiceEndpoints
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
-        [FromServices] ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> gagentDraftRunService,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
+        [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
-        // Try to resolve a bound default service first.
-        // If none is bound, fall back to a built-in simple llm_call workflow (draft-run).
+        // Refactor (iter39/cluster-039-scope-service-host-orchestration):
+        //   Old pattern: ScopeServiceEndpoints.HandleInvokeDefaultChatStreamAsync 在 unbound default service 情况下 launch Host-inline DefaultChatWorkflowYaml 作为 hidden fallback,把 Host 当成 business orchestrator。
+        //   New principle: Host endpoint 仅做 routing + bound service stream;unbound case 返回 explicit error;stream registration / static orchestration 归 Application owner。
         var serviceId = ResolveDefaultScopeServiceId(options.Value);
-        var identity = BuildScopeServiceIdentity(options.Value, scopeId, serviceId);
-        var hasBoundService = await resolutionService.HasServiceAsync(identity, ct);
-
-        if (hasBoundService)
-        {
-            await HandleInvokeStreamAsync(
-                http,
-                scopeId,
-                serviceId,
-                "chat",
-                request,
-                appId: null,
-                resolutionService,
-                admissionAuthorizer,
-                serviceRunRegistrationPort,
-                chatRunService,
-                gagentDraftRunService,
-                scriptServiceRunService,
-                options,
-                ct);
-            return;
-        }
-
-        // No service bound — run a built-in default chat workflow as draft-run.
-        try
-        {
-            if (await AevatarScopeAccessGuard.TryWriteScopeAccessDeniedAsync(http, scopeId, ct))
-                return;
-
-            var scopedHeaders = await BuildScopedHeadersAsync(scopeId, request.Headers, http, ct);
-            var chatInputParts = MapInputParts(request.InputParts);
-            var chatRequest = new WorkflowChatRunRequest(
-                Prompt: request.Prompt?.Trim() ?? string.Empty,
-                WorkflowName: null,
-                ActorId: null,
-                SessionId: request.SessionId,
-                WorkflowYamls: [DefaultChatWorkflowYaml],
-                Metadata: scopedHeaders,
-                ScopeId: scopeId);
-
-            await WorkflowCapabilityEndpoints.HandleChat(
-                http,
-                new ChatInput
-                {
-                    Prompt = chatRequest.Prompt,
-                    InputParts = chatInputParts,
-                    WorkflowYamls = chatRequest.WorkflowYamls,
-                    SessionId = chatRequest.SessionId,
-                    ScopeId = scopeId,
-                    Metadata = scopedHeaders,
-                },
-                chatRunService,
-                ct);
-        }
-        catch (InvalidOperationException ex)
-        {
-            await WriteJsonErrorResponseAsync(
-                http,
-                StatusCodes.Status400BadRequest,
-                "INVALID_SERVICE_STREAM_REQUEST",
-                ex.Message,
-                ct);
-        }
+        await HandleInvokeStreamAsync(
+            http,
+            scopeId,
+            serviceId,
+            "chat",
+            request,
+            appId: null,
+            resolutionService,
+            admissionAuthorizer,
+            serviceRunRegistrationPort,
+            chatRunService,
+            scriptServiceRunService,
+            staticGAgentStreamInvocationPort,
+            options,
+            ct);
     }
-
-    private const string DefaultChatWorkflowYaml = """
-        name: default_chat
-        description: Built-in default single-turn chat.
-        roles:
-          - id: assistant
-            name: Assistant
-            system_prompt: |
-              You are a helpful assistant.
-        steps:
-          - id: answer
-            type: llm_call
-            role: assistant
-            parameters: {}
-        """;
 
     private static Task<IResult> HandleInvokeDefaultAsync(
         HttpContext http,
@@ -697,8 +635,8 @@ public static class ScopeServiceEndpoints
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
-        [FromServices] ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> gagentDraftRunService,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
+        [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -724,8 +662,8 @@ public static class ScopeServiceEndpoints
                 admissionAuthorizer,
                 serviceRunRegistrationPort,
                 chatRunService,
-                gagentDraftRunService,
                 scriptServiceRunService,
+                staticGAgentStreamInvocationPort,
                 options,
                 ct);
         }
@@ -795,8 +733,8 @@ public static class ScopeServiceEndpoints
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
-        [FromServices] ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> gagentDraftRunService,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
+        [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -817,8 +755,8 @@ public static class ScopeServiceEndpoints
                 admissionAuthorizer,
                 serviceRunRegistrationPort,
                 chatRunService,
-                gagentDraftRunService,
                 scriptServiceRunService,
+                staticGAgentStreamInvocationPort,
                 options,
                 ct);
         }
@@ -1543,8 +1481,8 @@ public static class ScopeServiceEndpoints
         [FromServices] IInvokeAdmissionAuthorizer admissionAuthorizer,
         [FromServices] IServiceRunRegistrationPort serviceRunRegistrationPort,
         [FromServices] ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus> chatRunService,
-        [FromServices] ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> gagentDraftRunService,
         [FromServices] ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus> scriptServiceRunService,
+        [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         [FromServices] IOptions<ScopeWorkflowCapabilityOptions> options,
         CancellationToken ct)
     {
@@ -1607,17 +1545,14 @@ public static class ScopeServiceEndpoints
                 case ServiceImplementationKind.Static:
                     await HandleStaticGAgentChatStreamAsync(
                         http,
-                        target,
                         normalizedPrompt,
                         request.ActorId,
                         request.SessionId,
-                        scopeId,
-                        serviceId,
                         scopedHeaders,
                         request.InputParts,
-                        gagentDraftRunService,
+                        request.RevisionId,
                         invocationRequest,
-                        serviceRunRegistrationPort,
+                        staticGAgentStreamInvocationPort,
                         ct);
                     break;
 
@@ -1662,24 +1597,19 @@ public static class ScopeServiceEndpoints
 
     private static async Task HandleStaticGAgentChatStreamAsync(
         HttpContext http,
-        ServiceInvocationResolvedTarget target,
         string prompt,
         string? actorId,
         string? sessionId,
-        string scopeId,
-        string serviceId,
         IReadOnlyDictionary<string, string>? headers,
         IReadOnlyList<StreamContentPartHttpRequest>? inputParts,
-        ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> interactionService,
+        string? revisionId,
         ServiceInvocationRequest invocationRequest,
-        IServiceRunRegistrationPort serviceRunRegistrationPort,
+        IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         CancellationToken ct)
     {
-        var plan = target.Artifact.DeploymentPlan.StaticPlan;
-        var resolvedActorId = string.IsNullOrWhiteSpace(actorId)
-            ? null
-            : actorId.Trim();
-
+        // Refactor (iter39/cluster-039-scope-service-host-orchestration):
+        //   Old pattern: ScopeServiceEndpoints.HandleInvokeDefaultChatStreamAsync 在 unbound default service 情况下 launch Host-inline DefaultChatWorkflowYaml 作为 hidden fallback,把 Host 当成 business orchestrator。
+        //   New principle: Host endpoint 仅做 routing + bound service stream;unbound case 返回 explicit error;stream registration / static orchestration 归 Application owner。
         var writer = new AGUISseWriter(http.Response);
         var responseStarted = false;
 
@@ -1702,30 +1632,17 @@ public static class ScopeServiceEndpoints
             await writer.WriteAsync(aguiEvent, token);
         }
 
-        async ValueTask OnAcceptedAsync(GAgentDraftRunAcceptedReceipt receipt, CancellationToken token)
+        async ValueTask OnAcceptedAsync(StaticGAgentStreamAcceptedReceipt receipt, CancellationToken token)
         {
-            http.Response.Headers["X-Correlation-Id"] = receipt.CorrelationId;
-            // Register the service run with the same id we are about to send to the client
-            // so /runs/{runId} resolves immediately on refresh.
-            await RegisterStreamServiceRunAsync(
-                serviceRunRegistrationPort,
-                target,
-                invocationRequest,
-                scopeId,
-                serviceId,
-                runId: receipt.CommandId,
-                commandId: receipt.CommandId,
-                correlationId: receipt.CorrelationId,
-                targetActorId: receipt.ActorId,
-                token);
+            http.Response.Headers["X-Correlation-Id"] = receipt.GAgentReceipt.CorrelationId;
             await EnsureSseStartedAsync(token);
             await writer.WriteAsync(
                 new AGUIEvent
                 {
                     RunStarted = new RunStartedEvent
                     {
-                        ThreadId = receipt.ActorId,
-                        RunId = receipt.CommandId,
+                        ThreadId = receipt.GAgentReceipt.ActorId,
+                        RunId = receipt.GAgentReceipt.CommandId,
                     },
                 },
                 token);
@@ -1733,32 +1650,34 @@ public static class ScopeServiceEndpoints
 
         try
         {
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(TimeSpan.FromMinutes(2));
-
-            var interaction = await interactionService.ExecuteAsync(
-                new GAgentDraftRunCommand(
-                    ScopeId: scopeId,
-                    ActorTypeName: plan.ActorTypeName,
-                    Prompt: prompt,
-                    PreferredActorId: resolvedActorId,
-                    SessionId: sessionId,
-                    Headers: headers,
-                    InputParts: MapGAgentDraftRunInputParts(inputParts)),
+            var result = await staticGAgentStreamInvocationPort.InvokeAsync(
+                new StaticGAgentStreamInvocationRequest(
+                    invocationRequest.Identity?.Clone()
+                        ?? throw new InvalidOperationException("service identity is required."),
+                    invocationRequest.EndpointId,
+                    new StaticGAgentStreamInvocationInput(
+                        Prompt: prompt,
+                        PreferredActorId: actorId,
+                        SessionId: sessionId,
+                        RevisionId: revisionId,
+                        Headers: headers,
+                        InputParts: MapGAgentDraftRunInputParts(inputParts),
+                        Caller: invocationRequest.Caller?.Clone(),
+                        Timeout: TimeSpan.FromMinutes(2))),
                 EmitAsync,
                 OnAcceptedAsync,
-                timeoutCts.Token);
+                ct);
 
-            if (!interaction.Succeeded && interaction.Error == GAgentDraftRunStartError.UnknownActorType)
+            if (!result.Succeeded && result.StartError == GAgentDraftRunStartError.UnknownActorType)
             {
                 throw new InvalidOperationException(
-                    $"GAgent type '{plan.ActorTypeName}' could not be resolved.");
+                    "GAgent type could not be resolved.");
             }
 
-            if (!interaction.Succeeded && interaction.Error == GAgentDraftRunStartError.ActorTypeMismatch)
+            if (!result.Succeeded && result.StartError == GAgentDraftRunStartError.ActorTypeMismatch)
             {
                 throw new InvalidOperationException(
-                    $"Actor '{resolvedActorId}' is not compatible with requested type '{plan.ActorTypeName}'.");
+                    $"Actor '{actorId}' is not compatible with requested static GAgent service.");
             }
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested)

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -2,9 +2,6 @@ using System.Reflection;
 using Aevatar.AI.Abstractions;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
-using Aevatar.CQRS.Core.Commands;
-using Aevatar.CQRS.Core.Interactions;
-using Aevatar.CQRS.Core.Streaming;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.GAgentService.Abstractions;
@@ -34,10 +31,6 @@ namespace Aevatar.GAgentService.Integration.Tests;
 
 public sealed class ScopeServiceEndpointsStreamTests
 {
-    private static readonly MethodInfo HandleGAgentStreamMethod = typeof(ScopeServiceEndpoints)
-        .GetMethod("HandleStaticGAgentChatStreamAsync", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("HandleStaticGAgentChatStreamAsync not found.");
-
     private static readonly MethodInfo HandleScriptingStreamMethod = typeof(ScopeServiceEndpoints)
         .GetMethod("HandleScriptingServiceChatStreamAsync", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("HandleScriptingServiceChatStreamAsync not found.");
@@ -65,185 +58,9 @@ public sealed class ScopeServiceEndpointsStreamTests
         source.Should().NotContain("EnsureRunProjectionAsync");
         source.Should().NotContain("EnsureAndAttachLeaseAsync");
         source.Should().NotContain("RunRuntimeAsync");
-    }
-
-    [Fact]
-    public async Task HandleGAgentServiceChatStreamAsync_ShouldCreateActor_AndEmitSyntheticFinish()
-    {
-        var http = CreateHttpContext();
-        var runtime = new StubActorRuntime();
-        var projectionPort = new StubDraftRunProjectionPort
-        {
-            Messages =
-            {
-                new EventEnvelope
-                {
-                    Payload = Any.Pack(new AiTextEndEvent { Content = "done" }),
-                },
-            },
-        };
-        var interactionService = CreateStaticStreamInteractionService(runtime, projectionPort);
-
-        await InvokeStaticStreamAsync(
-            http,
-            CreateStaticTarget(typeof(StreamTestAgent).AssemblyQualifiedName!, primaryActorId: "actor-1"),
-            "hello",
-            "actor-1",
-            "session-1",
-            "scope-a",
-            new Dictionary<string, string> { ["trace-id"] = "abc" },
-            null,
-            interactionService,
-            CancellationToken.None);
-
-        runtime.CreateCalls.Should().ContainSingle(call => call.Id == "actor-1");
-        var actor = runtime.Actors["actor-1"].Should().BeOfType<StubActor>().Subject;
-        var request = actor.HandledEnvelopes.Should().ContainSingle().Subject.Payload.Unpack<ChatRequestEvent>();
-        request.Prompt.Should().Be("hello");
-        request.SessionId.Should().Be("session-1");
-        request.ScopeId.Should().Be("scope-a");
-        request.Metadata["trace-id"].Should().Be("abc");
-
-        var body = await ReadBodyAsync(http);
-        body.Should().Contain("runStarted");
-        body.Should().Contain("textMessageEnd");
-        body.Should().Contain("runFinished");
-    }
-
-    [Fact]
-    public async Task HandleGAgentServiceChatStreamAsync_ShouldReuseExistingActor_AndAvoidSyntheticDuplicateFinish()
-    {
-        var http = CreateHttpContext();
-        var runtime = new StubActorRuntime();
-        runtime.Actors["actor-1"] = new StubActor("actor-1");
-        var projectionPort = new StubDraftRunProjectionPort
-        {
-            Messages =
-            {
-                new EventEnvelope
-                {
-                    Payload = Any.Pack(new AGUIEvent
-                    {
-                        RunFinished = new RunFinishedEvent
-                        {
-                            ThreadId = "actor-1",
-                            RunId = "run-1",
-                        },
-                    }),
-                },
-            },
-        };
-        var interactionService = CreateStaticStreamInteractionService(runtime, projectionPort);
-
-        await InvokeStaticStreamAsync(
-            http,
-            CreateStaticTarget(typeof(StreamTestAgent).AssemblyQualifiedName!, primaryActorId: "actor-1"),
-            "hello",
-            "actor-1",
-            null,
-            "scope-a",
-            null,
-            null,
-            interactionService,
-            CancellationToken.None);
-
-        runtime.CreateCalls.Should().BeEmpty();
-        var body = await ReadBodyAsync(http);
-        body.Split("\"runFinished\"", StringSplitOptions.None).Length.Should().Be(2);
-    }
-
-    [Fact]
-    public async Task HandleGAgentServiceChatStreamAsync_ShouldMapAllInputPartKinds_WhenCreatingAnonymousActor()
-    {
-        var http = CreateHttpContext();
-        var runtime = new StubActorRuntime();
-        var projectionPort = new StubDraftRunProjectionPort
-        {
-            Messages =
-            {
-                new EventEnvelope
-                {
-                    Payload = Any.Pack(new AiTextEndEvent { Content = "done" }),
-                },
-            },
-        };
-        var interactionService = CreateStaticStreamInteractionService(runtime, projectionPort);
-
-        await InvokeStaticStreamAsync(
-            http,
-            CreateStaticTarget(typeof(StreamTestAgent).AssemblyQualifiedName!, primaryActorId: "actor-1"),
-            "hello",
-            null,
-            null,
-            "scope-a",
-            null,
-            new List<ScopeServiceEndpoints.StreamContentPartHttpRequest>
-            {
-                new("image", null, null, "image/png", "https://example.com/image.png", "image-1"),
-                new("audio", null, "ZGF0YQ==", "audio/mpeg", null, "audio-1"),
-                new("video", null, null, "video/mp4", "https://example.com/video.mp4", "video-1"),
-                new("text", "hello text"),
-                new("custom", "unknown"),
-            },
-            interactionService,
-            CancellationToken.None);
-
-        runtime.CreateCalls.Should().ContainSingle(call => call.Id == null);
-        var actor = runtime.Actors.Values.Should().ContainSingle().Subject.Should().BeOfType<StubActor>().Subject;
-        var envelope = actor.HandledEnvelopes.Should().ContainSingle().Subject;
-        var request = envelope.Payload.Unpack<ChatRequestEvent>();
-        request.SessionId.Should().Be(envelope.Propagation.CorrelationId);
-        request.InputParts.Select(part => part.Kind).Should().Equal(
-            ChatContentPartKind.Image,
-            ChatContentPartKind.Audio,
-            ChatContentPartKind.Video,
-            ChatContentPartKind.Text,
-            ChatContentPartKind.Unspecified);
-
-        var body = await ReadBodyAsync(http);
-        body.Should().Contain("textMessageEnd");
-        body.Should().Contain("runFinished");
-    }
-
-    [Fact]
-    public async Task HandleGAgentServiceChatStreamAsync_ShouldPreserveRunErrorWithoutSyntheticFinish()
-    {
-        var http = CreateHttpContext();
-        var runtime = new StubActorRuntime();
-        runtime.Actors["actor-1"] = new StubActor("actor-1");
-        var projectionPort = new StubDraftRunProjectionPort
-        {
-            Messages =
-            {
-                new EventEnvelope
-                {
-                    Payload = Any.Pack(new AGUIEvent
-                    {
-                        RunError = new RunErrorEvent
-                        {
-                            Message = "failed",
-                        },
-                    }),
-                },
-            },
-        };
-        var interactionService = CreateStaticStreamInteractionService(runtime, projectionPort);
-
-        await InvokeStaticStreamAsync(
-            http,
-            CreateStaticTarget(typeof(StreamTestAgent).AssemblyQualifiedName!, primaryActorId: "actor-1"),
-            "hello",
-            "actor-1",
-            null,
-            "scope-a",
-            null,
-            null,
-            interactionService,
-            CancellationToken.None);
-
-        var body = await ReadBodyAsync(http);
-        body.Should().Contain("runError");
-        body.Should().NotContain("runFinished");
+        source.Should().NotContain("private const string DefaultChatWorkflowYaml");
+        source.Should().NotContain("name: default_chat");
+        source.Should().NotContain("HasServiceAsync(identity");
     }
 
     [Fact]
@@ -767,25 +584,6 @@ public sealed class ScopeServiceEndpointsStreamTests
     }
 
     [Fact]
-    public async Task HandleGAgentServiceChatStreamAsync_ShouldThrow_WhenAgentTypeCannotBeResolved()
-    {
-        var act = () => InvokeStaticStreamAsync(
-            CreateHttpContext(),
-            CreateStaticTarget("Missing.Agent, Missing.Assembly", primaryActorId: "actor-1"),
-            "hello",
-            "actor-1",
-            null,
-            "scope-a",
-            null,
-            null,
-            CreateStaticStreamInteractionService(new StubActorRuntime(), new StubDraftRunProjectionPort()),
-            CancellationToken.None);
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*could not be resolved*");
-    }
-
-    [Fact]
     public async Task HandleScriptingServiceChatStreamAsync_ShouldThrow_WhenPrimaryActorMissing()
     {
         var interactionService = new StubScriptServiceRunInteractionService
@@ -1099,33 +897,6 @@ public sealed class ScopeServiceEndpointsStreamTests
             NullLoggerFactory.Instance,
             ct);
 
-    private static Task InvokeStaticStreamAsync(
-        HttpContext http,
-        ServiceInvocationResolvedTarget target,
-        string prompt,
-        string? actorId,
-        string? sessionId,
-        string scopeId,
-        IReadOnlyDictionary<string, string>? headers,
-        IReadOnlyList<ScopeServiceEndpoints.StreamContentPartHttpRequest>? inputParts,
-        ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> interactionService,
-        CancellationToken ct) =>
-        InvokePrivateTaskAsync(
-            HandleGAgentStreamMethod,
-            http,
-            target,
-            prompt,
-            actorId,
-            sessionId,
-            scopeId,
-            "svc-default",
-            headers,
-            inputParts,
-            interactionService,
-            new ServiceInvocationRequest(),
-            new NoOpServiceRunRegistrationPort(),
-            ct);
-
     private static Task InvokeScriptingStreamAsync(
         HttpContext http,
         ServiceInvocationResolvedTarget target,
@@ -1147,15 +918,6 @@ public sealed class ScopeServiceEndpointsStreamTests
             interactionService,
             new ServiceInvocationRequest(),
             ct);
-
-    private sealed class NoOpServiceRunRegistrationPort : IServiceRunRegistrationPort
-    {
-        public Task<ServiceRunRegistrationResult> RegisterAsync(ServiceRunRecord record, CancellationToken ct = default) =>
-            Task.FromResult(new ServiceRunRegistrationResult($"service-run:{record.RunId}", record.RunId));
-
-        public Task UpdateStatusAsync(string runActorId, string runId, ServiceRunStatus status, CancellationToken ct = default) =>
-            Task.CompletedTask;
-    }
 
     private sealed class RecordingDraftRunActorPreparationPort(GAgentDraftRunPreparedActor preparedActor)
         : IGAgentDraftRunActorPreparationPort
@@ -1228,221 +990,6 @@ public sealed class ScopeServiceEndpointsStreamTests
     {
         http.Response.Body.Position = 0;
         return await new StreamReader(http.Response.Body).ReadToEndAsync();
-    }
-
-    private static ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> CreateStaticStreamInteractionService(
-        StubActorRuntime runtime,
-        StubDraftRunProjectionPort projectionPort)
-    {
-        var terminalProjectionPort = new StubGAgentRunTerminalProjectionPort();
-        var pipeline = new DefaultCommandDispatchPipeline<GAgentDraftRunCommand, GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError>(
-            new GAgentDraftRunCommandTargetResolver(
-                runtime,
-                projectionPort,
-                terminalProjectionPort),
-            new DefaultCommandContextPolicy(),
-            new GAgentDraftRunCommandEnvelopeFactory(),
-            new ActorCommandTargetDispatcher<GAgentDraftRunCommandTarget>(new InlineActorDispatchPort(runtime)),
-            new GAgentDraftRunAcceptedReceiptFactory());
-
-        return new DefaultCommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, AGUIEvent, GAgentDraftRunCompletionStatus>(
-            pipeline,
-            new DefaultEventOutputStream<AGUIEvent, AGUIEvent>(new IdentityEventFrameMapper<AGUIEvent>()),
-            new GAgentDraftRunCompletionPolicy(),
-            new GAgentDraftRunFinalizeEmitter(),
-            new GAgentDraftRunDurableCompletionResolver(new StubGAgentRunTerminalQueryPort()),
-            NullLogger<DefaultCommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunCommandTarget, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, AGUIEvent, GAgentDraftRunCompletionStatus>>.Instance,
-            new GAgentDraftRunObservationLifecycle(projectionPort, terminalProjectionPort),
-            new GAgentDraftRunAcceptedReceiptFactory());
-    }
-
-    private sealed class StubActorRuntime : IActorRuntime
-    {
-        public Dictionary<string, IActor> Actors { get; } = [];
-        public List<(System.Type Type, string? Id)> CreateCalls { get; } = [];
-
-        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
-            where TAgent : IAgent => CreateAsync(typeof(TAgent), id, ct);
-
-        public Task<IActor> CreateAsync(System.Type agentType, string? id = null, CancellationToken ct = default)
-        {
-            var actor = new StubActor(id ?? Guid.NewGuid().ToString("N"));
-            Actors[actor.Id] = actor;
-            CreateCalls.Add((agentType, id));
-            return Task.FromResult<IActor>(actor);
-        }
-
-        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
-        public Task<IActor?> GetAsync(string id) => Task.FromResult(Actors.GetValueOrDefault(id));
-        public Task<bool> ExistsAsync(string id) => Task.FromResult(Actors.ContainsKey(id));
-        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
-        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
-    }
-
-    private sealed class InlineActorDispatchPort(StubActorRuntime runtime) : IActorDispatchPort
-    {
-        public async Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
-        {
-            var actor = await runtime.GetAsync(actorId);
-            if (actor == null)
-                throw new InvalidOperationException($"Actor '{actorId}' not found.");
-
-            await actor.HandleEventAsync(envelope, ct);
-        }
-    }
-
-    private sealed class StubActor(string id) : IActor
-    {
-        public string Id { get; } = id;
-        public IAgent Agent { get; } = new StreamTestAgent();
-        public List<EventEnvelope> HandledEnvelopes { get; } = [];
-
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
-        {
-            HandledEnvelopes.Add(envelope);
-            return Task.CompletedTask;
-        }
-
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
-    }
-
-    private sealed class StubDraftRunProjectionPort : IGAgentDraftRunProjectionPort
-    {
-        public List<EventEnvelope> Messages { get; } = [];
-
-        public bool ProjectionEnabled => true;
-
-        public Task<IGAgentDraftRunProjectionLease?> EnsureActorProjectionAsync(
-            string actorId,
-            string commandId,
-            CancellationToken ct = default)
-        {
-            _ = ct;
-            return Task.FromResult<IGAgentDraftRunProjectionLease?>(new StubDraftRunProjectionLease(actorId, commandId));
-        }
-
-        public async Task<EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>?> AttachExistingActorProjectionAsync(
-            string actorId,
-            string commandId,
-            IEventSink<AGUIEvent> sink,
-            CancellationToken ct = default)
-        {
-            var lease = new StubDraftRunProjectionLease(actorId, commandId);
-            var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct);
-            return new EventSinkProjectionAttachment<IGAgentDraftRunProjectionLease>(lease, liveSinkLease);
-        }
-
-        public async Task<IAsyncDisposable?> AttachLiveSinkAsync(
-            IGAgentDraftRunProjectionLease lease,
-            IEventSink<AGUIEvent> sink,
-            CancellationToken ct = default)
-        {
-            ArgumentNullException.ThrowIfNull(lease);
-            ArgumentNullException.ThrowIfNull(sink);
-            _ = ct;
-
-            foreach (var message in Messages)
-            {
-                var mapped = ScopeGAgentAguiEventMapper.TryMap(message);
-                if (mapped == null)
-                    continue;
-
-                try
-                {
-                    await sink.PushAsync(mapped, CancellationToken.None);
-                }
-                catch (EventSinkCompletedException)
-                {
-                    break;
-                }
-            }
-
-            return null;
-        }
-
-        public Task DetachLiveSinkAsync(
-            IAsyncDisposable? liveSinkLease,
-            CancellationToken ct = default)
-        {
-            _ = liveSinkLease;
-            _ = ct;
-            return Task.CompletedTask;
-        }
-
-        public Task ReleaseActorProjectionAsync(
-            IGAgentDraftRunProjectionLease lease,
-            CancellationToken ct = default)
-        {
-            _ = lease;
-            _ = ct;
-            return Task.CompletedTask;
-        }
-    }
-
-    private sealed record StubDraftRunProjectionLease(string ActorId, string CommandId) : IGAgentDraftRunProjectionLease;
-
-    private sealed class StubGAgentRunTerminalProjectionPort : IGAgentRunTerminalProjectionPort
-    {
-        public Task<IGAgentRunTerminalProjectionLease?> EnsureProjectionAsync(
-            string actorId,
-            string correlationId,
-            GAgentRunTerminalInteractionKind interactionKind,
-            CancellationToken ct = default)
-        {
-            _ = ct;
-            return Task.FromResult<IGAgentRunTerminalProjectionLease?>(
-                new StubGAgentRunTerminalProjectionLease(actorId, correlationId, interactionKind));
-        }
-
-        public Task<IGAgentRunTerminalProjectionLease?> AttachExistingProjectionAsync(
-            string actorId,
-            string correlationId,
-            GAgentRunTerminalInteractionKind interactionKind,
-            CancellationToken ct = default) =>
-            EnsureProjectionAsync(actorId, correlationId, interactionKind, ct);
-
-        public Task ReleaseProjectionAsync(
-            IGAgentRunTerminalProjectionLease lease,
-            CancellationToken ct = default)
-        {
-            _ = lease;
-            _ = ct;
-            return Task.CompletedTask;
-        }
-    }
-
-    private sealed record StubGAgentRunTerminalProjectionLease(
-        string ActorId,
-        string CorrelationId,
-        GAgentRunTerminalInteractionKind InteractionKind) : IGAgentRunTerminalProjectionLease;
-
-    private sealed class StubGAgentRunTerminalQueryPort : IGAgentRunTerminalQueryPort
-    {
-        public Task<GAgentRunTerminalSnapshot?> GetByCorrelationIdAsync(
-            string actorId,
-            string correlationId,
-            CancellationToken ct = default)
-        {
-            _ = actorId;
-            _ = correlationId;
-            _ = ct;
-            return Task.FromResult<GAgentRunTerminalSnapshot?>(null);
-        }
-
-        public Task<GAgentRunTerminalSnapshot?> GetBySessionIdAsync(
-            string actorId,
-            string sessionId,
-            CancellationToken ct = default)
-        {
-            _ = actorId;
-            _ = sessionId;
-            _ = ct;
-            return Task.FromResult<GAgentRunTerminalSnapshot?>(null);
-        }
     }
 
     private sealed class StubScriptServiceAguiProjectionPort : IScriptServiceAguiProjectionPort

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1483,6 +1483,24 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ScopeInvokeDefaultChatStreamEndpoint_ShouldReturnBadRequest_WhenDefaultServiceIsUnbound()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/invoke/chat:stream", new
+        {
+            prompt = "hello",
+        });
+        var body = await response.Content.ReadFromJsonAsync<Dictionary<string, string>>();
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        body.Should().NotBeNull();
+        body!["code"].Should().Be("INVALID_SERVICE_STREAM_REQUEST");
+        body["message"].Should().Contain("Service 'scope-a:default:default:default' was not found.");
+        host.InteractionService.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ScopeInvokeStreamEndpoint_ShouldReturnBadRequest_WhenStaticActorTypeCannotBeResolved()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -4454,6 +4472,8 @@ public sealed class ScopeServiceEndpointsTests
             var interactionService = new FakeCommandInteractionService();
             var gagentDraftRunInteractionService = new FakeGAgentDraftRunInteractionService();
             var scriptServiceRunInteractionService = new FakeScriptServiceRunInteractionService();
+            var staticGAgentStreamInvocationPort = new FakeStaticGAgentStreamInvocationPort(
+                gagentDraftRunInteractionService);
             var workflowQueryService = new FakeWorkflowExecutionQueryApplicationService();
             var runBindingReader = new FakeWorkflowRunBindingReader();
             var resumeDispatchService = new RecordingResumeDispatchService();
@@ -4492,6 +4512,7 @@ public sealed class ScopeServiceEndpointsTests
             builder.Services.AddSingleton<ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus>>(interactionService);
             builder.Services.AddSingleton<ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus>>(gagentDraftRunInteractionService);
             builder.Services.AddSingleton<ICommandInteractionService<ScriptServiceRunCommand, ScriptServiceRunAcceptedReceipt, ScriptServiceRunStartError, AGUIEvent, ScriptServiceRunCompletionStatus>>(scriptServiceRunInteractionService);
+            builder.Services.AddSingleton<IStaticGAgentStreamInvocationPort<AGUIEvent>>(staticGAgentStreamInvocationPort);
             builder.Services.AddSingleton<IWorkflowExecutionQueryApplicationService>(workflowQueryService);
             builder.Services.AddSingleton<IWorkflowRunBindingReader>(runBindingReader);
             builder.Services.AddSingleton<ICommandDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError>>(resumeDispatchService);
@@ -5226,19 +5247,78 @@ public sealed class ScopeServiceEndpointsTests
     private sealed class FakeGAgentDraftRunInteractionService
         : ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus>
     {
+        public GAgentDraftRunCommand? LastRequest { get; private set; }
+
         public Task<CommandInteractionResult<GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, GAgentDraftRunCompletionStatus>> ExecuteAsync(
             GAgentDraftRunCommand request,
             Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
             Func<GAgentDraftRunAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
             CancellationToken ct = default)
         {
-            _ = request;
+            LastRequest = request;
             _ = emitAsync;
             _ = onAcceptedAsync;
             ct.ThrowIfCancellationRequested();
             return Task.FromResult(
                 CommandInteractionResult<GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, GAgentDraftRunCompletionStatus>
                     .Failure(GAgentDraftRunStartError.UnknownActorType));
+        }
+    }
+
+    private sealed class FakeStaticGAgentStreamInvocationPort(
+        ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> interactionService)
+        : IStaticGAgentStreamInvocationPort<AGUIEvent>
+    {
+        public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+            StaticGAgentStreamInvocationRequest request,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default)
+        {
+            var input = request.Input;
+            var result = await interactionService.ExecuteAsync(
+                new GAgentDraftRunCommand(
+                    ScopeId: request.Identity.TenantId,
+                    ActorTypeName: "TestStaticGAgent",
+                    Prompt: input.Prompt,
+                    PreferredActorId: input.PreferredActorId,
+                    SessionId: input.SessionId,
+                    Headers: input.Headers,
+                    InputParts: input.InputParts),
+                emitAsync,
+                async (receipt, token) =>
+                {
+                    if (onAcceptedAsync == null)
+                        return;
+
+                    var serviceReceipt = new ServiceInvocationAcceptedReceipt
+                    {
+                        CommandId = receipt.CommandId,
+                        CorrelationId = receipt.CorrelationId,
+                        TargetActorId = receipt.ActorId,
+                        EndpointId = request.EndpointId,
+                    };
+                    await onAcceptedAsync(
+                        new StaticGAgentStreamAcceptedReceipt(serviceReceipt, receipt),
+                        token);
+                },
+                ct);
+
+            return new StaticGAgentStreamInvocationResult(
+                result.Receipt == null
+                    ? null
+                    : new StaticGAgentStreamAcceptedReceipt(
+                        new ServiceInvocationAcceptedReceipt
+                        {
+                            CommandId = result.Receipt.CommandId,
+                            CorrelationId = result.Receipt.CorrelationId,
+                            TargetActorId = result.Receipt.ActorId,
+                            EndpointId = request.EndpointId,
+                        },
+                        result.Receipt),
+                result.Error,
+                result.FinalizeResult?.Completion ?? GAgentDraftRunCompletionStatus.Unknown,
+                result.FinalizeResult?.Completed ?? false);
         }
     }
 

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsTests.cs
@@ -1577,6 +1577,160 @@ public sealed class ScopeServiceEndpointsTests
     }
 
     [Fact]
+    public async Task ScopeInvokeStreamEndpoint_ShouldDelegateStaticServiceToInvocationPort_AndEmitAguiFrames()
+    {
+        await using var host = await ScopeServiceEndpointTestHost.StartAsync();
+        var service = BuildService("scope-a", "default", "definition-actor-1");
+        host.ServiceCatalogReader.Service = service;
+        host.TrafficViewReader.View = new ServiceTrafficViewSnapshot(
+            service.ServiceKey,
+            1,
+            string.Empty,
+            [
+                new ServiceTrafficEndpointSnapshot(
+                    "chat",
+                    [
+                        new ServiceTrafficTargetSnapshot(
+                            "dep-1",
+                            "rev-1",
+                            "definition-actor-1",
+                            100,
+                            ServiceServingState.Active.ToString()),
+                    ]),
+            ],
+            DateTimeOffset.UtcNow);
+        await host.ArtifactStore.SaveAsync(
+            service.ServiceKey,
+            "rev-1",
+            new PreparedServiceRevisionArtifact
+            {
+                Identity = new ServiceIdentity
+                {
+                    TenantId = "scope-a",
+                    AppId = "default",
+                    Namespace = "default",
+                    ServiceId = "default",
+                },
+                RevisionId = "rev-1",
+                ImplementationKind = ServiceImplementationKind.Static,
+                Endpoints =
+                {
+                    new ServiceEndpointDescriptor
+                    {
+                        EndpointId = "chat",
+                        DisplayName = "chat",
+                        Kind = ServiceEndpointKind.Chat,
+                        RequestTypeUrl = Any.Pack(new ChatRequestEvent()).TypeUrl,
+                        ResponseTypeUrl = Any.Pack(new ChatResponseEvent()).TypeUrl,
+                    },
+                },
+                DeploymentPlan = new ServiceDeploymentPlan
+                {
+                    StaticPlan = new StaticServiceDeploymentPlan
+                    {
+                        ActorTypeName = "Test.StaticAgent, Tests",
+                    },
+                },
+            },
+            CancellationToken.None);
+        host.StaticGAgentStreamInvocationPort.ResultFactory = async (request, emitAsync, onAcceptedAsync, ct) =>
+        {
+            var receipt = new StaticGAgentStreamAcceptedReceipt(
+                new ServiceInvocationAcceptedReceipt
+                {
+                    ServiceKey = service.ServiceKey,
+                    DeploymentId = "dep-1",
+                    TargetActorId = "actor-static-1",
+                    EndpointId = request.EndpointId,
+                    CommandId = "cmd-static-1",
+                    CorrelationId = "corr-static-1",
+                },
+                new GAgentDraftRunAcceptedReceipt("actor-static-1", "TestStaticGAgent", "cmd-static-1", "corr-static-1"));
+
+            if (onAcceptedAsync != null)
+                await onAcceptedAsync(receipt, ct);
+
+            await emitAsync(
+                new AGUIEvent
+                {
+                    TextMessageContent = new Aevatar.Presentation.AGUI.TextMessageContentEvent
+                    {
+                        MessageId = "msg-1",
+                        Delta = "hello from static",
+                    },
+                },
+                ct);
+
+            return new StaticGAgentStreamInvocationResult(
+                receipt,
+                GAgentDraftRunStartError.None,
+                GAgentDraftRunCompletionStatus.RunFinished,
+                CompletionObserved: true);
+        };
+
+        var response = await host.Client.PostAsJsonAsync("/api/scopes/scope-a/invoke/chat:stream", new
+        {
+            prompt = " hello static ",
+            actorId = " actor-static-1 ",
+            sessionId = "session-1",
+            revisionId = "rev-1",
+            headers = new Dictionary<string, string> { ["source"] = "tests" },
+            inputParts = new[]
+            {
+                new
+                {
+                    type = "text",
+                    text = (string?)"attachment text",
+                    dataBase64 = (string?)null,
+                    mediaType = (string?)null,
+                    name = (string?)null,
+                },
+                new
+                {
+                    type = "image",
+                    text = (string?)null,
+                    dataBase64 = (string?)"aW1hZ2U=",
+                    mediaType = (string?)"image/png",
+                    name = (string?)"image.png",
+                },
+            },
+        });
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "stream body: {0}", body);
+        response.Headers.GetValues("X-Correlation-Id").Should().ContainSingle().Which.Should().Be("corr-static-1");
+        body.Should().Contain("runStarted");
+        body.Should().Contain("textMessageContent");
+        body.Should().Contain("hello from static");
+        host.StaticGAgentStreamInvocationPort.Requests.Should().ContainSingle();
+        var delegated = host.StaticGAgentStreamInvocationPort.Requests[0];
+        delegated.Identity.Should().BeEquivalentTo(new ServiceIdentity
+        {
+            TenantId = "scope-a",
+            AppId = "default",
+            Namespace = "default",
+            ServiceId = "default",
+        });
+        delegated.EndpointId.Should().Be("chat");
+        delegated.Input.Prompt.Should().Be("hello static");
+        delegated.Input.PreferredActorId.Should().Be(" actor-static-1 ");
+        delegated.Input.SessionId.Should().Be("session-1");
+        delegated.Input.RevisionId.Should().Be("rev-1");
+        delegated.Input.Headers.Should().ContainKey("source").WhoseValue.Should().Be("tests");
+        delegated.Input.Caller.Should().NotBeNull();
+        delegated.Input.Caller!.ServiceKey.Should().BeEmpty();
+        delegated.Input.Timeout.Should().Be(TimeSpan.FromMinutes(2));
+        delegated.Input.InputParts.Should().NotBeNull();
+        delegated.Input.InputParts!.Should().HaveCount(2);
+        delegated.Input.InputParts[0].Kind.Should().Be(GAgentDraftRunInputPartKind.Text);
+        delegated.Input.InputParts[0].Text.Should().Be("attachment text");
+        delegated.Input.InputParts[1].Kind.Should().Be(GAgentDraftRunInputPartKind.Image);
+        delegated.Input.InputParts[1].DataBase64.Should().Be("aW1hZ2U=");
+        delegated.Input.InputParts[1].MediaType.Should().Be("image/png");
+        delegated.Input.InputParts[1].Name.Should().Be("image.png");
+    }
+
+    [Fact]
     public async Task ScopeInvokeStreamEndpoint_ShouldReturnBadRequest_WhenWorkflowEndpointIsNotChat()
     {
         await using var host = await ScopeServiceEndpointTestHost.StartAsync();
@@ -4370,6 +4524,7 @@ public sealed class ScopeServiceEndpointsTests
             FakeServiceRevisionArtifactStore artifactStore,
             FakeTeamEntryMemberResolver teamEntryMemberResolver,
             FakeCommandInteractionService interactionService,
+            FakeStaticGAgentStreamInvocationPort staticGAgentStreamInvocationPort,
             FakeWorkflowExecutionQueryApplicationService workflowQueryService,
             FakeWorkflowRunBindingReader runBindingReader,
             RecordingResumeDispatchService resumeDispatchService,
@@ -4392,6 +4547,7 @@ public sealed class ScopeServiceEndpointsTests
             ArtifactStore = artifactStore;
             TeamEntryMemberResolver = teamEntryMemberResolver;
             InteractionService = interactionService;
+            StaticGAgentStreamInvocationPort = staticGAgentStreamInvocationPort;
             WorkflowQueryService = workflowQueryService;
             RunBindingReader = runBindingReader;
             ResumeDispatchService = resumeDispatchService;
@@ -4434,6 +4590,8 @@ public sealed class ScopeServiceEndpointsTests
         public FakeTeamEntryMemberResolver TeamEntryMemberResolver { get; }
 
         public FakeCommandInteractionService InteractionService { get; }
+
+        public FakeStaticGAgentStreamInvocationPort StaticGAgentStreamInvocationPort { get; }
 
         public FakeWorkflowExecutionQueryApplicationService WorkflowQueryService { get; }
 
@@ -4626,6 +4784,7 @@ public sealed class ScopeServiceEndpointsTests
                 artifactStore,
                 teamEntryMemberResolver,
                 interactionService,
+                staticGAgentStreamInvocationPort,
                 workflowQueryService,
                 runBindingReader,
                 resumeDispatchService,
@@ -5269,12 +5428,20 @@ public sealed class ScopeServiceEndpointsTests
         ICommandInteractionService<GAgentDraftRunCommand, GAgentDraftRunAcceptedReceipt, GAgentDraftRunStartError, AGUIEvent, GAgentDraftRunCompletionStatus> interactionService)
         : IStaticGAgentStreamInvocationPort<AGUIEvent>
     {
+        public List<StaticGAgentStreamInvocationRequest> Requests { get; } = [];
+
+        public Func<StaticGAgentStreamInvocationRequest, Func<AGUIEvent, CancellationToken, ValueTask>, Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>?, CancellationToken, Task<StaticGAgentStreamInvocationResult>>? ResultFactory { get; set; }
+
         public async Task<StaticGAgentStreamInvocationResult> InvokeAsync(
             StaticGAgentStreamInvocationRequest request,
             Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
             Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
             CancellationToken ct = default)
         {
+            Requests.Add(request);
+            if (ResultFactory != null)
+                return await ResultFactory(request, emitAsync, onAcceptedAsync, ct);
+
             var input = request.Input;
             var result = await interactionService.ExecuteAsync(
                 new GAgentDraftRunCommand(


### PR DESCRIPTION
## 摘要

**Cluster**: iter39 cluster-039-scope-service-host-orchestration
**Issue**: Closes #853
**Design**: Phase 9 r1 reflector `force-pick:delete-fallback`(`.refactor-loop/runs/meta-reflect-issue853-r1.md`)

**Old pattern**: `ScopeServiceEndpoints.HandleInvokeDefaultChatStreamAsync` 在 unbound default service 情况下 launch Host-inline `DefaultChatWorkflowYaml` 作为 hidden fallback,把 Host 当成 business orchestrator(无 service binding 也能跑 chat,业务逻辑藏在 Host endpoint)。

**New principle**: Host endpoint 仅做 routing + bound service stream;unbound case 返回 explicit error;stream registration / static orchestration 归 Application owner;Host 不再持有 inline workflow YAML 或 business fallback 逻辑。

## 改动

- `ScopeServiceEndpoints.cs`: 删除 unbound default-chat fallback branch + 删除 `DefaultChatWorkflowYaml`(189 LOC, 51 -)
- 保留 `POST /api/scopes/{scopeId}/invoke/chat:stream` route(走 bound default service stream path)
- Unbound default service → 返回 `INVALID_SERVICE_STREAM_REQUEST` 错误
- Stream registration / static orchestration 移到 existing Application owners
- 测试:加 bound default route + unbound error 两路覆盖;删除依赖 Host fallback 的过时测试(459 LOC test cleanup)

## 不允许(reflector r1 strict)

- ❌ structural broad `IScopeServiceStreamInvocationPort<TFrame>`(extra scope,本 issue 不做)
- ❌ 扩大到 member/team/app stream entrypoints(extra scope,留待 follow-up)
- ❌ 修改 top-level CLAUDE.md / docs/canon
- ❌ 添加 new actor type / new envelope kind / pipeline phase

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- targeted GAgentService tests ✅
- `bash tools/ci/test_stability_guards.sh` ✅
- `bash tools/ci/architecture_guards.sh` ✅
- 净 LOC: -454

## 已知 unrelated CI deviation

Full `Aevatar.GAgentService.Integration.Tests` 有 dev-wide pre-existing `PROJECTION_DISABLED` failure in `ScopeDraftRunActorQueryIntegrationTests` — 与本 PR 无关。**已在 PR #855 修复**。

## 测试计划

- [x] GAgentService unit tests pass(targeted)
- [x] bound default route(走 service stream)+ unbound error 两路覆盖
- [x] 架构守卫通过
- [x] 459 LOC 过时 Host-inline-fallback 测试删除

---

🤖 auto-loop Phase 9 reflector force-pick:delete-fallback

⟦AI:AUTO-LOOP⟧
