### PR TITLE
iter45 issue-867 session-projection-ensure-surface: 4 module 移除 public ensure surface,attach-existing 唯一

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
@@ -25,14 +25,9 @@ public interface INyxIdChatSessionProjectionLease
 public interface INyxIdChatSessionProjectionPort
     : IEventSinkProjectionLifecyclePort<INyxIdChatSessionProjectionLease, AGUIEvent>
 {
-    Task<INyxIdChatSessionProjectionLease?> EnsureChatProjectionAsync(
-        string actorId,
-        string sessionId,
-        CancellationToken ct = default);
-
-    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
-    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
-    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
         string actorId,
         string sessionId,
@@ -97,23 +92,9 @@ public sealed class NyxIdChatSessionProjectionPort
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
-    public Task<INyxIdChatSessionProjectionLease?> EnsureChatProjectionAsync(
-        string actorId,
-        string sessionId,
-        CancellationToken ct = default) =>
-        EnsureProjectionAsync(
-            new ProjectionScopeStartRequest
-            {
-                RootActorId = actorId,
-                ProjectionKind = NyxIdChatProjectionKinds.ChatSession,
-                Mode = ProjectionRuntimeMode.SessionObservation,
-                SessionId = sessionId,
-            },
-            ct);
-
-    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
-    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
-    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     public async Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
         string actorId,
         string sessionId,

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyEndpoints.cs
@@ -390,14 +390,20 @@ public static class StreamingProxyEndpoints
                 return;
             }
 
-            await writer.StartAsync(ct);
             var eventChannel = new EventChannel<StreamingProxyRoomSessionEnvelope>();
             var attachment = await subscriptionObservationPort.AttachAsync(actor.Id, eventChannel, ct);
+            if (attachment == null)
+            {
+                await eventChannel.DisposeAsync();
+                http.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return;
+            }
 
             Task? pumpTask = null;
 
             try
             {
+                await writer.StartAsync(ct);
                 pumpTask = PumpRoomSessionEventsAsync(eventChannel, writer);
                 await WaitForClientDisconnectAsync(ct);
             }

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionContracts.cs
@@ -12,28 +12,21 @@ public interface IStreamingProxyRoomSessionProjectionLease
 public interface IStreamingProxyRoomSessionProjectionPort
     : IEventSinkProjectionLifecyclePort<IStreamingProxyRoomSessionProjectionLease, StreamingProxyRoomSessionEnvelope>
 {
-    Task<IStreamingProxyRoomSessionProjectionLease?> EnsureRoomProjectionAsync(
-        string actorId,
-        string sessionId,
-        CancellationToken ct = default) =>
-        EnsureChatProjectionAsync(actorId, sessionId, ct);
-
-    Task<IStreamingProxyRoomSessionProjectionLease?> EnsureChatProjectionAsync(
-        string actorId,
-        string sessionId,
-        CancellationToken ct = default);
-
-    Task<IStreamingProxyRoomSessionProjectionLease?> EnsureSubscriptionProjectionAsync(
-        string actorId,
-        string subscriptionId,
-        CancellationToken ct = default);
-
-    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
-    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
-    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingChatProjectionAsync(
         string actorId,
         string sessionId,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default);
+
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
+    Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingSubscriptionProjectionAsync(
+        string actorId,
+        string subscriptionId,
         IEventSink<StreamingProxyRoomSessionEnvelope> sink,
         CancellationToken ct = default);
 }

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionPort.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionPort.cs
@@ -28,55 +28,46 @@ public sealed class StreamingProxyRoomSessionProjectionPort
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
-    public async Task<IStreamingProxyRoomSessionProjectionLease?> EnsureRoomProjectionAsync(
-        string actorId,
-        string sessionId,
-        CancellationToken ct = default)
-    {
-        return await EnsureChatProjectionAsync(actorId, sessionId, ct);
-    }
-
-    public async Task<IStreamingProxyRoomSessionProjectionLease?> EnsureChatProjectionAsync(
-        string actorId,
-        string sessionId,
-        CancellationToken ct = default)
-    {
-        return await EnsureProjectionAsync(actorId, sessionId, StreamingProxyProjectionKinds.RoomChatSession, ct);
-    }
-
-    public async Task<IStreamingProxyRoomSessionProjectionLease?> EnsureSubscriptionProjectionAsync(
-        string actorId,
-        string subscriptionId,
-        CancellationToken ct = default)
-    {
-        return await EnsureProjectionAsync(actorId, subscriptionId, StreamingProxyProjectionKinds.RoomSubscriptionSession, ct);
-    }
-
-    private async Task<IStreamingProxyRoomSessionProjectionLease?> EnsureProjectionAsync(
-        string actorId,
-        string sessionId,
-        string projectionKind,
-        CancellationToken ct)
-    {
-        return await EnsureProjectionAsync(
-            new ProjectionScopeStartRequest
-            {
-                RootActorId = actorId,
-                ProjectionKind = projectionKind,
-                Mode = ProjectionRuntimeMode.SessionObservation,
-                SessionId = sessionId,
-            },
-            ct);
-    }
-
-    // Refactor (iter37/cluster-037-agent-session-observation-attach-only):
-    //   Old pattern: Agent session observation binders 同步 prime projection lease before dispatch(NyxID/StreamingProxy session paths)。
-    //   New principle: Attach-existing NyxID/StreamingProxy observation ports;cold sessions return ProjectionUnavailable before dispatch;projection activation 移到 projection-owned lifecycle;不引入新 actor / 新 envelope / CLAUDE 例外。
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     public async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingChatProjectionAsync(
         string actorId,
         string sessionId,
         IEventSink<StreamingProxyRoomSessionEnvelope> sink,
         CancellationToken ct = default)
+    {
+        return await AttachExistingProjectionAsync(
+            actorId,
+            sessionId,
+            StreamingProxyProjectionKinds.RoomChatSession,
+            sink,
+            ct).ConfigureAwait(false);
+    }
+
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
+    public async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingSubscriptionProjectionAsync(
+        string actorId,
+        string subscriptionId,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct = default)
+    {
+        return await AttachExistingProjectionAsync(
+            actorId,
+            subscriptionId,
+            StreamingProxyProjectionKinds.RoomSubscriptionSession,
+            sink,
+            ct).ConfigureAwait(false);
+    }
+
+    private async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingProjectionAsync(
+        string actorId,
+        string sessionId,
+        string projectionKind,
+        IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+        CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(sink);
         ct.ThrowIfCancellationRequested();
@@ -90,7 +81,7 @@ public sealed class StreamingProxyRoomSessionProjectionPort
 
         var scopeKey = new ProjectionRuntimeScopeKey(
             actorId,
-            StreamingProxyProjectionKinds.RoomChatSession,
+            projectionKind,
             ProjectionRuntimeMode.SessionObservation,
             sessionId);
         if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
@@ -99,7 +90,7 @@ public sealed class StreamingProxyRoomSessionProjectionPort
         var lease = new StreamingProxyRoomSessionRuntimeLease(new StreamingProxyRoomSessionProjectionContext
         {
             RootActorId = actorId,
-            ProjectionKind = StreamingProxyProjectionKinds.RoomChatSession,
+            ProjectionKind = projectionKind,
             SessionId = sessionId,
         });
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSubscriptionObservationPort.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSubscriptionObservationPort.cs
@@ -4,7 +4,7 @@ namespace Aevatar.GAgents.StreamingProxy;
 
 public interface IStreamingProxyRoomSubscriptionObservationPort
 {
-    Task<StreamingProxyRoomSubscriptionObservationAttachment> AttachAsync(
+    Task<StreamingProxyRoomSubscriptionObservationAttachment?> AttachAsync(
         string roomId,
         IEventSink<StreamingProxyRoomSessionEnvelope> sink,
         CancellationToken ct = default);
@@ -39,26 +39,27 @@ internal sealed class StreamingProxyRoomSubscriptionObservationPort
     public static string RoomSubscriptionSessionId(string roomId) =>
         $"room:{NormalizeRoomId(roomId)}:subscription";
 
-    public async Task<StreamingProxyRoomSubscriptionObservationAttachment> AttachAsync(
+    public async Task<StreamingProxyRoomSubscriptionObservationAttachment?> AttachAsync(
         string roomId,
         IEventSink<StreamingProxyRoomSessionEnvelope> sink,
         CancellationToken ct = default)
     {
-        // Refactor (iter21/cluster-002-request-path-projection-session-priming):
-        //   Old pattern: request handlers synchronously ensure projection/session leases and wait on live sinks.
-        //   New principle: commands use accepted receipts; observation is owned by binders or attach-only sessions.
+        // Refactor (iter45/issue-867-session-projection-ensure-surface):
+        //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+        //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
         ArgumentNullException.ThrowIfNull(sink);
 
         var normalizedRoomId = NormalizeRoomId(roomId);
-        var lease = new StreamingProxyRoomSessionRuntimeLease(
-            new StreamingProxyRoomSessionProjectionContext
-            {
-                RootActorId = normalizedRoomId,
-                SessionId = RoomSubscriptionSessionId(normalizedRoomId),
-                ProjectionKind = StreamingProxyProjectionKinds.RoomSubscriptionSession,
-            });
-        var liveSinkLease = await _projectionPort.AttachLiveSinkAsync(lease, sink, ct);
-        return new StreamingProxyRoomSubscriptionObservationAttachment(lease, liveSinkLease);
+        var attachment = await _projectionPort.AttachExistingSubscriptionProjectionAsync(
+            normalizedRoomId,
+            RoomSubscriptionSessionId(normalizedRoomId),
+            sink,
+            ct).ConfigureAwait(false);
+        return attachment == null
+            ? null
+            : new StreamingProxyRoomSubscriptionObservationAttachment(
+                attachment.ProjectionLease,
+                attachment.LiveSinkLease);
     }
 
     public async Task DetachAndDisposeAsync(

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/IScriptServiceAguiProjectionPort.cs
@@ -23,15 +23,9 @@ public interface IScriptServiceAguiProjectionLease
 public interface IScriptServiceAguiProjectionPort
     : IEventSinkProjectionLifecyclePort<IScriptServiceAguiProjectionLease, AGUIEvent>
 {
-    Task<IScriptServiceAguiProjectionLease?> EnsureRunProjectionAsync(
-        string actorId,
-        string runId,
-        CancellationToken ct = default);
-
-    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
-    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
-    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
-    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
         string actorId,
         string runId,

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs
@@ -34,24 +34,9 @@ public sealed class ScriptServiceAguiProjectionPort
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
-    public Task<IScriptServiceAguiProjectionLease?> EnsureRunProjectionAsync(
-        string actorId,
-        string runId,
-        CancellationToken ct = default) =>
-        EnsureProjectionAsync(
-            new ProjectionScopeStartRequest
-            {
-                RootActorId = actorId,
-                ProjectionKind = ServiceProjectionKinds.ScriptServiceAguiSession,
-                Mode = ProjectionRuntimeMode.SessionObservation,
-                SessionId = runId,
-            },
-            ct);
-
-    // Refactor (iter37/cluster-037-gagentservice-binders-attach-existing):
-    //   Old pattern: GAgentService interaction binders synchronously prime projection sessions before dispatch(request-path projection activation in BindAsync).
-    //   New principle: Attach-only to existing projection sessions/materialization leases via capability-specific attach-existing ports.
-    //   Cold sessions return ProjectionUnavailable / pending before dispatch; no top-level live-observation exception.
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     public async Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
         string actorId,
         string runId,

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionProjectionPort.cs
@@ -6,14 +6,9 @@ namespace Aevatar.Workflow.Application.Abstractions.Projections;
 public interface IWorkflowExecutionProjectionPort
     : IEventSinkProjectionLifecyclePort<IWorkflowExecutionProjectionLease, WorkflowRunEventEnvelope>
 {
-    Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-        string rootActorId,
-        string commandId,
-        CancellationToken ct = default);
-
-    // Refactor (iter35/cluster-039-observation-binder-attach-only):
-    //   Old pattern: Command observation binders synchronously ensure and attach projection leases before dispatch,让 request/command preparation 拥有 projection lifecycle。
-    //   New principle: Command observation binders request attach only for an existing projection-owned session; cold sessions return unavailable without command-side ensure/activate.
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
         string rootActorId,
         string commandId,

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
@@ -29,24 +29,9 @@ public sealed class WorkflowExecutionProjectionPort
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
     }
 
-    public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-        string rootActorId,
-        string commandId,
-        CancellationToken ct = default) =>
-        EnsureProjectionAsync(
-            new ProjectionScopeStartRequest
-            {
-                RootActorId = rootActorId,
-                ProjectionKind = WorkflowProjectionKinds.ExecutionSession,
-                Mode = ProjectionRuntimeMode.SessionObservation,
-                SessionId = commandId,
-            },
-            ct);
-
-    // Refactor (iter41/cluster-041-command-observation-projection-activation):
-    //   Old pattern: command observation binders ensure/activate projection/readmodel sessions before dispatch.
-    //   New principle: observation binders attach only to existing projection-owned sessions;
-    //   activation happens in projection-owned startup/background/committed-state lifecycle.
+    // Refactor (iter45/issue-867-session-projection-ensure-surface):
+    //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
+    //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
     public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
         string rootActorId,
         string commandId,

--- a/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatEndpointsCoverageTests.cs
@@ -1146,7 +1146,6 @@ public class NyxIdChatEndpointsCoverageTests
         result.FinalizeResult.Should().NotBeNull();
         result.FinalizeResult!.Completed.Should().BeTrue();
         result.FinalizeResult.Completion.Should().Be(NyxIdChatCompletionStatus.Completed);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
@@ -1190,7 +1189,6 @@ public class NyxIdChatEndpointsCoverageTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(NyxIdChatStartError.ProjectionUnavailable);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
         projectionPort.AttachCount.Should().Be(0);
         projectionPort.DetachCount.Should().Be(0);
@@ -1220,7 +1218,6 @@ public class NyxIdChatEndpointsCoverageTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("dispatch failed");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle(x => x.ActorId == actor.Id && x.SessionId == "session-1");
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.DetachCount.Should().Be(1);
@@ -2855,27 +2852,12 @@ public class NyxIdChatEndpointsCoverageTests
         private INyxIdChatSessionProjectionLease? _lease;
 
         public List<AGUIEvent> Messages { get; } = [];
-        public List<(string ActorId, string SessionId)> EnsureCalls { get; } = [];
         public List<(string ActorId, string SessionId)> AttachExistingCalls { get; } = [];
         public bool ProjectionEnabled => true;
         public bool ReturnNullLease { get; init; }
         public int AttachCount { get; private set; }
         public int DetachCount { get; private set; }
         public int ReleaseCount { get; private set; }
-
-        public async Task<INyxIdChatSessionProjectionLease?> EnsureChatProjectionAsync(
-            string actorId,
-            string sessionId,
-            CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            EnsureCalls.Add((actorId, sessionId));
-            if (ReturnNullLease)
-                return null;
-
-            _lease = new StubNyxIdChatSessionProjectionLease(actorId, sessionId);
-            return _lease;
-        }
 
         public async Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
             string actorId,
@@ -2970,17 +2952,6 @@ public class NyxIdChatEndpointsCoverageTests
     private sealed class ThrowingNyxIdChatSessionProjectionPort(Exception exception) : INyxIdChatSessionProjectionPort
     {
         public bool ProjectionEnabled => true;
-
-        public Task<INyxIdChatSessionProjectionLease?> EnsureChatProjectionAsync(
-            string actorId,
-            string sessionId,
-            CancellationToken ct = default)
-        {
-            _ = actorId;
-            _ = sessionId;
-            _ = ct;
-            throw exception;
-        }
 
         public Task<EventSinkProjectionAttachment<INyxIdChatSessionProjectionLease>?> AttachExistingChatProjectionAsync(
             string actorId,

--- a/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
@@ -21,16 +21,17 @@ namespace Aevatar.AI.Tests;
 public sealed class NyxIdChatProjectionSessionTests
 {
     [Fact]
-    public async Task ProjectionPort_ShouldStartAttachDetachAndReleaseChatSession()
+    public async Task ProjectionPort_ShouldAttachExistingDetachAndReleaseChatSession()
     {
         var activation = new RecordingActivationService();
         var release = new RecordingReleaseService();
         var hub = new RecordingSessionEventHub();
-        var port = new NyxIdChatSessionProjectionPort(activation, release, hub, new RecordingActorRuntime());
+        var runtime = new RecordingActorRuntime();
+        runtime.MarkExists("projection.session.scope:nyxid-chat-session:chat-actor-1:session-1");
+        var port = new NyxIdChatSessionProjectionPort(activation, release, hub, runtime);
         var sink = new RecordingEventSink();
 
-        var lease = await port.EnsureChatProjectionAsync("chat-actor-1", "session-1", CancellationToken.None);
-        var liveSinkLease = await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var attachment = await port.AttachExistingChatProjectionAsync("chat-actor-1", "session-1", sink, CancellationToken.None);
         await hub.Handler!(new AGUIEvent
         {
             TextMessageContent = new Aevatar.Presentation.AGUI.TextMessageContentEvent
@@ -39,28 +40,32 @@ public sealed class NyxIdChatProjectionSessionTests
                 Delta = "hello",
             },
         });
-        await port.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
-        await port.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
+        await port.DetachLiveSinkAsync(attachment!.LiveSinkLease, CancellationToken.None);
+        await port.ReleaseActorProjectionAsync(attachment.ProjectionLease, CancellationToken.None);
 
-        var request = activation.Requests.Should().ContainSingle().Subject;
-        request.RootActorId.Should().Be("chat-actor-1");
-        request.SessionId.Should().Be("session-1");
-        request.ProjectionKind.Should().Be("nyxid-chat-session");
-        request.Mode.Should().Be(ProjectionRuntimeMode.SessionObservation);
-
-        var runtimeLease = lease.Should().BeOfType<NyxIdChatSessionRuntimeLease>().Subject;
+        activation.Requests.Should().BeEmpty();
+        var runtimeLease = attachment.ProjectionLease.Should().BeOfType<NyxIdChatSessionRuntimeLease>().Subject;
         runtimeLease.ActorId.Should().Be("chat-actor-1");
         runtimeLease.RootEntityId.Should().Be("chat-actor-1");
         runtimeLease.ScopeId.Should().Be("chat-actor-1");
         runtimeLease.SessionId.Should().Be("session-1");
-        runtimeLease.Context.Should().BeSameAs(activation.LeaseToReturn.Context);
 
         hub.SubscribeCalls.Should().Be(1);
         hub.LastScopeId.Should().Be("chat-actor-1");
         hub.LastSessionId.Should().Be("session-1");
         sink.Events.Should().ContainSingle().Which.TextMessageContent.Delta.Should().Be("hello");
         hub.DisposedSubscriptions.Should().Be(1);
-        release.Leases.Should().ContainSingle().Which.Should().BeSameAs(lease);
+        release.Leases.Should().ContainSingle().Which.Should().BeSameAs(attachment.ProjectionLease);
+    }
+
+    [Fact]
+    public void ProjectionPort_ShouldNotExposePublicEnsureProjectionApi()
+    {
+        typeof(INyxIdChatSessionProjectionPort)
+            .GetMethods()
+            .Select(method => method.Name)
+            .Should()
+            .NotContain(name => name.StartsWith("Ensure", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -407,11 +407,13 @@ public class StreamingProxyCoverageTests
         await using var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
 
         var attachment = await observationPort.AttachAsync(" room-a ", sink, CancellationToken.None);
-        await observationPort.DetachAndDisposeAsync(attachment, sink, CancellationToken.None);
+        attachment.Should().NotBeNull();
+        await observationPort.DetachAndDisposeAsync(attachment!, sink, CancellationToken.None);
 
-        attachment.ProjectionLease.ActorId.Should().Be("room-a");
+        attachment!.ProjectionLease.ActorId.Should().Be("room-a");
         attachment.ProjectionLease.SessionId.Should().Be("room:room-a:subscription");
-        projectionPort.EnsureCalls.Should().BeEmpty();
+        projectionPort.AttachExistingSubscriptionCalls.Should().ContainSingle()
+            .Which.Should().Be(("room-a", "room:room-a:subscription"));
         projectionPort.AttachCount.Should().Be(1);
         projectionPort.AttachedLeases.Should().ContainSingle(x =>
             x.ActorId == "room-a" &&
@@ -459,6 +461,16 @@ public class StreamingProxyCoverageTests
 
         attachment.Should().BeNull();
         hub.SubscribeCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void StreamingProxyRoomSessionProjectionPort_ShouldNotExposePublicEnsureProjectionApi()
+    {
+        typeof(IStreamingProxyRoomSessionProjectionPort)
+            .GetMethods()
+            .Select(method => method.Name)
+            .Should()
+            .NotContain(name => name.StartsWith("Ensure", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -717,7 +729,6 @@ public class StreamingProxyCoverageTests
         result.FinalizeResult.Should().NotBeNull();
         result.FinalizeResult!.Completed.Should().BeTrue();
         result.FinalizeResult.Completion.Should().Be(StreamingProxyProjectionCompletionStatus.Completed);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
             x.actorId == actor.Id &&
             x.sessionId == "session-123");
@@ -757,7 +768,6 @@ public class StreamingProxyCoverageTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(StreamingProxyRoomChatStartError.ProjectionUnavailable);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
             x.actorId == actor.Id &&
             x.sessionId == "session-123");
@@ -789,7 +799,6 @@ public class StreamingProxyCoverageTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("dispatch failed");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle(x =>
             x.actorId == actor.Id &&
             x.sessionId == "session-123");
@@ -1796,7 +1805,7 @@ public class StreamingProxyCoverageTests
         public TaskCompletionSource<bool> Attached { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task<StreamingProxyRoomSubscriptionObservationAttachment> AttachAsync(
+        public Task<StreamingProxyRoomSubscriptionObservationAttachment?> AttachAsync(
             string roomId,
             IEventSink<StreamingProxyRoomSessionEnvelope> sink,
             CancellationToken ct = default)
@@ -1805,7 +1814,7 @@ public class StreamingProxyCoverageTests
             _sink = sink;
             AttachCalls.Add((roomId, sink));
             Attached.TrySetResult(true);
-            return Task.FromResult(new StreamingProxyRoomSubscriptionObservationAttachment(
+            return Task.FromResult<StreamingProxyRoomSubscriptionObservationAttachment?>(new StreamingProxyRoomSubscriptionObservationAttachment(
                 new StubRoomSessionProjectionLease(
                     roomId,
                     $"room:{roomId}:subscription"),
@@ -1845,8 +1854,8 @@ public class StreamingProxyCoverageTests
         public bool ProjectionEnabled => true;
         public bool ReturnNullLease { get; init; }
 
-        public List<(string actorId, string sessionId, string projectionKind)> EnsureCalls { get; } = [];
         public List<(string actorId, string sessionId)> AttachExistingCalls { get; } = [];
+        public List<(string actorId, string subscriptionId)> AttachExistingSubscriptionCalls { get; } = [];
         public List<StreamingProxyRoomSessionEnvelope> Messages { get; } = [];
         public List<IStreamingProxyRoomSessionProjectionLease> AttachedLeases { get; } = [];
         public int AttachCount { get; private set; }
@@ -1855,46 +1864,6 @@ public class StreamingProxyCoverageTests
 
         public TaskCompletionSource<bool> Attached { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureRoomProjectionAsync(
-            string actorId,
-            string sessionId,
-            CancellationToken ct = default)
-        {
-            return EnsureProjectionAsync(actorId, sessionId, StreamingProxyProjectionKinds.RoomChatSession, ct);
-        }
-
-        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureChatProjectionAsync(
-            string actorId,
-            string sessionId,
-            CancellationToken ct = default)
-        {
-            return EnsureProjectionAsync(actorId, sessionId, StreamingProxyProjectionKinds.RoomChatSession, ct);
-        }
-
-        public Task<IStreamingProxyRoomSessionProjectionLease?> EnsureSubscriptionProjectionAsync(
-            string actorId,
-            string subscriptionId,
-            CancellationToken ct = default)
-        {
-            return EnsureProjectionAsync(actorId, subscriptionId, StreamingProxyProjectionKinds.RoomSubscriptionSession, ct);
-        }
-
-        private Task<IStreamingProxyRoomSessionProjectionLease?> EnsureProjectionAsync(
-            string actorId,
-            string sessionId,
-            string projectionKind,
-            CancellationToken ct)
-        {
-            _ = ct;
-
-            EnsureCalls.Add((actorId, sessionId, projectionKind));
-            if (ReturnNullLease)
-                return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(null);
-
-            _lease = new StubRoomSessionProjectionLease(actorId, sessionId);
-            return Task.FromResult<IStreamingProxyRoomSessionProjectionLease?>(_lease);
-        }
 
         public async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingChatProjectionAsync(
             string actorId,
@@ -1908,6 +1877,22 @@ public class StreamingProxyCoverageTests
                 return null;
 
             _lease = new StubRoomSessionProjectionLease(actorId, sessionId);
+            var liveSinkLease = await AttachLiveSinkAsync(_lease, sink, ct);
+            return new EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>(_lease, liveSinkLease);
+        }
+
+        public async Task<EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>?> AttachExistingSubscriptionProjectionAsync(
+            string actorId,
+            string subscriptionId,
+            IEventSink<StreamingProxyRoomSessionEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            AttachExistingSubscriptionCalls.Add((actorId, subscriptionId));
+            if (ReturnNullLease)
+                return null;
+
+            _lease = new StubRoomSessionProjectionLease(actorId, subscriptionId);
             var liveSinkLease = await AttachLiveSinkAsync(_lease, sink, ct);
             return new EventSinkProjectionAttachment<IStreamingProxyRoomSessionProjectionLease>(_lease, liveSinkLease);
         }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -995,19 +995,8 @@ public sealed class ScopeServiceEndpointsStreamTests
     private sealed class StubScriptServiceAguiProjectionPort : IScriptServiceAguiProjectionPort
     {
         public List<AGUIEvent> Messages { get; } = [];
-        public List<(string ActorId, string RunId)> EnsureCalls { get; } = [];
 
         public bool ProjectionEnabled => true;
-
-        public Task<IScriptServiceAguiProjectionLease?> EnsureRunProjectionAsync(
-            string actorId,
-            string runId,
-            CancellationToken ct = default)
-        {
-            _ = ct;
-            EnsureCalls.Add((actorId, runId));
-            return Task.FromResult<IScriptServiceAguiProjectionLease?>(new StubScriptServiceAguiProjectionLease(actorId, runId));
-        }
 
         public async Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
             string actorId,

--- a/test/Aevatar.GAgentService.Tests/Application/ScriptServiceRunInteractionTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScriptServiceRunInteractionTests.cs
@@ -67,7 +67,6 @@ public sealed class ScriptServiceRunInteractionTests
         runtimeRequest.ScopeId.Should().Be("scope-a");
         runtimeRequest.Metadata.Should().ContainKey("trace-id")
             .WhoseValue.Should().Be("trace-1");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.ReleaseCalls.Should().ContainSingle(call =>
             call.ActorId == "runtime-1" && call.RunId == "run-1");
         emitted.Should().ContainSingle(evt => evt.EventCase == AGUIEvent.EventOneofCase.RunFinished);
@@ -89,7 +88,6 @@ public sealed class ScriptServiceRunInteractionTests
         result.Succeeded.Should().BeFalse();
         result.Error.Code.Should().Be(ScriptServiceRunStartErrorCode.RuntimeActorUnavailable);
         result.Error.FieldName.Should().Be("runtimeActorId");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         runtimePort.Invocations.Should().BeEmpty();
     }
 
@@ -109,7 +107,6 @@ public sealed class ScriptServiceRunInteractionTests
         result.Succeeded.Should().BeFalse();
         result.Error.Code.Should().Be(ScriptServiceRunStartErrorCode.InvalidArgument);
         result.Error.FieldName.Should().Be("runId");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         runtimePort.Invocations.Should().BeEmpty();
     }
 
@@ -128,7 +125,6 @@ public sealed class ScriptServiceRunInteractionTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Code.Should().Be(ScriptServiceRunStartErrorCode.ProjectionUnavailable);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().BeEmpty();
         projectionPort.ReleaseCalls.Should().BeEmpty();
         runtimePort.Invocations.Should().BeEmpty();
@@ -155,7 +151,6 @@ public sealed class ScriptServiceRunInteractionTests
         runtimePort.Invocations.Should().ContainSingle(invocation =>
             invocation.RuntimeActorId == "runtime-1" &&
             invocation.RunId == "run-1");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().ContainSingle(call =>
             call.ActorId == "runtime-1" && call.RunId == "run-1");
         projectionPort.ReleaseCalls.Should().ContainSingle(call =>
@@ -373,23 +368,11 @@ public sealed class ScriptServiceRunInteractionTests
     private sealed class RecordingScriptServiceAguiProjectionPort : IScriptServiceAguiProjectionPort
     {
         public List<AGUIEvent> Messages { get; } = [];
-        public List<(string ActorId, string RunId)> EnsureCalls { get; } = [];
         public List<(string ActorId, string RunId)> AttachCalls { get; } = [];
         public List<(string ActorId, string RunId)> ReleaseCalls { get; } = [];
         public bool ReturnNullLease { get; init; }
         public bool CompleteAfterMessages { get; init; }
         public bool ProjectionEnabled => true;
-
-        public Task<IScriptServiceAguiProjectionLease?> EnsureRunProjectionAsync(
-            string actorId,
-            string runId,
-            CancellationToken ct = default)
-        {
-            ct.ThrowIfCancellationRequested();
-            EnsureCalls.Add((actorId, runId));
-            return Task.FromResult<IScriptServiceAguiProjectionLease?>(
-                ReturnNullLease ? null : new Lease(actorId, runId));
-        }
 
         public async Task<EventSinkProjectionAttachment<IScriptServiceAguiProjectionLease>?> AttachExistingRunProjectionAsync(
             string actorId,

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -19,21 +19,26 @@ public sealed class ScriptServiceAguiProjectionPortTests
     private const string ScriptServiceAguiProjectionKind = "script-service-agui-session";
 
     [Fact]
-    public async Task EnsureAttachDetachRelease_ShouldUseSessionProjectionLease()
+    public async Task AttachExistingDetachRelease_ShouldUseSessionProjectionLease()
     {
         var activation = new RecordingActivationService();
         var release = new RecordingReleaseService();
         var hub = new RecordingSessionEventHub();
+        var runtime = new RecordingActorRuntime();
+        runtime.KnownActorIds.Add(BuildScopeActorId(
+            "script-actor-1",
+            ScriptServiceAguiProjectionKind,
+            ProjectionRuntimeMode.SessionObservation,
+            "run-1"));
         var port = new ScriptServiceAguiProjectionPort(
             new ServiceProjectionOptions { Enabled = true },
             activation,
             release,
             hub,
-            new RecordingActorRuntime());
+            runtime);
         var sink = new RecordingEventSink();
 
-        var lease = await port.EnsureRunProjectionAsync("script-actor-1", "run-1", CancellationToken.None);
-        var liveSinkLease = await port.AttachLiveSinkAsync(lease!, sink, CancellationToken.None);
+        var attachment = await port.AttachExistingRunProjectionAsync("script-actor-1", "run-1", sink, CancellationToken.None);
         await hub.Handler!(new AGUIEvent
         {
             RunFinished = new RunFinishedEvent
@@ -42,29 +47,23 @@ public sealed class ScriptServiceAguiProjectionPortTests
                 RunId = "run-1",
             },
         });
-        await port.DetachLiveSinkAsync(liveSinkLease, CancellationToken.None);
-        await port.ReleaseActorProjectionAsync(lease!, CancellationToken.None);
+        await port.DetachLiveSinkAsync(attachment!.LiveSinkLease, CancellationToken.None);
+        await port.ReleaseActorProjectionAsync(attachment.ProjectionLease, CancellationToken.None);
 
-        var request = activation.Requests.Should().ContainSingle().Subject;
-        request.RootActorId.Should().Be("script-actor-1");
-        request.SessionId.Should().Be("run-1");
-        request.ProjectionKind.Should().Be(ScriptServiceAguiProjectionKind);
-        request.Mode.Should().Be(ProjectionRuntimeMode.SessionObservation);
-
-        var runtimeLease = lease.Should().BeOfType<ScriptServiceAguiRuntimeLease>().Subject;
+        activation.Requests.Should().BeEmpty();
+        var runtimeLease = attachment.ProjectionLease.Should().BeOfType<ScriptServiceAguiRuntimeLease>().Subject;
         runtimeLease.ActorId.Should().Be("script-actor-1");
         runtimeLease.RootEntityId.Should().Be("script-actor-1");
         runtimeLease.RunId.Should().Be("run-1");
         runtimeLease.SessionId.Should().Be("run-1");
         runtimeLease.ScopeId.Should().Be("script-actor-1");
-        runtimeLease.Context.Should().BeSameAs(activation.LeaseToReturn.Context);
 
         hub.SubscribeCalls.Should().Be(1);
         hub.LastScopeId.Should().Be("script-actor-1");
         hub.LastSessionId.Should().Be("run-1");
         sink.Events.Should().ContainSingle().Which.RunFinished.RunId.Should().Be("run-1");
         hub.DisposedSubscriptions.Should().Be(1);
-        release.Leases.Should().ContainSingle().Which.Should().BeSameAs(lease);
+        release.Leases.Should().ContainSingle().Which.Should().BeSameAs(attachment.ProjectionLease);
     }
 
     [Fact]
@@ -80,7 +79,11 @@ public sealed class ScriptServiceAguiProjectionPortTests
             hub,
             new RecordingActorRuntime());
 
-        var lease = await port.EnsureRunProjectionAsync("script-actor-1", "run-1", CancellationToken.None);
+        var attachment = await port.AttachExistingRunProjectionAsync(
+            "script-actor-1",
+            "run-1",
+            new RecordingEventSink(),
+            CancellationToken.None);
         await port.AttachLiveSinkAsync(new ScriptServiceAguiRuntimeLease(new ScriptServiceAguiProjectionContext
         {
             RootActorId = "script-actor-1",
@@ -94,10 +97,20 @@ public sealed class ScriptServiceAguiProjectionPortTests
             ProjectionKind = ScriptServiceAguiProjectionKind,
         }), CancellationToken.None);
 
-        lease.Should().BeNull();
+        attachment.Should().BeNull();
         activation.Requests.Should().BeEmpty();
         hub.SubscribeCalls.Should().Be(0);
         release.Leases.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ScriptServiceAguiProjectionPort_ShouldNotExposePublicEnsureProjectionApi()
+    {
+        typeof(IScriptServiceAguiProjectionPort)
+            .GetMethods()
+            .Select(method => method.Name)
+            .Should()
+            .NotContain(name => name.StartsWith("Ensure", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -579,13 +579,6 @@ public sealed class WorkflowApplicationLayerTests
         public int DetachFailureCount { get; set; }
         public int ReleaseFailureCount { get; set; }
         public int ReleaseAttemptCount => ReleaseAttempts.Count;
-
-        public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-            string rootActorId,
-            string commandId,
-            CancellationToken ct = default) =>
-            Task.FromResult<IWorkflowExecutionProjectionLease?>(new FakeProjectionLease(rootActorId, commandId));
-
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             IEventSink<WorkflowRunEventEnvelope> sink,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
@@ -102,13 +102,6 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
         : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled => true;
-
-        public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-            string rootActorId,
-            string commandId,
-            CancellationToken ct = default) =>
-            Task.FromResult<IWorkflowExecutionProjectionLease?>(null);
-
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             Aevatar.CQRS.Core.Abstractions.Streaming.IEventSink<WorkflowRunEventEnvelope> sink,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -394,10 +394,6 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         public Exception? DetachException { get; set; }
         public Exception? ReleaseException { get; set; }
         public List<string> Events { get; } = [];
-
-        public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(string rootActorId, string commandId, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(IWorkflowExecutionProjectionLease lease, IEventSink<WorkflowRunEventEnvelope> sink, CancellationToken ct = default) =>
             throw new NotSupportedException();
 

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -590,7 +590,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         var projectionPort = new FakeProjectionPort
         {
-            EnsureLease = new FakeProjectionLease("actor-1", "cmd-1"),
             AttachException = new InvalidOperationException("attach failed"),
         };
         var actorPort = new FakeWorkflowRunActorPort
@@ -621,7 +620,6 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         var ex = await act.Should().ThrowAsync<AggregateException>();
         ex.Which.Message.Should().Contain("rollback also failed");
         ex.Which.InnerExceptions.Should().HaveCount(2);
-        projectionPort.EnsureCalls.Should().Be(0);
         projectionPort.AttachExistingCalls.Should().ContainSingle()
             .Which.Should().Be(("actor-1", "cmd-1"));
     }
@@ -720,25 +718,11 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled { get; set; } = true;
-        public FakeProjectionLease? EnsureLease { get; set; }
         public FakeProjectionLease ExistingLease { get; set; } = new("actor-1", "cmd-1");
         public Exception? AttachException { get; set; }
         public Exception? ReleaseException { get; set; }
-        public int EnsureCalls { get; private set; }
         public List<(string RootActorId, string CommandId)> AttachExistingCalls { get; } = [];
         public List<string> Events { get; } = [];
-
-        public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-            string rootActorId,
-            string commandId,
-            CancellationToken ct = default)
-        {
-            _ = rootActorId;
-            _ = commandId;
-            ct.ThrowIfCancellationRequested();
-            EnsureCalls++;
-            return Task.FromResult<IWorkflowExecutionProjectionLease?>(EnsureLease);
-        }
 
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -358,13 +358,6 @@ public sealed class WorkflowRunFallbackCoverageTests
         : IWorkflowExecutionProjectionPort
     {
         public bool ProjectionEnabled => true;
-
-        public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-            string rootActorId,
-            string commandId,
-            CancellationToken ct = default) =>
-            Task.FromResult<IWorkflowExecutionProjectionLease?>(new FakeProjectionLease(rootActorId, commandId));
-
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,
             IEventSink<WorkflowRunEventEnvelope> sink,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -260,7 +260,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
         target.LiveSink.Should().NotBeNull();
         projectionPort.AttachCalls.Should().ContainSingle()
             .Which.Lease.Should().BeSameAs(projectionPort.ExistingLease);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle()
             .Which.Should().Be(("actor-1", "cmd-1"));
         actorPort.DestroyCalls.Should().BeEmpty();
@@ -295,7 +294,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         result.Succeeded.Should().BeFalse();
         result.Error.Should().Be(WorkflowChatRunStartError.ProjectionDisabled);
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle()
             .Which.Should().Be(("actor-1", "cmd-1"));
@@ -331,7 +329,6 @@ public sealed class WorkflowRunOrchestrationComponentTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("attach failed");
-        projectionPort.EnsureCalls.Should().BeEmpty();
         projectionPort.AttachExistingCalls.Should().ContainSingle()
             .Which.Should().Be(("actor-1", "cmd-1"));
         actorPort.DestroyCalls.Should().Equal("actor-1", "definition-1");
@@ -379,23 +376,9 @@ public sealed class WorkflowRunOrchestrationComponentTests
         public bool ProjectionEnabled { get; set; } = true;
         public bool AttachExistingReturnsNull { get; set; }
         public Exception? AttachException { get; set; }
-        public List<(string RootActorId, string CommandId)> EnsureCalls { get; } = [];
         public FakeProjectionLease ExistingLease { get; set; } = new("actor-1", "cmd-1");
         public List<(string RootActorId, string CommandId)> AttachExistingCalls { get; } = [];
         public List<(IWorkflowExecutionProjectionLease Lease, IEventSink<WorkflowRunEventEnvelope> Sink)> AttachCalls { get; } = [];
-
-        public Task<IWorkflowExecutionProjectionLease?> EnsureActorProjectionAsync(
-            string rootActorId,
-            string commandId,
-            CancellationToken ct = default)
-        {
-            _ = rootActorId;
-            _ = commandId;
-            ct.ThrowIfCancellationRequested();
-            EnsureCalls.Add((rootActorId, commandId));
-            ExistingLease = new FakeProjectionLease(rootActorId, commandId);
-            return Task.FromResult<IWorkflowExecutionProjectionLease?>(ExistingLease);
-        }
 
         public Task<IAsyncDisposable?> AttachLiveSinkAsync(
             IWorkflowExecutionProjectionLease lease,

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
@@ -14,23 +14,13 @@ namespace Aevatar.Workflow.Host.Api.Tests;
 public sealed class WorkflowExecutionProjectionPortTests
 {
     [Fact]
-    public async Task EnsureActorProjectionAsync_ShouldStartWorkflowExecutionSession()
+    public void WorkflowExecutionProjectionPort_ShouldNotExposePublicEnsureProjectionApi()
     {
-        var activation = new RecordingActivationService();
-        var port = new WorkflowExecutionProjectionPort(
-            new WorkflowExecutionProjectionOptions { Enabled = true },
-            activation,
-            new RecordingReleaseService(),
-            new RecordingRunEventHub(),
-            new RecordingActorRuntime());
-
-        var lease = await port.EnsureActorProjectionAsync("actor-1", "cmd-1");
-
-        lease.Should().BeSameAs(activation.LeaseToReturn);
-        activation.Requests.Should().ContainSingle();
-        activation.Requests[0].RootActorId.Should().Be("actor-1");
-        activation.Requests[0].ProjectionKind.Should().Be("workflow-execution-session");
-        activation.Requests[0].SessionId.Should().Be("cmd-1");
+        typeof(IWorkflowExecutionProjectionPort)
+            .GetMethods()
+            .Select(method => method.Name)
+            .Should()
+            .NotContain(name => name.StartsWith("Ensure", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

issue #867 cluster-045-session-projection-ensure-surface(medium,state-no-query-priming + projection-actor-state + projection-lease)。

- **Old**:Projection session ports 仍保留可被请求路径调用的 `Ensure*ProjectionAsync` 公开 API,即使当前调用点未触发,仍允许绕过 projection-owned lifecycle。
- **New**:4 module 的 public observation port 全部移除 `Ensure*ProjectionAsync`,只暴露 attach-existing;`StreamingProxyRoomSubscriptionObservationPort` 手动 lease+attach 改 standard attach-existing pattern;retained activation 私有于 projection-owned lifecycle。

Follow-up of cluster-041 / PR #861(workflow/script 已 attach-only,本 PR 收窄到 NyxIdChat / StreamingProxy / Workflow.Application / GAgentService 4 module 的 public surface 清理)。

## Phase 9 共识来源

`META_JUDGE_DONE:consensus:delete:remove public ensure projection session surface and require attach-existing observation, with any retained activation private to projection-owned lifecycle`

## 改动范围

22 files (+160/-351,**净 -191 LOC** 表面清理):

- **NyxidChat**:`NyxIdChatProjectionSession` 移除 `EnsureChatProjectionAsync`
- **StreamingProxy**:`StreamingProxyRoomSessionProjectionContracts/Port` 移除 3 个 Ensure API;`StreamingProxyRoomSubscriptionObservationPort` 手动 lease 改 attach-existing;`StreamingProxyEndpoints` 适配
- **Workflow**:`IWorkflowExecutionProjectionPort` + `WorkflowExecutionProjectionPort` 移除 `EnsureActorProjectionAsync`
- **GAgentService**:`IScriptServiceAguiProjectionPort` + `ScriptServiceAguiProjectionPort` 移除 ensure run-session activation
- **测试**:覆盖 attach-existing only(无 ensure path)

本地验证:`dotnet build aevatar.slnx --nologo` ✅ · architecture_guards.sh / test_stability_guards.sh / query_projection_priming_guard.sh ✅ · 相关 NyxidChat / StreamingProxy / Workflow / GAgentService 测试 ✅。

详见 [implement summary](.refactor-loop/runs/implement-issue867-session-projection-ensure-surface.md) 和 [meta-judge](.refactor-loop/runs/meta-judge-issue867-r1.md)。

Closes #867

📢 cc 原作者: @loning @eanzhao

🤖 Auto-loop / codex-refactor-loop iter45

⟦AI:AUTO-LOOP⟧
