### PR TITLE
iter51 issue-898 projection-attach-existing-side-read: typed lease lookup + 4 ports + recurrence guard

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdChatProjectionSession.cs
@@ -80,18 +80,21 @@ public sealed class NyxIdChatSessionProjectionPort
     : EventSinkProjectionLifecyclePortBase<INyxIdChatSessionProjectionLease, NyxIdChatSessionRuntimeLease, AGUIEvent>,
       INyxIdChatSessionProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<NyxIdChatSessionRuntimeLease> _attachExistingLeaseLookup;
 
     public NyxIdChatSessionProjectionPort(
         IProjectionScopeActivationService<NyxIdChatSessionRuntimeLease> activationService,
         IProjectionScopeReleaseService<NyxIdChatSessionRuntimeLease> releaseService,
         IProjectionSessionEventHub<AGUIEvent> sessionEventHub,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<NyxIdChatSessionRuntimeLease> attachExistingLeaseLookup)
         : base(static () => true, activationService, releaseService, sessionEventHub)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
+    // Refactor (iter51/issue-898-projection-attach-existing-side-read):
+    //   Old pattern: Feature projection ports duplicated IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()) for attach-existing checks (post-#884 #884 fixed 3 ports but more remained).
+    //   New principle: All attach-existing lease lookups go through typed IProjectionScopeAttachExistingLeaseLookup<TLease>; CI guard prevents recurrence.
     // Refactor (iter45/issue-867-session-projection-ensure-surface):
     //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
     //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
@@ -111,20 +114,16 @@ public sealed class NyxIdChatSessionProjectionPort
             return null;
         }
 
-        var scopeKey = new ProjectionRuntimeScopeKey(
-            actorId,
-            NyxIdChatProjectionKinds.ChatSession,
-            ProjectionRuntimeMode.SessionObservation,
-            sessionId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
-            return null;
-
-        var lease = new NyxIdChatSessionRuntimeLease(new NyxIdChatSessionProjectionContext
+        var lease = await _attachExistingLeaseLookup.TryGetAsync(new ProjectionScopeStartRequest
         {
             RootActorId = actorId,
             ProjectionKind = NyxIdChatProjectionKinds.ChatSession,
+            Mode = ProjectionRuntimeMode.SessionObservation,
             SessionId = sessionId,
-        });
+        }, ct).ConfigureAwait(false);
+        if (lease == null)
+            return null;
+
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
         return liveSinkLease == null
             ? null

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionPort.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyRoomSessionProjectionPort.cs
@@ -1,7 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
 
 namespace Aevatar.GAgents.StreamingProxy;
 
@@ -12,20 +11,20 @@ public sealed class StreamingProxyRoomSessionProjectionPort
     : EventSinkProjectionLifecyclePortBase<IStreamingProxyRoomSessionProjectionLease, StreamingProxyRoomSessionRuntimeLease, StreamingProxyRoomSessionEnvelope>,
       IStreamingProxyRoomSessionProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<StreamingProxyRoomSessionRuntimeLease> _attachExistingLeaseLookup;
 
     public StreamingProxyRoomSessionProjectionPort(
         IProjectionScopeActivationService<StreamingProxyRoomSessionRuntimeLease> activationService,
         IProjectionScopeReleaseService<StreamingProxyRoomSessionRuntimeLease> releaseService,
         IProjectionSessionEventHub<StreamingProxyRoomSessionEnvelope> sessionEventHub,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<StreamingProxyRoomSessionRuntimeLease> attachExistingLeaseLookup)
         : base(
             static () => true,
             activationService,
             releaseService,
             sessionEventHub)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
     // Refactor (iter45/issue-867-session-projection-ensure-surface):
@@ -79,20 +78,19 @@ public sealed class StreamingProxyRoomSessionProjectionPort
             return null;
         }
 
-        var scopeKey = new ProjectionRuntimeScopeKey(
-            actorId,
-            projectionKind,
-            ProjectionRuntimeMode.SessionObservation,
-            sessionId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
-            return null;
-
-        var lease = new StreamingProxyRoomSessionRuntimeLease(new StreamingProxyRoomSessionProjectionContext
+        // Refactor (iter51/issue-898-projection-attach-existing-side-read):
+        //   Old pattern: Feature projection ports duplicated IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()) for attach-existing checks (post-#884 #884 fixed 3 ports but more remained).
+        //   New principle: All attach-existing lease lookups go through typed IProjectionScopeAttachExistingLeaseLookup<TLease>; CI guard prevents recurrence.
+        var lease = await _attachExistingLeaseLookup.TryGetAsync(new ProjectionScopeStartRequest
         {
             RootActorId = actorId,
             ProjectionKind = projectionKind,
+            Mode = ProjectionRuntimeMode.SessionObservation,
             SessionId = sessionId,
-        });
+        }, ct).ConfigureAwait(false);
+        if (lease == null)
+            return null;
+
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
         return liveSinkLease == null
             ? null

--- a/src/Aevatar.Scripting.Projection/Orchestration/ScriptEvolutionProjectionPort.cs
+++ b/src/Aevatar.Scripting.Projection/Orchestration/ScriptEvolutionProjectionPort.cs
@@ -1,7 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Abstractions.Evolution;
 using Aevatar.Scripting.Projection.Configuration;
@@ -12,21 +11,21 @@ public sealed class ScriptEvolutionProjectionPort
     : EventSinkProjectionLifecyclePortBase<IScriptEvolutionProjectionLease, ScriptEvolutionRuntimeLease, ScriptEvolutionSessionCompletedEvent>,
       IScriptEvolutionProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<ScriptEvolutionRuntimeLease> _attachExistingLeaseLookup;
 
     public ScriptEvolutionProjectionPort(
         ScriptEvolutionProjectionOptions options,
         IProjectionScopeActivationService<ScriptEvolutionRuntimeLease> activationService,
         IProjectionScopeReleaseService<ScriptEvolutionRuntimeLease> releaseService,
         IProjectionSessionEventHub<ScriptEvolutionSessionCompletedEvent> sessionEventHub,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<ScriptEvolutionRuntimeLease> attachExistingLeaseLookup)
         : base(
             () => options?.Enabled ?? false,
             activationService,
             releaseService,
             sessionEventHub)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
     public Task<IScriptEvolutionProjectionLease?> EnsureActorProjectionAsync(
@@ -63,20 +62,19 @@ public sealed class ScriptEvolutionProjectionPort
             return null;
         }
 
-        var scopeKey = new ProjectionRuntimeScopeKey(
-            sessionActorId,
-            ScriptProjectionKinds.EvolutionSession,
-            ProjectionRuntimeMode.SessionObservation,
-            proposalId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
-            return null;
-
-        var lease = new ScriptEvolutionRuntimeLease(new ScriptEvolutionSessionProjectionContext
+        // Refactor (iter51/issue-898-projection-attach-existing-side-read):
+        //   Old pattern: Feature projection ports duplicated IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()) for attach-existing checks (post-#884 #884 fixed 3 ports but more remained).
+        //   New principle: All attach-existing lease lookups go through typed IProjectionScopeAttachExistingLeaseLookup<TLease>; CI guard prevents recurrence.
+        var lease = await _attachExistingLeaseLookup.TryGetAsync(new ProjectionScopeStartRequest
         {
             RootActorId = sessionActorId,
             ProjectionKind = ScriptProjectionKinds.EvolutionSession,
+            Mode = ProjectionRuntimeMode.SessionObservation,
             SessionId = proposalId,
-        });
+        }, ct).ConfigureAwait(false);
+        if (lease == null)
+            return null;
+
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
         return liveSinkLease == null
             ? null

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionProjectionPort.cs
@@ -3,7 +3,6 @@ using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Projection.Configuration;
 
 namespace Aevatar.Workflow.Projection.Orchestration;
@@ -12,23 +11,26 @@ public sealed class WorkflowExecutionProjectionPort
     : EventSinkProjectionLifecyclePortBase<IWorkflowExecutionProjectionLease, WorkflowExecutionRuntimeLease, WorkflowRunEventEnvelope>,
       IWorkflowExecutionProjectionPort
 {
-    private readonly IActorRuntime _runtime;
+    private readonly IProjectionScopeAttachExistingLeaseLookup<WorkflowExecutionRuntimeLease> _attachExistingLeaseLookup;
 
     public WorkflowExecutionProjectionPort(
         WorkflowExecutionProjectionOptions options,
         IProjectionScopeActivationService<WorkflowExecutionRuntimeLease> activationService,
         IProjectionScopeReleaseService<WorkflowExecutionRuntimeLease> releaseService,
         IProjectionSessionEventHub<WorkflowRunEventEnvelope> sessionEventHub,
-        IActorRuntime runtime)
+        IProjectionScopeAttachExistingLeaseLookup<WorkflowExecutionRuntimeLease> attachExistingLeaseLookup)
         : base(
             () => options.Enabled,
             activationService,
             releaseService,
             sessionEventHub)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _attachExistingLeaseLookup = attachExistingLeaseLookup ?? throw new ArgumentNullException(nameof(attachExistingLeaseLookup));
     }
 
+    // Refactor (iter51/issue-898-projection-attach-existing-side-read):
+    //   Old pattern: Feature projection ports duplicated IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()) for attach-existing checks (post-#884 #884 fixed 3 ports but more remained).
+    //   New principle: All attach-existing lease lookups go through typed IProjectionScopeAttachExistingLeaseLookup<TLease>; CI guard prevents recurrence.
     // Refactor (iter45/issue-867-session-projection-ensure-surface):
     //   Old pattern: Projection session ports exposed Ensure*ProjectionAsync activation surfaces next to attach-only observation APIs, allowing command/request paths to reactivate sessions.
     //   New principle: Public observation ports expose attach-existing only; projection-owned lifecycle activates sessions through committed-state/startup/background binders.
@@ -48,20 +50,16 @@ public sealed class WorkflowExecutionProjectionPort
             return null;
         }
 
-        var scopeKey = new ProjectionRuntimeScopeKey(
-            rootActorId,
-            WorkflowProjectionKinds.ExecutionSession,
-            ProjectionRuntimeMode.SessionObservation,
-            commandId);
-        if (!await _runtime.ExistsAsync(ProjectionScopeActorId.Build(scopeKey)).ConfigureAwait(false))
-            return null;
-
-        var lease = new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
+        var lease = await _attachExistingLeaseLookup.TryGetAsync(new ProjectionScopeStartRequest
         {
             RootActorId = rootActorId,
             ProjectionKind = WorkflowProjectionKinds.ExecutionSession,
+            Mode = ProjectionRuntimeMode.SessionObservation,
             SessionId = commandId,
-        });
+        }, ct).ConfigureAwait(false);
+        if (lease == null)
+            return null;
+
         var liveSinkLease = await AttachLiveSinkAsync(lease, sink, ct).ConfigureAwait(false);
         return liveSinkLease == null
             ? null

--- a/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
+++ b/test/Aevatar.AI.Tests/NyxIdChatProjectionSessionTests.cs
@@ -28,7 +28,7 @@ public sealed class NyxIdChatProjectionSessionTests
         var hub = new RecordingSessionEventHub();
         var runtime = new RecordingActorRuntime();
         runtime.MarkExists("projection.session.scope:nyxid-chat-session:chat-actor-1:session-1");
-        var port = new NyxIdChatSessionProjectionPort(activation, release, hub, runtime);
+        var port = new NyxIdChatSessionProjectionPort(activation, release, hub, CreateAttachExistingLookup(runtime));
         var sink = new RecordingEventSink();
 
         var attachment = await port.AttachExistingChatProjectionAsync("chat-actor-1", "session-1", sink, CancellationToken.None);
@@ -78,7 +78,7 @@ public sealed class NyxIdChatProjectionSessionTests
             new RecordingActivationService(),
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var sink = new RecordingEventSink();
 
         var attachment = await port.AttachExistingChatProjectionAsync(
@@ -106,7 +106,7 @@ public sealed class NyxIdChatProjectionSessionTests
             new RecordingActivationService(),
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
 
         var attachment = await port.AttachExistingChatProjectionAsync(
             "chat-actor-1",
@@ -255,6 +255,18 @@ public sealed class NyxIdChatProjectionSessionTests
             return Task.CompletedTask;
         }
     }
+
+    private static IProjectionScopeAttachExistingLeaseLookup<NyxIdChatSessionRuntimeLease> CreateAttachExistingLookup(
+        IActorRuntime runtime) =>
+        new ProjectionScopeAttachExistingLeaseLookup<NyxIdChatSessionRuntimeLease, NyxIdChatSessionProjectionContext>(
+            runtime,
+            request => new NyxIdChatSessionProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            (_, context) => new NyxIdChatSessionRuntimeLease(context));
 
     private sealed class RecordingActorRuntime : IActorRuntime
     {

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -458,7 +458,7 @@ public class StreamingProxyCoverageTests
             new RecordingRoomSessionActivationService(),
             new RecordingRoomSessionReleaseService(),
             hub,
-            runtime);
+            CreateRoomSessionAttachExistingLookup(runtime));
         await using var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
 
         var attachment = await port.AttachExistingChatProjectionAsync("room-a", "session-123", sink, CancellationToken.None);
@@ -479,7 +479,7 @@ public class StreamingProxyCoverageTests
             new RecordingRoomSessionActivationService(),
             new RecordingRoomSessionReleaseService(),
             hub,
-            new StubActorRuntime());
+            CreateRoomSessionAttachExistingLookup(new StubActorRuntime()));
         await using var sink = new EventChannel<StreamingProxyRoomSessionEnvelope>();
 
         var attachment = await port.AttachExistingChatProjectionAsync("room-a", "session-123", sink, CancellationToken.None);
@@ -2147,6 +2147,18 @@ public class StreamingProxyCoverageTests
             return Task.CompletedTask;
         }
     }
+
+    private static IProjectionScopeAttachExistingLeaseLookup<StreamingProxyRoomSessionRuntimeLease> CreateRoomSessionAttachExistingLookup(
+        IActorRuntime runtime) =>
+        new ProjectionScopeAttachExistingLeaseLookup<StreamingProxyRoomSessionRuntimeLease, StreamingProxyRoomSessionProjectionContext>(
+            runtime,
+            request => new StreamingProxyRoomSessionProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            (_, context) => new StreamingProxyRoomSessionRuntimeLease(context));
 
     private sealed class NoopAsyncDisposable : IAsyncDisposable
     {

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptEvolutionProjectionPortTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptEvolutionProjectionPortTests.cs
@@ -25,7 +25,7 @@ public sealed class ScriptEvolutionProjectionPortTests
             activationService,
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var sink = new RecordingCompletedEventSink();
 
         var attachment = await port.AttachExistingActorProjectionAsync("session-1", "proposal-1", sink);
@@ -51,7 +51,7 @@ public sealed class ScriptEvolutionProjectionPortTests
             new RecordingActivationService(),
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
 
         var attachment = await port.AttachExistingActorProjectionAsync(
             "session-1",
@@ -126,6 +126,18 @@ public sealed class ScriptEvolutionProjectionPortTests
             return Task.CompletedTask;
         }
     }
+
+    private static IProjectionScopeAttachExistingLeaseLookup<ScriptEvolutionRuntimeLease> CreateAttachExistingLookup(
+        IActorRuntime runtime) =>
+        new ProjectionScopeAttachExistingLeaseLookup<ScriptEvolutionRuntimeLease, ScriptEvolutionSessionProjectionContext>(
+            runtime,
+            request => new ScriptEvolutionSessionProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            (_, context) => new ScriptEvolutionRuntimeLease(context));
 
     private sealed class RecordingSessionEventHub : IProjectionSessionEventHub<ScriptEvolutionSessionCompletedEvent>
     {

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionPortTests.cs
@@ -1,5 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Streaming;
 using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -34,7 +35,7 @@ public sealed class WorkflowExecutionProjectionPortTests
             new RecordingActivationService(),
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var lease = new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
         {
             RootActorId = "actor-1",
@@ -69,7 +70,7 @@ public sealed class WorkflowExecutionProjectionPortTests
             new RecordingActivationService(),
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
         var sink = new RecordingRunEventSink();
 
         var attachment = await port.AttachExistingActorProjectionAsync("actor-1", "cmd-1", sink);
@@ -94,7 +95,7 @@ public sealed class WorkflowExecutionProjectionPortTests
             new RecordingActivationService(),
             new RecordingReleaseService(),
             hub,
-            runtime);
+            CreateAttachExistingLookup(runtime));
 
         var attachment = await port.AttachExistingActorProjectionAsync(
             "actor-1",
@@ -116,7 +117,7 @@ public sealed class WorkflowExecutionProjectionPortTests
             new RecordingActivationService(),
             release,
             new RecordingRunEventHub(),
-            new RecordingActorRuntime());
+            CreateAttachExistingLookup(new RecordingActorRuntime()));
         var lease = new WorkflowExecutionRuntimeLease(new WorkflowExecutionProjectionContext
         {
             RootActorId = "actor-1",
@@ -192,6 +193,18 @@ public sealed class WorkflowExecutionProjectionPortTests
             return Task.CompletedTask;
         }
     }
+
+    private static IProjectionScopeAttachExistingLeaseLookup<WorkflowExecutionRuntimeLease> CreateAttachExistingLookup(
+        IActorRuntime runtime) =>
+        new ProjectionScopeAttachExistingLeaseLookup<WorkflowExecutionRuntimeLease, WorkflowExecutionProjectionContext>(
+            runtime,
+            request => new WorkflowExecutionProjectionContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+                SessionId = request.SessionId,
+            },
+            (_, context) => new WorkflowExecutionRuntimeLease(context));
 
     private sealed class RecordingRunEventHub : IProjectionSessionEventHub<WorkflowRunEventEnvelope>
     {

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -293,6 +293,7 @@ fi
 
 bash "${SCRIPT_DIR}/query_projection_priming_guard.sh"
 bash "${SCRIPT_DIR}/command_observation_attach_only_guard.sh"
+bash "${SCRIPT_DIR}/projection_attach_existing_side_read_guard.sh"
 bash "${SCRIPT_DIR}/scripting_write_path_cqrs_guard.sh"
 bash "${SCRIPT_DIR}/projection_state_version_guard.sh"
 bash "${SCRIPT_DIR}/projection_state_mirror_current_state_guard.sh"

--- a/tools/ci/projection_attach_existing_side_read_guard.sh
+++ b/tools/ci/projection_attach_existing_side_read_guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Refactor (iter51/issue-898-projection-attach-existing-side-read):
+#   Old pattern: Feature projection ports duplicated IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build()) for attach-existing checks (post-#884 #884 fixed 3 ports but more remained).
+#   New principle: All attach-existing lease lookups go through typed IProjectionScopeAttachExistingLeaseLookup<TLease>; CI guard prevents recurrence.
+set +e
+report="$(
+  rg -n "IActorRuntime\.ExistsAsync\(ProjectionScopeActorId\.Build|\.ExistsAsync\(ProjectionScopeActorId\.Build" \
+    agents src \
+    -g '*.cs' \
+    -g '!**/bin/**' \
+    -g '!**/obj/**' \
+    -g '!*.g.cs' \
+    -g '!*.Designer.cs' \
+    | awk -F: '
+BEGIN {
+  allowed["src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeActorRuntime.cs"] = 1;
+  allowed["src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeAttachExistingLeaseLookup.cs"] = 1;
+}
+
+{
+  file = $1;
+  line_no = $2;
+  text = substr($0, length(file) + length(line_no) + 3);
+
+  if (file in allowed)
+    next;
+  if (text ~ /^[[:space:]]*\/\/\/?/)
+    next;
+
+  print $0;
+}'
+)"
+status=$?
+set -e
+
+if [[ ${status} -ne 0 && ${status} -ne 1 ]]; then
+  echo "projection_attach_existing_side_read_guard: scan failed"
+  exit "${status}"
+fi
+
+if [ -n "${report}" ]; then
+  echo "${report}"
+  echo "Attach-existing projection ports must use IProjectionScopeAttachExistingLeaseLookup<TLease>; do not duplicate IActorRuntime.ExistsAsync(ProjectionScopeActorId.Build(...)) side reads."
+  exit 1
+fi
+
+echo "projection_attach_existing_side_read_guard: ok"


### PR DESCRIPTION
## 摘要

Closes #898 — Phase 9 r1 consensus(unanimous structural)。机械扩展 #884 pattern。

## 改动

4 feature projection ports 改走 `IProjectionScopeAttachExistingLeaseLookup<TLease>`:
- NyxIdChatProjectionSession
- StreamingProxyRoomSessionProjectionPort
- ScriptEvolutionProjectionPort
- WorkflowExecutionProjectionPort

加 guard `tools/ci/projection_attach_existing_side_read_guard.sh` 挂 architecture_guards。

10 files +163/-66。

## 验证

- 4 port test files PASS
- architecture_guards / test_stability_guards PASS
- 无 CLAUDE.md / cross-cluster change

⟦AI:AUTO-LOOP⟧