### PR TITLE
test(#896): VoicePresence typed sentinel 4-branch endpoint coverage

### DIFF
--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -251,6 +251,26 @@ public sealed class PolicyAwareVoiceEndpointsTests
     }
 
     [Fact]
+    public async Task PolicyAwareVoice_TypedResolutionUnsupported_ShouldMapTo503WithoutSocketAccept()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = RecordingVoiceSessionResolver.Unsupported();
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await InvokeEndpointWithTimeoutAsync(app, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+        (await ReadBodyAsync(context)).Should().Be("remote_audio_transport_unavailable");
+        wsFeature.AcceptCalls.Should().Be(0);
+        resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent");
+    }
+
+    [Fact]
     public async Task PolicyAwareVoice_WhenTransportAlreadyAttached_ShouldReturnConflictBeforeUpgrade()
     {
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
@@ -266,6 +286,27 @@ public sealed class PolicyAwareVoiceEndpointsTests
 
         context.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
         wsFeature.AcceptCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_TypedResolutionTransportAlreadyAttached_ShouldMapAttachTo409WithoutSocketAccept()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var resolver = RecordingVoiceSessionResolver.PreflightFailed(
+            VoicePresencePreflightFailureKind.TransportAlreadyAttached);
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await InvokeEndpointWithTimeoutAsync(app, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+        (await ReadBodyAsync(context)).Should().Be("Voice transport already attached.");
+        wsFeature.AcceptCalls.Should().Be(0);
+        resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent");
     }
 
     [Fact]
@@ -306,6 +347,84 @@ public sealed class PolicyAwareVoiceEndpointsTests
         wsFeature.AcceptCalls.Should().Be(1);
         attached.Should().Be(1);
         detached.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_TypedResolutionLeaseAcceptedPendingAttach_ShouldAcceptAttachAndReleaseAfterCloseWaitTimeout()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var attached = 0;
+        var detached = 0;
+        var session = new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => false,
+            attachTransportAsync: (_, _) =>
+            {
+                attached++;
+                return Task.CompletedTask;
+            },
+            detachTransportAsync: (_, _) =>
+            {
+                detached++;
+                return Task.CompletedTask;
+            },
+            pcmSampleRateHz: 24000);
+        var resolver = RecordingVoiceSessionResolver.PendingAttach(session);
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        using var app = CreatePolicyAwareApp(
+            policyPort,
+            catalog,
+            resolver,
+            options => options.WebSocketCloseWaitTimeout = TimeSpan.FromMilliseconds(1));
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await InvokeEndpointWithTimeoutAsync(app, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        wsFeature.AcceptCalls.Should().Be(1);
+        attached.Should().Be(1);
+        detached.Should().Be(1);
+        resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent");
+    }
+
+    [Fact]
+    public async Task PolicyAwareVoice_TypedResolutionLeaseAcceptedAttached_ShouldAcceptAndDetachWhenSocketCloses()
+    {
+        var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
+        var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
+        var attached = 0;
+        var detached = 0;
+        var session = new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => true,
+            attachTransportAsync: (_, _) =>
+            {
+                attached++;
+                return Task.CompletedTask;
+            },
+            detachTransportAsync: (_, _) =>
+            {
+                detached++;
+                return Task.CompletedTask;
+            },
+            pcmSampleRateHz: 24000);
+        var resolver = RecordingVoiceSessionResolver.Attached(session);
+        var socket = new FakeWebSocket(WebSocketState.CloseReceived);
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
+        var context = CreateVoiceContext(app, "/ws/voice");
+        var wsFeature = new FakeHttpWebSocketFeature(socket);
+        context.Features.Set<IHttpWebSocketFeature>(wsFeature);
+
+        await InvokeEndpointWithTimeoutAsync(app, context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        wsFeature.AcceptCalls.Should().Be(1);
+        attached.Should().Be(1);
+        detached.Should().Be(1);
+        resolver.Requests.Should().ContainSingle(request => request.ActorId == "voice-agent");
     }
 
     private static ChatRouteAction ForwardToGAgent(string actorId, string voiceModuleName = "") =>
@@ -411,6 +530,9 @@ public sealed class PolicyAwareVoiceEndpointsTests
             .SelectMany(static dataSource => dataSource.Endpoints)
             .OfType<RouteEndpoint>()
             .Single(endpoint => endpoint.RoutePattern.RawText == pattern);
+
+    private static Task InvokeEndpointWithTimeoutAsync(WebApplication app, DefaultHttpContext context) =>
+        GetEndpoint(app, "/ws/voice").RequestDelegate!(context).WaitAsync(TimeSpan.FromSeconds(5));
 
     private static VoicePresenceSession CreateInitializedSession() =>
         new(

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWhipEndpointsTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWhipEndpointsTests.cs
@@ -232,6 +232,42 @@ public class VoicePresenceWhipEndpointsTests
     }
 
     [Fact]
+    public async Task Delete_should_detach_transport_already_attached_typed_preflight_session()
+    {
+        var attachCalls = 0;
+        var detachCalls = 0;
+        var session = new VoicePresenceSession(
+            isInitialized: static () => true,
+            isTransportAttached: static () => true,
+            attachTransportAsync: (_, _) =>
+            {
+                attachCalls++;
+                return Task.CompletedTask;
+            },
+            detachTransportAsync: (_, _) =>
+            {
+                detachCalls++;
+                return Task.CompletedTask;
+            },
+            pcmSampleRateHz: 24000);
+        var resolver = new RecordingSessionResolver(new VoicePresenceSessionResolution(
+            VoicePresenceSessionResolutionKind.PreflightFailed,
+            session,
+            VoicePresencePreflightFailureKind.TransportAlreadyAttached));
+        using var app = CreateApp(resolver);
+        var context = CreateContext(app, HttpMethods.Delete, string.Empty);
+        context.Request.RouteValues["actorId"] = "agent-1";
+
+        await GetWhipEndpoint(app, HttpMethods.Delete).RequestDelegate!(context)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        context.Response.StatusCode.ShouldBe(StatusCodes.Status204NoContent);
+        resolver.Requests.ShouldHaveSingleItem().Purpose.ShouldBe(VoicePresenceSessionRequestPurpose.Detach);
+        attachCalls.ShouldBe(0);
+        detachCalls.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Post_should_dispose_transport_when_attach_fails()
     {
         var transport = new StubVoiceTransport();


### PR DESCRIPTION
## 摘要

Closes #896 — retrospective 发现 #892 merge 后 typed sentinel 4-branch endpoint mapping 缺 focused coverage(原 fix-r2 用 fake-attached wrap 覆盖不全)。

## 改动

- PolicyAwareVoiceEndpointsTests + VoicePresenceWhipEndpointsTests + 158 LOC
- 覆盖 Unsupported(503) / PreflightFailed.TransportAlreadyAttached(409 attach / continue detach DELETE) / LeaseAcceptedPendingAttach(accept-await-attach with timeout) / LeaseAcceptedAttached(ok upgrade)
- 加 hang prevention timeout

## 验证

- PolicyAwareVoiceEndpointsTests PASS
- VoicePresenceWhipEndpointsTests PASS
- test_stability_guards PASS

⟦AI:AUTO-LOOP⟧