### PR TITLE
iter56 cluster-933: 删 channel registration public rebuild,narrow Runtime startup helper

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
@@ -7,7 +7,7 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// <summary>
 /// Activates the projection scope for the channel bot registration store
 /// at application startup, then re-emits the authoritative state root so the
-/// query-side read model can be rebuilt after a restart.
+/// query-side read model can be refreshed after a restart.
 ///
 /// StartAsync awaits the activation with retries so the host does not
 /// accept HTTP requests until the registration projection binder is active and
@@ -16,6 +16,9 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// </summary>
 internal sealed class ChannelBotRegistrationStartupService : IHostedService
 {
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual projection refresh surface, new=startup-owned actor inbox dispatch
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=operator-triggered rebuild, new=host startup refresh after projection activation
     private const int MaxRetries = 5;
     private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
 

--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStoreCommands.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStoreCommands.cs
@@ -4,23 +4,12 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.Channel.Runtime;
 
-public static class ChannelBotRegistrationStoreCommands
+internal static class ChannelBotRegistrationStoreCommands
 {
-    // Refactor (iter27/cluster-003-channel-registration-scope-backfill):
-    //   Old pattern: rebuild_projection could dispatch live ChannelBotRepairScopeIdCommand writes.
-    //   New principle: command helpers expose register/unregister/rebuild only; ChannelBotScopeIdRepairedEvent remains replay-only.
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=register/unregister/rebuild command helper, new=rebuild-only startup helper
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual projection refresh dispatch, new=startup-owned actor inbox dispatch
     private const string PublisherActorId = "channel-runtime.registration-store";
-
-    public static Task DispatchRegisterAsync(
-        IActorRuntime actorRuntime,
-        IActorDispatchPort dispatchPort,
-        ChannelBotRegisterCommand command,
-        CancellationToken ct = default) =>
-        DispatchAsync(
-            actorRuntime,
-            dispatchPort,
-            command,
-            ct);
 
     public static Task DispatchRebuildProjectionAsync(
         IActorRuntime actorRuntime,
@@ -33,20 +22,6 @@ public static class ChannelBotRegistrationStoreCommands
             new ChannelBotRebuildProjectionCommand
             {
                 Reason = reason ?? string.Empty,
-            },
-            ct);
-
-    public static Task DispatchUnregisterAsync(
-        IActorRuntime actorRuntime,
-        IActorDispatchPort dispatchPort,
-        string registrationId,
-        CancellationToken ct = default) =>
-        DispatchAsync(
-            actorRuntime,
-            dispatchPort,
-            new ChannelBotUnregisterCommand
-            {
-                RegistrationId = registrationId ?? string.Empty,
             },
             ct);
 

--- a/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/NyxIdRelayPromptConfiguration.cs
@@ -32,7 +32,7 @@ public static class NyxIdRelayPromptConfiguration
 Aevatar's Nyx relay callback URL is: `{relayCallbackUrl}`
 
 For new Aevatar-managed Lark relay provisioning, use `channel_registrations`.
-For existing-bot inspection, use `nyxid_channel_bots` and `nyxid_api_keys` to inspect Nyx state. If the authoritative Aevatar actor still exists but the read model is stale, use `channel_registrations action=rebuild_projection`. If the local Aevatar mirror is missing, provision through `channel_registrations action=register_lark_via_nyx`.
+For existing-bot inspection, use `nyxid_channel_bots` and `nyxid_api_keys` to inspect Nyx state. If the local Aevatar mirror is missing, provision through `channel_registrations action=register_lark_via_nyx`.
 
 For Lark, follow this guidance:
 
@@ -41,7 +41,7 @@ For Lark, follow this guidance:
    The Lark developer console callback URL must point to the Nyx webhook URL returned by that tool.
    This stage is for inbound relay wiring and basic relay replies.
 
-2. Existing-bot inspection: if Nyx already has the Lark bot and route but `channel_registrations action=list` is empty or Aevatar is silent, first call `channel_registrations action=rebuild_projection`. If the local list is still empty, inspect the Nyx bot via `nyxid_channel_bots action=show`, inspect routes via `nyxid_channel_bots action=routes`, inspect the relay API key callback via `nyxid_api_keys action=show`, then provision through `channel_registrations action=register_lark_via_nyx`.
+2. Existing-bot inspection: if Nyx already has the Lark bot and route but `channel_registrations action=list` is empty or Aevatar is silent, inspect the Nyx bot via `nyxid_channel_bots action=show`, inspect routes via `nyxid_channel_bots action=routes`, inspect the relay API key callback via `nyxid_api_keys action=show`, then provision through `channel_registrations action=register_lark_via_nyx`.
 
 3. Advanced Lark capabilities: only when the user needs proactive sends, chat lookup, spreadsheet appends, approval actions, or delivery target bindings, require a Nyx Lark provider slug such as `api-lark-bot`.
    In those cases, prefer typed Lark tools such as `lark_messages_send`, `lark_messages_search`, `lark_messages_batch_get`, `lark_messages_reactions_list`, `lark_messages_reactions_delete`, `lark_chats_lookup`, `lark_sheets_append_rows`, `lark_approvals_list`, and `lark_approvals_act`.

--- a/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
+++ b/agents/Aevatar.GAgents.NyxidChat/Skills/system-prompt.md
@@ -105,11 +105,10 @@ Do not assume `channel_registrations action=list` being empty means the Nyx bot 
 
 Add events: `im.message.receive_v1`, `card.action.trigger`.
 
-**Stage 2: Recover projection visibility** — when Nyx already has the Lark bot/route but Aevatar no longer replies or `channel_registrations action=list` is empty.
+**Stage 2: Existing-bot inspection** — when Nyx already has the Lark bot/route but Aevatar no longer replies or `channel_registrations action=list` is empty.
 
-1. `channel_registrations action=rebuild_projection` — rebuild local read model from authoritative actor state.
-2. Inspect Nyx-side first: `nyxid_channel_bots action=list` / `show` / `routes`. (For NyxID-side details, `use_skill(skill="nyxid")`.)
-3. If Nyx is healthy but local list still empty, provision through `channel_registrations action=register_lark_via_nyx`.
+1. Inspect Nyx-side first: `nyxid_channel_bots action=list` / `show` / `routes`. (For NyxID-side details, `use_skill(skill="nyxid")`.)
+2. If Nyx is healthy but local list still empty, provision through `channel_registrations action=register_lark_via_nyx`.
 
 **Stage 3: Advanced Lark capabilities** — only when the user needs proactive sends, typed Lark tools, delivery target bindings, spreadsheet appends, approval actions, or active chat lookup. Ensure NyxID has a usable Lark outbound provider slug (typically `api-lark-bot`); if not, `use_skill(skill="nyxid")` to drive the catalog connection flow.
 
@@ -117,7 +116,7 @@ For advanced Lark API operations outside the current relay reply, prefer typed t
 
 For inbound Lark relay turns that represent a fresh user message, do **not** call `lark_messages_reply` or `lark_messages_react` to deliver the answer. Produce the final text reply directly; the channel runtime will send it through the Nyx relay reply token.
 
-Managing registrations: `list`, `rebuild_projection`, `delete id=<reg_id> confirm=true`.
+Managing registrations: `list`, `delete id=<reg_id> confirm=true`.
 
 ### agent_delivery_targets
 

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelCallbackEndpoints.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.Workflow.Application.Abstractions.Runs;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -13,15 +12,15 @@ namespace Aevatar.GAgents.Channel.NyxIdRelay;
 
 public static class ChannelCallbackEndpoints
 {
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=/registrations/rebuild HTTP surface, new=no public rebuild route
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual projection refresh endpoint, new=startup-owned projection refresh
     // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
     //   Old pattern: Nyx relay registration endpoints + singleton provisioning services 在 Host 内做 platform selection / scope resolution / remote Nyx provisioning / actor creation / envelope construction / dispatch through raw runtime/dispatch helpers。
     //   New principle: Channel registration 暴露 typed application command facade(reuse existing CQRS command dispatch skeleton);Host 仅 adapt HTTP;provisioning adapters 只调 existing NyxID REST surfaces(**不修改 NyxID 仓库**);local mirror writes 进 standard command skeleton via narrow dispatch port。**不引入新 actor type / 新 envelope / 新 projection phase**(reflector force-pick minimal,排除 structural 的 ChannelRelayRegistrationRunGAgent)。
     // Refactor (iter36/cluster-042-channel-diagnostics-readmodel):
     //   Old pattern: Channel runtime diagnostics 用 singleton in-memory list with retention trimming;diagnostics endpoint 直接读 process-local list。
     //   New principle: Channel diagnostics 改为 logs/metrics only(observability path)OR actor/projection-backed diagnostic events with readmodel query。**禁止** public endpoint 读 singleton process memory 作 diagnostic fact source。
-    // Refactor (iter27/cluster-003-channel-registration-scope-backfill):
-    //   Old pattern: ChannelBotRegistrationScopeBackfill used readmodels to infer write candidates plus live repair_lark_mirror HTTP/tool surface and RepairLocalMirrorAsync.
-    //   New principle: remove backfill/repair_lark_mirror live recovery; rebuild_projection is projection-only; keep ChannelBotScopeIdRepairedEvent replay compatibility.
     public static IEndpointRouteBuilder MapChannelCallbackEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("/api/channels").WithTags("ChannelRuntime");
@@ -29,7 +28,6 @@ public static class ChannelCallbackEndpoints
         // Registration CRUD — requires authentication
         group.MapPost("/registrations", HandleRegisterAsync).RequireAuthorization();
         group.MapGet("/registrations", HandleListRegistrationsAsync).RequireAuthorization();
-        group.MapPost("/registrations/rebuild", HandleRebuildRegistrationsAsync).RequireAuthorization();
         group.MapDelete("/registrations/{registrationId}", HandleDeleteRegistrationAsync).RequireAuthorization();
 
         // Diagnostic: test reply path without going through full LLM chat
@@ -153,46 +151,6 @@ public static class ChannelCallbackEndpoints
         return Results.Ok(result);
     }
 
-    private static async Task<IResult> HandleRebuildRegistrationsAsync(
-        HttpContext http,
-        [FromServices] ChannelRegistrationCommandFacade commandFacade,
-        [FromServices] ILoggerFactory loggerFactory,
-        CancellationToken ct)
-    {
-        // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
-        //   Old pattern: rebuild endpoint called raw runtime/dispatch helper.
-        //   New principle: rebuild enters the channel registration command facade; Host only maps HTTP.
-        var logger = loggerFactory.CreateLogger("Aevatar.ChannelRuntime.Registration");
-        ChannelRegistrationRebuildRequest? request;
-        try
-        {
-            request = await ReadOptionalRebuildRequestAsync(http, ct);
-        }
-        catch (JsonException ex)
-        {
-            logger.LogWarning(ex, "Invalid channel registration rebuild request payload");
-            return Results.BadRequest(new { error = "Invalid JSON" });
-        }
-        catch (InvalidOperationException ex)
-        {
-            logger.LogWarning(ex, "Unsupported channel registration rebuild request content type");
-            return Results.BadRequest(new { error = "Unsupported content type. Use application/json for rebuild request payloads." });
-        }
-
-        await commandFacade.RebuildProjectionAsync(
-            string.IsNullOrWhiteSpace(request?.Reason)
-                ? "http_api_manual_rebuild"
-                : request.Reason.Trim(),
-            ct);
-
-        return Results.Accepted(value: new
-        {
-            status = "accepted",
-            actor_id = ChannelBotRegistrationGAgent.WellKnownId,
-            note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side registrations may take a moment to refresh.",
-        });
-    }
-
     private static string? ResolveBearerAccessToken(HttpContext http)
     {
         var accessToken = http.Request.Headers.Authorization.ToString();
@@ -263,19 +221,6 @@ public static class ChannelCallbackEndpoints
         };
     }
 
-    private static async Task<ChannelRegistrationRebuildRequest?> ReadOptionalRebuildRequestAsync(
-        HttpContext http,
-        CancellationToken ct)
-    {
-        if (http.Request.ContentLength == 0)
-            return null;
-        if (http.Request.Body.CanSeek && http.Request.Body.Length == http.Request.Body.Position)
-            return null;
-
-        // ReadFromJsonAsync throws InvalidOperationException for unsupported content types.
-        return await http.Request.ReadFromJsonAsync<ChannelRegistrationRebuildRequest>(RegistrationJsonOptions, ct);
-    }
-
     private static ScopeIdResolution ResolveScopeId(HttpContext http, string? explicitScopeId, bool required)
     {
         var explicitNormalized = NormalizeOptional(explicitScopeId);
@@ -301,9 +246,6 @@ public static class ChannelCallbackEndpoints
     }
 
     private sealed record ScopeIdResolution(string? ScopeId, string? Error);
-
-    private sealed record ChannelRegistrationRebuildRequest(
-        string? Reason);
 
     private sealed record RegistrationRequest(
         string? Platform,

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelRegistrationCommandFacade.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/ChannelRegistrationCommandFacade.cs
@@ -22,17 +22,17 @@ public enum ChannelRegistrationCommandStartError
 //   New principle: Channel registration 暴露 typed application command facade(reuse existing CQRS command dispatch skeleton);Host 仅 adapt HTTP;provisioning adapters 只调 existing NyxID REST surfaces(**不修改 NyxID 仓库**);local mirror writes 进 standard command skeleton via narrow dispatch port。**不引入新 actor type / 新 envelope / 新 projection phase**(reflector force-pick minimal,排除 structural 的 ChannelRelayRegistrationRunGAgent)。
 public sealed class ChannelRegistrationCommandFacade
 {
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=facade RebuildProjectionAsync, new=facade handles register/unregister only
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=relay-local rebuild command DI, new=runtime startup dispatch only
     private readonly ICommandDispatchService<ChannelBotRegisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError> _registerDispatchService;
-    private readonly ICommandDispatchService<ChannelBotRebuildProjectionCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError> _rebuildDispatchService;
     private readonly ICommandDispatchService<ChannelBotUnregisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError> _unregisterDispatchService;
 
     public ChannelRegistrationCommandFacade(
         ICommandDispatchService<ChannelBotRegisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError> registerDispatchService,
-        ICommandDispatchService<ChannelBotRebuildProjectionCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError> rebuildDispatchService,
         ICommandDispatchService<ChannelBotUnregisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError> unregisterDispatchService)
     {
         _registerDispatchService = registerDispatchService ?? throw new ArgumentNullException(nameof(registerDispatchService));
-        _rebuildDispatchService = rebuildDispatchService ?? throw new ArgumentNullException(nameof(rebuildDispatchService));
         _unregisterDispatchService = unregisterDispatchService ?? throw new ArgumentNullException(nameof(unregisterDispatchService));
     }
 
@@ -45,22 +45,6 @@ public sealed class ChannelRegistrationCommandFacade
         //   New principle: local mirror writes 只进入 typed command facade 和 standard command skeleton。
         ArgumentNullException.ThrowIfNull(command);
         var result = await _registerDispatchService.DispatchAsync(command, ct);
-        return ResolveReceipt(result);
-    }
-
-    public async Task<ChannelRegistrationCommandAcceptedReceipt> RebuildProjectionAsync(
-        string reason,
-        CancellationToken ct = default)
-    {
-        // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
-        //   Old pattern: Host/tool 直接通过 static helper 组 envelope 触发 rebuild。
-        //   New principle: rebuild 作为 typed command 经 facade 进入 CQRS command skeleton。
-        var result = await _rebuildDispatchService.DispatchAsync(
-            new ChannelBotRebuildProjectionCommand
-            {
-                Reason = reason ?? string.Empty,
-            },
-            ct);
         return ResolveReceipt(result);
     }
 
@@ -213,15 +197,11 @@ internal sealed class ChannelBotRegistrationCommandTargetResolver<TCommand>
 
 internal sealed class ChannelBotRegistrationCommandEnvelopeFactory :
     ICommandEnvelopeFactory<ChannelBotRegisterCommand>,
-    ICommandEnvelopeFactory<ChannelBotRebuildProjectionCommand>,
     ICommandEnvelopeFactory<ChannelBotUnregisterCommand>
 {
     private const string PublisherActorId = "channel-runtime.registration-store";
 
     public EventEnvelope CreateEnvelope(ChannelBotRegisterCommand command, CommandContext context) =>
-        CreateEnvelopeCore(command, context);
-
-    public EventEnvelope CreateEnvelope(ChannelBotRebuildProjectionCommand command, CommandContext context) =>
         CreateEnvelopeCore(command, context);
 
     public EventEnvelope CreateEnvelope(ChannelBotUnregisterCommand command, CommandContext context) =>

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/DependencyInjection/NyxIdRelayChannelServiceCollectionExtensions.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/DependencyInjection/NyxIdRelayChannelServiceCollectionExtensions.cs
@@ -23,9 +23,9 @@ public static class NyxIdRelayChannelServiceCollectionExtensions
     //   New principle: Channel registration 暴露 typed application command facade(reuse existing CQRS command dispatch skeleton);Host 仅 adapt HTTP;provisioning adapters 只调 existing NyxID REST surfaces(**不修改 NyxID 仓库**);local mirror writes 进 standard command skeleton via narrow dispatch port。**不引入新 actor type / 新 envelope / 新 projection phase**(reflector force-pick minimal,排除 structural 的 ChannelRelayRegistrationRunGAgent)。
     public static IServiceCollection AddNyxIdRelayChannel(this IServiceCollection services)
     {
-        // Refactor (iter27/cluster-003-channel-registration-scope-backfill):
-        //   Old pattern: repair_lark_mirror registered a live Nyx API-key ownership verifier for local mirror repair.
-        //   New principle: no live repair surface remains; recovery uses register_lark_via_nyx plus projection-only rebuild.
+        // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
+        // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=relay-local rebuild command pipeline, new=no relay DI for rebuild
+        // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public/manual projection refresh dispatch, new=startup-owned projection refresh
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<NyxIdApiClient>();
@@ -36,17 +36,13 @@ public static class NyxIdRelayChannelServiceCollectionExtensions
         services.TryAddSingleton<ChannelRegistrationCommandReceiptFactory>();
         services.TryAddSingleton<ICommandTargetDispatcher<ChannelBotRegistrationCommandTarget>, ActorCommandTargetDispatcher<ChannelBotRegistrationCommandTarget>>();
         services.TryAddSingleton<ICommandTargetResolver<ChannelBotRegisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandStartError>, ChannelBotRegistrationCommandTargetResolver<ChannelBotRegisterCommand>>();
-        services.TryAddSingleton<ICommandTargetResolver<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandStartError>, ChannelBotRegistrationCommandTargetResolver<ChannelBotRebuildProjectionCommand>>();
         services.TryAddSingleton<ICommandTargetResolver<ChannelBotUnregisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandStartError>, ChannelBotRegistrationCommandTargetResolver<ChannelBotUnregisterCommand>>();
         services.TryAddSingleton<ICommandEnvelopeFactory<ChannelBotRegisterCommand>>(sp => sp.GetRequiredService<ChannelBotRegistrationCommandEnvelopeFactory>());
-        services.TryAddSingleton<ICommandEnvelopeFactory<ChannelBotRebuildProjectionCommand>>(sp => sp.GetRequiredService<ChannelBotRegistrationCommandEnvelopeFactory>());
         services.TryAddSingleton<ICommandEnvelopeFactory<ChannelBotUnregisterCommand>>(sp => sp.GetRequiredService<ChannelBotRegistrationCommandEnvelopeFactory>());
         services.TryAddSingleton<ICommandReceiptFactory<ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt>>(sp => sp.GetRequiredService<ChannelRegistrationCommandReceiptFactory>());
         services.TryAddSingleton<ICommandDispatchPipeline<ChannelBotRegisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>, DefaultCommandDispatchPipeline<ChannelBotRegisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>>();
-        services.TryAddSingleton<ICommandDispatchPipeline<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>, DefaultCommandDispatchPipeline<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>>();
         services.TryAddSingleton<ICommandDispatchPipeline<ChannelBotUnregisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>, DefaultCommandDispatchPipeline<ChannelBotUnregisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>>();
         services.TryAddSingleton<ICommandDispatchService<ChannelBotRegisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>, DefaultCommandDispatchService<ChannelBotRegisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>>();
-        services.TryAddSingleton<ICommandDispatchService<ChannelBotRebuildProjectionCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>, DefaultCommandDispatchService<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>>();
         services.TryAddSingleton<ICommandDispatchService<ChannelBotUnregisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>, DefaultCommandDispatchService<ChannelBotUnregisterCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>>();
         services.TryAddSingleton<INyxLarkProvisioningService, NyxLarkProvisioningService>();
         services.TryAddSingleton<INyxTelegramProvisioningService, NyxTelegramProvisioningService>();

--- a/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
+++ b/docs/operations/2026-04-29-lark-mirror-recovery-runbook.md
@@ -5,10 +5,9 @@ This runbook covers the case where Lark messages reach
 with `401 Unauthorized` because the local channel registration read model is
 missing or stale.
 
-Refactor note (iter27/cluster-003-channel-registration-scope-backfill):
-operations recovery no longer uses readmodel-derived backfill or live local
-mirror repair. Use only `register_lark_via_nyx` and projection-only
-`rebuild_projection`.
+Refactor note (iter56/cluster-933-channel-registration-rebuild-narrow):
+operations recovery no longer exposes a public projection rebuild command.
+The registration projection refresh is internal startup maintenance only.
 
 ## Symptom Signature
 
@@ -40,30 +39,11 @@ aevatar-cli api GET /api/channels/registrations
 
 If the last command returns `[]`, continue.
 
-### 2. Rebuild Projection
+### 2. Re-Provision If Local State Is Missing
 
-`rebuild_projection` is projection-only. It does not read the read model, infer
-write candidates, or repair local mirror state.
-
-```bash
-aevatar-cli chat "Run channel_registrations action=rebuild_projection reason=lark-relay-readmodel-refresh"
-```
-
-Then verify:
-
-```bash
-aevatar-cli api GET /api/channels/registrations
-```
-
-If the registration appears with the expected `nyx_agent_api_key_id`, send a
-Lark message and confirm the relay no longer returns 401.
-
-### 3. Re-Provision If Authoritative State Is Missing
-
-If `rebuild_projection` completes but the registrations list is still empty,
-the authoritative `channel-bot-registration-store` state has no registration to
-project. Do not repair it from the read side and do not reuse existing Nyx
-resources through a local mirror repair surface.
+There is no online public rebuild command. If the registrations list is empty,
+do not repair it from the read side and do not reuse existing Nyx resources
+through a local mirror repair surface.
 
 Provision again through the supported path:
 
@@ -82,6 +62,8 @@ returned by the tool.
 
 - Do not call or document retired local mirror repair surfaces; the HTTP
   endpoint, tool action, service method, and live repair command path are gone.
+- Do not call or document public channel registration projection rebuild
+  surfaces; startup refresh is internal Runtime maintenance only.
 - Do not use readmodel contents to infer write candidates for scope repair.
 - Do not delete Nyx api-keys, channel-bots, or routes to force a clean state
   unless you are intentionally re-provisioning and updating the Lark developer

--- a/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs
+++ b/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs
@@ -15,7 +15,6 @@ namespace Aevatar.AI.ToolProviders.ChannelAdmin;
 public sealed class ChannelRegistrationTool : IAgentTool
 {
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
-    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=ChannelAdmin rebuild_projection, new=retired action with no dispatch
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual readmodel rematerialization path, new=startup-owned projection refresh
     // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
     //   Old pattern: Nyx relay registration endpoints + singleton provisioning services 在 Host 内做 platform selection / scope resolution / remote Nyx provisioning / actor creation / envelope construction / dispatch through raw runtime/dispatch helpers。
@@ -94,17 +93,16 @@ public sealed class ChannelRegistrationTool : IAgentTool
 
         using var document = JsonDocument.Parse(argumentsJson);
         var root = document.RootElement;
-        var action = GetStr(root, "action") ?? "list";
+        var action = NormalizeOptional(GetStr(root, "action")) ?? "list";
 
         return action switch
         {
             "list" => await ExecuteWithQueryAsync(queryPort => ListAsync(queryPort, ct)),
             "register_lark_via_nyx" => await RegisterLarkViaNyxAsync(token, root, ct),
-            "rebuild_projection" => RetiredActionError("rebuild_projection is retired. Channel registration projection refresh is internal startup maintenance only."),
             "delete" => await ExecuteWithCommandFacadeAsync((queryPort, commandFacade) => DeleteAsync(queryPort, commandFacade, root, ct)),
             "register" => RetiredActionError("Direct callback registration is retired. Use action=register_lark_via_nyx."),
             "update_token" => RetiredActionError("update_token is retired. ChannelRuntime no longer stores or refreshes channel credentials."),
-            _ => await ExecuteWithQueryAsync(queryPort => ListAsync(queryPort, ct)),
+            _ => SerializeError($"Unsupported channel registration action '{action}'."),
         };
     }
 

--- a/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs
+++ b/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs
@@ -3,7 +3,6 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.AI.ToolProviders.ChannelAdmin;
@@ -15,6 +14,9 @@ namespace Aevatar.AI.ToolProviders.ChannelAdmin;
 /// </summary>
 public sealed class ChannelRegistrationTool : IAgentTool
 {
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=ChannelAdmin rebuild_projection, new=retired action with no dispatch
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual readmodel rematerialization path, new=startup-owned projection refresh
     // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
     //   Old pattern: Nyx relay registration endpoints + singleton provisioning services 在 Host 内做 platform selection / scope resolution / remote Nyx provisioning / actor creation / envelope construction / dispatch through raw runtime/dispatch helpers。
     //   New principle: Channel registration 暴露 typed application command facade(reuse existing CQRS command dispatch skeleton);Host 仅 adapt HTTP;provisioning adapters 只调 existing NyxID REST surfaces(**不修改 NyxID 仓库**);local mirror writes 进 standard command skeleton via narrow dispatch port。**不引入新 actor type / 新 envelope / 新 projection phase**(reflector force-pick minimal,排除 structural 的 ChannelRelayRegistrationRunGAgent)。
@@ -30,8 +32,8 @@ public sealed class ChannelRegistrationTool : IAgentTool
 
     public string Description =>
         "Manage Aevatar ChannelRuntime registrations for the supported Nyx-backed Lark relay flow. " +
-        "Actions: list, register_lark_via_nyx, rebuild_projection, delete. " +
-        "Use register_lark_via_nyx for provisioning and rebuild_projection to re-materialize the local registration read model from authoritative actor state. " +
+        "Actions: list, register_lark_via_nyx, delete. " +
+        "Use register_lark_via_nyx for provisioning. " +
         "Legacy direct callback registration and update_token flows are retired because ChannelRuntime no longer stores channel credentials. " +
         "Do not ask the user for scope_id; it is resolved from the current NyxID request context and should only be supplied explicitly for diagnostics.";
 
@@ -41,7 +43,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
           "properties": {
             "action": {
               "type": "string",
-              "enum": ["list", "register_lark_via_nyx", "rebuild_projection", "delete"],
+              "enum": ["list", "register_lark_via_nyx", "delete"],
               "description": "Action to perform (default: list)."
             },
             "nyx_provider_slug": {
@@ -72,10 +74,6 @@ public sealed class ChannelRegistrationTool : IAgentTool
               "type": "string",
               "description": "Human-readable label for the Nyx channel bot (optional)"
             },
-            "reason": {
-              "type": "string",
-              "description": "Optional operator reason for rebuild_projection"
-            },
             "registration_id": {
               "type": "string",
               "description": "Registration ID for delete"
@@ -102,7 +100,7 @@ public sealed class ChannelRegistrationTool : IAgentTool
         {
             "list" => await ExecuteWithQueryAsync(queryPort => ListAsync(queryPort, ct)),
             "register_lark_via_nyx" => await RegisterLarkViaNyxAsync(token, root, ct),
-            "rebuild_projection" => await ExecuteWithCommandFacadeAsync((queryPort, commandFacade) => RebuildProjectionAsync(commandFacade, root, ct)),
+            "rebuild_projection" => RetiredActionError("rebuild_projection is retired. Channel registration projection refresh is internal startup maintenance only."),
             "delete" => await ExecuteWithCommandFacadeAsync((queryPort, commandFacade) => DeleteAsync(queryPort, commandFacade, root, ct)),
             "register" => RetiredActionError("Direct callback registration is retired. Use action=register_lark_via_nyx."),
             "update_token" => RetiredActionError("update_token is retired. ChannelRuntime no longer stores or refreshes channel credentials."),
@@ -263,26 +261,6 @@ public sealed class ChannelRegistrationTool : IAgentTool
             webhookUrl: result.WebhookUrl ?? string.Empty,
             error: result.Error ?? string.Empty,
             note: result.Note ?? string.Empty);
-    }
-
-    private async Task<string> RebuildProjectionAsync(
-        ChannelRegistrationCommandFacade commandFacade,
-        JsonElement args,
-        CancellationToken ct)
-    {
-        // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
-        //   Old pattern: tool resolved raw runtime/dispatch and called static command helper.
-        //   New principle: tool is an adapter; rebuild goes through typed channel registration command facade.
-        await commandFacade.RebuildProjectionAsync(
-            GetStr(args, "reason")?.Trim() ?? "tool_manual_rebuild",
-            ct);
-
-        return JsonSerializer.Serialize(new
-        {
-            status = "accepted",
-            actor_id = ChannelBotRegistrationGAgent.WellKnownId,
-            note = "Projection rebuild dispatched from authoritative channel-bot-registration-store state. Query-side registrations may take a moment to refresh.",
-        });
     }
 
     private async Task<string> DeleteAsync(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCallbackEndpointsTests.cs
@@ -62,6 +62,7 @@ public sealed class ChannelCallbackEndpointsTests
             .Should().BeFalse();
         routePatterns.Should().Contain("/api/channels/registrations");
         routePatterns.Should().Contain("/api/channels/diagnostics/errors");
+        routePatterns.Should().NotContain("/api/channels/registrations/rebuild");
     }
 
     [Fact]
@@ -217,115 +218,6 @@ public sealed class ChannelCallbackEndpointsTests
         response.StatusCode.Should().Be(StatusCodes.Status200OK);
         response.Body.Should().Contain("\"registration_mode\":\"nyx_relay_webhook\"");
         response.Body.Should().Contain("\"callback_url\":\"\"");
-    }
-
-    [Fact]
-    public async Task HandleRebuildRegistrationsAsync_DispatchesProjectionOnlyRefreshCommand()
-    {
-        EventEnvelope? capturedEnvelope = null;
-        var actor = Substitute.For<IActor>();
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            .Returns(Task.FromResult<IActor?>(actor));
-        ((IActorDispatchPort)actorRuntime).DispatchAsync(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-        var http = CreateJsonHttpContext("""{"reason":"manual-debug","registration_id":"ignored","force":true}""", "scope-1");
-        http.Request.Headers.Authorization = "Bearer test-token";
-
-        var result = await InvokeAsync(
-            "HandleRebuildRegistrationsAsync",
-            http,
-            ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime),
-            NullLoggerFactory.Instance,
-            CancellationToken.None);
-        var response = await ExecuteResultAsync(result);
-
-        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        response.Body.Should().Contain("\"status\":\"accepted\"");
-        response.Body.Should().Contain("\"actor_id\":\"channel-bot-registration-store\"");
-        response.Body.Should().NotContain("backfill_status");
-        capturedEnvelope.Should().NotBeNull();
-        capturedEnvelope!.Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
-    }
-
-    [Fact]
-    public async Task HandleRebuildRegistrationsAsync_ReturnsBadRequestForUnsupportedContentType()
-    {
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        var http = CreateHttpContext("scope-1");
-        http.Request.ContentType = "text/plain";
-        http.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes("registration_id=reg-1"));
-
-        var result = await InvokeAsync(
-            "HandleRebuildRegistrationsAsync",
-            http,
-            ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime),
-            NullLoggerFactory.Instance,
-            CancellationToken.None);
-        var response = await ExecuteResultAsync(result);
-
-        response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
-        response.Body.Should().Contain("Unsupported content type");
-        await ((IActorDispatchPort)actorRuntime).DidNotReceive().DispatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<EventEnvelope>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task HandleRebuildRegistrationsAsync_IgnoresDiagnosticScopeFields()
-    {
-        EventEnvelope? capturedEnvelope = null;
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
-        ((IActorDispatchPort)actorRuntime).DispatchAsync(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-
-        var result = await InvokeAsync(
-            "HandleRebuildRegistrationsAsync",
-            CreateJsonHttpContext("""{"scope_id":"scope-2","registration_id":"reg-1"}""", "scope-1"),
-            ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime),
-            NullLoggerFactory.Instance,
-            CancellationToken.None);
-        var response = await ExecuteResultAsync(result);
-
-        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        capturedEnvelope.Should().NotBeNull();
-    }
-
-    [Fact]
-    public async Task HandleRebuildRegistrationsAsync_DispatchesRefreshCommand_WhenReadModelIsUnavailable()
-    {
-        EventEnvelope? capturedEnvelope = null;
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
-        ((IActorDispatchPort)actorRuntime).DispatchAsync(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-
-        var result = await InvokeAsync(
-            "HandleRebuildRegistrationsAsync",
-            CreateHttpContext("scope-1"),
-            ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime),
-            NullLoggerFactory.Instance,
-            CancellationToken.None);
-        var response = await ExecuteResultAsync(result);
-
-        response.StatusCode.Should().Be(StatusCodes.Status202Accepted);
-        response.Body.Should().Contain("\"status\":\"accepted\"");
-        response.Body.Should().NotContain("observed_registrations_before_rebuild");
-        response.Body.Should().NotContain("backfill_status");
-        capturedEnvelope.Should().NotBeNull();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationCommandFacadeTestSupport.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationCommandFacadeTestSupport.cs
@@ -17,7 +17,6 @@ internal static class ChannelRegistrationCommandFacadeTestSupport
 
         return new ChannelRegistrationCommandFacade(
             CreateDispatchService<ChannelBotRegisterCommand>(actorRuntime, contextPolicy, envelopeFactory, targetDispatcher, receiptFactory),
-            CreateDispatchService<ChannelBotRebuildProjectionCommand>(actorRuntime, contextPolicy, envelopeFactory, targetDispatcher, receiptFactory),
             CreateDispatchService<ChannelBotUnregisterCommand>(actorRuntime, contextPolicy, envelopeFactory, targetDispatcher, receiptFactory));
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationCommandFacadeTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationCommandFacadeTests.cs
@@ -10,7 +10,7 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public sealed class ChannelRegistrationCommandFacadeTests
 {
     [Fact]
-    public async Task RebuildProjectionAsync_WhenStoreActorIsMissing_ShouldCreateActorBeforeDispatch()
+    public async Task RegisterLocalMirrorAsync_WhenStoreActorIsMissing_ShouldCreateActorBeforeDispatch()
     {
         EventEnvelope? capturedEnvelope = null;
         var createdActor = Substitute.For<IActor>();
@@ -30,13 +30,19 @@ public sealed class ChannelRegistrationCommandFacadeTests
             .Returns(Task.CompletedTask);
         var facade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, dispatchPort);
 
-        var receipt = await facade.RebuildProjectionAsync("manual-debug");
+        var receipt = await facade.RegisterLocalMirrorAsync(new ChannelBotRegisterCommand
+        {
+            RequestedId = "reg-1",
+            Platform = "lark",
+            ScopeId = "scope-1",
+            NyxProviderSlug = "api-lark-bot",
+        });
 
         receipt.ActorId.Should().Be(ChannelBotRegistrationGAgent.WellKnownId);
         receipt.CommandId.Should().NotBeNullOrWhiteSpace();
         receipt.CorrelationId.Should().Be(receipt.CommandId);
         capturedEnvelope.Should().NotBeNull();
-        capturedEnvelope!.Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+        capturedEnvelope!.Payload.Unpack<ChannelBotRegisterCommand>().RequestedId.Should().Be("reg-1");
         await actorRuntime.Received(1).CreateAsync<ChannelBotRegistrationGAgent>(
             ChannelBotRegistrationGAgent.WellKnownId,
             Arg.Any<CancellationToken>());
@@ -47,7 +53,7 @@ public sealed class ChannelRegistrationCommandFacadeTests
     }
 
     [Fact]
-    public async Task RebuildProjectionAsync_WhenStoreActorCannotBeCreated_ShouldFailWithoutDispatch()
+    public async Task UnregisterAsync_WhenStoreActorCannotBeCreated_ShouldFailWithoutDispatch()
     {
         var actorRuntime = Substitute.For<IActorRuntime>();
         var dispatchPort = Substitute.For<IActorDispatchPort>();
@@ -60,7 +66,7 @@ public sealed class ChannelRegistrationCommandFacadeTests
             .Returns(Task.FromResult<IActor>(null!));
         var facade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, dispatchPort);
 
-        var act = () => facade.RebuildProjectionAsync("manual-debug");
+        var act = () => facade.UnregisterAsync("reg-1");
 
         await act.Should()
             .ThrowAsync<InvalidOperationException>()

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -3,7 +3,6 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using FluentAssertions;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
@@ -22,8 +21,10 @@ public sealed class ChannelRegistrationToolTests
 
         tool.Name.Should().Be("channel_registrations");
         tool.Description.Should().Contain("register_lark_via_nyx");
-        tool.Description.Should().Contain("rebuild_projection");
+        tool.Description.Should().NotContain("rebuild_projection");
         tool.Description.Should().NotContain("repair_lark_mirror");
+        tool.ParametersSchema.Should().NotContain("rebuild_projection");
+        tool.ParametersSchema.Should().NotContain("reason");
         JsonDocument.Parse(tool.ParametersSchema).RootElement
             .GetProperty("properties")
             .GetProperty("action")
@@ -31,7 +32,7 @@ public sealed class ChannelRegistrationToolTests
             .EnumerateArray()
             .Select(static value => value.GetString())
             .Should()
-            .Equal("list", "register_lark_via_nyx", "rebuild_projection", "delete");
+            .Equal("list", "register_lark_via_nyx", "delete");
     }
 
     [Fact]
@@ -127,18 +128,9 @@ public sealed class ChannelRegistrationToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_RebuildProjection_DispatchesRefreshCommand()
+    public async Task ExecuteAsync_RebuildProjection_ReturnsRetiredAction_AndDoesNotDispatch()
     {
-        List<EventEnvelope> capturedEnvelopes = [];
-        var actor = Substitute.For<IActor>();
         var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            .Returns(Task.FromResult<IActor?>(actor));
-        ((IActorDispatchPort)actorRuntime).DispatchAsync(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelopes.Add(envelope)),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
         var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
 
         using var serviceProvider = new ServiceCollection()
@@ -151,43 +143,13 @@ public sealed class ChannelRegistrationToolTests
         var json = await tool.ExecuteAsync("""{"action":"rebuild_projection","reason":"manual-debug","registration_id":"reg-1","force":true}""");
         using var doc = JsonDocument.Parse(json);
 
-        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
-        doc.RootElement.TryGetProperty("backfill_status", out _).Should().BeFalse();
-        capturedEnvelopes.Should().ContainSingle();
-        capturedEnvelopes[0].Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("manual-debug");
+        doc.RootElement.GetProperty("error_code").GetString().Should().Be("retired_action");
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("internal startup maintenance");
         await queryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_RebuildProjection_DispatchesEvenWhenQueryObservationFails()
-    {
-        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromException<IReadOnlyList<ChannelBotRegistrationEntry>>(new InvalidOperationException("projection reader unavailable")));
-
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
-        EventEnvelope? capturedEnvelope = null;
-        ((IActorDispatchPort)actorRuntime).DispatchAsync(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
-
-        using var serviceProvider = new ServiceCollection()
-            .AddSingleton(queryPort)
-            .AddSingleton(ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime))
-            .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
-
-        using var scope = PushNyxToken();
-        var json = await tool.ExecuteAsync("""{"action":"rebuild_projection","reason":"manual-debug"}""");
-        using var doc = JsonDocument.Parse(json);
-
-        doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
-        capturedEnvelope.Should().NotBeNull();
-        await queryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
+        await ((IActorDispatchPort)actorRuntime).DidNotReceive().DispatchAsync(
+            Arg.Any<string>(),
+            Arg.Any<EventEnvelope>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -128,31 +128,6 @@ public sealed class ChannelRegistrationToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_RebuildProjection_ReturnsRetiredAction_AndDoesNotDispatch()
-    {
-        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
-        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
-
-        using var serviceProvider = new ServiceCollection()
-            .AddSingleton(queryPort)
-            .AddSingleton(ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime))
-            .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
-
-        using var scope = PushNyxToken();
-        var json = await tool.ExecuteAsync("""{"action":"rebuild_projection","reason":"manual-debug","registration_id":"reg-1","force":true}""");
-        using var doc = JsonDocument.Parse(json);
-
-        doc.RootElement.GetProperty("error_code").GetString().Should().Be("retired_action");
-        doc.RootElement.GetProperty("error").GetString().Should().Contain("internal startup maintenance");
-        await queryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
-        await ((IActorDispatchPort)actorRuntime).DidNotReceive().DispatchAsync(
-            Arg.Any<string>(),
-            Arg.Any<EventEnvelope>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
     public async Task ExecuteAsync_RegisterLarkViaNyx_RejectsMissingScopeContext()
     {
         var provisioningService = Substitute.For<INyxLarkProvisioningService>();
@@ -167,6 +142,24 @@ public sealed class ChannelRegistrationToolTests
 
         json.Should().Contain("scope_id is required");
         await provisioningService.DidNotReceive().ProvisionAsync(Arg.Any<NyxLarkProvisioningRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RebuildProjection_ReturnsUnsupportedAction()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(queryPort)
+            .BuildServiceProvider();
+        var tool = new ChannelRegistrationTool(serviceProvider);
+
+        using var scope = PushNyxToken();
+        var result = await tool.ExecuteAsync("""{"action":"rebuild_projection"}""");
+
+        result.Should().Contain("Unsupported channel registration action");
+        result.Should().Contain("rebuild_projection");
+        result.Should().NotContain("retired_action");
+        await queryPort.DidNotReceive().QueryAllAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -83,6 +83,14 @@ public sealed class ServiceCollectionExtensionsTests
             descriptor.ServiceType == typeof(ChannelRegistrationCommandFacade));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(ICommandDispatchService<ChannelBotRegisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandTargetResolver<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandStartError>));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandEnvelopeFactory<ChannelBotRebuildProjectionCommand>));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandDispatchPipeline<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
+        services.Should().NotContain(descriptor =>
+            descriptor.ServiceType == typeof(ICommandDispatchService<ChannelBotRebuildProjectionCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
         registry.Get(ChannelId.From("telegram")).Should().BeOfType<Aevatar.GAgents.Platform.Telegram.TelegramMessageComposer>();
     }
 

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -136,6 +136,47 @@ if rg -n "IProjectionReadModelBindingResolver|ProjectionReadModelBindingResolver
   exit 1
 fi
 
+# Refactor (iter56/cluster-933-channel-registration-rebuild-narrow):
+#   Old: channel registration projection rebuild was exposed through HTTP, tool,
+#   prompts, docs, facade, and relay-local DI.
+#   New: rebuild is only the internal Runtime startup refresh path.
+set +e
+channel_registration_public_rebuild_report="$(
+  rg -n "rebuild_projection|/registrations/rebuild|RebuildProjectionAsync|ChannelBotRebuildProjectionCommand" \
+    src/Aevatar.AI.ToolProviders.ChannelAdmin \
+    agents/channels/Aevatar.GAgents.Channel.NyxIdRelay \
+    agents/Aevatar.GAgents.NyxidChat \
+    docs/operations \
+    -g '!**/bin/**' \
+    -g '!**/obj/**' \
+    | awk -F: '
+{
+  file = $1;
+  line_no = $2;
+  text = substr($0, length(file) + length(line_no) + 3);
+
+  if (text ~ /Refactor \(iter56\/cluster-933-channel-registration-rebuild-narrow\)/)
+    next;
+  if (file == "src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs" && text ~ /RetiredActionError/)
+    next;
+
+  print $0;
+}'
+)"
+channel_registration_public_rebuild_status=$?
+set -e
+
+if [[ ${channel_registration_public_rebuild_status} -ne 0 && ${channel_registration_public_rebuild_status} -ne 1 ]]; then
+  echo "Channel registration public rebuild guard execution failed."
+  exit "${channel_registration_public_rebuild_status}"
+fi
+
+if [ -n "${channel_registration_public_rebuild_report}" ]; then
+  echo "${channel_registration_public_rebuild_report}"
+  echo "Channel registration projection rebuild must not be exposed through public/tool/prompt/docs/facade/relay DI surfaces."
+  exit 1
+fi
+
 if rg -n "IGAgentActorStore|ActorBackedGAgentActorStore" src agents; then
   echo "Legacy GAgent actor store is forbidden. Use registry command/query/admission ports."
   exit 1

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -157,8 +157,6 @@ channel_registration_public_rebuild_report="$(
 
   if (text ~ /Refactor \(iter56\/cluster-933-channel-registration-rebuild-narrow\)/)
     next;
-  if (file == "src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs" && text ~ /RetiredActionError/)
-    next;
 
   print $0;
 }'


### PR DESCRIPTION
## 摘要

iter56 cluster-933 — Phase 9 r3 unanimous(3/3 keep helper + delete public):

- **删** channel registration public/manual `rebuild_projection` surfaces(HTTP/tool/prompt)
- **删** `ChannelRegistrationCommandFacade.RebuildProjectionAsync` + relay-local rebuild DI
- **保留** Runtime startup helper(narrow 到 internal rebuild-only)
- **不加** 新 internal maintenance service(over-built)

## 边界

- 不加 new service / actor / envelope
- 不动 docs/canon
- Runtime startup helper 仅 internal

## 影响范围

15 files changed,LOC **+111 / -348** net **-237**

## 验证

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/...` 823/823 PASS
- `bash tools/ci/architecture_guards.sh` PASS
- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/query_projection_priming_guard.sh` PASS
- `bash tools/ci/projection_state_version_guard.sh` PASS
- `bash tools/ci/projection_state_mirror_current_state_guard.sh` PASS
- `dotnet build aevatar.slnx --nologo` PASS

Closes #933

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
