### PR TITLE
iter46 cluster-046 workflow-file-catalog-query-port: WorkflowGAgent + startup materializer + readmodel facade

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ using Aevatar.Studio.Projection.ReadModels;
 using Aevatar.Scripting.Hosting.DependencyInjection;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
+using Aevatar.Workflow.Projection.Metadata;
+using Aevatar.Workflow.Projection.ReadModels;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -122,6 +124,13 @@ public static class ServiceCollectionExtensions
         if (HasAllGAgentServiceProjectionReaders(services, selectedDocumentProvider))
             return services;
 
+        services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>,
+            WorkflowCatalogCurrentStateDocumentMetadataProvider>();
+        services.TryAddSingleton<
+            IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>,
+            WorkflowCapabilitiesCurrentStateDocumentMetadataProvider>();
+
         if (elasticsearchEnabled)
         {
             TryAddElasticsearchDocumentProjectionStore<ServiceCatalogReadModel>(services, configuration, static readModel => readModel.Id);
@@ -136,6 +145,8 @@ public static class ServiceCollectionExtensions
             TryAddElasticsearchDocumentProjectionStore<LlmSessionCurrentStateReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<ResponsesAgentToolStateCurrentStateReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowCapabilitiesCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
         }
         else
         {
@@ -151,6 +162,8 @@ public static class ServiceCollectionExtensions
             TryAddInMemoryDocumentProjectionStore<LlmSessionCurrentStateReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<ResponsesAgentToolStateCurrentStateReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<WorkflowCapabilitiesCurrentStateDocument>(services, static readModel => readModel.Id);
         }
 
         return services;
@@ -171,7 +184,9 @@ public static class ServiceCollectionExtensions
                && HasProjectionDocumentReaderForProvider<GAgentRunTerminalReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<LlmSessionCurrentStateReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<ResponsesAgentToolStateCurrentStateReadModel>(services, providerKind)
-               && HasProjectionDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind);
+               && HasProjectionDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind)
+               && HasProjectionDocumentReaderForProvider<WorkflowCapabilitiesCurrentStateDocument>(services, providerKind);
     }
 
     private static bool HasAnyProjectionDocumentReader<TReadModel>(IServiceCollection services)

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -20,6 +20,7 @@ message BindWorkflowDefinitionEvent
   string workflow_yaml = 2;
   map<string, string> inline_workflow_yamls = 3;
   string scope_id = 4;
+  string source_kind = 5;
 }
 message WorkflowRunExecutionStartedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowCapabilitiesModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowCapabilitiesModels.cs
@@ -5,6 +5,8 @@ public sealed class WorkflowCapabilitiesDocument
     public string SchemaVersion { get; set; } = "capabilities.v1";
 
     public DateTimeOffset GeneratedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+    public long AuthorityStateVersion { get; set; }
+    public DateTimeOffset ProjectionWatermark { get; set; }
 
     public List<WorkflowPrimitiveCapability> Primitives { get; set; } = [];
 
@@ -83,6 +85,8 @@ public sealed class WorkflowCapabilityWorkflow
     public List<string> WorkflowCalls { get; set; } = [];
 
     public List<WorkflowCapabilityWorkflowStep> Steps { get; set; } = [];
+    public long AuthorityStateVersion { get; set; }
+    public DateTimeOffset ProjectionWatermark { get; set; }
 }
 
 public sealed class WorkflowCapabilityWorkflowStep

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowExecutionQueryModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowExecutionQueryModels.cs
@@ -19,6 +19,9 @@ public sealed class WorkflowCatalogItem
     public bool IsPrimitiveExample { get; set; }
     public bool RequiresLlmProvider { get; set; }
     public List<string> Primitives { get; set; } = [];
+    public long AuthorityStateVersion { get; set; }
+    public DateTimeOffset ProjectionWatermark { get; set; }
+    public string LastEventId { get; set; } = string.Empty;
 }
 
 public sealed class WorkflowCatalogRole

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Workflows/IWorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Workflows/IWorkflowDefinitionCatalog.cs
@@ -6,7 +6,8 @@ namespace Aevatar.Workflow.Application.Abstractions.Workflows;
 public sealed record WorkflowDefinitionRegistration(
     string WorkflowName,
     string WorkflowYaml,
-    string DefinitionActorId);
+    string DefinitionActorId,
+    string SourceKind = "builtin");
 
 /// <summary>
 /// Read-only catalog of workflow YAML definitions loaded at application startup.

--- a/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Workflows/WorkflowDefinitionCatalog.cs
@@ -84,18 +84,28 @@ public sealed class WorkflowDefinitionCatalog : IWorkflowDefinitionCatalog
     /// <inheritdoc />
     public void Register(string name, string yaml)
     {
+        Register(name, yaml, "builtin");
+    }
+
+    public void Register(string name, string yaml, string sourceKind)
+    {
         var normalizedName = NormalizeName(name);
+        var normalizedSourceKind = string.IsNullOrWhiteSpace(sourceKind)
+            ? "builtin"
+            : sourceKind.Trim();
         ImmutableInterlocked.AddOrUpdate(
             ref _workflows,
             normalizedName,
             _ => new WorkflowDefinitionRegistration(
                 normalizedName,
                 yaml,
-                WorkflowDefinitionActorId.Format(normalizedName)),
+                WorkflowDefinitionActorId.Format(normalizedName),
+                normalizedSourceKind),
             (_, _) => new WorkflowDefinitionRegistration(
                 normalizedName,
                 yaml,
-                WorkflowDefinitionActorId.Format(normalizedName)));
+                WorkflowDefinitionActorId.Format(normalizedName),
+                normalizedSourceKind));
     }
 
     /// <inheritdoc />

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowGAgent.cs
@@ -21,6 +21,7 @@ public sealed class WorkflowGAgent : GAgentBase<WorkflowState>
         string? workflowName,
         IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,
         string? scopeId = null,
+        string? sourceKind = null,
         CancellationToken ct = default)
     {
         EnsureWorkflowNameCanBind(workflowName);
@@ -29,6 +30,7 @@ public sealed class WorkflowGAgent : GAgentBase<WorkflowState>
             WorkflowName = workflowName ?? string.Empty,
             WorkflowYaml = workflowYaml ?? string.Empty,
             ScopeId = scopeId?.Trim() ?? string.Empty,
+            SourceKind = sourceKind?.Trim() ?? string.Empty,
         };
         if (inlineWorkflowYamls != null)
         {
@@ -41,7 +43,7 @@ public sealed class WorkflowGAgent : GAgentBase<WorkflowState>
 
     [EventHandler]
     public Task HandleBindWorkflowDefinition(BindWorkflowDefinitionEvent request) =>
-        BindWorkflowDefinitionAsync(request.WorkflowYaml, request.WorkflowName, request.InlineWorkflowYamls, request.ScopeId);
+        BindWorkflowDefinitionAsync(request.WorkflowYaml, request.WorkflowName, request.InlineWorkflowYamls, request.ScopeId, request.SourceKind);
 
     [EventHandler]
     public Task HandleSubWorkflowDefinitionResolveRequested(SubWorkflowDefinitionResolveRequestedEvent request) =>
@@ -83,6 +85,9 @@ public sealed class WorkflowGAgent : GAgentBase<WorkflowState>
             next.WorkflowName = incomingWorkflowName;
         if (!string.IsNullOrWhiteSpace(evt.ScopeId))
             next.ScopeId = evt.ScopeId.Trim();
+        next.SourceKind = string.IsNullOrWhiteSpace(evt.SourceKind)
+            ? "builtin"
+            : evt.SourceKind.Trim();
 
         var compileResult = EvaluateWorkflowCompilation(next.WorkflowYaml);
         next.Compiled = compileResult.Compiled;

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -63,6 +63,7 @@ message WorkflowState
   map<string, int32> pending_sub_workflow_invocation_index_by_child_run_id = 12;
   map<string, ChildRunIdSet> pending_child_run_ids_by_parent_run_id = 13;
   string scope_id = 14;
+  string source_kind = 15;
 }
 
 message WorkflowRunState

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Infrastructure.Reporting;
 using Aevatar.Workflow.Infrastructure.Runs;
 using Aevatar.Workflow.Infrastructure.Workflows;
+using Aevatar.Workflow.Projection.Workflows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -38,10 +39,11 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<WorkflowDefinitionFileLoader>();
         services.Replace(ServiceDescriptor.Singleton<FileBackedWorkflowCatalogPort, FileBackedWorkflowCatalogPort>());
+        services.TryAddSingleton<WorkflowCapabilitiesStartupMaterializer>();
         services.Replace(ServiceDescriptor.Singleton<IWorkflowCatalogPort>(sp =>
-            sp.GetRequiredService<FileBackedWorkflowCatalogPort>()));
+            sp.GetRequiredService<WorkflowCatalogReadModelQueryPort>()));
         services.Replace(ServiceDescriptor.Singleton<IWorkflowCapabilitiesPort>(sp =>
-            sp.GetRequiredService<FileBackedWorkflowCatalogPort>()));
+            sp.GetRequiredService<WorkflowCatalogReadModelQueryPort>()));
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, WorkflowDefinitionBootstrapHostedService>());
         return services;
     }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/FileBackedWorkflowCatalogPort.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/FileBackedWorkflowCatalogPort.cs
@@ -1,739 +1,82 @@
-using Aevatar.Configuration;
-using Aevatar.Workflow.Application.Abstractions.Queries;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
+using Aevatar.Workflow.Application.Workflows;
 using Aevatar.Workflow.Core;
-using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Foundation.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace Aevatar.Workflow.Infrastructure.Workflows;
 
-internal sealed class FileBackedWorkflowCatalogPort : IWorkflowCatalogPort, IWorkflowCapabilitiesPort
+internal sealed class FileBackedWorkflowCatalogPort
 {
-    private static readonly TimeSpan WorkflowFileDiscoveryCacheTtl = TimeSpan.FromSeconds(5);
-
-    private static readonly HashSet<string> LlmLikeStepTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "llm_call",
-        "evaluate",
-        "reflect",
-        "tool_call",
-        "human_input",
-        "secure_input",
-        "human_approval",
-        "wait_signal",
-        "connector_call",
-        "secure_connector_call",
-    };
-
-    private static readonly IReadOnlyDictionary<string, PrimitiveMetadataDescriptor> PrimitiveMetadata =
-        new Dictionary<string, PrimitiveMetadataDescriptor>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["wait_signal"] = new(
-                "Suspends workflow execution until an external signal arrives.",
-                [
-                    new PrimitiveParameterDescriptor("signal_name", "string", true, "Signal name used to resume this waiter."),
-                    new PrimitiveParameterDescriptor("timeout_ms", "int", false, "Maximum wait duration in milliseconds."),
-                ]),
-            ["workflow_call"] = new(
-                "Invokes another workflow definition as a sub-workflow.",
-                [
-                    new PrimitiveParameterDescriptor("workflow", "string", true, "Referenced workflow name."),
-                    new PrimitiveParameterDescriptor("lifecycle", "string", false, "sync or async child lifecycle mode.", EnumValuesInput: ["sync", "async"]),
-                ]),
-            ["connector_call"] = new(
-                "Invokes an external connector configured in connectors.json.",
-                [
-                    new PrimitiveParameterDescriptor("connector", "string", true, "Connector name."),
-                    new PrimitiveParameterDescriptor("operation", "string", false, "Connector-specific operation or method."),
-                ]),
-            ["secure_connector_call"] = new(
-                "Invokes an external connector with secure payload handling.",
-                [
-                    new PrimitiveParameterDescriptor("connector", "string", true, "Connector name."),
-                    new PrimitiveParameterDescriptor("operation", "string", false, "Connector-specific operation or method."),
-                ]),
-            ["llm_call"] = new(
-                "Runs an LLM role step and returns generated output.",
-                [
-                    new PrimitiveParameterDescriptor("prompt", "string", false, "Prompt template or prompt override."),
-                ]),
-            ["evaluate"] = new(
-                "Runs an evaluation/judge step over current context.",
-                [
-                    new PrimitiveParameterDescriptor("criteria", "string", false, "Evaluation criteria."),
-                ]),
-            ["reflect"] = new(
-                "Runs a reflection step to refine prior output.",
-                [
-                    new PrimitiveParameterDescriptor("prompt", "string", false, "Reflection prompt."),
-                ]),
-        };
-
-    private readonly IWorkflowDefinitionCatalog _workflowRegistry;
-    private readonly IOptions<WorkflowDefinitionFileSourceOptions> _options;
-    private readonly WorkflowParser _parser = new();
+    private const string PublisherActorId = "workflow.definition.startup.materializer";
+    private readonly IActorRuntime _runtime;
+    private readonly IActorDispatchPort _dispatchPort;
     private readonly ILogger<FileBackedWorkflowCatalogPort> _logger;
-    private readonly object _cacheLock = new();
-    private FileDiscoveryCacheEntry? _workflowFileDiscoveryCache;
-    private readonly Dictionary<string, ParsedWorkflowCacheEntry> _parsedWorkflowCache = new(StringComparer.OrdinalIgnoreCase);
 
     public FileBackedWorkflowCatalogPort(
-        IWorkflowDefinitionCatalog workflowRegistry,
-        IOptions<WorkflowDefinitionFileSourceOptions> options,
+        IActorRuntime runtime,
+        IActorDispatchPort dispatchPort,
         ILogger<FileBackedWorkflowCatalogPort>? logger = null)
     {
-        _workflowRegistry = workflowRegistry;
-        _options = options;
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _logger = logger ?? NullLogger<FileBackedWorkflowCatalogPort>.Instance;
     }
 
-    public IReadOnlyList<WorkflowCatalogItem> ListWorkflowCatalog()
+    // Refactor (iter46/issue-871-workflow-file-catalog-query-port):
+    //   Old pattern: Workflow catalog/capabilities query port discovered files, parsed YAML, loaded connector config, and cached results in singleton process memory during query execution.
+    //   New principle: WorkflowGAgent per-definition authority; query ports only read freshness-bearing readmodels; file discovery/parsing happens at startup/import time, not in query path.
+    public async Task MaterializeAsync(
+        IEnumerable<WorkflowDefinitionRegistration> definitions,
+        CancellationToken ct = default)
     {
-        var fileEntries = DiscoverWorkflowFiles();
-        var items = new List<WorkflowCatalogItem>();
+        ArgumentNullException.ThrowIfNull(definitions);
 
-        foreach (var workflowName in _workflowRegistry.GetNames().OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
+        foreach (var definition in definitions.OrderBy(x => x.WorkflowName, StringComparer.OrdinalIgnoreCase))
         {
-            var yaml = _workflowRegistry.GetYaml(workflowName);
-            if (string.IsNullOrWhiteSpace(yaml))
-                continue;
-
-            fileEntries.TryGetValue(workflowName, out var fileEntry);
-            items.Add(BuildCatalogItem(workflowName, yaml, fileEntry));
-        }
-
-        return items
-            .OrderBy(item => item.Group, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(item => item.SortOrder)
-            .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
-    public WorkflowCatalogItemDetail? GetWorkflowDetail(string workflowName)
-    {
-        if (string.IsNullOrWhiteSpace(workflowName))
-            return null;
-
-        var normalizedName = workflowName.Trim();
-        var yaml = _workflowRegistry.GetYaml(normalizedName);
-        if (string.IsNullOrWhiteSpace(yaml))
-            return null;
-
-        if (!TryGetCachedDefinition(normalizedName, yaml, out var definition) || definition == null)
-            return null;
-
-        var fileEntries = DiscoverWorkflowFiles();
-        fileEntries.TryGetValue(normalizedName, out var fileEntry);
-        var catalogItem = BuildCatalogItem(normalizedName, yaml, fileEntry);
-
-        return new WorkflowCatalogItemDetail
-        {
-            Catalog = catalogItem,
-            Yaml = yaml,
-            Definition = BuildDefinition(definition),
-            Edges = ComputeEdges(definition),
-        };
-    }
-
-    public WorkflowCapabilitiesDocument GetCapabilities()
-    {
-        var fileEntries = DiscoverWorkflowFiles();
-        var connectorEntries = AevatarConnectorConfig.LoadConnectors();
-        return new WorkflowCapabilitiesDocument
-        {
-            SchemaVersion = "capabilities.v1",
-            GeneratedAtUtc = DateTimeOffset.UtcNow,
-            Primitives = BuildPrimitiveCapabilities(),
-            Connectors = BuildConnectorCapabilities(connectorEntries),
-            Workflows = BuildWorkflowCapabilities(fileEntries),
-        };
-    }
-
-    private WorkflowCatalogItem BuildCatalogItem(
-        string workflowName,
-        string yaml,
-        WorkflowFileEntry? fileEntry)
-    {
-        var source = fileEntry?.SourceKind ?? "builtin";
-
-        string description = string.Empty;
-        string category = "deterministic";
-        var requiresLlmProvider = false;
-        var primitives = new List<string>();
-
-        if (TryGetCachedDefinition(workflowName, yaml, out var definition) && definition != null)
-        {
-            description = definition.Description ?? string.Empty;
-            primitives = definition.Steps
-                .Select(step => WorkflowPrimitiveCatalog.ToCanonicalType(step.Type))
-                .Where(type => !string.IsNullOrWhiteSpace(type))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            requiresLlmProvider = WorkflowLlmRuntimePolicy.RequiresLlmProvider(definition);
-            category = primitives.Any(primitive => LlmLikeStepTypes.Contains(primitive))
-                ? "llm"
-                : "deterministic";
-        }
-
-        var classification = WorkflowLibraryClassifier.Classify(workflowName, source, category);
-
-        return new WorkflowCatalogItem
-        {
-            Name = workflowName,
-            Description = description,
-            Category = category,
-            Group = classification.Group,
-            GroupLabel = classification.GroupLabel,
-            SortOrder = classification.SortOrder,
-            Source = source,
-            SourceLabel = classification.SourceLabel,
-            ShowInLibrary = classification.ShowInLibrary,
-            IsPrimitiveExample = classification.IsPrimitiveExample,
-            RequiresLlmProvider = requiresLlmProvider,
-            Primitives = primitives,
-        };
-    }
-
-    private List<WorkflowPrimitiveCapability> BuildPrimitiveCapabilities()
-    {
-        var aliasByCanonical = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
-        var runtimeModuleByCanonical = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        var modulePack = new WorkflowCoreModulePack();
-        foreach (var registration in modulePack.Modules)
-        {
-            foreach (var name in registration.Names)
+            ct.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(definition.WorkflowName) ||
+                string.IsNullOrWhiteSpace(definition.WorkflowYaml))
             {
-                var canonical = WorkflowPrimitiveCatalog.ToCanonicalType(name);
-                if (string.IsNullOrWhiteSpace(canonical))
-                    continue;
-
-                if (!aliasByCanonical.TryGetValue(canonical, out var aliases))
-                {
-                    aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                    aliasByCanonical[canonical] = aliases;
-                }
-
-                aliases.Add(canonical);
-                aliases.Add(name);
-                runtimeModuleByCanonical.TryAdd(canonical, registration.ModuleType.Name);
-            }
-        }
-
-        var canonicalTypes = new HashSet<string>(WorkflowPrimitiveCatalog.BuiltInCanonicalTypes, StringComparer.OrdinalIgnoreCase);
-        foreach (var canonical in aliasByCanonical.Keys)
-            canonicalTypes.Add(canonical);
-
-        return canonicalTypes
-            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-            .Select(canonical =>
-            {
-                var aliases = aliasByCanonical.TryGetValue(canonical, out var aliasSet)
-                    ? aliasSet.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList()
-                    : [canonical];
-                var metadata = PrimitiveMetadata.TryGetValue(canonical, out var descriptor)
-                    ? descriptor
-                    : new PrimitiveMetadataDescriptor(
-                        $"Core workflow primitive `{canonical}`.",
-                        []);
-                return new WorkflowPrimitiveCapability
-                {
-                    Name = canonical,
-                    Aliases = aliases,
-                    Category = InferPrimitiveCategory(canonical),
-                    Description = metadata.Description,
-                    ClosedWorldBlocked = WorkflowPrimitiveCatalog.IsClosedWorldBlocked(canonical),
-                    RuntimeModule = runtimeModuleByCanonical.GetValueOrDefault(canonical, string.Empty),
-                    Parameters = metadata.Parameters
-                        .Select(parameter => new WorkflowPrimitiveParameterCapability
-                        {
-                            Name = parameter.Name,
-                            Type = parameter.Type,
-                            Required = parameter.Required,
-                            Description = parameter.Description,
-                            Default = parameter.DefaultValue,
-                            Enum = parameter.EnumValues.ToList(),
-                        })
-                        .ToList(),
-                };
-            })
-            .ToList();
-    }
-
-    private static List<WorkflowConnectorCapability> BuildConnectorCapabilities(
-        IReadOnlyList<ConnectorConfigEntry> connectorEntries)
-    {
-        return connectorEntries
-            .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
-            .Select(entry =>
-            {
-                var normalizedType = (entry.Type ?? string.Empty).Trim();
-                var typeKey = normalizedType.ToLowerInvariant();
-                var allowedInputKeys = typeKey switch
-                {
-                    "http" => NormalizeDistinct(entry.Http.AllowedInputKeys),
-                    "cli" => NormalizeDistinct(entry.Cli.AllowedInputKeys),
-                    "mcp" => NormalizeDistinct(entry.MCP.AllowedInputKeys),
-                    _ => [],
-                };
-                var allowedOperations = typeKey switch
-                {
-                    "http" => NormalizeDistinct(entry.Http.AllowedMethods),
-                    "cli" => NormalizeDistinct(entry.Cli.AllowedOperations),
-                    "mcp" => NormalizeDistinct(entry.MCP.AllowedTools.Concat([entry.MCP.DefaultTool])),
-                    _ => [],
-                };
-                var fixedArguments = typeKey switch
-                {
-                    "cli" => NormalizeDistinct(entry.Cli.FixedArguments),
-                    _ => [],
-                };
-
-                return new WorkflowConnectorCapability
-                {
-                    Name = entry.Name,
-                    Type = normalizedType,
-                    Enabled = entry.Enabled,
-                    TimeoutMs = entry.TimeoutMs,
-                    Retry = entry.Retry,
-                    AllowedInputKeys = allowedInputKeys,
-                    AllowedOperations = allowedOperations,
-                    FixedArguments = fixedArguments,
-                };
-            })
-            .ToList();
-    }
-
-    private List<WorkflowCapabilityWorkflow> BuildWorkflowCapabilities(
-        IReadOnlyDictionary<string, WorkflowFileEntry> fileEntries)
-    {
-        var workflows = new List<WorkflowCapabilityWorkflow>();
-        foreach (var workflowName in _workflowRegistry.GetNames().OrderBy(x => x, StringComparer.OrdinalIgnoreCase))
-        {
-            var yaml = _workflowRegistry.GetYaml(workflowName);
-            if (string.IsNullOrWhiteSpace(yaml))
-                continue;
-
-            fileEntries.TryGetValue(workflowName, out var fileEntry);
-            var source = fileEntry?.SourceKind ?? "builtin";
-            _ = TryGetCachedDefinition(workflowName, yaml, out var definition);
-
-            if (definition == null)
-            {
-                workflows.Add(new WorkflowCapabilityWorkflow
-                {
-                    Name = workflowName,
-                    Source = source,
-                });
                 continue;
             }
 
-            var primitives = EnumerateReferencedStepTypes(definition.Steps)
-                .Select(WorkflowPrimitiveCatalog.ToCanonicalType)
-                .Where(type => !string.IsNullOrWhiteSpace(type))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .OrderBy(type => type, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            var requiredConnectors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var connectorName in definition.Roles.SelectMany(role => role.Connectors))
-                AddIfNotWhitespace(requiredConnectors, connectorName);
-
-            var workflowCalls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var steps = new List<WorkflowCapabilityWorkflowStep>();
-            foreach (var step in EnumerateAllSteps(definition.Steps))
-            {
-                var canonicalType = WorkflowPrimitiveCatalog.ToCanonicalType(step.Type);
-                steps.Add(new WorkflowCapabilityWorkflowStep
-                {
-                    Id = step.Id,
-                    Type = canonicalType,
-                    Next = step.Next ?? string.Empty,
-                });
-
-                if (string.Equals(canonicalType, "connector_call", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(canonicalType, "secure_connector_call", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (step.Parameters.TryGetValue("connector", out var connector))
-                        AddIfNotWhitespace(requiredConnectors, connector);
-                }
-
-                if (string.Equals(canonicalType, "workflow_call", StringComparison.OrdinalIgnoreCase) &&
-                    step.Parameters.TryGetValue("workflow", out var calledWorkflow))
-                {
-                    AddIfNotWhitespace(workflowCalls, calledWorkflow);
-                }
-            }
-
-            workflows.Add(new WorkflowCapabilityWorkflow
-            {
-                Name = workflowName,
-                Description = definition.Description ?? string.Empty,
-                Source = source,
-                ClosedWorldMode = definition.Configuration.ClosedWorldMode,
-                RequiresLlmProvider = WorkflowLlmRuntimePolicy.RequiresLlmProvider(definition),
-                Primitives = primitives,
-                RequiredConnectors = requiredConnectors
-                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-                    .ToList(),
-                WorkflowCalls = workflowCalls
-                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
-                    .ToList(),
-                Steps = steps,
-            });
-        }
-
-        return workflows;
-    }
-
-    private static IEnumerable<StepDefinition> EnumerateAllSteps(IEnumerable<StepDefinition> steps)
-    {
-        foreach (var step in steps)
-        {
-            yield return step;
-
-            if (step.Children is { Count: > 0 })
-            {
-                foreach (var child in EnumerateAllSteps(step.Children))
-                    yield return child;
-            }
+            var actorId = string.IsNullOrWhiteSpace(definition.DefinitionActorId)
+                ? WorkflowDefinitionActorId.Format(definition.WorkflowName)
+                : definition.DefinitionActorId.Trim();
+            var actor = await _runtime.CreateAsync<WorkflowGAgent>(actorId, ct);
+            await _dispatchPort.DispatchAsync(
+                actor.Id,
+                CreateBindEnvelope(definition),
+                ct);
+            _logger.LogInformation(
+                "Materialized startup workflow definition '{WorkflowName}' into WorkflowGAgent '{ActorId}'.",
+                definition.WorkflowName,
+                actor.Id);
         }
     }
 
-    private static IEnumerable<string> EnumerateReferencedStepTypes(IEnumerable<StepDefinition> steps)
-    {
-        foreach (var step in steps)
+    private static EventEnvelope CreateBindEnvelope(WorkflowDefinitionRegistration definition) =>
+        new()
         {
-            yield return step.Type;
-
-            foreach (var (key, value) in step.Parameters)
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Payload = Any.Pack(new BindWorkflowDefinitionEvent
             {
-                if (WorkflowPrimitiveCatalog.IsStepTypeParameterKey(key) &&
-                    !string.IsNullOrWhiteSpace(value))
-                {
-                    yield return value;
-                }
-            }
-
-            if (step.Children is { Count: > 0 })
+                WorkflowName = definition.WorkflowName ?? string.Empty,
+                WorkflowYaml = definition.WorkflowYaml ?? string.Empty,
+                SourceKind = string.IsNullOrWhiteSpace(definition.SourceKind)
+                    ? "builtin"
+                    : definition.SourceKind.Trim(),
+            }),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(PublisherActorId, TopologyAudience.Self),
+            Propagation = new EnvelopePropagation
             {
-                foreach (var childType in EnumerateReferencedStepTypes(step.Children))
-                    yield return childType;
-            }
-        }
-    }
-
-    private static void AddIfNotWhitespace(ISet<string> set, string? value)
-    {
-        if (!string.IsNullOrWhiteSpace(value))
-            set.Add(value.Trim());
-    }
-
-    private static List<string> NormalizeDistinct(IEnumerable<string>? values)
-    {
-        if (values == null)
-            return [];
-
-        return values
-            .Where(value => !string.IsNullOrWhiteSpace(value))
-            .Select(value => value.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
-    private static string InferPrimitiveCategory(string canonicalType) =>
-        canonicalType switch
-        {
-            "transform" or "assign" or "retrieve_facts" or "cache" => "data",
-            "guard" or "conditional" or "switch" or "while" or "delay" or "wait_signal" or "checkpoint" or "workflow_loop" or "workflow_yaml_validate" => "control",
-            "foreach" or "parallel" or "race" or "map_reduce" or "workflow_call" or "vote" or "dynamic_workflow" => "composition",
-            "llm_call" or "tool_call" or "evaluate" or "reflect" => "ai",
-            "connector_call" or "secure_connector_call" or "emit" => "integration",
-            "human_input" or "human_approval" or "secure_input" => "human",
-            _ => "general",
+                CorrelationId = Guid.NewGuid().ToString("N"),
+            },
         };
-
-    private IReadOnlyDictionary<string, WorkflowFileEntry> DiscoverWorkflowFiles()
-    {
-        var now = DateTimeOffset.UtcNow;
-        lock (_cacheLock)
-        {
-            if (_workflowFileDiscoveryCache is { } cache &&
-                cache.ExpiresAtUtc > now)
-            {
-                return cache.Entries;
-            }
-        }
-
-        var entries = DiscoverWorkflowFilesCore();
-        lock (_cacheLock)
-        {
-            _workflowFileDiscoveryCache = new FileDiscoveryCacheEntry(
-                entries,
-                now.Add(WorkflowFileDiscoveryCacheTtl));
-        }
-
-        return entries;
-    }
-
-    private Dictionary<string, WorkflowFileEntry> DiscoverWorkflowFilesCore()
-    {
-        var entries = new Dictionary<string, WorkflowFileEntry>(StringComparer.OrdinalIgnoreCase);
-        foreach (var directory in ResolveNormalizedWorkflowDirectories())
-        {
-            var sourceKind = ResolveSourceKind(directory);
-            try
-            {
-                foreach (var file in Directory.EnumerateFiles(directory, "*.*")
-                             .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-                             .Where(f => f.EndsWith(".yaml", StringComparison.OrdinalIgnoreCase) ||
-                                         f.EndsWith(".yml", StringComparison.OrdinalIgnoreCase)))
-                {
-                    var name = Path.GetFileNameWithoutExtension(file);
-                    if (string.IsNullOrWhiteSpace(name))
-                        continue;
-
-                    entries[name] = new WorkflowFileEntry(name.Trim(), file, sourceKind);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to enumerate workflow files from directory '{WorkflowDirectory}'.", directory);
-            }
-        }
-
-        return entries;
-    }
-
-    private IReadOnlyList<string> ResolveNormalizedWorkflowDirectories()
-    {
-        var directories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var rawDirectory in _options.Value.WorkflowDirectories)
-        {
-            if (string.IsNullOrWhiteSpace(rawDirectory))
-                continue;
-
-            try
-            {
-                var normalized = Path.TrimEndingDirectorySeparator(Path.GetFullPath(rawDirectory));
-                if (Directory.Exists(normalized))
-                    directories.Add(normalized);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to normalize workflow directory '{WorkflowDirectory}'.", rawDirectory);
-            }
-        }
-
-        return directories
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
-    private bool TryGetCachedDefinition(
-        string workflowName,
-        string yaml,
-        out WorkflowDefinition? definition)
-    {
-        definition = null;
-        if (string.IsNullOrWhiteSpace(workflowName) || string.IsNullOrWhiteSpace(yaml))
-            return false;
-
-        var normalizedWorkflowName = workflowName.Trim();
-        lock (_cacheLock)
-        {
-            if (_parsedWorkflowCache.TryGetValue(normalizedWorkflowName, out var cached) &&
-                string.Equals(cached.Yaml, yaml, StringComparison.Ordinal))
-            {
-                definition = cached.Definition;
-                return definition != null;
-            }
-        }
-
-        WorkflowDefinition? parsed = null;
-        try
-        {
-            parsed = _parser.Parse(yaml);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to parse workflow yaml for '{WorkflowName}'.", normalizedWorkflowName);
-        }
-
-        lock (_cacheLock)
-        {
-            _parsedWorkflowCache[normalizedWorkflowName] = new ParsedWorkflowCacheEntry(yaml, parsed);
-        }
-
-        definition = parsed;
-        return definition != null;
-    }
-
-    private static WorkflowCatalogDefinition BuildDefinition(WorkflowDefinition definition)
-    {
-        return new WorkflowCatalogDefinition
-        {
-            Name = definition.Name,
-            Description = definition.Description,
-            ClosedWorldMode = definition.Configuration.ClosedWorldMode,
-            Roles = definition.Roles.Select(BuildRole).ToList(),
-            Steps = definition.Steps.Select(BuildStep).ToList(),
-        };
-    }
-
-    private static WorkflowCatalogRole BuildRole(RoleDefinition role)
-    {
-        return new WorkflowCatalogRole
-        {
-            Id = role.Id,
-            Name = role.Name,
-            SystemPrompt = role.SystemPrompt,
-            Provider = role.Provider ?? string.Empty,
-            Model = role.Model ?? string.Empty,
-            Temperature = role.Temperature is null ? null : (float)role.Temperature.Value,
-            MaxTokens = role.MaxTokens,
-            MaxToolRounds = role.MaxToolRounds,
-            MaxHistoryMessages = role.MaxHistoryMessages,
-            EventModules = SplitCsv(role.EventModules),
-            EventRoutes = role.EventRoutes ?? string.Empty,
-            Connectors = role.Connectors.ToList(),
-        };
-    }
-
-    private static WorkflowCatalogStep BuildStep(StepDefinition step)
-    {
-        return new WorkflowCatalogStep
-        {
-            Id = step.Id,
-            Type = step.Type,
-            TargetRole = step.TargetRole ?? string.Empty,
-            Parameters = step.Parameters.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
-            Next = step.Next ?? string.Empty,
-            Branches = step.Branches?.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal) ?? [],
-            Children = step.Children?.Select(child => new WorkflowCatalogChildStep
-            {
-                Id = child.Id,
-                Type = child.Type,
-                TargetRole = child.TargetRole ?? string.Empty,
-            }).ToList() ?? [],
-        };
-    }
-
-    private static List<WorkflowCatalogEdge> ComputeEdges(WorkflowDefinition definition)
-    {
-        var edges = new List<WorkflowCatalogEdge>();
-        for (var i = 0; i < definition.Steps.Count; i++)
-        {
-            var step = definition.Steps[i];
-            if (step.Branches is { Count: > 0 })
-            {
-                foreach (var (label, targetId) in step.Branches)
-                {
-                    if (definition.GetStep(targetId) != null)
-                    {
-                        edges.Add(new WorkflowCatalogEdge
-                        {
-                            From = step.Id,
-                            To = targetId,
-                            Label = label,
-                        });
-                    }
-                }
-            }
-            else if (!string.IsNullOrWhiteSpace(step.Next))
-            {
-                if (definition.GetStep(step.Next) != null)
-                {
-                    edges.Add(new WorkflowCatalogEdge
-                    {
-                        From = step.Id,
-                        To = step.Next,
-                    });
-                }
-            }
-            else if (i + 1 < definition.Steps.Count)
-            {
-                edges.Add(new WorkflowCatalogEdge
-                {
-                    From = step.Id,
-                    To = definition.Steps[i + 1].Id,
-                });
-            }
-
-            if (step.Children is { Count: > 0 })
-            {
-                foreach (var child in step.Children)
-                {
-                    edges.Add(new WorkflowCatalogEdge
-                    {
-                        From = step.Id,
-                        To = child.Id,
-                        Label = "child",
-                    });
-                }
-            }
-        }
-
-        return edges;
-    }
-
-    private static List<string> SplitCsv(string? raw)
-    {
-        if (string.IsNullOrWhiteSpace(raw))
-            return [];
-
-        return raw
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(part => part.Length > 0)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
-    private static string ResolveSourceKind(string directory)
-    {
-        var normalized = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
-        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(AevatarPaths.Workflows)), StringComparison.OrdinalIgnoreCase))
-            return "home";
-
-        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(AevatarPaths.RepoRootWorkflows)), StringComparison.OrdinalIgnoreCase))
-            return "repo";
-
-        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "workflows"))), StringComparison.OrdinalIgnoreCase))
-            return "cwd";
-
-        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "workflows"))), StringComparison.OrdinalIgnoreCase))
-            return "app";
-
-        if (normalized.EndsWith($"{Path.DirectorySeparatorChar}turing-completeness", StringComparison.OrdinalIgnoreCase))
-            return "turing";
-
-        return "file";
-    }
-
-    private sealed record FileDiscoveryCacheEntry(
-        IReadOnlyDictionary<string, WorkflowFileEntry> Entries,
-        DateTimeOffset ExpiresAtUtc);
-
-    private sealed record ParsedWorkflowCacheEntry(
-        string Yaml,
-        WorkflowDefinition? Definition);
-
-    private sealed record WorkflowFileEntry(string Name, string FilePath, string SourceKind);
-
-    private sealed record PrimitiveMetadataDescriptor(
-        string Description,
-        IReadOnlyList<PrimitiveParameterDescriptor> Parameters);
-
-    private sealed record PrimitiveParameterDescriptor(
-        string Name,
-        string Type,
-        bool Required,
-        string Description,
-        string DefaultValue = "",
-        IReadOnlyList<string>? EnumValuesInput = null)
-    {
-        public IReadOnlyList<string> EnumValues { get; } = EnumValuesInput ?? [];
-    }
-
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowCapabilitiesStartupMaterializer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowCapabilitiesStartupMaterializer.cs
@@ -1,0 +1,235 @@
+using Aevatar.Configuration;
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Projection.ReadModels;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+
+namespace Aevatar.Workflow.Infrastructure.Workflows;
+
+internal sealed class WorkflowCapabilitiesStartupMaterializer
+{
+    public const string DocumentId = "workflow-capabilities";
+
+    private static readonly IReadOnlyDictionary<string, PrimitiveMetadataDescriptor> PrimitiveDescriptors =
+        new Dictionary<string, PrimitiveMetadataDescriptor>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wait_signal"] = new(
+                "Suspends workflow execution until an external signal arrives.",
+                [
+                    new PrimitiveParameterDescriptor("signal_name", "string", true, "Signal name used to resume this waiter."),
+                    new PrimitiveParameterDescriptor("timeout_ms", "int", false, "Maximum wait duration in milliseconds."),
+                ]),
+            ["workflow_call"] = new(
+                "Invokes another workflow definition as a sub-workflow.",
+                [
+                    new PrimitiveParameterDescriptor("workflow", "string", true, "Referenced workflow name."),
+                    new PrimitiveParameterDescriptor("lifecycle", "string", false, "sync or async child lifecycle mode.", EnumValuesInput: ["sync", "async"]),
+                ]),
+            ["connector_call"] = new(
+                "Invokes an external connector configured in connectors.json.",
+                [
+                    new PrimitiveParameterDescriptor("connector", "string", true, "Connector name."),
+                    new PrimitiveParameterDescriptor("operation", "string", false, "Connector-specific operation or method."),
+                ]),
+            ["secure_connector_call"] = new(
+                "Invokes an external connector with secure payload handling.",
+                [
+                    new PrimitiveParameterDescriptor("connector", "string", true, "Connector name."),
+                    new PrimitiveParameterDescriptor("operation", "string", false, "Connector-specific operation or method."),
+                ]),
+            ["llm_call"] = new(
+                "Runs an LLM role step and returns generated output.",
+                [
+                    new PrimitiveParameterDescriptor("prompt", "string", false, "Prompt template or prompt override."),
+                ]),
+            ["evaluate"] = new(
+                "Runs an evaluation/judge step over current context.",
+                [
+                    new PrimitiveParameterDescriptor("criteria", "string", false, "Evaluation criteria."),
+                ]),
+            ["reflect"] = new(
+                "Runs a reflection step to refine prior output.",
+                [
+                    new PrimitiveParameterDescriptor("prompt", "string", false, "Reflection prompt."),
+                ]),
+        };
+
+    private readonly IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument> _writeDispatcher;
+    private readonly IEnumerable<IWorkflowModulePack> _modulePacks;
+
+    public WorkflowCapabilitiesStartupMaterializer(
+        IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument> writeDispatcher,
+        IEnumerable<IWorkflowModulePack> modulePacks)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _modulePacks = modulePacks ?? throw new ArgumentNullException(nameof(modulePacks));
+    }
+
+    // Refactor (iter46/issue-871-workflow-file-catalog-query-port):
+    //   Old pattern: Workflow catalog/capabilities query port discovered files, parsed YAML, loaded connector config, and cached results in singleton process memory during query execution.
+    //   New principle: WorkflowGAgent per-definition authority; query ports only read freshness-bearing readmodels; file discovery/parsing happens at startup/import time, not in query path.
+    public async Task MaterializeAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var now = DateTimeOffset.UtcNow;
+        var document = new WorkflowCapabilitiesCurrentStateDocument
+        {
+            Id = DocumentId,
+            ActorId = DocumentId,
+            StateVersion = 1,
+            LastEventId = "startup-materialization",
+            UpdatedAt = now,
+            SchemaVersion = "capabilities.v1",
+            Primitives = BuildPrimitiveCapabilities(),
+            Connectors = BuildConnectorCapabilities(AevatarConnectorConfig.LoadConnectors()),
+        };
+
+        await _writeDispatcher.UpsertAsync(document, ct);
+    }
+
+    private List<WorkflowPrimitiveCapabilityReadModel> BuildPrimitiveCapabilities()
+    {
+        var aliasByCanonical = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var runtimeModuleByCanonical = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var modulePacks = _modulePacks.ToList();
+        if (modulePacks.Count == 0)
+            modulePacks.Add(new WorkflowCoreModulePack());
+
+        foreach (var registration in modulePacks.SelectMany(pack => pack.Modules))
+        {
+            foreach (var name in registration.Names)
+            {
+                var canonical = WorkflowPrimitiveCatalog.ToCanonicalType(name);
+                if (string.IsNullOrWhiteSpace(canonical))
+                    continue;
+
+                if (!aliasByCanonical.TryGetValue(canonical, out var aliases))
+                {
+                    aliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    aliasByCanonical[canonical] = aliases;
+                }
+
+                aliases.Add(canonical);
+                aliases.Add(name);
+                runtimeModuleByCanonical.TryAdd(canonical, registration.ModuleType.Name);
+            }
+        }
+
+        var canonicalTypes = new HashSet<string>(WorkflowPrimitiveCatalog.BuiltInCanonicalTypes, StringComparer.OrdinalIgnoreCase);
+        foreach (var canonical in aliasByCanonical.Keys)
+            canonicalTypes.Add(canonical);
+
+        return canonicalTypes
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .Select(canonical =>
+            {
+                var aliases = aliasByCanonical.TryGetValue(canonical, out var aliasSet)
+                    ? aliasSet.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList()
+                    : [canonical];
+                var descriptor = PrimitiveDescriptors.TryGetValue(canonical, out var knownDescriptor)
+                    ? knownDescriptor
+                    : new PrimitiveMetadataDescriptor($"Core workflow primitive `{canonical}`.", []);
+                return new WorkflowPrimitiveCapabilityReadModel
+                {
+                    Name = canonical,
+                    Aliases = aliases,
+                    Category = InferPrimitiveCategory(canonical),
+                    Description = descriptor.Description,
+                    ClosedWorldBlocked = WorkflowPrimitiveCatalog.IsClosedWorldBlocked(canonical),
+                    RuntimeModule = runtimeModuleByCanonical.GetValueOrDefault(canonical, string.Empty),
+                    Parameters = descriptor.Parameters
+                        .Select(parameter => new WorkflowPrimitiveParameterCapabilityReadModel
+                        {
+                            Name = parameter.Name,
+                            Type = parameter.Type,
+                            Required = parameter.Required,
+                            Description = parameter.Description,
+                            DefaultValue = parameter.DefaultValue,
+                            Enum = parameter.EnumValues.ToList(),
+                        })
+                        .ToList(),
+                };
+            })
+            .ToList();
+    }
+
+    private static List<WorkflowConnectorCapabilityReadModel> BuildConnectorCapabilities(
+        IReadOnlyList<ConnectorConfigEntry> connectorEntries)
+    {
+        return connectorEntries
+            .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(entry =>
+            {
+                var normalizedType = (entry.Type ?? string.Empty).Trim();
+                var typeKey = normalizedType.ToLowerInvariant();
+                return new WorkflowConnectorCapabilityReadModel
+                {
+                    Name = entry.Name,
+                    Type = normalizedType,
+                    Enabled = entry.Enabled,
+                    TimeoutMs = entry.TimeoutMs,
+                    Retry = entry.Retry,
+                    AllowedInputKeys = typeKey switch
+                    {
+                        "http" => NormalizeDistinct(entry.Http.AllowedInputKeys),
+                        "cli" => NormalizeDistinct(entry.Cli.AllowedInputKeys),
+                        "mcp" => NormalizeDistinct(entry.MCP.AllowedInputKeys),
+                        _ => [],
+                    },
+                    AllowedOperations = typeKey switch
+                    {
+                        "http" => NormalizeDistinct(entry.Http.AllowedMethods),
+                        "cli" => NormalizeDistinct(entry.Cli.AllowedOperations),
+                        "mcp" => NormalizeDistinct(entry.MCP.AllowedTools.Concat([entry.MCP.DefaultTool])),
+                        _ => [],
+                    },
+                    FixedArguments = typeKey switch
+                    {
+                        "cli" => NormalizeDistinct(entry.Cli.FixedArguments),
+                        _ => [],
+                    },
+                };
+            })
+            .ToList();
+    }
+
+    private static List<string> NormalizeDistinct(IEnumerable<string>? values)
+    {
+        if (values == null)
+            return [];
+
+        return values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(value => value, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string InferPrimitiveCategory(string canonicalType) =>
+        canonicalType switch
+        {
+            "transform" or "assign" or "retrieve_facts" or "cache" => "data",
+            "guard" or "conditional" or "switch" or "while" or "delay" or "wait_signal" or "checkpoint" or "workflow_loop" or "workflow_yaml_validate" => "control",
+            "foreach" or "parallel" or "race" or "map_reduce" or "workflow_call" or "vote" or "dynamic_workflow" => "composition",
+            "llm_call" or "tool_call" or "evaluate" or "reflect" => "ai",
+            "connector_call" or "secure_connector_call" or "emit" => "integration",
+            "human_input" or "human_approval" or "secure_input" => "human",
+            _ => "general",
+        };
+
+    private sealed record PrimitiveMetadataDescriptor(
+        string Description,
+        IReadOnlyList<PrimitiveParameterDescriptor> Parameters);
+
+    private sealed record PrimitiveParameterDescriptor(
+        string Name,
+        string Type,
+        bool Required,
+        string Description,
+        string DefaultValue = "",
+        IReadOnlyList<string>? EnumValuesInput = null)
+    {
+        public IReadOnlyList<string> EnumValues { get; } = EnumValuesInput ?? [];
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionBootstrapHostedService.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionBootstrapHostedService.cs
@@ -9,22 +9,28 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
 {
     private readonly IWorkflowDefinitionCatalog _registry;
     private readonly WorkflowDefinitionFileLoader _loader;
+    private readonly FileBackedWorkflowCatalogPort _definitionMaterializer;
+    private readonly WorkflowCapabilitiesStartupMaterializer _capabilitiesMaterializer;
     private readonly IOptions<WorkflowDefinitionFileSourceOptions> _options;
     private readonly ILogger<WorkflowDefinitionBootstrapHostedService> _logger;
 
     public WorkflowDefinitionBootstrapHostedService(
         IWorkflowDefinitionCatalog registry,
         WorkflowDefinitionFileLoader loader,
+        FileBackedWorkflowCatalogPort definitionMaterializer,
+        WorkflowCapabilitiesStartupMaterializer capabilitiesMaterializer,
         IOptions<WorkflowDefinitionFileSourceOptions> options,
         ILogger<WorkflowDefinitionBootstrapHostedService> logger)
     {
         _registry = registry;
         _loader = loader;
+        _definitionMaterializer = definitionMaterializer;
+        _capabilitiesMaterializer = capabilitiesMaterializer;
         _options = options;
         _logger = logger;
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         _loader.LoadInto(
@@ -32,7 +38,13 @@ internal sealed class WorkflowDefinitionBootstrapHostedService : IHostedService
             _options.Value.WorkflowDirectories,
             _logger,
             _options.Value.DuplicatePolicy);
-        return Task.CompletedTask;
+        var definitions = _registry.GetNames()
+            .Select(name => _registry.GetDefinition(name))
+            .Where(definition => definition != null)
+            .Select(definition => definition!)
+            .ToList();
+        await _definitionMaterializer.MaterializeAsync(definitions, cancellationToken);
+        await _capabilitiesMaterializer.MaterializeAsync(cancellationToken);
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionFileLoader.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowDefinitionFileLoader.cs
@@ -1,4 +1,5 @@
 using Aevatar.Workflow.Application.Abstractions.Workflows;
+using Aevatar.Workflow.Application.Workflows;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Infrastructure.Workflows;
@@ -56,12 +57,36 @@ public sealed class WorkflowDefinitionFileLoader
                 }
 
                 var yaml = File.ReadAllText(file);
-                registry.Register(name, yaml);
+                if (registry is WorkflowDefinitionCatalog concreteCatalog)
+                    concreteCatalog.Register(name, yaml, ResolveSourceKind(directory));
+                else
+                    registry.Register(name, yaml);
                 loaded++;
             }
         }
 
         logger.LogInformation("Loaded {Count} workflow definition(s) from file sources.", loaded);
         return loaded;
+    }
+
+    private static string ResolveSourceKind(string directory)
+    {
+        var normalized = Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory));
+        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(Aevatar.Configuration.AevatarPaths.Workflows)), StringComparison.OrdinalIgnoreCase))
+            return "home";
+
+        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(Aevatar.Configuration.AevatarPaths.RepoRootWorkflows)), StringComparison.OrdinalIgnoreCase))
+            return "repo";
+
+        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "workflows"))), StringComparison.OrdinalIgnoreCase))
+            return "cwd";
+
+        if (string.Equals(normalized, Path.TrimEndingDirectorySeparator(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "workflows"))), StringComparison.OrdinalIgnoreCase))
+            return "app";
+
+        if (normalized.EndsWith($"{Path.DirectorySeparatorChar}turing-completeness", StringComparison.OrdinalIgnoreCase))
+            return "turing";
+
+        return "file";
     }
 }

--- a/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Aevatar.Workflow.Projection.Metadata;
 using Aevatar.Workflow.Projection.Orchestration;
 using Aevatar.Workflow.Projection.Projectors;
 using Aevatar.Workflow.Projection.ReadModels;
+using Aevatar.Workflow.Projection.Workflows;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
@@ -36,8 +37,12 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowExecutionCurrentStateDocument>, WorkflowExecutionCurrentStateDocumentMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowRunInsightReportDocument>, WorkflowRunInsightReportDocumentMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowActorBindingDocument>, WorkflowActorBindingDocumentMetadataProvider>();
+        services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>, WorkflowCatalogCurrentStateDocumentMetadataProvider>();
+        services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>, WorkflowCapabilitiesCurrentStateDocumentMetadataProvider>();
         services.TryAddSingleton<IProjectionClock, SystemProjectionClock>();
         services.TryAddSingleton<WorkflowExecutionReadModelMapper>();
+        services.TryAddSingleton<WorkflowCatalogReadModelMapper>();
+        services.TryAddSingleton<WorkflowCatalogReadModelQueryPort>();
         services.TryAddSingleton<IProjectionGraphMaterializer<WorkflowRunInsightReportDocument>, WorkflowRunInsightReportGraphMaterializer>();
         services.AddProjectionMaterializationRuntimeCore<
             WorkflowExecutionMaterializationContext,
@@ -104,6 +109,9 @@ public static class ServiceCollectionExtensions
         services.AddProjectionArtifactMaterializer<
             WorkflowBindingProjectionContext,
             WorkflowActorBindingProjector>();
+        services.AddCurrentStateProjectionMaterializer<
+            WorkflowBindingProjectionContext,
+            WorkflowCatalogCurrentStateProjector>();
         services.AddCurrentStateProjectionMaterializer<
             WorkflowExecutionMaterializationContext,
             WorkflowExecutionCurrentStateProjector>();

--- a/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCapabilitiesCurrentStateDocumentMetadataProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCapabilitiesCurrentStateDocumentMetadataProvider.cs
@@ -1,0 +1,16 @@
+using Aevatar.Workflow.Projection.ReadModels;
+
+namespace Aevatar.Workflow.Projection.Metadata;
+
+public sealed class WorkflowCapabilitiesCurrentStateDocumentMetadataProvider
+    : IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>
+{
+    public DocumentIndexMetadata Metadata { get; } = new(
+        IndexName: "workflow-capabilities-current-states",
+        Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["dynamic"] = true,
+        },
+        Settings: new Dictionary<string, object?>(StringComparer.Ordinal),
+        Aliases: new Dictionary<string, object?>(StringComparer.Ordinal));
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCatalogCurrentStateDocumentMetadataProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCatalogCurrentStateDocumentMetadataProvider.cs
@@ -1,0 +1,16 @@
+using Aevatar.Workflow.Projection.ReadModels;
+
+namespace Aevatar.Workflow.Projection.Metadata;
+
+public sealed class WorkflowCatalogCurrentStateDocumentMetadataProvider
+    : IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>
+{
+    public DocumentIndexMetadata Metadata { get; } = new(
+        IndexName: "workflow-catalog-current-states",
+        Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["dynamic"] = true,
+        },
+        Settings: new Dictionary<string, object?>(StringComparer.Ordinal),
+        Aliases: new Dictionary<string, object?>(StringComparer.Ordinal));
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowCommittedStateProjectionActivationPlanProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowCommittedStateProjectionActivationPlanProvider.cs
@@ -7,6 +7,9 @@ namespace Aevatar.Workflow.Projection.Orchestration;
 /// <summary>
 /// Maps workflow committed state events to existing durable projection scopes.
 /// </summary>
+// Refactor (iter46/issue-871-workflow-file-catalog-query-port):
+//   Old pattern: Workflow catalog/capabilities query port discovered files, parsed YAML, loaded connector config, and cached results in singleton process memory during query execution.
+//   New principle: WorkflowGAgent per-definition authority; query ports only read freshness-bearing readmodels; file discovery/parsing happens at startup/import time, not in query path.
 // Refactor (iter18/cluster-006):
 //   Old pattern: command-path projection activation facade with new actor/lifecycle phase
 //   New principle: committed-state publication hook activates existing projection scopes; no new actor/lifecycle phase

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowCatalogCurrentStateProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowCatalogCurrentStateProjector.cs
@@ -1,0 +1,309 @@
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Core.Primitives;
+using Aevatar.Workflow.Projection.Orchestration;
+using Aevatar.Workflow.Projection.Workflows;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+
+namespace Aevatar.Workflow.Projection.Projectors;
+
+public sealed class WorkflowCatalogCurrentStateProjector
+    : ICurrentStateProjectionMaterializer<WorkflowBindingProjectionContext>
+{
+    private static readonly HashSet<string> LlmLikeStepTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "llm_call",
+        "evaluate",
+        "reflect",
+        "tool_call",
+        "human_input",
+        "secure_input",
+        "human_approval",
+        "wait_signal",
+        "connector_call",
+        "secure_connector_call",
+    };
+
+    private readonly IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument> _writeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    public WorkflowCatalogCurrentStateProjector(
+        IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument> writeDispatcher,
+        IProjectionClock clock)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    // Refactor (iter46/issue-871-workflow-file-catalog-query-port):
+    //   Old pattern: Workflow catalog/capabilities query port discovered files, parsed YAML, loaded connector config, and cached results in singleton process memory during query execution.
+    //   New principle: WorkflowGAgent per-definition authority; query ports only read freshness-bearing readmodels; file discovery/parsing happens at startup/import time, not in query path.
+    public async ValueTask ProjectAsync(
+        WorkflowBindingProjectionContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!CommittedStateEventEnvelope.TryUnpackState<WorkflowState>(
+                envelope,
+                out var published,
+                out var stateEvent,
+                out var state) ||
+            published == null ||
+            stateEvent?.EventData == null ||
+            state == null ||
+            !stateEvent.EventData.Is(BindWorkflowDefinitionEvent.Descriptor))
+        {
+            return;
+        }
+
+        var workflowName = NormalizeWorkflowName(state.WorkflowName);
+        if (string.IsNullOrWhiteSpace(workflowName) ||
+            string.IsNullOrWhiteSpace(state.WorkflowYaml))
+        {
+            return;
+        }
+
+        var document = BuildDocument(
+            context.RootActorId,
+            workflowName,
+            state,
+            stateEvent.EventId ?? string.Empty,
+            stateEvent.Version,
+            CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow));
+        await _writeDispatcher.UpsertAsync(document, ct);
+    }
+
+    private static WorkflowCatalogCurrentStateDocument BuildDocument(
+        string actorId,
+        string workflowName,
+        WorkflowState state,
+        string eventId,
+        long stateVersion,
+        DateTimeOffset updatedAt)
+    {
+        var definition = new WorkflowParser().Parse(state.WorkflowYaml);
+        var primitives = EnumerateReferencedStepTypes(definition.Steps)
+            .Select(WorkflowPrimitiveCatalog.ToCanonicalType)
+            .Where(type => !string.IsNullOrWhiteSpace(type))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(type => type, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var category = primitives.Any(primitive => LlmLikeStepTypes.Contains(primitive))
+            ? "llm"
+            : "deterministic";
+        var source = string.IsNullOrWhiteSpace(state.SourceKind)
+            ? "builtin"
+            : state.SourceKind.Trim();
+        var classification = WorkflowCatalogClassificationPolicy.Classify(workflowName, source, category);
+        var requiredConnectors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var connectorName in definition.Roles.SelectMany(role => role.Connectors))
+            AddIfNotWhitespace(requiredConnectors, connectorName);
+
+        var workflowCalls = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var capabilitySteps = new List<WorkflowCatalogStepReadModel>();
+        foreach (var step in EnumerateAllSteps(definition.Steps))
+        {
+            var canonicalType = WorkflowPrimitiveCatalog.ToCanonicalType(step.Type);
+            capabilitySteps.Add(BuildStep(step));
+
+            if (string.Equals(canonicalType, "connector_call", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(canonicalType, "secure_connector_call", StringComparison.OrdinalIgnoreCase))
+            {
+                if (step.Parameters.TryGetValue("connector", out var connector))
+                    AddIfNotWhitespace(requiredConnectors, connector);
+            }
+
+            if (string.Equals(canonicalType, "workflow_call", StringComparison.OrdinalIgnoreCase) &&
+                step.Parameters.TryGetValue("workflow", out var calledWorkflow))
+            {
+                AddIfNotWhitespace(workflowCalls, calledWorkflow);
+            }
+        }
+
+        return new WorkflowCatalogCurrentStateDocument
+        {
+            Id = workflowName,
+            ActorId = actorId,
+            StateVersion = stateVersion,
+            LastEventId = eventId,
+            UpdatedAt = updatedAt,
+            WorkflowName = workflowName,
+            WorkflowYaml = state.WorkflowYaml ?? string.Empty,
+            Description = definition.Description ?? string.Empty,
+            Category = category,
+            Group = classification.Group,
+            GroupLabel = classification.GroupLabel,
+            SortOrder = classification.SortOrder,
+            Source = source,
+            SourceLabel = classification.SourceLabel,
+            ShowInLibrary = classification.ShowInLibrary,
+            IsPrimitiveExample = classification.IsPrimitiveExample,
+            RequiresLlmProvider = WorkflowLlmRuntimePolicy.RequiresLlmProvider(definition),
+            Primitives = primitives,
+            ClosedWorldMode = definition.Configuration.ClosedWorldMode,
+            Roles = definition.Roles.Select(BuildRole).ToList(),
+            Steps = capabilitySteps,
+            Edges = ComputeEdges(definition),
+            RequiredConnectors = requiredConnectors
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+            WorkflowCalls = workflowCalls
+                .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                .ToList(),
+        };
+    }
+
+    private static WorkflowCatalogRoleReadModel BuildRole(RoleDefinition role) =>
+        new()
+        {
+            Id = role.Id,
+            Name = role.Name,
+            SystemPrompt = role.SystemPrompt,
+            Provider = role.Provider ?? string.Empty,
+            Model = role.Model ?? string.Empty,
+            Temperature = role.Temperature is null ? null : (float)role.Temperature.Value,
+            MaxTokens = role.MaxTokens,
+            MaxToolRounds = role.MaxToolRounds,
+            MaxHistoryMessages = role.MaxHistoryMessages,
+            EventModules = SplitCsv(role.EventModules),
+            EventRoutes = role.EventRoutes ?? string.Empty,
+            Connectors = role.Connectors.ToList(),
+        };
+
+    private static WorkflowCatalogStepReadModel BuildStep(StepDefinition step) =>
+        new()
+        {
+            Id = step.Id,
+            Type = step.Type,
+            TargetRole = step.TargetRole ?? string.Empty,
+            Parameters = step.Parameters.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
+            Next = step.Next ?? string.Empty,
+            Branches = step.Branches?.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal) ?? [],
+            Children = step.Children?.Select(child => new WorkflowCatalogChildStepReadModel
+            {
+                Id = child.Id,
+                Type = child.Type,
+                TargetRole = child.TargetRole ?? string.Empty,
+            }).ToList() ?? [],
+        };
+
+    private static List<WorkflowCatalogEdgeReadModel> ComputeEdges(WorkflowDefinition definition)
+    {
+        var edges = new List<WorkflowCatalogEdgeReadModel>();
+        for (var i = 0; i < definition.Steps.Count; i++)
+        {
+            var step = definition.Steps[i];
+            if (step.Branches is { Count: > 0 })
+            {
+                foreach (var (label, targetId) in step.Branches)
+                {
+                    if (definition.GetStep(targetId) != null)
+                    {
+                        edges.Add(new WorkflowCatalogEdgeReadModel
+                        {
+                            From = step.Id,
+                            To = targetId,
+                            Label = label,
+                        });
+                    }
+                }
+            }
+            else if (!string.IsNullOrWhiteSpace(step.Next))
+            {
+                if (definition.GetStep(step.Next) != null)
+                {
+                    edges.Add(new WorkflowCatalogEdgeReadModel
+                    {
+                        From = step.Id,
+                        To = step.Next,
+                    });
+                }
+            }
+            else if (i + 1 < definition.Steps.Count)
+            {
+                edges.Add(new WorkflowCatalogEdgeReadModel
+                {
+                    From = step.Id,
+                    To = definition.Steps[i + 1].Id,
+                });
+            }
+
+            if (step.Children is { Count: > 0 })
+            {
+                foreach (var child in step.Children)
+                {
+                    edges.Add(new WorkflowCatalogEdgeReadModel
+                    {
+                        From = step.Id,
+                        To = child.Id,
+                        Label = "child",
+                    });
+                }
+            }
+        }
+
+        return edges;
+    }
+
+    private static IEnumerable<StepDefinition> EnumerateAllSteps(IEnumerable<StepDefinition> steps)
+    {
+        foreach (var step in steps)
+        {
+            yield return step;
+
+            if (step.Children is { Count: > 0 })
+            {
+                foreach (var child in EnumerateAllSteps(step.Children))
+                    yield return child;
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateReferencedStepTypes(IEnumerable<StepDefinition> steps)
+    {
+        foreach (var step in steps)
+        {
+            yield return step.Type;
+
+            foreach (var (key, value) in step.Parameters)
+            {
+                if (WorkflowPrimitiveCatalog.IsStepTypeParameterKey(key) &&
+                    !string.IsNullOrWhiteSpace(value))
+                {
+                    yield return value;
+                }
+            }
+
+            if (step.Children is { Count: > 0 })
+            {
+                foreach (var childType in EnumerateReferencedStepTypes(step.Children))
+                    yield return childType;
+            }
+        }
+    }
+
+    private static void AddIfNotWhitespace(ISet<string> set, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+            set.Add(value.Trim());
+    }
+
+    private static List<string> SplitCsv(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return [];
+
+        return raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(part => part.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string NormalizeWorkflowName(string? workflowName) =>
+        string.IsNullOrWhiteSpace(workflowName)
+            ? string.Empty
+            : workflowName.Trim();
+}

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowCatalogReadModels.Partial.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowCatalogReadModels.Partial.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Projection.ReadModels;
+
+public sealed partial class WorkflowCatalogCurrentStateDocument : IProjectionReadModel<WorkflowCatalogCurrentStateDocument>
+{
+    public DateTimeOffset UpdatedAt
+    {
+        get => UpdatedAtUtcValue == null ? default : UpdatedAtUtcValue.ToDateTimeOffset();
+        set => UpdatedAtUtcValue = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
+    }
+
+    public IList<string> Primitives
+    {
+        get => PrimitiveEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(PrimitiveEntries, value);
+    }
+
+    public IList<WorkflowCatalogRoleReadModel> Roles
+    {
+        get => RoleEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(RoleEntries, value);
+    }
+
+    public IList<WorkflowCatalogStepReadModel> Steps
+    {
+        get => StepEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(StepEntries, value);
+    }
+
+    public IList<WorkflowCatalogEdgeReadModel> Edges
+    {
+        get => EdgeEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(EdgeEntries, value);
+    }
+
+    public IList<string> RequiredConnectors
+    {
+        get => RequiredConnectorEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(RequiredConnectorEntries, value);
+    }
+
+    public IList<string> WorkflowCalls
+    {
+        get => WorkflowCallEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(WorkflowCallEntries, value);
+    }
+}
+
+public sealed partial class WorkflowCatalogRoleReadModel
+{
+    public IList<string> EventModules
+    {
+        get => EventModuleEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(EventModuleEntries, value);
+    }
+
+    public IList<string> Connectors
+    {
+        get => ConnectorEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(ConnectorEntries, value);
+    }
+}
+
+public sealed partial class WorkflowCatalogStepReadModel
+{
+    public IDictionary<string, string> Parameters
+    {
+        get => ParameterEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceMap(ParameterEntries, value);
+    }
+
+    public IDictionary<string, string> Branches
+    {
+        get => BranchEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceMap(BranchEntries, value);
+    }
+
+    public IList<WorkflowCatalogChildStepReadModel> Children
+    {
+        get => ChildEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(ChildEntries, value);
+    }
+}
+
+public sealed partial class WorkflowCapabilitiesCurrentStateDocument : IProjectionReadModel<WorkflowCapabilitiesCurrentStateDocument>
+{
+    public DateTimeOffset UpdatedAt
+    {
+        get => UpdatedAtUtcValue == null ? default : UpdatedAtUtcValue.ToDateTimeOffset();
+        set => UpdatedAtUtcValue = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
+    }
+
+    public IList<WorkflowPrimitiveCapabilityReadModel> Primitives
+    {
+        get => PrimitiveEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(PrimitiveEntries, value);
+    }
+
+    public IList<WorkflowConnectorCapabilityReadModel> Connectors
+    {
+        get => ConnectorEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(ConnectorEntries, value);
+    }
+}
+
+public sealed partial class WorkflowPrimitiveCapabilityReadModel
+{
+    public IList<string> Aliases
+    {
+        get => AliasEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(AliasEntries, value);
+    }
+
+    public IList<WorkflowPrimitiveParameterCapabilityReadModel> Parameters
+    {
+        get => ParameterEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(ParameterEntries, value);
+    }
+}
+
+public sealed partial class WorkflowPrimitiveParameterCapabilityReadModel
+{
+    public IList<string> Enum
+    {
+        get => EnumEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(EnumEntries, value);
+    }
+}
+
+public sealed partial class WorkflowConnectorCapabilityReadModel
+{
+    public IList<string> AllowedInputKeys
+    {
+        get => AllowedInputKeyEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(AllowedInputKeyEntries, value);
+    }
+
+    public IList<string> AllowedOperations
+    {
+        get => AllowedOperationEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(AllowedOperationEntries, value);
+    }
+
+    public IList<string> FixedArguments
+    {
+        get => FixedArgumentEntries;
+        set => WorkflowCatalogReadModelCollections.ReplaceCollection(FixedArgumentEntries, value);
+    }
+}
+
+internal static class WorkflowCatalogReadModelCollections
+{
+    public static void ReplaceCollection<T>(RepeatedField<T> target, IEnumerable<T>? source)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        target.Clear();
+        if (source == null)
+            return;
+
+        target.Add(source);
+    }
+
+    public static void ReplaceMap<TKey, TValue>(
+        MapField<TKey, TValue> target,
+        IEnumerable<KeyValuePair<TKey, TValue>>? source)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        target.Clear();
+        if (source == null)
+            return;
+
+        foreach (var (key, value) in source)
+            target[key] = value;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogClassificationPolicy.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogClassificationPolicy.cs
@@ -1,0 +1,150 @@
+namespace Aevatar.Workflow.Projection.Workflows;
+
+internal static class WorkflowCatalogClassificationPolicy
+{
+    private static readonly IReadOnlyDictionary<string, int> LegacyWorkflowIndexes =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["transform"] = 1,
+            ["guard"] = 2,
+            ["conditional"] = 3,
+            ["switch"] = 4,
+            ["assign"] = 5,
+            ["retrieve_facts"] = 6,
+            ["pipeline"] = 7,
+            ["llm_call"] = 8,
+            ["llm_chain"] = 9,
+            ["parallel"] = 10,
+            ["race"] = 11,
+            ["map_reduce"] = 12,
+            ["foreach"] = 13,
+            ["evaluate"] = 14,
+            ["reflect"] = 15,
+            ["cache"] = 16,
+            ["demo_template"] = 17,
+            ["demo_csv_markdown"] = 18,
+            ["demo_json_pick"] = 19,
+            ["role_event_module_template"] = 20,
+            ["role_event_module_csv_markdown"] = 21,
+            ["role_event_module_json_pick"] = 22,
+            ["role_event_module_multiplex_template"] = 23,
+            ["role_event_module_multiplex_csv"] = 24,
+            ["role_event_module_multiplex_json"] = 25,
+            ["role_event_module_multi_role_chain"] = 26,
+            ["role_event_module_extensions_template"] = 27,
+            ["role_event_module_extensions_csv"] = 28,
+            ["role_event_module_top_level_overrides_extensions"] = 29,
+            ["role_event_module_extensions_multi_role_chain"] = 30,
+            ["role_event_module_extensions_multiplex_json"] = 31,
+            ["role_event_module_top_level_overrides_extensions_multiplex"] = 32,
+            ["role_event_module_no_routes_template"] = 33,
+            ["role_event_module_route_dsl_csv"] = 34,
+            ["role_event_module_unknown_ignored_template"] = 35,
+            ["mixed_step_json_pick_then_role_template"] = 36,
+            ["mixed_step_csv_markdown_then_role_template"] = 37,
+            ["mixed_step_template_then_role_csv_markdown"] = 38,
+            ["human_input_basic_auto_resume"] = 39,
+            ["human_approval_approved_auto_resume"] = 40,
+            ["human_approval_rejected_fail_auto_resume"] = 41,
+            ["human_approval_rejected_skip_auto_resume"] = 42,
+            ["human_input_manual_triage"] = 43,
+            ["wait_signal_manual_success"] = 44,
+            ["wait_signal_timeout_failure"] = 45,
+            ["human_approval_release_gate"] = 46,
+            ["mixed_human_approval_wait_signal"] = 47,
+            ["subworkflow_level1"] = 48,
+            ["subworkflow_level2"] = 48,
+            ["subworkflow_level3"] = 48,
+            ["workflow_call_multilevel"] = 49,
+            ["connector_cli_demo"] = 50,
+            ["cli_call_alias"] = 51,
+            ["foreach_llm_alias"] = 52,
+            ["map_reduce_llm_alias"] = 53,
+            ["emit_publish_demo"] = 54,
+            ["tool_call_fallback_demo"] = 55,
+            ["delay_checkpoint_demo"] = 56,
+        };
+
+    public static WorkflowCatalogClassification Classify(
+        string workflowName,
+        string sourceKind,
+        string category)
+    {
+        var index = TryGetWorkflowIndex(workflowName);
+        var normalizedSource = sourceKind ?? string.Empty;
+
+        if (string.Equals(normalizedSource, "home", StringComparison.OrdinalIgnoreCase))
+            return new("your-workflows", "Your Workflows", index ?? 0, true, false, "Saved");
+
+        if (string.Equals(normalizedSource, "cwd", StringComparison.OrdinalIgnoreCase))
+            return new("your-workflows", "Your Workflows", index ?? 0, true, false, "Workspace");
+
+        if (string.Equals(normalizedSource, "turing", StringComparison.OrdinalIgnoreCase))
+        {
+            var turingOrder = workflowName.Contains("counter", StringComparison.OrdinalIgnoreCase) ? 901
+                : workflowName.Contains("minsky", StringComparison.OrdinalIgnoreCase) ? 902
+                : 999;
+            return new("advanced-patterns", "Advanced Patterns", turingOrder, true, false, "Advanced");
+        }
+
+        if (index is >= 1 and <= 7)
+            return new("primitive-examples", "Primitive Mini Examples", index.Value, false, true, "Mini");
+
+        if (index is >= 8 and <= 16)
+            return new("ai-workflows", "AI & Human Workflows", index.Value, true, false, "Starter");
+
+        if (index is >= 39 and <= 47)
+            return new("ai-workflows", "AI & Human Workflows", index.Value, true, false, "Interactive");
+
+        if (index is >= 50 and <= 67)
+            return new("integration-workflows", "Integrations & Tools", index.Value, true, false, "Integration");
+
+        if (index is >= 17 and <= 38 or 48 or 49)
+            return new("advanced-patterns", "Advanced Patterns", index.Value, true, false, "Advanced");
+
+        var sourceLabel = normalizedSource switch
+        {
+            "builtin" => "Built-in",
+            "app" => "Bundled",
+            "repo" => "Starter",
+            "demo" => "Starter",
+            _ => "Workflow",
+        };
+
+        return new(
+            "starter-workflows",
+            "Starter Workflows",
+            index ?? (string.Equals(category, "llm", StringComparison.OrdinalIgnoreCase) ? 100 : 200),
+            true,
+            false,
+            sourceLabel);
+    }
+
+    private static int? TryGetWorkflowIndex(string workflowName)
+    {
+        if (string.IsNullOrWhiteSpace(workflowName))
+            return null;
+
+        var normalizedName = workflowName.Trim();
+        if (LegacyWorkflowIndexes.TryGetValue(normalizedName, out var knownIndex))
+            return knownIndex;
+
+        var span = normalizedName.AsSpan();
+        var index = 0;
+        while (index < span.Length && char.IsDigit(span[index]))
+            index++;
+
+        if (index == 0 || index >= span.Length || span[index] != '_')
+            return null;
+
+        return int.TryParse(span[..index], out var value) ? value : null;
+    }
+}
+
+internal sealed record WorkflowCatalogClassification(
+    string Group,
+    string GroupLabel,
+    int SortOrder,
+    bool ShowInLibrary,
+    bool IsPrimitiveExample,
+    string SourceLabel);

--- a/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelMapper.cs
@@ -1,0 +1,165 @@
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using Aevatar.Workflow.Projection.ReadModels;
+
+namespace Aevatar.Workflow.Projection.Workflows;
+
+public sealed class WorkflowCatalogReadModelMapper
+{
+    public WorkflowCatalogItem ToCatalogItem(WorkflowCatalogCurrentStateDocument document) =>
+        new()
+        {
+            Name = document.WorkflowName,
+            Description = document.Description,
+            Category = document.Category,
+            Group = document.Group,
+            GroupLabel = document.GroupLabel,
+            SortOrder = document.SortOrder,
+            Source = document.Source,
+            SourceLabel = document.SourceLabel,
+            ShowInLibrary = document.ShowInLibrary,
+            IsPrimitiveExample = document.IsPrimitiveExample,
+            RequiresLlmProvider = document.RequiresLlmProvider,
+            Primitives = document.Primitives.ToList(),
+            AuthorityStateVersion = document.StateVersion,
+            ProjectionWatermark = document.UpdatedAt,
+            LastEventId = document.LastEventId,
+        };
+
+    public WorkflowCatalogItemDetail ToCatalogItemDetail(WorkflowCatalogCurrentStateDocument document) =>
+        new()
+        {
+            Catalog = ToCatalogItem(document),
+            Yaml = document.WorkflowYaml,
+            Definition = new WorkflowCatalogDefinition
+            {
+                Name = document.WorkflowName,
+                Description = document.Description,
+                ClosedWorldMode = document.ClosedWorldMode,
+                Roles = document.Roles.Select(ToCatalogRole).ToList(),
+                Steps = document.Steps.Select(ToCatalogStep).ToList(),
+            },
+            Edges = document.Edges.Select(edge => new WorkflowCatalogEdge
+            {
+                From = edge.From,
+                To = edge.To,
+                Label = edge.Label,
+            }).ToList(),
+        };
+
+    public WorkflowCapabilitiesDocument ToCapabilitiesDocument(
+        WorkflowCapabilitiesCurrentStateDocument capabilities,
+        IReadOnlyList<WorkflowCatalogCurrentStateDocument> workflows)
+    {
+        var workflowWatermark = workflows.Count == 0
+            ? default
+            : workflows.Max(workflow => workflow.UpdatedAt);
+        return new WorkflowCapabilitiesDocument
+        {
+            SchemaVersion = string.IsNullOrWhiteSpace(capabilities.SchemaVersion)
+                ? "capabilities.v1"
+                : capabilities.SchemaVersion,
+            GeneratedAtUtc = Max(capabilities.UpdatedAt, workflowWatermark),
+            AuthorityStateVersion = workflows.Count == 0
+                ? capabilities.StateVersion
+                : Math.Max(capabilities.StateVersion, workflows.Max(workflow => workflow.StateVersion)),
+            ProjectionWatermark = Max(capabilities.UpdatedAt, workflowWatermark),
+            Primitives = capabilities.Primitives.Select(ToPrimitiveCapability).ToList(),
+            Connectors = capabilities.Connectors.Select(ToConnectorCapability).ToList(),
+            Workflows = workflows
+                .OrderBy(workflow => workflow.WorkflowName, StringComparer.OrdinalIgnoreCase)
+                .Select(ToCapabilityWorkflow)
+                .ToList(),
+        };
+    }
+
+    private static WorkflowCatalogRole ToCatalogRole(WorkflowCatalogRoleReadModel role) =>
+        new()
+        {
+            Id = role.Id,
+            Name = role.Name,
+            SystemPrompt = role.SystemPrompt,
+            Provider = role.Provider,
+            Model = role.Model,
+            Temperature = role.Temperature,
+            MaxTokens = role.MaxTokens,
+            MaxToolRounds = role.MaxToolRounds,
+            MaxHistoryMessages = role.MaxHistoryMessages,
+            EventModules = role.EventModules.ToList(),
+            EventRoutes = role.EventRoutes,
+            Connectors = role.Connectors.ToList(),
+        };
+
+    private static WorkflowCatalogStep ToCatalogStep(WorkflowCatalogStepReadModel step) =>
+        new()
+        {
+            Id = step.Id,
+            Type = step.Type,
+            TargetRole = step.TargetRole,
+            Parameters = step.Parameters.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
+            Next = step.Next,
+            Branches = step.Branches.ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
+            Children = step.Children.Select(child => new WorkflowCatalogChildStep
+            {
+                Id = child.Id,
+                Type = child.Type,
+                TargetRole = child.TargetRole,
+            }).ToList(),
+        };
+
+    private static WorkflowCapabilityWorkflow ToCapabilityWorkflow(WorkflowCatalogCurrentStateDocument workflow) =>
+        new()
+        {
+            Name = workflow.WorkflowName,
+            Description = workflow.Description,
+            Source = workflow.Source,
+            ClosedWorldMode = workflow.ClosedWorldMode,
+            RequiresLlmProvider = workflow.RequiresLlmProvider,
+            Primitives = workflow.Primitives.ToList(),
+            RequiredConnectors = workflow.RequiredConnectors.ToList(),
+            WorkflowCalls = workflow.WorkflowCalls.ToList(),
+            Steps = workflow.Steps.Select(step => new WorkflowCapabilityWorkflowStep
+            {
+                Id = step.Id,
+                Type = step.Type,
+                Next = step.Next,
+            }).ToList(),
+            AuthorityStateVersion = workflow.StateVersion,
+            ProjectionWatermark = workflow.UpdatedAt,
+        };
+
+    private static WorkflowPrimitiveCapability ToPrimitiveCapability(WorkflowPrimitiveCapabilityReadModel primitive) =>
+        new()
+        {
+            Name = primitive.Name,
+            Aliases = primitive.Aliases.ToList(),
+            Category = primitive.Category,
+            Description = primitive.Description,
+            ClosedWorldBlocked = primitive.ClosedWorldBlocked,
+            RuntimeModule = primitive.RuntimeModule,
+            Parameters = primitive.Parameters.Select(parameter => new WorkflowPrimitiveParameterCapability
+            {
+                Name = parameter.Name,
+                Type = parameter.Type,
+                Required = parameter.Required,
+                Description = parameter.Description,
+                Default = parameter.DefaultValue,
+                Enum = parameter.Enum.ToList(),
+            }).ToList(),
+        };
+
+    private static WorkflowConnectorCapability ToConnectorCapability(WorkflowConnectorCapabilityReadModel connector) =>
+        new()
+        {
+            Name = connector.Name,
+            Type = connector.Type,
+            Enabled = connector.Enabled,
+            TimeoutMs = connector.TimeoutMs,
+            Retry = connector.Retry,
+            AllowedInputKeys = connector.AllowedInputKeys.ToList(),
+            AllowedOperations = connector.AllowedOperations.ToList(),
+            FixedArguments = connector.FixedArguments.ToList(),
+        };
+
+    private static DateTimeOffset Max(DateTimeOffset left, DateTimeOffset right) =>
+        left >= right ? left : right;
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelQueryPort.cs
@@ -1,0 +1,69 @@
+using Aevatar.Workflow.Application.Abstractions.Queries;
+using Aevatar.Workflow.Projection.ReadModels;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+
+namespace Aevatar.Workflow.Projection.Workflows;
+
+public sealed class WorkflowCatalogReadModelQueryPort : IWorkflowCatalogPort, IWorkflowCapabilitiesPort
+{
+    private const string CapabilitiesDocumentId = "workflow-capabilities";
+    private readonly IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string> _catalogReader;
+    private readonly IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string> _capabilitiesReader;
+    private readonly WorkflowCatalogReadModelMapper _mapper;
+
+    public WorkflowCatalogReadModelQueryPort(
+        IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string> catalogReader,
+        IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string> capabilitiesReader,
+        WorkflowCatalogReadModelMapper mapper)
+    {
+        _catalogReader = catalogReader ?? throw new ArgumentNullException(nameof(catalogReader));
+        _capabilitiesReader = capabilitiesReader ?? throw new ArgumentNullException(nameof(capabilitiesReader));
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+    }
+
+    // Refactor (iter46/issue-871-workflow-file-catalog-query-port):
+    //   Old pattern: Workflow catalog/capabilities query port discovered files, parsed YAML, loaded connector config, and cached results in singleton process memory during query execution.
+    //   New principle: WorkflowGAgent per-definition authority; query ports only read freshness-bearing readmodels; file discovery/parsing happens at startup/import time, not in query path.
+    public IReadOnlyList<WorkflowCatalogItem> ListWorkflowCatalog()
+    {
+        var documents = QueryCatalogDocuments();
+        return documents
+            .Select(_mapper.ToCatalogItem)
+            .OrderBy(item => item.Group, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.SortOrder)
+            .ThenBy(item => item.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public WorkflowCatalogItemDetail? GetWorkflowDetail(string workflowName)
+    {
+        if (string.IsNullOrWhiteSpace(workflowName))
+            return null;
+
+        var document = _catalogReader.GetAsync(workflowName.Trim()).Result;
+        return document == null
+            ? null
+            : _mapper.ToCatalogItemDetail(document);
+    }
+
+    public WorkflowCapabilitiesDocument GetCapabilities()
+    {
+        var capabilities = _capabilitiesReader.GetAsync(CapabilitiesDocumentId).Result
+            ?? new WorkflowCapabilitiesCurrentStateDocument
+            {
+                Id = CapabilitiesDocumentId,
+                ActorId = CapabilitiesDocumentId,
+                SchemaVersion = "capabilities.v1",
+            };
+        return _mapper.ToCapabilitiesDocument(capabilities, QueryCatalogDocuments());
+    }
+
+    private IReadOnlyList<WorkflowCatalogCurrentStateDocument> QueryCatalogDocuments()
+    {
+        var result = _catalogReader.QueryAsync(new ProjectionDocumentQuery
+        {
+            Take = 1000,
+        }).Result;
+        return result.Items;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
+++ b/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
@@ -105,3 +105,108 @@ message WorkflowExecutionSummary {
   int32 role_reply_count = 4;
   map<string, int32> step_type_counts_map = 5;
 }
+
+message WorkflowCatalogCurrentStateDocument {
+  string id = 1;
+  int64 state_version = 2;
+  string last_event_id = 3;
+  google.protobuf.Timestamp updated_at_utc_value = 4;
+  string actor_id = 5;
+  string workflow_name = 6;
+  string workflow_yaml = 7;
+  string description = 8;
+  string category = 9;
+  string group = 10;
+  string group_label = 11;
+  int32 sort_order = 12;
+  string source = 13;
+  string source_label = 14;
+  bool show_in_library = 15;
+  bool is_primitive_example = 16;
+  bool requires_llm_provider = 17;
+  repeated string primitive_entries = 18;
+  bool closed_world_mode = 19;
+  repeated WorkflowCatalogRoleReadModel role_entries = 20;
+  repeated WorkflowCatalogStepReadModel step_entries = 21;
+  repeated WorkflowCatalogEdgeReadModel edge_entries = 22;
+  repeated string required_connector_entries = 23;
+  repeated string workflow_call_entries = 24;
+}
+
+message WorkflowCatalogRoleReadModel {
+  string id = 1;
+  string name = 2;
+  string system_prompt = 3;
+  string provider = 4;
+  string model = 5;
+  google.protobuf.FloatValue temperature = 6;
+  google.protobuf.Int32Value max_tokens = 7;
+  google.protobuf.Int32Value max_tool_rounds = 8;
+  google.protobuf.Int32Value max_history_messages = 9;
+  repeated string event_module_entries = 10;
+  string event_routes = 11;
+  repeated string connector_entries = 12;
+}
+
+message WorkflowCatalogStepReadModel {
+  string id = 1;
+  string type = 2;
+  string target_role = 3;
+  map<string, string> parameter_entries = 4;
+  string next = 5;
+  map<string, string> branch_entries = 6;
+  repeated WorkflowCatalogChildStepReadModel child_entries = 7;
+}
+
+message WorkflowCatalogChildStepReadModel {
+  string id = 1;
+  string type = 2;
+  string target_role = 3;
+}
+
+message WorkflowCatalogEdgeReadModel {
+  string from = 1;
+  string to = 2;
+  string label = 3;
+}
+
+message WorkflowCapabilitiesCurrentStateDocument {
+  string id = 1;
+  int64 state_version = 2;
+  string last_event_id = 3;
+  google.protobuf.Timestamp updated_at_utc_value = 4;
+  string actor_id = 5;
+  string schema_version = 6;
+  repeated WorkflowPrimitiveCapabilityReadModel primitive_entries = 7;
+  repeated WorkflowConnectorCapabilityReadModel connector_entries = 8;
+}
+
+message WorkflowPrimitiveCapabilityReadModel {
+  string name = 1;
+  repeated string alias_entries = 2;
+  string category = 3;
+  string description = 4;
+  bool closed_world_blocked = 5;
+  string runtime_module = 6;
+  repeated WorkflowPrimitiveParameterCapabilityReadModel parameter_entries = 7;
+}
+
+message WorkflowPrimitiveParameterCapabilityReadModel {
+  string name = 1;
+  string type = 2;
+  bool required = 3;
+  string description = 4;
+  string default_value = 5;
+  repeated string enum_entries = 6;
+}
+
+message WorkflowConnectorCapabilityReadModel {
+  string name = 1;
+  string type = 2;
+  bool enabled = 3;
+  int32 timeout_ms = 4;
+  int32 retry = 5;
+  repeated string allowed_input_key_entries = 6;
+  repeated string allowed_operation_entries = 7;
+  repeated string fixed_argument_entries = 8;
+}

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
@@ -93,6 +93,14 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             services,
             configuration,
             static document => document.Id);
+        TryAddElasticsearchDocumentStore<WorkflowCatalogCurrentStateDocument>(
+            services,
+            configuration,
+            static document => document.Id);
+        TryAddElasticsearchDocumentStore<WorkflowCapabilitiesCurrentStateDocument>(
+            services,
+            configuration,
+            static document => document.Id);
     }
 
     private static void AddInMemoryDocumentStores(IServiceCollection services)
@@ -109,6 +117,14 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             services,
             static document => document.Id,
             static document => document.UpdatedAt);
+        TryAddInMemoryDocumentStore<WorkflowCatalogCurrentStateDocument>(
+            services,
+            static document => document.Id,
+            static document => document.UpdatedAt);
+        TryAddInMemoryDocumentStore<WorkflowCapabilitiesCurrentStateDocument>(
+            services,
+            static document => document.Id,
+            static document => document.UpdatedAt);
     }
 
     private static bool HasAllWorkflowDocumentReaders(
@@ -117,7 +133,9 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
     {
         return HasDocumentReaderForProvider<WorkflowExecutionCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<WorkflowRunInsightReportDocument>(services, providerKind)
-               && HasDocumentReaderForProvider<WorkflowActorBindingDocument>(services, providerKind);
+               && HasDocumentReaderForProvider<WorkflowActorBindingDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind)
+               && HasDocumentReaderForProvider<WorkflowCapabilitiesCurrentStateDocument>(services, providerKind);
     }
 
     private static bool HasAnyDocumentReader<TDocument>(IServiceCollection services)

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -12,12 +12,14 @@ using Aevatar.GAgentService.Hosting.DependencyInjection;
 using Aevatar.GAgentService.Hosting.Endpoints;
 using Aevatar.GAgentService.Projection.DependencyInjection;
 using Aevatar.GAgentService.Infrastructure.Adapters;
+using Aevatar.Bootstrap.Hosting;
 using Aevatar.Hosting;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Presentation.AGUI;
 using Aevatar.Studio.Projection.ReadModels;
+using Aevatar.Workflow.Projection.ReadModels;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Infrastructure.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
@@ -218,6 +220,60 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public async Task AddGAgentServiceCapabilityBundle_ShouldStartStandaloneWithoutMainnetWorkflowProviders()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Development,
+        });
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Host.UseDefaultServiceProvider(options =>
+        {
+            options.ValidateOnBuild = false;
+            options.ValidateScopes = false;
+        });
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["GAgentService:Demo:Enabled"] = "false",
+            ["Projection:Document:Providers:InMemory:Enabled"] = "true",
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+            ["Projection:Graph:Providers:InMemory:Enabled"] = "true",
+            ["Projection:Graph:Providers:Neo4j:Enabled"] = "false",
+            ["Projection:Policies:Environment"] = "Development",
+        });
+
+        builder.AddAevatarDefaultHost(options =>
+        {
+            options.ServiceName = "Aevatar.GAgentService.StandaloneStartup.Tests";
+            options.EnableConnectorBootstrap = false;
+            options.EnableHealthEndpoints = false;
+            options.MapRootHealthEndpoint = false;
+            options.EnableOpenApiDocument = false;
+            options.AutoMapCapabilities = false;
+        });
+        builder.AddGAgentServiceCapabilityBundle();
+
+        await using var app = builder.Build();
+        app.MapAevatarCapabilities();
+
+        await app.StartAsync();
+
+        app.Services.GetRequiredService<IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument>>()
+            .Should()
+            .NotBeNull();
+        app.Services.GetRequiredService<IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument>>()
+            .Should()
+            .NotBeNull();
+        var capabilitiesReader = app.Services.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string>>();
+        var capabilities = await capabilitiesReader.GetAsync(
+            "workflow-capabilities",
+            CancellationToken.None);
+
+        capabilities.Should().NotBeNull();
+        capabilities!.Id.Should().Be("workflow-capabilities");
+    }
+
+    [Fact]
     public void AddGAgentServiceCapabilityBundle_ShouldRejectNullBuilder()
     {
         WebApplicationBuilder? builder = null;
@@ -285,6 +341,8 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         using var provider = services.BuildServiceProvider();
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<UserConfigCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string>>().Should().NotBeNull();
         services.Count(x => x.ServiceType == typeof(IProjectionDocumentReader<ServiceCatalogReadModel, string>)).Should().Be(1);
     }
 
@@ -335,6 +393,10 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRevisionCatalogReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<GAgentRunTerminalReadModel, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string>>().Should().NotBeNull();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -4,6 +4,7 @@ using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Projection.Configuration;
 using Aevatar.Workflow.Projection.Orchestration;
 using Aevatar.Workflow.Projection.ReadModels;
+using Aevatar.Workflow.Projection.Workflows;
 using FluentAssertions;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
@@ -37,6 +38,62 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         snapshot.CompletionStatus.Should().Be(expected);
         snapshot.LastOutput.Should().Be("done");
         snapshot.LastError.Should().Be("err");
+    }
+
+    [Fact]
+    public void WorkflowCatalogReadModelQueryPort_ShouldOnlyReadAndMapReadModelDocuments()
+    {
+        var updatedAt = DateTimeOffset.Parse("2026-03-17T12:00:00+00:00");
+        var catalogReader = new RecordingDocumentReader<WorkflowCatalogCurrentStateDocument>
+        {
+            Item = BuildCatalogDocument("alpha", updatedAt),
+            Items =
+            [
+                BuildCatalogDocument("beta", updatedAt.AddMinutes(1), sortOrder: 2),
+                BuildCatalogDocument("alpha", updatedAt, sortOrder: 1),
+            ],
+        };
+        var capabilitiesReader = new RecordingDocumentReader<WorkflowCapabilitiesCurrentStateDocument>
+        {
+            Item = new WorkflowCapabilitiesCurrentStateDocument
+            {
+                Id = "workflow-capabilities",
+                ActorId = "workflow-capabilities",
+                StateVersion = 3,
+                LastEventId = "startup-materialization",
+                UpdatedAt = updatedAt.AddMinutes(2),
+                SchemaVersion = "capabilities.v1",
+                Primitives =
+                [
+                    new WorkflowPrimitiveCapabilityReadModel
+                    {
+                        Name = "assign",
+                        Category = "data",
+                    },
+                ],
+            },
+        };
+        var port = new WorkflowCatalogReadModelQueryPort(
+            catalogReader,
+            capabilitiesReader,
+            new WorkflowCatalogReadModelMapper());
+
+        var catalog = port.ListWorkflowCatalog();
+        var detail = port.GetWorkflowDetail("alpha");
+        var capabilities = port.GetCapabilities();
+
+        catalog.Select(x => x.Name).Should().Equal("alpha", "beta");
+        catalog[0].AuthorityStateVersion.Should().Be(11);
+        catalog[0].ProjectionWatermark.Should().Be(updatedAt);
+        detail.Should().NotBeNull();
+        detail!.Definition.Steps.Should().ContainSingle(step => step.Id == "start");
+        capabilities.Workflows.Should().HaveCount(2);
+        capabilities.AuthorityStateVersion.Should().Be(12);
+        capabilities.ProjectionWatermark.Should().Be(updatedAt.AddMinutes(2));
+        catalogReader.QueryCalls.Should().Be(2);
+        catalogReader.GetCalls.Should().Be(1);
+        capabilitiesReader.GetCalls.Should().Be(1);
+        capabilitiesReader.QueryCalls.Should().Be(0);
     }
 
     [Fact]
@@ -376,6 +433,38 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         RecordingDocumentReader<WorkflowExecutionCurrentStateDocument> CurrentStateReader,
         RecordingDocumentReader<WorkflowRunInsightReportDocument> ReportReader,
         RecordingProjectionGraphStore GraphStore);
+
+    private static WorkflowCatalogCurrentStateDocument BuildCatalogDocument(
+        string workflowName,
+        DateTimeOffset updatedAt,
+        int sortOrder = 1) =>
+        new()
+        {
+            Id = workflowName,
+            ActorId = $"workflow-definition:{workflowName}",
+            WorkflowName = workflowName,
+            WorkflowYaml = $"name: {workflowName}",
+            Description = "Workflow description",
+            Category = "deterministic",
+            Group = "starter-workflows",
+            GroupLabel = "Starter Workflows",
+            SortOrder = sortOrder,
+            Source = "repo",
+            SourceLabel = "Starter",
+            ShowInLibrary = true,
+            StateVersion = 10 + sortOrder,
+            LastEventId = $"evt-{sortOrder}",
+            UpdatedAt = updatedAt,
+            Primitives = ["assign"],
+            Steps =
+            [
+                new WorkflowCatalogStepReadModel
+                {
+                    Id = "start",
+                    Type = "assign",
+                },
+            ],
+        };
 
     private sealed class RecordingDocumentReader<TReadModel> : IProjectionDocumentReader<TReadModel, string>
         where TReadModel : class, IProjectionReadModel

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -68,7 +68,36 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
                     new WorkflowPrimitiveCapabilityReadModel
                     {
                         Name = "assign",
+                        Aliases = ["assign"],
                         Category = "data",
+                        Description = "Assigns a value.",
+                        RuntimeModule = "AssignModule",
+                        Parameters =
+                        [
+                            new WorkflowPrimitiveParameterCapabilityReadModel
+                            {
+                                Name = "target",
+                                Type = "string",
+                                Required = true,
+                                Description = "Target variable.",
+                                DefaultValue = "result",
+                                Enum = ["result"],
+                            },
+                        ],
+                    },
+                ],
+                Connectors =
+                [
+                    new WorkflowConnectorCapabilityReadModel
+                    {
+                        Name = "aevatar_cli",
+                        Type = "cli",
+                        Enabled = true,
+                        TimeoutMs = 1000,
+                        Retry = 1,
+                        AllowedInputKeys = ["prompt"],
+                        AllowedOperations = ["run"],
+                        FixedArguments = ["--json"],
                     },
                 ],
             },
@@ -87,13 +116,77 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         catalog[0].ProjectionWatermark.Should().Be(updatedAt);
         detail.Should().NotBeNull();
         detail!.Definition.Steps.Should().ContainSingle(step => step.Id == "start");
+        detail.Definition.Roles.Should().ContainSingle(role => role.Id == "operator");
+        detail.Definition.Roles[0].EventModules.Should().Equal("audit", "trace");
+        detail.Definition.Steps[0].Children.Should().ContainSingle(child => child.Id == "child");
+        detail.Edges.Should().ContainSingle(edge => edge.From == "start" && edge.To == "child" && edge.Label == "child");
         capabilities.Workflows.Should().HaveCount(2);
         capabilities.AuthorityStateVersion.Should().Be(12);
         capabilities.ProjectionWatermark.Should().Be(updatedAt.AddMinutes(2));
+        capabilities.Primitives.Should().ContainSingle(primitive =>
+            primitive.Name == "assign" &&
+            primitive.Parameters.Single().Default == "result");
+        capabilities.Connectors.Should().ContainSingle(connector =>
+            connector.Name == "aevatar_cli" &&
+            connector.FixedArguments.Single() == "--json");
         catalogReader.QueryCalls.Should().Be(2);
         catalogReader.GetCalls.Should().Be(1);
         capabilitiesReader.GetCalls.Should().Be(1);
         capabilitiesReader.QueryCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public void WorkflowCatalogReadModelQueryPort_WhenReadModelsAreMissing_ShouldReturnHonestDefaults()
+    {
+        var catalogReader = new RecordingDocumentReader<WorkflowCatalogCurrentStateDocument>();
+        var capabilitiesReader = new RecordingDocumentReader<WorkflowCapabilitiesCurrentStateDocument>();
+        var port = new WorkflowCatalogReadModelQueryPort(
+            catalogReader,
+            capabilitiesReader,
+            new WorkflowCatalogReadModelMapper());
+
+        port.GetWorkflowDetail("   ").Should().BeNull();
+        port.GetWorkflowDetail("missing").Should().BeNull();
+        var capabilities = port.GetCapabilities();
+
+        capabilities.SchemaVersion.Should().Be("capabilities.v1");
+        capabilities.AuthorityStateVersion.Should().Be(0);
+        capabilities.ProjectionWatermark.Should().Be(default);
+        capabilities.Workflows.Should().BeEmpty();
+        catalogReader.GetCalls.Should().Be(1);
+        catalogReader.QueryCalls.Should().Be(1);
+        capabilitiesReader.GetCalls.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("custom", "home", "deterministic", "your-workflows", 0, "Saved")]
+    [InlineData("custom", "cwd", "deterministic", "your-workflows", 0, "Workspace")]
+    [InlineData("counter-addition", "turing", "deterministic", "advanced-patterns", 901, "Advanced")]
+    [InlineData("minsky-inc-dec-jz", "turing", "deterministic", "advanced-patterns", 902, "Advanced")]
+    [InlineData("machine", "turing", "deterministic", "advanced-patterns", 999, "Advanced")]
+    [InlineData("transform", "builtin", "deterministic", "primitive-examples", 1, "Mini")]
+    [InlineData("llm_call", "builtin", "llm", "ai-workflows", 8, "Starter")]
+    [InlineData("human_input_basic_auto_resume", "builtin", "llm", "ai-workflows", 39, "Interactive")]
+    [InlineData("connector_cli_demo", "builtin", "llm", "integration-workflows", 50, "Integration")]
+    [InlineData("demo_template", "builtin", "deterministic", "advanced-patterns", 17, "Advanced")]
+    [InlineData("48_custom", "app", "deterministic", "advanced-patterns", 48, "Advanced")]
+    [InlineData("49_custom", "demo", "deterministic", "advanced-patterns", 49, "Advanced")]
+    [InlineData("custom", "repo", "llm", "starter-workflows", 100, "Starter")]
+    [InlineData("custom", "external", "deterministic", "starter-workflows", 200, "Workflow")]
+    [InlineData("", "builtin", "deterministic", "starter-workflows", 200, "Built-in")]
+    public void WorkflowCatalogClassificationPolicy_ShouldClassifyCatalogGroups(
+        string workflowName,
+        string sourceKind,
+        string category,
+        string expectedGroup,
+        int expectedSortOrder,
+        string expectedSourceLabel)
+    {
+        var classification = WorkflowCatalogClassificationPolicy.Classify(workflowName, sourceKind, category);
+
+        classification.Group.Should().Be(expectedGroup);
+        classification.SortOrder.Should().Be(expectedSortOrder);
+        classification.SourceLabel.Should().Be(expectedSourceLabel);
     }
 
     [Fact]
@@ -456,14 +549,55 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             LastEventId = $"evt-{sortOrder}",
             UpdatedAt = updatedAt,
             Primitives = ["assign"],
+            Roles =
+            [
+                new WorkflowCatalogRoleReadModel
+                {
+                    Id = "operator",
+                    Name = "Operator",
+                    SystemPrompt = "Operate.",
+                    Provider = "openai",
+                    Model = "gpt-test",
+                    Temperature = 0.1f,
+                    MaxTokens = 512,
+                    MaxToolRounds = 2,
+                    MaxHistoryMessages = 3,
+                    EventModules = ["audit", "trace"],
+                    EventRoutes = "route:*",
+                    Connectors = ["aevatar_cli"],
+                },
+            ],
             Steps =
             [
                 new WorkflowCatalogStepReadModel
                 {
                     Id = "start",
                     Type = "assign",
+                    TargetRole = "operator",
+                    Parameters = { ["target"] = "result" },
+                    Branches = { ["done"] = "child" },
+                    Children =
+                    [
+                        new WorkflowCatalogChildStepReadModel
+                        {
+                            Id = "child",
+                            Type = "assign",
+                            TargetRole = "operator",
+                        },
+                    ],
                 },
             ],
+            Edges =
+            [
+                new WorkflowCatalogEdgeReadModel
+                {
+                    From = "start",
+                    To = "child",
+                    Label = "child",
+                },
+            ],
+            RequiredConnectors = ["aevatar_cli"],
+            WorkflowCalls = ["child_workflow"],
         };
 
     private sealed class RecordingDocumentReader<TReadModel> : IProjectionDocumentReader<TReadModel, string>

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -1,7 +1,10 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Configuration;
 using Aevatar.Hosting;
+using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -14,6 +17,9 @@ using Aevatar.Workflow.Infrastructure.DependencyInjection;
 using Aevatar.Workflow.Infrastructure.Reporting;
 using Aevatar.Workflow.Infrastructure.Runs;
 using Aevatar.Workflow.Infrastructure.Workflows;
+using Aevatar.Workflow.Projection.ReadModels;
+using Aevatar.Workflow.Projection.Workflows;
+using Google.Protobuf;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -69,16 +75,11 @@ public sealed class WorkflowInfrastructureCoverageTests
         services.Should().Contain(x => x.ServiceType == typeof(FileBackedWorkflowCatalogPort));
         services.Should().Contain(x => x.ServiceType == typeof(IWorkflowCatalogPort));
         services.Should().Contain(x => x.ServiceType == typeof(IWorkflowCapabilitiesPort));
+        services.Should().Contain(x => x.ImplementationFactory != null &&
+            x.ServiceType == typeof(IWorkflowCatalogPort));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IHostedService) &&
             x.ImplementationType == typeof(WorkflowDefinitionBootstrapHostedService));
-
-        using var provider = services.BuildServiceProvider();
-        var catalogPort = provider.GetRequiredService<IWorkflowCatalogPort>();
-        var capabilitiesPort = provider.GetRequiredService<IWorkflowCapabilitiesPort>();
-        catalogPort.Should().BeOfType<FileBackedWorkflowCatalogPort>();
-        capabilitiesPort.Should().BeOfType<FileBackedWorkflowCatalogPort>();
-        catalogPort.Should().BeSameAs(capabilitiesPort);
     }
 
     [Fact]
@@ -100,57 +101,30 @@ public sealed class WorkflowInfrastructureCoverageTests
     }
 
     [Fact]
-    public void FileBackedWorkflowCatalogPort_ShouldReturnCatalogAndDetail()
+    public async Task FileBackedWorkflowCatalogPort_ShouldMaterializeStartupDefinitions()
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), "aevatar-workflow-catalog-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDir);
-        try
-        {
-            var yamlPath = Path.Combine(tempDir, "repo_install.yaml");
-            File.WriteAllText(yamlPath, """
-            name: repo_install
-            description: Bootstrap runtime.
-            roles:
-              - id: operator
-                name: Operator
-                system_prompt: ""
-            steps:
-              - id: bootstrap
-                type: assign
-                parameters:
-                  target: result
-                  value: "ok"
-            """);
+        var runtime = new RecordingActorRuntime();
+        var dispatch = new RecordingActorDispatchPort();
+        var port = new FileBackedWorkflowCatalogPort(
+            runtime,
+            dispatch,
+            NullLogger<FileBackedWorkflowCatalogPort>.Instance);
 
-            var options = new WorkflowDefinitionFileSourceOptions();
-            options.WorkflowDirectories.Add(tempDir);
+        await port.MaterializeAsync(
+        [
+            new WorkflowDefinitionRegistration(
+                "repo_install",
+                "name: repo_install",
+                "workflow-definition:repo_install",
+                "repo"),
+        ]);
 
-            var registry = new WorkflowDefinitionCatalog();
-            registry.Register("direct", WorkflowDefinitionCatalog.BuiltInDirectYaml);
-            registry.Register("repo_install", File.ReadAllText(yamlPath));
-
-            var port = new FileBackedWorkflowCatalogPort(registry, Options.Create(options));
-
-            var catalog = port.ListWorkflowCatalog();
-            catalog.Should().Contain(item => item.Name == "repo_install" && item.Source == "file");
-            catalog.Should().Contain(item => item.Name == "direct" && item.Source == "builtin");
-
-            var detail = port.GetWorkflowDetail("repo_install");
-            detail.Should().NotBeNull();
-            detail!.Catalog.Name.Should().Be("repo_install");
-            detail.Catalog.RequiresLlmProvider.Should().BeFalse();
-            detail.Definition.Description.Should().Be("Bootstrap runtime.");
-            detail.Definition.Steps.Should().ContainSingle(step => step.Id == "bootstrap");
-
-            var capabilities = port.GetCapabilities();
-            capabilities.SchemaVersion.Should().Be("capabilities.v1");
-            capabilities.Workflows.Should().Contain(item => item.Name == "repo_install");
-            capabilities.Primitives.Should().Contain(item => item.Name == "assign");
-        }
-        finally
-        {
-            TryDeleteDirectory(tempDir);
-        }
+        runtime.Created.Should().ContainSingle(x => x.ActorId == "workflow-definition:repo_install" && x.AgentType == typeof(Aevatar.Workflow.Core.WorkflowGAgent));
+        dispatch.Envelopes.Should().ContainSingle();
+        var request = dispatch.Envelopes[0].Envelope.Payload!.Unpack<Aevatar.Workflow.Abstractions.BindWorkflowDefinitionEvent>();
+        request.WorkflowName.Should().Be("repo_install");
+        request.WorkflowYaml.Should().Be("name: repo_install");
+        request.SourceKind.Should().Be("repo");
     }
 
     [Fact]
@@ -306,6 +280,13 @@ public sealed class WorkflowInfrastructureCoverageTests
             var service = new WorkflowDefinitionBootstrapHostedService(
                 registry,
                 new WorkflowDefinitionFileLoader(),
+                new FileBackedWorkflowCatalogPort(
+                    new RecordingActorRuntime(),
+                    new RecordingActorDispatchPort(),
+                    NullLogger<FileBackedWorkflowCatalogPort>.Instance),
+                new WorkflowCapabilitiesStartupMaterializer(
+                    new RecordingCapabilitiesWriteDispatcher(),
+                    []),
                 Options.Create(options),
                 NullLogger<WorkflowDefinitionBootstrapHostedService>.Instance);
 
@@ -333,6 +314,72 @@ public sealed class WorkflowInfrastructureCoverageTests
             ct.ThrowIfCancellationRequested();
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class RecordingActorRuntime : IActorRuntime
+    {
+        public List<(string ActorId, Type AgentType)> Created { get; } = [];
+
+        public Task<IActor> CreateAsync<TAgent>(string? id = null, CancellationToken ct = default)
+            where TAgent : IAgent =>
+            CreateAsync(typeof(TAgent), id, ct);
+
+        public Task<IActor> CreateAsync(Type agentType, string? id = null, CancellationToken ct = default)
+        {
+            var actorId = id ?? Guid.NewGuid().ToString("N");
+            Created.Add((actorId, agentType));
+            return Task.FromResult<IActor>(new RecordingActor(actorId));
+        }
+
+        public Task DestroyAsync(string id, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<IActor?> GetAsync(string id) => Task.FromResult<IActor?>(null);
+        public Task<bool> ExistsAsync(string id) => Task.FromResult(false);
+        public Task LinkAsync(string parentId, string childId, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UnlinkAsync(string childId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Envelopes { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Envelopes.Add((actorId, envelope));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingActor : IActor
+    {
+        public RecordingActor(string id)
+        {
+            Id = id;
+        }
+
+        public string Id { get; }
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingCapabilitiesWriteDispatcher
+        : IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument>
+    {
+        public WorkflowCapabilitiesCurrentStateDocument? LastWritten { get; private set; }
+
+        public Task<ProjectionWriteResult> UpsertAsync(
+            WorkflowCapabilitiesCurrentStateDocument readModel,
+            CancellationToken ct = default)
+        {
+            LastWritten = readModel;
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
+            Task.FromResult(ProjectionWriteResult.Applied());
     }
 
     private static WorkflowRunReport BuildReport()

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -5,10 +5,14 @@ using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Configuration;
 using Aevatar.Hosting;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Workflow.Application.Abstractions.Queries;
 using Aevatar.Workflow.Application.Abstractions.Reporting;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
+using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core;
+using Aevatar.Workflow.Core.Composition;
 using Aevatar.Workflow.Application.Queries;
 using Aevatar.Workflow.Application.Reporting;
 using Aevatar.Workflow.Application.Workflows;
@@ -306,6 +310,107 @@ public sealed class WorkflowInfrastructureCoverageTests
         }
     }
 
+    [Fact]
+    public async Task WorkflowCapabilitiesStartupMaterializer_ShouldMaterializePrimitiveAndConnectorReadModels()
+    {
+        var tempHome = Path.Combine(Path.GetTempPath(), "wf-capabilities-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempHome);
+        var previousHome = Environment.GetEnvironmentVariable(AevatarPaths.HomeEnv);
+        Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, tempHome);
+        try
+        {
+            await File.WriteAllTextAsync(
+                AevatarPaths.ConnectorsJson,
+                """
+                {
+                  "connectors": [
+                    {
+                      "name": "http_news",
+                      "type": " HTTP ",
+                      "enabled": true,
+                      "timeoutMs": 5000,
+                      "retry": 2,
+                      "http": {
+                        "allowedInputKeys": [" query ", "query", "", "limit"],
+                        "allowedMethods": ["POST", "get", "GET"]
+                      }
+                    },
+                    {
+                      "name": "cli_runner",
+                      "type": "cli",
+                      "enabled": true,
+                      "cli": {
+                        "allowedInputKeys": ["prompt"],
+                        "allowedOperations": ["run", "RUN"],
+                        "fixedArguments": [" --json ", "--json", ""]
+                      }
+                    },
+                    {
+                      "name": "mcp_tools",
+                      "type": "mcp",
+                      "enabled": true,
+                      "mcp": {
+                        "allowedInputKeys": ["topic"],
+                        "allowedTools": ["search", ""],
+                        "defaultTool": "search"
+                      }
+                    },
+                    {
+                      "name": "custom_sink",
+                      "type": "custom",
+                      "enabled": true
+                    }
+                  ]
+                }
+                """);
+            var writer = new RecordingCapabilitiesWriteDispatcher();
+            var materializer = new WorkflowCapabilitiesStartupMaterializer(
+                writer,
+                [new CustomModulePack()]);
+
+            await materializer.MaterializeAsync(CancellationToken.None);
+
+            writer.LastWritten.Should().NotBeNull();
+            var document = writer.LastWritten!;
+            document.Id.Should().Be(WorkflowCapabilitiesStartupMaterializer.DocumentId);
+            document.Primitives.Should().Contain(primitive =>
+                primitive.Name == "custom_assign" &&
+                primitive.Aliases.Contains("custom_assign") &&
+                primitive.RuntimeModule == nameof(CustomAssignModule));
+            document.Connectors.Select(connector => connector.Name)
+                .Should().Equal("cli_runner", "custom_sink", "http_news", "mcp_tools");
+            document.Connectors.Single(connector => connector.Name == "http_news")
+                .AllowedInputKeys.Should().Equal("limit", "query");
+            document.Connectors.Single(connector => connector.Name == "http_news")
+                .AllowedOperations.Should().Equal("get", "POST");
+            document.Connectors.Single(connector => connector.Name == "cli_runner")
+                .FixedArguments.Should().Equal("--json");
+            document.Connectors.Single(connector => connector.Name == "mcp_tools")
+                .AllowedOperations.Should().Equal("search");
+            document.Connectors.Single(connector => connector.Name == "custom_sink")
+                .AllowedOperations.Should().BeEmpty();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, previousHome);
+            TryDeleteDirectory(tempHome);
+        }
+    }
+
+    [Fact]
+    public async Task WorkflowCapabilitiesStartupMaterializer_ShouldHonorCancellation()
+    {
+        var writer = new RecordingCapabilitiesWriteDispatcher();
+        var materializer = new WorkflowCapabilitiesStartupMaterializer(writer, []);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = async () => await materializer.MaterializeAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        writer.LastWritten.Should().BeNull();
+    }
+
     private sealed class FakeReportExporter : IWorkflowRunReportExportPort
     {
         public Task ExportAsync(WorkflowRunReport report, CancellationToken ct = default)
@@ -380,6 +485,26 @@ public sealed class WorkflowInfrastructureCoverageTests
 
         public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
             Task.FromResult(ProjectionWriteResult.Applied());
+    }
+
+    private sealed class CustomModulePack : IWorkflowModulePack
+    {
+        public string Name => "custom";
+        public IReadOnlyList<WorkflowModuleRegistration> Modules =>
+        [
+            WorkflowModuleRegistration.Create<CustomAssignModule>("custom_assign", "   "),
+        ];
+        public IReadOnlyList<IWorkflowModuleDependencyExpander> DependencyExpanders => [];
+        public IReadOnlyList<IWorkflowModuleConfigurator> Configurators => [];
+    }
+
+    private sealed class CustomAssignModule : IEventModule<IWorkflowExecutionContext>
+    {
+        public string Name => "custom_assign";
+        public int Priority => 0;
+        public bool CanHandle(EventEnvelope envelope) => false;
+        public Task HandleAsync(EventEnvelope envelope, IWorkflowExecutionContext ctx, CancellationToken ct) =>
+            Task.CompletedTask;
     }
 
     private static WorkflowRunReport BuildReport()

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
@@ -97,6 +97,50 @@ public sealed class WorkflowProjectionMaterializationTests
     }
 
     [Fact]
+    public async Task WorkflowCatalogCurrentStateProjector_ShouldProjectDefinitionReadModelWithFreshness()
+    {
+        var store = new RecordingDocumentStore<WorkflowCatalogCurrentStateDocument>(x => x.Id);
+        var projector = new WorkflowCatalogCurrentStateProjector(
+            store,
+            new FixedClock(DateTimeOffset.Parse("2026-03-17T10:00:00+00:00")));
+        var context = new WorkflowBindingProjectionContext
+        {
+            RootActorId = "workflow-definition:repo_install",
+            ProjectionKind = "workflow-binding",
+        };
+
+        await projector.ProjectAsync(context, new EventEnvelope());
+        await projector.ProjectAsync(
+            context,
+            BuildDefinitionCommittedEnvelope(
+                7,
+                new BindWorkflowDefinitionEvent
+                {
+                    WorkflowName = "repo_install",
+                    WorkflowYaml = BuildDefinitionYaml("repo_install"),
+                    SourceKind = "repo",
+                },
+                new WorkflowState
+                {
+                    WorkflowName = "repo_install",
+                    WorkflowYaml = BuildDefinitionYaml("repo_install"),
+                    SourceKind = "repo",
+                    Compiled = true,
+                }));
+
+        store.UpsertCount.Should().Be(1);
+        store.Stored.Should().ContainKey("repo_install");
+        var document = store.Stored["repo_install"];
+        document.ActorId.Should().Be("workflow-definition:repo_install");
+        document.StateVersion.Should().Be(7);
+        document.LastEventId.Should().Be("definition-evt-7");
+        document.UpdatedAt.Should().Be(DateTimeOffset.Parse("2026-03-17T11:07:00+00:00"));
+        document.Source.Should().Be("repo");
+        document.Primitives.Should().Contain("assign");
+        document.Steps.Should().ContainSingle(step => step.Id == "bootstrap");
+    }
+
+    [Fact]
     public async Task WorkflowRunInsightReportArtifactProjector_ShouldTrackLifecycleReplyAndCompletionBranches()
     {
         var store = new RecordingDocumentStore<WorkflowRunInsightReportDocument>(x => x.Id);
@@ -493,6 +537,46 @@ public sealed class WorkflowProjectionMaterializationTests
             }),
         };
     }
+
+    private static EventEnvelope BuildDefinitionCommittedEnvelope(
+        long version,
+        IMessage payload,
+        WorkflowState state)
+    {
+        var timestamp = DateTimeOffset.Parse($"2026-03-17T11:{version:00}:00+00:00");
+        return new EventEnvelope
+        {
+            Id = $"definition-outer-{version}",
+            Timestamp = Timestamp.FromDateTimeOffset(timestamp),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = $"definition-evt-{version}",
+                    Version = version,
+                    Timestamp = Timestamp.FromDateTimeOffset(timestamp),
+                    EventData = Any.Pack(payload),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+    }
+
+    private static string BuildDefinitionYaml(string name) =>
+        $"""
+        name: {name}
+        description: Bootstrap runtime.
+        roles:
+          - id: operator
+            name: Operator
+            system_prompt: ""
+        steps:
+          - id: bootstrap
+            type: assign
+            parameters:
+              target: result
+              value: "ok"
+        """;
 
     private static WorkflowRunState BuildState(
         string status,

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowProjectionMaterializationTests.cs
@@ -141,6 +141,78 @@ public sealed class WorkflowProjectionMaterializationTests
     }
 
     [Fact]
+    public async Task WorkflowCatalogCurrentStateProjector_ShouldProjectGraphAndDependencyBranches()
+    {
+        var store = new RecordingDocumentStore<WorkflowCatalogCurrentStateDocument>(x => x.Id);
+        var projector = new WorkflowCatalogCurrentStateProjector(
+            store,
+            new FixedClock(DateTimeOffset.Parse("2026-03-17T10:00:00+00:00")));
+        var context = new WorkflowBindingProjectionContext
+        {
+            RootActorId = "workflow-definition:complex",
+            ProjectionKind = "workflow-binding",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildDefinitionCommittedEnvelope(
+                8,
+                new BindWorkflowDefinitionEvent
+                {
+                    WorkflowName = "complex",
+                    WorkflowYaml = BuildComplexDefinitionYaml("complex"),
+                },
+                new WorkflowState
+                {
+                    WorkflowName = " complex ",
+                    WorkflowYaml = BuildComplexDefinitionYaml("complex"),
+                    Compiled = true,
+                }));
+        await projector.ProjectAsync(
+            context,
+            BuildDefinitionCommittedEnvelope(
+                9,
+                new BindWorkflowDefinitionEvent
+                {
+                    WorkflowName = "blank",
+                    WorkflowYaml = "",
+                },
+                new WorkflowState
+                {
+                    WorkflowName = "   ",
+                    WorkflowYaml = BuildComplexDefinitionYaml("blank"),
+                }));
+        await projector.ProjectAsync(
+            context,
+            BuildDefinitionCommittedEnvelope(
+                10,
+                new WorkflowCompletedEvent(),
+                new WorkflowState
+                {
+                    WorkflowName = "ignored",
+                    WorkflowYaml = BuildComplexDefinitionYaml("ignored"),
+                }));
+
+        store.UpsertCount.Should().Be(1);
+        var document = store.Stored["complex"];
+        document.Source.Should().Be("builtin");
+        document.Category.Should().Be("llm");
+        document.RequiresLlmProvider.Should().BeFalse();
+        document.Primitives.Should().Contain(["conditional", "connector_call", "foreach", "llm_call", "workflow_call"]);
+        document.RequiredConnectors.Should().Equal("aevatar_cli", "mcp_tools");
+        document.WorkflowCalls.Should().Equal("child_workflow");
+        document.Roles.Should().ContainSingle(role => role.Id == "operator");
+        document.Roles[0].EventModules.Should().Equal("audit", "trace");
+        document.Steps.Should().Contain(step => step.Id == "child_llm" && step.TargetRole == "operator");
+        document.Steps.Should().Contain(step =>
+            step.Id == "fanout" &&
+            step.Children.Single().Id == "child_llm");
+        document.Edges.Should().Contain(edge => edge.From == "decide" && edge.To == "call_connector" && edge.Label == "true");
+        document.Edges.Should().Contain(edge => edge.From == "call_connector" && edge.To == "call_child");
+        document.Edges.Should().Contain(edge => edge.From == "fanout" && edge.To == "child_llm" && edge.Label == "child");
+    }
+
+    [Fact]
     public async Task WorkflowRunInsightReportArtifactProjector_ShouldTrackLifecycleReplyAndCompletionBranches()
     {
         var store = new RecordingDocumentStore<WorkflowRunInsightReportDocument>(x => x.Id);
@@ -576,6 +648,55 @@ public sealed class WorkflowProjectionMaterializationTests
             parameters:
               target: result
               value: "ok"
+        """;
+
+    private static string BuildComplexDefinitionYaml(string name) =>
+        $"""
+        name: {name}
+        description: Complex runtime.
+        roles:
+          - id: operator
+            name: Operator
+            system_prompt: "Operate."
+            provider: openai
+            model: gpt-test
+            temperature: 0.2
+            max_tokens: 128
+            max_tool_rounds: 2
+            max_history_messages: 3
+            event_modules: "audit, trace, audit"
+            event_routes: "route:*"
+            connectors:
+              - aevatar_cli
+        steps:
+          - id: decide
+            type: conditional
+            parameters:
+              condition: "ready"
+            branches:
+              true:
+                next: call_connector
+              false:
+                next: fanout
+          - id: call_connector
+            type: connector_call
+            target_role: operator
+            parameters:
+              connector: mcp_tools
+              operation: search
+            next: call_child
+          - id: call_child
+            type: workflow_call
+            workflow: child_workflow
+            next: fanout
+          - id: fanout
+            type: foreach
+            sub_step_type: llm_call
+            children:
+              - id: child_llm
+                type: llm_call
+                target_role: operator
+                prompt: "Summarize."
         """;
 
     private static WorkflowRunState BuildState(

--- a/tools/ci/workflow_catalog_query_port_guard.sh
+++ b/tools/ci/workflow_catalog_query_port_guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+query_hits="$(
+  rg -n "Directory\\.EnumerateFiles|WorkflowParser\\.Parse|AevatarConnectorConfig\\.LoadConnectors|_cacheLock|_workflowFileDiscoveryCache|_parsedWorkflowCache|lock\\s*\\(" \
+    src/workflow/Aevatar.Workflow.Application/Queries \
+    src/workflow/Aevatar.Workflow.Projection/Workflows \
+    -g '*.cs' \
+    | rg -v "Refactor \\(iter46/issue-871-workflow-file-catalog-query-port\\)|Old pattern:|New principle:" \
+    || true
+)"
+
+legacy_port_hits="$(
+  rg -n "class FileBackedWorkflowCatalogPort\\s*:\\s*IWorkflowCatalogPort|class FileBackedWorkflowCatalogPort\\s*:\\s*IWorkflowCapabilitiesPort" \
+    src/workflow/Aevatar.Workflow.Infrastructure/Workflows/FileBackedWorkflowCatalogPort.cs \
+    || true
+)"
+
+if [[ -n "${query_hits}${legacy_port_hits}" ]]; then
+  if [[ -n "${query_hits}" ]]; then
+    echo "${query_hits}"
+  fi
+  if [[ -n "${legacy_port_hits}" ]]; then
+    echo "${legacy_port_hits}"
+    echo "FileBackedWorkflowCatalogPort must not be an online workflow catalog/capabilities query source."
+  fi
+  echo "Workflow catalog/capabilities query ports must only read freshness-bearing readmodels; file discovery/parsing/connector loading belongs to startup/import materialization."
+  exit 1
+fi
+
+echo "Workflow catalog query port guard passed."


### PR DESCRIPTION
## 摘要

Closes #871 — Phase 9 r1 consensus(unanimous):WorkflowGAgent 为 per-definition authority,file-backed YAML 仅 startup/import 输入,online catalog/capabilities queries 走 freshness-bearing readmodel。

## 改动

- 删 `FileBackedWorkflowCatalogPort` 作为 online 查询源
- discovery / parsing / connector loading 移到 startup/import materialization
- WorkflowGAgent committed definition state → catalog/capability readmodels(权威 version / projection watermark)
- query ports 只 map/sort readmodel documents
- 加 guard 防 `Directory.EnumerateFiles` / `WorkflowParser.Parse` / `AevatarConnectorConfig.LoadConnectors` / `_cacheLock` / `_workflowFileDiscoveryCache` / `_parsedWorkflowCache` in workflow query ports

## 验证

- architecture_guards / test_stability_guards / query_projection_priming_guard / workflow_catalog_query_port_guard 全 PASS

⟦AI:AUTO-LOOP⟧