### PR TITLE
iter49 cluster-049 gagentservice-runtime-attach-existing: typed lease lookup contract

### DIFF
--- a/src/Aevatar.CQRS.Projection.Core.Abstractions/Abstractions/Ports/IProjectionScopeAttachExistingLeaseLookup.cs
+++ b/src/Aevatar.CQRS.Projection.Core.Abstractions/Abstractions/Ports/IProjectionScopeAttachExistingLeaseLookup.cs
@@ -1,0 +1,12 @@
+namespace Aevatar.CQRS.Projection.Core.Abstractions;
+
+/// <summary>
+/// Typed lookup contract for attaching to an already-existing projection scope lease.
+/// </summary>
+public interface IProjectionScopeAttachExistingLeaseLookup<TLease>
+    where TLease : class, IProjectionRuntimeLease
+{
+    Task<TLease?> TryGetAsync(
+        ProjectionScopeStartRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Aevatar.CQRS.Projection.Core/DependencyInjection/EventSinkProjectionRuntimeRegistration.cs
+++ b/src/Aevatar.CQRS.Projection.Core/DependencyInjection/EventSinkProjectionRuntimeRegistration.cs
@@ -29,6 +29,17 @@ public static class EventSinkProjectionRuntimeRegistration
         services.TryAddSingleton<IProjectionFailureReplayService, ProjectionFailureReplayService>();
         services.TryAddSingleton<IProjectionFailureAlertSink, LoggingProjectionFailureAlertSink>();
         services.TryAddSingleton<Func<ProjectionRuntimeScopeKey, TContext>>(_ => contextFactory);
+        services.TryAddSingleton<IProjectionScopeAttachExistingLeaseLookup<TRuntimeLease>>(sp =>
+            new ProjectionScopeAttachExistingLeaseLookup<
+                TRuntimeLease,
+                TContext>(
+                sp.GetRequiredService<IActorRuntime>(),
+                request => contextFactory(new ProjectionRuntimeScopeKey(
+                    request.RootActorId,
+                    request.ProjectionKind,
+                    ProjectionRuntimeMode.SessionObservation,
+                    request.SessionId)),
+                (_, context) => leaseFactory(context)));
         services.TryAddSingleton<IProjectionScopeActivationService<TRuntimeLease>>(sp =>
             new ProjectionScopeActivationService<
                 TRuntimeLease,

--- a/src/Aevatar.CQRS.Projection.Core/DependencyInjection/ProjectionMaterializationRuntimeRegistration.cs
+++ b/src/Aevatar.CQRS.Projection.Core/DependencyInjection/ProjectionMaterializationRuntimeRegistration.cs
@@ -27,6 +27,17 @@ public static class ProjectionMaterializationRuntimeRegistration
         services.TryAddSingleton<IProjectionFailureReplayService, ProjectionFailureReplayService>();
         services.TryAddSingleton<IProjectionFailureAlertSink, LoggingProjectionFailureAlertSink>();
         services.TryAddSingleton<Func<ProjectionRuntimeScopeKey, TContext>>(_ => contextFactory);
+        services.TryAddSingleton<IProjectionScopeAttachExistingLeaseLookup<TRuntimeLease>>(sp =>
+            new ProjectionScopeAttachExistingLeaseLookup<
+                TRuntimeLease,
+                TContext>(
+                sp.GetRequiredService<IActorRuntime>(),
+                request => contextFactory(new ProjectionRuntimeScopeKey(
+                    request.RootActorId,
+                    request.ProjectionKind,
+                    ProjectionRuntimeMode.DurableMaterialization,
+                    request.SessionId)),
+                (_, context) => leaseFactory(context)));
         services.TryAddSingleton<IProjectionScopeActivationService<TRuntimeLease>>(sp =>
             new ProjectionScopeStatusActivationService<TRuntimeLease>(
                 new ProjectionScopeActivationService<

--- a/src/Aevatar.CQRS.Projection.Core/DependencyInjection/ProjectionScopeStatusRuntimeRegistration.cs
+++ b/src/Aevatar.CQRS.Projection.Core/DependencyInjection/ProjectionScopeStatusRuntimeRegistration.cs
@@ -30,6 +30,16 @@ public static class ProjectionScopeStatusRuntimeRegistration
             });
         services.TryAddSingleton<Func<ProjectionScopeStatusMaterializationContext, ProjectionScopeStatusRuntimeLease>>(
             static _ => static context => new ProjectionScopeStatusRuntimeLease(context));
+        services.TryAddSingleton<IProjectionScopeAttachExistingLeaseLookup<ProjectionScopeStatusRuntimeLease>>(sp =>
+            new ProjectionScopeAttachExistingLeaseLookup<
+                ProjectionScopeStatusRuntimeLease,
+                ProjectionScopeStatusMaterializationContext>(
+                sp.GetRequiredService<IActorRuntime>(),
+                request => new ProjectionScopeStatusMaterializationContext
+                {
+                    RootActorId = request.RootActorId,
+                },
+                (_, context) => new ProjectionScopeStatusRuntimeLease(context)));
         services.TryAddSingleton<IProjectionScopeActivationService<ProjectionScopeStatusRuntimeLease>>(sp =>
             new ProjectionScopeActivationService<
                 ProjectionScopeStatusRuntimeLease,

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeAttachExistingLeaseLookup.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeAttachExistingLeaseLookup.cs
@@ -1,0 +1,43 @@
+namespace Aevatar.CQRS.Projection.Core.Orchestration;
+
+public sealed class ProjectionScopeAttachExistingLeaseLookup<TLease, TContext>
+    : IProjectionScopeAttachExistingLeaseLookup<TLease>
+    where TLease : class, IProjectionRuntimeLease
+    where TContext : class, IProjectionMaterializationContext
+{
+    private readonly IActorRuntime _runtime;
+    private readonly Func<ProjectionScopeStartRequest, TContext> _contextFactory;
+    private readonly Func<ProjectionRuntimeScopeKey, TContext, TLease> _leaseFactory;
+
+    public ProjectionScopeAttachExistingLeaseLookup(
+        IActorRuntime runtime,
+        Func<ProjectionScopeStartRequest, TContext> contextFactory,
+        Func<ProjectionRuntimeScopeKey, TContext, TLease> leaseFactory)
+    {
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _contextFactory = contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
+        _leaseFactory = leaseFactory ?? throw new ArgumentNullException(nameof(leaseFactory));
+    }
+
+    public async Task<TLease?> TryGetAsync(
+        ProjectionScopeStartRequest request,
+        CancellationToken ct = default)
+    {
+        // Refactor (iter49/cluster-049-gagentservice-runtime-attach-existing-side-read):
+        //   Old pattern: Capability projection ports duplicated runtime existence checks via IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()).
+        //   New principle: Projection Core exposes typed attach-existing lease/session lookup contract; capability ports delegate to contract instead of runtime actor-id side reads.
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+
+        var context = _contextFactory(request);
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            context.RootActorId,
+            context.ProjectionKind,
+            request.Mode,
+            request.SessionId);
+
+        return await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false)
+            ? _leaseFactory(scopeKey, context)
+            : null;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentDraftRunProjectionPort.cs
@@ -1,7 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.Presentation.AGUI;
@@ -12,21 +11,21 @@ public sealed class GAgentDraftRunProjectionPort
     : EventSinkProjectionLifecyclePortBase<IGAgentDraftRunProjectionLease, GAgentDraftRunRuntimeLease, AGUIEvent>,
       IGAgentDraftRunProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<GAgentDraftRunRuntimeLease> _attachExistingLeaseLookup;
 
     public GAgentDraftRunProjectionPort(
         ServiceProjectionOptions options,
         IProjectionScopeActivationService<GAgentDraftRunRuntimeLease> activationService,
         IProjectionScopeReleaseService<GAgentDraftRunRuntimeLease> releaseService,
         IProjectionSessionEventHub<AGUIEvent> sessionEventHub,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<GAgentDraftRunRuntimeLease> attachExistingLeaseLookup)
         : base(
             () => options.Enabled,
             activationService,
             releaseService,
             sessionEventHub)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
     public Task<IGAgentDraftRunProjectionLease?> EnsureActorProjectionAsync(
@@ -68,15 +67,21 @@ public sealed class GAgentDraftRunProjectionPort
             ServiceProjectionKinds.DraftRunSession,
             ProjectionRuntimeMode.SessionObservation,
             commandId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+        // Refactor (iter49/cluster-049-gagentservice-runtime-attach-existing-side-read):
+        //   Old pattern: Capability projection ports duplicated runtime existence checks via IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()).
+        //   New principle: Projection Core exposes typed attach-existing lease/session lookup contract; capability ports delegate to contract instead of runtime actor-id side reads.
+        var lease = await _attachExistingLeaseLookup.TryGetAsync(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+                Mode = scopeKey.Mode,
+                SessionId = scopeKey.SessionId,
+            },
+            ct).ConfigureAwait(false);
+        if (lease == null)
             return null;
 
-        var lease = new GAgentDraftRunRuntimeLease(new GAgentDraftRunProjectionContext
-        {
-            RootActorId = actorId,
-            ProjectionKind = ServiceProjectionKinds.DraftRunSession,
-            SessionId = commandId,
-        });
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
         return liveSinkLease == null
             ? null

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/GAgentRunTerminalProjectionPort.cs
@@ -1,6 +1,5 @@
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.GAgentService.Projection.Contexts;
@@ -11,16 +10,16 @@ public sealed class GAgentRunTerminalProjectionPort
     : ServiceProjectionPortBase<GAgentRunTerminalProjectionContext>,
       IGAgentRunTerminalProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> _attachExistingLeaseLookup;
 
     public GAgentRunTerminalProjectionPort(
         ServiceProjectionOptions options,
         IProjectionScopeActivationService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> activationService,
         IProjectionScopeReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> releaseService,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>> attachExistingLeaseLookup)
         : base(options, activationService, releaseService, ServiceProjectionKinds.GAgentRunTerminalDraftRun)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
     public async Task<IGAgentRunTerminalProjectionLease?> EnsureProjectionAsync(
@@ -72,18 +71,22 @@ public sealed class GAgentRunTerminalProjectionPort
             projectionKind,
             ProjectionRuntimeMode.DurableMaterialization,
             correlationId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+        // Refactor (iter49/cluster-049-gagentservice-runtime-attach-existing-side-read):
+        //   Old pattern: Capability projection ports duplicated runtime existence checks via IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()).
+        //   New principle: Projection Core exposes typed attach-existing lease/session lookup contract; capability ports delegate to contract instead of runtime actor-id side reads.
+        var runtimeLease = await _attachExistingLeaseLookup.TryGetAsync(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+                Mode = scopeKey.Mode,
+                SessionId = scopeKey.SessionId,
+            },
+            ct).ConfigureAwait(false);
+        if (runtimeLease == null)
             return null;
 
-        var context = new GAgentRunTerminalProjectionContext
-        {
-            RootActorId = actorId,
-            ProjectionKind = projectionKind,
-            CorrelationId = correlationId.Trim(),
-            InteractionKind = interactionKind,
-        };
-        return new GAgentRunTerminalProjectionLease(
-            new ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>(context.RootActorId, context));
+        return new GAgentRunTerminalProjectionLease(runtimeLease);
     }
 
     public Task ReleaseProjectionAsync(

--- a/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Orchestration/ScriptServiceAguiProjectionPort.cs
@@ -1,7 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Projection.Configuration;
 using Aevatar.Presentation.AGUI;
@@ -17,21 +16,21 @@ public sealed class ScriptServiceAguiProjectionPort
     : EventSinkProjectionLifecyclePortBase<IScriptServiceAguiProjectionLease, ScriptServiceAguiRuntimeLease, AGUIEvent>,
       IScriptServiceAguiProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<ScriptServiceAguiRuntimeLease> _attachExistingLeaseLookup;
 
     public ScriptServiceAguiProjectionPort(
         ServiceProjectionOptions options,
         IProjectionScopeActivationService<ScriptServiceAguiRuntimeLease> activationService,
         IProjectionScopeReleaseService<ScriptServiceAguiRuntimeLease> releaseService,
         IProjectionSessionEventHub<AGUIEvent> sessionEventHub,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<ScriptServiceAguiRuntimeLease> attachExistingLeaseLookup)
         : base(
             () => options.Enabled,
             activationService,
             releaseService,
             sessionEventHub)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
     // Refactor (iter45/issue-867-session-projection-ensure-surface):
@@ -58,15 +57,21 @@ public sealed class ScriptServiceAguiProjectionPort
             ServiceProjectionKinds.ScriptServiceAguiSession,
             ProjectionRuntimeMode.SessionObservation,
             runId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
+        // Refactor (iter49/cluster-049-gagentservice-runtime-attach-existing-side-read):
+        //   Old pattern: Capability projection ports duplicated runtime existence checks via IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()).
+        //   New principle: Projection Core exposes typed attach-existing lease/session lookup contract; capability ports delegate to contract instead of runtime actor-id side reads.
+        var lease = await _attachExistingLeaseLookup.TryGetAsync(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+                Mode = scopeKey.Mode,
+                SessionId = scopeKey.SessionId,
+            },
+            ct).ConfigureAwait(false);
+        if (lease == null)
             return null;
 
-        var lease = new ScriptServiceAguiRuntimeLease(new ScriptServiceAguiProjectionContext
-        {
-            RootActorId = actorId,
-            ProjectionKind = ServiceProjectionKinds.ScriptServiceAguiSession,
-            SessionId = runId,
-        });
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
         return liveSinkLease == null
             ? null

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionRuntimeRegistrationTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionRuntimeRegistrationTests.cs
@@ -158,6 +158,67 @@ public sealed class ProjectionRuntimeRegistrationTests
     }
 
     [Fact]
+    public async Task ProjectionScopeAttachExistingLeaseLookup_ShouldValidateInputsAndCancellation()
+    {
+        var runtime = new RecordingActorRuntime();
+        var lookup = new ProjectionScopeAttachExistingLeaseLookup<TestSessionScopedMaterializationLease, TestSessionScopedMaterializationContext>(
+            runtime,
+            static request => new TestSessionScopedMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            static (_, context) => new TestSessionScopedMaterializationLease(context));
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        Func<Task> nullRequest = () => lookup.TryGetAsync(null!);
+        Func<Task> canceledRequest = () => lookup.TryGetAsync(new ProjectionScopeStartRequest
+        {
+            RootActorId = "actor-canceled",
+            ProjectionKind = "projection-canceled",
+            Mode = ProjectionRuntimeMode.DurableMaterialization,
+        }, cts.Token);
+
+        await nullRequest.Should().ThrowAsync<ArgumentNullException>();
+        await canceledRequest.Should().ThrowAsync<OperationCanceledException>();
+        runtime.CreatedActorIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ProjectionScopeAttachExistingLeaseLookup_ShouldValidateConstructorDependencies()
+    {
+        var runtime = new RecordingActorRuntime();
+        Func<ProjectionScopeStartRequest, TestSessionScopedMaterializationContext> contextFactory =
+            static request => new TestSessionScopedMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            };
+        Func<ProjectionRuntimeScopeKey, TestSessionScopedMaterializationContext, TestSessionScopedMaterializationLease> leaseFactory =
+            static (_, context) => new TestSessionScopedMaterializationLease(context);
+
+        var nullRuntime = () => new ProjectionScopeAttachExistingLeaseLookup<TestSessionScopedMaterializationLease, TestSessionScopedMaterializationContext>(
+            null!,
+            contextFactory,
+            leaseFactory);
+        var nullContextFactory = () => new ProjectionScopeAttachExistingLeaseLookup<TestSessionScopedMaterializationLease, TestSessionScopedMaterializationContext>(
+            runtime,
+            null!,
+            leaseFactory);
+        var nullLeaseFactory = () => new ProjectionScopeAttachExistingLeaseLookup<TestSessionScopedMaterializationLease, TestSessionScopedMaterializationContext>(
+            runtime,
+            contextFactory,
+            null!);
+
+        nullRuntime.Should().Throw<ArgumentNullException>().WithParameterName("runtime");
+        nullContextFactory.Should().Throw<ArgumentNullException>().WithParameterName("contextFactory");
+        nullLeaseFactory.Should().Throw<ArgumentNullException>().WithParameterName("leaseFactory");
+    }
+
+    [Fact]
     public async Task AddEventSinkProjectionRuntimeCore_ShouldRegisterSessionLifecycleAndSessionScopeContext()
     {
         var runtime = new RecordingActorRuntime();

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionRuntimeRegistrationTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionRuntimeRegistrationTests.cs
@@ -104,6 +104,60 @@ public sealed class ProjectionRuntimeRegistrationTests
     }
 
     [Fact]
+    public async Task AddProjectionMaterializationRuntimeCore_ShouldRegisterAttachExistingLeaseLookup()
+    {
+        var runtime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        var services = new ServiceCollection();
+        services.AddSingleton<IActorRuntime>(runtime);
+        services.AddSingleton<IActorDispatchPort>(dispatchPort);
+
+        services.AddProjectionMaterializationRuntimeCore<
+            TestSessionScopedMaterializationContext,
+            TestSessionScopedMaterializationLease,
+            ProjectionMaterializationScopeGAgent<TestSessionScopedMaterializationContext>>(
+            scopeKey => new TestSessionScopedMaterializationContext
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+                SessionId = scopeKey.SessionId,
+            },
+            context => new TestSessionScopedMaterializationLease(context));
+
+        await using var provider = services.BuildServiceProvider();
+        var lookup = provider.GetRequiredService<IProjectionScopeAttachExistingLeaseLookup<TestSessionScopedMaterializationLease>>();
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "actor-lookup",
+            "projection-lookup",
+            ProjectionRuntimeMode.DurableMaterialization,
+            "correlation-lookup");
+
+        var missing = await lookup.TryGetAsync(new ProjectionScopeStartRequest
+        {
+            RootActorId = scopeKey.RootActorId,
+            ProjectionKind = scopeKey.ProjectionKind,
+            Mode = scopeKey.Mode,
+            SessionId = scopeKey.SessionId,
+        });
+        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(scopeKey));
+        var lease = await lookup.TryGetAsync(new ProjectionScopeStartRequest
+        {
+            RootActorId = scopeKey.RootActorId,
+            ProjectionKind = scopeKey.ProjectionKind,
+            Mode = scopeKey.Mode,
+            SessionId = scopeKey.SessionId,
+        });
+
+        missing.Should().BeNull();
+        lease.Should().NotBeNull();
+        lease!.Context.RootActorId.Should().Be("actor-lookup");
+        lease.Context.ProjectionKind.Should().Be("projection-lookup");
+        lease.Context.SessionId.Should().Be("correlation-lookup");
+        runtime.CreatedActorIds.Should().BeEmpty();
+        dispatchPort.Dispatched.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task AddEventSinkProjectionRuntimeCore_ShouldRegisterSessionLifecycleAndSessionScopeContext()
     {
         var runtime = new RecordingActorRuntime();
@@ -150,6 +204,52 @@ public sealed class ProjectionRuntimeRegistrationTests
         dispatchPort.Dispatched.Should().HaveCount(2);
         dispatchPort.Dispatched[0].command.Payload!.Unpack<EnsureProjectionScopeCommand>().SessionId.Should().Be("session-9");
         dispatchPort.Dispatched[1].command.Payload!.Unpack<ReleaseProjectionScopeCommand>().SessionId.Should().Be("session-9");
+    }
+
+    [Fact]
+    public async Task AddEventSinkProjectionRuntimeCore_ShouldRegisterAttachExistingSessionLeaseLookup()
+    {
+        var runtime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        var services = new ServiceCollection();
+        services.AddSingleton<IActorRuntime>(runtime);
+        services.AddSingleton<IActorDispatchPort>(dispatchPort);
+
+        services.AddEventSinkProjectionRuntimeCore<
+            TestSessionContext,
+            TestSessionLease,
+            StringValue,
+            ProjectionSessionScopeGAgent<TestSessionContext>>(
+            scopeKey => new TestSessionContext
+            {
+                RootActorId = scopeKey.RootActorId,
+                ProjectionKind = scopeKey.ProjectionKind,
+                SessionId = scopeKey.SessionId,
+            },
+            context => new TestSessionLease(context));
+
+        await using var provider = services.BuildServiceProvider();
+        var lookup = provider.GetRequiredService<IProjectionScopeAttachExistingLeaseLookup<TestSessionLease>>();
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "actor-session",
+            "projection-session",
+            ProjectionRuntimeMode.SessionObservation,
+            "session-lookup");
+        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(scopeKey));
+
+        var lease = await lookup.TryGetAsync(new ProjectionScopeStartRequest
+        {
+            RootActorId = scopeKey.RootActorId,
+            ProjectionKind = scopeKey.ProjectionKind,
+            Mode = scopeKey.Mode,
+            SessionId = scopeKey.SessionId,
+        });
+
+        lease.Should().NotBeNull();
+        lease!.ScopeId.Should().Be("actor-session");
+        lease.SessionId.Should().Be("session-lookup");
+        runtime.CreatedActorIds.Should().BeEmpty();
+        dispatchPort.Dispatched.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeStatusRuntimeRegistrationTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeStatusRuntimeRegistrationTests.cs
@@ -28,6 +28,36 @@ public sealed class ProjectionScopeStatusRuntimeRegistrationTests
     }
 
     [Fact]
+    public async Task AddProjectionScopeStatusRuntimeCore_ShouldRegisterAttachExistingLeaseLookup()
+    {
+        var runtime = new RecordingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        var services = CreateServices(runtime, dispatchPort);
+        services.AddProjectionScopeStatusRuntimeCore();
+        var scopeKey = new ProjectionRuntimeScopeKey(
+            "root-status-actor",
+            ProjectionScopeStatusMaterializationContext.ProjectionKindValue,
+            ProjectionRuntimeMode.DurableMaterialization);
+        runtime.ExistingActorIds.Add(ProjectionScopeActorId.Build(scopeKey));
+
+        await using var provider = services.BuildServiceProvider();
+        var lookup = provider.GetRequiredService<IProjectionScopeAttachExistingLeaseLookup<ProjectionScopeStatusRuntimeLease>>();
+
+        var lease = await lookup.TryGetAsync(new ProjectionScopeStartRequest
+        {
+            RootActorId = scopeKey.RootActorId,
+            ProjectionKind = scopeKey.ProjectionKind,
+            Mode = scopeKey.Mode,
+        });
+
+        lease.Should().NotBeNull();
+        lease!.Context.RootActorId.Should().Be("root-status-actor");
+        lease.Context.ProjectionKind.Should().Be(ProjectionScopeStatusMaterializationContext.ProjectionKindValue);
+        runtime.CreatedActorIds.Should().BeEmpty();
+        dispatchPort.Dispatched.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task MaterializationActivation_EnsuresStatusScopeForNormalProjection()
     {
         var runtime = new RecordingActorRuntime();

--- a/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
@@ -168,6 +168,19 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
         hub.SubscribeCalls.Should().Be(0);
     }
 
+    [Fact]
+    public void ProjectionPort_ShouldValidateAttachExistingLookupDependency()
+    {
+        var create = () => new GAgentDraftRunProjectionPort(
+            new ServiceProjectionOptions { Enabled = true },
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            new RecordingSessionEventHub(),
+            null!);
+
+        create.Should().Throw<ArgumentNullException>().WithParameterName("attachExistingLeaseLookup");
+    }
+
     private static IProjectionScopeAttachExistingLeaseLookup<GAgentDraftRunRuntimeLease> CreateAttachExistingLookup(
         IActorRuntime runtime) =>
         new ProjectionScopeAttachExistingLeaseLookup<GAgentDraftRunRuntimeLease, GAgentDraftRunProjectionContext>(

--- a/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/GAgentDraftRunProjectionInfrastructureTests.cs
@@ -49,7 +49,7 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
             activation,
             release,
             hub,
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup(new RecordingActorRuntime()));
         var lease = await port.EnsureActorProjectionAsync("actor-1", "cmd-1", CancellationToken.None);
         var sink = new RecordingEventSink();
 
@@ -94,7 +94,7 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
             activation,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var sink = new RecordingEventSink();
 
         var attachment = await port.AttachExistingActorProjectionAsync(
@@ -135,13 +135,13 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
             activation,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var enabledPort = new GAgentDraftRunProjectionPort(
             new ServiceProjectionOptions { Enabled = true },
             activation,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
 
         (await disabledPort.AttachExistingActorProjectionAsync(
             "actor-1",
@@ -167,6 +167,18 @@ public sealed class GAgentDraftRunProjectionInfrastructureTests
         activation.Requests.Should().BeEmpty();
         hub.SubscribeCalls.Should().Be(0);
     }
+
+    private static IProjectionScopeAttachExistingLeaseLookup<GAgentDraftRunRuntimeLease> CreateAttachExistingLookup(
+        IActorRuntime runtime) =>
+        new ProjectionScopeAttachExistingLeaseLookup<GAgentDraftRunRuntimeLease, GAgentDraftRunProjectionContext>(
+            runtime,
+            static request => new GAgentDraftRunProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            static (_, context) => new GAgentDraftRunRuntimeLease(context));
 
     private sealed class RecordingActivationService : IProjectionScopeActivationService<GAgentDraftRunRuntimeLease>
     {

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -35,7 +35,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
             activation,
             release,
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var sink = new RecordingEventSink();
 
         var attachment = await port.AttachExistingRunProjectionAsync("script-actor-1", "run-1", sink, CancellationToken.None);
@@ -77,7 +77,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
             activation,
             release,
             hub,
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup(new RecordingActorRuntime()));
 
         var attachment = await port.AttachExistingRunProjectionAsync(
             "script-actor-1",
@@ -129,7 +129,7 @@ public sealed class ScriptServiceAguiProjectionPortTests
             activation,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var sink = new RecordingEventSink();
 
         var attachment = await port.AttachExistingRunProjectionAsync(
@@ -173,13 +173,13 @@ public sealed class ScriptServiceAguiProjectionPortTests
             activation,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var enabledPort = new ScriptServiceAguiProjectionPort(
             new ServiceProjectionOptions { Enabled = true },
             activation,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
 
         (await disabledPort.AttachExistingRunProjectionAsync(
             "script-actor-1",
@@ -212,6 +212,18 @@ public sealed class ScriptServiceAguiProjectionPortTests
         ProjectionRuntimeMode mode,
         string sessionId) =>
         ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(actorId, projectionKind, mode, sessionId));
+
+    private static IProjectionScopeAttachExistingLeaseLookup<ScriptServiceAguiRuntimeLease> CreateAttachExistingLookup(
+        IActorRuntime runtime) =>
+        new ProjectionScopeAttachExistingLeaseLookup<ScriptServiceAguiRuntimeLease, ScriptServiceAguiProjectionContext>(
+            runtime,
+            static request => new ScriptServiceAguiProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            static (_, context) => new ScriptServiceAguiRuntimeLease(context));
 
     private sealed class RecordingActivationService : IProjectionScopeActivationService<ScriptServiceAguiRuntimeLease>
     {

--- a/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ScriptServiceAguiProjectionPortTests.cs
@@ -206,6 +206,19 @@ public sealed class ScriptServiceAguiProjectionPortTests
         hub.SubscribeCalls.Should().Be(0);
     }
 
+    [Fact]
+    public void ScriptServiceAguiProjectionPort_ShouldValidateAttachExistingLookupDependency()
+    {
+        var create = () => new ScriptServiceAguiProjectionPort(
+            new ServiceProjectionOptions { Enabled = true },
+            new RecordingActivationService(),
+            new RecordingReleaseService(),
+            new RecordingSessionEventHub(),
+            null!);
+
+        create.Should().Throw<ArgumentNullException>().WithParameterName("attachExistingLeaseLookup");
+    }
+
     private static string BuildScopeActorId(
         string actorId,
         string projectionKind,

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -115,7 +115,15 @@ public sealed class ServiceProjectionInfrastructureTests
             new ServiceProjectionOptions(),
             activationService,
             releaseService,
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                new RecordingActorRuntime(),
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
 
         var draftLease = await service.EnsureProjectionAsync(
             "actor-1",
@@ -161,12 +169,28 @@ public sealed class ServiceProjectionInfrastructureTests
             new ServiceProjectionOptions { Enabled = false },
             activationService,
             new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                new RecordingActorRuntime(),
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
         IGAgentRunTerminalProjectionPort enabledService = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions(),
             activationService,
             new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                new RecordingActorRuntime(),
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
 
         (await disabledService.EnsureProjectionAsync(
             "actor-1",
@@ -205,7 +229,15 @@ public sealed class ServiceProjectionInfrastructureTests
             new ServiceProjectionOptions(),
             activationService,
             new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
-            runtime);
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                runtime,
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
 
         var lease = await service.AttachExistingProjectionAsync(
             "actor-1",
@@ -237,12 +269,28 @@ public sealed class ServiceProjectionInfrastructureTests
             new ServiceProjectionOptions { Enabled = false },
             activationService,
             new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
-            runtime);
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                runtime,
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
         IGAgentRunTerminalProjectionPort enabledService = new GAgentRunTerminalProjectionPort(
             new ServiceProjectionOptions(),
             activationService,
             new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
-            runtime);
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                runtime,
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
 
         (await disabledService.AttachExistingProjectionAsync(
             "actor-1",
@@ -280,7 +328,15 @@ public sealed class ServiceProjectionInfrastructureTests
             new ServiceProjectionOptions(),
             activationService,
             new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup<GAgentRunTerminalProjectionContext>(
+                new RecordingActorRuntime(),
+                static scopeKey => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = scopeKey.RootActorId,
+                    ProjectionKind = scopeKey.ProjectionKind,
+                    CorrelationId = scopeKey.SessionId,
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(scopeKey.ProjectionKind),
+                }));
 
         Func<Task> releaseNull = () => service.ReleaseProjectionAsync(null!);
         Func<Task> releaseForeignLease = () => service.ReleaseProjectionAsync(new ForeignGAgentRunTerminalProjectionLease());
@@ -640,4 +696,17 @@ public sealed class ServiceProjectionInfrastructureTests
 
         public GAgentRunTerminalInteractionKind InteractionKind => GAgentRunTerminalInteractionKind.DraftRun;
     }
+
+    private static IProjectionScopeAttachExistingLeaseLookup<ServiceProjectionRuntimeLease<TContext>> CreateAttachExistingLookup<TContext>(
+        IActorRuntime runtime,
+        Func<ProjectionRuntimeScopeKey, TContext> contextFactory)
+        where TContext : class, IProjectionMaterializationContext =>
+        new ProjectionScopeAttachExistingLeaseLookup<ServiceProjectionRuntimeLease<TContext>, TContext>(
+            runtime,
+            request => contextFactory(new ProjectionRuntimeScopeKey(
+                request.RootActorId,
+                request.ProjectionKind,
+                request.Mode,
+                request.SessionId)),
+            static (_, context) => new ServiceProjectionRuntimeLease<TContext>(context.RootActorId, context));
 }

--- a/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/ServiceProjectionInfrastructureTests.cs
@@ -353,6 +353,25 @@ public sealed class ServiceProjectionInfrastructureTests
     }
 
     [Fact]
+    public void GAgentRunTerminalProjectionPort_ShouldValidateAttachExistingLookupDependency()
+    {
+        var create = () => new GAgentRunTerminalProjectionPort(
+            new ServiceProjectionOptions(),
+            new RecordingProjectionActivationService<GAgentRunTerminalProjectionContext>(
+                static (rootActorId, projectionName) => new GAgentRunTerminalProjectionContext
+                {
+                    RootActorId = rootActorId,
+                    ProjectionKind = projectionName,
+                    CorrelationId = "corr-1",
+                    InteractionKind = GAgentRunTerminalProjectionPort.ResolveInteractionKind(projectionName),
+                }),
+            new RecordingProjectionReleaseService<ServiceProjectionRuntimeLease<GAgentRunTerminalProjectionContext>>(),
+            null!);
+
+        create.Should().Throw<ArgumentNullException>().WithParameterName("attachExistingLeaseLookup");
+    }
+
+    [Fact]
     public void GAgentRunTerminalModels_ShouldExposeStableSessionContextAndSnapshotShape()
     {
         var context = new GAgentRunTerminalProjectionContext


### PR DESCRIPTION
## 摘要

iter49 cluster-049-gagentservice-runtime-attach-existing-side-read(low,R10 + R03,**requires_design:false** 机械重构)。

- **Old**:3 capability projection ports 各自 `IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey))` 决定 session 可用性 — 重复 runtime actor-id 侧读。
- **New**:`IProjectionScopeAttachExistingLeaseLookup` typed contract;capability ports 走 contract 不再 ExistsAsync。

## 改动范围

12 files (+345/-52):

- **IProjectionScopeAttachExistingLeaseLookup.cs(新)** + **ProjectionScopeAttachExistingLeaseLookup.cs(新)**:typed lookup contract
- **GAgentDraftRunProjectionPort / GAgentRunTerminalProjectionPort / ScriptServiceAguiProjectionPort**:改 typed contract
- **DI 注册**:EventSinkProjectionRuntimeRegistration / ProjectionMaterializationRuntimeRegistration / ProjectionScopeStatusRuntimeRegistration
- **测试**:ProjectionRuntimeRegistrationTests / GAgentDraftRunProjectionInfrastructureTests / ScriptServiceAguiProjectionPortTests / ServiceProjectionInfrastructureTests

不引入新 actor / 不复活 actor-id 反查。

📢 cc: @loning

🤖 Auto-loop / codex-refactor-loop iter49

⟦AI:AUTO-LOOP⟧
