### PR TITLE
iter53 issue-906 oauth-bootstrap: one-shot bootstrap + actor-owned retry via durable self-callback

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientBootstrapService.cs
@@ -6,163 +6,44 @@ using Microsoft.Extensions.Logging;
 namespace Aevatar.GAgents.Channel.Identity;
 
 /// <summary>
-/// On host startup, provisions the cluster-singleton OAuth client at NyxID
-/// (RFC 7591 DCR) when the binding readmodel reports no registered client.
-/// Idempotent: subsequent silos boot, see the cached <c>client_id</c>, and
-/// skip the call. The actor seeds its own HMAC key on first activation —
-/// no operator step needed beyond enabling <c>broker_capability_enabled</c>
-/// at NyxID admin once per cluster (see /api/oauth/aevatar-client/status
-/// for the post-boot ops handoff).
+/// On host startup, publishes one bootstrap intent to the cluster-singleton
+/// OAuth client actor. The actor owns DCR, drift reconciliation, retry, and
+/// backoff.
 /// </summary>
 /// <remarks>
-/// Bootstrap runs as a non-blocking background task with retry: a transient
-/// NyxID/DCR outage during host startup must not leave the cluster
-/// permanently unprovisioned (PR #521 Codex P1). The retry loop continues
-/// until either provisioning succeeds, the host shuts down, or the back-off
-/// reaches the configured ceiling (~30 min); the status endpoint surfaces
-/// the gap to ops while the loop runs.
+/// Refactor (iter53/issue-906-oauth-bootstrap):
+///   Old pattern: Hosted service ran a Task.Run + Task.Delay retry loop driving OAuth client provisioning lifecycle from outside the actor turn.
+///   New principle: Bootstrap is one-shot signal publisher; AevatarOAuthClientGAgent owns retry/backoff via durable self-callbacks and drift reconciliation in actor turn.
 /// </remarks>
 public sealed class AevatarOAuthClientBootstrapService : IHostedService
 {
     private const string ClientName = "aevatar";
 
-    /// <summary>
-    /// First retry delay after a failed provisioning attempt (5s). Doubles
-    /// on each failure up to <see cref="MaxRetryDelay"/>.
-    /// </summary>
-    internal static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
-
-    /// <summary>
-    /// Upper bound on the back-off interval (30 min). At this point the
-    /// loop stops doubling and keeps retrying at this cadence — the cluster
-    /// is dead enough that ops attention is required, but we still self-heal
-    /// when NyxID returns.
-    /// </summary>
-    internal static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(30);
-
-    private readonly IAevatarOAuthClientProvider _clientProvider;
     private readonly ICommandDispatchService<EnsureAevatarOAuthClientProvisionedCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> _provisioningDispatch;
     private readonly ILogger<AevatarOAuthClientBootstrapService> _logger;
-    private readonly CancellationTokenSource _stoppingCts = new();
-    private Task? _bootstrapTask;
 
     public AevatarOAuthClientBootstrapService(
-        IAevatarOAuthClientProvider clientProvider,
         ICommandDispatchService<EnsureAevatarOAuthClientProvisionedCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> provisioningDispatch,
         ILogger<AevatarOAuthClientBootstrapService> logger)
     {
-        // Refactor (iter27/cluster-028-identity-oauth-endpoint):
-        //   Old pattern: IdentityOAuthEndpoints + AevatarOAuthClientBootstrapService 直接构造 EventEnvelope 投递,然后在 endpoint 内同步等 projection readiness / rebuild observation / readmodel polling (3-15s timeout + 50-250ms polling),违反 ACK 协议 + query-time projection priming
-        //   New principle: 加 module-local CQRS dispatch adapters(ChannelIdentityOAuthCommandDispatch);endpoint inject typed ICommandDispatchService<...>,返回 accepted/pending + status URL,不再等 projection;删 IProjectionReadinessPort/ExternalIdentityBindingProjectionPort/AevatarOAuthClientProjectionPort/AevatarOAuthClientRebuildCoordinator/ProjectionWaitTimeout 等
-        // Provider is registered as a singleton (so are its transitive deps);
-        // injecting it directly avoids the brittle "resolve from the root
-        // IServiceProvider" pattern, which would silently mask any future
-        // scoped dep being added to the provider chain (ValidateScopes
-        // catches scoped → singleton at resolve time, not at AddHostedService
-        // wiring time).
-        _clientProvider = clientProvider ?? throw new ArgumentNullException(nameof(clientProvider));
         _provisioningDispatch = provisioningDispatch ?? throw new ArgumentNullException(nameof(provisioningDispatch));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
-    {
-        // Run the bootstrap as a background task so a transient NyxID
-        // outage does not block host startup, but DO retry indefinitely
-        // (capped backoff) so the cluster self-heals when NyxID returns.
-        // Wrap RunWithRetryAsync in a top-level try/catch so any escape
-        // (e.g. ObjectDisposed on _stoppingCts after race-y shutdown) is
-        // logged and observed rather than swallowed by the unobserved-task
-        // exception sink.
-        _bootstrapTask = Task.Run(RunSafelyAsync, CancellationToken.None);
-        return Task.CompletedTask;
-    }
+    public Task StartAsync(CancellationToken cancellationToken) =>
+        DispatchBootstrapIntentAsync(cancellationToken);
 
-    private async Task RunSafelyAsync()
-    {
-        try
-        {
-            await RunWithRetryAsync(_stoppingCts.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (_stoppingCts.IsCancellationRequested)
-        {
-            // expected when host shutdown cancels mid-flight
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Aevatar OAuth client bootstrap loop exited unexpectedly; broker mode unavailable until host restart.");
-        }
-    }
+    public Task StopAsync(CancellationToken cancellationToken) =>
+        Task.CompletedTask;
 
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        await _stoppingCts.CancelAsync().ConfigureAwait(false);
-        if (_bootstrapTask is null)
-            return;
-
-        try
-        {
-            await _bootstrapTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // expected when the host's shutdown CT fires before the bootstrap
-            // task observes its own _stoppingCts cancellation.
-        }
-        catch (TimeoutException)
-        {
-            // WaitAsync(TimeSpan)-shaped overloads can throw TimeoutException;
-            // host shutdown timeout (Host:ShutdownTimeoutSeconds) is the path
-            // here. Log + continue — the task has already been cancelled via
-            // _stoppingCts so it will self-terminate even after we return.
-            _logger.LogInformation(
-                "Aevatar OAuth client bootstrap did not complete within host shutdown timeout; continuing in background.");
-        }
-    }
-
-    private async Task RunWithRetryAsync(CancellationToken ct)
-    {
-        var delay = InitialRetryDelay;
-        while (!ct.IsCancellationRequested)
-        {
-            try
-            {
-                await EnsureProvisionedAsync(ct).ConfigureAwait(false);
-                return;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(
-                    ex,
-                    "Aevatar OAuth client bootstrap failed; retrying in {DelaySeconds}s. Broker mode unavailable until the next successful attempt.",
-                    (int)delay.TotalSeconds);
-            }
-
-            try
-            {
-                await Task.Delay(delay, ct).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                return;
-            }
-
-            // Exponential backoff with a 30-minute ceiling. Stays self-healing
-            // forever without spamming the log on a long outage.
-            delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, MaxRetryDelay.Ticks));
-        }
-    }
-
-    internal async Task EnsureProvisionedAsync(CancellationToken ct)
+    internal async Task DispatchBootstrapIntentAsync(CancellationToken ct)
     {
         // Refactor (iter27/cluster-028-identity-oauth-endpoint):
         //   Old pattern: IdentityOAuthEndpoints + AevatarOAuthClientBootstrapService 直接构造 EventEnvelope 投递,然后在 endpoint 内同步等 projection readiness / rebuild observation / readmodel polling (3-15s timeout + 50-250ms polling),违反 ACK 协议 + query-time projection priming
         //   New principle: 加 module-local CQRS dispatch adapters(ChannelIdentityOAuthCommandDispatch);endpoint inject typed ICommandDispatchService<...>,返回 accepted/pending + status URL,不再等 projection;删 IProjectionReadinessPort/ExternalIdentityBindingProjectionPort/AevatarOAuthClientProjectionPort/AevatarOAuthClientRebuildCoordinator/ProjectionWaitTimeout 等
+        // Refactor (iter53/issue-906-oauth-bootstrap):
+        //   Old pattern: Hosted service ran a Task.Run + Task.Delay retry loop driving OAuth client provisioning lifecycle from outside the actor turn.
+        //   New principle: Bootstrap is one-shot signal publisher; AevatarOAuthClientGAgent owns retry/backoff via durable self-callbacks and drift reconciliation in actor turn.
         var authority = NyxIdAuthorityResolver.Resolve(_logger);
 
         // Cold-boot DCR is mediated by the well-known actor (PR #521 review):
@@ -174,49 +55,6 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
         // authorize / token time — both call sites use NyxIdRedirectUriResolver.
         var redirectUri = NyxIdRedirectUriResolver.Resolve(_logger);
 
-        AevatarOAuthClientSnapshot? cached = null;
-        try
-        {
-            cached = await _clientProvider.GetAsync(ct).ConfigureAwait(false);
-        }
-        catch (AevatarOAuthClientNotProvisionedException)
-        {
-            // expected on the first run
-        }
-
-        var redirectDrifted = cached is not null && RedirectUriDrifted(cached.RedirectUri, redirectUri);
-        var oauthScopeDrifted = cached is not null &&
-                                !AevatarOAuthClientScopes.ContainsRequiredScopes(cached.OauthScope);
-        if (cached is not null
-            && string.Equals(cached.NyxIdAuthority, authority, StringComparison.Ordinal)
-            && !string.IsNullOrEmpty(cached.ClientId)
-            && !redirectDrifted
-            && !oauthScopeDrifted)
-        {
-            _logger.LogInformation(
-                "Aevatar OAuth client already provisioned at NyxID: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}, oauth_scope={OauthScope}, broker_capability_observed={BrokerObserved}",
-                cached.ClientId,
-                cached.NyxIdAuthority,
-                cached.RedirectUri ?? "<unrecorded>",
-                cached.OauthScope ?? "<unrecorded>",
-                cached.BrokerCapabilityObserved);
-            return;
-        }
-
-        if (redirectDrifted)
-        {
-            _logger.LogWarning(
-                "Aevatar OAuth client redirect URI drifted (stored='{Stored}', resolved='{Resolved}'); dispatching EnsureProvisioned so the actor re-runs DCR.",
-                cached!.RedirectUri,
-                redirectUri);
-        }
-        if (oauthScopeDrifted)
-        {
-            _logger.LogWarning(
-                "Aevatar OAuth client scope drifted (stored='{Stored}', required='{Required}'); dispatching EnsureProvisioned so the actor re-runs DCR.",
-                cached!.OauthScope ?? "<unrecorded>",
-                AevatarOAuthClientScopes.AuthorizationScope);
-        }
         var accepted = await _provisioningDispatch
             .DispatchAsync(new EnsureAevatarOAuthClientProvisionedCommand
             {
@@ -235,17 +73,4 @@ public sealed class AevatarOAuthClientBootstrapService : IHostedService
             authority,
             accepted.Receipt.CommandId);
     }
-
-    /// <summary>
-    /// True when the snapshot either predates redirect-uri tracking or no
-    /// longer matches the current resolver output. Legacy empty redirect_uri
-    /// is unknown, not trustworthy: the production incident this code heals
-    /// already has a persisted client_id at NyxID with no recorded callback
-    /// in our state, so treating empty as "match anything" would keep the
-    /// broken client forever.
-    /// </summary>
-    private static bool RedirectUriDrifted(string? stored, string resolved) =>
-        string.IsNullOrEmpty(stored)
-        || !string.Equals(stored, resolved, StringComparison.Ordinal);
-
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -74,7 +74,23 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     [EventHandler]
     public async Task HandleEnsureProvisioned(EnsureAevatarOAuthClientProvisionedCommand cmd)
     {
+        await HandleEnsureProvisionedAsync(cmd, allowPendingRetryBypass: false).ConfigureAwait(false);
+    }
+
+    private async Task HandleEnsureProvisionedAsync(
+        EnsureAevatarOAuthClientProvisionedCommand cmd,
+        bool allowPendingRetryBypass)
+    {
         ArgumentNullException.ThrowIfNull(cmd);
+        if (!allowPendingRetryBypass && HasPendingProvisioningRetryNotDue(DateTimeOffset.UtcNow))
+        {
+            Logger.LogInformation(
+                "Ignoring duplicate external aevatar OAuth client provisioning ensure while actor-owned retry is pending: attempt={Attempt}, due_unix_ms={DueUnixMs}",
+                State.ProvisioningRetryAttempt,
+                State.ProvisioningRetryDueUnixMs);
+            return;
+        }
+
         try
         {
             await TryEnsureProvisionedAsync(cmd).ConfigureAwait(false);
@@ -272,13 +288,17 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             return;
         }
 
-        await HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        await HandleEnsureProvisionedAsync(new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = State.ProvisioningRetryAuthority,
             RedirectUri = State.ProvisioningRetryRedirectUri,
             ClientName = State.ProvisioningRetryClientName,
-        }).ConfigureAwait(false);
+        }, allowPendingRetryBypass: true).ConfigureAwait(false);
     }
+
+    private bool HasPendingProvisioningRetryNotDue(DateTimeOffset now) =>
+        State.ProvisioningRetryAttempt > 0
+        && State.ProvisioningRetryDueUnixMs > now.ToUnixTimeMilliseconds();
 
     private bool RetryFiredMatchesPendingState(AevatarOAuthClientProvisioningRetryFiredEvent evt)
     {

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Aevatar.Foundation.Abstractions.Attributes;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Google.Protobuf;
@@ -15,8 +16,8 @@ namespace Aevatar.GAgents.Channel.Identity;
 /// registration against NyxID. Holds <see cref="AevatarOAuthClientState"/>
 /// (client_id + HMAC key + observed broker capability) so the entire silo
 /// fleet shares one provisioning record — no IConfiguration / appsettings /
-/// secrets store needed. See cluster bootstrap service for the
-/// caller-side wiring.
+/// secrets store needed. See cluster bootstrap service for the startup
+/// signal wiring.
 /// </summary>
 public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientState>
 {
@@ -33,6 +34,10 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     /// falls back to <c>"v{rotated_at_unix}"</c>.
     /// </summary>
     public const string InitialHmacKid = "v1";
+    internal static readonly TimeSpan InitialRetryDelay = TimeSpan.FromSeconds(5);
+    internal static readonly TimeSpan MaxRetryDelay = TimeSpan.FromMinutes(30);
+
+    private const string ProvisioningRetryCallbackPrefix = "aevatar-oauth-client-provisioning-retry";
 
     /// <inheritdoc />
     /// <remarks>
@@ -51,6 +56,9 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             .On<AevatarOAuthClientHmacKeyRotatedEvent>(ApplyHmacKeyRotated)
             .On<AevatarOAuthClientBrokerCapabilityObservedEvent>(ApplyBrokerCapabilityObserved)
             .On<AevatarOAuthClientProjectionRebuildRequestedEvent>(static (state, _) => state)
+            .On<AevatarOAuthClientProvisioningRetryScheduledEvent>(ApplyProvisioningRetryScheduled)
+            .On<AevatarOAuthClientProvisioningRetryClearedEvent>(ApplyProvisioningRetryCleared)
+            .On<AevatarOAuthClientDriftReconciledEvent>(static (state, _) => state)
             .OrCurrent();
 
     // ─── Commands ───
@@ -67,6 +75,21 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
     public async Task HandleEnsureProvisioned(EnsureAevatarOAuthClientProvisionedCommand cmd)
     {
         ArgumentNullException.ThrowIfNull(cmd);
+        try
+        {
+            await TryEnsureProvisionedAsync(cmd).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await ScheduleProvisioningRetryAsync(cmd, ex).ConfigureAwait(false);
+        }
+    }
+
+    private async Task TryEnsureProvisionedAsync(EnsureAevatarOAuthClientProvisionedCommand cmd)
+    {
+        // Refactor (iter53/issue-906-oauth-bootstrap):
+        //   Old pattern: Hosted service ran a Task.Run + Task.Delay retry loop driving OAuth client provisioning lifecycle from outside the actor turn.
+        //   New principle: Bootstrap is one-shot signal publisher; AevatarOAuthClientGAgent owns retry/backoff via durable self-callbacks and drift reconciliation in actor turn.
         if (string.IsNullOrWhiteSpace(cmd.NyxidAuthority))
         {
             Logger.LogWarning("EnsureProvisioned rejected: nyxid_authority is required");
@@ -107,6 +130,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             if (State.HmacKey.Length == 0)
             {
                 await PersistDomainEventAsync(BuildHmacKeyRotatedEvent());
+                await ClearProvisioningRetryAsync("hmac_seeded_existing_client");
                 Logger.LogInformation("Seeded HMAC key for aevatar OAuth client (existing client_id)");
                 return;
             }
@@ -124,6 +148,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 Reason = "ensure_already_provisioned",
                 RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             });
+            await ClearProvisioningRetryAsync("ensure_already_provisioned");
             Logger.LogInformation(
                 "Requested aevatar OAuth client projection rebuild: actorId={ActorId}, authority={Authority}",
                 Id,
@@ -151,9 +176,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var registrar = Services.GetService<NyxIdDynamicClientRegistrationClient>();
         if (registrar is null)
         {
-            Logger.LogError(
-                "EnsureProvisioned cannot resolve NyxIdDynamicClientRegistrationClient; DI is missing the registrar");
-            return;
+            throw new InvalidOperationException(
+                "EnsureProvisioned cannot resolve NyxIdDynamicClientRegistrationClient; DI is missing the registrar.");
         }
 
         // CancellationToken.None is the contract here: the framework's
@@ -179,6 +203,8 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // store before invoking the callback, and there is no protected
         // "replay state" helper a future handler could misuse outside an
         // active commit path (PR #552 review codex/glm-5.1).
+        var previousRedirectUri = State.RedirectUri;
+        var previousOauthScope = State.OauthScope;
         await PersistDomainEventAsync(
             new AevatarOAuthClientProvisionedEvent
             {
@@ -196,7 +222,17 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // peer's id, this handler must NOT continue with the post-
         // Provisioned HMAC seed against state we did not produce.
         if (!string.Equals(State.ClientId, registration.ClientId, StringComparison.Ordinal))
+        {
+            if (StateMatchesProvisioningIntent(cmd))
+                await ClearProvisioningRetryAsync("ensure_provisioned_by_peer").ConfigureAwait(false);
             return;
+        }
+
+        await PersistDriftReconciledEventsAsync(
+            redirectUriDrifted,
+            oauthScopeDrifted,
+            previousRedirectUri,
+            previousOauthScope);
 
         Logger.LogInformation(
             "Provisioned aevatar OAuth client via DCR: client_id={ClientId}, authority={Authority}, redirect_uri={RedirectUri}",
@@ -218,7 +254,191 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 onOptimisticConcurrencyConflict: AbsorbPeerHmacSeedAsync);
             Logger.LogInformation("Seeded HMAC key for aevatar OAuth client");
         }
+
+        await ClearProvisioningRetryAsync("ensure_provisioned");
     }
+
+    [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
+    public async Task HandleProvisioningRetryFired(AevatarOAuthClientProvisioningRetryFiredEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        if (!RetryFiredMatchesPendingState(evt))
+        {
+            Logger.LogInformation(
+                "Ignoring stale aevatar OAuth client provisioning retry callback: callback_id={CallbackId}, attempt={Attempt}, due_unix_ms={DueUnixMs}",
+                evt.CallbackId,
+                evt.Attempt,
+                evt.DueUnixMs);
+            return;
+        }
+
+        await HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = State.ProvisioningRetryAuthority,
+            RedirectUri = State.ProvisioningRetryRedirectUri,
+            ClientName = State.ProvisioningRetryClientName,
+        }).ConfigureAwait(false);
+    }
+
+    private bool RetryFiredMatchesPendingState(AevatarOAuthClientProvisioningRetryFiredEvent evt)
+    {
+        if (State.ProvisioningRetryAttempt <= 0)
+            return false;
+
+        if (!string.Equals(evt.CallbackId, State.ProvisioningRetryCallbackId, StringComparison.Ordinal)
+            || evt.Attempt != State.ProvisioningRetryAttempt
+            || evt.DueUnixMs != State.ProvisioningRetryDueUnixMs
+            || !string.Equals(evt.NyxidAuthority, State.ProvisioningRetryAuthority, StringComparison.Ordinal)
+            || !string.Equals(evt.RedirectUri, State.ProvisioningRetryRedirectUri, StringComparison.Ordinal)
+            || !string.Equals(evt.ClientName, State.ProvisioningRetryClientName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (ActiveInboundEnvelope is not null &&
+            RuntimeCallbackEnvelopeStateReader.TryRead(ActiveInboundEnvelope, out var callbackState))
+        {
+            return string.Equals(callbackState.CallbackId, State.ProvisioningRetryCallbackId, StringComparison.Ordinal)
+                   && callbackState.Generation == State.ProvisioningRetryCallbackGeneration;
+        }
+
+        return evt.CallbackGeneration <= 0 || evt.CallbackGeneration == State.ProvisioningRetryCallbackGeneration;
+    }
+
+    private bool StateMatchesProvisioningIntent(EnsureAevatarOAuthClientProvisionedCommand cmd) =>
+        !string.IsNullOrEmpty(State.ClientId)
+        && string.Equals(State.NyxidAuthority, cmd.NyxidAuthority, StringComparison.Ordinal)
+        && string.Equals(State.RedirectUri, cmd.RedirectUri, StringComparison.Ordinal)
+        && AevatarOAuthClientScopes.ContainsRequiredScopes(State.OauthScope)
+        && State.HmacKey.Length > 0;
+
+    private async Task ScheduleProvisioningRetryAsync(
+        EnsureAevatarOAuthClientProvisionedCommand cmd,
+        Exception error)
+    {
+        var normalized = NormalizeEnsureProvisionedCommand(cmd);
+        if (normalized is null)
+        {
+            Logger.LogWarning(
+                error,
+                "Aevatar OAuth client provisioning failed but retry was not scheduled because command fields are invalid");
+            return;
+        }
+
+        var nextAttempt = State.ProvisioningRetryAttempt > 0 ? State.ProvisioningRetryAttempt + 1 : 1;
+        var delay = ComputeRetryDelay(nextAttempt);
+        var due = DateTimeOffset.UtcNow.Add(delay);
+        var callbackId = BuildProvisioningRetryCallbackId();
+        var callbackPayload = new AevatarOAuthClientProvisioningRetryFiredEvent
+        {
+            Attempt = nextAttempt,
+            DueUnixMs = due.ToUnixTimeMilliseconds(),
+            NyxidAuthority = normalized.NyxidAuthority,
+            RedirectUri = normalized.RedirectUri,
+            ClientName = normalized.ClientName,
+            CallbackId = callbackId,
+            FiredAtUnixMs = due.ToUnixTimeMilliseconds(),
+        };
+        var lease = await ScheduleSelfDurableTimeoutAsync(
+                callbackId,
+                delay,
+                callbackPayload,
+                ct: CancellationToken.None)
+            .ConfigureAwait(false);
+
+        await PersistDomainEventAsync(new AevatarOAuthClientProvisioningRetryScheduledEvent
+        {
+            Attempt = nextAttempt,
+            DueUnixMs = due.ToUnixTimeMilliseconds(),
+            NyxidAuthority = normalized.NyxidAuthority,
+            RedirectUri = normalized.RedirectUri,
+            ClientName = normalized.ClientName,
+            CallbackId = lease.CallbackId,
+            CallbackGeneration = lease.Generation,
+            LastError = error.Message,
+            ScheduledAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        }).ConfigureAwait(false);
+
+        Logger.LogWarning(
+            error,
+            "Aevatar OAuth client provisioning failed; actor-owned retry scheduled in {DelaySeconds}s (attempt={Attempt}, callback_generation={Generation}).",
+            (int)delay.TotalSeconds,
+            nextAttempt,
+            lease.Generation);
+    }
+
+    private async Task ClearProvisioningRetryAsync(string reason)
+    {
+        if (State.ProvisioningRetryAttempt <= 0)
+            return;
+
+        await PersistDomainEventAsync(new AevatarOAuthClientProvisioningRetryClearedEvent
+        {
+            Reason = reason,
+            ClearedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        }).ConfigureAwait(false);
+    }
+
+    private async Task PersistDriftReconciledEventsAsync(
+        bool redirectUriDrifted,
+        bool oauthScopeDrifted,
+        string previousRedirectUri,
+        string previousOauthScope)
+    {
+        var events = new List<IMessage>(capacity: 2);
+        var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        if (redirectUriDrifted)
+        {
+            events.Add(new AevatarOAuthClientDriftReconciledEvent
+            {
+                DriftKind = "redirect_uri",
+                PreviousValue = previousRedirectUri ?? string.Empty,
+                ExpectedValue = State.RedirectUri,
+                ActiveClientId = State.ClientId,
+                ReconciledAt = now,
+            });
+        }
+        if (oauthScopeDrifted)
+        {
+            events.Add(new AevatarOAuthClientDriftReconciledEvent
+            {
+                DriftKind = "oauth_scope",
+                PreviousValue = previousOauthScope ?? string.Empty,
+                ExpectedValue = State.OauthScope,
+                ActiveClientId = State.ClientId,
+                ReconciledAt = now,
+            });
+        }
+
+        if (events.Count > 0)
+            await PersistDomainEventsAsync(events).ConfigureAwait(false);
+    }
+
+    private static EnsureAevatarOAuthClientProvisionedCommand? NormalizeEnsureProvisionedCommand(
+        EnsureAevatarOAuthClientProvisionedCommand cmd)
+    {
+        if (string.IsNullOrWhiteSpace(cmd.NyxidAuthority) || string.IsNullOrWhiteSpace(cmd.RedirectUri))
+            return null;
+
+        return new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = cmd.NyxidAuthority.Trim(),
+            RedirectUri = cmd.RedirectUri.Trim(),
+            ClientName = string.IsNullOrWhiteSpace(cmd.ClientName) ? "aevatar" : cmd.ClientName.Trim(),
+        };
+    }
+
+    private static TimeSpan ComputeRetryDelay(int attempt)
+    {
+        var exponent = Math.Max(0, Math.Min(attempt - 1, 20));
+        var ticks = InitialRetryDelay.Ticks;
+        for (var i = 0; i < exponent && ticks < MaxRetryDelay.Ticks; i++)
+            ticks = Math.Min(ticks * 2, MaxRetryDelay.Ticks);
+        return TimeSpan.FromTicks(ticks);
+    }
+
+    private static string BuildProvisioningRetryCallbackId() =>
+        RuntimeCallbackKeyComposer.BuildCallbackId(ProvisioningRetryCallbackPrefix, WellKnownId);
 
     private Task<bool> AbsorbPeerDcrProvisioningAsync(
         EnsureAevatarOAuthClientProvisionedCommand cmd,
@@ -249,7 +469,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         }
 
         Logger.LogError(
-            "Aevatar OAuth client OCC race did not converge on the desired shape after replay; rethrowing so the bootstrap retry path can re-evaluate. "
+            "Aevatar OAuth client OCC race did not converge on the desired shape after replay; actor-owned retry will re-evaluate. "
             + "stored_client_id={StoredClientId}, stored_redirect_uri={StoredRedirect}, expected_redirect_uri={ExpectedRedirect}, "
             + "orphan_client_id={OrphanClientId}, expected_version={Expected}, actual_version={Actual}.",
             State.ClientId,
@@ -275,7 +495,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         }
 
         Logger.LogError(
-            "Aevatar OAuth client HMAC-seed OCC fired but the post-replay state has no HMAC key; rethrowing so the bootstrap retry path can complete the seed. "
+            "Aevatar OAuth client HMAC-seed OCC fired but the post-replay state has no HMAC key; actor-owned retry will complete the seed. "
             + "active_client_id={ClientId}, expected_version={Expected}, actual_version={Actual}.",
             State.ClientId,
             occ.ExpectedVersion,
@@ -472,6 +692,39 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         var next = current.Clone();
         next.BrokerCapabilityObserved = true;
         next.BrokerCapabilityObservedAtUnix = evt.ObservedAtUnix;
+        return next;
+    }
+
+    private static AevatarOAuthClientState ApplyProvisioningRetryScheduled(
+        AevatarOAuthClientState current,
+        AevatarOAuthClientProvisioningRetryScheduledEvent evt)
+    {
+        var next = current.Clone();
+        next.ProvisioningRetryAttempt = evt.Attempt;
+        next.ProvisioningRetryDueUnixMs = evt.DueUnixMs;
+        next.ProvisioningRetryAuthority = evt.NyxidAuthority ?? string.Empty;
+        next.ProvisioningRetryRedirectUri = evt.RedirectUri ?? string.Empty;
+        next.ProvisioningRetryClientName = evt.ClientName ?? string.Empty;
+        next.ProvisioningRetryCallbackId = evt.CallbackId ?? string.Empty;
+        next.ProvisioningRetryCallbackGeneration = evt.CallbackGeneration;
+        next.ProvisioningRetryLastError = evt.LastError ?? string.Empty;
+        return next;
+    }
+
+    private static AevatarOAuthClientState ApplyProvisioningRetryCleared(
+        AevatarOAuthClientState current,
+        AevatarOAuthClientProvisioningRetryClearedEvent evt)
+    {
+        _ = evt;
+        var next = current.Clone();
+        next.ProvisioningRetryAttempt = 0;
+        next.ProvisioningRetryDueUnixMs = 0;
+        next.ProvisioningRetryAuthority = string.Empty;
+        next.ProvisioningRetryRedirectUri = string.Empty;
+        next.ProvisioningRetryClientName = string.Empty;
+        next.ProvisioningRetryCallbackId = string.Empty;
+        next.ProvisioningRetryCallbackGeneration = 0;
+        next.ProvisioningRetryLastError = string.Empty;
         return next;
     }
 }

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -59,6 +59,17 @@ message AevatarOAuthClientState {
   // means legacy/unknown and forces one re-DCR on the next EnsureProvisioned
   // command so existing clients missing the proxy scope are healed.
   string oauth_scope = 13;
+  // Actor-owned OAuth provisioning retry facts. Empty/zero means no retry is
+  // pending. These facts are control-flow state, so they are typed fields
+  // instead of a generic bag.
+  int32 provisioning_retry_attempt = 14;
+  int64 provisioning_retry_due_unix_ms = 15;
+  string provisioning_retry_authority = 16;
+  string provisioning_retry_redirect_uri = 17;
+  string provisioning_retry_client_name = 18;
+  string provisioning_retry_callback_id = 19;
+  int64 provisioning_retry_callback_generation = 20;
+  string provisioning_retry_last_error = 21;
 }
 
 // Issued by the bootstrap startup service from every silo on cluster cold-
@@ -71,6 +82,20 @@ message EnsureAevatarOAuthClientProvisionedCommand {
   string redirect_uri = 2;
   // Optional override for the DCR <c>client_name</c>; bootstrap leaves blank.
   string client_name = 3;
+}
+
+// Durable self-callback payload fired when an actor-owned OAuth provisioning
+// retry becomes due. The actor validates it against typed retry facts before
+// re-entering the DCR path.
+message AevatarOAuthClientProvisioningRetryFiredEvent {
+  int32 attempt = 1;
+  int64 due_unix_ms = 2;
+  string nyxid_authority = 3;
+  string redirect_uri = 4;
+  string client_name = 5;
+  string callback_id = 6;
+  int64 callback_generation = 7;
+  int64 fired_at_unix_ms = 8;
 }
 
 // Issued by tests / manual operator scripts that already hold a client_id
@@ -112,6 +137,36 @@ message ObserveBrokerCapabilityCommand {}
 message AevatarOAuthClientProjectionRebuildRequestedEvent {
   string reason = 1;
   google.protobuf.Timestamp requested_at = 2;
+}
+
+// Persisted after a failed actor-owned provisioning attempt schedules a
+// durable self-callback for the next retry.
+message AevatarOAuthClientProvisioningRetryScheduledEvent {
+  int32 attempt = 1;
+  int64 due_unix_ms = 2;
+  string nyxid_authority = 3;
+  string redirect_uri = 4;
+  string client_name = 5;
+  string callback_id = 6;
+  int64 callback_generation = 7;
+  string last_error = 8;
+  google.protobuf.Timestamp scheduled_at = 9;
+}
+
+// Persisted when provisioning reaches a terminal successful branch and the
+// actor no longer owns a pending retry.
+message AevatarOAuthClientProvisioningRetryClearedEvent {
+  string reason = 1;
+  google.protobuf.Timestamp cleared_at = 2;
+}
+
+// Persisted when actor-owned drift reconciliation succeeds through DCR.
+message AevatarOAuthClientDriftReconciledEvent {
+  string drift_kind = 1;
+  string previous_value = 2;
+  string expected_value = 3;
+  string active_client_id = 4;
+  google.protobuf.Timestamp reconciled_at = 5;
 }
 
 // Persisted on successful provision. Carries the client_id + issuance

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientBootstrapServiceTests.cs
@@ -1,6 +1,5 @@
 using Aevatar.CQRS.Core.Abstractions.Commands;
 using Aevatar.GAgents.Channel.Identity;
-using Aevatar.GAgents.Channel.Identity.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -13,32 +12,14 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 public sealed class AevatarOAuthClientBootstrapServiceTests
 {
     [Fact]
-    public async Task EnsureProvisionedAsync_SkipsDispatch_WhenSnapshotAlreadyMatchesResolvedClient()
+    public async Task StartAsync_DispatchesOneBootstrapIntent()
     {
         using var environment = new OAuthBootstrapEnvironment();
         var dispatch = new RecordingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>(
             static _ => OAuthClientReceipt());
-        var service = NewService(
-            new StaticClientProvider(Snapshot(
-                authority: environment.Authority,
-                redirectUri: environment.RedirectUri,
-                oauthScope: AevatarOAuthClientScopes.AuthorizationScope)),
-            dispatch);
+        var service = NewService(dispatch);
 
-        await service.EnsureProvisionedAsync(CancellationToken.None);
-
-        dispatch.Commands.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task EnsureProvisionedAsync_DispatchesAcceptedCommand_WhenSnapshotIsMissing()
-    {
-        using var environment = new OAuthBootstrapEnvironment();
-        var dispatch = new RecordingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>(
-            static _ => OAuthClientReceipt());
-        var service = NewService(new MissingClientProvider(), dispatch);
-
-        await service.EnsureProvisionedAsync(CancellationToken.None);
+        await service.StartAsync(CancellationToken.None);
 
         dispatch.Commands.Should().ContainSingle();
         var command = dispatch.Commands[0];
@@ -48,19 +29,14 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
     }
 
     [Fact]
-    public async Task EnsureProvisionedAsync_DispatchesAcceptedCommand_WhenSnapshotDrifted()
+    public async Task DispatchBootstrapIntentAsync_DispatchesAcceptedCommand()
     {
         using var environment = new OAuthBootstrapEnvironment();
         var dispatch = new RecordingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>(
             static _ => OAuthClientReceipt());
-        var service = NewService(
-            new StaticClientProvider(Snapshot(
-                authority: environment.Authority,
-                redirectUri: "https://old.example.com/api/oauth/nyxid-callback",
-                oauthScope: "openid")),
-            dispatch);
+        var service = NewService(dispatch);
 
-        await service.EnsureProvisionedAsync(CancellationToken.None);
+        await service.DispatchBootstrapIntentAsync(CancellationToken.None);
 
         dispatch.Commands.Should().ContainSingle();
         var command = dispatch.Commands[0];
@@ -70,18 +46,24 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
     }
 
     [Fact]
-    public async Task EnsureProvisionedAsync_Throws_WhenDispatchRejects()
+    public async Task DispatchBootstrapIntentAsync_Throws_WhenDispatchRejects()
     {
         using var environment = new OAuthBootstrapEnvironment();
-        var service = NewService(
-            new MissingClientProvider(),
-            new RejectingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>());
+        var service = NewService(new RejectingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>());
 
-        var act = () => service.EnsureProvisionedAsync(CancellationToken.None);
+        var act = () => service.DispatchBootstrapIntentAsync(CancellationToken.None);
 
         await act.Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage("*InvalidTarget*");
+    }
+
+    [Fact]
+    public async Task StopAsync_IsNoOp()
+    {
+        var service = NewService(new RejectingCommandDispatch<EnsureAevatarOAuthClientProvisionedCommand>());
+
+        await service.StopAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -108,28 +90,13 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
         combinedSource.Should().NotContain("Rebuild" + "Observation");
         combinedSource.Should().NotContain("WaitForBinding" + "StateAsync");
         combinedSource.Should().NotContain(string.Concat("Task", ".Delay"));
+        combinedSource.Should().NotContain(string.Concat("Task", ".Run"));
+        bootstrapSource.Should().NotContain("IAevatarOAuthClient" + "Provider");
     }
 
     private static AevatarOAuthClientBootstrapService NewService(
-        IAevatarOAuthClientProvider provider,
         ICommandDispatchService<EnsureAevatarOAuthClientProvisionedCommand, ChannelIdentityOAuthAcceptedReceipt, ChannelIdentityOAuthDispatchError> dispatch) =>
-        new(provider, dispatch, NullLogger<AevatarOAuthClientBootstrapService>.Instance);
-
-    private static AevatarOAuthClientSnapshot Snapshot(
-        string authority,
-        string redirectUri,
-        string oauthScope) =>
-        new(
-            ClientId: "client-1",
-            ClientIdIssuedAt: DateTimeOffset.FromUnixTimeSeconds(1700000000),
-            HmacKid: AevatarOAuthClientGAgent.InitialHmacKid,
-            HmacKey: new byte[32],
-            HmacKeyRotatedAt: DateTimeOffset.UtcNow,
-            NyxIdAuthority: authority,
-            BrokerCapabilityObserved: true,
-            BrokerCapabilityObservedAt: DateTimeOffset.UtcNow,
-            RedirectUri: redirectUri,
-            OauthScope: oauthScope);
+        new(dispatch, NullLogger<AevatarOAuthClientBootstrapService>.Instance);
 
     private static ChannelIdentityOAuthAcceptedReceipt OAuthClientReceipt() =>
         new(
@@ -164,7 +131,7 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
 
     private static string ExtractEnsureProvisionedSource(string source)
     {
-        const string marker = "internal async Task EnsureProvisionedAsync";
+        const string marker = "internal async Task DispatchBootstrapIntentAsync";
         var start = source.IndexOf(marker, StringComparison.Ordinal);
         start.Should().BeGreaterThanOrEqualTo(0, "bootstrap source should keep the dispatch completion method");
         return source[start..];
@@ -192,18 +159,6 @@ public sealed class AevatarOAuthClientBootstrapServiceTests
             Environment.SetEnvironmentVariable(NyxIdAuthorityResolver.OverrideEnvVar, _oldAuthority);
             Environment.SetEnvironmentVariable(NyxIdRedirectUriResolver.OverrideEnvVar, _oldRedirectBaseUrl);
         }
-    }
-
-    private sealed class StaticClientProvider(AevatarOAuthClientSnapshot snapshot) : IAevatarOAuthClientProvider
-    {
-        public Task<AevatarOAuthClientSnapshot> GetAsync(CancellationToken ct = default) =>
-            Task.FromResult(snapshot);
-    }
-
-    private sealed class MissingClientProvider : IAevatarOAuthClientProvider
-    {
-        public Task<AevatarOAuthClientSnapshot> GetAsync(CancellationToken ct = default) =>
-            throw new AevatarOAuthClientNotProvisionedException();
     }
 
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -245,6 +245,52 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleEnsureProvisioned_DuplicateExternalEnsures_DoNotBypassPendingBackoff()
+    {
+        _registrar.ThrowOnRegister = new InvalidOperationException("nyxid unavailable");
+        var cmd = new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+        };
+
+        await _agent.HandleEnsureProvisioned(cmd);
+
+        _registrar.Calls.Should().HaveCount(1);
+        _agent.State.ProvisioningRetryAttempt.Should().Be(1);
+        _callbackScheduler.TimeoutRequests.Should().ContainSingle();
+
+        _registrar.ThrowOnRegister = null;
+        _registrar.NextClientId = "client-after-self-callback";
+        await _agent.HandleEnsureProvisioned(cmd);
+        await _agent.HandleEnsureProvisioned(cmd);
+        await _agent.HandleEnsureProvisioned(cmd);
+
+        _registrar.Calls.Should().HaveCount(1,
+            "duplicate cold-boot external ensures must not drive retry timing while backoff is pending");
+        _agent.State.ProvisioningRetryAttempt.Should().Be(1);
+        _callbackScheduler.TimeoutRequests.Should().ContainSingle();
+
+        await _agent.HandleProvisioningRetryFired(new AevatarOAuthClientProvisioningRetryFiredEvent
+        {
+            Attempt = _agent.State.ProvisioningRetryAttempt,
+            DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+            NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
+            RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            ClientName = _agent.State.ProvisioningRetryClientName,
+            CallbackId = _agent.State.ProvisioningRetryCallbackId,
+            CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
+            FiredAtUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+        });
+
+        _registrar.Calls.Should().HaveCount(2,
+            "only the durable self-callback may re-enter DCR before the external due-time gate opens");
+        _agent.State.ClientId.Should().Be("client-after-self-callback");
+        _agent.State.ProvisioningRetryAttempt.Should().Be(0);
+    }
+
+    [Fact]
     public async Task HandleProvisioningRetryFired_RetriesAndClearsRetry_WhenCallbackMatches()
     {
         _registrar.ThrowOnRegister = new InvalidOperationException("nyxid unavailable");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -1,11 +1,13 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Identity;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Reflection;
 using Xunit;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
@@ -28,10 +30,12 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     private AevatarOAuthClientGAgent _agent = null!;
     private ServiceProvider _serviceProvider = null!;
     private RecordingDcrClient _registrar = null!;
+    private IdentityGAgentTestHarness.NoopCallbackScheduler _callbackScheduler = null!;
 
     public async Task InitializeAsync()
     {
         _registrar = new RecordingDcrClient();
+        _callbackScheduler = new IdentityGAgentTestHarness.NoopCallbackScheduler();
 
         var services = new ServiceCollection();
         services.AddSingleton<IEventStore, IdentityGAgentTestHarness.InMemoryEventStore>();
@@ -39,8 +43,8 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         services.AddTransient(
             typeof(IEventSourcingBehaviorFactory<>),
             typeof(DefaultEventSourcingBehaviorFactory<>));
-        services.AddSingleton<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler,
-            IdentityGAgentTestHarness.NoopCallbackScheduler>();
+        services.AddSingleton<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler>(
+            _callbackScheduler);
         // The actor resolves the registrar by abstract NyxIdDynamicClientRegistrationClient
         // type; tests inject a recording stub so HandleEnsureProvisioned exercises the
         // full code path without a real HTTP call.
@@ -54,6 +58,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             EventSourcingBehaviorFactory =
                 _serviceProvider.GetRequiredService<IEventSourcingBehaviorFactory<AevatarOAuthClientState>>(),
         };
+        SetActorId(_agent, AevatarOAuthClientGAgent.WellKnownId);
         await _agent.ActivateAsync();
     }
 
@@ -80,6 +85,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.NyxidAuthority.Should().Be("https://nyxid.test");
         _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
         _agent.State.HmacKey.Length.Should().Be(32);
+        _agent.State.ProvisioningRetryAttempt.Should().Be(0);
     }
 
     [Fact]
@@ -138,6 +144,9 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.ClientId.Should().Be("client-after-redirect-fix");
         _agent.State.ClientId.Should().NotBe(firstClientId);
         _agent.State.RedirectUri.Should().Be("https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback");
+        (await ReadEventsAsync<AevatarOAuthClientDriftReconciledEvent>())
+            .Should()
+            .ContainSingle(e => e.DriftKind == "redirect_uri");
     }
 
     [Fact]
@@ -203,6 +212,127 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             "legacy clients without proxy scope cannot mint NyxID LLM API tokens");
         _agent.State.ClientId.Should().Be("client-after-scope-heal");
         _agent.State.OauthScope.Should().Be(AevatarOAuthClientScopes.AuthorizationScope);
+        (await ReadEventsAsync<AevatarOAuthClientDriftReconciledEvent>())
+            .Should()
+            .ContainSingle(e => e.DriftKind == "oauth_scope");
+    }
+
+    [Fact]
+    public async Task HandleEnsureProvisioned_SchedulesDurableRetry_WhenDcrFails()
+    {
+        _registrar.ThrowOnRegister = new InvalidOperationException("nyxid unavailable");
+
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+        });
+
+        _agent.State.ClientId.Should().BeEmpty();
+        _agent.State.ProvisioningRetryAttempt.Should().Be(1);
+        _agent.State.ProvisioningRetryAuthority.Should().Be("https://nyxid.test");
+        _agent.State.ProvisioningRetryRedirectUri.Should().Be("https://aevatar.test/api/oauth/nyxid-callback");
+        _agent.State.ProvisioningRetryClientName.Should().Be("aevatar");
+        _agent.State.ProvisioningRetryDueUnixMs.Should().BeGreaterThan(0);
+        _agent.State.ProvisioningRetryCallbackGeneration.Should().Be(1);
+        _agent.State.ProvisioningRetryLastError.Should().Contain("nyxid unavailable");
+        _callbackScheduler.TimeoutRequests.Should().ContainSingle();
+        _callbackScheduler.TimeoutRequests[0].DueTime.Should().Be(AevatarOAuthClientGAgent.InitialRetryDelay);
+        (await ReadEventsAsync<AevatarOAuthClientProvisioningRetryScheduledEvent>())
+            .Should()
+            .ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleProvisioningRetryFired_RetriesAndClearsRetry_WhenCallbackMatches()
+    {
+        _registrar.ThrowOnRegister = new InvalidOperationException("nyxid unavailable");
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            ClientName = "aevatar",
+        });
+
+        _registrar.ThrowOnRegister = null;
+        _registrar.NextClientId = "client-after-retry";
+        await _agent.HandleProvisioningRetryFired(new AevatarOAuthClientProvisioningRetryFiredEvent
+        {
+            Attempt = _agent.State.ProvisioningRetryAttempt,
+            DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+            NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
+            RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            ClientName = _agent.State.ProvisioningRetryClientName,
+            CallbackId = _agent.State.ProvisioningRetryCallbackId,
+            CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
+            FiredAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        _registrar.Calls.Should().HaveCount(2);
+        _agent.State.ClientId.Should().Be("client-after-retry");
+        _agent.State.ProvisioningRetryAttempt.Should().Be(0);
+        _agent.State.ProvisioningRetryCallbackId.Should().BeEmpty();
+        (await ReadEventsAsync<AevatarOAuthClientProvisioningRetryClearedEvent>())
+            .Should()
+            .ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleProvisioningRetryFired_IgnoresStaleCallback()
+    {
+        _registrar.ThrowOnRegister = new InvalidOperationException("nyxid unavailable");
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+        });
+
+        _registrar.ThrowOnRegister = null;
+        await _agent.HandleProvisioningRetryFired(new AevatarOAuthClientProvisioningRetryFiredEvent
+        {
+            Attempt = _agent.State.ProvisioningRetryAttempt + 1,
+            DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+            NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
+            RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            ClientName = _agent.State.ProvisioningRetryClientName,
+            CallbackId = _agent.State.ProvisioningRetryCallbackId,
+            CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
+        });
+
+        _registrar.Calls.Should().ContainSingle("stale callback must not re-enter DCR");
+        _agent.State.ClientId.Should().BeEmpty();
+        _agent.State.ProvisioningRetryAttempt.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleProvisioningRetryFired_DoublesBackoff_WhenRetryFailsAgain()
+    {
+        _registrar.ThrowOnRegister = new InvalidOperationException("first failure");
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        {
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+        });
+
+        _registrar.ThrowOnRegister = new InvalidOperationException("second failure");
+        await _agent.HandleProvisioningRetryFired(new AevatarOAuthClientProvisioningRetryFiredEvent
+        {
+            Attempt = _agent.State.ProvisioningRetryAttempt,
+            DueUnixMs = _agent.State.ProvisioningRetryDueUnixMs,
+            NyxidAuthority = _agent.State.ProvisioningRetryAuthority,
+            RedirectUri = _agent.State.ProvisioningRetryRedirectUri,
+            ClientName = _agent.State.ProvisioningRetryClientName,
+            CallbackId = _agent.State.ProvisioningRetryCallbackId,
+            CallbackGeneration = _agent.State.ProvisioningRetryCallbackGeneration,
+        });
+
+        _agent.State.ProvisioningRetryAttempt.Should().Be(2);
+        _callbackScheduler.TimeoutRequests.Should().HaveCount(2);
+        _callbackScheduler.TimeoutRequests[1].DueTime.Should().Be(TimeSpan.FromSeconds(10));
+        (await ReadEventsAsync<AevatarOAuthClientProvisioningRetryScheduledEvent>())
+            .Should()
+            .HaveCount(2);
     }
 
     [Fact]
@@ -493,13 +623,13 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleEnsureProvisioned_RethrowsOcc_WhenPeerCommitDoesNotHealDrift()
+    public async Task HandleEnsureProvisioned_SchedulesRetry_WhenPeerCommitDoesNotHealDrift()
     {
         // The OCC absorber must NOT swallow conflicts where the peer's
         // commit was something unrelated (e.g. a future schema event the
-        // actor doesn't know about). In that case the bootstrap retry
-        // path must observe the failure and re-evaluate against fresh
-        // state, otherwise we'd silently leave drift unhealed.
+        // actor doesn't know about). In the actor-owned retry model this
+        // schedules a durable callback so the actor re-evaluates against
+        // fresh state on a later turn.
         await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = "https://nyxid.test",
@@ -511,7 +641,8 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         {
             // Peer's commit is a rebuild request — Apply is identity, so
             // it does NOT update RedirectUri. State stays drifted after
-            // refresh, the absorber returns false, OCC propagates.
+            // refresh, the absorber returns false, and actor-owned retry
+            // captures the failed attempt.
             var store = _serviceProvider.GetRequiredService<IEventStore>();
             var actorId = _agent.Id;
             var current = await store.GetVersionAsync(actorId);
@@ -536,13 +667,17 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
                 current);
         };
 
-        var act = () => _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
+        await _agent.HandleEnsureProvisioned(new EnsureAevatarOAuthClientProvisionedCommand
         {
             NyxidAuthority = "https://nyxid.test",
             RedirectUri = "https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback",
         });
 
-        await act.Should().ThrowAsync<EventStoreOptimisticConcurrencyException>();
+        _agent.State.RedirectUri.Should().Be("http://+:8080/api/oauth/nyxid-callback");
+        _agent.State.ProvisioningRetryAttempt.Should().Be(1);
+        _agent.State.ProvisioningRetryRedirectUri.Should()
+            .Be("https://aevatar-console-backend-api.aevatar.ai/api/oauth/nyxid-callback");
+        _callbackScheduler.TimeoutRequests.Should().ContainSingle();
     }
 
     [Fact]
@@ -566,6 +701,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     {
         public string NextClientId { get; set; } = "client-first";
         public List<(string Authority, string ClientName, string RedirectUri)> Calls { get; } = new();
+        public Exception? ThrowOnRegister { get; set; }
 
         /// <summary>
         /// Hook that runs after the DCR call records the request but before
@@ -593,6 +729,8 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
                 _owner.Calls.Add((authority, clientName, redirectUri));
                 if (_owner.OnRegistered is not null)
                     await _owner.OnRegistered().ConfigureAwait(false);
+                if (_owner.ThrowOnRegister is not null)
+                    throw _owner.ThrowOnRegister;
                 return new RegistrationResult(_owner.NextClientId, DateTimeOffset.UtcNow);
             }
         }
@@ -602,5 +740,25 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
                 throw new InvalidOperationException("HTTP client must not be invoked in unit tests");
         }
+    }
+
+    private async Task<IReadOnlyList<T>> ReadEventsAsync<T>()
+        where T : class, Google.Protobuf.IMessage<T>, new()
+    {
+        var store = _serviceProvider.GetRequiredService<IEventStore>();
+        var events = await store.GetEventsAsync(_agent.Id);
+        return events
+            .Select(e => e.EventData)
+            .OfType<Any>()
+            .Where(any => any.Is(new T().Descriptor))
+            .Select(any => any.Unpack<T>())
+            .ToList();
+    }
+
+    private static void SetActorId(GAgentBase agent, string id)
+    {
+        var method = typeof(GAgentBase).GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("SetId not found on GAgentBase");
+        method.Invoke(agent, new object[] { id });
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityGAgentTestHarness.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/IdentityGAgentTestHarness.cs
@@ -20,14 +20,21 @@ internal static class IdentityGAgentTestHarness
     /// </summary>
     internal sealed class NoopCallbackScheduler : IActorRuntimeCallbackScheduler
     {
+        private long _nextGeneration;
+
+        public List<RuntimeCallbackTimeoutRequest> TimeoutRequests { get; } = new();
+
         public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
             RuntimeCallbackTimeoutRequest request,
-            CancellationToken ct = default) =>
-            Task.FromResult(new RuntimeCallbackLease(
+            CancellationToken ct = default)
+        {
+            TimeoutRequests.Add(request);
+            return Task.FromResult(new RuntimeCallbackLease(
                 request.ActorId,
                 request.CallbackId,
-                Generation: 0,
+                Generation: ++_nextGeneration,
                 RuntimeCallbackBackend.InMemory));
+        }
 
         public Task<RuntimeCallbackLease> ScheduleTimerAsync(
             RuntimeCallbackTimerRequest request,


### PR DESCRIPTION
## 摘要

Closes #906 — Phase 9 r1 consensus(unanimous):actor-owned-oauth-provisioning-retry。

## 改动

- `AevatarOAuthClientBootstrapService`:改 one-shot signal publisher,不持 Task.Run/retry loop/Task.Delay
- `AevatarOAuthClientGAgent`:内 own retry/backoff via durable self-callbacks(per CLAUDE 延迟/超时事件化)
- Drift reconciliation 同 actor 内 emit `OAuthClientDriftReconciled` event
- 不动 NyxID 外部 surface

6 files +527/-274。27 OAuth tests PASS。

⟦AI:AUTO-LOOP⟧