### PR TITLE
fix(#889): integration fixture pre-activate script evolution session projection

### DIFF
--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunActorQueryIntegrationTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeDraftRunActorQueryIntegrationTests.cs
@@ -3,13 +3,18 @@ using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text.Json;
 using Aevatar.Bootstrap.Hosting;
+using Aevatar.CQRS.Core.Abstractions.Streaming;
+using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Extensions.Hosting;
 using Aevatar.Workflow.Infrastructure.CapabilityApi;
+using Aevatar.Workflow.Projection;
+using Aevatar.Workflow.Projection.Orchestration;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -20,6 +25,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.GAgentService.Integration.Tests;
@@ -149,6 +155,8 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
             builder.Services.AddSingleton<IGAgentActorRegistryCommandPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
             builder.Services.AddSingleton<IGAgentActorRegistryQueryPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
             builder.Services.AddSingleton<IScopeResourceAdmissionPort>(sp => sp.GetRequiredService<InMemoryGAgentActorStore>());
+            DraftRunProjectionActivationServiceCollectionExtensions.AddWorkflowRunProjectionActivatingInteractionService(
+                builder.Services);
             builder.Services.AddAuthentication("Test")
                 .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
             builder.Services.AddAuthorization();
@@ -206,6 +214,62 @@ public sealed class ScopeDraftRunActorQueryIntegrationTests
 
             throw new InvalidOperationException("Unable to locate repository root from test base directory.");
         }
+    }
+
+    private static class DraftRunProjectionActivationServiceCollectionExtensions
+    {
+        public static IServiceCollection AddWorkflowRunProjectionActivatingInteractionService(
+            IServiceCollection services)
+        {
+            services.Replace(ServiceDescriptor.Singleton<IWorkflowExecutionProjectionPort>(sp =>
+                new ActivatingWorkflowExecutionProjectionPort(
+                    sp.GetRequiredService<WorkflowExecutionProjectionPort>(),
+                    sp.GetRequiredService<IProjectionScopeActivationService<WorkflowExecutionRuntimeLease>>())));
+            return services;
+        }
+    }
+
+    private sealed class ActivatingWorkflowExecutionProjectionPort(
+        IWorkflowExecutionProjectionPort inner,
+        IProjectionScopeActivationService<WorkflowExecutionRuntimeLease> activationService)
+        : IWorkflowExecutionProjectionPort
+    {
+        public bool ProjectionEnabled => inner.ProjectionEnabled;
+
+        public async Task<EventSinkProjectionAttachment<IWorkflowExecutionProjectionLease>?> AttachExistingActorProjectionAsync(
+            string rootActorId,
+            string commandId,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default)
+        {
+            _ = await activationService.EnsureAsync(
+                new ProjectionScopeStartRequest
+                {
+                    RootActorId = rootActorId,
+                    ProjectionKind = "workflow-execution-session",
+                    Mode = ProjectionRuntimeMode.SessionObservation,
+                    SessionId = commandId,
+                },
+                ct);
+
+            return await inner.AttachExistingActorProjectionAsync(rootActorId, commandId, sink, ct);
+        }
+
+        public Task<IAsyncDisposable?> AttachLiveSinkAsync(
+            IWorkflowExecutionProjectionLease lease,
+            IEventSink<WorkflowRunEventEnvelope> sink,
+            CancellationToken ct = default) =>
+            inner.AttachLiveSinkAsync(lease, sink, ct);
+
+        public Task DetachLiveSinkAsync(
+            IAsyncDisposable? liveSinkLease,
+            CancellationToken ct = default) =>
+            inner.DetachLiveSinkAsync(liveSinkLease, ct);
+
+        public Task ReleaseActorProjectionAsync(
+            IWorkflowExecutionProjectionLease lease,
+            CancellationToken ct = default) =>
+            inner.ReleaseActorProjectionAsync(lease, ct);
     }
 
     private sealed class InMemoryGAgentActorStore :

--- a/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
@@ -358,6 +358,7 @@ public sealed class ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests
                     options.TopicPartitionCount = 4;
                 });
                 services.AddScriptCapability(context.Configuration);
+                services.AddAuthorityActivatingScriptEvolutionApplicationService();
             })
             .Build();
 

--- a/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationTestKit.cs
+++ b/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationTestKit.cs
@@ -4,6 +4,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Runtime.Implementations.Local.DependencyInjection;
 using Aevatar.Integration.Tests.Protocols;
 using Aevatar.Scripting.Abstractions.Definitions;
+using Aevatar.Scripting.Abstractions.Evolution;
 using Aevatar.Scripting.Application;
 using Aevatar.Scripting.Application.Queries;
 using Aevatar.Scripting.Abstractions;
@@ -11,9 +12,11 @@ using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Scripting.Core;
 using Aevatar.Scripting.Core.Ports;
 using Aevatar.Scripting.Hosting.DependencyInjection;
+using Aevatar.Scripting.Infrastructure.Ports;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Collections.Concurrent;
 
 namespace Aevatar.Integration.Tests;
@@ -30,12 +33,27 @@ internal static class ScriptEvolutionIntegrationTestKit
         services.AddAevatarRuntime();
         configure?.Invoke(services);
         services.AddScriptCapability();
-        services.AddSingleton<IScriptEvolutionApplicationService>(sp =>
+        services.AddAuthorityActivatingScriptEvolutionApplicationService();
+        return services.BuildServiceProvider();
+    }
+
+    public static IServiceCollection AddAuthorityActivatingScriptEvolutionApplicationService(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.Replace(ServiceDescriptor.Singleton<IScriptEvolutionApplicationService>(sp =>
             new AuthorityActivatingScriptEvolutionApplicationService(
                 new ScriptEvolutionApplicationService(sp.GetRequiredService<IScriptEvolutionProposalPort>()),
                 sp.GetRequiredService<IScriptAuthorityReadModelActivationPort>(),
-                sp.GetRequiredService<IScriptingActorAddressResolver>()));
-        return services.BuildServiceProvider();
+                sp.GetRequiredService<IScriptEvolutionProjectionPort>(),
+                sp.GetRequiredService<IScriptingActorAddressResolver>())));
+        services.Replace(ServiceDescriptor.Singleton<IScriptEvolutionProposalPort>(sp =>
+            new AuthorityActivatingScriptEvolutionProposalPort(
+                sp.GetRequiredService<RuntimeScriptEvolutionInteractionService>(),
+                sp.GetRequiredService<IScriptEvolutionProjectionPort>(),
+                sp.GetRequiredService<IScriptingActorAddressResolver>())));
+        return services;
     }
 
     public static async Task<string> UpsertDefinitionAsync(
@@ -432,6 +450,7 @@ internal static class ScriptEvolutionIntegrationTestKit
     private sealed class AuthorityActivatingScriptEvolutionApplicationService(
         IScriptEvolutionApplicationService inner,
         IScriptAuthorityReadModelActivationPort activationPort,
+        IScriptEvolutionProjectionPort evolutionProjectionPort,
         IScriptingActorAddressResolver addressResolver)
         : IScriptEvolutionApplicationService
     {
@@ -441,11 +460,77 @@ internal static class ScriptEvolutionIntegrationTestKit
         {
             ArgumentNullException.ThrowIfNull(request);
 
-            await activationPort.ActivateAsync(addressResolver.GetCatalogActorId(request.ScopeId), ct);
+            var normalizedScopeId = request.ScopeId?.Trim() ?? string.Empty;
+            var normalizedProposalId = string.IsNullOrWhiteSpace(request.ProposalId)
+                ? Guid.NewGuid().ToString("N")
+                : request.ProposalId.Trim();
+            if (!string.IsNullOrWhiteSpace(normalizedScopeId) &&
+                !normalizedProposalId.StartsWith($"{normalizedScopeId}:", StringComparison.Ordinal))
+            {
+                normalizedProposalId = $"{normalizedScopeId}:{normalizedProposalId}";
+            }
+            var normalizedRequest = request with
+            {
+                ScopeId = normalizedScopeId,
+                ProposalId = normalizedProposalId,
+            };
+
+            await activationPort.ActivateAsync(addressResolver.GetCatalogActorId(normalizedScopeId), ct);
             await activationPort.ActivateAsync(
-                addressResolver.GetDefinitionActorId(request.ScriptId, request.ScopeId),
+                addressResolver.GetDefinitionActorId(request.ScriptId, normalizedScopeId),
                 ct);
-            return await inner.ProposeAsync(request, ct);
+            var sessionActorId = addressResolver.GetEvolutionSessionActorId(
+                normalizedProposalId,
+                normalizedScopeId);
+            var lease = await evolutionProjectionPort.EnsureActorProjectionAsync(
+                sessionActorId,
+                normalizedProposalId,
+                ct);
+            if (lease == null)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to ensure script evolution projection. actor_id={sessionActorId}, proposal_id={normalizedProposalId}");
+            }
+
+            return await inner.ProposeAsync(normalizedRequest, ct);
+        }
+    }
+
+    private sealed class AuthorityActivatingScriptEvolutionProposalPort(
+        IScriptEvolutionProposalPort inner,
+        IScriptEvolutionProjectionPort evolutionProjectionPort,
+        IScriptingActorAddressResolver addressResolver)
+        : IScriptEvolutionProposalPort
+    {
+        public async Task<ScriptPromotionDecision> ProposeAsync(
+            ScriptEvolutionProposal proposal,
+            CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(proposal);
+
+            var normalizedProposalId = string.IsNullOrWhiteSpace(proposal.ProposalId)
+                ? Guid.NewGuid().ToString("N")
+                : proposal.ProposalId;
+            var normalizedScopeId = proposal.ScopeId?.Trim() ?? string.Empty;
+            var normalizedProposal = proposal with
+            {
+                ProposalId = normalizedProposalId,
+                ScopeId = normalizedScopeId,
+            };
+            var sessionActorId = addressResolver.GetEvolutionSessionActorId(
+                normalizedProposalId,
+                normalizedScopeId);
+            var lease = await evolutionProjectionPort.EnsureActorProjectionAsync(
+                sessionActorId,
+                normalizedProposalId,
+                ct);
+            if (lease == null)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to ensure script evolution projection. actor_id={sessionActorId}, proposal_id={normalizedProposalId}");
+            }
+
+            return await inner.ProposeAsync(normalizedProposal, ct);
         }
     }
 }


### PR DESCRIPTION
## 解决

#889 — `coverage-quality` CI 反复 fail `Script evolution projection is disabled`(同时阻塞 #883/#884/#886)。

Root:attach-only projection lifecycle refactor 后,integration test 调 `ProposeAsync` 之前没 activate evolution session projection。CI `coverage-quality` 跑 full `aevatar.slnx --collect:"XPlat Code Coverage"` 暴露 fixture drift。

## 修法(test-only,不动 production)

`test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationTestKit.cs`:
- Test-only DI wrapper for `IScriptEvolutionApplicationService` + 直接 `IScriptEvolutionProposalPort`
- normalize `ScopeId` / `ProposalId` 用同 production rules(trim / blank 生成 / scoped 加 `{scopeId}:`)
- resolve `sessionActorId = IScriptingActorAddressResolver.GetEvolutionSessionActorId(...)`
- `EnsureActorProjectionAsync(sessionActorId, ...)` 前置 lease
- lease null → 显式失败

`test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs`:同样 post-`AddScriptCapability` 应用。

## 验证

- `dotnet test ... --filter "FullyQualifiedName~ScriptExternalEvolutionE2ETests"` PASS
- `dotnet test ... --filter "FullyQualifiedName~ScriptAutonomousEvolutionComprehensiveE2ETests"` PASS
- `bash tools/ci/test_stability_guards.sh` PASS

## 已知

`coverage_quality_guard.sh` 仍可能 exit 1 — 独立 `ScopeDraftRunActorQueryIntegrationTests` 也走相同 `PROJECTION_DISABLED` 路径(draft-run 而非 evolution session)。**Follow-up**:同模式扩展应用到 draft-run integration test。

Closes #889

⟦AI:AUTO-LOOP⟧