### PR TITLE
iter49 cluster-049 chat-history-index-side-lifecycle: 删 service locator,改 typed provisioning port

### DIFF
--- a/agents/Aevatar.GAgents.ChatHistory/ChatConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.ChatHistory/ChatConversationGAgent.cs
@@ -3,7 +3,6 @@ using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Google.Protobuf;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.GAgents.ChatHistory;
 
@@ -17,6 +16,13 @@ namespace Aevatar.GAgents.ChatHistory;
 /// </summary>
 public sealed class ChatConversationGAgent : GAgentBase<ChatConversationState>, IProjectedActor
 {
+    private readonly IChatHistoryIndexTopologyPort _indexTopologyPort;
+
+    public ChatConversationGAgent(IChatHistoryIndexTopologyPort indexTopologyPort)
+    {
+        _indexTopologyPort = indexTopologyPort ?? throw new ArgumentNullException(nameof(indexTopologyPort));
+    }
+
     public static string ProjectionKind => "chat-conversation";
 
     /// <summary>Maximum messages retained per conversation.</summary>
@@ -36,8 +42,10 @@ public sealed class ChatConversationGAgent : GAgentBase<ChatConversationState>, 
         // Forward index upsert to the index actor
         if (!string.IsNullOrWhiteSpace(evt.ScopeId))
         {
-            var indexActorId = IndexActorId(evt.ScopeId);
-            await EnsureIndexActorAsync(indexActorId);
+            // Refactor (iter49/cluster-049-chat-history-index-side-lifecycle):
+            //   Old pattern: ChatConversationGAgent resolved IActorRuntime via Services locator and created index actor inline during event handling.
+            //   New principle: Index actor addressing/provisioning is a constructor-injected narrow domain port; ChatHistoryIndexGAgent created via topology setup, not inline event handling.
+            var indexActorId = _indexTopologyPort.GetIndexActorId(evt.ScopeId);
             var indexMeta = State.Meta?.Clone();
             if (indexMeta is not null)
             {
@@ -62,8 +70,7 @@ public sealed class ChatConversationGAgent : GAgentBase<ChatConversationState>, 
         // Forward index removal to the index actor
         if (!string.IsNullOrWhiteSpace(evt.ScopeId))
         {
-            var indexActorId = IndexActorId(evt.ScopeId);
-            await EnsureIndexActorAsync(indexActorId);
+            var indexActorId = _indexTopologyPort.GetIndexActorId(evt.ScopeId);
             await SendToAsync(indexActorId, new ConversationRemovedEvent { ConversationId = evt.ConversationId });
         }
     }
@@ -112,13 +119,4 @@ public sealed class ChatConversationGAgent : GAgentBase<ChatConversationState>, 
     {
         return new ChatConversationState();
     }
-
-    private async Task EnsureIndexActorAsync(string indexActorId)
-    {
-        var runtime = Services.GetRequiredService<IActorRuntime>();
-        if (await runtime.GetAsync(indexActorId) is null)
-            await runtime.CreateAsync<ChatHistoryIndexGAgent>(indexActorId);
-    }
-
-    private static string IndexActorId(string scopeId) => $"chat-index-{scopeId}";
 }

--- a/agents/Aevatar.GAgents.ChatHistory/DefaultChatHistoryIndexTopologyPort.cs
+++ b/agents/Aevatar.GAgents.ChatHistory/DefaultChatHistoryIndexTopologyPort.cs
@@ -1,0 +1,10 @@
+namespace Aevatar.GAgents.ChatHistory;
+
+public sealed class DefaultChatHistoryIndexTopologyPort : IChatHistoryIndexTopologyPort
+{
+    public string GetIndexActorId(string scopeId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scopeId);
+        return $"chat-index-{scopeId}";
+    }
+}

--- a/agents/Aevatar.GAgents.ChatHistory/DependencyInjection/ChatHistoryServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.ChatHistory/DependencyInjection/ChatHistoryServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Aevatar.GAgents.ChatHistory.DependencyInjection;
+
+public static class ChatHistoryServiceCollectionExtensions
+{
+    public static IServiceCollection AddChatHistoryGAgents(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IChatHistoryIndexTopologyPort, DefaultChatHistoryIndexTopologyPort>();
+        return services;
+    }
+}

--- a/agents/Aevatar.GAgents.ChatHistory/IChatHistoryIndexTopologyPort.cs
+++ b/agents/Aevatar.GAgents.ChatHistory/IChatHistoryIndexTopologyPort.cs
@@ -1,0 +1,10 @@
+namespace Aevatar.GAgents.ChatHistory;
+
+/// <summary>
+/// Provides ChatHistory index actor addressing without exposing runtime
+/// lifecycle APIs to conversation actors.
+/// </summary>
+public interface IChatHistoryIndexTopologyPort
+{
+    string GetIndexActorId(string scopeId);
+}

--- a/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedChatHistoryStore.cs
+++ b/src/Aevatar.Studio.Infrastructure/ActorBacked/ActorBackedChatHistoryStore.cs
@@ -17,6 +17,7 @@ internal sealed class ActorBackedChatHistoryStore : IChatHistoryStore
 {
     private readonly IStudioActorBootstrap _bootstrap;
     private readonly IActorDispatchPort _dispatchPort;
+    private readonly IChatHistoryIndexTopologyPort _indexTopologyPort;
     private readonly IProjectionDocumentReader<ChatHistoryIndexCurrentStateDocument, string> _indexDocumentReader;
     private readonly IProjectionDocumentReader<ChatConversationCurrentStateDocument, string> _conversationDocumentReader;
     private readonly ILogger<ActorBackedChatHistoryStore> _logger;
@@ -24,12 +25,14 @@ internal sealed class ActorBackedChatHistoryStore : IChatHistoryStore
     public ActorBackedChatHistoryStore(
         IStudioActorBootstrap bootstrap,
         IActorDispatchPort dispatchPort,
+        IChatHistoryIndexTopologyPort indexTopologyPort,
         IProjectionDocumentReader<ChatHistoryIndexCurrentStateDocument, string> indexDocumentReader,
         IProjectionDocumentReader<ChatConversationCurrentStateDocument, string> conversationDocumentReader,
         ILogger<ActorBackedChatHistoryStore> logger)
     {
         _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
+        _indexTopologyPort = indexTopologyPort ?? throw new ArgumentNullException(nameof(indexTopologyPort));
         _indexDocumentReader = indexDocumentReader ?? throw new ArgumentNullException(nameof(indexDocumentReader));
         _conversationDocumentReader = conversationDocumentReader ?? throw new ArgumentNullException(nameof(conversationDocumentReader));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -37,7 +40,7 @@ internal sealed class ActorBackedChatHistoryStore : IChatHistoryStore
 
     public async Task<ChatHistoryIndex> GetIndexAsync(string scopeId, CancellationToken ct = default)
     {
-        var actorId = IndexActorId(scopeId);
+        var actorId = _indexTopologyPort.GetIndexActorId(scopeId);
         var document = await _indexDocumentReader.GetAsync(actorId, ct);
         if (document?.StateRoot == null ||
             !document.StateRoot.Is(ChatHistoryIndexState.Descriptor))
@@ -106,14 +109,13 @@ internal sealed class ActorBackedChatHistoryStore : IChatHistoryStore
         // The conversation actor forwards events to the per-scope index
         // actor internally, so we bootstrap both so their projections
         // materialize. Ordering doesn't matter; each call is idempotent.
-        await _bootstrap.EnsureAsync<ChatHistoryIndexGAgent>(IndexActorId(scopeId), ct);
+        await _bootstrap.EnsureAsync<ChatHistoryIndexGAgent>(_indexTopologyPort.GetIndexActorId(scopeId), ct);
         return await _bootstrap.EnsureAsync<ChatConversationGAgent>(
             ConversationActorId(scopeId, conversationId), ct);
     }
 
     // ── Actor ID conventions ───────────────────────────────────
 
-    private static string IndexActorId(string scopeId) => $"chat-index-{scopeId}";
     private static string ConversationActorId(string scopeId, string conversationId) => $"chat-{scopeId}-{conversationId}";
 
     // ── Mapping helpers ────────────────────────────────────────

--- a/src/Aevatar.Studio.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions.Middleware;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Authoring;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgents.ChatHistory.DependencyInjection;
 using Aevatar.Studio.Infrastructure.Authoring;
 using Aevatar.Studio.Domain.Studio.Compatibility;
 using Aevatar.Studio.Domain.Studio.Services;
@@ -21,6 +22,7 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.AddChatHistoryGAgents();
         services.Configure<StudioStorageOptions>(configuration.GetSection("Studio:Storage"));
         services.Configure<ConnectorCatalogStorageOptions>(configuration.GetSection(ConnectorCatalogStorageOptions.SectionName));
         services.AddSingleton(WorkflowCompatibilityProfile.AevatarV1);

--- a/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ActorBackedStoreAdapterTests.cs
@@ -288,6 +288,7 @@ public sealed class ActorBackedStoreAdapterTests
             where TAgent : IAgent, IProjectedActor
         {
             EnsureCalls++;
+            EnsuredActorIds.Add(actorId);
             if (ThrowOnEnsure)
                 throw new InvalidOperationException("Bootstrap should not be used for this path.");
 
@@ -296,6 +297,8 @@ public sealed class ActorBackedStoreAdapterTests
         }
 
         public int EnsureCalls { get; private set; }
+
+        public List<string> EnsuredActorIds { get; } = [];
 
         public bool ThrowOnEnsure { get; set; }
     }
@@ -784,7 +787,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         var meta = new ConversationMeta(
             Id: "conv-1", Title: "Test", ServiceId: "svc",
@@ -814,7 +817,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         await store.DeleteConversationAsync("scope-1", "conv-1");
 
@@ -831,7 +834,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         var index = await store.GetIndexAsync("scope-1");
 
@@ -863,7 +866,7 @@ public sealed class ActorBackedStoreAdapterTests
             StateRoot = Any.Pack(state),
         });
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), indexReader, EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), indexReader, EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         var index = await store.GetIndexAsync("scope-1");
 
@@ -1621,7 +1624,7 @@ public sealed class ActorBackedStoreAdapterTests
         });
         var convReader = PackedReader("chat-scope-1-conv-1", state);
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), convReader, logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), convReader, logger);
 
         var messages = await store.GetMessagesAsync("scope-1", "conv-1");
 
@@ -1640,7 +1643,7 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         var messages = await store.GetMessagesAsync("scope-1", "conv-1");
 
@@ -1668,7 +1671,7 @@ public sealed class ActorBackedStoreAdapterTests
         });
         var indexReader = PackedReader("chat-index-scope-1", state);
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), indexReader, EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), indexReader, EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         var index = await store.GetIndexAsync("scope-1");
 
@@ -1682,7 +1685,8 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var bootstrap = new FakeStudioActorBootstrap(runtime);
+        var store = new ActorBackedChatHistoryStore(bootstrap, new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         await store.SaveMessagesAsync(
             "scope-1",
@@ -1708,6 +1712,7 @@ public sealed class ActorBackedStoreAdapterTests
                     Thinking: "reasoning")
             ]);
 
+        bootstrap.EnsuredActorIds.Should().Equal("chat-index-scope-1", "chat-scope-1-conv-1");
         var actor = runtime.Actors["chat-scope-1-conv-1"];
         var evt = actor.ReceivedEnvelopes[0].Payload.Unpack<MessagesReplacedEvent>();
         evt.ScopeId.Should().Be("scope-1");
@@ -1724,10 +1729,12 @@ public sealed class ActorBackedStoreAdapterTests
     {
         var runtime = new FakeActorRuntime();
         var logger = NullLogger<ActorBackedChatHistoryStore>.Instance;
-        var store = new ActorBackedChatHistoryStore(new FakeStudioActorBootstrap(runtime), new FakeActorDispatchPort(runtime), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
+        var bootstrap = new FakeStudioActorBootstrap(runtime);
+        var store = new ActorBackedChatHistoryStore(bootstrap, new FakeActorDispatchPort(runtime), new DefaultChatHistoryIndexTopologyPort(), EmptyReader<ChatHistoryIndexCurrentStateDocument>(), EmptyReader<ChatConversationCurrentStateDocument>(), logger);
 
         await store.DeleteConversationAsync("scope-1", "conv-1");
 
+        bootstrap.EnsuredActorIds.Should().Equal("chat-index-scope-1", "chat-scope-1-conv-1");
         var actor = runtime.Actors["chat-scope-1-conv-1"];
         var evt = actor.ReceivedEnvelopes[0].Payload.Unpack<ConversationDeletedEvent>();
         evt.ScopeId.Should().Be("scope-1");

--- a/test/Aevatar.Tools.Cli.Tests/ChatConversationGAgentLifecycleBoundaryTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ChatConversationGAgentLifecycleBoundaryTests.cs
@@ -1,0 +1,46 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.ChatHistory;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aevatar.Tools.Cli.Tests;
+
+public sealed class ChatConversationGAgentLifecycleBoundaryTests
+{
+    [Fact]
+    public void ChatConversationGAgent_ShouldUseNarrowTopologyPort_NotRuntimeServiceLocator()
+    {
+        // Refactor (iter49/cluster-049-chat-history-index-side-lifecycle):
+        //   Old pattern: ChatConversationGAgent resolved IActorRuntime via Services locator and created index actor inline during event handling.
+        //   New principle: Index actor addressing/provisioning is a constructor-injected narrow domain port; ChatHistoryIndexGAgent created via topology setup, not inline event handling.
+        var constructor = typeof(ChatConversationGAgent).GetConstructors()
+            .Should().ContainSingle().Subject;
+
+        constructor.GetParameters()
+            .Should().ContainSingle(p => p.ParameterType == typeof(IChatHistoryIndexTopologyPort));
+
+        var source = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "agents",
+            "Aevatar.GAgents.ChatHistory",
+            "ChatConversationGAgent.cs"));
+
+        source.Should().NotContain(nameof(ServiceProviderServiceExtensions.GetRequiredService));
+        source.Should().NotContain(nameof(ServiceProviderServiceExtensions.GetService));
+        source.Should().NotContain("CreateAsync<ChatHistoryIndexGAgent>");
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "aevatar.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root not found.");
+    }
+}

--- a/test/Aevatar.Tools.Cli.Tests/ChatConversationGAgentLifecycleBoundaryTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/ChatConversationGAgentLifecycleBoundaryTests.cs
@@ -1,6 +1,11 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.ChatHistory;
+using Aevatar.GAgents.ChatHistory.DependencyInjection;
+using Aevatar.Studio.Infrastructure.DependencyInjection;
 using FluentAssertions;
+using Google.Protobuf;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.Tools.Cli.Tests;
@@ -30,6 +35,153 @@ public sealed class ChatConversationGAgentLifecycleBoundaryTests
         source.Should().NotContain("CreateAsync<ChatHistoryIndexGAgent>");
     }
 
+    [Fact]
+    public void ChatConversationGAgent_Constructor_ShouldRequireTopologyPort()
+    {
+        var port = new DefaultChatHistoryIndexTopologyPort();
+
+        var agent = new ChatConversationGAgent(port);
+        var act = () => new ChatConversationGAgent(null!);
+
+        agent.Should().NotBeNull();
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("indexTopologyPort");
+    }
+
+    [Theory]
+    [InlineData("scope-1", "chat-index-scope-1")]
+    [InlineData("tenant/a", "chat-index-tenant/a")]
+    public void DefaultChatHistoryIndexTopologyPort_ShouldDeriveIndexActorId(
+        string scopeId,
+        string expectedActorId)
+    {
+        var port = new DefaultChatHistoryIndexTopologyPort();
+
+        var actorId = port.GetIndexActorId(scopeId);
+
+        actorId.Should().Be(expectedActorId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DefaultChatHistoryIndexTopologyPort_ShouldRejectMissingScope(string? scopeId)
+    {
+        var port = new DefaultChatHistoryIndexTopologyPort();
+
+        var act = () => port.GetIndexActorId(scopeId!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddChatHistoryGAgents_ShouldRegisterDefaultTopologyPort()
+    {
+        var services = new ServiceCollection();
+
+        services.AddChatHistoryGAgents();
+
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(IChatHistoryIndexTopologyPort) &&
+            descriptor.ImplementationType == typeof(DefaultChatHistoryIndexTopologyPort) &&
+            descriptor.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddChatHistoryGAgents_ShouldPreserveCustomTopologyPort()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IChatHistoryIndexTopologyPort, CustomChatHistoryIndexTopologyPort>();
+
+        services.AddChatHistoryGAgents();
+
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(IChatHistoryIndexTopologyPort) &&
+            descriptor.ImplementationType == typeof(CustomChatHistoryIndexTopologyPort));
+    }
+
+    [Fact]
+    public void AddStudioInfrastructure_ShouldIncludeChatHistoryTopologyRegistration()
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder().Build();
+
+        services.AddStudioInfrastructure(configuration);
+
+        services.Should().ContainSingle(descriptor =>
+            descriptor.ServiceType == typeof(IChatHistoryIndexTopologyPort) &&
+            descriptor.ImplementationType == typeof(DefaultChatHistoryIndexTopologyPort) &&
+            descriptor.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public async Task HandleMessagesReplaced_ShouldForwardUpsertToTopologyIndexActor()
+    {
+        var publisher = new CapturingEventPublisher();
+        var agent = new ChatConversationGAgent(new CustomChatHistoryIndexTopologyPort())
+        {
+            EventSourcing = new ChatConversationEventSourcing(),
+            EventPublisher = publisher,
+        };
+
+        var evt = new MessagesReplacedEvent
+        {
+            ScopeId = "scope-1",
+            Meta = new ConversationMetaProto
+            {
+                Id = "conv-1",
+                Title = "Conversation",
+                MessageCount = 99,
+            },
+        };
+        evt.Messages.Add(new StoredChatMessageProto
+        {
+            Id = "msg-1",
+            Role = "user",
+            Content = "hello",
+        });
+
+        await agent.HandleMessagesReplaced(evt);
+
+        publisher.Sent.Should().ContainSingle();
+        publisher.Sent[0].TargetActorId.Should().Be("custom-scope-1");
+        var forwarded = publisher.Sent[0].Payload.Should()
+            .BeOfType<ConversationUpsertedEvent>().Subject;
+        forwarded.Meta.Id.Should().Be("conv-1");
+        forwarded.Meta.MessageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleConversationDeleted_ShouldForwardRemovalToTopologyIndexActor()
+    {
+        var publisher = new CapturingEventPublisher();
+        var agent = new ChatConversationGAgent(new CustomChatHistoryIndexTopologyPort())
+        {
+            EventSourcing = new ChatConversationEventSourcing(),
+            EventPublisher = publisher,
+        };
+        await agent.HandleMessagesReplaced(new MessagesReplacedEvent
+        {
+            ScopeId = "scope-1",
+            Meta = new ConversationMetaProto { Id = "conv-1", Title = "Conversation" },
+            Messages = { new StoredChatMessageProto { Id = "msg-1", Role = "user" } },
+        });
+        publisher.Sent.Clear();
+
+        await agent.HandleConversationDeleted(new ConversationDeletedEvent
+        {
+            ScopeId = "scope-1",
+            ConversationId = "conv-1",
+        });
+
+        publisher.Sent.Should().ContainSingle();
+        publisher.Sent[0].TargetActorId.Should().Be("custom-scope-1");
+        var forwarded = publisher.Sent[0].Payload.Should()
+            .BeOfType<ConversationRemovedEvent>().Subject;
+        forwarded.ConversationId.Should().Be("conv-1");
+    }
+
     private static string FindRepositoryRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);
@@ -42,5 +194,85 @@ public sealed class ChatConversationGAgentLifecycleBoundaryTests
         }
 
         throw new InvalidOperationException("Repository root not found.");
+    }
+
+    private sealed class CustomChatHistoryIndexTopologyPort : IChatHistoryIndexTopologyPort
+    {
+        public string GetIndexActorId(string scopeId) => $"custom-{scopeId}";
+    }
+
+    private sealed class CapturingEventPublisher : IEventPublisher
+    {
+        public List<SentEnvelope> Sent { get; } = [];
+
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage =>
+            Task.CompletedTask;
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage
+        {
+            Sent.Add(new SentEnvelope(targetActorId, evt));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record SentEnvelope(string TargetActorId, IMessage Payload);
+
+    private sealed class ChatConversationEventSourcing : IEventSourcingBehavior<ChatConversationState>
+    {
+        private readonly List<IMessage> _pending = [];
+
+        public long CurrentVersion { get; private set; }
+
+        public void RaiseEvent<TEvent>(TEvent evt) where TEvent : IMessage
+        {
+            _pending.Add(evt);
+        }
+
+        public Task<EventStoreCommitResult> ConfirmEventsAsync(CancellationToken ct = default)
+        {
+            CurrentVersion += _pending.Count;
+            _pending.Clear();
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                LatestVersion = CurrentVersion,
+            });
+        }
+
+        public Task PersistSnapshotAsync(ChatConversationState currentState, CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task<ChatConversationState?> ReplayAsync(string agentId, CancellationToken ct = default) =>
+            Task.FromResult<ChatConversationState?>(null);
+
+        public void DiscardPendingEvents()
+        {
+            _pending.Clear();
+        }
+
+        public ChatConversationState TransitionState(ChatConversationState current, IMessage evt)
+        {
+            if (evt is MessagesReplacedEvent messagesReplaced)
+            {
+                var next = new ChatConversationState { Meta = messagesReplaced.Meta?.Clone() };
+                next.Messages.AddRange(messagesReplaced.Messages);
+                return next;
+            }
+
+            return evt is ConversationDeletedEvent
+                ? new ChatConversationState()
+                : current;
+        }
     }
 }


### PR DESCRIPTION
## 摘要

iter49 cluster-049-chat-history-index-side-lifecycle(medium,R11-actor-lifecycle-execution + R05-dependency-inversion,**requires_design:false** 机械重构)。

- **Old**:ChatConversationGAgent 从 `Services.GetService(IActorRuntime)` 反射 resolve + inline 创 ChatHistoryIndexGAgent
- **New**:Constructor-injected narrow provisioning/topology port(`IChatHistoryIndexTopologyPort`);ChatHistoryIndexGAgent 由 topology setup 前创

## 改动范围

7 files (含 1 删 / 3 新):

- **ChatConversationGAgent.cs**:删 service locator + inline create
- **IChatHistoryIndexTopologyPort.cs(新)** + **DefaultChatHistoryIndexTopologyPort.cs(新)**:typed provisioning port
- **DependencyInjection/ChatHistoryServiceCollectionExtensions.cs(新)**:DI 注册
- **ActorBackedChatHistoryStore.cs / ServiceCollectionExtensions.cs**:适配
- **ChatConversationGAgentLifecycleBoundaryTests.cs(新)** + **ActorBackedStoreAdapterTests.cs**:测试覆盖

📢 cc: @loning

🤖 Auto-loop / codex-refactor-loop iter49

⟦AI:AUTO-LOOP⟧
