### PR TITLE
iter56 cluster-912: ExternalLink WebSocket callback → typed signal sink

### DIFF
--- a/aevatar.slnx
+++ b/aevatar.slnx
@@ -158,6 +158,7 @@
     <Project Path="test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj" />
     <Project Path="test/Aevatar.ChatRouting.Core.Tests/Aevatar.ChatRouting.Core.Tests.csproj" />
     <Project Path="test/Aevatar.ChatRouting.Voice.Integration.Tests/Aevatar.ChatRouting.Voice.Integration.Tests.csproj" />
+    <Project Path="test/Aevatar.Foundation.ExternalLinks.WebSocket.Tests/Aevatar.Foundation.ExternalLinks.WebSocket.Tests.csproj" />
     <Project Path="test/Aevatar.GAgents.ChatRouting.Tests/Aevatar.GAgents.ChatRouting.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Core.Tests\Aevatar.AI.Core.Tests.csproj" />
     <Project Path="test\Aevatar.AI.Tests\Aevatar.AI.Tests.csproj" />

--- a/src/Aevatar.Foundation.Abstractions/ExternalLinks/IExternalLinkTransport.cs
+++ b/src/Aevatar.Foundation.Abstractions/ExternalLinks/IExternalLinkTransport.cs
@@ -1,9 +1,19 @@
 namespace Aevatar.Foundation.Abstractions.ExternalLinks;
 
+public interface IExternalLinkSignalSink
+{
+    Task PublishMessageReceivedAsync(ExternalLinkMessageReceivedSignal signal, CancellationToken ct);
+    Task PublishStateChangedAsync(ExternalLinkTransportStateChangedSignal signal, CancellationToken ct);
+}
+
 /// <summary>
 /// Transport-level contract for a single external connection.
 /// Each protocol (WebSocket, gRPC stream, MQTT, TCP) implements this.
 /// </summary>
+// Refactor (iter56/cluster-912-external-link-signal-contract):
+// old=transport direct callback, new=typed signal sink.
+// Transport implementations publish protobuf internal signals only.
+// Actor/module turns consume the signals and perform reconciliation.
 public interface IExternalLinkTransport : IAsyncDisposable
 {
     string TransportType { get; }
@@ -12,16 +22,7 @@ public interface IExternalLinkTransport : IAsyncDisposable
     Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct);
     Task DisconnectAsync(CancellationToken ct);
 
-    /// <summary>
-    /// Set by the runtime. Called on I/O thread when data arrives.
-    /// Must NOT directly modify actor state — only dispatch events.
-    /// </summary>
-    Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { set; }
-
-    /// <summary>
-    /// Set by the runtime. Called on I/O thread when connection state changes.
-    /// </summary>
-    Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { set; }
+    IExternalLinkSignalSink? SignalSink { set; }
 }
 
 public enum ExternalLinkStateChange

--- a/src/Aevatar.Foundation.Abstractions/ExternalLinks/external_link_messages.proto
+++ b/src/Aevatar.Foundation.Abstractions/ExternalLinks/external_link_messages.proto
@@ -56,6 +56,16 @@ message ExternalLinkReconnectDueSignal {
   int32 expected_attempt = 2;
 }
 
+// Refactor (iter56/cluster-912-external-link-signal-contract):
+//   old=transport direct callback, new=typed signal sink.
+//   Transport receive loops publish this internal signal; actor-turn code
+//   reconciles the link and emits the observable event.
+message ExternalLinkMessageReceivedSignal {
+  string link_id = 1;
+  bytes raw_payload = 2;
+  google.protobuf.Timestamp received_at = 3;
+}
+
 // Refactor (iter22/cluster-004):
 //   Old pattern: transport callback state was passed straight into manager mutation from the callback thread.
 //   New principle: callback state is captured as a protobuf enum so the actor turn owns the transition.

--- a/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
+++ b/src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
@@ -51,18 +51,27 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
     // Refactor (iter22/cluster-004):
     //   Old pattern: callback envelopes were indistinguishable from user-observable events in the normal handler pipeline.
     //   New principle: the manager advertises only its typed internal callback signals for actor-turn short-circuiting.
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // Inbound transport messages now enter through ExternalLinkMessageReceivedSignal.
+    // The regular event pipeline still only sees committed external-link events.
     public bool CanHandle(EventEnvelope envelope)
     {
         if (envelope.Payload == null)
             return false;
 
         return envelope.Payload.Is(ExternalLinkReconnectDueSignal.Descriptor)
+               || envelope.Payload.Is(ExternalLinkMessageReceivedSignal.Descriptor)
                || envelope.Payload.Is(ExternalLinkTransportStateChangedSignal.Descriptor);
     }
 
     // Refactor (iter22/cluster-004):
     //   Old pattern: callback work could continue on background threads after transport callbacks or delayed reconnect loops.
     //   New principle: internal callback envelopes are unpacked and handled as explicit actor-turn signals.
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // Message/state signals are consumed here before business events are emitted.
+    // Link existence is reconciled inside the manager's actor-turn handling.
     public async Task HandleAsync(EventEnvelope envelope, CancellationToken ct = default)
     {
         if (envelope.Payload == null)
@@ -71,6 +80,12 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
         if (envelope.Payload.Is(ExternalLinkReconnectDueSignal.Descriptor))
         {
             await HandleReconnectDueAsync(envelope.Payload.Unpack<ExternalLinkReconnectDueSignal>(), ct);
+            return;
+        }
+
+        if (envelope.Payload.Is(ExternalLinkMessageReceivedSignal.Descriptor))
+        {
+            await HandleMessageReceivedAsync(envelope.Payload.Unpack<ExternalLinkMessageReceivedSignal>(), ct);
             return;
         }
 
@@ -96,9 +111,13 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             var link = new ManagedLink(descriptor, transport);
             _links[descriptor.LinkId] = link;
 
-            transport.OnMessageReceived = (data, innerCt) => OnMessageReceivedAsync(link, data, innerCt);
-            transport.OnStateChanged = (state, reason, innerCt) =>
-                OnTransportStateChangedSignalAsync(link.Descriptor.LinkId, state, reason, innerCt);
+            // Refactor (iter56/cluster-912-external-link-signal-contract):
+            // old=transport direct callback, new=typed signal sink.
+            // The transport receives only a sink that can publish internal signals.
+            // This manager stamps link identity and dispatches to the actor inbox.
+            transport.SignalSink = new ExternalLinkTransportSignalSink(
+                descriptor.LinkId,
+                DispatchSignalAsync);
 
             await ConnectLinkAsync(link, ct);
         }
@@ -258,13 +277,17 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
 
     // ── Transport callbacks ───────────────────────────────────
 
-    private async Task OnMessageReceivedAsync(ManagedLink link, ReadOnlyMemory<byte> data, CancellationToken ct)
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // Public ExternalLinkMessageReceivedEvent is emitted from a handled signal.
+    // The transport no longer invokes this conversion directly.
+    private async Task OnMessageReceivedAsync(ManagedLink link, ExternalLinkMessageReceivedSignal signal, CancellationToken ct)
     {
         var evt = new ExternalLinkMessageReceivedEvent
         {
             LinkId = link.Descriptor.LinkId,
-            RawPayload = Google.Protobuf.ByteString.CopyFrom(data.Span),
-            ReceivedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            RawPayload = signal.RawPayload,
+            ReceivedAt = signal.ReceivedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
         };
 
         await DispatchEventAsync(evt, ct);
@@ -338,19 +361,18 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
     // Refactor (iter22/cluster-004):
     //   Old pattern: transport callbacks directly mutated ManagedLink or started reconnect loops from I/O callback threads.
     //   New principle: callbacks only signal the actor inbox; state changes happen when the signal is handled in the actor turn.
-    private Task OnTransportStateChangedSignalAsync(
-        string linkId,
-        ExternalLinkStateChange state,
-        string? reason,
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // Transport-owned callbacks publish protobuf signals with link identity.
+    // Business events are emitted only after this manager handles the signal.
+    private async Task HandleMessageReceivedAsync(
+        ExternalLinkMessageReceivedSignal signal,
         CancellationToken ct)
     {
-        var signal = new ExternalLinkTransportStateChangedSignal
-        {
-            LinkId = linkId,
-            State = ToSignalKind(state),
-            Reason = reason ?? string.Empty,
-        };
-        return DispatchSignalAsync(signal, ct);
+        if (!_links.TryGetValue(signal.LinkId, out var link))
+            return;
+
+        await OnMessageReceivedAsync(link, signal, ct);
     }
 
     private Task<RuntimeCallbackLease> ScheduleSignalAfterDelayAsync(
@@ -425,16 +447,6 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
     private static string? EmptyToNull(string value) =>
         string.IsNullOrEmpty(value) ? null : value;
 
-    private static ExternalLinkTransportStateSignalKind ToSignalKind(ExternalLinkStateChange state) =>
-        state switch
-        {
-            ExternalLinkStateChange.Connected => ExternalLinkTransportStateSignalKind.Connected,
-            ExternalLinkStateChange.Disconnected => ExternalLinkTransportStateSignalKind.Disconnected,
-            ExternalLinkStateChange.Error => ExternalLinkTransportStateSignalKind.Error,
-            ExternalLinkStateChange.Closed => ExternalLinkTransportStateSignalKind.Closed,
-            _ => ExternalLinkTransportStateSignalKind.Unspecified,
-        };
-
     private static ExternalLinkStateChange ToTransportStateChange(ExternalLinkTransportStateSignalKind state) =>
         state switch
         {
@@ -444,4 +456,27 @@ internal sealed class ExternalLinkManager : IExternalLinkPort, IAsyncDisposable
             ExternalLinkTransportStateSignalKind.Closed => ExternalLinkStateChange.Closed,
             _ => ExternalLinkStateChange.Error,
         };
+
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // This adapter stamps link identity on transport signals and dispatches them.
+    // Actor/module turns remain the only place where link facts are changed.
+    private sealed class ExternalLinkTransportSignalSink(
+        string linkId,
+        Func<IMessage, CancellationToken, Task> dispatchSignalAsync) : IExternalLinkSignalSink
+    {
+        public Task PublishMessageReceivedAsync(ExternalLinkMessageReceivedSignal signal, CancellationToken ct)
+        {
+            signal.LinkId = linkId;
+            if (signal.ReceivedAt == null)
+                signal.ReceivedAt = Timestamp.FromDateTime(DateTime.UtcNow);
+            return dispatchSignalAsync(signal, ct);
+        }
+
+        public Task PublishStateChangedAsync(ExternalLinkTransportStateChangedSignal signal, CancellationToken ct)
+        {
+            signal.LinkId = linkId;
+            return dispatchSignalAsync(signal, ct);
+        }
+    }
 }

--- a/src/Aevatar.Foundation.ExternalLinks.WebSocket/Aevatar.Foundation.ExternalLinks.WebSocket.csproj
+++ b/src/Aevatar.Foundation.ExternalLinks.WebSocket/Aevatar.Foundation.ExternalLinks.WebSocket.csproj
@@ -8,6 +8,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Aevatar.Foundation.ExternalLinks.WebSocket.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     </ItemGroup>
 

--- a/src/Aevatar.Foundation.ExternalLinks.WebSocket/WebSocketTransport.cs
+++ b/src/Aevatar.Foundation.ExternalLinks.WebSocket/WebSocketTransport.cs
@@ -13,6 +13,10 @@ namespace Aevatar.Foundation.ExternalLinks.WebSocket;
 /// - No custom HTTP headers for the handshake.
 /// - Receive buffer is fixed at 8 KB.
 /// </summary>
+// Refactor (iter56/cluster-912-external-link-signal-contract):
+// old=transport direct callback, new=typed signal sink.
+// The WebSocket I/O loop publishes typed internal signals only.
+// Actor/module turns consume those signals and reconcile link state.
 internal sealed class WebSocketTransport : IExternalLinkTransport
 {
     private const int ReceiveBufferSize = 8192;
@@ -24,8 +28,7 @@ internal sealed class WebSocketTransport : IExternalLinkTransport
 
     public string TransportType => "websocket";
 
-    public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { private get; set; }
-    public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { private get; set; }
+    public IExternalLinkSignalSink? SignalSink { private get; set; }
 
     public WebSocketTransport(ILogger logger)
     {
@@ -93,6 +96,10 @@ internal sealed class WebSocketTransport : IExternalLinkTransport
 
     private async Task ReceiveLoopAsync(CancellationToken ct)
     {
+        // Refactor (iter56/cluster-912-external-link-signal-contract):
+        // old=transport direct callback, new=typed signal sink.
+        // Received frames become ExternalLinkMessageReceivedSignal only.
+        // Caller business handlers are never invoked from this I/O loop.
         var buffer = new byte[ReceiveBufferSize];
         using var ms = new MemoryStream();
 
@@ -117,10 +124,16 @@ internal sealed class WebSocketTransport : IExternalLinkTransport
                     endOfMessage = vResult.EndOfMessage;
                 } while (!endOfMessage);
 
-                if (ms.Length > 0 && OnMessageReceived != null)
+                if (ms.Length > 0 && SignalSink != null)
                 {
                     var data = ms.ToArray();
-                    await OnMessageReceived(data, ct);
+                    await SignalSink.PublishMessageReceivedAsync(
+                        new ExternalLinkMessageReceivedSignal
+                        {
+                            RawPayload = Google.Protobuf.ByteString.CopyFrom(data),
+                            ReceivedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow),
+                        },
+                        ct);
                 }
             }
         }
@@ -140,6 +153,26 @@ internal sealed class WebSocketTransport : IExternalLinkTransport
         }
     }
 
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // State transitions are serialized as ExternalLinkTransportStateChangedSignal.
+    // The owning actor/module turn decides the resulting business event.
     private Task NotifyStateChangedAsync(ExternalLinkStateChange state, string? reason, CancellationToken ct) =>
-        OnStateChanged?.Invoke(state, reason, ct) ?? Task.CompletedTask;
+        SignalSink?.PublishStateChangedAsync(
+            new ExternalLinkTransportStateChangedSignal
+            {
+                State = ToSignalKind(state),
+                Reason = reason ?? string.Empty,
+            },
+            ct) ?? Task.CompletedTask;
+
+    private static ExternalLinkTransportStateSignalKind ToSignalKind(ExternalLinkStateChange state) =>
+        state switch
+        {
+            ExternalLinkStateChange.Connected => ExternalLinkTransportStateSignalKind.Connected,
+            ExternalLinkStateChange.Disconnected => ExternalLinkTransportStateSignalKind.Disconnected,
+            ExternalLinkStateChange.Error => ExternalLinkTransportStateSignalKind.Error,
+            ExternalLinkStateChange.Closed => ExternalLinkTransportStateSignalKind.Closed,
+            _ => ExternalLinkTransportStateSignalKind.Unspecified,
+        };
 }

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
@@ -17,8 +17,11 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
 
     public string TransportType => TransportTypeName;
 
-    public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { private get; set; }
-    public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { private get; set; }
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // This transport emits typed ExternalLink signals instead of arbitrary delegates.
+    // The owning actor/module turn decides how to process each signal.
+    public IExternalLinkSignalSink? SignalSink { private get; set; }
 
     public async Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
     {
@@ -107,8 +110,20 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
                 result.RequestedOffset = request.RequestedOffset;
         }
 
-        if (OnMessageReceived != null)
-            await OnMessageReceived(result.ToByteArray(), ct);
+        // Refactor (iter56/cluster-912-external-link-signal-contract):
+        // old=transport direct callback, new=typed signal sink.
+        // Connector completion is serialized as an internal message signal.
+        // ExternalLinkManager decides the observable event in the actor turn.
+        if (SignalSink != null)
+        {
+            await SignalSink.PublishMessageReceivedAsync(
+                new ExternalLinkMessageReceivedSignal
+                {
+                    RawPayload = Google.Protobuf.ByteString.CopyFrom(result.ToByteArray()),
+                    ReceivedAt = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(DateTime.UtcNow),
+                },
+                ct);
+        }
     }
 
     private static ConnectorRequest BuildConnectorRequest(TelegramGetUpdatesRequest request)
@@ -172,8 +187,28 @@ public sealed class TelegramGetUpdatesExternalLinkTransport(
         return result;
     }
 
+    // Refactor (iter56/cluster-912-external-link-signal-contract):
+    // old=transport direct callback, new=typed signal sink.
+    // Lifecycle changes leave this transport as typed state signals.
+    // No caller callback is invoked from transport execution.
     private Task NotifyStateChangedAsync(ExternalLinkStateChange state, string? reason, CancellationToken ct) =>
-        OnStateChanged?.Invoke(state, reason, ct) ?? Task.CompletedTask;
+        SignalSink?.PublishStateChangedAsync(
+            new ExternalLinkTransportStateChangedSignal
+            {
+                State = ToSignalKind(state),
+                Reason = reason ?? string.Empty,
+            },
+            ct) ?? Task.CompletedTask;
+
+    private static ExternalLinkTransportStateSignalKind ToSignalKind(ExternalLinkStateChange state) =>
+        state switch
+        {
+            ExternalLinkStateChange.Connected => ExternalLinkTransportStateSignalKind.Connected,
+            ExternalLinkStateChange.Disconnected => ExternalLinkTransportStateSignalKind.Disconnected,
+            ExternalLinkStateChange.Error => ExternalLinkTransportStateSignalKind.Error,
+            ExternalLinkStateChange.Closed => ExternalLinkTransportStateSignalKind.Closed,
+            _ => ExternalLinkTransportStateSignalKind.Unspecified,
+        };
 }
 
 // Refactor (iter26/cluster-030-telegram-connector-watchdog-blocks-actor-turn):

--- a/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
@@ -20,6 +20,7 @@ public sealed class ExternalLinkManagerTests
         var manager = CreateManager(new RecordingDispatchPort(), new RecordingCallbackScheduler(), new RecordingTransport());
 
         manager.CanHandle(Envelope(new ExternalLinkReconnectDueSignal())).Should().BeTrue();
+        manager.CanHandle(Envelope(new ExternalLinkMessageReceivedSignal())).Should().BeTrue();
         manager.CanHandle(Envelope(new ExternalLinkTransportStateChangedSignal())).Should().BeTrue();
         manager.CanHandle(new EventEnvelope()).Should().BeFalse();
         manager.CanHandle(Envelope(new ExternalLinkConnectedEvent())).Should().BeFalse();
@@ -539,10 +540,9 @@ public sealed class ExternalLinkManagerTests
         public int ConnectCalls { get; private set; }
         public int ConnectFailuresRemaining { get; set; }
         public string TransportType => "recording";
-        public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived { private get; set; }
-        public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged { private get; set; }
-        public bool HasMessageReceivedHandler => OnMessageReceived != null;
-        public bool HasStateChangedHandler => OnStateChanged != null;
+        public IExternalLinkSignalSink? SignalSink { private get; set; }
+        public bool HasMessageReceivedHandler => SignalSink != null;
+        public bool HasStateChangedHandler => SignalSink != null;
 
         public Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
         {
@@ -565,8 +565,21 @@ public sealed class ExternalLinkManagerTests
             string? reason,
             CancellationToken ct)
         {
-            OnStateChanged.Should().NotBeNull();
-            return OnStateChanged(state, reason, ct);
+            SignalSink.Should().NotBeNull();
+            return SignalSink.PublishStateChangedAsync(
+                new ExternalLinkTransportStateChangedSignal
+                {
+                    State = state switch
+                    {
+                        ExternalLinkStateChange.Connected => ExternalLinkTransportStateSignalKind.Connected,
+                        ExternalLinkStateChange.Disconnected => ExternalLinkTransportStateSignalKind.Disconnected,
+                        ExternalLinkStateChange.Error => ExternalLinkTransportStateSignalKind.Error,
+                        ExternalLinkStateChange.Closed => ExternalLinkTransportStateSignalKind.Closed,
+                        _ => ExternalLinkTransportStateSignalKind.Unspecified,
+                    },
+                    Reason = reason ?? string.Empty,
+                },
+                ct);
         }
     }
 

--- a/test/Aevatar.Foundation.ExternalLinks.WebSocket.Tests/Aevatar.Foundation.ExternalLinks.WebSocket.Tests.csproj
+++ b/test/Aevatar.Foundation.ExternalLinks.WebSocket.Tests/Aevatar.Foundation.ExternalLinks.WebSocket.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <AssemblyName>Aevatar.Foundation.ExternalLinks.WebSocket.Tests</AssemblyName>
+        <RootNamespace>Aevatar.Foundation.ExternalLinks.WebSocket.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Aevatar.Foundation.ExternalLinks.WebSocket\Aevatar.Foundation.ExternalLinks.WebSocket.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="FluentAssertions" />
+    </ItemGroup>
+</Project>

--- a/test/Aevatar.Foundation.ExternalLinks.WebSocket.Tests/WebSocketTransportTests.cs
+++ b/test/Aevatar.Foundation.ExternalLinks.WebSocket.Tests/WebSocketTransportTests.cs
@@ -1,0 +1,240 @@
+using NetWebSocket = System.Net.WebSockets.WebSocket;
+using System.Net.WebSockets;
+using System.Reflection;
+using Aevatar.Foundation.Abstractions.ExternalLinks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aevatar.Foundation.ExternalLinks.WebSocket.Tests;
+
+public sealed class WebSocketTransportTests
+{
+    [Fact]
+    public async Task NotifyStateChangedAsync_ShouldMapStateKindsToTypedSignals()
+    {
+        await using var transport = new WebSocketTransport(NullLogger<WebSocketTransport>.Instance);
+        var sink = new RecordingExternalLinkSignalSink();
+        transport.SignalSink = sink;
+
+        transport.TransportType.Should().Be("websocket");
+        await InvokeNotifyStateChangedAsync(transport, ExternalLinkStateChange.Connected, null);
+        await InvokeNotifyStateChangedAsync(transport, ExternalLinkStateChange.Error, "boom");
+        await InvokeNotifyStateChangedAsync(transport, ExternalLinkStateChange.Closed, "closed");
+        await InvokeNotifyStateChangedAsync(transport, (ExternalLinkStateChange)999, "unknown");
+
+        sink.StateSignals.Select(x => (x.State, x.Reason)).Should().Equal(
+            (ExternalLinkTransportStateSignalKind.Connected, string.Empty),
+            (ExternalLinkTransportStateSignalKind.Error, "boom"),
+            (ExternalLinkTransportStateSignalKind.Closed, "closed"),
+            (ExternalLinkTransportStateSignalKind.Unspecified, "unknown"));
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenConnected_ShouldSendBinaryPayload()
+    {
+        var payload = new byte[] { 9, 8, 7 };
+        var received = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var server = CreateServer(async webSocket =>
+        {
+            var buffer = new byte[16];
+            var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None);
+            received.TrySetResult(buffer[..result.Count]);
+        });
+        await using var transport = new WebSocketTransport(NullLogger<WebSocketTransport>.Instance)
+        {
+            SignalSink = new RecordingExternalLinkSignalSink(),
+        };
+
+        await transport.ConnectAsync(
+            new ExternalLinkDescriptor("link-1", "websocket", server.BaseAddress),
+            CancellationToken.None);
+        await transport.SendAsync(payload, CancellationToken.None);
+
+        var sent = await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        sent.Should().Equal(payload);
+        await transport.DisconnectAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenNotConnected_ShouldThrow()
+    {
+        await using var transport = new WebSocketTransport(NullLogger<WebSocketTransport>.Instance);
+
+        var act = () => transport.SendAsync(new byte[] { 1 }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("WebSocket is not connected.");
+    }
+
+    [Fact]
+    public async Task ReceiveLoop_WhenMessageArrives_ShouldPublishTypedMessageSignal()
+    {
+        var payload = new byte[] { 1, 2, 3, 4 };
+        using var server = CreateServer(async webSocket =>
+        {
+            await webSocket.SendAsync(
+                payload,
+                WebSocketMessageType.Binary,
+                endOfMessage: true,
+                CancellationToken.None);
+        });
+        var sink = new RecordingExternalLinkSignalSink();
+        await using var transport = new WebSocketTransport(NullLogger<WebSocketTransport>.Instance)
+        {
+            SignalSink = sink,
+        };
+
+        await transport.ConnectAsync(
+            new ExternalLinkDescriptor("link-1", "websocket", server.BaseAddress),
+            CancellationToken.None);
+        await sink.WaitForMessagesAsync(1);
+
+        var signal = sink.MessageSignals.Should().ContainSingle().Subject;
+        signal.LinkId.Should().BeEmpty();
+        signal.RawPayload.ToByteArray().Should().Equal(payload);
+        signal.ReceivedAt.Should().NotBeNull();
+        await transport.DisconnectAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ReceiveLoop_WhenRemoteCloses_ShouldPublishTypedStateSignal()
+    {
+        using var server = CreateServer(async webSocket =>
+        {
+            await webSocket.CloseAsync(
+                WebSocketCloseStatus.NormalClosure,
+                "server done",
+                CancellationToken.None);
+        });
+        var sink = new RecordingExternalLinkSignalSink();
+        await using var transport = new WebSocketTransport(NullLogger<WebSocketTransport>.Instance)
+        {
+            SignalSink = sink,
+        };
+
+        await transport.ConnectAsync(
+            new ExternalLinkDescriptor("link-1", "websocket", server.BaseAddress),
+            CancellationToken.None);
+        await sink.WaitForStatesAsync(1);
+
+        var signal = sink.StateSignals.Should().ContainSingle().Subject;
+        signal.LinkId.Should().BeEmpty();
+        signal.State.Should().Be(ExternalLinkTransportStateSignalKind.Disconnected);
+        signal.Reason.Should().Be("server done");
+        await transport.DisconnectAsync(CancellationToken.None);
+    }
+
+    private static WebSocketTestServer CreateServer(Func<NetWebSocket, Task> handleWebSocketAsync) =>
+        WebSocketTestServer.Start(handleWebSocketAsync);
+
+    private static async Task InvokeNotifyStateChangedAsync(
+        WebSocketTransport transport,
+        ExternalLinkStateChange state,
+        string? reason)
+    {
+        var method = typeof(WebSocketTransport).GetMethod(
+            "NotifyStateChangedAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull();
+        var task = (Task)method!.Invoke(
+            transport,
+            [state, reason, CancellationToken.None])!;
+        await task;
+    }
+
+    private sealed class WebSocketTestServer : IDisposable
+    {
+        private readonly IHost _host;
+
+        private WebSocketTestServer(IHost host, string baseAddress)
+        {
+            _host = host;
+            BaseAddress = baseAddress;
+        }
+
+        public string BaseAddress { get; }
+
+        public static WebSocketTestServer Start(Func<NetWebSocket, Task> handleWebSocketAsync)
+        {
+            var host = Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseKestrel();
+                    webBuilder.UseUrls("http://127.0.0.1:0");
+                    webBuilder.Configure(app =>
+                    {
+                        app.UseWebSockets();
+                        app.Run(async context =>
+                        {
+                            if (!context.WebSockets.IsWebSocketRequest)
+                            {
+                                context.Response.StatusCode = 400;
+                                return;
+                            }
+
+                            using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                            await handleWebSocketAsync(webSocket);
+                        });
+                    });
+                })
+                .ConfigureServices(services => services.AddLogging())
+                .Build();
+
+            host.Start();
+            var address = host.Services.GetRequiredService<IServer>()
+                .Features.Get<IServerAddressesFeature>()!
+                .Addresses.Single();
+            var uri = new UriBuilder(address)
+            {
+                Scheme = "ws",
+            };
+            return new WebSocketTestServer(host, uri.Uri.ToString());
+        }
+
+        public void Dispose() => _host.Dispose();
+    }
+
+    private sealed class RecordingExternalLinkSignalSink : IExternalLinkSignalSink
+    {
+        private readonly TaskCompletionSource _messagePublished =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _statePublished =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<ExternalLinkMessageReceivedSignal> MessageSignals { get; } = [];
+        public List<ExternalLinkTransportStateChangedSignal> StateSignals { get; } = [];
+
+        public Task PublishMessageReceivedAsync(ExternalLinkMessageReceivedSignal signal, CancellationToken ct)
+        {
+            MessageSignals.Add(signal);
+            _messagePublished.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task PublishStateChangedAsync(ExternalLinkTransportStateChangedSignal signal, CancellationToken ct)
+        {
+            StateSignals.Add(signal);
+            _statePublished.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public async Task WaitForMessagesAsync(int count)
+        {
+            if (MessageSignals.Count < count)
+                await _messagePublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        public async Task WaitForStatesAsync(int count)
+        {
+            if (StateSignals.Count < count)
+                await _statePublished.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -1176,22 +1176,18 @@ public sealed class TelegramBridgeGAgentTests
     {
         public string TransportType => TelegramGetUpdatesExternalLinkTransport.TransportTypeName;
 
-        public Func<ReadOnlyMemory<byte>, CancellationToken, Task>? OnMessageReceived
-        {
-            private get;
-            set;
-        }
-
-        public Func<ExternalLinkStateChange, string?, CancellationToken, Task>? OnStateChanged
-        {
-            private get;
-            set;
-        }
+        public IExternalLinkSignalSink? SignalSink { private get; set; }
 
         public Task ConnectAsync(ExternalLinkDescriptor descriptor, CancellationToken ct)
         {
             _ = descriptor;
-            return OnStateChanged?.Invoke(ExternalLinkStateChange.Connected, null, ct) ?? Task.CompletedTask;
+            return SignalSink?.PublishStateChangedAsync(
+                new ExternalLinkTransportStateChangedSignal
+                {
+                    State = ExternalLinkTransportStateSignalKind.Connected,
+                    Reason = string.Empty,
+                },
+                ct) ?? Task.CompletedTask;
         }
 
         public Task SendAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
@@ -21,12 +21,8 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(connector);
         var transport = CreateTransport(registry);
-        var received = new List<TelegramGetUpdatesResult>();
-        transport.OnMessageReceived = (payload, ct) =>
-        {
-            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
-            return Task.CompletedTask;
-        };
+        var sink = new RecordingExternalLinkSignalSink();
+        transport.SignalSink = sink;
         var request = BuildRequest();
 
         await transport.SendAsync(request.ToByteArray(), CancellationToken.None);
@@ -45,29 +41,25 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
         connector.Received[0].Parameters["method"].Should().Be("POST");
         connector.Received[0].Parameters["content_type"].Should().Be("application/json");
         connector.Received[0].Parameters["timeout_ms"].Should().Be("4000");
-        received.Should().ContainSingle();
-        received[0].CommandId.Should().Be("cmd-1");
-        received[0].Generation.Should().Be(7);
-        received[0].RequestId.Should().Be("request-1");
-        received[0].Success.Should().BeTrue();
-        received[0].Output.Should().Be("""{"ok":true,"result":[]}""");
-        received[0].RequestedOffset.Should().Be(42);
+        var result = ParseSingleMessage(sink);
+        result.CommandId.Should().Be("cmd-1");
+        result.Generation.Should().Be(7);
+        result.RequestId.Should().Be("request-1");
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("""{"ok":true,"result":[]}""");
+        result.RequestedOffset.Should().Be(42);
     }
 
     [Fact]
     public async Task SendAsync_WhenConnectorMissing_ShouldPublishFailureResult()
     {
         var transport = CreateTransport(new InMemoryConnectorRegistry());
-        var received = new List<TelegramGetUpdatesResult>();
-        transport.OnMessageReceived = (payload, ct) =>
-        {
-            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
-            return Task.CompletedTask;
-        };
+        var sink = new RecordingExternalLinkSignalSink();
+        transport.SignalSink = sink;
 
         await transport.SendAsync(BuildRequest().ToByteArray(), CancellationToken.None);
 
-        var result = received.Should().ContainSingle().Subject;
+        var result = ParseSingleMessage(sink);
         result.Success.Should().BeFalse();
         result.Error.Should().Be("telegram connector 'telegram' not found");
     }
@@ -78,16 +70,12 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(new ThrowingConnector(new InvalidOperationException("sync broke")));
         var transport = CreateTransport(registry);
-        var received = new List<TelegramGetUpdatesResult>();
-        transport.OnMessageReceived = (payload, ct) =>
-        {
-            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
-            return Task.CompletedTask;
-        };
+        var sink = new RecordingExternalLinkSignalSink();
+        transport.SignalSink = sink;
 
         await transport.SendAsync(BuildRequest().ToByteArray(), CancellationToken.None);
 
-        var result = received.Should().ContainSingle().Subject;
+        var result = ParseSingleMessage(sink);
         result.Success.Should().BeFalse();
         result.Error.Should().Be("telegram getUpdates execution failed: sync broke");
     }
@@ -98,16 +86,12 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
         var registry = new InMemoryConnectorRegistry();
         registry.Register(new FaultingConnector(new InvalidOperationException("async broke")));
         var transport = CreateTransport(registry);
-        var received = new List<TelegramGetUpdatesResult>();
-        transport.OnMessageReceived = (payload, ct) =>
-        {
-            received.Add(TelegramGetUpdatesResult.Parser.ParseFrom(payload.Span));
-            return Task.CompletedTask;
-        };
+        var sink = new RecordingExternalLinkSignalSink();
+        transport.SignalSink = sink;
 
         await transport.SendAsync(BuildRequest().ToByteArray(), CancellationToken.None);
 
-        var result = received.Should().ContainSingle().Subject;
+        var result = ParseSingleMessage(sink);
         result.Success.Should().BeFalse();
         result.Error.Should().Be("telegram getUpdates execution failed: async broke");
     }
@@ -116,21 +100,17 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
     public async Task ConnectAndDisconnect_ShouldPublishStateCallbacks()
     {
         var transport = CreateTransport(new InMemoryConnectorRegistry());
-        var states = new List<(ExternalLinkStateChange State, string? Reason)>();
-        transport.OnStateChanged = (state, reason, ct) =>
-        {
-            states.Add((state, reason));
-            return Task.CompletedTask;
-        };
+        var sink = new RecordingExternalLinkSignalSink();
+        transport.SignalSink = sink;
 
         await transport.ConnectAsync(
             new ExternalLinkDescriptor("telegram-get-updates", "telegram-get-updates", "telegram://get-updates"),
             CancellationToken.None);
         await transport.DisconnectAsync(CancellationToken.None);
 
-        states.Should().Equal(
-            (ExternalLinkStateChange.Connected, null),
-            (ExternalLinkStateChange.Closed, "closed"));
+        sink.StateSignals.Select(x => (x.State, x.Reason)).Should().Equal(
+            (ExternalLinkTransportStateSignalKind.Connected, string.Empty),
+            (ExternalLinkTransportStateSignalKind.Closed, "closed"));
     }
 
     [Fact]
@@ -148,6 +128,31 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
 
     private static TelegramGetUpdatesExternalLinkTransport CreateTransport(IConnectorRegistry registry) =>
         new(registry, NullLogger<TelegramGetUpdatesExternalLinkTransport>.Instance);
+
+    private static TelegramGetUpdatesResult ParseSingleMessage(RecordingExternalLinkSignalSink sink)
+    {
+        var signal = sink.MessageSignals.Should().ContainSingle().Subject;
+        signal.ReceivedAt.Should().NotBeNull();
+        return TelegramGetUpdatesResult.Parser.ParseFrom(signal.RawPayload);
+    }
+
+    private sealed class RecordingExternalLinkSignalSink : IExternalLinkSignalSink
+    {
+        public List<ExternalLinkMessageReceivedSignal> MessageSignals { get; } = [];
+        public List<ExternalLinkTransportStateChangedSignal> StateSignals { get; } = [];
+
+        public Task PublishMessageReceivedAsync(ExternalLinkMessageReceivedSignal signal, CancellationToken ct)
+        {
+            MessageSignals.Add(signal);
+            return Task.CompletedTask;
+        }
+
+        public Task PublishStateChangedAsync(ExternalLinkTransportStateChangedSignal signal, CancellationToken ct)
+        {
+            StateSignals.Add(signal);
+            return Task.CompletedTask;
+        }
+    }
 
     private static TelegramGetUpdatesRequest BuildRequest()
     {


### PR DESCRIPTION
## 摘要

iter56 cluster-912 — audit-iter-56 cluster-056-external-link-callbacks-bypass-actor-signal-contract(no design,直接 implement):

- **新增 \`ExternalLinkMessageReceivedSignal\`** + reuse 已有 typed state signal
- **WebSocketTransport 不再直接 invoke** \`OnMessageReceived\` / \`OnStateChanged\` callback
- Transport 只 publish typed signal,**ExternalLinkManager 在 actor turn 内消费**再 emit public event
- Telegram external-link transport / fakes / tests 同步迁移

## 边界

- 不加 reconnection feature(per cluster boundary)
- 不动 protocol behavior
- 不依赖外部仓库

## 影响范围

```
src/Aevatar.Foundation.Abstractions/ExternalLinks/* (proto + interface)
src/Aevatar.Foundation.Core/ExternalLinks/ExternalLinkManager.cs
src/Aevatar.Foundation.ExternalLinks.WebSocket/* (transport + new test project)
src/workflow/extensions/Aevatar.Workflow.Extensions.Bridge/TelegramGetUpdatesExternalLinkTransport.cs
test/Aevatar.Foundation.Core.Tests/ExternalLinkManagerTests.cs
test/Aevatar.Workflow.Host.Api.Tests/Telegram*.cs
```

LOC +508/-108 across 12 files(新增 WebSocketTransportTests + project)

## Coverage

- WebSocketTransport line-rate 1.0 / branch-rate 0.82

## 验证

- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/architecture_guards.sh` PASS
- WebSocket + Foundation + Workflow Telegram tests PASS

Closes #912

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
