### PR TITLE
iter47 issue-873 device-endpoint-direct-runtime-dispatch: typed facade + 删 callback auto-create + registration admission

### DIFF
--- a/agents/Aevatar.GAgents.Device/Aevatar.GAgents.Device.csproj
+++ b/agents/Aevatar.GAgents.Device/Aevatar.GAgents.Device.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Core.Abstractions\Aevatar.CQRS.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.CQRS.Core\Aevatar.CQRS.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core\Aevatar.CQRS.Projection.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Core.Abstractions\Aevatar.CQRS.Projection.Core.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Projection.Runtime\Aevatar.CQRS.Projection.Runtime.csproj" />

--- a/agents/Aevatar.GAgents.Device/DependencyInjection/DeviceServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Device/DependencyInjection/DeviceServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Commands;
 using Aevatar.CQRS.Projection.Core.DependencyInjection;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
@@ -60,6 +62,33 @@ public static class DeviceServiceCollectionExtensions
         services.AddHostedService<DeviceRegistrationStartupService>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<ITombstoneCompactionTarget, DeviceTombstoneCompactionTarget>());
+
+        // Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
+        //   Old pattern: Device HTTP endpoint resolves/creates actors, builds EventEnvelope directly, and dispatches through runtime/dispatch ports.
+        //   New principle: Endpoint delegates to typed application command facade; target resolution, envelope construction, dispatch receipt, and resource ownership live behind command skeleton contracts. No callback-time auto-create.
+        services.TryAddSingleton<ICommandContextPolicy, DefaultCommandContextPolicy>();
+        services.TryAddSingleton<DeviceRegistrationCommandFacade>();
+        services.TryAddSingleton<IDeviceCallbackCommandService, DeviceCallbackCommandFacade>();
+        services.TryAddSingleton<DeviceRegistrationCommandEnvelopeFactory>();
+        services.TryAddSingleton<DeviceRegistrationCommandReceiptFactory>();
+        services.TryAddSingleton<DeviceCallbackCommandEnvelopeFactory>();
+        services.TryAddSingleton<DeviceCallbackCommandReceiptFactory>();
+        services.TryAddSingleton<ICommandTargetDispatcher<DeviceRegistrationCommandTarget>, ActorCommandTargetDispatcher<DeviceRegistrationCommandTarget>>();
+        services.TryAddSingleton<ICommandTargetDispatcher<DeviceCallbackCommandTarget>, ActorCommandTargetDispatcher<DeviceCallbackCommandTarget>>();
+        services.TryAddSingleton<ICommandTargetResolver<DeviceRegisterCommand, DeviceRegistrationCommandTarget, DeviceRegistrationCommandStartError>, DeviceRegistrationCommandTargetResolver<DeviceRegisterCommand>>();
+        services.TryAddSingleton<ICommandTargetResolver<DeviceUnregisterCommand, DeviceRegistrationCommandTarget, DeviceRegistrationCommandStartError>, DeviceRegistrationCommandTargetResolver<DeviceUnregisterCommand>>();
+        services.TryAddSingleton<ICommandTargetResolver<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>, DeviceCallbackCommandTargetResolver>();
+        services.TryAddSingleton<ICommandEnvelopeFactory<DeviceRegisterCommand>>(sp => sp.GetRequiredService<DeviceRegistrationCommandEnvelopeFactory>());
+        services.TryAddSingleton<ICommandEnvelopeFactory<DeviceUnregisterCommand>>(sp => sp.GetRequiredService<DeviceRegistrationCommandEnvelopeFactory>());
+        services.TryAddSingleton<ICommandEnvelopeFactory<DeviceCallbackDispatchCommand>>(sp => sp.GetRequiredService<DeviceCallbackCommandEnvelopeFactory>());
+        services.TryAddSingleton<ICommandReceiptFactory<DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt>>(sp => sp.GetRequiredService<DeviceRegistrationCommandReceiptFactory>());
+        services.TryAddSingleton<ICommandReceiptFactory<DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt>>(sp => sp.GetRequiredService<DeviceCallbackCommandReceiptFactory>());
+        services.TryAddSingleton<ICommandDispatchPipeline<DeviceRegisterCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>, DefaultCommandDispatchPipeline<DeviceRegisterCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>>();
+        services.TryAddSingleton<ICommandDispatchPipeline<DeviceUnregisterCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>, DefaultCommandDispatchPipeline<DeviceUnregisterCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>>();
+        services.TryAddSingleton<ICommandDispatchPipeline<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>, DefaultCommandDispatchPipeline<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>>();
+        services.TryAddSingleton<ICommandDispatchService<DeviceRegisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>, DefaultCommandDispatchService<DeviceRegisterCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>>();
+        services.TryAddSingleton<ICommandDispatchService<DeviceUnregisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>, DefaultCommandDispatchService<DeviceUnregisterCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>>();
+        services.TryAddSingleton<ICommandDispatchService<DeviceCallbackDispatchCommand, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>, DefaultCommandDispatchService<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>>();
 
         if (useElasticsearch)
         {

--- a/agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceCommandFacades.cs
@@ -1,0 +1,281 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Household;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.Device;
+
+public sealed record DeviceCommandAcceptedReceipt(
+    string ActorId,
+    string CommandId,
+    string CorrelationId,
+    string RegistrationId = "");
+
+public enum DeviceRegistrationCommandStartError
+{
+    None = 0,
+    StoreActorUnavailable = 1,
+}
+
+public enum DeviceCallbackCommandStartError
+{
+    None = 0,
+    RegistrationNotFound = 1,
+    RegistrationNotAdmitted = 2,
+    TargetActorUnavailable = 3,
+}
+
+public interface IDeviceCallbackCommandService
+{
+    Task<CommandDispatchResult<DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>> DispatchCallbackAsync(
+        DeviceCallbackDispatchCommand command,
+        CancellationToken ct = default);
+}
+
+public sealed record DeviceCallbackDispatchCommand(
+    string RegistrationId,
+    DeviceInbound Inbound,
+    string? CommandId = null,
+    string? CorrelationId = null,
+    IReadOnlyDictionary<string, string>? Headers = null) : ICommandContextSeed;
+
+// Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
+//   Old pattern: Device HTTP endpoint resolves/creates actors, builds EventEnvelope directly, and dispatches through runtime/dispatch ports.
+//   New principle: Endpoint delegates to typed application command facade; target resolution, envelope construction, dispatch receipt, and resource ownership live behind command skeleton contracts. No callback-time auto-create.
+public sealed class DeviceRegistrationCommandFacade
+{
+    private readonly ICommandDispatchService<DeviceRegisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError> _registerDispatchService;
+    private readonly ICommandDispatchService<DeviceUnregisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError> _unregisterDispatchService;
+
+    public DeviceRegistrationCommandFacade(
+        ICommandDispatchService<DeviceRegisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError> registerDispatchService,
+        ICommandDispatchService<DeviceUnregisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError> unregisterDispatchService)
+    {
+        _registerDispatchService = registerDispatchService ?? throw new ArgumentNullException(nameof(registerDispatchService));
+        _unregisterDispatchService = unregisterDispatchService ?? throw new ArgumentNullException(nameof(unregisterDispatchService));
+    }
+
+    public async Task<DeviceCommandAcceptedReceipt> RegisterAsync(
+        DeviceRegisterCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        var result = await _registerDispatchService.DispatchAsync(command, ct);
+        return ResolveReceipt(result);
+    }
+
+    public async Task<DeviceCommandAcceptedReceipt> UnregisterAsync(
+        string registrationId,
+        CancellationToken ct = default)
+    {
+        var result = await _unregisterDispatchService.DispatchAsync(
+            new DeviceUnregisterCommand
+            {
+                RegistrationId = registrationId ?? string.Empty,
+            },
+            ct);
+        return ResolveReceipt(result);
+    }
+
+    private static DeviceCommandAcceptedReceipt ResolveReceipt(
+        CommandDispatchResult<DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError> result)
+    {
+        if (result.Succeeded && result.Receipt is not null)
+            return result.Receipt;
+
+        throw new InvalidOperationException($"Device registration command dispatch failed: {result.Error}");
+    }
+}
+
+// Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
+//   Old pattern: Device HTTP endpoint resolves/creates actors, builds EventEnvelope directly, and dispatches through runtime/dispatch ports.
+//   New principle: Endpoint delegates to typed application command facade; target resolution, envelope construction, dispatch receipt, and resource ownership live behind command skeleton contracts. No callback-time auto-create.
+public sealed class DeviceCallbackCommandFacade : IDeviceCallbackCommandService
+{
+    private readonly ICommandDispatchService<DeviceCallbackDispatchCommand, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError> _dispatchService;
+
+    public DeviceCallbackCommandFacade(
+        ICommandDispatchService<DeviceCallbackDispatchCommand, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError> dispatchService)
+    {
+        _dispatchService = dispatchService ?? throw new ArgumentNullException(nameof(dispatchService));
+    }
+
+    public Task<CommandDispatchResult<DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>> DispatchCallbackAsync(
+        DeviceCallbackDispatchCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        return _dispatchService.DispatchAsync(command, ct);
+    }
+}
+
+internal sealed record DeviceRegistrationCommandTarget(IActor Actor) : IActorCommandDispatchTarget
+{
+    public string TargetId => DeviceRegistrationGAgent.WellKnownId;
+}
+
+internal sealed class DeviceRegistrationCommandTargetResolver<TCommand>
+    : ICommandTargetResolver<TCommand, DeviceRegistrationCommandTarget, DeviceRegistrationCommandStartError>
+{
+    private readonly IActorRuntime _actorRuntime;
+
+    public DeviceRegistrationCommandTargetResolver(IActorRuntime actorRuntime)
+    {
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+    }
+
+    public async Task<CommandTargetResolution<DeviceRegistrationCommandTarget, DeviceRegistrationCommandStartError>> ResolveAsync(
+        TCommand command,
+        CancellationToken ct = default)
+    {
+        var actor = await _actorRuntime.GetAsync(DeviceRegistrationGAgent.WellKnownId)
+            ?? await _actorRuntime.CreateAsync<DeviceRegistrationGAgent>(
+                DeviceRegistrationGAgent.WellKnownId,
+                ct);
+
+        return actor is null
+            ? CommandTargetResolution<DeviceRegistrationCommandTarget, DeviceRegistrationCommandStartError>.Failure(DeviceRegistrationCommandStartError.StoreActorUnavailable)
+            : CommandTargetResolution<DeviceRegistrationCommandTarget, DeviceRegistrationCommandStartError>.Success(new DeviceRegistrationCommandTarget(actor));
+    }
+}
+
+internal sealed class DeviceRegistrationCommandEnvelopeFactory :
+    ICommandEnvelopeFactory<DeviceRegisterCommand>,
+    ICommandEnvelopeFactory<DeviceUnregisterCommand>
+{
+    private const string PublisherActorId = "device-events.registration";
+
+    public EventEnvelope CreateEnvelope(DeviceRegisterCommand command, CommandContext context) =>
+        CreateEnvelopeCore(command, context);
+
+    public EventEnvelope CreateEnvelope(DeviceUnregisterCommand command, CommandContext context) =>
+        CreateEnvelopeCore(command, context);
+
+    private static EventEnvelope CreateEnvelopeCore(IMessage command, CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new EventEnvelope
+        {
+            Id = context.CommandId,
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(command),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, DeviceRegistrationGAgent.WellKnownId),
+        };
+    }
+}
+
+internal sealed class DeviceRegistrationCommandReceiptFactory
+    : ICommandReceiptFactory<DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt>
+{
+    public DeviceCommandAcceptedReceipt Create(
+        DeviceRegistrationCommandTarget target,
+        CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new DeviceCommandAcceptedReceipt(
+            target.TargetId,
+            context.CommandId,
+            context.CorrelationId);
+    }
+}
+
+internal sealed record DeviceCallbackCommandTarget(IActor Actor, string RegistrationId)
+    : IActorCommandDispatchTarget
+{
+    public string TargetId => Actor.Id;
+}
+
+internal sealed class DeviceCallbackCommandTargetResolver
+    : ICommandTargetResolver<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>
+{
+    private readonly IDeviceRegistrationQueryPort _queryPort;
+    private readonly IActorRuntime _actorRuntime;
+
+    public DeviceCallbackCommandTargetResolver(
+        IDeviceRegistrationQueryPort queryPort,
+        IActorRuntime actorRuntime)
+    {
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
+    }
+
+    public async Task<CommandTargetResolution<DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>> ResolveAsync(
+        DeviceCallbackDispatchCommand command,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (string.IsNullOrWhiteSpace(command.RegistrationId))
+        {
+            return CommandTargetResolution<DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>.Failure(
+                DeviceCallbackCommandStartError.RegistrationNotFound);
+        }
+
+        var registration = await _queryPort.GetAsync(command.RegistrationId, ct);
+        if (registration is null)
+        {
+            return CommandTargetResolution<DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>.Failure(
+                DeviceCallbackCommandStartError.RegistrationNotFound);
+        }
+
+        if (registration.Tombstoned || string.IsNullOrWhiteSpace(registration.DeviceEventTargetActorId))
+        {
+            return CommandTargetResolution<DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>.Failure(
+                DeviceCallbackCommandStartError.RegistrationNotAdmitted);
+        }
+
+        var actor = await _actorRuntime.GetAsync(registration.DeviceEventTargetActorId);
+        if (actor is null)
+        {
+            return CommandTargetResolution<DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>.Failure(
+                DeviceCallbackCommandStartError.TargetActorUnavailable);
+        }
+
+        return CommandTargetResolution<DeviceCallbackCommandTarget, DeviceCallbackCommandStartError>.Success(
+            new DeviceCallbackCommandTarget(actor, registration.Id ?? command.RegistrationId));
+    }
+}
+
+internal sealed class DeviceCallbackCommandEnvelopeFactory
+    : ICommandEnvelopeFactory<DeviceCallbackDispatchCommand>
+{
+    private const string PublisherActorId = "device-events.callback";
+
+    public EventEnvelope CreateEnvelope(DeviceCallbackDispatchCommand command, CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(command.Inbound);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new EventEnvelope
+        {
+            Id = context.CommandId,
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(command.Inbound),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, context.TargetId),
+        };
+    }
+}
+
+internal sealed class DeviceCallbackCommandReceiptFactory
+    : ICommandReceiptFactory<DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt>
+{
+    public DeviceCommandAcceptedReceipt Create(
+        DeviceCallbackCommandTarget target,
+        CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(context);
+
+        return new DeviceCommandAcceptedReceipt(
+            target.TargetId,
+            context.CommandId,
+            context.CorrelationId,
+            target.RegistrationId);
+    }
+}

--- a/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs
@@ -1,9 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Household;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -21,9 +19,6 @@ public sealed class DeviceEventOptions
 
 public static class DeviceEventEndpoints
 {
-    private const string DeviceCallbackPublisherActorId = "device-events.callback";
-    private const string DeviceRegistrationPublisherActorId = "device-events.registration";
-
     public static IEndpointRouteBuilder MapDeviceEventEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/device-events").WithTags("DeviceEvents");
@@ -49,15 +44,17 @@ public static class DeviceEventEndpoints
     /// 1. Lookup registration from projection read model.
     /// 2. HMAC verification (configurable).
     /// 3. Parse CallbackPayload → DeviceInbound.
-    /// 4. Synchronous dispatch to HouseholdEntity actor.
+    /// 4. Dispatch via typed device callback command facade.
     /// 5. Return 202 Accepted (or 502 on dispatch failure — NyxID retries at transport level).
     /// </summary>
+    // Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
+    //   Old pattern: Device HTTP endpoint resolves/creates actors, builds EventEnvelope directly, and dispatches through runtime/dispatch ports.
+    //   New principle: Endpoint delegates to typed application command facade; target resolution, envelope construction, dispatch receipt, and resource ownership live behind command skeleton contracts. No callback-time auto-create.
     private static async Task<IResult> HandleDeviceCallbackAsync(
         HttpContext http,
         string registrationId,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort dispatchPort,
         [FromServices] IDeviceRegistrationQueryPort queryPort,
+        [FromServices] IDeviceCallbackCommandService callbackCommandService,
         [FromServices] IOptions<DeviceEventOptions> options,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
@@ -101,13 +98,34 @@ public static class DeviceEventEndpoints
             "Device event received: event_id={EventId}, source={Source}, type={EventType}",
             inbound.EventId, inbound.Source, inbound.EventType);
 
-        // Resolve HouseholdEntity actor
-        var householdActorId = $"household-{registration.ScopeId}";
-
-        // Synchronous dispatch — failure returns 502 so NyxID retries at transport level
+        // Dispatch admission + target resolution live behind the typed command facade.
         try
         {
-            await DispatchToHouseholdAsync(inbound, householdActorId, actorRuntime, dispatchPort, loggerFactory, ct);
+            var dispatch = await callbackCommandService.DispatchCallbackAsync(
+                new DeviceCallbackDispatchCommand(registrationId, inbound),
+                ct);
+            if (!dispatch.Succeeded)
+            {
+                return dispatch.Error switch
+                {
+                    DeviceCallbackCommandStartError.RegistrationNotFound =>
+                        Results.NotFound(new { error = "Registration not found" }),
+                    DeviceCallbackCommandStartError.RegistrationNotAdmitted =>
+                        Results.Conflict(new { error = "Registration is not admitted for device callbacks" }),
+                    DeviceCallbackCommandStartError.TargetActorUnavailable =>
+                        Results.Conflict(new { error = "Device callback target is unavailable" }),
+                    _ => Results.StatusCode(502),
+                };
+            }
+
+            return Results.Accepted(value: new
+            {
+                status = "accepted",
+                actor_id = dispatch.Receipt!.ActorId,
+                command_id = dispatch.Receipt.CommandId,
+                correlation_id = dispatch.Receipt.CorrelationId,
+                registration_id = dispatch.Receipt.RegistrationId,
+            });
         }
         catch (Exception ex)
         {
@@ -115,22 +133,6 @@ public static class DeviceEventEndpoints
             logger2.LogError(ex, "Device event dispatch failed: event_id={EventId}", inbound.EventId);
             return Results.StatusCode(502);
         }
-
-        return Results.Accepted();
-    }
-
-    /// <summary>
-    /// Gets or creates the well-known DeviceRegistrationGAgent singleton actor.
-    /// Lifecycle: created on first request, never destroyed (long-lived fact owner per CLAUDE.md).
-    /// Thread safety: Orleans grain runtime guarantees single-activation, so concurrent
-    /// CreateAsync calls from multiple requests safely converge to the same grain.
-    /// </summary>
-    private static async Task<IActor> GetOrCreateRegistrationActorAsync(
-        IActorRuntime actorRuntime,
-        CancellationToken ct)
-    {
-        return await actorRuntime.GetAsync(DeviceRegistrationGAgent.WellKnownId)
-               ?? await actorRuntime.CreateAsync<DeviceRegistrationGAgent>(DeviceRegistrationGAgent.WellKnownId, ct);
     }
 
     internal static bool VerifyHmacSignature(
@@ -210,48 +212,14 @@ public static class DeviceEventEndpoints
         };
     }
 
-    /// <summary>
-    /// Dispatches a device event to the HouseholdEntity actor (single attempt).
-    /// On failure the caller returns 502, allowing NyxID to retry at transport level.
-    /// Lifecycle: the household actor is created on first request for a given scope,
-    /// never destroyed (long-lived fact owner per CLAUDE.md).
-    /// Thread safety: Orleans grain runtime guarantees single-activation, so concurrent
-    /// CreateAsync calls from multiple requests safely converge to the same grain.
-    /// </summary>
-    private static async Task DispatchToHouseholdAsync(
-        DeviceInbound inbound,
-        string householdActorId,
-        IActorRuntime actorRuntime,
-        IActorDispatchPort dispatchPort,
-        ILoggerFactory loggerFactory,
-        CancellationToken ct)
-    {
-        var logger = loggerFactory.CreateLogger("Aevatar.ChannelRuntime.DeviceEvent");
-
-        var actor = await actorRuntime.GetAsync(householdActorId)
-                    ?? await actorRuntime.CreateAsync<HouseholdEntity>(householdActorId, ct);
-
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(inbound),
-            Route = EnvelopeRouteSemantics.CreateDirect(DeviceCallbackPublisherActorId, actor.Id),
-        };
-
-        await dispatchPort.DispatchAsync(actor.Id, envelope, ct);
-
-        logger.LogInformation(
-            "Device event dispatched: event_id={EventId}, target={HouseholdActorId}",
-            inbound.EventId, householdActorId);
-    }
-
     // ─── Registration CRUD ───
 
+    // Refactor (iter47/issue-873-device-endpoint-direct-runtime-dispatch):
+    //   Old pattern: Device HTTP endpoint resolves/creates actors, builds EventEnvelope directly, and dispatches through runtime/dispatch ports.
+    //   New principle: Endpoint delegates to typed application command facade; target resolution, envelope construction, dispatch receipt, and resource ownership live behind command skeleton contracts. No callback-time auto-create.
     private static async Task<IResult> HandleRegisterDeviceAsync(
         HttpContext http,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort dispatchPort,
+        [FromServices] DeviceRegistrationCommandFacade registrationCommandFacade,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -273,34 +241,35 @@ public static class DeviceEventEndpoints
             return Results.BadRequest(new { error = "scope_id is required" });
         }
 
-        var actor = await GetOrCreateRegistrationActorAsync(actorRuntime, ct);
+        if (string.IsNullOrWhiteSpace(request.DeviceEventTargetActorId))
+        {
+            return Results.BadRequest(new { error = "device_event_target_actor_id is required" });
+        }
 
-        // Dispatch register command to actor
+        var scopeId = request.ScopeId.Trim();
+        var targetActorId = request.DeviceEventTargetActorId.Trim();
+
         var cmd = new DeviceRegisterCommand
         {
-            ScopeId = request.ScopeId.Trim(),
+            ScopeId = scopeId,
             HmacKey = request.HmacKey?.Trim() ?? string.Empty,
             NyxConversationId = request.NyxConversationId?.Trim() ?? string.Empty,
             Description = request.Description?.Trim() ?? string.Empty,
+            DeviceEventTargetActorId = targetActorId,
         };
 
-        var cmdEnvelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(cmd),
-            Route = EnvelopeRouteSemantics.CreateDirect(DeviceRegistrationPublisherActorId, actor.Id),
-        };
-
-        await dispatchPort.DispatchAsync(actor.Id, cmdEnvelope, ct);
+        var receipt = await registrationCommandFacade.RegisterAsync(cmd, ct);
 
         // Command accepted — the projection pipeline will materialize the read model.
         // Return accepted with the command details (eventual consistency).
         return Results.Accepted(value: new
         {
             status = "accepted",
-            scope_id = request.ScopeId.Trim(),
+            scope_id = scopeId,
             description = request.Description?.Trim() ?? string.Empty,
+            device_event_target_actor_id = targetActorId,
+            command_id = receipt.CommandId,
+            correlation_id = receipt.CorrelationId,
         });
     }
 
@@ -322,32 +291,27 @@ public static class DeviceEventEndpoints
 
     private static async Task<IResult> HandleDeleteDeviceRegistrationAsync(
         string registrationId,
-        [FromServices] IActorRuntime actorRuntime,
-        [FromServices] IActorDispatchPort dispatchPort,
         [FromServices] IDeviceRegistrationQueryPort queryPort,
+        [FromServices] DeviceRegistrationCommandFacade registrationCommandFacade,
         CancellationToken ct)
     {
         var exists = await queryPort.GetAsync(registrationId, ct);
         if (exists is null)
             return Results.NotFound(new { error = "Registration not found" });
 
-        var actor = await GetOrCreateRegistrationActorAsync(actorRuntime, ct);
-        var cmd = new DeviceUnregisterCommand { RegistrationId = registrationId };
-        var cmdEnvelope = new EventEnvelope
+        var receipt = await registrationCommandFacade.UnregisterAsync(registrationId, ct);
+        return Results.Ok(new
         {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(cmd),
-            Route = EnvelopeRouteSemantics.CreateDirect(DeviceRegistrationPublisherActorId, actor.Id),
-        };
-
-        await dispatchPort.DispatchAsync(actor.Id, cmdEnvelope, ct);
-        return Results.Ok(new { status = "deleted" });
+            status = "deleted",
+            command_id = receipt.CommandId,
+            correlation_id = receipt.CorrelationId,
+        });
     }
 
     private sealed record DeviceRegistrationRequest(
         string? ScopeId,
         string? HmacKey,
         string? NyxConversationId,
-        string? Description);
+        string? Description,
+        string? DeviceEventTargetActorId);
 }

--- a/agents/Aevatar.GAgents.Device/DeviceRegistrationGAgent.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceRegistrationGAgent.cs
@@ -39,6 +39,7 @@ public sealed class DeviceRegistrationGAgent : GAgentBase<DeviceRegistrationStat
             HmacKey = cmd.HmacKey,
             NyxConversationId = cmd.NyxConversationId,
             Description = cmd.Description,
+            DeviceEventTargetActorId = cmd.DeviceEventTargetActorId,
             CreatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
 

--- a/agents/Aevatar.GAgents.Device/DeviceRegistrationProjector.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceRegistrationProjector.cs
@@ -46,6 +46,7 @@ public sealed class DeviceRegistrationProjector
             HmacKey = entry.HmacKey ?? string.Empty,
             NyxConversationId = entry.NyxConversationId ?? string.Empty,
             Description = entry.Description ?? string.Empty,
+            DeviceEventTargetActorId = entry.DeviceEventTargetActorId ?? string.Empty,
             StateVersion = stateEvent.Version,
             LastEventId = stateEvent.EventId ?? string.Empty,
             ActorId = context.RootActorId,

--- a/agents/Aevatar.GAgents.Device/DeviceRegistrationQueryPort.cs
+++ b/agents/Aevatar.GAgents.Device/DeviceRegistrationQueryPort.cs
@@ -40,5 +40,6 @@ public sealed class DeviceRegistrationQueryPort : IDeviceRegistrationQueryPort
             HmacKey = document.HmacKey ?? string.Empty,
             NyxConversationId = document.NyxConversationId ?? string.Empty,
             Description = document.Description ?? string.Empty,
+            DeviceEventTargetActorId = document.DeviceEventTargetActorId ?? string.Empty,
         };
 }

--- a/agents/Aevatar.GAgents.Device/protos/device_registration.proto
+++ b/agents/Aevatar.GAgents.Device/protos/device_registration.proto
@@ -10,7 +10,7 @@ import "google/protobuf/timestamp.proto";
 
 message DeviceRegistrationEntry {
   string id = 1;
-  string scope_id = 2;                    // Maps to household-{scope_id} actor
+  string scope_id = 2;                    // Device registration scope
   string hmac_key = 3;                    // HMAC-SHA256 signing key for NyxID relay verification
   string nyx_conversation_id = 4;         // NyxID conversation ID
   string description = 5;                 // Human-readable label
@@ -21,6 +21,7 @@ message DeviceRegistrationEntry {
   // .DeleteAsync. Housekeeping cleans watermark-passed entries.
   bool tombstoned = 7;
   int64 tombstone_state_version = 8;
+  string device_event_target_actor_id = 9; // Explicit callback target selected during registration admission
 }
 
 message DeviceRegistrationState {
@@ -43,6 +44,7 @@ message DeviceRegisterCommand {
   string hmac_key = 2;
   string nyx_conversation_id = 3;
   string description = 4;
+  string device_event_target_actor_id = 5;
 }
 
 message DeviceUnregisterCommand {
@@ -69,4 +71,5 @@ message DeviceRegistrationDocument {
   string last_event_id = 7;
   google.protobuf.Timestamp updated_at_utc = 8;
   string actor_id = 9;                    // Source actor ID
+  string device_event_target_actor_id = 10;
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTestSupport.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTestSupport.cs
@@ -1,0 +1,60 @@
+using Aevatar.CQRS.Core.Abstractions.Commands;
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Device;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+internal static class DeviceCommandFacadeTestSupport
+{
+    public static DeviceRegistrationCommandFacade CreateRegistrationFacade(
+        IActorRuntime actorRuntime,
+        IActorDispatchPort dispatchPort)
+    {
+        var contextPolicy = new DefaultCommandContextPolicy();
+        var envelopeFactory = new DeviceRegistrationCommandEnvelopeFactory();
+        var targetDispatcher = new ActorCommandTargetDispatcher<DeviceRegistrationCommandTarget>(dispatchPort);
+        var receiptFactory = new DeviceRegistrationCommandReceiptFactory();
+
+        return new DeviceRegistrationCommandFacade(
+            CreateRegistrationDispatchService<DeviceRegisterCommand>(actorRuntime, contextPolicy, envelopeFactory, targetDispatcher, receiptFactory),
+            CreateRegistrationDispatchService<DeviceUnregisterCommand>(actorRuntime, contextPolicy, envelopeFactory, targetDispatcher, receiptFactory));
+    }
+
+    public static DeviceCallbackCommandFacade CreateCallbackFacade(
+        IDeviceRegistrationQueryPort queryPort,
+        IActorRuntime actorRuntime,
+        IActorDispatchPort dispatchPort)
+    {
+        var contextPolicy = new DefaultCommandContextPolicy();
+        var resolver = new DeviceCallbackCommandTargetResolver(queryPort, actorRuntime);
+        var envelopeFactory = new DeviceCallbackCommandEnvelopeFactory();
+        var targetDispatcher = new ActorCommandTargetDispatcher<DeviceCallbackCommandTarget>(dispatchPort);
+        var receiptFactory = new DeviceCallbackCommandReceiptFactory();
+        var pipeline = new DefaultCommandDispatchPipeline<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>(
+            resolver,
+            contextPolicy,
+            envelopeFactory,
+            targetDispatcher,
+            receiptFactory);
+        return new DeviceCallbackCommandFacade(
+            new DefaultCommandDispatchService<DeviceCallbackDispatchCommand, DeviceCallbackCommandTarget, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>(pipeline));
+    }
+
+    private static ICommandDispatchService<TCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError> CreateRegistrationDispatchService<TCommand>(
+        IActorRuntime actorRuntime,
+        ICommandContextPolicy contextPolicy,
+        ICommandEnvelopeFactory<TCommand> envelopeFactory,
+        ICommandTargetDispatcher<DeviceRegistrationCommandTarget> targetDispatcher,
+        ICommandReceiptFactory<DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt> receiptFactory)
+    {
+        var resolver = new DeviceRegistrationCommandTargetResolver<TCommand>(actorRuntime);
+        var pipeline = new DefaultCommandDispatchPipeline<TCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>(
+            resolver,
+            contextPolicy,
+            envelopeFactory,
+            targetDispatcher,
+            receiptFactory);
+        return new DefaultCommandDispatchService<TCommand, DeviceRegistrationCommandTarget, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>(pipeline);
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceCommandFacadeTests.cs
@@ -1,0 +1,151 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Device;
+using Aevatar.GAgents.Household;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class DeviceCommandFacadeTests
+{
+    [Fact]
+    public async Task RegisterAsync_WhenStoreActorIsMissing_ShouldCreateStoreActorAndDispatchTypedEnvelope()
+    {
+        EventEnvelope? capturedEnvelope = null;
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns(DeviceRegistrationGAgent.WellKnownId);
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var dispatchPort = Substitute.For<IActorDispatchPort>();
+        actorRuntime.GetAsync(DeviceRegistrationGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(null));
+        actorRuntime.CreateAsync<DeviceRegistrationGAgent>(
+                DeviceRegistrationGAgent.WellKnownId,
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(actor));
+        dispatchPort.DispatchAsync(
+                DeviceRegistrationGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var facade = DeviceCommandFacadeTestSupport.CreateRegistrationFacade(actorRuntime, dispatchPort);
+
+        var receipt = await facade.RegisterAsync(new DeviceRegisterCommand
+        {
+            ScopeId = "scope-a",
+            HmacKey = "key-a",
+            DeviceEventTargetActorId = "household-scope-a",
+        });
+
+        receipt.ActorId.Should().Be(DeviceRegistrationGAgent.WellKnownId);
+        receipt.CommandId.Should().NotBeNullOrWhiteSpace();
+        receipt.CorrelationId.Should().Be(receipt.CommandId);
+        capturedEnvelope.Should().NotBeNull();
+        var command = capturedEnvelope!.Payload.Unpack<DeviceRegisterCommand>();
+        command.ScopeId.Should().Be("scope-a");
+        command.DeviceEventTargetActorId.Should().Be("household-scope-a");
+        await actorRuntime.Received(1).CreateAsync<DeviceRegistrationGAgent>(
+            DeviceRegistrationGAgent.WellKnownId,
+            Arg.Any<CancellationToken>());
+        await dispatchPort.Received(1).DispatchAsync(
+            DeviceRegistrationGAgent.WellKnownId,
+            Arg.Any<EventEnvelope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DispatchCallbackAsync_WhenRegistrationMissing_ShouldReturnAdmissionErrorAndNotDispatch()
+    {
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var dispatchPort = Substitute.For<IActorDispatchPort>();
+        queryPort.GetAsync("reg-missing", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(null));
+        var facade = DeviceCommandFacadeTestSupport.CreateCallbackFacade(queryPort, actorRuntime, dispatchPort);
+
+        var result = await facade.DispatchCallbackAsync(new DeviceCallbackDispatchCommand(
+            "reg-missing",
+            new DeviceInbound { EventId = "evt-1" }));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(DeviceCallbackCommandStartError.RegistrationNotFound);
+        await actorRuntime.DidNotReceiveWithAnyArgs().CreateAsync(default!, default, default);
+        await dispatchPort.DidNotReceiveWithAnyArgs().DispatchAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task DispatchCallbackAsync_WhenRegistrationHasNoTarget_ShouldReturnAdmissionErrorAndNotCreateHousehold()
+    {
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var dispatchPort = Substitute.For<IActorDispatchPort>();
+        queryPort.GetAsync("reg-targetless", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(new DeviceRegistrationEntry
+            {
+                Id = "reg-targetless",
+                ScopeId = "scope-a",
+                HmacKey = "key-a",
+            }));
+        var facade = DeviceCommandFacadeTestSupport.CreateCallbackFacade(queryPort, actorRuntime, dispatchPort);
+
+        var result = await facade.DispatchCallbackAsync(new DeviceCallbackDispatchCommand(
+            "reg-targetless",
+            new DeviceInbound { EventId = "evt-2" }));
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Be(DeviceCallbackCommandStartError.RegistrationNotAdmitted);
+        await actorRuntime.DidNotReceiveWithAnyArgs().CreateAsync(default!, default, default);
+        await dispatchPort.DidNotReceiveWithAnyArgs().DispatchAsync(default!, default!, default);
+    }
+
+    [Fact]
+    public async Task DispatchCallbackAsync_WhenTargetExists_ShouldDispatchInboundAndReturnAcceptedReceipt()
+    {
+        EventEnvelope? capturedEnvelope = null;
+        var targetActor = Substitute.For<IActor>();
+        targetActor.Id.Returns("household-scope-a");
+        var queryPort = Substitute.For<IDeviceRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime>();
+        var dispatchPort = Substitute.For<IActorDispatchPort>();
+        queryPort.GetAsync("reg-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<DeviceRegistrationEntry?>(new DeviceRegistrationEntry
+            {
+                Id = "reg-1",
+                ScopeId = "scope-a",
+                HmacKey = "key-a",
+                DeviceEventTargetActorId = "household-scope-a",
+            }));
+        actorRuntime.GetAsync("household-scope-a")
+            .Returns(Task.FromResult<IActor?>(targetActor));
+        dispatchPort.DispatchAsync(
+                "household-scope-a",
+                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var facade = DeviceCommandFacadeTestSupport.CreateCallbackFacade(queryPort, actorRuntime, dispatchPort);
+
+        var result = await facade.DispatchCallbackAsync(new DeviceCallbackDispatchCommand(
+            "reg-1",
+            new DeviceInbound
+            {
+                EventId = "evt-3",
+                EventType = "temperature_change",
+            },
+            CommandId: "cmd-1",
+            CorrelationId: "corr-1"));
+
+        result.Succeeded.Should().BeTrue();
+        result.Receipt.Should().NotBeNull();
+        result.Receipt!.ActorId.Should().Be("household-scope-a");
+        result.Receipt.CommandId.Should().Be("cmd-1");
+        result.Receipt.CorrelationId.Should().Be("corr-1");
+        result.Receipt.RegistrationId.Should().Be("reg-1");
+        capturedEnvelope.Should().NotBeNull();
+        capturedEnvelope!.Id.Should().Be("cmd-1");
+        capturedEnvelope.Payload.Unpack<DeviceInbound>().EventId.Should().Be("evt-3");
+        await actorRuntime.DidNotReceiveWithAnyArgs().CreateAsync(default!, default, default);
+        await dispatchPort.Received(1).DispatchAsync(
+            "household-scope-a",
+            Arg.Any<EventEnvelope>(),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceEventEndpointsTests.cs
@@ -17,6 +17,22 @@ public class DeviceEventEndpointsTests
     // ─── Parse Callback Payload Tests ───
 
     [Fact]
+    public void DeviceEventEndpoints_ShouldNotOwnActorRuntimeDispatchOrEnvelopeConstruction()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "../../../../../agents/Aevatar.GAgents.Device/DeviceEventEndpoints.cs"));
+        var source = File.ReadAllText(sourcePath);
+
+        source.Should().NotContain("IActorRuntime");
+        source.Should().NotContain("IActorDispatchPort");
+        source.Should().NotContain("new EventEnvelope");
+        source.Should().NotContain("Any.Pack");
+        source.Should().NotContain("EnvelopeRouteSemantics");
+        source.Should().NotContain("CreateAsync<HouseholdEntity>");
+    }
+
+    [Fact]
     public void ParseCallbackPayload_nyxid_format_returns_device_inbound()
     {
         // NyxID's actual CallbackPayload format (sender.platform_id, nested conversation)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceRegistrationGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/DeviceRegistrationGAgentTests.cs
@@ -53,6 +53,7 @@ public class DeviceRegistrationGAgentTests : IAsyncLifetime
             ScopeId = "scope-1",
             HmacKey = "key-1",
             Description = "Test device",
+            DeviceEventTargetActorId = "household-scope-1",
         };
 
         await _agent.HandleRegister(cmd);
@@ -62,6 +63,7 @@ public class DeviceRegistrationGAgentTests : IAsyncLifetime
         entry.ScopeId.Should().Be("scope-1");
         entry.HmacKey.Should().Be("key-1");
         entry.Description.Should().Be("Test device");
+        entry.DeviceEventTargetActorId.Should().Be("household-scope-1");
         entry.Id.Should().NotBeNullOrWhiteSpace();
     }
 
@@ -89,6 +91,7 @@ public class DeviceRegistrationGAgentTests : IAsyncLifetime
             HmacKey = "hmac-secret",
             NyxConversationId = "conv-42",
             Description = "Living room sensor hub",
+            DeviceEventTargetActorId = "household-scope-x",
         };
 
         await _agent.HandleRegister(cmd);
@@ -99,6 +102,7 @@ public class DeviceRegistrationGAgentTests : IAsyncLifetime
         entry.HmacKey.Should().Be("hmac-secret");
         entry.NyxConversationId.Should().Be("conv-42");
         entry.Description.Should().Be("Living room sensor hub");
+        entry.DeviceEventTargetActorId.Should().Be("household-scope-x");
         entry.CreatedAt.Should().NotBeNull();
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/RegistrationQueryPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/RegistrationQueryPortTests.cs
@@ -21,6 +21,7 @@ public sealed class RegistrationQueryPortTests
                 HmacKey = "key-abc",
                 NyxConversationId = "conv-42",
                 Description = "Test device",
+                DeviceEventTargetActorId = "household-scope-a",
             }));
 
         var queryPort = new DeviceRegistrationQueryPort(reader);
@@ -32,6 +33,7 @@ public sealed class RegistrationQueryPortTests
         result.HmacKey.Should().Be("key-abc");
         result.NyxConversationId.Should().Be("conv-42");
         result.Description.Should().Be("Test device");
+        result.DeviceEventTargetActorId.Should().Be("household-scope-a");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -6,6 +6,7 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.Device;
 using Aevatar.GAgents.NyxidChat;
 using Aevatar.GAgents.Platform.Lark;
 using Aevatar.GAgents.Platform.Telegram;
@@ -77,6 +78,25 @@ public sealed class ServiceCollectionExtensionsTests
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(ICommandDispatchService<ChannelBotRegisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
         registry.Get(ChannelId.From("telegram")).Should().BeOfType<Aevatar.GAgents.Platform.Telegram.TelegramMessageComposer>();
+    }
+
+    [Fact]
+    public void AddDeviceRegistration_RegistersDeviceCommandFacades()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddDeviceRegistration();
+
+        result.Should().BeSameAs(services);
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(DeviceRegistrationCommandFacade));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IDeviceCallbackCommandService) &&
+            descriptor.ImplementationType == typeof(DeviceCallbackCommandFacade));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandDispatchService<DeviceRegisterCommand, DeviceCommandAcceptedReceipt, DeviceRegistrationCommandStartError>));
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandDispatchService<DeviceCallbackDispatchCommand, DeviceCommandAcceptedReceipt, DeviceCallbackCommandStartError>));
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

iter47 issue-873 cluster-001-device-endpoint-direct-runtime-dispatch(high,top-layering + command-skeleton + runtime-dispatch-separation + default-resource-semantics)。

- **Old**:Device HTTP endpoint 注入 IActorRuntime / IActorDispatchPort,resolve/create `household-{scopeId}` actor,手动构造 EventEnvelope,直接 dispatch。API 层承担业务编排,资源 ownership 不明,callback 缺失时 silent auto-create。
- **New**:Endpoint 仅 HTTP parse + HMAC verify + 调 typed command facade + 返回 accepted/error receipt。Callback admission via `DeviceRegistrationGAgent`(第一权威 actor),未注册 → return error 不 auto-create。HouseholdEntity 作为 callback target 复用(无新 actor)。

## Phase 9 共识来源

`META_JUDGE_DONE:consensus:delete:delete callback-time household auto-create; require device registration admission and route all device commands through a typed facade/command skeleton`

## 改动范围

14 files (+629/-95):

- **DeviceCommandFacades.cs(新)**:typed facade(IDeviceCallbackCommandService + IDeviceRegistrationCommandService)+ target resolver + envelope factory + receipt factory(参考 ChannelRegistrationCommandFacade pattern)
- **DeviceEventEndpoints.cs**:删 IActorRuntime / IActorDispatchPort 注入,改 typed command facade only
- **DeviceRegistrationGAgent.cs**:扩展 admission events
- **device_registration.proto**:typed events 扩展
- **DeviceServiceCollectionExtensions.cs**:注册新 facade
- **测试**:DeviceCommandFacadeTests + Support / DeviceEventEndpointsTests / DeviceRegistrationGAgentTests 等覆盖

本地验证:`dotnet build aevatar.slnx --nologo` ✅ · architecture_guards.sh ✅ · ChannelRuntime.Tests 811/811 ✅(本 PR scope)。Note:slnx 全量 test 有 pre-existing scripting/GAgentService 失败不在本 PR scope。

Closes #873

📢 cc 原作者: @eanzhao @loning

🤖 Auto-loop / codex-refactor-loop iter47

⟦AI:AUTO-LOOP⟧
