### PR TITLE
iter56 cluster-921: actor-type marker recovery,删 Hosting actorId prefix predicate

### DIFF
--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeGAgentBase.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionScopeGAgentBase.cs
@@ -1,4 +1,5 @@
 using Aevatar.Foundation.Abstractions.Attributes;
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
@@ -11,6 +12,7 @@ namespace Aevatar.CQRS.Projection.Core.Orchestration;
 
 public abstract class ProjectionScopeGAgentBase<TContext>
     : GAgentBase<ProjectionScopeState>
+    , IEventSourcingVersionDriftRecoverableActor
     where TContext : class, IProjectionMaterializationContext
 {
     private ILogger _logger = NullLogger.Instance;

--- a/src/Aevatar.Foundation.Abstractions/Persistence/IEventSourcingVersionDriftRecoverableActor.cs
+++ b/src/Aevatar.Foundation.Abstractions/Persistence/IEventSourcingVersionDriftRecoverableActor.cs
@@ -1,0 +1,6 @@
+namespace Aevatar.Foundation.Abstractions.Persistence;
+
+/// <summary>
+/// Marks actor types whose event replay can reconverge after store-version drift.
+/// </summary>
+public interface IEventSourcingVersionDriftRecoverableActor;

--- a/src/Aevatar.Foundation.Core/EventSourcing/DefaultEventSourcingBehaviorFactory.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/DefaultEventSourcingBehaviorFactory.cs
@@ -33,9 +33,11 @@ public sealed class DefaultEventSourcingBehaviorFactory<TState>
 
     public IEventSourcingBehavior<TState> Create(
         string agentId,
+        Type actorType,
         Func<TState, IMessage, TState> transitionState)
     {
         ArgumentNullException.ThrowIfNull(agentId);
+        ArgumentNullException.ThrowIfNull(actorType);
         ArgumentNullException.ThrowIfNull(transitionState);
 
         var snapshotsEnabled = _options.EnableSnapshots && _snapshotStore != null;
@@ -44,8 +46,9 @@ public sealed class DefaultEventSourcingBehaviorFactory<TState>
             ? new IntervalSnapshotStrategy(_options.SnapshotInterval)
             : NeverSnapshotStrategy.Instance;
 
+        // Refactor (iter56/cluster-921-runtime-recovery-actor-type-marker): old=hosting actorId prefix recovery, new=actor-type marker in factory
         var recoverFromVersionDrift = _options.RecoverFromVersionDriftOnReplay
-            || (_options.ShouldRecoverFromVersionDriftOnReplay?.Invoke(agentId) ?? false);
+            || typeof(IEventSourcingVersionDriftRecoverableActor).IsAssignableFrom(actorType);
 
         return new DelegatingEventSourcingBehavior(
             _eventStore,

--- a/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingRuntimeOptions.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/EventSourcingRuntimeOptions.cs
@@ -39,25 +39,12 @@ public sealed class EventSourcingRuntimeOptions
     ///
     /// Set this flag to <c>true</c> only when every actor sharing this
     /// options instance can tolerate replaying with stale state at the
-    /// store-side version. Prefer <see
-    /// cref="ShouldRecoverFromVersionDriftOnReplay"/> for per-actor opt-in
-    /// (e.g. only projection scope actors) and leave this off as the safe
-    /// global default. With recovery active, ReplayAsync logs the drift at
+    /// store-side version. Projection scope actors opt in through
+    /// IEventSourcingVersionDriftRecoverableActor; leave this flag off as
+    /// the safe global default. With recovery active, ReplayAsync logs the drift at
     /// warning, sets <c>_currentVersion</c> to the store version, and lets
     /// the next commit proceed; the ConfirmEventsAsync catch path remains a
     /// second line of defense.
     /// </summary>
     public bool RecoverFromVersionDriftOnReplay { get; set; }
-
-    /// <summary>
-    /// Per-agent opt-in predicate evaluated at behavior construction time.
-    /// Returning <c>true</c> for a given agent id enables drift recovery on
-    /// replay for that actor regardless of the global
-    /// <see cref="RecoverFromVersionDriftOnReplay"/> flag. Use this to scope
-    /// recovery to actor families that are known to be idempotent (e.g.
-    /// <c>agentId =&gt; agentId.StartsWith("projection.durable.scope:")</c>)
-    /// without granting the same affordance to domain GAgents that hold
-    /// non-idempotent state.
-    /// </summary>
-    public Func<string, bool>? ShouldRecoverFromVersionDriftOnReplay { get; set; }
 }

--- a/src/Aevatar.Foundation.Core/EventSourcing/IEventSourcingBehaviorFactory.cs
+++ b/src/Aevatar.Foundation.Core/EventSourcing/IEventSourcingBehaviorFactory.cs
@@ -13,5 +13,6 @@ public interface IEventSourcingBehaviorFactory<TState>
     /// </summary>
     IEventSourcingBehavior<TState> Create(
         string agentId,
+        Type actorType,
         Func<TState, IMessage, TState> transitionState);
 }

--- a/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
+++ b/src/Aevatar.Foundation.Core/GAgentBase.TState.cs
@@ -193,7 +193,7 @@ public abstract class GAgentBase<TState> : GAgentBase, IAgent<TState>, IEventSou
 
         if (EventSourcingBehaviorFactory != null)
         {
-            EventSourcing = EventSourcingBehaviorFactory.Create(Id, TransitionState);
+            EventSourcing = EventSourcingBehaviorFactory.Create(Id, GetType(), TransitionState);
             return EventSourcing;
         }
 

--- a/src/Aevatar.Foundation.Runtime.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Foundation.Runtime.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -143,18 +143,6 @@ public static class ServiceCollectionExtensions
             $"Unsupported Orleans stream backend '{options.OrleansStreamBackend}'.");
     }
 
-    // Projection scope actor IDs use these well-known prefixes (durable
-    // materialization scopes and ephemeral session scopes). The actors
-    // observe committed facts and re-converge on replay, so it is safe for
-    // them to recover from version-key/sorted-set drift by activating at the
-    // store version with stale state — production incident #502 hit this
-    // exact wedge. Domain GAgents are NOT in this set: they keep the safe
-    // default of throwing EventStoreVersionDriftException so the divergence
-    // surfaces to operators instead of silently building new authoritative
-    // state on incomplete history.
-    private const string ProjectionDurableScopeActorIdPrefix = "projection.durable.scope:";
-    private const string ProjectionSessionScopeActorIdPrefix = "projection.session.scope:";
-
     private static void AddAevatarRuntimeWithEventSourcingOptions(
         IServiceCollection services,
         AevatarActorRuntimeOptions options)
@@ -165,9 +153,6 @@ public static class ServiceCollectionExtensions
             eventSourcingOptions.SnapshotInterval = options.EventSourcingSnapshotInterval;
             eventSourcingOptions.EnableEventCompaction = options.EventSourcingEnableEventCompaction;
             eventSourcingOptions.RetainedEventsAfterSnapshot = options.EventSourcingRetainedEventsAfterSnapshot;
-            eventSourcingOptions.ShouldRecoverFromVersionDriftOnReplay = static agentId =>
-                agentId.StartsWith(ProjectionDurableScopeActorIdPrefix, StringComparison.Ordinal)
-                || agentId.StartsWith(ProjectionSessionScopeActorIdPrefix, StringComparison.Ordinal);
         });
     }
 

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeGAgentBaseTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionScopeGAgentBaseTests.cs
@@ -15,6 +15,14 @@ namespace Aevatar.CQRS.Projection.Core.Tests;
 public sealed class ProjectionScopeGAgentBaseTests
 {
     [Fact]
+    public void ProjectionScopeGAgentBase_ShouldOptIntoEventSourcingVersionDriftRecovery()
+    {
+        var agent = new TestScopeAgent(_ => ProjectionScopeDispatchResult.Skip());
+
+        agent.Should().BeAssignableTo<IEventSourcingVersionDriftRecoverableActor>();
+    }
+
+    [Fact]
     public async Task HandleObservedEnvelopeAsync_ShouldPropagate_RetryableOptimisticConcurrencyException()
     {
         var agent = BuildActivatedAgent(

--- a/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
+++ b/test/Aevatar.Foundation.Core.Tests/EventSourcingTests.cs
@@ -339,7 +339,8 @@ public class EventSourcingBehaviorTests
         // arbitrary domain GAgents because it builds new authoritative state
         // on top of facts that were never applied. Default behavior must
         // surface the drift so an operator decides; the projection-scope
-        // recovery path is opt-in via RecoverFromVersionDriftOnReplay.
+        // recovery path is opt-in via actor-type marker or the provider-wide
+        // RecoverFromVersionDriftOnReplay emergency switch.
         var store = new InMemoryEventStore();
         var behavior = new CounterEventSourcingBehavior(store, "agent-version-drift");
 
@@ -438,40 +439,43 @@ public class EventSourcingBehaviorTests
     }
 
     [Fact]
-    public async Task DefaultEventSourcingBehaviorFactory_AppliesPerAgentRecoveryPredicate()
+    public async Task DefaultEventSourcingBehaviorFactory_AppliesActorTypeRecoveryMarker()
     {
-        // Per-actor opt-in (EventSourcingRuntimeOptions.ShouldRecoverFromVersionDriftOnReplay)
-        // is the production wiring point for projection scope actors: they
-        // get drift recovery while domain GAgents keep the safe default.
+        // Refactor (iter56/cluster-921-runtime-recovery-actor-type-marker): old=hosting actorId prefix recovery, new=actor-type marker in factory
         var store = new InMemoryEventStore();
         var options = new EventSourcingRuntimeOptions
         {
             EnableSnapshots = false,
             EnableEventCompaction = false,
-            ShouldRecoverFromVersionDriftOnReplay = id => id.StartsWith("recoverable:", StringComparison.Ordinal),
         };
         var factory = new DefaultEventSourcingBehaviorFactory<CounterState>(store, options);
 
         await store.AppendAsync(
-            "recoverable:agent-1",
+            "projection.durable.scope:agent-1",
             [BuildEvent(version: 1, amount: 5)],
             expectedVersion: 0);
-        await store.DeleteEventsUpToAsync("recoverable:agent-1", 1);
+        await store.DeleteEventsUpToAsync("projection.durable.scope:agent-1", 1);
 
-        var recoverable = factory.Create("recoverable:agent-1", static (state, _) => state);
-        var recovered = await recoverable.ReplayAsync("recoverable:agent-1");
+        var recoverable = factory.Create(
+            "projection.durable.scope:agent-1",
+            typeof(RecoverableProjectionActor),
+            static (state, _) => state);
+        var recovered = await recoverable.ReplayAsync("projection.durable.scope:agent-1");
         recovered.ShouldBeNull();
         recoverable.CurrentVersion.ShouldBe(1);
 
         await store.AppendAsync(
-            "strict:agent-2",
+            "projection.durable.scope:fake-domain-agent",
             [BuildEvent(version: 1, amount: 7)],
             expectedVersion: 0);
-        await store.DeleteEventsUpToAsync("strict:agent-2", 1);
+        await store.DeleteEventsUpToAsync("projection.durable.scope:fake-domain-agent", 1);
 
-        var strict = factory.Create("strict:agent-2", static (state, _) => state);
+        var strict = factory.Create(
+            "projection.durable.scope:fake-domain-agent",
+            typeof(StrictDomainActor),
+            static (state, _) => state);
         await Should.ThrowAsync<EventStoreVersionDriftException>(
-            () => strict.ReplayAsync("strict:agent-2"));
+            () => strict.ReplayAsync("projection.durable.scope:fake-domain-agent"));
     }
 
     [Fact]
@@ -643,6 +647,10 @@ public class EventSourcingBehaviorTests
             throw new InvalidOperationException("snapshot-store-failure");
         }
     }
+
+    private sealed class RecoverableProjectionActor : IEventSourcingVersionDriftRecoverableActor;
+
+    private sealed class StrictDomainActor;
 
     private sealed class MalformedConflictEventStore : IEventStore
     {

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/AevatarActorRuntimeServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/AevatarActorRuntimeServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Abstractions.TypeSystem;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Runtime.Hosting;
 using Aevatar.Foundation.Runtime.Hosting.DependencyInjection;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Actors;
@@ -174,6 +175,30 @@ public class AevatarActorRuntimeServiceCollectionExtensionsTests
         options.EventSourcingSnapshotInterval.Should().Be(17);
         options.EventSourcingEnableEventCompaction.Should().BeFalse();
         options.EventSourcingRetainedEventsAfterSnapshot.Should().Be(9);
+    }
+
+    [Fact]
+    public void AddAevatarActorRuntime_ShouldWireEventSourcingOptionsWithoutActorIdPrefixRecovery()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"{AevatarActorRuntimeOptions.SectionName}:EventSourcing:EnableSnapshots"] = "false",
+            [$"{AevatarActorRuntimeOptions.SectionName}:EventSourcing:SnapshotInterval"] = "23",
+            [$"{AevatarActorRuntimeOptions.SectionName}:EventSourcing:EnableEventCompaction"] = "false",
+            [$"{AevatarActorRuntimeOptions.SectionName}:EventSourcing:RetainedEventsAfterSnapshot"] = "11",
+        });
+
+        services.AddAevatarActorRuntime(configuration);
+        using var provider = services.BuildServiceProvider();
+
+        // Refactor (iter56/cluster-921-runtime-recovery-actor-type-marker): old=hosting actorId prefix recovery, new=actor-type marker in factory
+        var eventSourcingOptions = provider.GetRequiredService<EventSourcingRuntimeOptions>();
+        eventSourcingOptions.EnableSnapshots.Should().BeFalse();
+        eventSourcingOptions.SnapshotInterval.Should().Be(23);
+        eventSourcingOptions.EnableEventCompaction.Should().BeFalse();
+        eventSourcingOptions.RetainedEventsAfterSnapshot.Should().Be(11);
+        eventSourcingOptions.RecoverFromVersionDriftOnReplay.Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

iter56 cluster-921 — Phase 9 r3 unanimous(3/3 direct actor-type marker):

- **新增** `IEventSourcingVersionDriftRecoverableActor` Foundation marker contract
- **ProjectionScopeGAgentBase<TContext> 实现 marker**(per consensus)
- `IEventSourcingBehaviorFactory.Create` 接 `actorType`
- `DefaultEventSourcingBehaviorFactory` 按 marker type 启用 drift recovery
- **删除** Hosting actorId prefix recovery predicate(违反 "actorId 对调用方不透明" 条款)
- **删除** `ShouldRecoverFromVersionDriftOnReplay`

## 边界

- **不加** `IEventSourcingRecoveryPolicyResolver` seam(over-built,per consensus)
- preserve #502/#503 projection scope drift recovery 行为
- domain actor 仍 fail-fast
- 不依赖外部仓库

## 影响范围

LOC +72/-47 net **+25**(精简 cleanup)

## 验证

- `dotnet build aevatar.slnx --nologo` PASS
- `dotnet test aevatar.slnx --nologo` PASS
- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/architecture_guards.sh` PASS
- `bash tools/ci/coverage_quality_guard.sh` line 88.7% / branch 72.6%

Closes #921

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
