### PR TITLE
iter56 cluster-929: 删 AppScopedWorkflowService obsolete compat wrappers (-968 LOC)

### DIFF
--- a/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
+++ b/src/Aevatar.Studio.Application/AppScopedWorkflowService.cs
@@ -1,12 +1,3 @@
-using System.Net;
-using Microsoft.AspNetCore.Http;
-using System.Net.Http.Json;
-using System.Text.Json;
-using Aevatar.Configuration;
-using Aevatar.GAgentService.Abstractions;
-using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.GAgentService.Abstractions.Services;
-using Aevatar.Workflow.Application.Abstractions.Runs;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Domain.Studio.Models;
@@ -21,40 +12,18 @@ namespace Aevatar.Studio.Application;
 //   New principle: Studio executions are a bounded ServiceRunGAgent readmodel facade; UI/layout/draft index are deleted/downgraded to client cache or derived from existing actor-backed sources. No new history/draft index actor.
 public sealed class AppScopedWorkflowService
 {
-    private const string BackendClientName = "AppBridgeBackend";
-
-    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
-    {
-        PropertyNameCaseInsensitive = true,
-    };
-
-    private readonly IScopeWorkflowQueryPort? _workflowQueryPort;
-    private readonly IWorkflowActorBindingReader? _workflowActorBindingReader;
-    private readonly IServiceRevisionArtifactStore? _artifactStore;
-    private readonly IServiceLifecycleQueryPort? _serviceLifecycleQueryPort;
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IWorkflowYamlDocumentService _yamlDocumentService;
     private readonly IStudioWorkspaceQueryPort? _workspaceQueryPort;
     private readonly IStudioWorkspaceCommandPort? _workspaceCommandPort;
     private readonly ILogger<AppScopedWorkflowService>? _logger;
 
     public AppScopedWorkflowService(
-        IHttpClientFactory httpClientFactory,
         IWorkflowYamlDocumentService yamlDocumentService,
-        IScopeWorkflowQueryPort? workflowQueryPort = null,
-        IWorkflowActorBindingReader? workflowActorBindingReader = null,
-        IServiceRevisionArtifactStore? artifactStore = null,
-        IServiceLifecycleQueryPort? serviceLifecycleQueryPort = null,
         IStudioWorkspaceQueryPort? workspaceQueryPort = null,
         IStudioWorkspaceCommandPort? workspaceCommandPort = null,
         ILogger<AppScopedWorkflowService>? logger = null)
     {
-        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _yamlDocumentService = yamlDocumentService ?? throw new ArgumentNullException(nameof(yamlDocumentService));
-        _workflowQueryPort = workflowQueryPort;
-        _workflowActorBindingReader = workflowActorBindingReader;
-        _artifactStore = artifactStore;
-        _serviceLifecycleQueryPort = serviceLifecycleQueryPort;
         _workspaceQueryPort = workspaceQueryPort;
         _workspaceCommandPort = workspaceCommandPort;
         _logger = logger;
@@ -195,142 +164,9 @@ public sealed class AppScopedWorkflowService
         await workspaceCommandPort.DeleteDraftAsync(normalizedScopeId, normalizedWorkflowId, workspace.StateVersion, ct);
     }
 
-    #pragma warning disable CS0618
-    [Obsolete("Use ListDraftsAsync.")]
-    public async Task<IReadOnlyList<WorkflowSummary>> ListAsync(
-        string scopeId,
-        CancellationToken ct = default)
-    {
-        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
-        var workflows = _workflowQueryPort != null
-            ? await _workflowQueryPort.ListAsync(normalizedScopeId, ct)
-            : await SendAsync<List<ScopeWorkflowSummary>>(
-                HttpMethod.Get,
-                $"/api/scopes/{Uri.EscapeDataString(normalizedScopeId)}/workflows",
-                body: null,
-                ct) ?? [];
-
-        var draftsById = await ListDraftsByIdAsync(normalizedScopeId, ct);
-        var summaries = workflows
-            .OrderByDescending(static item => item.UpdatedAt)
-            .Select(workflow => ToLegacyWorkflowSummary(
-                normalizedScopeId,
-                workflow,
-                draftsById.TryGetValue(workflow.WorkflowId, out var draft)
-                    ? draft
-                    : null))
-            .ToList();
-
-        return MergeLegacyDraftSummaries(normalizedScopeId, summaries, draftsById);
-    }
-
-    [Obsolete("Use GetDraftAsync.")]
-    public async Task<WorkflowFileResponse?> GetAsync(
-        string scopeId,
-        string workflowId,
-        CancellationToken ct = default)
-    {
-        var normalizedScopeId = NormalizeRequired(scopeId, nameof(scopeId));
-        var normalizedWorkflowId = NormalizeRequired(workflowId, nameof(workflowId));
-        var draft = await TryGetDraftAsync(normalizedScopeId, normalizedWorkflowId, ct);
-
-        if (draft != null)
-        {
-            return ToLegacyDraftWorkflowFileResponse(
-                normalizedScopeId,
-                draft);
-        }
-
-        if (_workflowQueryPort != null && _workflowActorBindingReader != null)
-        {
-            var workflow = await _workflowQueryPort.GetByWorkflowIdAsync(normalizedScopeId, normalizedWorkflowId, ct);
-            if (workflow != null)
-            {
-                var binding = string.IsNullOrWhiteSpace(workflow.ActorId)
-                    ? null
-                    : await _workflowActorBindingReader.GetAsync(workflow.ActorId, ct);
-
-                var yaml = binding?.WorkflowYaml ?? string.Empty;
-                if (string.IsNullOrWhiteSpace(yaml) &&
-                    _artifactStore != null &&
-                    !string.IsNullOrWhiteSpace(workflow.ServiceKey))
-                {
-                    if (!string.IsNullOrWhiteSpace(workflow.ActiveRevisionId))
-                    {
-                        var artifact = await _artifactStore.GetAsync(workflow.ServiceKey, workflow.ActiveRevisionId, ct);
-                        yaml = artifact?.DeploymentPlan?.WorkflowPlan?.WorkflowYaml ?? string.Empty;
-                    }
-
-                    if (string.IsNullOrWhiteSpace(yaml) &&
-                        _workflowQueryPort != null &&
-                        _serviceLifecycleQueryPort != null)
-                    {
-                        var identity = new ServiceIdentity
-                        {
-                            TenantId = normalizedScopeId,
-                            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
-                            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
-                            ServiceId = normalizedWorkflowId,
-                        };
-                        var svc = await _serviceLifecycleQueryPort.GetServiceAsync(identity, ct);
-                        var revId = svc?.ActiveServingRevisionId;
-                        if (string.IsNullOrWhiteSpace(revId))
-                            revId = svc?.DefaultServingRevisionId;
-                        if (!string.IsNullOrWhiteSpace(revId))
-                        {
-                            var artifact = await _artifactStore.GetAsync(workflow.ServiceKey, revId, ct);
-                            yaml = artifact?.DeploymentPlan?.WorkflowPlan?.WorkflowYaml ?? string.Empty;
-                        }
-                    }
-                }
-
-                return ToLegacyCommittedWorkflowFileResponse(
-                    normalizedScopeId,
-                    workflow,
-                    yaml,
-                    findingsFallbackMessage: "Workflow YAML is not available yet.");
-            }
-
-            return null;
-        }
-
-        var detail = await SendAsync<ScopeWorkflowDetail>(
-            HttpMethod.Get,
-            $"/api/scopes/{Uri.EscapeDataString(normalizedScopeId)}/workflows/{Uri.EscapeDataString(normalizedWorkflowId)}",
-            body: null,
-            ct,
-            allowNotFound: true);
-
-        if (detail == null || detail.Workflow == null)
-            return null;
-
-        return ToLegacyCommittedWorkflowFileResponse(
-            normalizedScopeId,
-            detail.Workflow,
-            detail.Source?.WorkflowYaml ?? string.Empty,
-            findingsFallbackMessage: "Workflow YAML is not available yet.");
-    }
-
-    [Obsolete("Use CreateDraftAsync or UpdateDraftAsync.")]
-    public async Task<WorkflowFileResponse> SaveDraftAsync(
-        string scopeId,
-        SaveWorkflowFileRequest request,
-        CancellationToken ct = default)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        var nextRequest = new SaveWorkflowDraftRequest(
-            request.DirectoryId,
-            request.WorkflowName,
-            request.FileName,
-            request.Yaml,
-            Layout: null);
-        var saved = string.IsNullOrWhiteSpace(request.WorkflowId)
-            ? await CreateDraftAsync(scopeId, nextRequest, ct)
-            : await UpdateDraftAsync(scopeId, request.WorkflowId, nextRequest, ct);
-        return ToLegacyWorkflowFileResponse(saved);
-    }
-    #pragma warning restore CS0618
+    // Refactor (iter56/cluster-929-studio-workflow-obsolete-shims):
+    //   old=Obsolete wrapper, new=removed (use draft methods)
+    //   ListAsync/GetAsync/SaveDraftAsync legacy shims were deleted; callers use draft methods directly.
 
     private string AlignWorkflowYamlName(string yaml, string workflowName)
     {
@@ -359,47 +195,6 @@ public sealed class AppScopedWorkflowService
 
     public static string BuildScopeDirectoryId(string scopeId) =>
         $"scope:{NormalizeRequired(scopeId, nameof(scopeId))}";
-
-    private WorkflowCommittedResponse ToWorkflowCommittedResponse(
-        string scopeId,
-        ScopeWorkflowSummary workflow,
-        string yaml,
-        WorkflowParseResult? parseResult = null,
-        string? findingsFallbackMessage = null)
-    {
-        var parse = parseResult ?? _yamlDocumentService.Parse(yaml);
-        var findings = parse.Findings;
-        if (parse.Document == null &&
-            findings.Count == 0 &&
-            !string.IsNullOrWhiteSpace(findingsFallbackMessage))
-        {
-            findings =
-            [
-                new ValidationFinding(
-                    ValidationLevel.Error,
-                    "/",
-                    findingsFallbackMessage),
-            ];
-        }
-
-        return new WorkflowCommittedResponse(
-            workflow.WorkflowId,
-            !string.IsNullOrWhiteSpace(parse.Document?.Name) ? parse.Document.Name : ResolveWorkflowDisplayName(workflow),
-            yaml,
-            parse.Document,
-            findings,
-            workflow.UpdatedAt);
-    }
-
-    private static string ResolveWorkflowDisplayName(ScopeWorkflowSummary workflow)
-    {
-        if (!string.IsNullOrWhiteSpace(workflow.DisplayName))
-            return workflow.DisplayName;
-        if (!string.IsNullOrWhiteSpace(workflow.WorkflowName))
-            return workflow.WorkflowName;
-
-        return workflow.WorkflowId;
-    }
 
     // Refactor (iter42/issue-864-studio-workspace-execution-fact-owner):
     //   Old pattern: Studio executions/workspace facts mixed FileStudioWorkspaceStore JSON, draft index sidecars, and authoritative server UI/layout state across multiple owners.
@@ -430,7 +225,7 @@ public sealed class AppScopedWorkflowService
         {
             _logger?.LogWarning(
                 exception,
-                "Failed to list stored scoped workflow drafts for scope {ScopeId}. Falling back to runtime workflows only.",
+                "Failed to list stored scoped workflow drafts for scope {ScopeId}. Returning an empty draft list.",
                 scopeId);
             return new Dictionary<string, StudioWorkflowDraftRecord>(StringComparer.Ordinal);
         }
@@ -461,7 +256,7 @@ public sealed class AppScopedWorkflowService
         {
             _logger?.LogWarning(
                 exception,
-                "Failed to load stored scoped workflow draft {WorkflowId} for scope {ScopeId}. Falling back to runtime workflow content.",
+                "Failed to load stored scoped workflow draft {WorkflowId} for scope {ScopeId}. Returning no draft.",
                 workflowId,
                 scopeId);
             return null;
@@ -487,90 +282,6 @@ public sealed class AppScopedWorkflowService
             draft.UpdatedAtUtc);
     }
 
-    private WorkflowSummary ToLegacyWorkflowSummary(
-        string scopeId,
-        ScopeWorkflowSummary workflow,
-        StudioWorkflowDraftRecord? draft)
-    {
-        var parse = !string.IsNullOrWhiteSpace(draft?.Yaml)
-            ? _yamlDocumentService.Parse(draft.Yaml)
-            : null;
-        var scopeDirectory = CreateScopeDirectory(scopeId);
-        return new WorkflowSummary(
-            workflow.WorkflowId,
-            ResolveWorkflowSummaryName(workflow, draft, parse),
-            parse?.Document?.Description ?? string.Empty,
-            $"{workflow.WorkflowId}.yaml",
-            $"{scopeDirectory.Path}/{workflow.WorkflowId}.yaml",
-            scopeDirectory.DirectoryId,
-            scopeDirectory.Label,
-            parse?.Document?.Steps.Count ?? 0,
-            HasLayout: false,
-            ResolveWorkflowSummaryUpdatedAt(workflow, draft));
-    }
-
-    private IReadOnlyList<WorkflowSummary> MergeLegacyDraftSummaries(
-        string scopeId,
-        IReadOnlyList<WorkflowSummary> runtimeSummaries,
-        IReadOnlyDictionary<string, StudioWorkflowDraftRecord> draftsById)
-    {
-        if (draftsById.Count == 0)
-            return runtimeSummaries;
-
-        var merged = runtimeSummaries.ToDictionary(summary => summary.WorkflowId, StringComparer.Ordinal);
-        foreach (var draft in draftsById.Values)
-        {
-            if (merged.ContainsKey(draft.WorkflowId))
-                continue;
-
-            var nextDraftSummary = ToDraftWorkflowSummary(scopeId, draft);
-            merged[draft.WorkflowId] = new WorkflowSummary(
-                nextDraftSummary.WorkflowId,
-                nextDraftSummary.Name,
-                nextDraftSummary.Description,
-                nextDraftSummary.FileName,
-                nextDraftSummary.FilePath,
-                nextDraftSummary.DirectoryId,
-                nextDraftSummary.DirectoryLabel,
-                nextDraftSummary.StepCount,
-                HasLayout: false,
-                nextDraftSummary.UpdatedAtUtc);
-        }
-
-        return merged.Values
-            .OrderByDescending(static item => item.UpdatedAtUtc)
-            .ToList();
-    }
-
-    private static string ResolveWorkflowSummaryName(
-        ScopeWorkflowSummary workflow,
-        StudioWorkflowDraftRecord? draft,
-        WorkflowParseResult? parseResult)
-    {
-        var parsedName = parseResult?.Document?.Name?.Trim();
-        if (!string.IsNullOrWhiteSpace(parsedName))
-            return parsedName;
-
-        var storedName = draft?.Name?.Trim();
-        if (!string.IsNullOrWhiteSpace(storedName))
-            return storedName;
-
-        return ResolveWorkflowDisplayName(workflow);
-    }
-
-    private static DateTimeOffset ResolveWorkflowSummaryUpdatedAt(
-        ScopeWorkflowSummary workflow,
-        StudioWorkflowDraftRecord? draft)
-    {
-        if (draft is not null &&
-            draft.UpdatedAtUtc > workflow.UpdatedAt)
-        {
-            return draft.UpdatedAtUtc;
-        }
-
-        return workflow.UpdatedAt;
-    }
-
     private WorkflowDraftResponse ToDraftWorkflowResponse(
         string scopeId,
         StudioWorkflowDraftRecord draft)
@@ -586,80 +297,6 @@ public sealed class AppScopedWorkflowService
             draft.Yaml,
             Layout: null,
             draft.UpdatedAtUtc);
-    }
-
-    private WorkflowFileResponse ToLegacyDraftWorkflowFileResponse(
-        string scopeId,
-        StudioWorkflowDraftRecord draft)
-    {
-        var parse = _yamlDocumentService.Parse(draft.Yaml);
-        var scopeDirectory = CreateScopeDirectory(scopeId);
-        return new WorkflowFileResponse(
-            draft.WorkflowId,
-            ResolveDraftWorkflowName(draft, parse),
-            string.IsNullOrWhiteSpace(draft.FileName) ? $"{draft.WorkflowId}.yaml" : draft.FileName,
-            string.IsNullOrWhiteSpace(draft.FilePath) ? $"{scopeDirectory.Path}/{draft.WorkflowId}.yaml" : draft.FilePath,
-            scopeDirectory.DirectoryId,
-            scopeDirectory.Label,
-            draft.Yaml,
-            parse.Document,
-            Layout: null,
-            parse.Findings,
-            draft.UpdatedAtUtc);
-    }
-
-    private WorkflowFileResponse ToLegacyCommittedWorkflowFileResponse(
-        string scopeId,
-        ScopeWorkflowSummary workflow,
-        string yaml,
-        WorkflowParseResult? parseResult = null,
-        string? findingsFallbackMessage = null)
-    {
-        var parse = parseResult ?? _yamlDocumentService.Parse(yaml);
-        var findings = parse.Findings;
-        if (parse.Document == null &&
-            findings.Count == 0 &&
-            !string.IsNullOrWhiteSpace(findingsFallbackMessage))
-        {
-            findings =
-            [
-                new ValidationFinding(
-                    ValidationLevel.Error,
-                    "/",
-                    findingsFallbackMessage),
-            ];
-        }
-
-        var scopeDirectory = CreateScopeDirectory(scopeId);
-        return new WorkflowFileResponse(
-            workflow.WorkflowId,
-            !string.IsNullOrWhiteSpace(parse.Document?.Name) ? parse.Document.Name : ResolveWorkflowDisplayName(workflow),
-            $"{workflow.WorkflowId}.yaml",
-            $"{scopeDirectory.Path}/{workflow.WorkflowId}.yaml",
-            scopeDirectory.DirectoryId,
-            scopeDirectory.Label,
-            yaml,
-            parse.Document,
-            Layout: null,
-            findings,
-            workflow.UpdatedAt);
-    }
-
-    private WorkflowFileResponse ToLegacyWorkflowFileResponse(WorkflowDraftResponse draftResponse)
-    {
-        var parse = _yamlDocumentService.Parse(draftResponse.Yaml);
-        return new WorkflowFileResponse(
-            draftResponse.WorkflowId,
-            draftResponse.Name,
-            draftResponse.FileName,
-            draftResponse.FilePath,
-            draftResponse.DirectoryId,
-            draftResponse.DirectoryLabel,
-            draftResponse.Yaml,
-            parse.Document,
-            Layout: null,
-            parse.Findings,
-            draftResponse.UpdatedAtUtc);
     }
 
     private static string ResolveDraftWorkflowName(
@@ -700,124 +337,6 @@ public sealed class AppScopedWorkflowService
         throw new InvalidOperationException("Unable to allocate a unique scoped workflow draft id.");
     }
 
-    private async Task<T?> SendAsync<T>(
-        HttpMethod method,
-        string relativePath,
-        object? body,
-        CancellationToken ct,
-        bool allowNotFound = false)
-    {
-        var client = _httpClientFactory.CreateClient(BackendClientName);
-        using var request = new HttpRequestMessage(method, relativePath);
-        if (body != null)
-            request.Content = JsonContent.Create(body);
-
-        using var response = await client.SendAsync(request, ct);
-        if (allowNotFound && response.StatusCode == HttpStatusCode.NotFound)
-            return default;
-
-        if (!response.IsSuccessStatusCode)
-        {
-            throw await BuildApiExceptionAsync(response, ct);
-        }
-
-        if (response.Content == null)
-            return default;
-
-        var mediaType = response.Content.Headers.ContentType?.MediaType;
-        if (!IsJsonContentType(mediaType))
-        {
-            throw new AppApiException(
-                StatusCodes.Status502BadGateway,
-                AppApiErrors.BackendInvalidResponseCode,
-                "Workflow backend returned a non-JSON response.");
-        }
-
-        await using var stream = await response.Content.ReadAsStreamAsync(ct);
-        if (stream == Stream.Null)
-            return default;
-
-        try
-        {
-            return await JsonSerializer.DeserializeAsync<T>(stream, JsonOptions, ct);
-        }
-        catch (JsonException ex)
-        {
-            throw new AppApiException(
-                StatusCodes.Status502BadGateway,
-                AppApiErrors.BackendInvalidResponseCode,
-                "Workflow backend returned invalid JSON.",
-                innerException: ex);
-        }
-    }
-
-    private static async Task<AppApiException> BuildApiExceptionAsync(HttpResponseMessage response, CancellationToken ct)
-    {
-        var content = response.Content;
-        var mediaType = response.Content?.Headers.ContentType?.MediaType;
-        var redirectUrl = ResolveRedirectUrl(response);
-        if (redirectUrl != null &&
-            response.StatusCode is HttpStatusCode.Moved or
-                HttpStatusCode.Redirect or
-                HttpStatusCode.RedirectMethod or
-                HttpStatusCode.TemporaryRedirect or
-                HttpStatusCode.PermanentRedirect)
-        {
-            return new AppApiException(
-                StatusCodes.Status401Unauthorized,
-                AppApiErrors.BackendAuthRequiredCode,
-                "Backend authentication required.",
-                redirectUrl);
-        }
-
-        if (content == null)
-        {
-            return new AppApiException(
-                (int)response.StatusCode,
-                "WORKFLOW_REQUEST_FAILED",
-                $"Workflow request failed with status {(int)response.StatusCode}.",
-                redirectUrl);
-        }
-
-        try
-        {
-            var payload = await content.ReadFromJsonAsync<RemoteErrorResponse>(JsonOptions, ct);
-            if (!string.IsNullOrWhiteSpace(payload?.Message))
-            {
-                return new AppApiException(
-                    (int)response.StatusCode,
-                    string.IsNullOrWhiteSpace(payload.Code) ? "WORKFLOW_REQUEST_FAILED" : payload.Code.Trim(),
-                    payload.Message.Trim(),
-                    redirectUrl);
-            }
-        }
-        catch
-        {
-            // Ignore body parse failures and fall through to status-based message.
-        }
-
-        if (IsHtmlContentType(mediaType))
-        {
-            return new AppApiException(
-                response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
-                    ? StatusCodes.Status401Unauthorized
-                    : StatusCodes.Status502BadGateway,
-                response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
-                    ? AppApiErrors.BackendAuthRequiredCode
-                    : AppApiErrors.BackendInvalidResponseCode,
-                response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
-                    ? "Backend authentication required."
-                    : "Workflow backend returned HTML for an API request.",
-                redirectUrl);
-        }
-
-        return new AppApiException(
-            (int)response.StatusCode,
-            "WORKFLOW_REQUEST_FAILED",
-            $"Workflow request failed with status {(int)response.StatusCode}.",
-            redirectUrl);
-    }
-
     private static string NormalizeRequired(string value, string fieldName)
     {
         var normalized = value?.Trim() ?? string.Empty;
@@ -836,30 +355,4 @@ public sealed class AppScopedWorkflowService
             : $"{normalized}.yaml";
     }
 
-    private static string? ResolveRedirectUrl(HttpResponseMessage response)
-    {
-        var location = response.Headers.Location;
-        if (location == null)
-            return null;
-
-        if (location.IsAbsoluteUri)
-            return location.ToString();
-
-        var requestUri = response.RequestMessage?.RequestUri;
-        return requestUri == null
-            ? location.ToString()
-            : new Uri(requestUri, location).ToString();
-    }
-
-    private static bool IsJsonContentType(string? mediaType) =>
-        !string.IsNullOrWhiteSpace(mediaType) &&
-        (mediaType.Contains("application/json", StringComparison.OrdinalIgnoreCase) ||
-         mediaType.Contains("+json", StringComparison.OrdinalIgnoreCase));
-
-    private static bool IsHtmlContentType(string? mediaType) =>
-        !string.IsNullOrWhiteSpace(mediaType) &&
-        (mediaType.Contains("text/html", StringComparison.OrdinalIgnoreCase) ||
-         mediaType.Contains("application/xhtml+xml", StringComparison.OrdinalIgnoreCase));
-
-    private sealed record RemoteErrorResponse(string? Code, string? Message);
 }

--- a/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioHostingServiceCollectionExtensions.cs
@@ -42,12 +42,7 @@ internal static class StudioHostingServiceCollectionExtensions
     internal static IServiceCollection AddStudioBridgeServices(this IServiceCollection services)
     {
         services.AddSingleton(sp => new AppScopedWorkflowService(
-            sp.GetRequiredService<IHttpClientFactory>(),
             sp.GetRequiredService<IWorkflowYamlDocumentService>(),
-            sp.GetService<IScopeWorkflowQueryPort>(),
-            sp.GetService<Aevatar.Workflow.Application.Abstractions.Runs.IWorkflowActorBindingReader>(),
-            sp.GetService<Aevatar.GAgentService.Abstractions.Ports.IServiceRevisionArtifactStore>(),
-            sp.GetService<Aevatar.GAgentService.Abstractions.Ports.IServiceLifecycleQueryPort>(),
             sp.GetService<IStudioWorkspaceQueryPort>(),
             sp.GetService<IStudioWorkspaceCommandPort>(),
             sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<AppScopedWorkflowService>>()));

--- a/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
+++ b/test/Aevatar.Studio.Tests/AppScopedWorkflowServiceDeleteDraftTests.cs
@@ -1,7 +1,4 @@
 using Aevatar.Configuration;
-using Aevatar.GAgentService.Abstractions;
-using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio;
 using Aevatar.Studio.Application.Studio.Abstractions;
@@ -9,7 +6,6 @@ using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Application.Studio.Services;
 using Aevatar.Studio.Domain.Studio.Models;
 using Aevatar.Studio.Tests.Shared;
-using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 
 namespace Aevatar.Studio.Tests;
@@ -46,13 +42,7 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     public async Task DeleteDraftAsync_ShouldNotCallRuntimePorts()
     {
         using var environment = new ScopedWorkflowEnvironment();
-        var runtimePorts = new RuntimePortSpies();
         var service = environment.CreateService(
-            workflowQueryPort: runtimePorts.QueryPort,
-            workflowCommandPort: runtimePorts.CommandPort,
-            workflowActorBindingReader: runtimePorts.BindingReader,
-            artifactStore: runtimePorts.ArtifactStore,
-            serviceLifecycleQueryPort: runtimePorts.ServiceLifecycleQueryPort,
             workspaceQueryPort: new RecordingStudioWorkspacePorts(new[]
             {
                 new ScopedDraft(
@@ -67,21 +57,15 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
 
         await service.DeleteDraftAsync("scope-1", "workflow-1");
 
-        runtimePorts.TotalInvocations.Should().Be(0);
+        // Runtime ports are not part of AppScopedWorkflowService anymore; draft deletion stays on workspace ports.
     }
 
     [Fact]
     public async Task CreateDraftAsync_ShouldPersistScopedDraftWithoutCallingRuntimePorts()
     {
         using var environment = new ScopedWorkflowEnvironment();
-        var runtimePorts = new RuntimePortSpies();
         var workspacePort = new RecordingStudioWorkspacePorts();
         var service = environment.CreateService(
-            workflowQueryPort: runtimePorts.QueryPort,
-            workflowCommandPort: runtimePorts.CommandPort,
-            workflowActorBindingReader: runtimePorts.BindingReader,
-            artifactStore: runtimePorts.ArtifactStore,
-            serviceLifecycleQueryPort: runtimePorts.ServiceLifecycleQueryPort,
             workspaceQueryPort: workspacePort,
             workspaceCommandPort: workspacePort);
 
@@ -93,7 +77,6 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
                 FileName: null,
                 Yaml: "name: workflow-1\nsteps: []\n"));
 
-        runtimePorts.TotalInvocations.Should().Be(0);
         workspacePort.SavedDrafts.Should().ContainSingle();
         workspacePort.SavedDrafts[0].ScopeId.Should().Be("scope-1");
         workspacePort.SavedDrafts[0].ExpectedVersion.Should().Be(11);
@@ -104,9 +87,7 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
     public async Task ListDraftsAsync_WhenDraftHasTypedLayout_ShouldDeriveDraftSummaryWithoutLayoutBadge()
     {
         using var environment = new ScopedWorkflowEnvironment();
-        var runtimePorts = new RuntimePortSpies();
         var service = environment.CreateService(
-            workflowQueryPort: runtimePorts.QueryPort,
             workspaceQueryPort: new RecordingStudioWorkspacePorts(new[]
             {
                 new ScopedDraft(
@@ -264,21 +245,11 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
         public string HomeDirectory { get; }
 
         public AppScopedWorkflowService CreateService(
-            IScopeWorkflowQueryPort? workflowQueryPort = null,
-            IScopeWorkflowCommandPort? workflowCommandPort = null,
-            IWorkflowActorBindingReader? workflowActorBindingReader = null,
-            IServiceRevisionArtifactStore? artifactStore = null,
-            IServiceLifecycleQueryPort? serviceLifecycleQueryPort = null,
             IStudioWorkspaceQueryPort? workspaceQueryPort = null,
             IStudioWorkspaceCommandPort? workspaceCommandPort = null)
         {
             return new AppScopedWorkflowService(
-                new StubHttpClientFactory(),
                 new StubWorkflowYamlDocumentService(),
-                workflowQueryPort,
-                workflowActorBindingReader,
-                artifactStore,
-                serviceLifecycleQueryPort,
                 workspaceQueryPort,
                 workspaceCommandPort);
         }
@@ -298,12 +269,6 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
                 Directory.Delete(HomeDirectory, recursive: true);
             }
         }
-    }
-
-    private sealed class StubHttpClientFactory : IHttpClientFactory
-    {
-        public HttpClient CreateClient(string name) =>
-            throw new InvalidOperationException("HTTP backend should not be called.");
     }
 
     private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
@@ -381,145 +346,4 @@ public sealed class AppScopedWorkflowServiceDeleteDraftTests
             updatedAtUtc,
             1);
 
-    private sealed class RuntimePortSpies
-    {
-        public RuntimePortSpies()
-        {
-            QueryPort = new RecordingScopeWorkflowQueryPort(this);
-            CommandPort = new RecordingScopeWorkflowCommandPort(this);
-            BindingReader = new RecordingWorkflowActorBindingReader(this);
-            ArtifactStore = new RecordingServiceRevisionArtifactStore(this);
-            ServiceLifecycleQueryPort = new RecordingServiceLifecycleQueryPort(this);
-        }
-
-        public int TotalInvocations { get; private set; }
-
-        public IScopeWorkflowQueryPort QueryPort { get; }
-
-        public IScopeWorkflowCommandPort CommandPort { get; }
-
-        public IWorkflowActorBindingReader BindingReader { get; }
-
-        public IServiceRevisionArtifactStore ArtifactStore { get; }
-
-        public IServiceLifecycleQueryPort ServiceLifecycleQueryPort { get; }
-
-        public void RecordInvocation() => TotalInvocations += 1;
-    }
-
-    private sealed class RecordingScopeWorkflowQueryPort : IScopeWorkflowQueryPort
-    {
-        private readonly RuntimePortSpies _owner;
-
-        public RecordingScopeWorkflowQueryPort(RuntimePortSpies owner)
-        {
-            _owner = owner;
-        }
-
-        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>([]);
-        }
-
-        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<ScopeWorkflowSummary?>(null);
-        }
-
-        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(string scopeId, string actorId, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<ScopeWorkflowSummary?>(null);
-        }
-    }
-
-    private sealed class RecordingScopeWorkflowCommandPort : IScopeWorkflowCommandPort
-    {
-        private readonly RuntimePortSpies _owner;
-
-        public RecordingScopeWorkflowCommandPort(RuntimePortSpies owner)
-        {
-            _owner = owner;
-        }
-
-        public Task<ScopeWorkflowUpsertResult> UpsertAsync(ScopeWorkflowUpsertRequest request, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            throw new InvalidOperationException("Runtime command port should not be called.");
-        }
-    }
-
-    private sealed class RecordingWorkflowActorBindingReader : IWorkflowActorBindingReader
-    {
-        private readonly RuntimePortSpies _owner;
-
-        public RecordingWorkflowActorBindingReader(RuntimePortSpies owner)
-        {
-            _owner = owner;
-        }
-
-        public Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<WorkflowActorBinding?>(null);
-        }
-    }
-
-    private sealed class RecordingServiceRevisionArtifactStore : IServiceRevisionArtifactStore
-    {
-        private readonly RuntimePortSpies _owner;
-
-        public RecordingServiceRevisionArtifactStore(RuntimePortSpies owner)
-        {
-            _owner = owner;
-        }
-
-        public Task SaveAsync(string serviceKey, string revisionId, PreparedServiceRevisionArtifact artifact, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.CompletedTask;
-        }
-
-        public Task<PreparedServiceRevisionArtifact?> GetAsync(string serviceKey, string revisionId, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<PreparedServiceRevisionArtifact?>(null);
-        }
-    }
-
-    private sealed class RecordingServiceLifecycleQueryPort : IServiceLifecycleQueryPort
-    {
-        private readonly RuntimePortSpies _owner;
-
-        public RecordingServiceLifecycleQueryPort(RuntimePortSpies owner)
-        {
-            _owner = owner;
-        }
-
-        public Task<ServiceCatalogSnapshot?> GetServiceAsync(ServiceIdentity identity, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<ServiceCatalogSnapshot?>(null);
-        }
-
-        public Task<IReadOnlyList<ServiceCatalogSnapshot>> ListServicesAsync(string tenantId, string appId, string @namespace, int take = 200, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<IReadOnlyList<ServiceCatalogSnapshot>>([]);
-        }
-
-        public Task<ServiceRevisionCatalogSnapshot?> GetServiceRevisionsAsync(ServiceIdentity identity, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<ServiceRevisionCatalogSnapshot?>(null);
-        }
-
-        public Task<ServiceDeploymentCatalogSnapshot?> GetServiceDeploymentsAsync(ServiceIdentity identity, CancellationToken ct = default)
-        {
-            _owner.RecordInvocation();
-            return Task.FromResult<ServiceDeploymentCatalogSnapshot?>(null);
-        }
-    }
 }

--- a/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/AppScopedWorkflowServiceTests.cs
@@ -1,118 +1,41 @@
-using System.Net;
-using System.Text;
+using System.Text.RegularExpressions;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
-using Aevatar.GAgentService.Abstractions;
-using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Studio.Domain.Studio.Models;
 using Aevatar.Studio.Tests.Shared;
-using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
-using Microsoft.AspNetCore.Http;
-using System.Text.RegularExpressions;
 
 namespace Aevatar.Tools.Cli.Tests;
 
-#pragma warning disable CS0618
 public sealed class AppScopedWorkflowServiceTests
 {
     [Fact]
-    public async Task ListAsync_WhenBackendRedirectsToLogin_ShouldThrowAuthRequiredException()
+    public void PublicSurface_ShouldNotExposeObsoleteCompatWrappers()
     {
-        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.Found)
-        {
-            Headers =
-            {
-                Location = new Uri("https://login.example/sign-in", UriKind.Absolute),
-            },
-        });
+        var publicInstanceMethods = typeof(AppScopedWorkflowService)
+            .GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+            .Where(method => method.DeclaringType == typeof(AppScopedWorkflowService))
+            .Select(static method => method.Name)
+            .ToList();
 
-        var act = () => service.ListAsync("scope-1");
-
-        var exception = await Assert.ThrowsAsync<AppApiException>(act);
-        exception.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-        exception.Code.Should().Be(AppApiErrors.BackendAuthRequiredCode);
-        exception.LoginUrl.Should().Be("https://login.example/sign-in");
+        publicInstanceMethods.Should().NotContain("ListAsync");
+        publicInstanceMethods.Should().NotContain("GetAsync");
+        publicInstanceMethods.Should().NotContain("SaveDraftAsync");
     }
 
     [Fact]
-    public async Task ListAsync_WhenBackendReturnsHtml_ShouldThrowInvalidResponseException()
-    {
-        var service = CreateService(_ => new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StringContent(
-                "<!DOCTYPE html><html><body>sign in</body></html>",
-                Encoding.UTF8,
-                "text/html"),
-        });
-
-        var act = () => service.ListAsync("scope-1");
-
-        var exception = await Assert.ThrowsAsync<AppApiException>(act);
-        exception.StatusCode.Should().Be(StatusCodes.Status502BadGateway);
-        exception.Code.Should().Be(AppApiErrors.BackendInvalidResponseCode);
-        exception.Message.Should().Be("Workflow backend returned a non-JSON response.");
-    }
-
-    [Fact]
-    public async Task GetAsync_WhenLifecycleQueryPortIsUnavailable_ShouldSkipRevisionFallback()
-    {
-        var workflow = new ScopeWorkflowSummary(
-            ScopeId: "scope-1",
-            WorkflowId: "workflow-1",
-            DisplayName: "Workflow 1",
-            ServiceKey: "scope-1:default:default:workflow-1",
-            WorkflowName: "Workflow 1",
-            ActorId: "actor-1",
-            ActiveRevisionId: string.Empty,
-            DeploymentId: string.Empty,
-            DeploymentStatus: "active",
-            UpdatedAt: DateTimeOffset.UtcNow);
-
-        var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
-            new StubWorkflowYamlDocumentService(),
-            new StubScopeWorkflowQueryPort(workflow),
-            workflowActorBindingReader: new StubWorkflowActorBindingReader(
-                new WorkflowActorBinding(
-                    WorkflowActorKind.Definition,
-                    "actor-1",
-                    "actor-1",
-                    string.Empty,
-                    "Workflow 1",
-                    string.Empty,
-                    new Dictionary<string, string>(StringComparer.Ordinal))),
-            artifactStore: new StubArtifactStore());
-
-        var response = await service.GetAsync("scope-1", "workflow-1");
-
-        response.Should().NotBeNull();
-        response!.Yaml.Should().BeEmpty();
-        response.Findings.Should().ContainSingle();
-        response.Findings[0].Message.Should().Be("Workflow YAML is not available yet.");
-    }
-
-    [Fact]
-    public async Task SaveAsync_ShouldRewriteYamlNameFromRequestedWorkflowName()
+    public async Task CreateDraftAsync_ShouldRewriteYamlNameFromRequestedWorkflowName()
     {
         var workspacePort = new RecordingStudioWorkspacePorts();
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
             workspaceQueryPort: workspacePort,
             workspaceCommandPort: workspacePort);
 
-        var response = await service.SaveDraftAsync(
+        var response = await service.CreateDraftAsync(
             "scope-1",
-            new SaveWorkflowFileRequest(
-                WorkflowId: null,
+            new SaveWorkflowDraftRequest(
                 DirectoryId: "scope:scope-1",
                 WorkflowName: "renamed-workflow",
                 FileName: null,
@@ -128,15 +51,44 @@ public sealed class AppScopedWorkflowServiceTests
     }
 
     [Fact]
-    public async Task ListAsync_WhenStoredDraftExistsUnderDifferentScope_ShouldNotLeakAcrossScopes()
+    public async Task UpdateDraftAsync_ShouldRewriteYamlNameFromRequestedWorkflowName()
+    {
+        var originalCreatedAt = new DateTimeOffset(2026, 4, 9, 8, 0, 0, TimeSpan.Zero);
+        var workspacePort = new RecordingStudioWorkspacePorts(
+            NewDraft(
+                "renamed-workflow",
+                "old-name",
+                "name: old-name\nsteps: []\n",
+                originalCreatedAt));
+        var service = new AppScopedWorkflowService(
+            new StubWorkflowYamlDocumentService(),
+            workspaceQueryPort: workspacePort,
+            workspaceCommandPort: workspacePort);
+
+        var response = await service.UpdateDraftAsync(
+            "scope-1",
+            "renamed-workflow",
+            new SaveWorkflowDraftRequest(
+                DirectoryId: "scope:scope-1",
+                WorkflowName: "renamed-workflow",
+                FileName: null,
+                Yaml: "name: draft\nsteps: []\n"));
+
+        workspacePort.LastUpload.Should().NotBeNull();
+        workspacePort.LastUpload!.ScopeId.Should().Be("scope-1");
+        workspacePort.LastUpload.WorkflowId.Should().Be("renamed-workflow");
+        workspacePort.LastUpload.WorkflowName.Should().Be("renamed-workflow");
+        workspacePort.LastUpload.Yaml.Should().StartWith("name: renamed-workflow");
+        response.WorkflowId.Should().Be("renamed-workflow");
+        response.Name.Should().Be("renamed-workflow");
+        response.Yaml.Should().StartWith("name: renamed-workflow");
+    }
+
+    [Fact]
+    public async Task ListDraftsAsync_WhenStoredDraftExistsUnderDifferentScope_ShouldNotLeakAcrossScopes()
     {
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(),
             workspaceQueryPort: new RecordingStudioWorkspacePorts(new[]
             {
                 new ScopedDraft(
@@ -148,22 +100,16 @@ public sealed class AppScopedWorkflowServiceTests
                         new DateTimeOffset(2026, 4, 10, 9, 0, 0, TimeSpan.Zero))),
             }));
 
-        var workflows = await service.ListAsync("scope-1");
+        var workflows = await service.ListDraftsAsync("scope-1");
 
         workflows.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetAsync_WhenStoredDraftExistsUnderDifferentScope_ShouldNotLeakAcrossScopes()
+    public async Task GetDraftAsync_WhenStoredDraftExistsUnderDifferentScope_ShouldNotLeakAcrossScopes()
     {
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(),
-            workflowActorBindingReader: new StubWorkflowActorBindingReader(null),
             workspaceQueryPort: new RecordingStudioWorkspacePorts(new[]
             {
                 new ScopedDraft(
@@ -175,21 +121,16 @@ public sealed class AppScopedWorkflowServiceTests
                         new DateTimeOffset(2026, 4, 10, 9, 0, 0, TimeSpan.Zero))),
             }));
 
-        var workflow = await service.GetAsync("scope-1", "hello-chat");
+        var workflow = await service.GetDraftAsync("scope-1", "hello-chat");
 
         workflow.Should().BeNull();
     }
 
     [Fact]
-    public async Task ListAsync_WhenRuntimeListIsEmpty_ShouldFallbackToWorkflowDraft()
+    public async Task ListDraftsAsync_WhenWorkspaceContainsDraft_ShouldReturnDraftSummary()
     {
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(),
             workspaceQueryPort: new RecordingStudioWorkspacePorts(
                 NewDraft(
                     "hello-chat",
@@ -197,7 +138,7 @@ public sealed class AppScopedWorkflowServiceTests
                     "name: hello-chat\ndescription: stored workflow\nsteps: []\n",
                     new DateTimeOffset(2026, 4, 10, 9, 0, 0, TimeSpan.Zero))));
 
-        var workflows = await service.ListAsync("scope-1");
+        var workflows = await service.ListDraftsAsync("scope-1");
 
         workflows.Should().ContainSingle();
         workflows[0].WorkflowId.Should().Be("hello-chat");
@@ -206,28 +147,11 @@ public sealed class AppScopedWorkflowServiceTests
     }
 
     [Fact]
-    public async Task ListAsync_WhenRuntimeWorkflowExists_ShouldUseStoredYamlToPopulateStepCount()
+    public async Task ListDraftsAsync_ShouldUseStoredYamlToPopulateStepCount()
     {
         var storedUpdatedAt = new DateTimeOffset(2026, 4, 16, 10, 53, 48, TimeSpan.Zero);
-        var workflow = new ScopeWorkflowSummary(
-            ScopeId: "scope-1",
-            WorkflowId: "test03",
-            DisplayName: "test03",
-            ServiceKey: "scope-1:default:default:test03",
-            WorkflowName: "test03",
-            ActorId: "actor-1",
-            ActiveRevisionId: "rev-1",
-            DeploymentId: "deploy-1",
-            DeploymentStatus: "active",
-            UpdatedAt: storedUpdatedAt.AddMinutes(-10));
-
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(workflow),
             workspaceQueryPort: new RecordingStudioWorkspacePorts(
                 NewDraft(
                     "test03",
@@ -235,7 +159,7 @@ public sealed class AppScopedWorkflowServiceTests
                     "name: test03\ndescription: restored from storage\nsteps:\n  - id: llm_call\n",
                     storedUpdatedAt)));
 
-        var workflows = await service.ListAsync("scope-1");
+        var workflows = await service.ListDraftsAsync("scope-1");
 
         workflows.Should().ContainSingle();
         workflows[0].WorkflowId.Should().Be("test03");
@@ -245,16 +169,10 @@ public sealed class AppScopedWorkflowServiceTests
     }
 
     [Fact]
-    public async Task GetAsync_WhenRuntimeWorkflowMissing_ShouldFallbackToWorkflowDraft()
+    public async Task GetDraftAsync_WhenWorkspaceContainsDraft_ShouldReturnDraft()
     {
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(),
-            workflowActorBindingReader: new StubWorkflowActorBindingReader(null),
             workspaceQueryPort: new RecordingStudioWorkspacePorts(
                 NewDraft(
                     "hello-chat",
@@ -262,93 +180,19 @@ public sealed class AppScopedWorkflowServiceTests
                     "name: hello-chat\ndescription: restored from storage\nsteps: []\n",
                     new DateTimeOffset(2026, 4, 10, 9, 0, 0, TimeSpan.Zero))));
 
-        var workflow = await service.GetAsync("scope-1", "hello-chat");
+        var workflow = await service.GetDraftAsync("scope-1", "hello-chat");
 
         workflow.Should().NotBeNull();
         workflow!.WorkflowId.Should().Be("hello-chat");
         workflow.Name.Should().Be("hello-chat");
         workflow.Yaml.Should().Contain("restored from storage");
-        workflow.Findings.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetAsync_WhenRuntimeWorkflowExistsButBindingYamlIsEmpty_ShouldFallbackToWorkflowDraft()
+    public async Task GetDraftAsync_WhenStoredDraftExists_ShouldPreferWorkflowDraftData()
     {
-        var workflow = new ScopeWorkflowSummary(
-            ScopeId: "scope-1",
-            WorkflowId: "test03",
-            DisplayName: "test03",
-            ServiceKey: "scope-1:default:default:test03",
-            WorkflowName: "test03",
-            ActorId: "actor-1",
-            ActiveRevisionId: "rev-1",
-            DeploymentId: "deploy-1",
-            DeploymentStatus: "active",
-            UpdatedAt: DateTimeOffset.UtcNow);
-
         var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
             new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(workflow),
-            workflowActorBindingReader: new StubWorkflowActorBindingReader(
-                new WorkflowActorBinding(
-                    WorkflowActorKind.Definition,
-                    "actor-1",
-                    "actor-1",
-                    string.Empty,
-                    "test03",
-                    string.Empty,
-                    new Dictionary<string, string>(StringComparer.Ordinal))),
-            workspaceQueryPort: new RecordingStudioWorkspacePorts(
-                NewDraft(
-                    "test03",
-                    "test03",
-                    "name: test03\ndescription: restored from storage\nsteps:\n  - id: llm_call\n",
-                    new DateTimeOffset(2026, 4, 16, 10, 53, 48, TimeSpan.Zero))));
-
-        var result = await service.GetAsync("scope-1", "test03");
-
-        result.Should().NotBeNull();
-        result!.Yaml.Should().Contain("llm_call");
-        result.Document.Should().NotBeNull();
-        result.Document!.Steps.Should().ContainSingle();
-        result.Findings.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task GetAsync_WhenStoredDraftExists_ShouldPreferWorkflowDraftOverRuntimeBindingYaml()
-    {
-        var workflow = new ScopeWorkflowSummary(
-            ScopeId: "scope-1",
-            WorkflowId: "test03",
-            DisplayName: "test03",
-            ServiceKey: "scope-1:default:default:test03",
-            WorkflowName: "test03",
-            ActorId: "actor-1",
-            ActiveRevisionId: "rev-1",
-            DeploymentId: "deploy-1",
-            DeploymentStatus: "active",
-            UpdatedAt: DateTimeOffset.UtcNow);
-
-        var service = new AppScopedWorkflowService(
-            new StubHttpClientFactory(new HttpClient(new StubHttpMessageHandler(_ => throw new InvalidOperationException("HTTP backend should not be called.")))
-            {
-                BaseAddress = new Uri("https://backend.example"),
-            }),
-            new StubWorkflowYamlDocumentService(),
-            workflowQueryPort: new StubScopeWorkflowQueryPort(workflow),
-            workflowActorBindingReader: new StubWorkflowActorBindingReader(
-                new WorkflowActorBinding(
-                    WorkflowActorKind.Definition,
-                    "actor-1",
-                    "actor-1",
-                    string.Empty,
-                    "test03",
-                    "name: runtime-version\nsteps: []\n",
-                    new Dictionary<string, string>(StringComparer.Ordinal))),
             workspaceQueryPort: new RecordingStudioWorkspacePorts(
                 NewDraft(
                     "test03",
@@ -356,60 +200,12 @@ public sealed class AppScopedWorkflowServiceTests
                     "name: draft-version\ndescription: prefer stored draft\nsteps:\n  - id: llm_call\n",
                     new DateTimeOffset(2026, 4, 16, 10, 53, 48, TimeSpan.Zero))));
 
-        var result = await service.GetAsync("scope-1", "test03");
+        var result = await service.GetDraftAsync("scope-1", "test03");
 
         result.Should().NotBeNull();
         result!.Name.Should().Be("draft-version");
         result.Yaml.Should().Contain("draft-version");
-        result.Yaml.Should().NotContain("runtime-version");
-        result.Document.Should().NotBeNull();
-        result.Document!.Steps.Should().ContainSingle();
-        result.Findings.Should().BeEmpty();
-    }
-
-    private static AppScopedWorkflowService CreateService(
-        Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
-    {
-        var handler = new StubHttpMessageHandler(responseFactory);
-        var httpClient = new HttpClient(handler)
-        {
-            BaseAddress = new Uri("https://backend.example"),
-        };
-
-        return new AppScopedWorkflowService(
-            new StubHttpClientFactory(httpClient),
-            new StubWorkflowYamlDocumentService());
-    }
-
-    private sealed class StubHttpClientFactory : IHttpClientFactory
-    {
-        private readonly HttpClient _httpClient;
-
-        public StubHttpClientFactory(HttpClient httpClient)
-        {
-            _httpClient = httpClient;
-        }
-
-        public HttpClient CreateClient(string name) => _httpClient;
-    }
-
-    private sealed class StubHttpMessageHandler : HttpMessageHandler
-    {
-        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
-
-        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
-        {
-            _responseFactory = responseFactory;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request,
-            CancellationToken cancellationToken)
-        {
-            var response = _responseFactory(request);
-            response.RequestMessage ??= request;
-            return Task.FromResult(response);
-        }
+        result.Yaml.Should().Contain("llm_call");
     }
 
     private sealed class StubWorkflowYamlDocumentService : IWorkflowYamlDocumentService
@@ -449,60 +245,6 @@ public sealed class AppScopedWorkflowServiceTests
         public string Serialize(WorkflowDocument document) => $"name: {document.Name}\nsteps: []\n";
     }
 
-    private sealed class StubScopeWorkflowQueryPort : IScopeWorkflowQueryPort
-    {
-        private readonly ScopeWorkflowSummary? _workflow;
-
-        public StubScopeWorkflowQueryPort()
-        {
-        }
-
-        public StubScopeWorkflowQueryPort(ScopeWorkflowSummary workflow)
-        {
-            _workflow = workflow;
-        }
-
-        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<ScopeWorkflowSummary>>(_workflow == null ? [] : [_workflow]);
-
-        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(string scopeId, string workflowId, CancellationToken ct = default) =>
-            Task.FromResult<ScopeWorkflowSummary?>(
-                _workflow != null && string.Equals(workflowId, _workflow.WorkflowId, StringComparison.Ordinal)
-                    ? _workflow
-                    : null);
-
-        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(string scopeId, string actorId, CancellationToken ct = default) =>
-            Task.FromResult<ScopeWorkflowSummary?>(
-                _workflow != null && string.Equals(actorId, _workflow.ActorId, StringComparison.Ordinal)
-                    ? _workflow
-                    : null);
-    }
-
-    private sealed class StubWorkflowActorBindingReader : IWorkflowActorBindingReader
-    {
-        private readonly WorkflowActorBinding? _binding;
-
-        public StubWorkflowActorBindingReader(WorkflowActorBinding? binding)
-        {
-            _binding = binding;
-        }
-
-        public Task<WorkflowActorBinding?> GetAsync(string actorId, CancellationToken ct = default) =>
-            Task.FromResult<WorkflowActorBinding?>(
-                _binding != null && string.Equals(actorId, _binding.ActorId, StringComparison.Ordinal)
-                    ? _binding
-                    : null);
-    }
-
-    private sealed class StubArtifactStore : IServiceRevisionArtifactStore
-    {
-        public Task SaveAsync(string serviceKey, string revisionId, PreparedServiceRevisionArtifact artifact, CancellationToken ct = default) =>
-            Task.CompletedTask;
-
-        public Task<PreparedServiceRevisionArtifact?> GetAsync(string serviceKey, string revisionId, CancellationToken ct = default) =>
-            Task.FromResult<PreparedServiceRevisionArtifact?>(null);
-    }
-
     private static StudioWorkflowDraftRecord NewDraft(
         string workflowId,
         string name,
@@ -522,4 +264,3 @@ public sealed class AppScopedWorkflowServiceTests
             updatedAtUtc,
             1);
 }
-#pragma warning restore CS0618

--- a/test/Aevatar.Tools.Cli.Tests/WorkspaceDeleteDraftControllerAndStorageTests.cs
+++ b/test/Aevatar.Tools.Cli.Tests/WorkspaceDeleteDraftControllerAndStorageTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Text.RegularExpressions;
 using Aevatar.Studio.Application;
 using Aevatar.Studio.Application.Studio.Abstractions;
@@ -652,14 +651,12 @@ public sealed class WorkspaceDeleteDraftControllerAndStorageTests
 
     private static AppScopedWorkflowService CreateScopeWorkflowService(RecordingStudioWorkspacePorts workspacePorts) =>
         new(
-            new StubHttpClientFactory(new HttpClient(new ThrowingHttpMessageHandler())),
             new StubWorkflowYamlDocumentService(),
             workspaceQueryPort: workspacePorts,
             workspaceCommandPort: workspacePorts);
 
     private static AppScopedWorkflowService CreateScopeWorkflowService(ThrowingScopedWorkspaceCommandPort commandPort) =>
         new(
-            new StubHttpClientFactory(new HttpClient(new ThrowingHttpMessageHandler())),
             new StubWorkflowYamlDocumentService(),
             workspaceQueryPort: new RecordingStudioWorkspacePorts([
                 new ScopedDraft(
@@ -692,24 +689,6 @@ public sealed class WorkspaceDeleteDraftControllerAndStorageTests
 
         public string Serialize(WorkflowDocument document) =>
             $"name: {document.Name}\nsteps: []\n";
-    }
-
-    private sealed class StubHttpClientFactory : IHttpClientFactory
-    {
-        private readonly HttpClient _client;
-
-        public StubHttpClientFactory(HttpClient client)
-        {
-            _client = client;
-        }
-
-        public HttpClient CreateClient(string name) => _client;
-    }
-
-    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
-            throw new InvalidOperationException("HTTP client should not be used in this test.");
     }
 
     private sealed class ThrowingScopedWorkspaceCommandPort : IStudioWorkspaceCommandPort


### PR DESCRIPTION
## 摘要

iter56 cluster-929 — audit-iter-62 no-design,直接 implement:

- **删** `AppScopedWorkflowService` obsolete compat wrappers:`ListAsync` / `GetAsync` / `SaveDraftAsync`(public legacy)
- **删** dead support:backend HTTP fallback / runtime/binding/artifact fallback dependencies / legacy DTO conversion helpers
- 更新 DI + direct test callers 走 draft methods
- 加 public-surface test 验证 obsolete methods 已删

## 边界

- 不动 workflow draft semantics / storage contracts / service lifecycle
- 完整体现 "删除优于兼容" 原则

## 影响范围

5 files changed,LOC **+63 / -1031** net **-968**(大 cleanup!)

## 验证

- `dotnet build aevatar.slnx --nologo` PASS
- `dotnet test aevatar.slnx --nologo` PASS
- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/architecture_guards.sh` PASS
- targeted Studio/CLI tests PASS

Closes #929

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
