### PR TITLE
iter56 cluster-925: workflow binding query readmodel-only

### DIFF
--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/ProjectionWorkflowActorBindingReader.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/ProjectionWorkflowActorBindingReader.cs
@@ -1,7 +1,5 @@
-using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.Workflow.Application.Abstractions.Runs;
-using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Core.Primitives;
 using Aevatar.Workflow.Projection.ReadModels;
 
@@ -11,34 +9,22 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
 {
     private readonly Func<string, CancellationToken, Task<WorkflowActorBindingDocument?>> _getDocumentAsync;
     private readonly Func<ProjectionDocumentQuery, CancellationToken, Task<ProjectionDocumentQueryResult<WorkflowActorBindingDocument>>> _queryDocumentsAsync;
-    private readonly Func<string, Task<bool>> _existsAsync;
-    private readonly Func<string, Type, CancellationToken, Task<bool>> _isExpectedAsync;
 
     public ProjectionWorkflowActorBindingReader(
-        IProjectionDocumentReader<WorkflowActorBindingDocument, string> documentStore,
-        IActorRuntime runtime,
-        IAgentTypeVerifier agentTypeVerifier)
+        IProjectionDocumentReader<WorkflowActorBindingDocument, string> documentStore)
     {
         ArgumentNullException.ThrowIfNull(documentStore);
-        ArgumentNullException.ThrowIfNull(runtime);
-        ArgumentNullException.ThrowIfNull(agentTypeVerifier);
 
         _getDocumentAsync = (actorId, ct) => documentStore.GetAsync(actorId, ct);
         _queryDocumentsAsync = documentStore.QueryAsync;
-        _existsAsync = runtime.ExistsAsync;
-        _isExpectedAsync = agentTypeVerifier.IsExpectedAsync;
     }
 
     internal ProjectionWorkflowActorBindingReader(
         Func<string, CancellationToken, Task<WorkflowActorBindingDocument?>> getDocumentAsync,
-        Func<ProjectionDocumentQuery, CancellationToken, Task<ProjectionDocumentQueryResult<WorkflowActorBindingDocument>>> queryDocumentsAsync,
-        Func<string, Task<bool>> existsAsync,
-        Func<string, Type, CancellationToken, Task<bool>> isExpectedAsync)
+        Func<ProjectionDocumentQuery, CancellationToken, Task<ProjectionDocumentQueryResult<WorkflowActorBindingDocument>>> queryDocumentsAsync)
     {
         _getDocumentAsync = getDocumentAsync ?? throw new ArgumentNullException(nameof(getDocumentAsync));
         _queryDocumentsAsync = queryDocumentsAsync ?? throw new ArgumentNullException(nameof(queryDocumentsAsync));
-        _existsAsync = existsAsync ?? throw new ArgumentNullException(nameof(existsAsync));
-        _isExpectedAsync = isExpectedAsync ?? throw new ArgumentNullException(nameof(isExpectedAsync));
     }
 
     public async Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default)
@@ -46,17 +32,11 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
         ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
         ct.ThrowIfCancellationRequested();
 
-        if (!await _existsAsync(actorId))
-            return null;
-
-        var actorKind = await ResolveActorKindAsync(actorId, ct);
-        if (actorKind == WorkflowActorKind.Unsupported)
-            return WorkflowActorBinding.Unsupported(actorId);
-
+        // Refactor (iter56/cluster-925-binding-query-readmodel-only): old=runtime existence/type fallback, new=readmodel-only
         var document = await _getDocumentAsync(actorId, ct);
         return document == null
-            ? CreateUnboundBinding(actorId, actorKind)
-            : MapDocument(document, actorId, actorKind);
+            ? null
+            : MapDocument(document, actorId);
     }
 
     public async Task<IReadOnlyList<WorkflowActorBinding>> ListByRunIdAsync(
@@ -98,14 +78,12 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
         foreach (var document in result.Items)
         {
             var actorId = document.ActorId?.Trim();
-            if (string.IsNullOrWhiteSpace(actorId) ||
-                !await _existsAsync(actorId) ||
-                !await _isExpectedAsync(actorId, typeof(WorkflowRunGAgent), ct))
+            if (string.IsNullOrWhiteSpace(actorId))
             {
                 continue;
             }
 
-            bindings.Add(MapDocument(document, actorId, WorkflowActorKind.Run));
+            bindings.Add(MapDocument(document, actorId));
         }
 
         return bindings;
@@ -186,53 +164,27 @@ internal sealed class ProjectionWorkflowActorBindingReader : IWorkflowActorBindi
         foreach (var document in result.Items)
         {
             var actorId = document.ActorId?.Trim();
-            if (string.IsNullOrWhiteSpace(actorId) ||
-                !await _existsAsync(actorId) ||
-                !await _isExpectedAsync(actorId, typeof(WorkflowRunGAgent), ct))
+            if (string.IsNullOrWhiteSpace(actorId))
             {
                 continue;
             }
 
-            bindings.Add(MapDocument(document, actorId, WorkflowActorKind.Run));
+            bindings.Add(MapDocument(document, actorId));
         }
 
         return bindings;
     }
 
-    private async Task<WorkflowActorKind> ResolveActorKindAsync(string actorId, CancellationToken ct)
-    {
-        if (await _isExpectedAsync(actorId, typeof(WorkflowGAgent), ct))
-            return WorkflowActorKind.Definition;
-        if (await _isExpectedAsync(actorId, typeof(WorkflowRunGAgent), ct))
-            return WorkflowActorKind.Run;
-
-        return WorkflowActorKind.Unsupported;
-    }
-
-    private static WorkflowActorBinding CreateUnboundBinding(string actorId, WorkflowActorKind actorKind) =>
-        new(
-            actorKind,
-            actorId,
-            actorKind == WorkflowActorKind.Definition ? actorId : string.Empty,
-            string.Empty,
-            string.Empty,
-            string.Empty,
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
-            string.Empty);
-
     private static WorkflowActorBinding MapDocument(
         WorkflowActorBindingDocument document,
-        string fallbackActorId,
-        WorkflowActorKind fallbackActorKind)
+        string fallbackActorId)
     {
         ArgumentNullException.ThrowIfNull(document);
 
         var actorId = string.IsNullOrWhiteSpace(document.ActorId)
             ? fallbackActorId
             : document.ActorId;
-        var actorKind = document.ActorKind == WorkflowActorKind.Unsupported
-            ? fallbackActorKind
-            : document.ActorKind;
+        var actorKind = document.ActorKind;
         var definitionActorId = string.IsNullOrWhiteSpace(document.DefinitionActorId) && actorKind == WorkflowActorKind.Definition
             ? actorId
             : document.DefinitionActorId ?? string.Empty;

--- a/test/Aevatar.Workflow.Host.Api.Tests/RuntimeWorkflowActorBindingReaderTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/RuntimeWorkflowActorBindingReaderTests.cs
@@ -19,27 +19,13 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
     }
 
     [Fact]
-    public async Task GetAsync_ShouldReturnNull_WhenActorMissing()
-    {
-        var reader = CreateReader(existsAsync: _ => Task.FromResult(false));
-
-        var result = await reader.GetAsync("missing", CancellationToken.None);
-
-        result.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task GetAsync_ShouldReturnUnsupportedBinding_WhenActorIsNotWorkflowCapable()
+    public async Task GetAsync_ShouldReturnNull_WhenReadModelDocumentMissing()
     {
         var reader = CreateReader();
 
         var result = await reader.GetAsync("actor-1", CancellationToken.None);
 
-        result.Should().NotBeNull();
-        result!.ActorKind.Should().Be(WorkflowActorKind.Unsupported);
-        result.ActorId.Should().Be("actor-1");
-        result.WorkflowName.Should().BeEmpty();
-        result.WorkflowYaml.Should().BeEmpty();
+        result.Should().BeNull();
     }
 
     [Fact]
@@ -58,9 +44,7 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
                 {
                     ["child"] = "yaml-child",
                 },
-            }),
-            isExpectedAsync: static (actorId, expectedType, _) => Task.FromResult(
-                actorId == "actor-1" && expectedType == typeof(Aevatar.Workflow.Core.WorkflowRunGAgent)));
+            }));
 
         var result = await reader.GetAsync("actor-1", CancellationToken.None);
 
@@ -75,7 +59,7 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
     }
 
     [Fact]
-    public async Task GetAsync_ShouldUseVerifierKind_WhenProjectedDocumentDoesNotDeclareKind()
+    public async Task GetAsync_ShouldUseProjectedDocumentKind_WhenRuntimeWouldInferDifferentKind()
     {
         var reader = CreateReader(
             getDocumentAsync: (_, _) => Task.FromResult<WorkflowActorBindingDocument?>(new WorkflowActorBindingDocument
@@ -83,32 +67,104 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
                 Id = "actor-2",
                 ActorId = "binding-actor-2",
                 ActorKind = WorkflowActorKind.Unsupported,
-            }),
-            isExpectedAsync: static (actorId, expectedType, _) => Task.FromResult(
-                actorId == "actor-2" && expectedType == typeof(Aevatar.Workflow.Core.WorkflowGAgent)));
+            }));
 
         var result = await reader.GetAsync("actor-2", CancellationToken.None);
 
         result.Should().NotBeNull();
-        result!.ActorKind.Should().Be(WorkflowActorKind.Definition);
+        result!.ActorKind.Should().Be(WorkflowActorKind.Unsupported);
         result.ActorId.Should().Be("binding-actor-2");
     }
 
     [Fact]
-    public async Task GetAsync_ShouldReturnUnboundDefinitionBinding_WhenProjectionHasNoDocument()
+    public async Task ListByRunIdAsync_ShouldReturnProjectedRunRows_WithoutRuntimeFiltering()
     {
         var reader = CreateReader(
-            getDocumentAsync: (_, _) => Task.FromResult<WorkflowActorBindingDocument?>(null),
-            isExpectedAsync: static (actorId, expectedType, _) => Task.FromResult(
-                actorId == "actor-3" && expectedType == typeof(Aevatar.Workflow.Core.WorkflowGAgent)));
+            queryDocumentsAsync: (query, _) =>
+            {
+                query.Filters.Should().Contain(filter =>
+                    filter.FieldPath == nameof(WorkflowActorBindingDocument.RunId) &&
+                    filter.Operator == ProjectionDocumentFilterOperator.Eq);
+                query.Filters.Should().Contain(filter =>
+                    filter.FieldPath == nameof(WorkflowActorBindingDocument.ActorKindValue) &&
+                    filter.Operator == ProjectionDocumentFilterOperator.Eq);
 
-        var result = await reader.GetAsync("actor-3", CancellationToken.None);
+                return Task.FromResult(new ProjectionDocumentQueryResult<WorkflowActorBindingDocument>
+                {
+                    Items =
+                    [
+                        new WorkflowActorBindingDocument
+                        {
+                            ActorId = "run-actor-1",
+                            ActorKind = WorkflowActorKind.Run,
+                            DefinitionActorId = "definition-1",
+                            RunId = "run-1",
+                            WorkflowName = "projected",
+                        },
+                        new WorkflowActorBindingDocument
+                        {
+                            ActorId = " ",
+                            ActorKind = WorkflowActorKind.Run,
+                            DefinitionActorId = "definition-2",
+                            RunId = "run-1",
+                        },
+                    ],
+                });
+            });
 
-        result.Should().NotBeNull();
-        result!.ActorKind.Should().Be(WorkflowActorKind.Definition);
-        result.ActorId.Should().Be("actor-3");
-        result.DefinitionActorId.Should().Be("actor-3");
-        result.WorkflowYaml.Should().BeEmpty();
+        var result = await reader.ListByRunIdAsync(" run-1 ", take: 500, CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].ActorId.Should().Be("run-actor-1");
+        result[0].ActorKind.Should().Be(WorkflowActorKind.Run);
+        result[0].DefinitionActorId.Should().Be("definition-1");
+        result[0].RunId.Should().Be("run-1");
+        result[0].WorkflowName.Should().Be("projected");
+    }
+
+    [Fact]
+    public async Task QueryAsync_ShouldReturnProjectedRunRows_WithoutRuntimeFiltering()
+    {
+        var reader = CreateReader(
+            queryDocumentsAsync: (query, _) =>
+            {
+                query.Take.Should().Be(200);
+                query.Filters.Should().Contain(filter =>
+                    filter.FieldPath == nameof(WorkflowActorBindingDocument.ScopeId) &&
+                    filter.Operator == ProjectionDocumentFilterOperator.Eq);
+                query.Filters.Should().Contain(filter =>
+                    filter.FieldPath == nameof(WorkflowActorBindingDocument.DefinitionActorId) &&
+                    filter.Operator == ProjectionDocumentFilterOperator.In);
+
+                return Task.FromResult(new ProjectionDocumentQueryResult<WorkflowActorBindingDocument>
+                {
+                    Items =
+                    [
+                        new WorkflowActorBindingDocument
+                        {
+                            ActorId = "run-actor-2",
+                            ActorKind = WorkflowActorKind.Run,
+                            DefinitionActorId = "definition-2",
+                            RunId = "run-2",
+                            ScopeId = "scope-1",
+                        },
+                    ],
+                });
+            });
+
+        var result = await reader.QueryAsync(
+            new WorkflowRunBindingQuery(
+                " scope-1 ",
+                ["definition-1", "definition-2", "definition-1", " "],
+                Take: 500),
+            CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].ActorId.Should().Be("run-actor-2");
+        result[0].ActorKind.Should().Be(WorkflowActorKind.Run);
+        result[0].DefinitionActorId.Should().Be("definition-2");
+        result[0].RunId.Should().Be("run-2");
+        result[0].ScopeId.Should().Be("scope-1");
     }
 
     [Fact]
@@ -125,9 +181,7 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
 
     private static ProjectionWorkflowActorBindingReader CreateReader(
         Func<string, CancellationToken, Task<WorkflowActorBindingDocument?>>? getDocumentAsync = null,
-        Func<ProjectionDocumentQuery, CancellationToken, Task<ProjectionDocumentQueryResult<WorkflowActorBindingDocument>>>? queryDocumentsAsync = null,
-        Func<string, Task<bool>>? existsAsync = null,
-        Func<string, Type, CancellationToken, Task<bool>>? isExpectedAsync = null)
+        Func<ProjectionDocumentQuery, CancellationToken, Task<ProjectionDocumentQueryResult<WorkflowActorBindingDocument>>>? queryDocumentsAsync = null)
     {
         var queryAsync = queryDocumentsAsync;
         if (queryAsync == null)
@@ -141,8 +195,6 @@ public sealed class ProjectionWorkflowActorBindingReaderTests
 
         return new ProjectionWorkflowActorBindingReader(
             getDocumentAsync ?? ((_, _) => Task.FromResult<WorkflowActorBindingDocument?>(null)),
-            queryAsync,
-            existsAsync ?? (_ => Task.FromResult(true)),
-            isExpectedAsync ?? ((_, _, _) => Task.FromResult(false)));
+            queryAsync);
     }
 }


### PR DESCRIPTION
## 摘要

iter56 cluster-925 — Phase 9 r1 unanimous(3/3 一轮达成):

- **ProjectionWorkflowActorBindingReader** 删 `IActorRuntime` / `IAgentTypeVerifier` 依赖
- 删 runtime existence check + type fallback + 合成 unbound binding
- binding query 只 map `WorkflowActorBindingDocument` readmodel(per CLAUDE "查询走 readmodel" 条款)
- 不动 binding readmodel/query interface(保留)
- 不动 domain actor / runtime path

## 边界

- query 不再 side-read runtime existence/type — 完全 readmodel-based
- 不依赖外部仓库

## 影响范围

2 files changed,LOC +103/-99(基本 wash)

## Coverage

- ProjectionWorkflowActorBindingReader line 81.08% / branch 59.09%

## 验证

- `dotnet test test/Aevatar.Workflow.Host.Api.Tests/...` 373/373 PASS
- `bash tools/ci/workflow_binding_boundary_guard.sh` PASS
- `bash tools/ci/query_projection_priming_guard.sh` PASS
- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/architecture_guards.sh` PASS

Closes #925

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
