### PR TITLE
iter51 issue-900 workflow-actor-port-runtime-object: typed actor-id receipts + 3 narrow ports

### DIFF
--- a/src/Aevatar.CQRS.Core/Commands/ActorCommandTargetDispatcher.cs
+++ b/src/Aevatar.CQRS.Core/Commands/ActorCommandTargetDispatcher.cs
@@ -4,7 +4,7 @@ namespace Aevatar.CQRS.Core.Commands;
 
 public sealed class ActorCommandTargetDispatcher<TTarget>
     : ICommandTargetDispatcher<TTarget>
-    where TTarget : class, IActorCommandDispatchTarget
+    where TTarget : class, ICommandDispatchTarget
 {
     private readonly IActorDispatchPort _dispatchPort;
 

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -25,7 +25,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
     private readonly IServiceGovernanceQueryPort _serviceGovernanceQueryPort;
     private readonly IScopeScriptQueryPort _scopeScriptQueryPort;
     private readonly IScriptDefinitionSnapshotPort _scriptDefinitionSnapshotPort;
-    private readonly IWorkflowRunActorPort _workflowRunActorPort;
+    private readonly IWorkflowDefinitionParser _workflowDefinitionParser;
     private readonly ScopeWorkflowCapabilityOptions _options;
 
     public ScopeBindingCommandApplicationService(
@@ -35,7 +35,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         IServiceGovernanceQueryPort serviceGovernanceQueryPort,
         IScopeScriptQueryPort scopeScriptQueryPort,
         IScriptDefinitionSnapshotPort scriptDefinitionSnapshotPort,
-        IWorkflowRunActorPort workflowRunActorPort,
+        IWorkflowDefinitionParser workflowDefinitionParser,
         IOptions<ScopeWorkflowCapabilityOptions> options)
     {
         _serviceCommandPort = serviceCommandPort ?? throw new ArgumentNullException(nameof(serviceCommandPort));
@@ -44,7 +44,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         _serviceGovernanceQueryPort = serviceGovernanceQueryPort ?? throw new ArgumentNullException(nameof(serviceGovernanceQueryPort));
         _scopeScriptQueryPort = scopeScriptQueryPort ?? throw new ArgumentNullException(nameof(scopeScriptQueryPort));
         _scriptDefinitionSnapshotPort = scriptDefinitionSnapshotPort ?? throw new ArgumentNullException(nameof(scriptDefinitionSnapshotPort));
-        _workflowRunActorPort = workflowRunActorPort ?? throw new ArgumentNullException(nameof(workflowRunActorPort));
+        _workflowDefinitionParser = workflowDefinitionParser ?? throw new ArgumentNullException(nameof(workflowDefinitionParser));
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value ?? throw new InvalidOperationException("Scope workflow capability options are required.");
     }
@@ -515,7 +515,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
             if (string.IsNullOrWhiteSpace(workflowYaml))
                 throw new InvalidOperationException("workflowYamls must not contain empty YAML entries.");
 
-            var parse = await _workflowRunActorPort.ParseWorkflowYamlAsync(workflowYaml, ct);
+            var parse = await _workflowDefinitionParser.ParseWorkflowYamlAsync(workflowYaml, ct);
             if (!parse.Succeeded)
                 throw new InvalidOperationException(parse.Error);
 

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs
@@ -13,18 +13,18 @@ public sealed class DefaultServiceRuntimeActivator : IServiceRuntimeActivator
     private readonly IActorRuntime _runtime;
     private readonly IScriptDefinitionSnapshotPort _scriptDefinitionSnapshotPort;
     private readonly IScriptRuntimeProvisioningPort _scriptRuntimeProvisioningPort;
-    private readonly IWorkflowRunActorPort _workflowRunActorPort;
+    private readonly IWorkflowDefinitionProvisioningPort _workflowDefinitionProvisioningPort;
 
     public DefaultServiceRuntimeActivator(
         IActorRuntime runtime,
         IScriptDefinitionSnapshotPort scriptDefinitionSnapshotPort,
         IScriptRuntimeProvisioningPort scriptRuntimeProvisioningPort,
-        IWorkflowRunActorPort workflowRunActorPort)
+        IWorkflowDefinitionProvisioningPort workflowDefinitionProvisioningPort)
     {
         _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _scriptDefinitionSnapshotPort = scriptDefinitionSnapshotPort ?? throw new ArgumentNullException(nameof(scriptDefinitionSnapshotPort));
         _scriptRuntimeProvisioningPort = scriptRuntimeProvisioningPort ?? throw new ArgumentNullException(nameof(scriptRuntimeProvisioningPort));
-        _workflowRunActorPort = workflowRunActorPort ?? throw new ArgumentNullException(nameof(workflowRunActorPort));
+        _workflowDefinitionProvisioningPort = workflowDefinitionProvisioningPort ?? throw new ArgumentNullException(nameof(workflowDefinitionProvisioningPort));
     }
 
     public async Task<ServiceRuntimeActivationResult> ActivateAsync(
@@ -108,25 +108,23 @@ public sealed class DefaultServiceRuntimeActivator : IServiceRuntimeActivator
         var preferredActorId = string.IsNullOrWhiteSpace(plan.DefinitionActorId)
             ? $"gagent-service:workflow-definition:{deploymentId}"
             : $"{plan.DefinitionActorId}:{deploymentId}";
-        IActor actor;
-        if (await _runtime.ExistsAsync(preferredActorId))
-        {
-            actor = await _runtime.GetAsync(preferredActorId)
-                ?? throw new InvalidOperationException($"Workflow definition actor '{preferredActorId}' was not found.");
-        }
-        else
-        {
-            actor = await _workflowRunActorPort.CreateDefinitionAsync(preferredActorId, ct);
-        }
+        var receipt = await _workflowDefinitionProvisioningPort.EnsureDefinitionAsync(
+            new WorkflowDefinitionBinding(
+                preferredActorId,
+                plan.WorkflowName,
+                plan.WorkflowYaml,
+                plan.InlineWorkflowYamls),
+            preferredActorId,
+            ct);
 
-        await _workflowRunActorPort.BindWorkflowDefinitionAsync(
-            actor,
+        await _workflowDefinitionProvisioningPort.BindWorkflowDefinitionAsync(
+            receipt.ActorId,
             plan.WorkflowYaml,
             plan.WorkflowName,
             plan.InlineWorkflowYamls,
             ct: ct);
 
-        return new ServiceRuntimeActivationResult(deploymentId, actor.Id, "active");
+        return new ServiceRuntimeActivationResult(deploymentId, receipt.ActorId, "active");
     }
 
     private static Type? ResolveActorType(string typeName)

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs
@@ -117,13 +117,6 @@ public sealed class DefaultServiceRuntimeActivator : IServiceRuntimeActivator
             preferredActorId,
             ct);
 
-        await _workflowDefinitionProvisioningPort.BindWorkflowDefinitionAsync(
-            receipt.ActorId,
-            plan.WorkflowYaml,
-            plan.WorkflowName,
-            plan.InlineWorkflowYamls,
-            ct: ct);
-
         return new ServiceRuntimeActivationResult(deploymentId, receipt.ActorId, "active");
     }
 

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/WorkflowServiceImplementationAdapter.cs
@@ -7,11 +7,11 @@ namespace Aevatar.GAgentService.Infrastructure.Adapters;
 
 public sealed class WorkflowServiceImplementationAdapter : IServiceImplementationAdapter
 {
-    private readonly IWorkflowRunActorPort _workflowRunActorPort;
+    private readonly IWorkflowDefinitionParser _workflowDefinitionParser;
 
-    public WorkflowServiceImplementationAdapter(IWorkflowRunActorPort workflowRunActorPort)
+    public WorkflowServiceImplementationAdapter(IWorkflowDefinitionParser workflowDefinitionParser)
     {
-        _workflowRunActorPort = workflowRunActorPort ?? throw new ArgumentNullException(nameof(workflowRunActorPort));
+        _workflowDefinitionParser = workflowDefinitionParser ?? throw new ArgumentNullException(nameof(workflowDefinitionParser));
     }
 
     public ServiceImplementationKind ImplementationKind => ServiceImplementationKind.Workflow;
@@ -29,7 +29,7 @@ public sealed class WorkflowServiceImplementationAdapter : IServiceImplementatio
         var resolvedWorkflowName = spec.WorkflowName;
         if (string.IsNullOrWhiteSpace(resolvedWorkflowName))
         {
-            var parse = await _workflowRunActorPort.ParseWorkflowYamlAsync(spec.WorkflowYaml, ct);
+            var parse = await _workflowDefinitionParser.ParseWorkflowYamlAsync(spec.WorkflowYaml, ct);
             if (!parse.Succeeded)
                 throw new InvalidOperationException(parse.Error);
 

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Dispatch/DefaultServiceInvocationDispatcher.cs
@@ -13,18 +13,18 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
 {
     private readonly IActorDispatchPort _dispatchPort;
     private readonly IScriptRuntimeCommandPort _scriptRuntimeCommandPort;
-    private readonly IWorkflowRunActorPort _workflowRunActorPort;
+    private readonly IWorkflowRunProvisioningPort _workflowRunProvisioningPort;
     private readonly IServiceRunRegistrationPort _serviceRunRegistrationPort;
 
     public DefaultServiceInvocationDispatcher(
         IActorDispatchPort dispatchPort,
         IScriptRuntimeCommandPort scriptRuntimeCommandPort,
-        IWorkflowRunActorPort workflowRunActorPort,
+        IWorkflowRunProvisioningPort workflowRunProvisioningPort,
         IServiceRunRegistrationPort serviceRunRegistrationPort)
     {
         _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
         _scriptRuntimeCommandPort = scriptRuntimeCommandPort ?? throw new ArgumentNullException(nameof(scriptRuntimeCommandPort));
-        _workflowRunActorPort = workflowRunActorPort ?? throw new ArgumentNullException(nameof(workflowRunActorPort));
+        _workflowRunProvisioningPort = workflowRunProvisioningPort ?? throw new ArgumentNullException(nameof(workflowRunProvisioningPort));
         _serviceRunRegistrationPort = serviceRunRegistrationPort ?? throw new ArgumentNullException(nameof(serviceRunRegistrationPort));
     }
 
@@ -90,7 +90,7 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
         var chatRequest = request.Payload?.Unpack<ChatRequestEvent>()
             ?? throw new InvalidOperationException("Workflow services require ChatRequestEvent payload.");
         var plan = target.Artifact.DeploymentPlan.WorkflowPlan;
-        var run = await _workflowRunActorPort.CreateRunAsync(
+        var run = await _workflowRunProvisioningPort.CreateRunAsync(
             new WorkflowDefinitionBinding(
                 target.Service.PrimaryActorId,
                 plan.WorkflowName,
@@ -101,10 +101,10 @@ public sealed class DefaultServiceInvocationDispatcher : IServiceInvocationDispa
         var commandId = ResolveCommandId(request);
         var correlationId = ResolveCorrelationId(request, commandId);
         var runId = ResolveRunId(request, commandId);
-        await RegisterRunAsync(target, request, runId, commandId, correlationId, run.Actor.Id, ServiceImplementationKind.Workflow, ct);
-        var envelope = CreateEnvelope(run.Actor.Id, Any.Pack(chatRequest), commandId, correlationId);
-        await _dispatchPort.DispatchAsync(run.Actor.Id, envelope, ct);
-        return CreateReceipt(target, run.Actor.Id, commandId, correlationId);
+        await RegisterRunAsync(target, request, runId, commandId, correlationId, run.ActorId, ServiceImplementationKind.Workflow, ct);
+        var envelope = CreateEnvelope(run.ActorId, Any.Pack(chatRequest), commandId, correlationId);
+        await _dispatchPort.DispatchAsync(run.ActorId, envelope, ct);
+        return CreateReceipt(target, run.ActorId, commandId, correlationId);
     }
 
     private async Task RegisterRunAsync(

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/WorkflowRunPorts.cs
@@ -1,5 +1,3 @@
-using Aevatar.Foundation.Abstractions;
-
 namespace Aevatar.Workflow.Application.Abstractions.Runs;
 
 public sealed record WorkflowYamlParseResult(
@@ -29,10 +27,14 @@ public sealed record WorkflowDefinitionBinding(
     IReadOnlyDictionary<string, string> InlineWorkflowYamls,
     string ScopeId = "");
 
-public sealed record WorkflowRunCreationResult(
-    IActor Actor,
+public sealed record WorkflowRunCreationReceipt(
+    string ActorId,
     string DefinitionActorId,
     IReadOnlyList<string> CreatedActorIds);
+
+public sealed record WorkflowDefinitionProvisioningReceipt(
+    string ActorId,
+    bool CreatedNow);
 
 public sealed record WorkflowActorBinding(
     WorkflowActorKind ActorKind,
@@ -101,31 +103,36 @@ public interface IWorkflowRunBindingReader
         CancellationToken ct = default);
 }
 
-/// <summary>
-/// Port for resolving workflow definition actors and creating workflow execution actors.
-/// Implemented by infrastructure to avoid Application depending on Workflow.Core.
-/// </summary>
-public interface IWorkflowRunActorPort
+public interface IWorkflowDefinitionProvisioningPort
 {
-    Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default);
-
-    Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default);
+    Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(
+        WorkflowDefinitionBinding definition,
+        string? preferredActorId = null,
+        CancellationToken ct = default);
 
     Task DestroyAsync(string actorId, CancellationToken ct = default);
 
     Task BindWorkflowDefinitionAsync(
-        IActor actor,
+        string actorId,
         string workflowYaml,
         string workflowName,
         IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,
         string? scopeId = null,
         CancellationToken ct = default);
+}
 
-    Task MarkStoppedAsync(
-        string actorId,
-        string runId,
-        string reason,
+public interface IWorkflowRunProvisioningPort
+{
+    Task<WorkflowRunCreationReceipt> CreateRunAsync(
+        WorkflowDefinitionBinding definition,
         CancellationToken ct = default);
 
-    Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default);
+    Task DestroyAsync(string actorId, CancellationToken ct = default);
+}
+
+public interface IWorkflowDefinitionParser
+{
+    Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(
+        string workflowYaml,
+        CancellationToken ct = default);
 }

--- a/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -47,7 +47,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IWorkflowRunActorResolver>(sp =>
             new WorkflowRunActorResolver(
                 sp.GetRequiredService<IWorkflowActorBindingReader>(),
-                sp.GetRequiredService<IWorkflowRunActorPort>(),
+                sp.GetRequiredService<IWorkflowRunProvisioningPort>(),
+                sp.GetRequiredService<IWorkflowDefinitionParser>(),
                 sp.GetRequiredService<IWorkflowDefinitionCatalog>(),
                 sp.GetRequiredService<WorkflowRunBehaviorOptions>()));
         services.TryAddSingleton<ICommandContextPolicy, DefaultCommandContextPolicy>();

--- a/src/workflow/Aevatar.Workflow.Application/Runs/IWorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/IWorkflowRunActorResolver.cs
@@ -1,4 +1,3 @@
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -11,7 +10,6 @@ public interface IWorkflowRunActorResolver
 }
 
 public sealed record WorkflowActorResolutionResult(
-    IActor? Actor,
+    WorkflowRunCreationReceipt? Target,
     string WorkflowNameForRun,
-    WorkflowChatRunStartError Error,
-    IReadOnlyList<string>? CreatedActorIds = null);
+    WorkflowChatRunStartError Error);

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowResumeCommandTargetResolver.cs
@@ -1,4 +1,3 @@
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -7,9 +6,8 @@ internal sealed class WorkflowResumeCommandTargetResolver
     : WorkflowRunControlCommandTargetResolverBase<WorkflowResumeCommand>
 {
     public WorkflowResumeCommandTargetResolver(
-        IActorRuntime runtime,
         IWorkflowActorBindingReader bindingReader)
-        : base(runtime, bindingReader)
+        : base(bindingReader)
     {
     }
 

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunAcceptedCommandTarget.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunAcceptedCommandTarget.cs
@@ -1,6 +1,5 @@
 using System.Runtime.ExceptionServices;
 using Aevatar.CQRS.Core.Abstractions.Commands;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -9,29 +8,30 @@ namespace Aevatar.Workflow.Application.Runs;
 //   Old pattern: accepted-only dispatch reused interaction targets that owned live sinks
 //   New principle: accepted-only target split + NoOp binder default + receipt-only(no live sink acquired)
 internal sealed class WorkflowRunAcceptedCommandTarget
-    : IActorCommandDispatchTarget,
+    : ICommandDispatchTarget,
       ICommandDispatchCleanupAware
 {
-    private readonly IWorkflowRunActorPort _actorPort;
+    private readonly IWorkflowRunProvisioningPort _runProvisioningPort;
     private bool _createdActorsDestroyed;
 
     public WorkflowRunAcceptedCommandTarget(
-        IActor actor,
+        string actorId,
         string workflowName,
         IReadOnlyList<string>? createdActorIds,
-        IWorkflowRunActorPort actorPort)
+        IWorkflowRunProvisioningPort runProvisioningPort)
     {
-        Actor = actor ?? throw new ArgumentNullException(nameof(actor));
+        ActorId = string.IsNullOrWhiteSpace(actorId)
+            ? throw new ArgumentException("Actor id is required.", nameof(actorId))
+            : actorId;
         WorkflowName = string.IsNullOrWhiteSpace(workflowName)
             ? throw new ArgumentException("Workflow name is required.", nameof(workflowName))
             : workflowName;
         CreatedActorIds = createdActorIds ?? [];
-        _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
+        _runProvisioningPort = runProvisioningPort ?? throw new ArgumentNullException(nameof(runProvisioningPort));
     }
 
-    public IActor Actor { get; }
-    public string ActorId => Actor.Id;
-    public string TargetId => Actor.Id;
+    public string ActorId { get; }
+    public string TargetId => ActorId;
     public string WorkflowName { get; }
     public IReadOnlyList<string> CreatedActorIds { get; }
 
@@ -56,7 +56,7 @@ internal sealed class WorkflowRunAcceptedCommandTarget
         {
             try
             {
-                await _actorPort.DestroyAsync(actorId, ct);
+                await _runProvisioningPort.DestroyAsync(actorId, ct);
             }
             catch (Exception ex)
             {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunAcceptedCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunAcceptedCommandTargetResolver.cs
@@ -10,14 +10,14 @@ internal sealed class WorkflowRunAcceptedCommandTargetResolver
     : ICommandTargetResolver<WorkflowChatRunRequest, WorkflowRunAcceptedCommandTarget, WorkflowChatRunStartError>
 {
     private readonly IWorkflowRunActorResolver _actorResolver;
-    private readonly IWorkflowRunActorPort _actorPort;
+    private readonly IWorkflowRunProvisioningPort _runProvisioningPort;
 
     public WorkflowRunAcceptedCommandTargetResolver(
         IWorkflowRunActorResolver actorResolver,
-        IWorkflowRunActorPort actorPort)
+        IWorkflowRunProvisioningPort runProvisioningPort)
     {
         _actorResolver = actorResolver ?? throw new ArgumentNullException(nameof(actorResolver));
-        _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
+        _runProvisioningPort = runProvisioningPort ?? throw new ArgumentNullException(nameof(runProvisioningPort));
     }
 
     public async Task<CommandTargetResolution<WorkflowRunAcceptedCommandTarget, WorkflowChatRunStartError>> ResolveAsync(
@@ -30,14 +30,14 @@ internal sealed class WorkflowRunAcceptedCommandTargetResolver
         ArgumentNullException.ThrowIfNull(command);
 
         var actorResolution = await _actorResolver.ResolveOrCreateAsync(command, ct);
-        if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Actor == null)
+        if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Target == null)
             return CommandTargetResolution<WorkflowRunAcceptedCommandTarget, WorkflowChatRunStartError>.Failure(actorResolution.Error);
 
         return CommandTargetResolution<WorkflowRunAcceptedCommandTarget, WorkflowChatRunStartError>.Success(
             new WorkflowRunAcceptedCommandTarget(
-                actorResolution.Actor,
+                actorResolution.Target.ActorId,
                 actorResolution.WorkflowNameForRun,
-                actorResolution.CreatedActorIds,
-                _actorPort));
+                actorResolution.Target.CreatedActorIds,
+                _runProvisioningPort));
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunActorResolver.cs
@@ -1,4 +1,3 @@
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
 
@@ -7,18 +6,21 @@ namespace Aevatar.Workflow.Application.Runs;
 public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
 {
     private readonly IWorkflowActorBindingReader _bindingReader;
-    private readonly IWorkflowRunActorPort _actorPort;
+    private readonly IWorkflowRunProvisioningPort _runProvisioningPort;
+    private readonly IWorkflowDefinitionParser _definitionParser;
     private readonly IWorkflowDefinitionCatalog _workflowRegistry;
     private readonly WorkflowRunBehaviorOptions _behaviorOptions;
 
     public WorkflowRunActorResolver(
         IWorkflowActorBindingReader bindingReader,
-        IWorkflowRunActorPort actorPort,
+        IWorkflowRunProvisioningPort runProvisioningPort,
+        IWorkflowDefinitionParser definitionParser,
         IWorkflowDefinitionCatalog workflowRegistry,
         WorkflowRunBehaviorOptions? behaviorOptions = null)
     {
         _bindingReader = bindingReader ?? throw new ArgumentNullException(nameof(bindingReader));
-        _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
+        _runProvisioningPort = runProvisioningPort ?? throw new ArgumentNullException(nameof(runProvisioningPort));
+        _definitionParser = definitionParser ?? throw new ArgumentNullException(nameof(definitionParser));
         _workflowRegistry = workflowRegistry ?? throw new ArgumentNullException(nameof(workflowRegistry));
         _behaviorOptions = behaviorOptions ?? new WorkflowRunBehaviorOptions();
     }
@@ -96,10 +98,9 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             ct);
 
         return new WorkflowActorResolutionResult(
-            createdRun.Actor,
+            createdRun,
             workflowNameForRun,
-            WorkflowChatRunStartError.None,
-            createdRun.CreatedActorIds);
+            WorkflowChatRunStartError.None);
     }
 
     private async Task<WorkflowActorResolutionResult> ResolveFromSourceActorAsync(
@@ -143,10 +144,9 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
                 wrapAsFallbackTrigger: false,
                 ct);
             return new WorkflowActorResolutionResult(
-                inlineRunActor.Actor,
+                inlineRunActor,
                 workflowNameForRun,
-                WorkflowChatRunStartError.None,
-                inlineRunActor.CreatedActorIds);
+                WorkflowChatRunStartError.None);
         }
 
         if (string.IsNullOrWhiteSpace(boundWorkflowName))
@@ -187,10 +187,9 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             ct);
 
         return new WorkflowActorResolutionResult(
-            runActor.Actor,
+            runActor,
             boundWorkflowName,
-            WorkflowChatRunStartError.None,
-            runActor.CreatedActorIds);
+            WorkflowChatRunStartError.None);
     }
 
     private string ResolveDefaultWorkflowName()
@@ -221,7 +220,7 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             if (string.IsNullOrWhiteSpace(yaml))
                 return InlineWorkflowBundle.Invalid;
 
-            var parseResult = await _actorPort.ParseWorkflowYamlAsync(yaml, ct);
+            var parseResult = await _definitionParser.ParseWorkflowYamlAsync(yaml, ct);
             if (!parseResult.Succeeded)
                 return InlineWorkflowBundle.Invalid;
 
@@ -248,14 +247,14 @@ public sealed class WorkflowRunActorResolver : IWorkflowRunActorResolver
             workflowByName);
     }
 
-    private async Task<WorkflowRunCreationResult> CreateRunActorAsync(
+    private async Task<WorkflowRunCreationReceipt> CreateRunActorAsync(
         WorkflowDefinitionBinding definitionBinding,
         bool wrapAsFallbackTrigger,
         CancellationToken ct)
     {
         try
         {
-            return await _actorPort.CreateRunAsync(definitionBinding, ct);
+            return await _runProvisioningPort.CreateRunAsync(definitionBinding, ct);
         }
         catch (Exception ex) when (wrapAsFallbackTrigger && ex is InvalidOperationException or NotSupportedException)
         {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTarget.cs
@@ -1,7 +1,6 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.CQRS.Core.Abstractions.Interactions;
 using Aevatar.CQRS.Core.Abstractions.Streaming;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Projections;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using System.Runtime.ExceptionServices;
@@ -9,43 +8,44 @@ using System.Runtime.ExceptionServices;
 namespace Aevatar.Workflow.Application.Runs;
 
 internal sealed class WorkflowRunCommandTarget
-    : IActorCommandDispatchTarget,
+    : ICommandDispatchTarget,
       ICommandEventTarget<WorkflowRunEventEnvelope>,
       ICommandInteractionCleanupTarget<WorkflowChatRunAcceptedReceipt, WorkflowProjectionCompletionStatus>,
       ICommandDetachedContinuationTarget<WorkflowChatRunAcceptedReceipt, WorkflowProjectionCompletionStatus>,
       ICommandDispatchCleanupAware
 {
     private readonly IWorkflowExecutionProjectionPort _projectionPort;
-    private readonly IWorkflowRunActorPort _actorPort;
+    private readonly IWorkflowRunProvisioningPort _runProvisioningPort;
     private readonly WorkflowRunDurableCompletionResolver _durableCompletionResolver;
     private bool _createdActorsDestroyed;
 
     public WorkflowRunCommandTarget(
-        IActor actor,
+        string actorId,
         string workflowName,
         IReadOnlyList<string>? createdActorIds,
         IWorkflowExecutionProjectionPort projectionPort,
-        IWorkflowRunActorPort actorPort,
+        IWorkflowRunProvisioningPort runProvisioningPort,
         WorkflowRunDurableCompletionResolver durableCompletionResolver)
     {
         // Refactor (iter18/cluster-005):
         //   Old pattern: accepted-only dispatch reused interaction targets that owned live sinks
         //   New principle: accepted-only target split + NoOp binder default + receipt-only(no live sink acquired)
-        Actor = actor ?? throw new ArgumentNullException(nameof(actor));
+        ActorId = string.IsNullOrWhiteSpace(actorId)
+            ? throw new ArgumentException("Actor id is required.", nameof(actorId))
+            : actorId;
         WorkflowName = string.IsNullOrWhiteSpace(workflowName)
             ? throw new ArgumentException("Workflow name is required.", nameof(workflowName))
             : workflowName;
         CreatedActorIds = createdActorIds ?? [];
         _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
-        _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
+        _runProvisioningPort = runProvisioningPort ?? throw new ArgumentNullException(nameof(runProvisioningPort));
         _durableCompletionResolver = durableCompletionResolver ?? throw new ArgumentNullException(nameof(durableCompletionResolver));
     }
 
-    public IActor Actor { get; }
+    public string ActorId { get; }
     public string WorkflowName { get; }
     public IReadOnlyList<string> CreatedActorIds { get; }
-    public string TargetId => Actor.Id;
-    public string ActorId => Actor.Id;
+    public string TargetId => ActorId;
     public IWorkflowExecutionProjectionLease? ProjectionLease { get; private set; }
     public IAsyncDisposable? LiveSinkLease { get; private set; }
     public IEventSink<WorkflowRunEventEnvelope>? LiveSink { get; private set; }
@@ -245,7 +245,7 @@ internal sealed class WorkflowRunCommandTarget
         {
             try
             {
-                await _actorPort.DestroyAsync(actorId, ct);
+                await _runProvisioningPort.DestroyAsync(actorId, ct);
             }
             catch (Exception ex)
             {

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunCommandTargetResolver.cs
@@ -9,18 +9,18 @@ internal sealed class WorkflowRunCommandTargetResolver
 {
     private readonly IWorkflowRunActorResolver _actorResolver;
     private readonly IWorkflowExecutionProjectionPort _projectionPort;
-    private readonly IWorkflowRunActorPort _actorPort;
+    private readonly IWorkflowRunProvisioningPort _runProvisioningPort;
     private readonly WorkflowRunDurableCompletionResolver _durableCompletionResolver;
 
     public WorkflowRunCommandTargetResolver(
         IWorkflowRunActorResolver actorResolver,
         IWorkflowExecutionProjectionPort projectionPort,
-        IWorkflowRunActorPort actorPort,
+        IWorkflowRunProvisioningPort runProvisioningPort,
         WorkflowRunDurableCompletionResolver durableCompletionResolver)
     {
         _actorResolver = actorResolver ?? throw new ArgumentNullException(nameof(actorResolver));
         _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
-        _actorPort = actorPort ?? throw new ArgumentNullException(nameof(actorPort));
+        _runProvisioningPort = runProvisioningPort ?? throw new ArgumentNullException(nameof(runProvisioningPort));
         _durableCompletionResolver = durableCompletionResolver ?? throw new ArgumentNullException(nameof(durableCompletionResolver));
     }
 
@@ -35,16 +35,16 @@ internal sealed class WorkflowRunCommandTargetResolver
                 WorkflowChatRunStartError.ProjectionDisabled);
 
         var actorResolution = await _actorResolver.ResolveOrCreateAsync(command, ct);
-        if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Actor == null)
+        if (actorResolution.Error != WorkflowChatRunStartError.None || actorResolution.Target == null)
             return CommandTargetResolution<WorkflowRunCommandTarget, WorkflowChatRunStartError>.Failure(actorResolution.Error);
 
         return CommandTargetResolution<WorkflowRunCommandTarget, WorkflowChatRunStartError>.Success(
             new WorkflowRunCommandTarget(
-                actorResolution.Actor,
+                actorResolution.Target.ActorId,
                 actorResolution.WorkflowNameForRun,
-                actorResolution.CreatedActorIds,
+                actorResolution.Target.CreatedActorIds,
                 _projectionPort,
-                _actorPort,
+                _runProvisioningPort,
                 _durableCompletionResolver));
     }
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunControlCommandTarget.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunControlCommandTarget.cs
@@ -1,25 +1,24 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
-using Aevatar.Foundation.Abstractions;
 
 namespace Aevatar.Workflow.Application.Runs;
 
-internal sealed class WorkflowRunControlCommandTarget : IActorCommandDispatchTarget
+internal sealed class WorkflowRunControlCommandTarget : ICommandDispatchTarget
 {
     public WorkflowRunControlCommandTarget(
-        IActor actor,
+        string actorId,
         string runId)
     {
-        Actor = actor ?? throw new ArgumentNullException(nameof(actor));
+        ActorId = string.IsNullOrWhiteSpace(actorId)
+            ? throw new ArgumentException("Actor id is required.", nameof(actorId))
+            : actorId;
         RunId = string.IsNullOrWhiteSpace(runId)
             ? throw new ArgumentException("Run id is required.", nameof(runId))
             : runId;
     }
 
-    public IActor Actor { get; }
+    public string ActorId { get; }
 
     public string RunId { get; }
 
-    public string TargetId => Actor.Id;
-
-    public string ActorId => Actor.Id;
+    public string TargetId => ActorId;
 }

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunControlCommandTargetResolverBase.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowRunControlCommandTargetResolverBase.cs
@@ -1,5 +1,4 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -8,14 +7,11 @@ internal abstract class WorkflowRunControlCommandTargetResolverBase<TCommand>
     : ICommandTargetResolver<TCommand, WorkflowRunControlCommandTarget, WorkflowRunControlStartError>
     where TCommand : IWorkflowRunControlCommand
 {
-    private readonly IActorRuntime _runtime;
     private readonly IWorkflowActorBindingReader _bindingReader;
 
     protected WorkflowRunControlCommandTargetResolverBase(
-        IActorRuntime runtime,
         IWorkflowActorBindingReader bindingReader)
     {
-        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         _bindingReader = bindingReader ?? throw new ArgumentNullException(nameof(bindingReader));
     }
 
@@ -46,14 +42,13 @@ internal abstract class WorkflowRunControlCommandTargetResolverBase<TCommand>
                 validationError);
         }
 
-        var actor = await _runtime.GetAsync(actorId);
-        if (actor == null)
+        var binding = await _bindingReader.GetAsync(actorId, ct);
+        if (binding == null)
         {
             return CommandTargetResolution<WorkflowRunControlCommandTarget, WorkflowRunControlStartError>.Failure(
                 WorkflowRunControlStartError.ActorNotFound(actorId, runId));
         }
 
-        var binding = await _bindingReader.GetAsync(actorId, ct);
         if (binding?.ActorKind != WorkflowActorKind.Run)
         {
             return CommandTargetResolution<WorkflowRunControlCommandTarget, WorkflowRunControlStartError>.Failure(
@@ -74,7 +69,7 @@ internal abstract class WorkflowRunControlCommandTargetResolverBase<TCommand>
         }
 
         return CommandTargetResolution<WorkflowRunControlCommandTarget, WorkflowRunControlStartError>.Success(
-            new WorkflowRunControlCommandTarget(actor, boundRunId));
+            new WorkflowRunControlCommandTarget(actorId, boundRunId));
     }
 
     protected virtual WorkflowRunControlStartError? ValidateCommand(

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowSignalCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowSignalCommandTargetResolver.cs
@@ -1,4 +1,3 @@
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -7,9 +6,8 @@ internal sealed class WorkflowSignalCommandTargetResolver
     : WorkflowRunControlCommandTargetResolverBase<WorkflowSignalCommand>
 {
     public WorkflowSignalCommandTargetResolver(
-        IActorRuntime runtime,
         IWorkflowActorBindingReader bindingReader)
-        : base(runtime, bindingReader)
+        : base(bindingReader)
     {
     }
 

--- a/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowStopCommandTargetResolver.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Runs/WorkflowStopCommandTargetResolver.cs
@@ -1,4 +1,3 @@
-using Aevatar.Foundation.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 
 namespace Aevatar.Workflow.Application.Runs;
@@ -7,9 +6,8 @@ internal sealed class WorkflowStopCommandTargetResolver
     : WorkflowRunControlCommandTargetResolverBase<WorkflowStopCommand>
 {
     public WorkflowStopCommandTargetResolver(
-        IActorRuntime runtime,
         IWorkflowActorBindingReader bindingReader)
-        : base(runtime, bindingReader)
+        : base(bindingReader)
     {
     }
 }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -23,7 +23,13 @@ public static class ServiceCollectionExtensions
 
         // Replace the Noop fallback from Application layer with the real file export adapter.
         services.Replace(ServiceDescriptor.Singleton<IWorkflowRunReportExportPort, FileSystemWorkflowRunReportExporter>());
-        services.TryAddSingleton<IWorkflowRunActorPort, WorkflowRunActorPort>();
+        services.TryAddSingleton<WorkflowRunActorPort>();
+        services.TryAddSingleton<IWorkflowDefinitionProvisioningPort>(sp =>
+            sp.GetRequiredService<WorkflowRunActorPort>());
+        services.TryAddSingleton<IWorkflowRunProvisioningPort>(sp =>
+            sp.GetRequiredService<WorkflowRunActorPort>());
+        services.TryAddSingleton<IWorkflowDefinitionParser>(sp =>
+            sp.GetRequiredService<WorkflowRunActorPort>());
         services.TryAddSingleton<IWorkflowDefinitionResolver, RegistryWorkflowDefinitionResolver>();
         return services;
     }

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowRunActorPort.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Runs/WorkflowRunActorPort.cs
@@ -11,7 +11,13 @@ namespace Aevatar.Workflow.Infrastructure.Runs;
 /// <summary>
 /// Infrastructure adapter for workflow definition actor lifecycle and run actor creation.
 /// </summary>
-internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
+// Refactor (iter51/issue-900-workflow-actor-port-runtime-object):
+//   Old pattern: Application layer ports returned and passed IActor runtime objects directly; one port owned actor lifecycle + topology + dispatch + parse.
+//   New principle: Application layer exchanges typed actor-id receipts (ActorId, DefinitionActorId, CreatedActorIds); runtime IActor objects stay infrastructure-only; lifecycle/provisioning, dispatch, and YAML parsing are split into narrow ports.
+internal sealed class WorkflowRunActorPort :
+    IWorkflowDefinitionProvisioningPort,
+    IWorkflowRunProvisioningPort,
+    IWorkflowDefinitionParser
 {
     private const string WorkflowRunActorPortPublisherId = "workflow.run.actor.port";
     private readonly IActorRuntime _runtime;
@@ -37,10 +43,24 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
             packs.SelectMany(x => x.Modules).SelectMany(x => x.Names));
     }
 
-    public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-        _runtime.CreateAsync<WorkflowGAgent>(actorId, ct: ct);
+    public async Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(
+        WorkflowDefinitionBinding definition,
+        string? preferredActorId = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+        var requestedDefinitionActorId = NormalizeActorId(preferredActorId)
+                                         ?? NormalizeActorId(definition.DefinitionActorId);
+        var definitionResolution = requestedDefinitionActorId == null
+            ? await CreateBoundDefinitionActorAsync(definition, preferredActorId: null, ct)
+            : await EnsureDefinitionActorAsync(definition, requestedDefinitionActorId, ct);
 
-    public async Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default)
+        return new WorkflowDefinitionProvisioningReceipt(
+            definitionResolution.ActorId,
+            definitionResolution.CreatedNow);
+    }
+
+    public async Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(definition);
         if (string.IsNullOrWhiteSpace(definition.WorkflowYaml) ||
@@ -55,7 +75,7 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
         var createdActorIds = new List<string>(2);
         try
         {
-            definitionResolution = await EnsureDefinitionActorAsync(definition, ct);
+            definitionResolution = await EnsureDefinitionActorAsync(definition, NormalizeActorId(definition.DefinitionActorId), ct);
             if (definitionResolution.CreatedNow && !string.IsNullOrWhiteSpace(definitionResolution.ActorId))
                 createdActorIds.Add(definitionResolution.ActorId);
 
@@ -80,8 +100,8 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
                     definition.ScopeId),
                 ct);
 
-            return new WorkflowRunCreationResult(
-                runActor,
+            return new WorkflowRunCreationReceipt(
+                runActor.Id,
                 definitionResolution.ActorId,
                 createdActorIds);
         }
@@ -101,19 +121,21 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
     }
 
     public async Task BindWorkflowDefinitionAsync(
-        IActor actor,
+        string actorId,
         string workflowYaml,
         string workflowName,
         IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,
         string? scopeId = null,
         CancellationToken ct = default)
     {
-        ArgumentNullException.ThrowIfNull(actor);
+        if (string.IsNullOrWhiteSpace(actorId))
+            throw new ArgumentException("Actor id is required.", nameof(actorId));
+
         // Refactor (iter18/cluster-006):
         //   Old pattern: command-path projection activation facade with new actor/lifecycle phase
         //   New principle: committed-state publication hook activates existing projection scopes; no new actor/lifecycle phase
         var envelope = CreateWorkflowDefinitionBindEnvelope(workflowYaml, workflowName, inlineWorkflowYamls, scopeId);
-        await _dispatchPort.DispatchAsync(actor.Id, envelope, ct);
+        await _dispatchPort.DispatchAsync(actorId, envelope, ct);
     }
 
     public Task MarkStoppedAsync(
@@ -167,9 +189,9 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
 
     private async Task<DefinitionActorResolutionResult> EnsureDefinitionActorAsync(
         WorkflowDefinitionBinding definition,
+        string? requestedDefinitionActorId,
         CancellationToken ct)
     {
-        var requestedDefinitionActorId = NormalizeActorId(definition.DefinitionActorId);
         if (requestedDefinitionActorId != null)
         {
             var existingActor = await _runtime.GetAsync(requestedDefinitionActorId);
@@ -189,7 +211,7 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
             if (!binding.HasDefinitionPayload || !IsSameDefinition(binding, definition))
             {
                 await BindWorkflowDefinitionAsync(
-                    existingActor,
+                    existingActor.Id,
                     definition.WorkflowYaml,
                     definition.WorkflowName,
                     definition.InlineWorkflowYamls,
@@ -211,7 +233,7 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
         IActor definitionActor;
         try
         {
-            definitionActor = await CreateDefinitionAsync(preferredActorId, ct);
+            definitionActor = await _runtime.CreateAsync<WorkflowGAgent>(preferredActorId, ct: ct);
         }
         catch (InvalidOperationException) when (!string.IsNullOrWhiteSpace(preferredActorId))
         {
@@ -225,7 +247,7 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
         try
         {
             await BindWorkflowDefinitionAsync(
-                definitionActor,
+                definitionActor.Id,
                 definition.WorkflowYaml,
                 definition.WorkflowName,
                 definition.InlineWorkflowYamls,
@@ -258,7 +280,7 @@ internal sealed class WorkflowRunActorPort : IWorkflowRunActorPort
         if (!binding.HasDefinitionPayload || !IsSameDefinition(binding, definition))
         {
             await BindWorkflowDefinitionAsync(
-                existingActor,
+                existingActor.Id,
                 definition.WorkflowYaml,
                 definition.WorkflowName,
                 definition.InlineWorkflowYamls,

--- a/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ScopeBindingCommandApplicationServiceTests.cs
@@ -1828,22 +1828,22 @@ public sealed class ScopeBindingCommandApplicationServiceTests
             Task.FromResult<ServicePolicyCatalogSnapshot?>(null);
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class FakeWorkflowRunActorPort : IWorkflowDefinitionProvisioningPort, IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public Dictionary<string, WorkflowYamlParseResult> ParseResultsByYaml { get; } =
             new(StringComparer.Ordinal);
 
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
+        public Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(WorkflowDefinitionBinding definition, string? preferredActorId = null, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task BindWorkflowDefinitionAsync(
-            IActor actor,
+            string actorId,
             string workflowYaml,
             string workflowName,
             IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceInvocationDispatcherTests.cs
@@ -621,19 +621,19 @@ public sealed class DefaultServiceInvocationDispatcherTests
         }
     }
 
-    private sealed class RecordingWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class RecordingWorkflowRunActorPort : IWorkflowDefinitionProvisioningPort, IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public List<WorkflowDefinitionBinding> CreateRunCalls { get; } = [];
 
         public RecordingActor RunActor { get; } = new("workflow-run");
 
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            Task.FromResult<IActor>(new RecordingActor(actorId ?? "workflow-definition"));
+        public Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(WorkflowDefinitionBinding definition, string? preferredActorId = null, CancellationToken ct = default) =>
+            Task.FromResult(new WorkflowDefinitionProvisioningReceipt(preferredActorId ?? definition.DefinitionActorId, CreatedNow: true));
 
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default)
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default)
         {
             CreateRunCalls.Add(definition);
-            return Task.FromResult(new WorkflowRunCreationResult(RunActor, definition.DefinitionActorId, [RunActor.Id]));
+            return Task.FromResult(new WorkflowRunCreationReceipt(RunActor.Id, definition.DefinitionActorId, [RunActor.Id]));
         }
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
@@ -642,7 +642,7 @@ public sealed class DefaultServiceInvocationDispatcherTests
             Task.CompletedTask;
 
         public Task BindWorkflowDefinitionAsync(
-            IActor actor,
+            string actorId,
             string workflowYaml,
             string workflowName,
             IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
@@ -71,6 +71,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
 
         result.PrimaryActorId.Should().Be("workflow-definition-1:deployment-actor:r1");
         workflowPort.BindCalls.Should().ContainSingle();
+        workflowPort.ExplicitBindCalls.Should().BeEmpty();
         workflowPort.CreateDefinitionCalls.Should().ContainSingle("workflow-definition-1:deployment-actor:r1");
     }
 
@@ -202,6 +203,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
         result.PrimaryActorId.Should().Be("gagent-service:workflow-definition:deployment-actor:r1");
         workflowPort.CreateDefinitionCalls.Should().ContainSingle("gagent-service:workflow-definition:deployment-actor:r1");
         workflowPort.BindCalls.Should().ContainSingle();
+        workflowPort.ExplicitBindCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -244,6 +246,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
         workflowPort.BindCalls.Should().ContainSingle();
         workflowPort.BindCalls[0].inlineWorkflowYamls.Should().ContainKey("child");
         workflowPort.BindCalls[0].inlineWorkflowYamls["child"].Should().Be("name: child");
+        workflowPort.ExplicitBindCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -283,6 +286,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
         result.PrimaryActorId.Should().Be("workflow-definition-1:deployment-actor:r1");
         workflowPort.CreateDefinitionCalls.Should().ContainSingle("workflow-definition-1:deployment-actor:r1");
         workflowPort.BindCalls.Should().ContainSingle();
+        workflowPort.ExplicitBindCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -450,6 +454,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
     {
         public List<string?> CreateDefinitionCalls { get; } = [];
         public List<(string actorId, string workflowName, string workflowYaml, IReadOnlyDictionary<string, string> inlineWorkflowYamls)> BindCalls { get; } = [];
+        public List<(string actorId, string workflowName, string workflowYaml, IReadOnlyDictionary<string, string> inlineWorkflowYamls)> ExplicitBindCalls { get; } = [];
 
         public Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(
             WorkflowDefinitionBinding definition,
@@ -457,6 +462,12 @@ public sealed class DefaultServiceRuntimeActivatorTests
             CancellationToken ct = default)
         {
             CreateDefinitionCalls.Add(preferredActorId);
+            RecordBind(
+                preferredActorId ?? definition.DefinitionActorId,
+                definition.WorkflowYaml,
+                definition.WorkflowName,
+                definition.InlineWorkflowYamls,
+                BindCalls);
             return Task.FromResult(new WorkflowDefinitionProvisioningReceipt(
                 preferredActorId ?? definition.DefinitionActorId,
                 CreatedNow: true));
@@ -478,12 +489,27 @@ public sealed class DefaultServiceRuntimeActivatorTests
             string? scopeId = null,
             CancellationToken ct = default)
         {
-            BindCalls.Add((actorId, workflowName, workflowYaml, inlineWorkflowYamls?.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal) ?? new Dictionary<string, string>(StringComparer.Ordinal)));
+            RecordBind(actorId, workflowYaml, workflowName, inlineWorkflowYamls, ExplicitBindCalls);
             return Task.CompletedTask;
         }
 
         public Task<WorkflowYamlParseResult> ParseWorkflowYamlAsync(string workflowYaml, CancellationToken ct = default) =>
             Task.FromResult(WorkflowYamlParseResult.Success("workflow"));
+
+        private static void RecordBind(
+            string actorId,
+            string workflowYaml,
+            string workflowName,
+            IReadOnlyDictionary<string, string>? inlineWorkflowYamls,
+            List<(string actorId, string workflowName, string workflowYaml, IReadOnlyDictionary<string, string> inlineWorkflowYamls)> target)
+        {
+            target.Add((
+                actorId,
+                workflowName,
+                workflowYaml,
+                inlineWorkflowYamls?.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal)
+                ?? new Dictionary<string, string>(StringComparer.Ordinal)));
+        }
     }
 
     private sealed class RecordingActor : IActor

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
@@ -71,7 +71,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
 
         result.PrimaryActorId.Should().Be("workflow-definition-1:deployment-actor:r1");
         workflowPort.BindCalls.Should().ContainSingle();
-        workflowPort.CreateDefinitionCalls.Should().BeEmpty();
+        workflowPort.CreateDefinitionCalls.Should().ContainSingle("workflow-definition-1:deployment-actor:r1");
     }
 
     [Fact]
@@ -247,15 +247,16 @@ public sealed class DefaultServiceRuntimeActivatorTests
     }
 
     [Fact]
-    public async Task ActivateAsync_ShouldRejectMissingWorkflowDefinitionActor_WhenRuntimeClaimsItExists()
+    public async Task ActivateAsync_ShouldUseWorkflowProvisioning_WhenRuntimeClaimsDefinitionExists()
     {
         var runtime = new RecordingActorRuntime();
         runtime.MarkExistsWithoutActor("workflow-definition-1:deployment-actor:r1");
+        var workflowPort = new RecordingWorkflowRunActorPort();
         var activator = new DefaultServiceRuntimeActivator(
             runtime,
             new RecordingScriptDefinitionSnapshotPort(),
             new RecordingScriptRuntimeProvisioningPort(),
-            new RecordingWorkflowRunActorPort());
+            workflowPort);
         var artifact = new PreparedServiceRevisionArtifact
         {
             Identity = GAgentServiceTestKit.CreateIdentity(),
@@ -272,15 +273,16 @@ public sealed class DefaultServiceRuntimeActivatorTests
             },
         };
 
-        var act = () => activator.ActivateAsync(
+        var result = await activator.ActivateAsync(
             new ServiceRuntimeActivationRequest(
                 GAgentServiceTestKit.CreateIdentity(),
                 artifact,
                 "r1",
                 "deployment-actor"));
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*was not found*");
+        result.PrimaryActorId.Should().Be("workflow-definition-1:deployment-actor:r1");
+        workflowPort.CreateDefinitionCalls.Should().ContainSingle("workflow-definition-1:deployment-actor:r1");
+        workflowPort.BindCalls.Should().ContainSingle();
     }
 
     [Fact]
@@ -444,18 +446,23 @@ public sealed class DefaultServiceRuntimeActivatorTests
         }
     }
 
-    private sealed class RecordingWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class RecordingWorkflowRunActorPort : IWorkflowDefinitionProvisioningPort, IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public List<string?> CreateDefinitionCalls { get; } = [];
         public List<(string actorId, string workflowName, string workflowYaml, IReadOnlyDictionary<string, string> inlineWorkflowYamls)> BindCalls { get; } = [];
 
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default)
+        public Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(
+            WorkflowDefinitionBinding definition,
+            string? preferredActorId = null,
+            CancellationToken ct = default)
         {
-            CreateDefinitionCalls.Add(actorId);
-            return Task.FromResult<IActor>(new RecordingActor(actorId ?? "created-definition"));
+            CreateDefinitionCalls.Add(preferredActorId);
+            return Task.FromResult(new WorkflowDefinitionProvisioningReceipt(
+                preferredActorId ?? definition.DefinitionActorId,
+                CreatedNow: true));
         }
 
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
@@ -464,14 +471,14 @@ public sealed class DefaultServiceRuntimeActivatorTests
             Task.CompletedTask;
 
         public Task BindWorkflowDefinitionAsync(
-            IActor actor,
+            string actorId,
             string workflowYaml,
             string workflowName,
             IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,
             string? scopeId = null,
             CancellationToken ct = default)
         {
-            BindCalls.Add((actor.Id, workflowName, workflowYaml, inlineWorkflowYamls?.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal) ?? new Dictionary<string, string>(StringComparer.Ordinal)));
+            BindCalls.Add((actorId, workflowName, workflowYaml, inlineWorkflowYamls?.ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal) ?? new Dictionary<string, string>(StringComparer.Ordinal)));
             return Task.CompletedTask;
         }
 

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
@@ -635,16 +635,16 @@ public sealed class ServiceImplementationAdaptersTests
         }
     }
 
-    private sealed class RecordingWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class RecordingWorkflowRunActorPort : IWorkflowDefinitionProvisioningPort, IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public WorkflowYamlParseResult ParseResult { get; init; } = WorkflowYamlParseResult.Success("workflow");
 
         public List<string> ParseCalls { get; } = [];
 
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            Task.FromResult<IActor>(new RecordingActor(actorId ?? "workflow-definition"));
+        public Task<WorkflowDefinitionProvisioningReceipt> EnsureDefinitionAsync(WorkflowDefinitionBinding definition, string? preferredActorId = null, CancellationToken ct = default) =>
+            Task.FromResult(new WorkflowDefinitionProvisioningReceipt(preferredActorId ?? definition.DefinitionActorId, CreatedNow: true));
 
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
@@ -653,7 +653,7 @@ public sealed class ServiceImplementationAdaptersTests
             Task.CompletedTask;
 
         public Task BindWorkflowDefinitionAsync(
-            IActor actor,
+            string actorId,
             string workflowYaml,
             string workflowName,
             IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowApplicationLayerTests.cs
@@ -283,8 +283,7 @@ public sealed class WorkflowApplicationLayerTests
     public async Task AcceptedOnlyCommandDispatchService_ShouldReturnReceipt_WithoutConsumingRunEvents()
     {
         var actorPort = new FakeWorkflowRunActorPort();
-        var target = new WorkflowRunAcceptedCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunAcceptedCommandTarget("actor-1",
             "direct",
             ["definition-1", "actor-1"],
             actorPort);
@@ -349,7 +348,7 @@ public sealed class WorkflowApplicationLayerTests
         IReadOnlyList<string>? createdActorIds = null)
     {
         var target = new WorkflowRunCommandTarget(
-            new FakeActor(actorId),
+            actorId,
             workflowName,
             createdActorIds ?? [],
             projectionPort,
@@ -667,17 +666,13 @@ public sealed class WorkflowApplicationLayerTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public List<string> DestroyCalls { get; } = [];
         public int ExpectedDestroyCount { get; set; } = int.MaxValue;
         public TaskCompletionSource<bool> DestroyCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public Exception? DestroyException { get; set; }
-
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowCommandPolicyAndAdapterTests.cs
@@ -57,9 +57,8 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
     public void WorkflowRunAcceptedReceiptFactory_ShouldCreateReceiptFromTargetAndContext()
     {
         var projectionPort = new NoOpProjectionPort();
-        var actor = new FakeActor("actor-1");
         var target = new WorkflowRunCommandTarget(
-            actor,
+            "actor-1",
             "direct",
             createdActorIds: [],
             projectionPort,
@@ -80,8 +79,7 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
     [Fact]
     public void WorkflowRunAcceptedReceiptFactory_ShouldCreateReceiptFromAcceptedTargetAndContext()
     {
-        var target = new WorkflowRunAcceptedCommandTarget(
-            new FakeActor("actor-accepted"),
+        var target = new WorkflowRunAcceptedCommandTarget("actor-accepted",
             "direct",
             createdActorIds: [],
             new NoOpWorkflowRunActorPort());
@@ -126,12 +124,9 @@ public sealed class WorkflowCommandPolicyAndAdapterTests
             Task.CompletedTask;
     }
 
-    private sealed class NoOpWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class NoOpWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunActorResolverTests.cs
@@ -15,7 +15,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         var registry = new InMemoryWorkflowDefinitionCatalog();
         registry.Register("direct", "name: direct\nroles: []\nsteps: []\n");
-        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, registry);
+        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, registry);
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", " direct ", null),
@@ -36,7 +36,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         var registry = new InMemoryWorkflowDefinitionCatalog();
         registry.Register("direct", "name: direct\nroles: []\nsteps: []\n");
-        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, registry);
+        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, registry);
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest(
@@ -58,11 +58,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         var registry = new InMemoryWorkflowDefinitionCatalog();
         registry.Register("auto", "name: auto\nroles: []\nsteps: []\n");
-        var resolver = new WorkflowRunActorResolver(
-            bindingReader,
-            actorPort,
-            registry,
-            new WorkflowRunBehaviorOptions
+        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, registry, new WorkflowRunBehaviorOptions
             {
                 UseAutoAsDefaultWhenWorkflowUnspecified = true,
             });
@@ -83,11 +79,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         var registry = new InMemoryWorkflowDefinitionCatalog();
         registry.Register("review", "name: review\nroles: []\nsteps: []\n");
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            actorPort,
-            registry,
-            new WorkflowRunBehaviorOptions
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, registry, new WorkflowRunBehaviorOptions
             {
                 DefaultWorkflowName = "review",
             });
@@ -105,17 +97,14 @@ public sealed class WorkflowRunActorResolverTests
     [Fact]
     public async Task ResolveOrCreateAsync_ShouldReturnWorkflowNotFound_WhenRegistryDoesNotContainWorkflow()
     {
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            new RecordingWorkflowRunActorPort(),
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", "missing", null),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNotFound);
-        result.Actor.Should().BeNull();
+        result.Target.Should().BeNull();
         result.WorkflowNameForRun.Should().Be("missing");
     }
 
@@ -149,10 +138,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         actorPort.ParseResults[entryWorkflowYaml] = WorkflowYamlParseResult.Success("inline_entry");
         actorPort.ParseResults[helperWorkflowYaml] = WorkflowYamlParseResult.Success("helper");
-        var resolver = new WorkflowRunActorResolver(
-            bindingReader,
-            actorPort,
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, "agent-1", WorkflowYamls: [entryWorkflowYaml, helperWorkflowYaml]),
@@ -160,9 +146,9 @@ public sealed class WorkflowRunActorResolverTests
 
         result.Error.Should().Be(WorkflowChatRunStartError.None);
         result.WorkflowNameForRun.Should().Be("inline_entry");
-        result.Actor.Should().NotBeNull();
-        result.Actor!.Id.Should().Be("run-1");
-        result.CreatedActorIds.Should().Equal("definition-isolated-1", "run-1");
+        result.Target.Should().NotBeNull();
+        result.Target!.ActorId.Should().Be("run-1");
+        result.Target!.CreatedActorIds.Should().Equal("definition-isolated-1", "run-1");
         actorPort.CreateRunBindings.Should().ContainSingle();
         actorPort.CreateRunBindings[0].DefinitionActorId.Should().BeEmpty();
         actorPort.CreateRunBindings[0].WorkflowName.Should().Be("inline_entry");
@@ -193,10 +179,7 @@ public sealed class WorkflowRunActorResolverTests
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
         var actorPort = new RecordingWorkflowRunActorPort();
         actorPort.ParseResults[entryWorkflowYaml] = WorkflowYamlParseResult.Success("inline_entry");
-        var resolver = new WorkflowRunActorResolver(
-            bindingReader,
-            actorPort,
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, "agent-1", WorkflowYamls: [entryWorkflowYaml]),
@@ -225,10 +208,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         actorPort.ParseResults[entryWorkflowYaml] = WorkflowYamlParseResult.Success("inline_entry");
         actorPort.ParseResults[helperWorkflowYaml] = WorkflowYamlParseResult.Success("helper");
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            actorPort,
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", "auto", null, WorkflowYamls: [entryWorkflowYaml, helperWorkflowYaml]),
@@ -236,7 +216,7 @@ public sealed class WorkflowRunActorResolverTests
 
         result.Error.Should().Be(WorkflowChatRunStartError.WorkflowNameMismatch);
         result.WorkflowNameForRun.Should().Be("inline_entry");
-        result.Actor.Should().BeNull();
+        result.Target.Should().BeNull();
         actorPort.CreateRunBindings.Should().BeEmpty();
     }
 
@@ -245,10 +225,7 @@ public sealed class WorkflowRunActorResolverTests
     {
         var actorPort = new RecordingWorkflowRunActorPort();
         actorPort.ParseResults["bad"] = WorkflowYamlParseResult.Invalid("bad yaml");
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            actorPort,
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, null, WorkflowYamls: ["bad"]),
@@ -276,10 +253,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         actorPort.ParseResults[firstYaml] = WorkflowYamlParseResult.Success("duplicate");
         actorPort.ParseResults[secondYaml] = WorkflowYamlParseResult.Success("duplicate");
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            actorPort,
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, null, WorkflowYamls: [firstYaml, secondYaml]),
@@ -292,33 +266,27 @@ public sealed class WorkflowRunActorResolverTests
     [Fact]
     public async Task ResolveOrCreateAsync_ShouldReturnAgentNotFound_WhenSourceActorBindingMissing()
     {
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            new RecordingWorkflowRunActorPort(),
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, "agent-404"),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.AgentNotFound);
-        result.Actor.Should().BeNull();
+        result.Target.Should().BeNull();
     }
 
     [Fact]
     public async Task ResolveOrCreateAsync_ShouldReturnAgentTypeNotSupported_WhenSourceActorIsUnsupported()
     {
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(WorkflowActorBinding.Unsupported("agent-1")),
-            new RecordingWorkflowRunActorPort(),
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(WorkflowActorBinding.Unsupported("agent-1")), new RecordingWorkflowRunActorPort(), new RecordingWorkflowRunActorPort(), new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, "agent-1"),
             CancellationToken.None);
 
         result.Error.Should().Be(WorkflowChatRunStartError.AgentTypeNotSupported);
-        result.Actor.Should().BeNull();
+        result.Target.Should().BeNull();
     }
 
     [Fact]
@@ -334,6 +302,7 @@ public sealed class WorkflowRunActorResolverTests
                     string.Empty,
                     string.Empty,
                     new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))),
+            new RecordingWorkflowRunActorPort(),
             new RecordingWorkflowRunActorPort(),
             new InMemoryWorkflowDefinitionCatalog());
 
@@ -357,6 +326,7 @@ public sealed class WorkflowRunActorResolverTests
                     "bound",
                     string.Empty,
                     new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))),
+            new RecordingWorkflowRunActorPort(),
             new RecordingWorkflowRunActorPort(),
             new InMemoryWorkflowDefinitionCatalog());
 
@@ -384,6 +354,7 @@ public sealed class WorkflowRunActorResolverTests
                     "direct",
                     string.Empty,
                     new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))),
+            actorPort,
             actorPort,
             registry);
 
@@ -413,6 +384,7 @@ public sealed class WorkflowRunActorResolverTests
                     "direct",
                     "name: source\nroles: []\nsteps: []\n",
                     new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))),
+            actorPort,
             actorPort,
             registry);
 
@@ -458,7 +430,7 @@ public sealed class WorkflowRunActorResolverTests
         var actorPort = new RecordingWorkflowRunActorPort();
         var registry = new InMemoryWorkflowDefinitionCatalog();
         registry.Register("direct", latestYaml);
-        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, registry);
+        var resolver = new WorkflowRunActorResolver(bindingReader, actorPort, actorPort, registry);
 
         var boundResult = await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, opaqueActorId),
@@ -499,6 +471,7 @@ public sealed class WorkflowRunActorResolverTests
                     string.Empty,
                     new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase))),
             actorPort,
+            actorPort,
             new InMemoryWorkflowDefinitionCatalog());
 
         var result = await resolver.ResolveOrCreateAsync(
@@ -518,10 +491,7 @@ public sealed class WorkflowRunActorResolverTests
         };
         var registry = new InMemoryWorkflowDefinitionCatalog();
         registry.Register("direct", "name: direct\nroles: []\nsteps: []\n");
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            actorPort,
-            registry);
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, registry);
 
         var act = async () => await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", "direct", null),
@@ -545,10 +515,7 @@ public sealed class WorkflowRunActorResolverTests
             CreateRunException = new InvalidOperationException("inline failed"),
         };
         actorPort.ParseResults[entryWorkflowYaml] = WorkflowYamlParseResult.Success("inline_entry");
-        var resolver = new WorkflowRunActorResolver(
-            new StaticWorkflowActorBindingReader(null),
-            actorPort,
-            new InMemoryWorkflowDefinitionCatalog());
+        var resolver = new WorkflowRunActorResolver(new StaticWorkflowActorBindingReader(null), actorPort, actorPort, new InMemoryWorkflowDefinitionCatalog());
 
         var act = async () => await resolver.ResolveOrCreateAsync(
             new WorkflowChatRunRequest("hello", null, null, WorkflowYamls: [entryWorkflowYaml]),
@@ -592,24 +559,19 @@ public sealed class WorkflowRunActorResolverTests
         }
     }
 
-    private sealed class RecordingWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class RecordingWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public Dictionary<string, WorkflowYamlParseResult> ParseResults { get; } = new(StringComparer.Ordinal);
         public List<WorkflowDefinitionBinding> CreateRunBindings { get; } = [];
         public Exception? CreateRunException { get; set; }
-
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default)
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default)
         {
             ct.ThrowIfCancellationRequested();
             if (CreateRunException != null)
                 throw CreateRunException;
             CreateRunBindings.Add(definition);
             return Task.FromResult(
-                new WorkflowRunCreationResult(
-                    new FakeActor("run-1"),
+                new WorkflowRunCreationReceipt("run-1",
                     "definition-isolated-1",
                     ["definition-isolated-1", "run-1"]));
         }

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunCommandTargetAndPolicyTests.cs
@@ -35,8 +35,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
     public void Constructor_ShouldRejectMissingDurableCompletionResolver()
     {
         var projectionPort = new FakeProjectionPort();
-        var act = () => new WorkflowRunCommandTarget(
-            new FakeActor("run-1"),
+        var act = () => new WorkflowRunCommandTarget("run-1",
             "direct",
             [],
             projectionPort,
@@ -378,8 +377,7 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         projectionPort ??= new FakeProjectionPort();
         actorPort ??= new FakeWorkflowRunActorPort();
         currentStateQueryPort ??= new FakeCurrentStateQueryPort();
-        return new WorkflowRunCommandTarget(
-            new FakeActor("run-1"),
+        return new WorkflowRunCommandTarget("run-1",
             "direct",
             createdActorIds ?? [],
             projectionPort,
@@ -458,15 +456,11 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public Exception? DestroyException { get; set; }
         public List<string> DestroyCalls { get; } = [];
-
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default)
@@ -476,10 +470,6 @@ public sealed class WorkflowRunCommandTargetAndPolicyTests
                 throw DestroyException;
             return Task.CompletedTask;
         }
-
-        public Task BindWorkflowDefinitionAsync(IActor actor, string workflowYaml, string workflowName, IReadOnlyDictionary<string, string>? inlineWorkflowYamls = null, string? scopeId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
         public Task MarkStoppedAsync(
             string actorId,
             string runId,

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlAndAbstractionsCoverageTests.cs
@@ -219,14 +219,12 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public void WorkflowRunControlCommandTarget_ShouldValidateRunIdAndExposeActorIdentity()
     {
-        var actor = new FakeActor("actor-1");
-        var target = new WorkflowRunControlCommandTarget(actor, "run-1");
+        var target = new WorkflowRunControlCommandTarget("actor-1", "run-1");
 
-        target.Actor.Should().BeSameAs(actor);
         target.ActorId.Should().Be("actor-1");
         target.TargetId.Should().Be("actor-1");
 
-        var act = () => new WorkflowRunControlCommandTarget(actor, " ");
+        var act = () => new WorkflowRunControlCommandTarget("actor-1", " ");
 
         act.Should().Throw<ArgumentException>();
     }
@@ -308,9 +306,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public async Task WorkflowRunControlResolver_ShouldRejectInvalidActorId()
     {
-        var resolver = new WorkflowResumeCommandTargetResolver(
-            new FakeActorRuntime(),
-            new FakeWorkflowActorBindingReader());
+        var resolver = new WorkflowResumeCommandTargetResolver(new FakeWorkflowActorBindingReader());
 
         var result = await resolver.ResolveAsync(
             new WorkflowResumeCommand(" ", "run-1", "step-1", "cmd-1", true, "approved"),
@@ -323,9 +319,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public async Task WorkflowRunControlResolver_ShouldRejectInvalidRunId()
     {
-        var resolver = new WorkflowResumeCommandTargetResolver(
-            new FakeActorRuntime(),
-            new FakeWorkflowActorBindingReader());
+        var resolver = new WorkflowResumeCommandTargetResolver(new FakeWorkflowActorBindingReader());
 
         var result = await resolver.ResolveAsync(
             new WorkflowResumeCommand("actor-1", " ", "step-1", "cmd-1", true, "approved"),
@@ -338,9 +332,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public async Task WorkflowRunControlResolver_ShouldRejectInvalidStepId()
     {
-        var resolver = new WorkflowResumeCommandTargetResolver(
-            new FakeActorRuntime(),
-            new FakeWorkflowActorBindingReader());
+        var resolver = new WorkflowResumeCommandTargetResolver(new FakeWorkflowActorBindingReader());
 
         var result = await resolver.ResolveAsync(
             new WorkflowResumeCommand("actor-1", "run-1", " ", "cmd-1", true, "approved"),
@@ -353,9 +345,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public async Task WorkflowRunControlResolver_ShouldRejectInvalidSignalName()
     {
-        var resolver = new WorkflowSignalCommandTargetResolver(
-            new FakeActorRuntime(),
-            new FakeWorkflowActorBindingReader());
+        var resolver = new WorkflowSignalCommandTargetResolver(new FakeWorkflowActorBindingReader());
 
         var result = await resolver.ResolveAsync(
             new WorkflowSignalCommand("actor-1", "run-1", " ", "cmd-1", "yes"),
@@ -368,9 +358,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public async Task WorkflowRunControlResolver_ShouldReturnActorNotFound_WhenRuntimeDoesNotContainActor()
     {
-        var resolver = new WorkflowSignalCommandTargetResolver(
-            new FakeActorRuntime(),
-            new FakeWorkflowActorBindingReader());
+        var resolver = new WorkflowSignalCommandTargetResolver(new FakeWorkflowActorBindingReader());
 
         var result = await resolver.ResolveAsync(
             new WorkflowSignalCommand("actor-404", "run-1", "approve", "cmd-1", "yes"),
@@ -385,9 +373,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         var runtime = new FakeActorRuntime();
         runtime.StoredActors["actor-1"] = new FakeActor("actor-1");
-        var resolver = new WorkflowResumeCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(
+        var resolver = new WorkflowResumeCommandTargetResolver(new FakeWorkflowActorBindingReader(
                 new WorkflowActorBinding(
                     WorkflowActorKind.Definition,
                     "actor-1",
@@ -410,9 +396,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         var runtime = new FakeActorRuntime();
         runtime.StoredActors["actor-1"] = new FakeActor("actor-1");
-        var resolver = new WorkflowSignalCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(
+        var resolver = new WorkflowSignalCommandTargetResolver(new FakeWorkflowActorBindingReader(
                 new WorkflowActorBinding(
                     WorkflowActorKind.Run,
                     "actor-1",
@@ -437,16 +421,16 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         var actorPort = new FakeWorkflowRunActorPort();
 
         var actOnActor = () => new WorkflowRunCommandTarget(null!, "workflow-1", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnWorkflowName = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), " ", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnProjectionPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], null!, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
-        var actOnActorPort = () => new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, null!, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnWorkflowName = () => new WorkflowRunCommandTarget("actor-1", " ", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnProjectionPort = () => new WorkflowRunCommandTarget("actor-1", "workflow-1", [], null!, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var actOnActorPort = () => new WorkflowRunCommandTarget("actor-1", "workflow-1", [], projectionPort, null!, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
 
-        actOnActor.Should().Throw<ArgumentNullException>();
+        actOnActor.Should().Throw<ArgumentException>();
         actOnWorkflowName.Should().Throw<ArgumentException>();
         actOnProjectionPort.Should().Throw<ArgumentNullException>();
         actOnActorPort.Should().Throw<ArgumentNullException>();
 
-        var target = new WorkflowRunCommandTarget(new FakeActor("actor-1"), "workflow-1", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
+        var target = new WorkflowRunCommandTarget("actor-1", "workflow-1", [], projectionPort, actorPort, new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
         var lease = new FakeProjectionLease("actor-1", "cmd-1");
         var sink = new FakeEventSink();
 
@@ -468,8 +452,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     {
         var projectionPort = new FakeProjectionPort();
         var actorPort = new FakeWorkflowRunActorPort();
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "workflow-1",
             ["definition-1", "run-1"],
             projectionPort,
@@ -501,8 +484,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
     [Fact]
     public async Task WorkflowRunCommandTarget_ReleaseAfterInteraction_ShouldValidateArguments()
     {
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "workflow-1",
             [],
             new FakeProjectionPort(),
@@ -597,8 +579,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
             DestroyException = new InvalidOperationException("destroy failed"),
         };
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "workflow-1",
             ["actor-1"],
             projectionPort,
@@ -632,8 +613,7 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         projectionPort ??= new FakeProjectionPort();
         actorPort ??= new FakeWorkflowRunActorPort();
         sink ??= new FakeEventSink();
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "workflow-1",
             ["definition-1", "run-1"],
             projectionPort,
@@ -773,15 +753,11 @@ public sealed class WorkflowRunControlAndAbstractionsCoverageTests
         }
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public Exception? DestroyException { get; set; }
         public List<string> DestroyCalls { get; } = [];
-
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunControlCommandTests.cs
@@ -14,9 +14,7 @@ public sealed class WorkflowRunControlCommandTests
     {
         var runtime = new FakeActorRuntime();
         runtime.StoredActors["actor-1"] = new FakeActor("actor-1");
-        var resolver = new WorkflowResumeCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(
+        var resolver = new WorkflowResumeCommandTargetResolver(new FakeWorkflowActorBindingReader(
                 new WorkflowActorBinding(
                     WorkflowActorKind.Run,
                     "actor-1",
@@ -41,9 +39,7 @@ public sealed class WorkflowRunControlCommandTests
     {
         var runtime = new FakeActorRuntime();
         runtime.StoredActors["actor-1"] = new FakeActor("actor-1");
-        var resolver = new WorkflowSignalCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(
+        var resolver = new WorkflowSignalCommandTargetResolver(new FakeWorkflowActorBindingReader(
                 new WorkflowActorBinding(
                     WorkflowActorKind.Run,
                     "actor-1",
@@ -65,9 +61,7 @@ public sealed class WorkflowRunControlCommandTests
     public async Task ResumeResolver_ShouldRejectBlankStepId_BeforeRuntimeLookup()
     {
         var runtime = new FakeActorRuntime();
-        var resolver = new WorkflowResumeCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(null));
+        var resolver = new WorkflowResumeCommandTargetResolver(new FakeWorkflowActorBindingReader(null));
 
         var result = await resolver.ResolveAsync(
             new WorkflowResumeCommand("actor-1", "run-1", " ", "cmd-1", true, "approved"),
@@ -81,9 +75,7 @@ public sealed class WorkflowRunControlCommandTests
     public async Task SignalResolver_ShouldRejectBlankSignalName_BeforeRuntimeLookup()
     {
         var runtime = new FakeActorRuntime();
-        var resolver = new WorkflowSignalCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(null));
+        var resolver = new WorkflowSignalCommandTargetResolver(new FakeWorkflowActorBindingReader(null));
 
         var result = await resolver.ResolveAsync(
             new WorkflowSignalCommand("actor-1", "run-1", " ", "cmd-1", "yes"),
@@ -98,9 +90,7 @@ public sealed class WorkflowRunControlCommandTests
     {
         var runtime = new FakeActorRuntime();
         runtime.StoredActors["actor-1"] = new FakeActor("actor-1");
-        var resolver = new WorkflowStopCommandTargetResolver(
-            runtime,
-            new FakeWorkflowActorBindingReader(
+        var resolver = new WorkflowStopCommandTargetResolver(new FakeWorkflowActorBindingReader(
                 new WorkflowActorBinding(
                     WorkflowActorKind.Run,
                     "actor-1",
@@ -218,7 +208,7 @@ public sealed class WorkflowRunControlCommandTests
     {
         var factory = new WorkflowRunControlAcceptedReceiptFactory();
         var receipt = factory.Create(
-            new WorkflowRunControlCommandTarget(new FakeActor("actor-1"), "run-1"),
+            new WorkflowRunControlCommandTarget("actor-1", "run-1"),
             new CommandContext("actor-1", "cmd-1", "corr-1", new Dictionary<string, string>()));
 
         receipt.ActorId.Should().Be("actor-1");

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunFallbackCoverageTests.cs
@@ -185,7 +185,7 @@ public sealed class WorkflowRunFallbackCoverageTests
         string commandId)
     {
         var target = new WorkflowRunCommandTarget(
-            new FakeActor(actorId),
+            actorId,
             workflowName,
             [actorId],
             projectionPort,
@@ -382,15 +382,11 @@ public sealed class WorkflowRunFallbackCoverageTests
             Task.CompletedTask;
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public List<string> DestroyCalls { get; } = [];
         public TaskCompletionSource<bool> Destroyed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowRunOrchestrationComponentTests.cs
@@ -16,7 +16,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
     public async Task WorkflowRunCommandTargetResolver_ShouldFail_WhenProjectionIsDisabled()
     {
         var actorResolver = new FakeWorkflowRunActorResolver(
-            new WorkflowActorResolutionResult(new FakeActor("actor-1"), "auto", WorkflowChatRunStartError.None));
+            new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt("actor-1", string.Empty, []), "auto", WorkflowChatRunStartError.None));
         var resolver = new WorkflowRunCommandTargetResolver(
             actorResolver,
             new FakeProjectionPort { ProjectionEnabled = false },
@@ -36,7 +36,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var actor = new FakeActor("actor-1");
         var resolver = new WorkflowRunCommandTargetResolver(
             new FakeWorkflowRunActorResolver(
-                new WorkflowActorResolutionResult(actor, "auto", WorkflowChatRunStartError.None, ["definition-1", "actor-1"])),
+                new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt(actor.Id, string.Empty, ["definition-1", "actor-1"]), "auto", WorkflowChatRunStartError.None)),
             new FakeProjectionPort(),
             new FakeWorkflowRunActorPort(),
             new WorkflowRunDurableCompletionResolver(new NoopCurrentStateQueryPort()));
@@ -58,15 +58,14 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var actorPort = new FakeWorkflowRunActorPort();
         var resolver = new WorkflowRunAcceptedCommandTargetResolver(
             new FakeWorkflowRunActorResolver(
-                new WorkflowActorResolutionResult(actor, "direct", WorkflowChatRunStartError.None, ["definition-1", "actor-accepted"])),
+                new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt(actor.Id, string.Empty, ["definition-1", "actor-accepted"]), "direct", WorkflowChatRunStartError.None)),
             actorPort);
 
         var result = await resolver.ResolveAsync(new WorkflowChatRunRequest("hello", "direct", null), CancellationToken.None);
 
         result.Succeeded.Should().BeTrue();
         result.Target.Should().NotBeNull();
-        result.Target!.Actor.Should().BeSameAs(actor);
-        result.Target.ActorId.Should().Be("actor-accepted");
+        result.Target!.ActorId.Should().Be("actor-accepted");
         result.Target.WorkflowName.Should().Be("direct");
         result.Target.CreatedActorIds.Should().Equal("definition-1", "actor-accepted");
         projectionPort.AttachCalls.Should().BeEmpty();
@@ -76,7 +75,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
     public async Task WorkflowRunAcceptedCommandTargetResolver_ShouldNotConsultProjectionReadiness()
     {
         var actorResolver = new FakeWorkflowRunActorResolver(
-            new WorkflowActorResolutionResult(new FakeActor("actor-1"), "auto", WorkflowChatRunStartError.None));
+            new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt("actor-1", string.Empty, []), "auto", WorkflowChatRunStartError.None));
         var resolver = new WorkflowRunAcceptedCommandTargetResolver(
             actorResolver,
             new FakeWorkflowRunActorPort());
@@ -107,13 +106,12 @@ public sealed class WorkflowRunOrchestrationComponentTests
     [Fact]
     public void WorkflowRunAcceptedCommandTarget_ShouldExposeOnlyDispatchCleanupInterface()
     {
-        var target = new WorkflowRunAcceptedCommandTarget(
-            new FakeActor("actor-accepted"),
+        var target = new WorkflowRunAcceptedCommandTarget("actor-accepted",
             "direct",
             [],
             new FakeWorkflowRunActorPort());
 
-        target.Should().BeAssignableTo<IActorCommandDispatchTarget>();
+        target.Should().BeAssignableTo<ICommandDispatchTarget>();
         target.Should().BeAssignableTo<ICommandDispatchCleanupAware>();
         target.Should().NotBeAssignableTo<ICommandEventTarget<WorkflowRunEventEnvelope>>();
         target.Should().NotBeAssignableTo<ICommandDetachedContinuationTarget<WorkflowChatRunAcceptedReceipt, WorkflowProjectionCompletionStatus>>();
@@ -124,8 +122,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
     public async Task WorkflowRunAcceptedCommandTarget_ShouldDestroyOnlyActorsCreatedDuringResolution_OnDispatchFailureCleanup()
     {
         var actorPort = new FakeWorkflowRunActorPort();
-        var target = new WorkflowRunAcceptedCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunAcceptedCommandTarget("actor-1",
             "direct",
             ["definition-1", "actor-1", "definition-1"],
             actorPort);
@@ -143,8 +140,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         {
             DestroyException = new InvalidOperationException("destroy failed"),
         };
-        var target = new WorkflowRunAcceptedCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunAcceptedCommandTarget("actor-1",
             "direct",
             ["actor-1"],
             actorPort);
@@ -165,8 +161,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         {
             DestroyException = new InvalidOperationException("destroy failed"),
         };
-        var target = new WorkflowRunAcceptedCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunAcceptedCommandTarget("actor-1",
             "direct",
             ["definition-1", "actor-1"],
             actorPort);
@@ -191,7 +186,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var projectionPort = new FakeProjectionPort();
         var act = () => new WorkflowRunCommandTargetResolver(
             new FakeWorkflowRunActorResolver(
-                new WorkflowActorResolutionResult(new FakeActor("actor-1"), "direct", WorkflowChatRunStartError.None)),
+                new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt("actor-1", string.Empty, []), "direct", WorkflowChatRunStartError.None)),
             projectionPort,
             new FakeWorkflowRunActorPort(),
             durableCompletionResolver: null!);
@@ -209,7 +204,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var queryPort = new CompletingCurrentStateQueryPort();
         var resolver = new WorkflowRunCommandTargetResolver(
             new FakeWorkflowRunActorResolver(
-                new WorkflowActorResolutionResult(actor, "direct", WorkflowChatRunStartError.None, ["definition-1", "actor-1"])),
+                new WorkflowActorResolutionResult(new WorkflowRunCreationReceipt(actor.Id, string.Empty, ["definition-1", "actor-1"]), "direct", WorkflowChatRunStartError.None)),
             projectionPort,
             actorPort,
             new WorkflowRunDurableCompletionResolver(queryPort));
@@ -237,8 +232,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         var projectionPort = new FakeProjectionPort();
         var actorPort = new FakeWorkflowRunActorPort();
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "direct",
             [],
             projectionPort,
@@ -274,8 +268,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         };
         var actorPort = new FakeWorkflowRunActorPort();
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "direct",
             ["definition-1", "actor-1", "definition-1"],
             projectionPort,
@@ -309,8 +302,7 @@ public sealed class WorkflowRunOrchestrationComponentTests
         };
         var actorPort = new FakeWorkflowRunActorPort();
         var lifecycle = new WorkflowRunObservationLifecycle(projectionPort);
-        var target = new WorkflowRunCommandTarget(
-            new FakeActor("actor-1"),
+        var target = new WorkflowRunCommandTarget("actor-1",
             "direct",
             ["definition-1", "actor-1"],
             projectionPort,
@@ -426,15 +418,11 @@ public sealed class WorkflowRunOrchestrationComponentTests
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    private sealed class FakeWorkflowRunActorPort : IWorkflowRunActorPort
+    private sealed class FakeWorkflowRunActorPort : IWorkflowRunProvisioningPort, IWorkflowDefinitionParser
     {
         public List<string> DestroyCalls { get; } = [];
         public Exception? DestroyException { get; set; }
-
-        public Task<IActor> CreateDefinitionAsync(string? actorId = null, CancellationToken ct = default) =>
-            throw new NotSupportedException();
-
-        public Task<WorkflowRunCreationResult> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
+        public Task<WorkflowRunCreationReceipt> CreateRunAsync(WorkflowDefinitionBinding definition, CancellationToken ct = default) =>
             throw new NotSupportedException();
 
         public Task DestroyAsync(string actorId, CancellationToken ct = default)

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHostingExtensionsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHostingExtensionsCoverageTests.cs
@@ -61,7 +61,9 @@ public sealed class WorkflowHostingExtensionsCoverageTests
 
         builder.Services.Any(x => x.ServiceType == typeof(ICommandInteractionService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError, WorkflowRunEventEnvelope, WorkflowProjectionCompletionStatus>)).Should().BeTrue();
         builder.Services.Any(x => x.ServiceType == typeof(ICommandDispatchService<WorkflowChatRunRequest, WorkflowChatRunAcceptedReceipt, WorkflowChatRunStartError>)).Should().BeTrue();
-        builder.Services.Any(x => x.ServiceType == typeof(IWorkflowRunActorPort)).Should().BeTrue();
+        builder.Services.Any(x => x.ServiceType == typeof(IWorkflowRunProvisioningPort)).Should().BeTrue();
+        builder.Services.Any(x => x.ServiceType == typeof(IWorkflowDefinitionProvisioningPort)).Should().BeTrue();
+        builder.Services.Any(x => x.ServiceType == typeof(IWorkflowDefinitionParser)).Should().BeTrue();
         builder.Services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<WorkflowRunInsightReportDocument, string>)).Should().BeTrue();
         builder.Services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<WorkflowActorBindingDocument, string>)).Should().BeTrue();
         builder.Services

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -47,8 +47,11 @@ public sealed class WorkflowInfrastructureCoverageTests
         provider.GetRequiredService<IWorkflowRunReportExportPort>()
             .Should().BeOfType<FileSystemWorkflowRunReportExporter>();
         services.Should().Contain(x =>
-            x.ServiceType == typeof(IWorkflowRunActorPort) &&
+            x.ServiceType == typeof(WorkflowRunActorPort) &&
             x.ImplementationType == typeof(WorkflowRunActorPort));
+        services.Should().Contain(x => x.ServiceType == typeof(IWorkflowDefinitionProvisioningPort));
+        services.Should().Contain(x => x.ServiceType == typeof(IWorkflowRunProvisioningPort));
+        services.Should().Contain(x => x.ServiceType == typeof(IWorkflowDefinitionParser));
         services.Should().Contain(x =>
             x.ServiceType == typeof(IWorkflowDefinitionResolver) &&
             x.ImplementationType == typeof(RegistryWorkflowDefinitionResolver));

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunActorPortBranchTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunActorPortBranchTests.cs
@@ -15,15 +15,22 @@ namespace Aevatar.Workflow.Host.Api.Tests;
 public sealed class WorkflowRunActorPortBranchTests
 {
     [Fact]
-    public async Task CreateDefinitionAsync_ShouldForwardPreferredActorId()
+    public async Task EnsureDefinitionAsync_ShouldForwardPreferredActorId()
     {
         var runtime = new RecordingActorRuntime();
         runtime.ActorsToCreate.Enqueue(new RecordingActor("definition-preferred", new WorkflowGAgent()));
         var port = CreatePort(runtime);
 
-        var actor = await port.CreateDefinitionAsync("definition-preferred", CancellationToken.None);
+        var receipt = await port.EnsureDefinitionAsync(
+            new WorkflowDefinitionBinding(
+                "definition-preferred",
+                "direct",
+                "name: direct\nroles: []\nsteps: []\n",
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)),
+            "definition-preferred",
+            CancellationToken.None);
 
-        actor.Id.Should().Be("definition-preferred");
+        receipt.ActorId.Should().Be("definition-preferred");
         runtime.CreateRequests.Should().ContainSingle()
             .Which.Should().Be((typeof(WorkflowGAgent), "definition-preferred"));
     }
@@ -332,12 +339,12 @@ public sealed class WorkflowRunActorPortBranchTests
     }
 
     [Fact]
-    public async Task BindWorkflowDefinitionAsync_ShouldValidateNullActorInput()
+    public async Task BindWorkflowDefinitionAsync_ShouldValidateMissingActorIdInput()
     {
         var port = CreatePort(new RecordingActorRuntime());
 
-        await FluentActions.Invoking(() => port.BindWorkflowDefinitionAsync(null!, "name: x", "x", null, ct: CancellationToken.None))
-            .Should().ThrowAsync<ArgumentNullException>();
+        await FluentActions.Invoking(() => port.BindWorkflowDefinitionAsync(" ", "name: x", "x", null, ct: CancellationToken.None))
+            .Should().ThrowAsync<ArgumentException>();
     }
 
     [Fact]
@@ -349,7 +356,7 @@ public sealed class WorkflowRunActorPortBranchTests
         var port = CreatePort(runtime);
 
         await port.BindWorkflowDefinitionAsync(
-            actor,
+            actor.Id,
             "name: direct\nroles: []\nsteps: []\n",
             "direct",
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunActorPortBranchTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowRunActorPortBranchTests.cs
@@ -1,6 +1,13 @@
 using Aevatar.AI.Abstractions.Agents;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Abstractions.Streaming;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.Foundation.Runtime.Callbacks;
+using Aevatar.Foundation.Runtime.Persistence;
+using Aevatar.Foundation.Runtime.Streaming;
 using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Application.Abstractions.Projections;
@@ -9,11 +16,35 @@ using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Core.Composition;
 using Aevatar.Workflow.Infrastructure.Runs;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
 public sealed class WorkflowRunActorPortBranchTests
 {
+    [Fact]
+    public async Task EnsureDefinitionAsync_WithRealPort_ShouldBindDefinitionOnce()
+    {
+        var runtime = new RecordingActorRuntime();
+        var definitionAgent = CreateWorkflowDefinitionAgent();
+        runtime.ActorsToCreate.Enqueue(new RecordingActor("definition-once", definitionAgent, forwardToAgent: true));
+        var port = CreatePort(runtime);
+
+        var receipt = await port.EnsureDefinitionAsync(
+            new WorkflowDefinitionBinding(
+                "definition-once",
+                "direct",
+                "name: direct\nroles: []\nsteps: []\n",
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)),
+            "definition-once",
+            CancellationToken.None);
+
+        receipt.ActorId.Should().Be("definition-once");
+        definitionAgent.State.Version.Should().Be(1);
+        definitionAgent.State.WorkflowName.Should().Be("direct");
+        definitionAgent.State.WorkflowYaml.Should().Be("name: direct\nroles: []\nsteps: []\n");
+    }
+
     [Fact]
     public async Task EnsureDefinitionAsync_ShouldForwardPreferredActorId()
     {
@@ -570,6 +601,25 @@ public sealed class WorkflowRunActorPortBranchTests
             bindingReader ?? new RuntimeBackedWorkflowActorBindingReader(runtime),
             [new WorkflowCoreModulePack()]);
 
+    private static WorkflowGAgent CreateWorkflowDefinitionAgent()
+    {
+        var eventStore = new InMemoryEventStore();
+        var services = new ServiceCollection()
+            .AddSingleton(eventStore)
+            .AddSingleton<IEventStore>(eventStore)
+            .AddSingleton<IStreamProvider, InMemoryStreamProvider>()
+            .AddSingleton<InMemoryActorRuntimeCallbackScheduler>()
+            .AddSingleton<IActorRuntimeCallbackScheduler>(sp =>
+                sp.GetRequiredService<InMemoryActorRuntimeCallbackScheduler>())
+            .AddSingleton<EventSourcingRuntimeOptions>()
+            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
+            .BuildServiceProvider();
+        var agent = new WorkflowGAgent();
+        agent.Services = services;
+        agent.EventSourcingBehaviorFactory = services.GetRequiredService<IEventSourcingBehaviorFactory<WorkflowState>>();
+        return agent;
+    }
+
     private static string ResolveRepositoryRoot()
     {
         var current = AppContext.BaseDirectory;
@@ -671,10 +721,13 @@ public sealed class WorkflowRunActorPortBranchTests
 
     private sealed class RecordingActor : IActor
     {
-        public RecordingActor(string id, IAgent agent)
+        private readonly bool _forwardToAgent;
+
+        public RecordingActor(string id, IAgent agent, bool forwardToAgent = false)
         {
             Id = id;
             Agent = agent;
+            _forwardToAgent = forwardToAgent;
         }
 
         public string Id { get; }
@@ -687,10 +740,11 @@ public sealed class WorkflowRunActorPortBranchTests
 
         public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
 
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
+        public async Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
         {
             LastHandledEnvelope = envelope;
-            return Task.CompletedTask;
+            if (_forwardToAgent)
+                await Agent.HandleEventAsync(envelope, ct);
         }
 
         public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);


### PR DESCRIPTION
## 摘要

Closes #900 — Phase 9 r1 consensus(unanimous):actor-id-workflow-receipts-split-ports。

## 改动

**Application 层删 IActor 暴露**:
- `IWorkflowRunActorPort` 拆为 3 个窄端口:
  - `IWorkflowDefinitionProvisioningPort`(definition lifecycle)
  - `IWorkflowRunProvisioningPort`(run lifecycle)
  - `IWorkflowDefinitionParser`(YAML parse,纯函数)
- Application 改 typed `WorkflowRunCreationReceipt(ActorId, DefinitionActorId, CreatedActorIds)`
- `WorkflowRunCommandTarget` 基于 ActorId + dispatch contract,不持 `IActor`
- 一次性替换 caller,不留 backwards-compat shim

35 files +312/-382(净 -70 LOC,删除压倒添加)。

## 验证

- test_stability_guards / workflow_binding_boundary_guard / architecture_guards PASS
- workflow tests update + pass

⟦AI:AUTO-LOOP⟧