### PR TITLE
iter56 cluster-894: Nyx coordinator adapter-only + room actor 唯一 fact committer

### DIFF
--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
@@ -6,9 +6,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.StreamingProxy.Application.Rooms;
 
-// Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
-//   Old pattern: endpoints built room envelopes and dispatched post-message, join, and terminal-state events directly.
-//   New principle: the existing room command service owns room command normalization, envelope construction, and dispatch.
+// Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+// The service is the existing application write boundary for room effects.
+// It dispatches command/request payloads to StreamingProxyGAgent, never committed room facts for mutable room effects.
+// The room actor validates state and commits the existing domain events.
 public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomCommandService
 {
     private const string DefaultRoomName = "Group Chat";
@@ -88,6 +89,10 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         StreamingProxyRoomPostMessageCommand command,
         CancellationToken cancellationToken = default)
     {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Post-message callers now submit a typed request payload to the room actor.
+        // The application service normalizes transport input but does not mint committed message facts.
+        // StreamingProxyGAgent owns the final persisted/published room message.
         ArgumentNullException.ThrowIfNull(command);
 
         var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
@@ -97,7 +102,7 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         var agentId = NormalizeRequiredValue(command.AgentId, nameof(command.AgentId));
         var envelope = BuildRoomEnvelope(
             actor.Id,
-            new GroupChatMessageEvent
+            new StreamingProxyParticipantMessageRequested
             {
                 AgentId = agentId,
                 AgentName = NormalizeOptionalValue(command.AgentName) ?? agentId,
@@ -113,6 +118,10 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         StreamingProxyRoomJoinCommand command,
         CancellationToken cancellationToken = default)
     {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Join callers now submit a typed request payload to the room actor.
+        // Idempotency and participant authority stay with StreamingProxyGAgent state.
+        // This service returns dispatch acceptance, not committed participant visibility.
         ArgumentNullException.ThrowIfNull(command);
 
         var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
@@ -123,7 +132,7 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         var displayName = NormalizeOptionalValue(command.DisplayName) ?? agentId;
         var envelope = BuildRoomEnvelope(
             actor.Id,
-            new GroupChatParticipantJoinedEvent
+            new StreamingProxyParticipantJoinRequested
             {
                 AgentId = agentId,
                 DisplayName = displayName,
@@ -133,20 +142,50 @@ public sealed class StreamingProxyRoomCommandService : IStreamingProxyRoomComman
         return new StreamingProxyRoomJoinResult(StreamingProxyRoomJoinStatus.Joined, agentId, displayName);
     }
 
+    public async Task<StreamingProxyRoomLeaveResult> LeaveAsync(
+        StreamingProxyRoomLeaveCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Leave callers now send a typed request payload through the existing room command service.
+        // The room actor decides whether that request becomes a committed participant-left event.
+        // This prevents Nyx/application adapters from minting committed room lifecycle facts.
+        ArgumentNullException.ThrowIfNull(command);
+
+        var actor = await _actorRuntime.GetAsync(command.RoomId.Trim());
+        if (actor is null)
+            return new StreamingProxyRoomLeaveResult(StreamingProxyRoomLeaveStatus.RoomNotFound, null);
+
+        var agentId = NormalizeRequiredValue(command.AgentId, nameof(command.AgentId));
+        var envelope = BuildRoomEnvelope(
+            actor.Id,
+            new StreamingProxyParticipantLeaveRequested
+            {
+                AgentId = agentId,
+                Reason = NormalizeOptionalValue(command.Reason) ?? string.Empty,
+            });
+
+        await DispatchRoomEnvelopeAsync(actor.Id, envelope, cancellationToken);
+        return new StreamingProxyRoomLeaveResult(StreamingProxyRoomLeaveStatus.Accepted, agentId);
+    }
+
     public Task PublishTerminalStateAsync(
         StreamingProxyRoomTerminalStateCommand command,
         CancellationToken cancellationToken = default)
     {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Terminal publication is a request to the room actor, not an application-owned committed fact.
+        // The actor stamps commit time and persists the existing terminal state event.
+        // Callers only learn that dispatch was attempted through the existing command boundary.
         ArgumentNullException.ThrowIfNull(command);
 
         var roomId = NormalizeRequiredValue(command.RoomId, nameof(command.RoomId));
         var envelope = BuildRoomEnvelope(
             roomId,
-            new StreamingProxyChatSessionTerminalStateChanged
+            new StreamingProxySessionTerminalStateRequested
             {
                 SessionId = NormalizeRequiredValue(command.SessionId, nameof(command.SessionId)),
                 Status = command.Status,
-                TerminalAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                 ErrorMessage = command.ErrorMessage ?? string.Empty,
             });
 

--- a/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
@@ -17,6 +17,10 @@ public interface IStreamingProxyRoomCommandService
         StreamingProxyRoomJoinCommand command,
         CancellationToken cancellationToken = default);
 
+    Task<StreamingProxyRoomLeaveResult> LeaveAsync(
+        StreamingProxyRoomLeaveCommand command,
+        CancellationToken cancellationToken = default);
+
     Task PublishTerminalStateAsync(
         StreamingProxyRoomTerminalStateCommand command,
         CancellationToken cancellationToken = default);
@@ -47,6 +51,15 @@ public sealed record StreamingProxyRoomJoinCommand(
     string AgentId,
     string? DisplayName);
 
+// Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+// Leave is now a typed room command request, not direct construction of a committed leave event.
+// Callers report participant lifecycle observations; StreamingProxyGAgent owns fact commitment.
+// This keeps Nyx adapter behavior on the existing room command-service boundary.
+public sealed record StreamingProxyRoomLeaveCommand(
+    string RoomId,
+    string AgentId,
+    string? Reason);
+
 // Refactor (iter38/cluster-038-streaming-proxy-reuse-existing):
 //   Old pattern: Streaming proxy endpoints published terminal state envelopes through raw dispatch helpers.
 //   New principle: The Application command service owns typed terminal-state publication without adding a second room interaction port.
@@ -69,6 +82,10 @@ public sealed record StreamingProxyRoomJoinResult(
     string? AgentId,
     string? DisplayName);
 
+public sealed record StreamingProxyRoomLeaveResult(
+    StreamingProxyRoomLeaveStatus Status,
+    string? AgentId);
+
 public enum StreamingProxyRoomCreateStatus
 {
     Created = 0,
@@ -85,5 +102,11 @@ public enum StreamingProxyRoomPostMessageStatus
 public enum StreamingProxyRoomJoinStatus
 {
     Joined = 0,
+    RoomNotFound = 1,
+}
+
+public enum StreamingProxyRoomLeaveStatus
+{
+    Accepted = 0,
     RoomNotFound = 1,
 }

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyGAgent.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyGAgent.cs
@@ -14,6 +14,10 @@ namespace Aevatar.GAgents.StreamingProxy;
 /// OpenClaw agents. Does NOT call LLM itself — it receives messages from
 /// participants and broadcasts them to all SSE subscribers.
 /// </summary>
+// Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+// Room effects from adapters enter as typed request payloads through the actor inbox.
+// This actor remains the only component that converts those requests into committed room domain events.
+// External Nyx streaming I/O stays outside actor turns.
 public sealed class StreamingProxyGAgent : GAgentBase<StreamingProxyGAgentState>, IProjectedActor
 {
     public static string ProjectionKind => StreamingProxyProjectionKinds.CurrentState;
@@ -76,6 +80,22 @@ public sealed class StreamingProxyGAgent : GAgentBase<StreamingProxyGAgentState>
             evt.Content.Length > 100 ? evt.Content[..100] + "..." : evt.Content);
     }
 
+    [EventHandler(EndpointName = "requestPostMessage")]
+    public async Task HandleParticipantMessageRequested(StreamingProxyParticipantMessageRequested request)
+    {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Room command adapters now submit request payloads instead of committed room facts.
+        // This actor validates its authoritative state boundary and mints the committed message event.
+        // Projection and SSE continue to observe only the existing committed event types.
+        await HandleGroupChatMessage(new GroupChatMessageEvent
+        {
+            AgentId = request.AgentId,
+            AgentName = string.IsNullOrWhiteSpace(request.AgentName) ? request.AgentId : request.AgentName,
+            Content = request.Content,
+            SessionId = request.SessionId,
+        });
+    }
+
     [EventHandler(EndpointName = "joinRoom")]
     public async Task HandleGroupChatParticipantJoined(GroupChatParticipantJoinedEvent evt)
     {
@@ -93,6 +113,20 @@ public sealed class StreamingProxyGAgent : GAgentBase<StreamingProxyGAgentState>
         Logger.LogInformation("[StreamingProxy] Participant joined: {Name} ({Id})", evt.DisplayName, evt.AgentId);
     }
 
+    [EventHandler(EndpointName = "requestJoinRoom")]
+    public async Task HandleParticipantJoinRequested(StreamingProxyParticipantJoinRequested request)
+    {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Join requests are command input, not already-committed participant facts.
+        // Idempotent participant ownership stays inside this room actor state.
+        // Downstream projections still receive GroupChatParticipantJoinedEvent only after this handler commits it.
+        await HandleGroupChatParticipantJoined(new GroupChatParticipantJoinedEvent
+        {
+            AgentId = request.AgentId,
+            DisplayName = string.IsNullOrWhiteSpace(request.DisplayName) ? request.AgentId : request.DisplayName,
+        });
+    }
+
     [EventHandler(EndpointName = "leaveRoom")]
     public async Task HandleGroupChatParticipantLeft(GroupChatParticipantLeftEvent evt)
     {
@@ -102,6 +136,25 @@ public sealed class StreamingProxyGAgent : GAgentBase<StreamingProxyGAgentState>
         await PublishAsync(evt, TopologyAudience.Parent);
 
         Logger.LogInformation("[StreamingProxy] Participant left: {Id}", evt.AgentId);
+    }
+
+    [EventHandler(EndpointName = "requestLeaveRoom")]
+    public async Task HandleParticipantLeaveRequested(StreamingProxyParticipantLeaveRequested request)
+    {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Leave requests report adapter observations; this actor owns whether a leave fact is committed.
+        // Missing participants remain a no-op so stale Nyx failures cannot invent room history.
+        // Committed leave events remain the only projection/SSE participant removal signal.
+        if (!HasParticipant(request.AgentId))
+        {
+            Logger.LogInformation("[StreamingProxy] Participant leave ignored because participant is not joined: {Id}", request.AgentId);
+            return;
+        }
+
+        await HandleGroupChatParticipantLeft(new GroupChatParticipantLeftEvent
+        {
+            AgentId = request.AgentId,
+        });
     }
 
     [EventHandler(EndpointName = "completeSession")]
@@ -117,6 +170,22 @@ public sealed class StreamingProxyGAgent : GAgentBase<StreamingProxyGAgentState>
             Id,
             evt.SessionId,
             evt.Status);
+    }
+
+    [EventHandler(EndpointName = "requestCompleteSession")]
+    public async Task HandleSessionTerminalStateRequested(StreamingProxySessionTerminalStateRequested request)
+    {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Terminal requests carry observed adapter outcome; this actor owns the committed terminal fact.
+        // The actor stamps terminal time at commit so callers cannot imply a stronger ACK than dispatch.
+        // Existing terminal projection remains keyed by StreamingProxyChatSessionTerminalStateChanged.
+        await HandleChatSessionTerminalStateChanged(new StreamingProxyChatSessionTerminalStateChanged
+        {
+            SessionId = request.SessionId,
+            Status = request.Status,
+            TerminalAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            ErrorMessage = request.ErrorMessage ?? string.Empty,
+        });
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyNyxParticipantCoordinator.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/StreamingProxyNyxParticipantCoordinator.cs
@@ -4,21 +4,23 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.Foundation.Abstractions;
-using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.StreamingProxy;
 
+// Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+// Nyx-specific HTTP/status parsing and ChatStreamAsync reading stay outside the room actor turn.
+// Room effects are submitted only through IStreamingProxyRoomCommandService typed requests.
+// The adapter keeps no authority to create committed room facts.
 internal sealed class StreamingProxyNyxParticipantCoordinator
 {
     private const string NyxIdProviderName = "nyxid";
     private const string GatewaySuffix = "/api/v1/llm/gateway/v1";
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
-    private readonly IActorDispatchPort _actorDispatchPort;
+    private readonly IStreamingProxyRoomCommandService _roomCommandService;
     private readonly ILLMProviderFactory _llmProviderFactory;
     private readonly IConfiguration _configuration;
     private readonly IHttpClientFactory _httpClientFactory;
@@ -26,14 +28,14 @@ internal sealed class StreamingProxyNyxParticipantCoordinator
     private readonly ILogger<StreamingProxyNyxParticipantCoordinator> _logger;
 
     public StreamingProxyNyxParticipantCoordinator(
-        IActorDispatchPort actorDispatchPort,
+        IStreamingProxyRoomCommandService roomCommandService,
         ILLMProviderFactory llmProviderFactory,
         IConfiguration configuration,
         IHttpClientFactory httpClientFactory,
         ILogger<StreamingProxyNyxParticipantCoordinator> logger,
         INyxIdUserLlmPreferencesStore? preferencesStore = null)
     {
-        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _roomCommandService = roomCommandService ?? throw new ArgumentNullException(nameof(roomCommandService));
         _llmProviderFactory = llmProviderFactory;
         _configuration = configuration;
         _httpClientFactory = httpClientFactory;
@@ -49,17 +51,26 @@ internal sealed class StreamingProxyNyxParticipantCoordinator
         string? preferredRoute = null,
         string? defaultModel = null)
     {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // This method resolves Nyx participant definitions and forwards join intent.
+        // It does not publish committed room history or bypass the room command service.
+        // Room actor state remains the only participant fact source.
         var participants = await ResolveParticipantsAsync(accessToken, preferredRoute, defaultModel, ct);
         if (participants.Count == 0)
             return participants;
 
         foreach (var participant in participants)
         {
-            await DispatchAsync(roomId, new GroupChatParticipantJoinedEvent
-            {
-                AgentId = participant.ParticipantId,
-                DisplayName = participant.DisplayName,
-            }, ct);
+            // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+            // Nyx catalog resolution remains outside the actor, but joining is now only a room command request.
+            // The adapter does not construct committed join facts or dispatch raw room envelopes.
+            // StreamingProxyGAgent remains the only committer of participant facts.
+            await _roomCommandService.JoinAsync(
+                new StreamingProxyRoomJoinCommand(
+                    roomId,
+                    participant.ParticipantId,
+                    participant.DisplayName),
+                ct);
         }
 
         return participants;
@@ -89,6 +100,10 @@ internal sealed class StreamingProxyNyxParticipantCoordinator
         string accessToken,
         CancellationToken ct)
     {
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // This method performs external Nyx streaming I/O and normalizes adapter outcomes.
+        // Successful replies and unavailable participants are forwarded as typed room commands.
+        // Committed message/leave facts are owned exclusively by StreamingProxyGAgent.
         if (participants.Count == 0)
             return 0;
 
@@ -168,13 +183,14 @@ internal sealed class StreamingProxyNyxParticipantCoordinator
                     transcript.Add((participant.DisplayName, content));
                     successfulReplies++;
                     totalSuccessfulReplies++;
-                    await DispatchAsync(roomId, new GroupChatMessageEvent
-                    {
-                        AgentId = participant.ParticipantId,
-                        AgentName = participant.DisplayName,
-                        Content = content,
-                        SessionId = sessionId,
-                    }, ct);
+                    await _roomCommandService.PostMessageAsync(
+                        new StreamingProxyRoomPostMessageCommand(
+                            roomId,
+                            participant.ParticipantId,
+                            participant.DisplayName,
+                            content,
+                            sessionId),
+                        ct);
                 }
                 catch (OperationCanceledException)
                 {
@@ -940,10 +956,16 @@ Return only {participant.DisplayName}'s reply text, with no prefixed name and no
         if (string.IsNullOrWhiteSpace(participantId))
             return;
 
-        await DispatchAsync(roomId, new GroupChatParticipantLeftEvent
-        {
-            AgentId = participantId,
-        }, ct);
+        // Refactor (iter56/cluster-894-nyx-coordinator-adapter-only): old=coordinator-owned facts, new=adapter-only + room-actor-owned facts
+        // Participant failure is reported as a typed leave command request.
+        // The adapter does not decide or publish the committed left event.
+        // Room actor state determines whether the request produces a fact.
+        await _roomCommandService.LeaveAsync(
+            new StreamingProxyRoomLeaveCommand(
+                roomId,
+                participantId,
+                "Nyx participant unavailable."),
+            ct);
     }
 
     private static bool IsUnavailableResponse(LLMResponse response)
@@ -991,32 +1013,6 @@ Return only {participant.DisplayName}'s reply text, with no prefixed name and no
         yield return $"**{trimmed}**";
     }
 
-    private async Task DispatchAsync(string actorId, IMessage payload, CancellationToken ct)
-    {
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(payload),
-            Route = new EnvelopeRoute
-            {
-                Direct = new DirectRoute { TargetActorId = actorId },
-            },
-        };
-
-        await DispatchRoomEnvelopeAsync(actorId, envelope, ct);
-    }
-
-    private Task DispatchRoomEnvelopeAsync(
-        string actorId,
-        EventEnvelope envelope,
-        CancellationToken ct)
-    {
-        // Refactor (iter4/cluster-008):
-        //   Old pattern: the Nyx participant coordinator invoked room actors inline.
-        //   New principle: coordinators deliver StreamingProxy room events through IActorDispatchPort.
-        return _actorDispatchPort.DispatchAsync(actorId, envelope, ct);
-    }
 }
 
 internal sealed record StreamingProxyNyxParticipantDefinition(

--- a/agents/Aevatar.GAgents.StreamingProxy/streaming_proxy_messages.proto
+++ b/agents/Aevatar.GAgents.StreamingProxy/streaming_proxy_messages.proto
@@ -46,6 +46,31 @@ message StreamingProxyChatLifecycleRecord {
   string default_model = 5;
 }
 
+// ─── Commands / Requests ───
+
+message StreamingProxyParticipantJoinRequested {
+  string agent_id = 1;
+  string display_name = 2;
+}
+
+message StreamingProxyParticipantMessageRequested {
+  string agent_id = 1;
+  string agent_name = 2;
+  string content = 3;
+  string session_id = 4;
+}
+
+message StreamingProxyParticipantLeaveRequested {
+  string agent_id = 1;
+  string reason = 2;
+}
+
+message StreamingProxySessionTerminalStateRequested {
+  string session_id = 1;
+  StreamingProxyChatSessionTerminalStatus status = 2;
+  string error_message = 3;
+}
+
 // ─── Events ───
 
 enum StreamingProxyChatSessionTerminalStatus {

--- a/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyCoverageTests.cs
@@ -204,6 +204,11 @@ public class StreamingProxyCoverageTests
         roomCommandService.Should().NotContain(".HandleEventAsync(");
         nyxCoordinator.Should().NotContain("actor.HandleEventAsync(");
         nyxCoordinator.Should().NotContain(".HandleEventAsync(");
+        nyxCoordinator.Should().NotContain("IActorDispatchPort", "Nyx participant coordination must stay adapter-only.");
+        nyxCoordinator.Should().NotContain("GroupChatParticipantJoinedEvent", "Nyx adapter must forward join commands only.");
+        nyxCoordinator.Should().NotContain("GroupChatMessageEvent", "Nyx adapter must forward message commands only.");
+        nyxCoordinator.Should().NotContain("GroupChatParticipantLeftEvent", "Nyx adapter must forward leave commands only.");
+        nyxCoordinator.Should().NotContain("StreamingProxyChatSessionTerminalStateChanged", "Nyx adapter must not mint terminal facts.");
     }
 
     [Fact]
@@ -1572,6 +1577,68 @@ public class StreamingProxyCoverageTests
     }
 
     [Fact]
+    public async Task GAgent_RequestPayloads_ShouldCommitExistingRoomFacts()
+    {
+        using var provider = AgentCoverageTestSupport.BuildServiceProvider();
+        var agent = CreateAgent(provider, "streaming-proxy-agent");
+        var publisher = new TestRecordingEventPublisher();
+        agent.EventPublisher = publisher;
+
+        await agent.ActivateAsync();
+        await agent.HandleParticipantJoinRequested(new StreamingProxyParticipantJoinRequested
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alice",
+        });
+        await agent.HandleParticipantJoinRequested(new StreamingProxyParticipantJoinRequested
+        {
+            AgentId = "agent-1",
+            DisplayName = "Alice Again",
+        });
+        await agent.HandleParticipantMessageRequested(new StreamingProxyParticipantMessageRequested
+        {
+            AgentId = "agent-1",
+            AgentName = "Alice",
+            Content = "room-owned message",
+            SessionId = "session-1",
+        });
+        await agent.HandleParticipantLeaveRequested(new StreamingProxyParticipantLeaveRequested
+        {
+            AgentId = "agent-1",
+            Reason = "done",
+        });
+        await agent.HandleParticipantLeaveRequested(new StreamingProxyParticipantLeaveRequested
+        {
+            AgentId = "missing",
+            Reason = "stale",
+        });
+        await agent.HandleSessionTerminalStateRequested(new StreamingProxySessionTerminalStateRequested
+        {
+            SessionId = "session-1",
+            Status = StreamingProxyChatSessionTerminalStatus.Completed,
+        });
+
+        agent.State.Participants.Should().BeEmpty();
+        agent.State.Messages.Should().ContainSingle(message =>
+            message.SenderAgentId == "agent-1" &&
+            message.Content == "room-owned message");
+        agent.State.TerminalSessions["session-1"].Status
+            .Should()
+            .Be(StreamingProxyChatSessionTerminalStatus.Completed);
+        agent.State.TerminalSessions["session-1"].TerminalAt.Should().NotBeNull();
+
+        publisher.Published.OfType<GroupChatParticipantJoinedEvent>()
+            .Should()
+            .ContainSingle(x => x.AgentId == "agent-1" && x.DisplayName == "Alice");
+        publisher.Published.OfType<GroupChatMessageEvent>()
+            .Should()
+            .ContainSingle(x => x.AgentId == "agent-1" && x.Content == "room-owned message");
+        publisher.Published.OfType<GroupChatParticipantLeftEvent>()
+            .Should()
+            .ContainSingle(x => x.AgentId == "agent-1");
+    }
+
+    [Fact]
     public async Task StreamingProxySseWriter_ShouldStartStream_AndSerializeRoomFrames()
     {
         var context = new DefaultHttpContext();
@@ -2325,6 +2392,7 @@ public class StreamingProxyCoverageTests
         public List<StreamingProxyRoomCreateCommand> Commands { get; } = [];
         public List<StreamingProxyRoomPostMessageCommand> PostMessageCommands { get; } = [];
         public List<StreamingProxyRoomJoinCommand> JoinCommands { get; } = [];
+        public List<StreamingProxyRoomLeaveCommand> LeaveCommands { get; } = [];
         public List<StreamingProxyRoomTerminalStateCommand> TerminalCommands { get; } = [];
         public StreamingProxyRoomPostMessageResult PostMessageResult { get; init; } =
             new(StreamingProxyRoomPostMessageStatus.Accepted);
@@ -2361,6 +2429,17 @@ public class StreamingProxyCoverageTests
                 StreamingProxyRoomJoinStatus.Joined,
                 command.AgentId?.Trim(),
                 command.DisplayName?.Trim()));
+        }
+
+        public Task<StreamingProxyRoomLeaveResult> LeaveAsync(
+            StreamingProxyRoomLeaveCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LeaveCommands.Add(command);
+            return Task.FromResult(new StreamingProxyRoomLeaveResult(
+                StreamingProxyRoomLeaveStatus.Accepted,
+                command.AgentId?.Trim()));
         }
 
         public Task PublishTerminalStateAsync(

--- a/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyEndpointsCoverageTests.cs
@@ -339,6 +339,16 @@ public sealed class StreamingProxyEndpointsCoverageTests
                 command.DisplayName?.Trim()));
         }
 
+        public Task<StreamingProxyRoomLeaveResult> LeaveAsync(
+            StreamingProxyRoomLeaveCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new StreamingProxyRoomLeaveResult(
+                StreamingProxyRoomLeaveStatus.Accepted,
+                command.AgentId?.Trim()));
+        }
+
         public Task PublishTerminalStateAsync(
             StreamingProxyRoomTerminalStateCommand command,
             CancellationToken cancellationToken = default)

--- a/test/Aevatar.AI.Tests/StreamingProxyNyxParticipantCoordinatorTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyNyxParticipantCoordinatorTests.cs
@@ -3,10 +3,9 @@ using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.StreamingProxy;
+using Aevatar.GAgents.StreamingProxy.Application.Rooms;
 using FluentAssertions;
-using Google.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -18,7 +17,7 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
     [Fact]
     public async Task EnsureParticipantsJoinedAsync_ShouldPreserveDistinctNodesWithSharedSlug()
     {
-        var (coordinator, actor, _) = CreateCoordinator();
+        var (coordinator, roomCommands, _) = CreateCoordinator();
 
         var participants = await coordinator.EnsureParticipantsJoinedAsync(
             "scope-1",
@@ -32,19 +31,16 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
         participants.Select(participant => participant.DisplayName).Should().OnlyHaveUniqueItems();
         participants.Select(participant => participant.DisplayName).Should().OnlyContain(name => name.StartsWith("OpenClaw-Node", StringComparison.Ordinal));
 
-        var joinedEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatParticipantJoinedEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatParticipantJoinedEvent>())
-            .ToList();
-
-        joinedEvents.Should().HaveCount(3);
-        joinedEvents.Select(evt => evt.AgentId).Should().OnlyHaveUniqueItems();
+        roomCommands.JoinCommands.Should().HaveCount(3);
+        roomCommands.JoinCommands.Select(command => command.AgentId).Should().OnlyHaveUniqueItems();
+        roomCommands.PostMessageCommands.Should().BeEmpty();
+        roomCommands.LeaveCommands.Should().BeEmpty();
     }
 
     [Fact]
     public async Task GenerateRepliesAsync_ShouldSkipUnavailableOpenerAndContinueWithHealthyParticipant()
     {
-        var (coordinator, actor, llmProvider) = CreateCoordinator();
+        var (coordinator, roomCommands, llmProvider) = CreateCoordinator();
         var participants = await coordinator.EnsureParticipantsJoinedAsync(
             "scope-1",
             "room-1",
@@ -67,29 +63,19 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
         llmProvider.Requests[0].RequestId.Should().Contain("node-a");
         llmProvider.Requests[1].RequestId.Should().Contain("node-b");
 
-        var messageEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatMessageEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatMessageEvent>())
-            .ToList();
-
-        var leftEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatParticipantLeftEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatParticipantLeftEvent>())
-            .ToList();
-
-        messageEvents.Should().HaveCount(1);
-        messageEvents.Should().NotContain(evt => evt.Content.StartsWith("当前暂时不可用", StringComparison.Ordinal));
-        messageEvents.Single().Content.Should().Contain("reply from");
-        messageEvents.Single().Content.Should().Contain("node-b");
-        messageEvents.Select(evt => evt.AgentId).Should().OnlyHaveUniqueItems();
-        leftEvents.Should().HaveCount(1);
-        leftEvents.Single().AgentId.Should().Contain("node-a");
+        roomCommands.PostMessageCommands.Should().HaveCount(1);
+        roomCommands.PostMessageCommands.Should().NotContain(command => command.Content.StartsWith("当前暂时不可用", StringComparison.Ordinal));
+        roomCommands.PostMessageCommands.Single().Content.Should().Contain("reply from");
+        roomCommands.PostMessageCommands.Single().Content.Should().Contain("node-b");
+        roomCommands.PostMessageCommands.Select(command => command.AgentId).Should().OnlyHaveUniqueItems();
+        roomCommands.LeaveCommands.Should().HaveCount(1);
+        roomCommands.LeaveCommands.Single().AgentId.Should().Contain("node-a");
     }
 
     [Fact]
     public async Task GenerateRepliesAsync_ShouldIgnoreUnavailableTextResponseAndContinueWithHealthyParticipant()
     {
-        var (coordinator, actor, llmProvider) = CreateCoordinator(request =>
+        var (coordinator, roomCommands, llmProvider) = CreateCoordinator(request =>
         {
             if (request.RequestId?.Contains("node-a", StringComparison.OrdinalIgnoreCase) == true)
             {
@@ -127,28 +113,18 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
         llmProvider.Requests[0].RequestId.Should().Contain("node-a");
         llmProvider.Requests[1].RequestId.Should().Contain("node-b");
 
-        var messageEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatMessageEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatMessageEvent>())
-            .ToList();
-
-        var leftEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatParticipantLeftEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatParticipantLeftEvent>())
-            .ToList();
-
-        messageEvents.Should().HaveCount(1);
-        messageEvents.Single().Content.Should().Contain("reply from");
-        messageEvents.Single().Content.Should().Contain("node-b");
-        messageEvents.Should().NotContain(evt => evt.Content.Contains("503", StringComparison.OrdinalIgnoreCase));
-        leftEvents.Should().HaveCount(1);
-        leftEvents.Single().AgentId.Should().Contain("node-a");
+        roomCommands.PostMessageCommands.Should().HaveCount(1);
+        roomCommands.PostMessageCommands.Single().Content.Should().Contain("reply from");
+        roomCommands.PostMessageCommands.Single().Content.Should().Contain("node-b");
+        roomCommands.PostMessageCommands.Should().NotContain(command => command.Content.Contains("503", StringComparison.OrdinalIgnoreCase));
+        roomCommands.LeaveCommands.Should().HaveCount(1);
+        roomCommands.LeaveCommands.Single().AgentId.Should().Contain("node-a");
     }
 
     [Fact]
     public async Task GenerateRepliesAsync_ShouldUseStreamContentWhenSynchronousContentIsMissing()
     {
-        var (coordinator, actor, llmProvider) = CreateCoordinator(
+        var (coordinator, roomCommands, llmProvider) = CreateCoordinator(
             responseFactory: _ => new LLMResponse(),
             streamFactory: request =>
             [
@@ -176,27 +152,17 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
 
         llmProvider.Requests.Should().HaveCount(1);
 
-        var messageEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatMessageEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatMessageEvent>())
-            .ToList();
-
-        var leftEvents = actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatParticipantLeftEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatParticipantLeftEvent>())
-            .ToList();
-
-        messageEvents.Should().HaveCount(1);
-        messageEvents.Single().Content.Should().Contain("streamed reply from");
-        messageEvents.Single().SessionId.Should().Be("session-1");
-        leftEvents.Should().BeEmpty();
+        roomCommands.PostMessageCommands.Should().HaveCount(1);
+        roomCommands.PostMessageCommands.Single().Content.Should().Contain("streamed reply from");
+        roomCommands.PostMessageCommands.Single().SessionId.Should().Be("session-1");
+        roomCommands.LeaveCommands.Should().BeEmpty();
     }
 
     [Fact]
     public async Task EnsureParticipantsJoinedAsync_ShouldFallbackToLegacyStatus_WhenServicesEndpointIsMissing()
     {
         var handler = new StreamingProxyHttpHandler(servicesNotFound: true);
-        var (coordinator, actor, _) = CreateCoordinator(null, null, handler);
+        var (coordinator, roomCommands, _) = CreateCoordinator(null, null, handler);
 
         var participants = await coordinator.EnsureParticipantsJoinedAsync(
             "scope-1",
@@ -209,21 +175,19 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
         participants.Should().ContainSingle();
         participants.Single().RoutePreference.Should().Be("/api/v1/proxy/s/openclaw/legacy");
         participants.Single().Model.Should().Be("legacy-model");
-        actor.Events
-            .Where(envelope => envelope.Payload!.Is(GroupChatParticipantJoinedEvent.Descriptor))
-            .Select(envelope => envelope.Payload!.Unpack<GroupChatParticipantJoinedEvent>())
+        roomCommands.JoinCommands
             .Should()
-            .ContainSingle(evt => evt.AgentId.Contains("svc-legacy", StringComparison.OrdinalIgnoreCase));
+            .ContainSingle(command => command.AgentId.Contains("svc-legacy", StringComparison.OrdinalIgnoreCase));
     }
 
-    private static (StreamingProxyNyxParticipantCoordinator Coordinator, RecordingActor Actor, RecordingLlmProvider Provider) CreateCoordinator()
+    private static (StreamingProxyNyxParticipantCoordinator Coordinator, RecordingRoomCommandService RoomCommands, RecordingLlmProvider Provider) CreateCoordinator()
         => CreateCoordinator(null);
 
-    private static (StreamingProxyNyxParticipantCoordinator Coordinator, RecordingActor Actor, RecordingLlmProvider Provider) CreateCoordinator(
+    private static (StreamingProxyNyxParticipantCoordinator Coordinator, RecordingRoomCommandService RoomCommands, RecordingLlmProvider Provider) CreateCoordinator(
         Func<LLMRequest, LLMResponse>? responseFactory)
         => CreateCoordinator(responseFactory, null);
 
-    private static (StreamingProxyNyxParticipantCoordinator Coordinator, RecordingActor Actor, RecordingLlmProvider Provider) CreateCoordinator(
+    private static (StreamingProxyNyxParticipantCoordinator Coordinator, RecordingRoomCommandService RoomCommands, RecordingLlmProvider Provider) CreateCoordinator(
         Func<LLMRequest, LLMResponse>? responseFactory,
         Func<LLMRequest, IReadOnlyList<LLMStreamChunk>>? streamFactory,
         StreamingProxyHttpHandler? handler = null)
@@ -240,15 +204,15 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
             })
             .Build();
 
-        var actor = new RecordingActor("room-1");
+        var roomCommands = new RecordingRoomCommandService();
         var coordinator = new StreamingProxyNyxParticipantCoordinator(
-            new RecordingActorDispatchPort(actor),
+            roomCommands,
             llmFactory,
             configuration,
             httpClientFactory,
             NullLogger<StreamingProxyNyxParticipantCoordinator>.Instance);
 
-        return (coordinator, actor, provider);
+        return (coordinator, roomCommands, provider);
     }
 
     private sealed class StreamingProxyHttpHandler(bool servicesNotFound = false) : HttpMessageHandler
@@ -426,64 +390,66 @@ public sealed class StreamingProxyNyxParticipantCoordinatorTests
         }
     }
 
-    private sealed class RecordingActor(string id) : IActor
+    private sealed class RecordingRoomCommandService : IStreamingProxyRoomCommandService
     {
-        private readonly IAgent _agent = new RecordingAgent(id);
+        public List<StreamingProxyRoomCreateCommand> CreateCommands { get; } = [];
+        public List<StreamingProxyRoomJoinCommand> JoinCommands { get; } = [];
+        public List<StreamingProxyRoomPostMessageCommand> PostMessageCommands { get; } = [];
+        public List<StreamingProxyRoomLeaveCommand> LeaveCommands { get; } = [];
+        public List<StreamingProxyRoomTerminalStateCommand> TerminalCommands { get; } = [];
 
-        public List<EventEnvelope> Events { get; } = [];
-
-        public string Id { get; } = id;
-
-        public IAgent Agent => _agent;
-
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default)
+        public Task<StreamingProxyRoomCreateResult> CreateRoomAsync(
+            StreamingProxyRoomCreateCommand command,
+            CancellationToken cancellationToken = default)
         {
-            Events.Add(envelope);
+            cancellationToken.ThrowIfCancellationRequested();
+            CreateCommands.Add(command);
+            return Task.FromResult(new StreamingProxyRoomCreateResult(
+                StreamingProxyRoomCreateStatus.Created,
+                "room-1",
+                "Room 1"));
+        }
+
+        public Task<StreamingProxyRoomPostMessageResult> PostMessageAsync(
+            StreamingProxyRoomPostMessageCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            PostMessageCommands.Add(command);
+            return Task.FromResult(new StreamingProxyRoomPostMessageResult(
+                StreamingProxyRoomPostMessageStatus.Accepted));
+        }
+
+        public Task<StreamingProxyRoomJoinResult> JoinAsync(
+            StreamingProxyRoomJoinCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            JoinCommands.Add(command);
+            return Task.FromResult(new StreamingProxyRoomJoinResult(
+                StreamingProxyRoomJoinStatus.Joined,
+                command.AgentId,
+                command.DisplayName));
+        }
+
+        public Task<StreamingProxyRoomLeaveResult> LeaveAsync(
+            StreamingProxyRoomLeaveCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LeaveCommands.Add(command);
+            return Task.FromResult(new StreamingProxyRoomLeaveResult(
+                StreamingProxyRoomLeaveStatus.Accepted,
+                command.AgentId));
+        }
+
+        public Task PublishTerminalStateAsync(
+            StreamingProxyRoomTerminalStateCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TerminalCommands.Add(command);
             return Task.CompletedTask;
         }
-
-        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
-
-        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
-    }
-
-    private sealed class RecordingActorDispatchPort : IActorDispatchPort
-    {
-        private readonly Dictionary<string, RecordingActor> _actors;
-
-        public RecordingActorDispatchPort(params RecordingActor[] actors)
-        {
-            _actors = actors.ToDictionary(actor => actor.Id, StringComparer.OrdinalIgnoreCase);
-        }
-
-        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
-
-        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
-        {
-            Dispatches.Add((actorId, envelope));
-            if (_actors.TryGetValue(actorId, out var actor))
-                actor.Events.Add(envelope);
-
-            return Task.CompletedTask;
-        }
-    }
-
-    private sealed class RecordingAgent(string id) : IAgent
-    {
-        public string Id { get; } = id;
-
-        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task<string> GetDescriptionAsync() => Task.FromResult("recording-agent");
-
-        public Task<IReadOnlyList<Type>> GetSubscribedEventTypesAsync() => Task.FromResult<IReadOnlyList<Type>>([]);
-
-        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
-
-        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 }

--- a/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
+++ b/test/Aevatar.AI.Tests/StreamingProxyRoomCommandServiceTests.cs
@@ -249,7 +249,7 @@ public sealed class StreamingProxyRoomCommandServiceTests
 
         result.Status.Should().Be(StreamingProxyRoomPostMessageStatus.Accepted);
         dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
-        var message = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<GroupChatMessageEvent>();
+        var message = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<StreamingProxyParticipantMessageRequested>();
         message.AgentId.Should().Be("agent-1");
         message.AgentName.Should().Be("agent-1");
         message.Content.Should().Be("hello");
@@ -300,7 +300,7 @@ public sealed class StreamingProxyRoomCommandServiceTests
             "agent-1",
             "Alice"));
         dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
-        var joined = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<GroupChatParticipantJoinedEvent>();
+        var joined = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<StreamingProxyParticipantJoinRequested>();
         joined.AgentId.Should().Be("agent-1");
         joined.DisplayName.Should().Be("Alice");
     }
@@ -329,6 +329,56 @@ public sealed class StreamingProxyRoomCommandServiceTests
     }
 
     [Fact]
+    public async Task LeaveAsync_ShouldLookupRoomAndDispatchTypedLeaveRequest()
+    {
+        var operations = new List<string>();
+        var actor = new RecordingActor("room-a", operations);
+        var runtime = new RecordingActorRuntime(operations, actor);
+        await runtime.CreateAsync<StreamingProxyGAgent>("room-a");
+        operations.Clear();
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.LeaveAsync(
+            new StreamingProxyRoomLeaveCommand("room-a", " agent-1 ", " unavailable "),
+            CancellationToken.None);
+
+        result.Should().Be(new StreamingProxyRoomLeaveResult(
+            StreamingProxyRoomLeaveStatus.Accepted,
+            "agent-1"));
+        dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
+        var left = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<StreamingProxyParticipantLeaveRequested>();
+        left.AgentId.Should().Be("agent-1");
+        left.Reason.Should().Be("unavailable");
+    }
+
+    [Fact]
+    public async Task LeaveAsync_ShouldReturnRoomNotFound_WhenRoomIsMissing()
+    {
+        var operations = new List<string>();
+        var runtime = new RecordingActorRuntime(operations, new RecordingActor("room-a", operations));
+        var dispatchPort = new RecordingActorDispatchPort(operations, runtime);
+        var service = new StreamingProxyRoomCommandService(
+            runtime,
+            dispatchPort,
+            new RecordingGAgentActorRegistryCommandPort(operations),
+            NullLogger<StreamingProxyRoomCommandService>.Instance);
+
+        var result = await service.LeaveAsync(
+            new StreamingProxyRoomLeaveCommand("missing-room", "agent-1", "unavailable"),
+            CancellationToken.None);
+
+        result.Should().Be(new StreamingProxyRoomLeaveResult(
+            StreamingProxyRoomLeaveStatus.RoomNotFound,
+            null));
+        dispatchPort.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task PublishTerminalStateAsync_ShouldDispatchTypedTerminalStateWithoutRuntimeLookup()
     {
         var operations = new List<string>();
@@ -352,7 +402,7 @@ public sealed class StreamingProxyRoomCommandServiceTests
             CancellationToken.None);
 
         dispatchPort.Dispatches.Should().ContainSingle(x => x.ActorId == "room-a");
-        var terminal = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<StreamingProxyChatSessionTerminalStateChanged>();
+        var terminal = dispatchPort.Dispatches.Single().Envelope.Payload.Unpack<StreamingProxySessionTerminalStateRequested>();
         terminal.SessionId.Should().Be("session-1");
         terminal.Status.Should().Be(StreamingProxyChatSessionTerminalStatus.Failed);
         terminal.ErrorMessage.Should().Be("failed");


### PR DESCRIPTION
## 摘要

iter56 cluster-894 — Phase 9 r2 unanimous(3/3 minimal/structural/delete 全 command-service typed payloads):

- StreamingProxyNyxParticipantCoordinator 收缩为 **adapter-only**:只 forward Nyx LLM I/O 结果到 typed room request payloads,不再 dispatch 决策事件
- StreamingProxyGAgent(**room actor**)处理 join/post/leave/terminal request,**唯一 committer** of room facts(per CLAUDE 单一权威拥有者)
- IStreamingProxyRoomCommandService 加 LeaveAsync + 新 typed request payloads
- Nyx LLM 长 I/O(ChatStreamAsync)**保持在 coordinator 外 actor turn**(per "跨 actor 等待 continuation 化")

## 边界

- 不新增 actor type / envelope kind / Projection phase
- 不动 Nyx LLM runtime / chat 子系统
- 不依赖外部仓库(NyxID / chrono-*)

## 影响范围

```
agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomCommandService.cs
agents/Aevatar.GAgents.StreamingProxy/Application/Rooms/StreamingProxyRoomContracts.cs
agents/Aevatar.GAgents.StreamingProxy/StreamingProxyGAgent.cs
agents/Aevatar.GAgents.StreamingProxy/StreamingProxyNyxParticipantCoordinator.cs
agents/Aevatar.GAgents.StreamingProxy/streaming_proxy_messages.proto
test/Aevatar.AI.Tests/StreamingProxy*.cs
```

LOC +433/-176;StreamingProxyGAgent 95.94% / coordinator 86.00% / command service 97.11% coverage

## 验证

- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/architecture_guards.sh` PASS
- `dotnet test test/Aevatar.AI.Tests/Aevatar.AI.Tests.csproj --filter StreamingProxy --nologo` 82/82 PASS

Closes #894

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
