### PR TITLE
iter49 issue-882 script-command-readmodel-activation: 移 activation 出 command service

### DIFF
--- a/src/Aevatar.Scripting.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Scripting.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Core.Streaming;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Scripting.Abstractions.Evolution;
@@ -110,6 +111,13 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IScriptCatalogQueryPort, ProjectionScriptCatalogQueryPort>();
         services.TryAddSingleton<IScriptAuthorityReadModelActivationPort>(sp =>
             sp.GetRequiredService<ScriptAuthorityProjectionPort>());
+        services.TryAddSingleton<ProjectionActivationPlanDispatcher>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            ICommittedStatePublicationHook,
+            CommittedStateProjectionActivationHook>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IProjectionActivationPlanProvider,
+            ScriptingCommittedStateProjectionActivationPlanProvider>());
         services.TryAddSingleton<IScriptNativeDocumentMaterializer, ScriptNativeDocumentMaterializer>();
         services.TryAddSingleton<ScriptNativeGraphMaterializer>();
         services.TryAddSingleton<IScriptNativeGraphMaterializer>(sp =>

--- a/src/Aevatar.Scripting.Projection/Orchestration/ScriptingCommittedStateProjectionActivationPlanProvider.cs
+++ b/src/Aevatar.Scripting.Projection/Orchestration/ScriptingCommittedStateProjectionActivationPlanProvider.cs
@@ -1,0 +1,64 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Core;
+
+namespace Aevatar.Scripting.Projection.Orchestration;
+
+/// <summary>
+/// Maps scripting authority committed state events to the durable authority readmodel projection scope.
+/// </summary>
+// Refactor (iter49/issue-882-script-command-readmodel-activation):
+//   Old pattern: ScopeScriptCommandApplicationService.UpsertAsync explicitly activated definition/catalog readmodels via ActivateAsync before write commands.
+//   New principle: Command service dispatches accepted-only write commands; readmodel activation is owned by scripting committed-state projection activation plan provider.
+public sealed class ScriptingCommittedStateProjectionActivationPlanProvider : IProjectionActivationPlanProvider
+{
+    public IEnumerable<ProjectionActivationPlan> GetPlans(CommittedStatePublicationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (context.Published.StateEvent?.EventData == null)
+            yield break;
+
+        if (context.ActorType == typeof(ScriptDefinitionGAgent) &&
+            context.Published.StateEvent.EventData.Is(ScriptDefinitionUpsertedEvent.Descriptor))
+        {
+            yield return DurableAuthorityPlan(context.ActorId);
+            yield break;
+        }
+
+        if (context.ActorType != typeof(ScriptCatalogGAgent) ||
+            !IsCatalogAuthorityMutation(context.Published.StateEvent.EventData))
+        {
+            yield break;
+        }
+
+        yield return DurableAuthorityPlan(context.ActorId);
+    }
+
+    private static ProjectionActivationPlan DurableAuthorityPlan(string actorId) =>
+        new()
+        {
+            LeaseType = typeof(ScriptAuthorityRuntimeLease),
+            StartRequest = new ProjectionScopeStartRequest
+            {
+                RootActorId = actorId,
+                ProjectionKind = ScriptProjectionKinds.AuthorityMaterialization,
+                Mode = ProjectionRuntimeMode.DurableMaterialization,
+            },
+        };
+
+    private static bool IsCatalogAuthorityMutation(Google.Protobuf.WellKnownTypes.Any eventData)
+    {
+        if (eventData.Is(ScriptCatalogRevisionPromotedEvent.Descriptor))
+            return true;
+
+        if (eventData.Is(ScriptCatalogRollbackRequestedEvent.Descriptor))
+            return true;
+
+        if (eventData.Is(ScriptCatalogRolledBackEvent.Descriptor))
+            return true;
+
+        return false;
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Scripts/ScopeScriptCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Scripts/ScopeScriptCommandApplicationService.cs
@@ -11,18 +11,15 @@ public sealed class ScopeScriptCommandApplicationService : IScopeScriptCommandPo
 {
     private readonly IScriptDefinitionCommandPort _definitionCommandPort;
     private readonly IScriptCatalogCommandPort _catalogCommandPort;
-    private readonly IScriptAuthorityReadModelActivationPort _authorityReadModelActivationPort;
     private readonly ScopeScriptCapabilityOptions _options;
 
     public ScopeScriptCommandApplicationService(
         IScriptDefinitionCommandPort definitionCommandPort,
         IScriptCatalogCommandPort catalogCommandPort,
-        IScriptAuthorityReadModelActivationPort authorityReadModelActivationPort,
         IOptions<ScopeScriptCapabilityOptions> options)
     {
         _definitionCommandPort = definitionCommandPort ?? throw new ArgumentNullException(nameof(definitionCommandPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
-        _authorityReadModelActivationPort = authorityReadModelActivationPort ?? throw new ArgumentNullException(nameof(authorityReadModelActivationPort));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value ?? throw new InvalidOperationException("Scope script capability options are required.");
     }
@@ -47,9 +44,9 @@ public sealed class ScopeScriptCommandApplicationService : IScopeScriptCommandPo
         var sourceHash = ScriptPackageModel.ComputePackageHash(scriptPackage);
         var proposalId = BuildProposalId(normalizedScopeId, normalizedScriptId, revisionId);
 
-        await _authorityReadModelActivationPort.ActivateAsync(definitionActorId, ct);
-        await _authorityReadModelActivationPort.ActivateAsync(catalogActorId, ct);
-
+        // Refactor (iter49/issue-882-script-command-readmodel-activation):
+        //   Old pattern: ScopeScriptCommandApplicationService.UpsertAsync explicitly activated definition/catalog readmodels via ActivateAsync before write commands.
+        //   New principle: Command service dispatches accepted-only write commands; readmodel activation is owned by scripting committed-state projection activation plan provider.
         var definitionUpsert = await _definitionCommandPort.UpsertDefinitionWithSnapshotAsync(
             normalizedScriptId,
             revisionId,

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeScriptCapabilityServiceTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeScriptCapabilityServiceTests.cs
@@ -36,11 +36,9 @@ public sealed class ScopeScriptApplicationServicesTests
                 new ScriptingCommandAcceptedReceipt(expectedDefinitionActorId, "definition-command-1", "definition-correlation-1")),
         };
         var catalogCommandPort = new FakeScriptCatalogCommandPort();
-        var authorityReadModelActivationPort = new RecordingScriptAuthorityReadModelActivationPort();
         var service = new ScopeScriptCommandApplicationService(
             definitionCommandPort,
             catalogCommandPort,
-            authorityReadModelActivationPort,
             Options.Create(options));
 
         var result = await service.UpsertAsync(
@@ -60,7 +58,6 @@ public sealed class ScopeScriptApplicationServicesTests
         result.DefinitionActorId.Should().Be(expectedDefinitionActorId);
         result.DefinitionCommand.CommandId.Should().Be("definition-command-1");
         result.CatalogCommand.CommandId.Should().Be("catalog-command-1");
-        authorityReadModelActivationPort.Calls.Should().Equal(expectedDefinitionActorId, expectedCatalogActorId);
 
         definitionCommandPort.LastRequest.Should().BeEquivalentTo(
             new FakeScriptDefinitionCommandPort.Request(
@@ -424,18 +421,6 @@ public sealed class ScopeScriptApplicationServicesTests
             string SourceHash,
             string? DefinitionActorId,
             string? ScopeId);
-    }
-
-    private sealed class RecordingScriptAuthorityReadModelActivationPort : IScriptAuthorityReadModelActivationPort
-    {
-        public List<string> Calls { get; } = [];
-
-        public Task ActivateAsync(string actorId, CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-            Calls.Add(actorId);
-            return Task.CompletedTask;
-        }
     }
 
     private sealed class FakeScriptCatalogCommandPort : IScriptCatalogCommandPort

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeScriptCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeScriptCommandApplicationServiceTests.cs
@@ -6,6 +6,7 @@ using Aevatar.Scripting.Core.Compilation;
 using Aevatar.Scripting.Core.Ports;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
+using System.Reflection;
 
 namespace Aevatar.GAgentService.Tests.Application;
 
@@ -36,24 +37,36 @@ public sealed class ScopeScriptCommandApplicationServiceTests
     }
 
     [Fact]
-    public async Task UpsertAsync_ShouldActivateAuthorityReadModelsBeforeWritingDefinitionAndCatalog()
+    public async Task UpsertAsync_ShouldDispatchAcceptedOnlyCommandsWithoutReadModelActivation()
     {
         var executionLog = new List<string>();
         var definitionPort = new RecordingDefinitionCommandPort(executionLog);
         var catalogPort = new RecordingCatalogCommandPort(executionLog);
-        var activationPort = new RecordingScriptAuthorityReadModelActivationPort(executionLog);
-        var service = BuildService(definitionPort, catalogPort, activationPort);
-        var expectedDefinitionActorId = DefaultOptions.BuildDefinitionActorId("scope-1", "my-script", "rev-1");
-        var expectedCatalogActorId = DefaultOptions.BuildCatalogActorId("scope-1");
+        var service = BuildService(definitionPort, catalogPort);
 
-        await service.UpsertAsync(new ScopeScriptUpsertRequest("scope-1", "my-script", SingleSource("source"), "rev-1"));
+        var result = await service.UpsertAsync(
+            new ScopeScriptUpsertRequest("scope-1", "my-script", SingleSource("source"), "rev-1"));
 
-        activationPort.Calls.Should().Equal(expectedDefinitionActorId, expectedCatalogActorId);
-        executionLog.Should().Equal(
-            $"authority-activate:{expectedDefinitionActorId}",
-            $"authority-activate:{expectedCatalogActorId}",
-            "definition-upsert",
-            "catalog-promote");
+        executionLog.Should().Equal("definition-upsert", "catalog-promote");
+        result.DefinitionCommand.CommandId.Should().Be("definition-command-1");
+        result.CatalogCommand.CommandId.Should().Be("catalog-command-1");
+    }
+
+    [Fact]
+    public void Constructor_ShouldNotDependOnAuthorityReadModelActivationPort()
+    {
+        // Refactor (iter49/issue-882-script-command-readmodel-activation):
+        //   Old pattern: ScopeScriptCommandApplicationService.UpsertAsync explicitly activated definition/catalog readmodels via ActivateAsync before write commands.
+        //   New principle: Command service dispatches accepted-only write commands; readmodel activation is owned by scripting committed-state projection activation plan provider.
+        typeof(ScopeScriptCommandApplicationService)
+            .GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+            .Should()
+            .ContainSingle()
+            .Subject
+            .GetParameters()
+            .Select(x => x.ParameterType)
+            .Should()
+            .NotContain(typeof(IScriptAuthorityReadModelActivationPort));
     }
 
     [Fact]
@@ -171,34 +184,14 @@ public sealed class ScopeScriptCommandApplicationServiceTests
 
     private static ScopeScriptCommandApplicationService BuildService(
         IScriptDefinitionCommandPort definitionPort,
-        IScriptCatalogCommandPort catalogPort,
-        IScriptAuthorityReadModelActivationPort? authorityReadModelActivationPort = null) =>
+        IScriptCatalogCommandPort catalogPort) =>
         new(
             definitionPort,
             catalogPort,
-            authorityReadModelActivationPort ?? new RecordingScriptAuthorityReadModelActivationPort(),
             Options.Create(DefaultOptions));
 
     private static ScriptPackageSpec SingleSource(string source) =>
         ScriptPackageSpecExtensions.CreateSingleSource(source);
-
-    private sealed class RecordingScriptAuthorityReadModelActivationPort : IScriptAuthorityReadModelActivationPort
-    {
-        private readonly List<string>? _executionLog;
-
-        public RecordingScriptAuthorityReadModelActivationPort(List<string>? executionLog = null) =>
-            _executionLog = executionLog;
-
-        public List<string> Calls { get; } = [];
-
-        public Task ActivateAsync(string actorId, CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-            Calls.Add(actorId);
-            _executionLog?.Add($"authority-activate:{actorId}");
-            return Task.CompletedTask;
-        }
-    }
 
     private sealed class RecordingDefinitionCommandPort : IScriptDefinitionCommandPort
     {

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptingCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptingCommittedStateProjectionActivationPlanProviderTests.cs
@@ -15,6 +15,45 @@ namespace Aevatar.Scripting.Core.Tests.Projection;
 public sealed class ScriptingCommittedStateProjectionActivationPlanProviderTests
 {
     [Fact]
+    public void GetPlans_ShouldRejectNullContext()
+    {
+        var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
+
+        var act = () => provider.GetPlans(null!).ToArray();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void GetPlans_ShouldIgnoreMissingStateEventPayload()
+    {
+        var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
+
+        provider.GetPlans(new CommittedStatePublicationContext
+            {
+                ActorId = "user-script-definition:scope-1:my-script:rev-1",
+                ActorType = typeof(ScriptDefinitionGAgent),
+                Published = new CommittedStateEventPublished(),
+            })
+            .Should().BeEmpty();
+
+        provider.GetPlans(new CommittedStatePublicationContext
+            {
+                ActorId = "user-script-definition:scope-1:my-script:rev-1",
+                ActorType = typeof(ScriptDefinitionGAgent),
+                Published = new CommittedStateEventPublished
+                {
+                    StateEvent = new StateEvent
+                    {
+                        AgentId = "user-script-definition:scope-1:my-script:rev-1",
+                        EventId = "evt-1",
+                    },
+                },
+            })
+            .Should().BeEmpty();
+    }
+
+    [Fact]
     public void GetPlans_ShouldMapScriptDefinitionUpsertedToAuthorityMaterializationScope()
     {
         var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
@@ -87,6 +126,11 @@ public sealed class ScriptingCommittedStateProjectionActivationPlanProviderTests
                 typeof(string),
                 new ScriptDefinitionUpsertedEvent { ScriptId = "my-script", ScriptRevision = "rev-1" },
                 "user-script-definition:scope-1:my-script:rev-1"))
+            .Should().BeEmpty();
+        provider.GetPlans(BuildContext(
+                typeof(ScriptCatalogGAgent),
+                new StringValue { Value = "not-catalog-authority-mutation" },
+                "user-script-catalog:scope-1"))
             .Should().BeEmpty();
     }
 

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptingCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptingCommittedStateProjectionActivationPlanProviderTests.cs
@@ -1,0 +1,112 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Scripting.Core;
+using Aevatar.Scripting.Projection.Orchestration;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Scripting.Core.Tests.Projection;
+
+// Refactor (iter49/issue-882-script-command-readmodel-activation):
+//   Old pattern: ScopeScriptCommandApplicationService.UpsertAsync explicitly activated definition/catalog readmodels via ActivateAsync before write commands.
+//   New principle: Command service dispatches accepted-only write commands; readmodel activation is owned by scripting committed-state projection activation plan provider.
+public sealed class ScriptingCommittedStateProjectionActivationPlanProviderTests
+{
+    [Fact]
+    public void GetPlans_ShouldMapScriptDefinitionUpsertedToAuthorityMaterializationScope()
+    {
+        var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
+
+        var plans = provider.GetPlans(BuildContext(
+            typeof(ScriptDefinitionGAgent),
+            new ScriptDefinitionUpsertedEvent
+            {
+                ScriptId = "my-script",
+                ScriptRevision = "rev-1",
+            },
+            "user-script-definition:scope-1:my-script:rev-1")).ToArray();
+
+        plans.Should().ContainSingle();
+        plans[0].LeaseType.Should().Be(typeof(ScriptAuthorityRuntimeLease));
+        plans[0].StartRequest.RootActorId.Should().Be("user-script-definition:scope-1:my-script:rev-1");
+        plans[0].StartRequest.ProjectionKind.Should().Be("script-authority-read-model");
+        plans[0].StartRequest.Mode.Should().Be(ProjectionRuntimeMode.DurableMaterialization);
+    }
+
+    [Fact]
+    public void GetPlans_ShouldMapScriptCatalogAuthorityMutationsToAuthorityMaterializationScope()
+    {
+        var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
+
+        var promoted = provider.GetPlans(BuildContext(
+            typeof(ScriptCatalogGAgent),
+            new ScriptCatalogRevisionPromotedEvent
+            {
+                ScriptId = "my-script",
+                Revision = "rev-1",
+            },
+            "user-script-catalog:scope-1")).ToArray();
+        var rollbackRequested = provider.GetPlans(BuildContext(
+            typeof(ScriptCatalogGAgent),
+            new ScriptCatalogRollbackRequestedEvent
+            {
+                ScriptId = "my-script",
+                TargetRevision = "rev-0",
+            },
+            "user-script-catalog:scope-1")).ToArray();
+        var rolledBack = provider.GetPlans(BuildContext(
+            typeof(ScriptCatalogGAgent),
+            new ScriptCatalogRolledBackEvent
+            {
+                ScriptId = "my-script",
+                TargetRevision = "rev-0",
+            },
+            "user-script-catalog:scope-1")).ToArray();
+
+        promoted.Should().ContainSingle();
+        rollbackRequested.Should().ContainSingle();
+        rolledBack.Should().ContainSingle();
+        promoted[0].LeaseType.Should().Be(typeof(ScriptAuthorityRuntimeLease));
+        promoted[0].StartRequest.RootActorId.Should().Be("user-script-catalog:scope-1");
+        promoted[0].StartRequest.ProjectionKind.Should().Be("script-authority-read-model");
+    }
+
+    [Fact]
+    public void GetPlans_ShouldNotMatchUnrelatedActorOrStateEvent()
+    {
+        var provider = new ScriptingCommittedStateProjectionActivationPlanProvider();
+
+        provider.GetPlans(BuildContext(
+                typeof(ScriptDefinitionGAgent),
+                new StringValue { Value = "not-scripting" },
+                "user-script-definition:scope-1:my-script:rev-1"))
+            .Should().BeEmpty();
+        provider.GetPlans(BuildContext(
+                typeof(string),
+                new ScriptDefinitionUpsertedEvent { ScriptId = "my-script", ScriptRevision = "rev-1" },
+                "user-script-definition:scope-1:my-script:rev-1"))
+            .Should().BeEmpty();
+    }
+
+    private static CommittedStatePublicationContext BuildContext(
+        System.Type actorType,
+        IMessage evt,
+        string actorId) =>
+        new()
+        {
+            ActorId = actorId,
+            ActorType = actorType,
+            Published = new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    AgentId = actorId,
+                    EventId = "evt-1",
+                    EventData = Any.Pack(evt),
+                },
+                StateRoot = Any.Pack(new StringValue { Value = "state" }),
+            },
+        };
+}

--- a/test/Aevatar.Scripting.Core.Tests/ScriptingProjectWiringTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/ScriptingProjectWiringTests.cs
@@ -49,6 +49,8 @@ public sealed class ScriptingProjectWiringTests
             .And.Contain(x => IsObservedCurrentStateMaterializerFor<ScriptCatalogEntryProjector>(x));
         provider.GetServices<ICurrentStateProjectionMaterializer<ScriptEvolutionMaterializationContext>>()
             .Should().ContainSingle(x => IsObservedCurrentStateMaterializerFor<ScriptEvolutionReadModelProjector>(x));
+        provider.GetServices<IProjectionActivationPlanProvider>()
+            .Should().ContainSingle(x => x is ScriptingCommittedStateProjectionActivationPlanProvider);
     }
 
     private static bool IsObservedCurrentStateMaterializerFor<TProjector>(object materializer)


### PR DESCRIPTION
## 摘要

iter49 issue-882 cluster-049-script-command-readmodel-activation(high,R04-cqrs-read-write-separation)。

- **Old**:`ScopeScriptCommandApplicationService.UpsertAsync` 调 `_authorityReadModelActivationPort.ActivateAsync(definitionActorId/catalogActorId)` 在写命令前先启动 readmodel projection — query/write 绑同请求栈。
- **New**:删 ActivateAsync;新 `ScriptingCommittedStateProjectionActivationPlanProvider`(参考 #875 HealthProbe pattern);command receipts accepted-only。

## Phase 9 共识

`META_JUDGE_DONE:consensus:structural:move scope-script authority readmodel activation out of command service into scripting committed-state projection activation plans, with command receipts accepted-only`

## 改动范围

6 files (+217/-41):

- **ScopeScriptCommandApplicationService.cs**:删 ActivateAsync calls
- **ScriptingCommittedStateProjectionActivationPlanProvider.cs(新)**:committed-state activation plan
- **DI 注册**:Scripting.Projection ServiceCollectionExtensions
- **测试**:ScopeScriptCommandApplicationServiceTests + ScriptingCommittedStateProjectionActivationPlanProviderTests + ScriptingProjectWiringTests

不引入新 actor。

Closes #882

📢 cc: @loning

🤖 Auto-loop / codex-refactor-loop iter49

⟦AI:AUTO-LOOP⟧
