### PR TITLE
iter56 cluster-935: agent run actor-owned admission + plain Task DispatchAsync

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -262,6 +262,9 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             var runCopy = result.LlmReplyRequest.Clone();
             runCopy.TargetActorId = Id;
             runCopy.TargetRef = targetRef.Clone();
+            runCopy.RunId = NormalizeOptional(runCopy.RunId) ??
+                            NormalizeOptional(runCopy.CorrelationId) ??
+                            activity.Id;
             ApplyRuntimeReplyToken(runCopy, runtimeContext);
             RestoreRuntimeTransportCredentials(runCopy.Activity, runtimeContext);
             var persistedCopy = runCopy.Clone();
@@ -582,17 +585,15 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
         try
         {
-            var outcome = await dispatcher.DispatchAsync(request.Clone(), ct);
+            // Refactor (iter56/cluster-935-agent-run-actor-admission): old=dispatcher in-process admission, new=actor-owned admission with plain Task
+            //   Conversation observes only dispatch handoff success/failure here.
+            //   Run duplicate/stale decisions are committed by AgentRunGAgent events.
+            await dispatcher.DispatchAsync(request.Clone(), ct);
             Logger.LogInformation(
-                "Dispatched LLM reply run request: correlation={CorrelationId} conversation={Key} phase={Phase} commandId={CommandId}",
+                "Dispatched LLM reply run request: runId={RunId} correlation={CorrelationId} conversation={Key}",
+                request.RunId,
                 request.CorrelationId,
-                request.Activity?.Conversation?.CanonicalKey,
-                outcome.Phase,
-                outcome.CommandId);
-            // C3 will branch on outcome.Phase to retire the pending entry on
-            // Rejected* outcomes. Today the run actor inbox handler drops
-            // stale requests and surfaces them through DeferredLlmReplyDroppedEvent,
-            // so behaviour is preserved either way.
+                request.Activity?.Conversation?.CanonicalKey);
         }
         catch (Exception ex)
         {

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/IChannelLlmReplyRunDispatcher.cs
@@ -5,64 +5,13 @@ namespace Aevatar.GAgents.Channel.Runtime;
 /// LLM reply run to its run-scoped continuation owner.
 /// </summary>
 /// <remarks>
-/// The synchronous return only promises <c>accepted</c> per ADR-0021: the run
-/// request has been validated as fresh and enqueued onto the run actor's inbox.
+/// A normal return only promises accepted-for-dispatch per ADR-0021: the run
+/// request has been handed to the run actor dispatch port.
 /// It does NOT promise the LLM has started, that any reply has been produced,
-/// or that any user-visible delivery has happened. Strong guarantees only
-/// arrive via downstream events.
+/// that the actor admitted the run, or that any user-visible delivery has
+/// happened. Strong guarantees only arrive via downstream events.
 /// </remarks>
 public interface IChannelLlmReplyRunDispatcher
 {
-    Task<DispatchOutcome> DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct);
-}
-
-/// <summary>
-/// Synchronous outcome of <see cref="IChannelLlmReplyRunDispatcher.DispatchAsync"/>.
-/// </summary>
-/// <param name="Phase">
-/// The completion phase actually reached. By contract dispatcher implementations
-/// MUST only return <see cref="DispatchPhase.Accepted"/> or one of the
-/// <c>Rejected*</c> variants — never <c>Committed</c> or <c>Delivered</c>; those
-/// strong phases are observed asynchronously per ADR-0021.
-/// </param>
-/// <param name="CommandId">
-/// Stable id of the dispatched command (run actor envelope id). Empty when the
-/// outcome is a rejection that occurred before envelope construction.
-/// </param>
-/// <param name="RunActorId">
-/// Id of the target <c>AgentRunGAgent</c> the request was routed to, when
-/// available; <c>null</c> when no actor was created (e.g. stale-rejected).
-/// </param>
-/// <param name="AcceptedAtUnixMs">
-/// Wall-clock at which the dispatcher accepted/rejected the request. Zero when
-/// not applicable.
-/// </param>
-public sealed record DispatchOutcome(
-    DispatchPhase Phase,
-    string CommandId,
-    string? RunActorId,
-    long AcceptedAtUnixMs);
-
-/// <summary>
-/// Phase reached by <see cref="IChannelLlmReplyRunDispatcher.DispatchAsync"/>.
-/// </summary>
-/// <remarks>
-/// Per ADR-0021 the dispatcher is only allowed to report <c>Accepted</c> or one
-/// of the <c>Rejected*</c> variants. Stronger phases (committed, delivered,
-/// finalized) are not observable at the synchronous dispatcher boundary.
-/// </remarks>
-public enum DispatchPhase
-{
-    Accepted = 0,
-    /// <summary>
-    /// The request's <c>requested_at_unix_ms</c> exceeded the freshness window,
-    /// so the dispatcher refused to enqueue it (the run actor would have
-    /// dropped it anyway).
-    /// </summary>
-    RejectedStale = 1,
-    /// <summary>
-    /// The request's <c>correlation_id</c> matches an already-dispatched run
-    /// command and was suppressed to keep the run actor inbox idempotent.
-    /// </summary>
-    RejectedDuplicate = 2,
+    Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct);
 }

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -49,6 +49,9 @@ message NeedsLlmReplyEvent {
   // command copy may carry it so AgentRunGAgent can apply the route before execution.
   // Never persist to event store, projection, read model, or actor state.
   aevatar.chat_routing.v1.ChatRouteAction target_ref = 10;
+  // Stable run identity owned by AgentRunGAgent. Dispatcher adapters may use
+  // correlation_id only as a bounded fallback for older persisted requests.
+  string run_id = 11;
 }
 
 // Transient actor-inbox envelope used by the NyxID relay endpoint to hand a single

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
@@ -11,139 +11,80 @@ namespace Aevatar.GAgents.NyxidChat;
 /// </summary>
 public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
 {
-    // Must match AgentRunGAgent.MaxRunRequestAgeMs so the dispatcher rejects
-    // freshness violations at the boundary rather than letting them propagate
-    // to the run actor inbox (where they would just be dropped). See ADR-0021.
-    private const long MaxRequestAgeMs = 5L * 60_000L;
-
     private readonly IActorRuntime _actorRuntime;
-    private readonly IStreamProvider _streamProvider;
+    private readonly IActorDispatchPort _actorDispatchPort;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<AgentRunDispatcher> _logger;
-    private readonly SemaphoreSlim _dispatchGate = new(1, 1);
 
     public AgentRunDispatcher(
         IActorRuntime actorRuntime,
-        IStreamProvider streamProvider,
+        IActorDispatchPort actorDispatchPort,
         ILogger<AgentRunDispatcher> logger,
         TimeProvider? timeProvider = null)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
-        _streamProvider = streamProvider ?? throw new ArgumentNullException(nameof(streamProvider));
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task<DispatchOutcome> DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+    public async Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        if (string.IsNullOrWhiteSpace(request.CorrelationId))
-            throw new InvalidOperationException("Deferred LLM reply request requires correlation_id for AgentRunGAgent dispatch.");
-
-        var runId = request.CorrelationId.Trim();
+        var runId = NormalizeRunId(request);
         var actorId = AgentRunGAgent.BuildActorId(runId);
-        await _dispatchGate.WaitAsync(ct);
-        try
+
+        var actor = await _actorRuntime.CreateAsync<AgentRunGAgent>(actorId, ct);
+
+        var commandId = BuildStartCommandId(runId);
+        var command = new AgentRunStartRequested
         {
-            var nowMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
-
-            if (request.RequestedAtUnixMs > 0 && nowMs - request.RequestedAtUnixMs > MaxRequestAgeMs)
-            {
-                _logger.LogWarning(
-                    "Rejected stale deferred LLM reply run at dispatcher: runId={RunId} ageMs={AgeMs} thresholdMs={Threshold} target={TargetActorId}",
-                    runId,
-                    nowMs - request.RequestedAtUnixMs,
-                    MaxRequestAgeMs,
-                    request.TargetActorId);
-                return new DispatchOutcome(
-                    Phase: DispatchPhase.RejectedStale,
-                    CommandId: string.Empty,
-                    RunActorId: null,
-                    AcceptedAtUnixMs: 0);
-            }
-
-            if (await _actorRuntime.ExistsAsync(actorId))
-            {
-                _logger.LogInformation(
-                    "Rejected duplicate deferred LLM reply run at dispatcher: runId={RunId} actorId={ActorId} target={TargetActorId}",
-                    runId,
-                    actorId,
-                    request.TargetActorId);
-                return new DispatchOutcome(
-                    Phase: DispatchPhase.RejectedDuplicate,
-                    CommandId: string.Empty,
-                    RunActorId: actorId,
-                    AcceptedAtUnixMs: 0);
-            }
-
-            var actor = await _actorRuntime.CreateAsync<AgentRunGAgent>(actorId, ct);
-
-            var commandId = BuildStartCommandId(runId);
-            var command = new AgentRunStartRequested
-            {
-                Request = request.Clone(),
-            };
-            var envelope = new EventEnvelope
-            {
-                Id = commandId,
-                Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
-                Payload = Any.Pack(command),
-                Route = EnvelopeRouteSemantics.CreateDirect("channel-llm-reply-run-dispatcher", actor.Id),
-                Propagation = new EnvelopePropagation
-                {
-                    CorrelationId = runId,
-                },
-                Runtime = new EnvelopeRuntime
-                {
-                    Deduplication = new DeliveryDeduplication
-                    {
-                        OperationId = commandId,
-                    },
-                },
-            };
-
-            try
-            {
-                await _streamProvider.GetStream(actor.Id).ProduceAsync(envelope, ct);
-            }
-            catch
-            {
-                await DestroyCreatedActorAfterDispatchFailureAsync(actor.Id);
-                throw;
-            }
-
-            _logger.LogInformation(
-                "Accepted deferred LLM reply run for actor inbox: runId={RunId} actorId={ActorId} commandId={CommandId} target={TargetActorId}",
-                runId,
-                actor.Id,
-                commandId,
-                request.TargetActorId);
-            return new DispatchOutcome(
-                Phase: DispatchPhase.Accepted,
-                CommandId: commandId,
-                RunActorId: actor.Id,
-                AcceptedAtUnixMs: nowMs);
-        }
-        finally
+            Request = request.Clone(),
+        };
+        command.Request.RunId = runId;
+        var envelope = new EventEnvelope
         {
-            _dispatchGate.Release();
-        }
+            Id = commandId,
+            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
+            Payload = Any.Pack(command),
+            Route = EnvelopeRouteSemantics.CreateDirect("channel-llm-reply-run-dispatcher", actor.Id),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = string.IsNullOrWhiteSpace(request.CorrelationId)
+                    ? runId
+                    : request.CorrelationId.Trim(),
+            },
+            Runtime = new EnvelopeRuntime
+            {
+                Deduplication = new DeliveryDeduplication
+                {
+                    OperationId = commandId,
+                },
+            },
+        };
+
+        // Refactor (iter56/cluster-935-agent-run-actor-admission): old=dispatcher in-process admission, new=actor-owned admission with plain Task
+        //   This adapter only hands the start envelope to IActorDispatchPort.
+        //   AgentRunGAgent owns stale/duplicate admission after inbox delivery.
+        await _actorDispatchPort.DispatchAsync(actor.Id, envelope, ct);
+
+        _logger.LogInformation(
+            "Accepted deferred LLM reply run for actor dispatch: runId={RunId} actorId={ActorId} commandId={CommandId} target={TargetActorId}",
+            runId,
+            actor.Id,
+            commandId,
+            request.TargetActorId);
     }
 
     private static string BuildStartCommandId(string runId) => $"agent-run-start:{runId}";
 
-    private async Task DestroyCreatedActorAfterDispatchFailureAsync(string actorId)
+    private static string NormalizeRunId(NeedsLlmReplyEvent request)
     {
-        try
-        {
-            await _actorRuntime.DestroyAsync(actorId, CancellationToken.None);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to destroy agent run actor after dispatch enqueue failed: actorId={ActorId}",
-                actorId);
-        }
+        var runId = request.RunId;
+        if (string.IsNullOrWhiteSpace(runId))
+            runId = request.CorrelationId;
+        if (string.IsNullOrWhiteSpace(runId))
+            throw new InvalidOperationException("Deferred LLM reply request requires run_id for AgentRunGAgent dispatch.");
+        return runId.Trim();
     }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -122,7 +122,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         var request = command.Request.Clone();
         ApplyTargetRefOverrides(request);
-        var runId = NormalizeOptional(request.CorrelationId) ?? Id;
+        var runId = ResolveRunId(request);
         var startedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
         // ADR-0021 chain.finalized precondition: terminal status means the run has
@@ -1282,6 +1282,11 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         var trimmed = value?.Trim();
         return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
+
+    private string ResolveRunId(NeedsLlmReplyEvent request) =>
+        NormalizeOptional(request.RunId) ??
+        NormalizeOptional(request.CorrelationId) ??
+        Id;
 
     private sealed class AgentRunOutputDispatchException(string message, Exception innerException)
         : Exception(message, innerException);

--- a/docs/adr/0021-lark-reply-chain-completion-semantics.md
+++ b/docs/adr/0021-lark-reply-chain-completion-semantics.md
@@ -25,7 +25,7 @@ Issues #647 / #648 / #649 都源于这一根本：契约不显式，每层承诺
 
 | 阶段 | 推进方 | 同步入口 | 异步事件 | 可观察 state | 承诺 |
 |---|---|---|---|---|---|
-| **accepted** | dispatcher | `DispatchAsync` return | `NeedsLlmReplyEvent` appended | `ConversationState.PendingLlmReply` | 已收到 & 入 actor inbox stream；**不**承诺 LLM 已开始处理 |
+| **accepted** | dispatcher | `DispatchAsync` normal return | `NeedsLlmReplyEvent` appended | `ConversationState.PendingLlmReply` | 已收到 & accepted for dispatch to run actor；**不**承诺 LLM 已开始处理或 run 已 admitted |
 | **committed** | `AgentRunGAgent` | — | `AgentRunReplyProducedEvent` persisted | `AgentRunState.Status = REPLY_PRODUCED` | LLM 已产出 & state event 已落库；**不**承诺消费方已收到 |
 | **delivered** | `ConversationGAgent` + channel sink | — | `LlmReplyDeliveredEvent` (新增) | `ConversationState.LastReplyDelivery.{outcome, channel_message_id, ack_at_unix_ms}` | channel sink 已 ack；**user-visible** |
 | **finalized** | `AgentRunGAgent` + `ConversationGAgent` | — | `ConversationTurnCompletedEvent` + `AgentRunState.cleanup_completed_at != 0` | terminal status + cleanup 已完 | 所有副作用收尾；**吸收态** |
@@ -101,29 +101,18 @@ message ConversationState {
 - streaming 路径：`HandleLlmReplyStreamChunkAsync` (cs:532) / `HandleLlmReplyCardStreamChunkAsync` (cs:546) 在 final chunk emit 之后 raise event
 - 失败路径：lark API 4xx/5xx / 超时 → raise `LlmReplyDeliveryFailedEvent`
 
-### 4. Dispatcher 返回值显式化
+### 4. Dispatcher ACK 语义
 
 ```csharp
 public interface IChannelLlmReplyRunDispatcher
 {
-    Task<DispatchOutcome> DispatchAsync(NeedsLlmReplyEvent evt, CancellationToken ct = default);
-}
-
-public sealed record DispatchOutcome(
-    DispatchPhase Phase,
-    string CommandId,
-    string? RunActorId,
-    long AcceptedAtUnixMs);
-
-public enum DispatchPhase
-{
-    Accepted = 0,
-    RejectedStale = 1,        // request age > MaxRunRequestAgeMs
-    RejectedDuplicate = 2,    // dedup hit on CommandId
+    Task DispatchAsync(NeedsLlmReplyEvent evt, CancellationToken ct = default);
 }
 ```
 
-**`DispatchPhase` 只能取 `Accepted` / `Rejected*`**，**不允许** `Committed` / `Delivered` — dispatcher 不承诺 downstream 任何事。
+`DispatchAsync` 正常返回只表示请求已交给 `IActorDispatchPort` 做 run actor inbox handoff；异常表示 handoff 失败，调用方可按 durable retry 处理。`AgentRunGAgent` 拥有 run admission：typed `run_id`、duplicate absorption、stale rejection/drop 都是 actor-owned 事实，后续只能通过 `AgentRunReplyProducedEvent` / `AgentRunDroppedEvent` / `AgentRunFailedEvent` 等异步事件观察。
+
+Dispatcher 不返回 receipt，也不返回 rejected phase；`commandId` 与 `runActorId` 由 typed `run_id` 确定性派生，`acceptedAt` 只是日志时间，不是 committed / observed 事实。
 
 **兼容性**：接口 `IChannelLlmReplyRunDispatcher` 完全仓库内部消费，无 NuGet 包发布；调用方 3 处（`ConversationGAgent.cs:349` + 2 处测试 mock）随 ADR 适配。无线上兼容性风险。
 
@@ -131,7 +120,7 @@ public enum DispatchPhase
 
 | 调用点 | 同步返回承诺 | 异步可观察 |
 |---|---|---|
-| `IChannelLlmReplyRunDispatcher.DispatchAsync` return | `DispatchPhase.Accepted` (仅入 inbox) | `AgentRunReplyProducedEvent` / `AgentRunDroppedEvent` / `AgentRunFailedEvent` |
+| `IChannelLlmReplyRunDispatcher.DispatchAsync` return | accepted-for-dispatch (仅 handoff to dispatch port) | `AgentRunReplyProducedEvent` / `AgentRunDroppedEvent` / `AgentRunFailedEvent` |
 | `AgentRunGAgent.HandleAgentRunStartRequested` 返回 | run 已接收 | committed → handed_off |
 | `ConversationGAgent.HandleLlmReplyReadyAsync` 返回 | handed_off 达成（ack from AgentRunGAgent 视角） | delivered → finalized |
 | 对外 HTTP `/v1/messages` 等 | accepted 等价语义 | client 自行 poll readmodel |
@@ -149,7 +138,7 @@ public enum DispatchPhase
   - `IsTerminal` helper 统一收口（替代 cs:114-124 散落的 ad-hoc 判断）
   - 所有 handler 入口先短路终态
   - cleanup 显式幂等（`cleanup_completed_at != 0` 即视为已完成，no-op）
-  - stale signal 校验统一通过 `commandId` + `runId` + `MaxRunRequestAgeMs`
+  - stale signal 校验统一通过 typed `runId` + `MaxRunRequestAgeMs`
 
 ## Consequences
 
@@ -158,7 +147,7 @@ public enum DispatchPhase
 1. `agent_run.proto`：扩 `AgentRunStatus` enum 加 `REPLY_HANDED_OFF`；`reply_dispatched` bool 标记 reserved
 2. `conversation_state.proto`：新增 `ReplyDeliveryStatus` 消息 + `last_reply_delivery` 字段
 3. 新增 domain event：`LlmReplyDeliveredEvent` / `LlmReplyDeliveryFailedEvent`
-4. `IChannelLlmReplyRunDispatcher.DispatchAsync` 改返回 `Task<DispatchOutcome>`；新增 `DispatchOutcome` record + `DispatchPhase` enum
+4. `IChannelLlmReplyRunDispatcher.DispatchAsync` 返回 plain `Task`；删除 `DispatchOutcome` record + `DispatchPhase` enum
 5. `AgentRunGAgent` 把 `Status==ReplyProduced && reply_dispatched==true` 重写为 `Status==REPLY_HANDED_OFF`；新增 `IsTerminal` helper
 6. `ConversationGAgent.RunLlmReplyAsync` + streaming chunk path 在 lark API 调用后 raise delivery event 落地 `last_reply_delivery`
 7. 配套 `docs/canon/lark-reply-completion-semantics.md`：详细可观察 state 表 + 时序图 + 跨阶段故障矩阵

--- a/docs/adr/0021-lark-reply-chain-completion-semantics.md
+++ b/docs/adr/0021-lark-reply-chain-completion-semantics.md
@@ -25,7 +25,7 @@ Issues #647 / #648 / #649 都源于这一根本：契约不显式，每层承诺
 
 | 阶段 | 推进方 | 同步入口 | 异步事件 | 可观察 state | 承诺 |
 |---|---|---|---|---|---|
-| **accepted** | dispatcher | `DispatchAsync` normal return | `NeedsLlmReplyEvent` appended | `ConversationState.PendingLlmReply` | 已收到 & accepted for dispatch to run actor；**不**承诺 LLM 已开始处理或 run 已 admitted |
+| **accepted** | dispatcher | `DispatchAsync` return | `NeedsLlmReplyEvent` appended | `ConversationState.PendingLlmReply` | 已收到 & 入 actor inbox stream；**不**承诺 LLM 已开始处理 |
 | **committed** | `AgentRunGAgent` | — | `AgentRunReplyProducedEvent` persisted | `AgentRunState.Status = REPLY_PRODUCED` | LLM 已产出 & state event 已落库；**不**承诺消费方已收到 |
 | **delivered** | `ConversationGAgent` + channel sink | — | `LlmReplyDeliveredEvent` (新增) | `ConversationState.LastReplyDelivery.{outcome, channel_message_id, ack_at_unix_ms}` | channel sink 已 ack；**user-visible** |
 | **finalized** | `AgentRunGAgent` + `ConversationGAgent` | — | `ConversationTurnCompletedEvent` + `AgentRunState.cleanup_completed_at != 0` | terminal status + cleanup 已完 | 所有副作用收尾；**吸收态** |
@@ -101,18 +101,29 @@ message ConversationState {
 - streaming 路径：`HandleLlmReplyStreamChunkAsync` (cs:532) / `HandleLlmReplyCardStreamChunkAsync` (cs:546) 在 final chunk emit 之后 raise event
 - 失败路径：lark API 4xx/5xx / 超时 → raise `LlmReplyDeliveryFailedEvent`
 
-### 4. Dispatcher ACK 语义
+### 4. Dispatcher 返回值显式化
 
 ```csharp
 public interface IChannelLlmReplyRunDispatcher
 {
-    Task DispatchAsync(NeedsLlmReplyEvent evt, CancellationToken ct = default);
+    Task<DispatchOutcome> DispatchAsync(NeedsLlmReplyEvent evt, CancellationToken ct = default);
+}
+
+public sealed record DispatchOutcome(
+    DispatchPhase Phase,
+    string CommandId,
+    string? RunActorId,
+    long AcceptedAtUnixMs);
+
+public enum DispatchPhase
+{
+    Accepted = 0,
+    RejectedStale = 1,        // request age > MaxRunRequestAgeMs
+    RejectedDuplicate = 2,    // dedup hit on CommandId
 }
 ```
 
-`DispatchAsync` 正常返回只表示请求已交给 `IActorDispatchPort` 做 run actor inbox handoff；异常表示 handoff 失败，调用方可按 durable retry 处理。`AgentRunGAgent` 拥有 run admission：typed `run_id`、duplicate absorption、stale rejection/drop 都是 actor-owned 事实，后续只能通过 `AgentRunReplyProducedEvent` / `AgentRunDroppedEvent` / `AgentRunFailedEvent` 等异步事件观察。
-
-Dispatcher 不返回 receipt，也不返回 rejected phase；`commandId` 与 `runActorId` 由 typed `run_id` 确定性派生，`acceptedAt` 只是日志时间，不是 committed / observed 事实。
+**`DispatchPhase` 只能取 `Accepted` / `Rejected*`**，**不允许** `Committed` / `Delivered` — dispatcher 不承诺 downstream 任何事。
 
 **兼容性**：接口 `IChannelLlmReplyRunDispatcher` 完全仓库内部消费，无 NuGet 包发布；调用方 3 处（`ConversationGAgent.cs:349` + 2 处测试 mock）随 ADR 适配。无线上兼容性风险。
 
@@ -120,7 +131,7 @@ Dispatcher 不返回 receipt，也不返回 rejected phase；`commandId` 与 `ru
 
 | 调用点 | 同步返回承诺 | 异步可观察 |
 |---|---|---|
-| `IChannelLlmReplyRunDispatcher.DispatchAsync` return | accepted-for-dispatch (仅 handoff to dispatch port) | `AgentRunReplyProducedEvent` / `AgentRunDroppedEvent` / `AgentRunFailedEvent` |
+| `IChannelLlmReplyRunDispatcher.DispatchAsync` return | `DispatchPhase.Accepted` (仅入 inbox) | `AgentRunReplyProducedEvent` / `AgentRunDroppedEvent` / `AgentRunFailedEvent` |
 | `AgentRunGAgent.HandleAgentRunStartRequested` 返回 | run 已接收 | committed → handed_off |
 | `ConversationGAgent.HandleLlmReplyReadyAsync` 返回 | handed_off 达成（ack from AgentRunGAgent 视角） | delivered → finalized |
 | 对外 HTTP `/v1/messages` 等 | accepted 等价语义 | client 自行 poll readmodel |
@@ -138,7 +149,7 @@ Dispatcher 不返回 receipt，也不返回 rejected phase；`commandId` 与 `ru
   - `IsTerminal` helper 统一收口（替代 cs:114-124 散落的 ad-hoc 判断）
   - 所有 handler 入口先短路终态
   - cleanup 显式幂等（`cleanup_completed_at != 0` 即视为已完成，no-op）
-  - stale signal 校验统一通过 typed `runId` + `MaxRunRequestAgeMs`
+  - stale signal 校验统一通过 `commandId` + `runId` + `MaxRunRequestAgeMs`
 
 ## Consequences
 
@@ -147,7 +158,7 @@ Dispatcher 不返回 receipt，也不返回 rejected phase；`commandId` 与 `ru
 1. `agent_run.proto`：扩 `AgentRunStatus` enum 加 `REPLY_HANDED_OFF`；`reply_dispatched` bool 标记 reserved
 2. `conversation_state.proto`：新增 `ReplyDeliveryStatus` 消息 + `last_reply_delivery` 字段
 3. 新增 domain event：`LlmReplyDeliveredEvent` / `LlmReplyDeliveryFailedEvent`
-4. `IChannelLlmReplyRunDispatcher.DispatchAsync` 返回 plain `Task`；删除 `DispatchOutcome` record + `DispatchPhase` enum
+4. `IChannelLlmReplyRunDispatcher.DispatchAsync` 改返回 `Task<DispatchOutcome>`；新增 `DispatchOutcome` record + `DispatchPhase` enum
 5. `AgentRunGAgent` 把 `Status==ReplyProduced && reply_dispatched==true` 重写为 `Status==REPLY_HANDED_OFF`；新增 `IsTerminal` helper
 6. `ConversationGAgent.RunLlmReplyAsync` + streaming chunk path 在 lark API 调用后 raise delivery event 落地 `last_reply_delivery`
 7. 配套 `docs/canon/lark-reply-completion-semantics.md`：详细可观察 state 表 + 时序图 + 跨阶段故障矩阵

--- a/docs/adr/0027-lark-reply-run-dispatcher-plain-task-handoff.md
+++ b/docs/adr/0027-lark-reply-run-dispatcher-plain-task-handoff.md
@@ -1,0 +1,50 @@
+---
+title: Lark Reply Run Dispatcher Plain Task Handoff
+status: Accepted
+owner: eanzhao
+supersedes: ADR-0021 dispatcher return value sections
+---
+
+# ADR-0027: Lark Reply Run Dispatcher Plain Task Handoff
+
+## Context
+
+ADR-0021 made Lark reply-chain completion stages explicit, but its dispatcher section introduced a `DispatchOutcome` / `DispatchPhase` return shape for `IChannelLlmReplyRunDispatcher.DispatchAsync`.
+
+The implementation now follows actor-owned run admission: stale detection, duplicate absorption, reply production, dropped, and failed outcomes are facts owned by `AgentRunGAgent`, not by the dispatcher adapter. Keeping a dispatcher result type would invite callers to treat admission decisions as synchronously known before the run actor has processed its inbox.
+
+## Decision
+
+`IChannelLlmReplyRunDispatcher.DispatchAsync` returns plain `Task`.
+
+A normal return means only:
+
+- the request was normalized
+- the run actor id was derived from typed `run_id`
+- the run actor exists or was created
+- the start envelope was accepted by `IActorDispatchPort` for actor inbox handoff
+
+It does not mean:
+
+- the run actor has admitted the request
+- stale or duplicate checks have completed
+- the LLM has started
+- a reply has been produced, handed off, delivered, or finalized
+
+Transport failure to hand the message to the dispatch port may still surface as an exception. Downstream execution failure must surface through `AgentRunReplyProducedEvent`, `AgentRunDroppedEvent`, `AgentRunFailedEvent`, and readmodel/projection observation.
+
+## Superseded ADR-0021 Sections
+
+This ADR supersedes ADR-0021 section 4, "Dispatcher 返回值显式化", and the related rows in section 5 / consequences that require `Task<DispatchOutcome>`, `DispatchOutcome`, or `DispatchPhase`.
+
+ADR-0021 remains the source of record for the four reply-chain stages, `AgentRunStatus.REPLY_HANDED_OFF`, delivery tracking intent, streaming closeout bridge, and terminal idempotency bridge.
+
+Detailed implementation guidance lives in [docs/canon/lark-reply-completion-semantics.md](../canon/lark-reply-completion-semantics.md).
+
+## Consequences
+
+- `IChannelLlmReplyRunDispatcher.DispatchAsync` has no receipt/result type.
+- `AgentRunDispatcher` creates the run actor and hands off an `AgentRunStartRequested` envelope through `IActorDispatchPort`.
+- Stale and duplicate admission tests belong to `AgentRunGAgent`.
+- Callers must not branch on dispatcher-local accepted/rejected phases.
+- Orleans `IActorDispatchPort` uses actor stream handoff and does not couple the ACK to `_agent.HandleEventAsync` execution.

--- a/docs/canon/lark-reply-completion-semantics.md
+++ b/docs/canon/lark-reply-completion-semantics.md
@@ -51,8 +51,8 @@ sequenceDiagram
     U->>CGA: inbound message
     CGA->>CGA: raise NeedsLlmReplyEvent<br/>(accepted)
     CGA->>D: DispatchAsync(evt)
-    D-->>CGA: DispatchOutcome{Phase=Accepted}
-    D->>ARG: AgentRunStartRequested (via inbox stream)
+    D-->>CGA: normal return (accepted for dispatch)
+    D->>ARG: AgentRunStartRequested (via IActorDispatchPort)
     ARG->>CR: ChatStreamAsync(...)
     loop streaming chunks
         CR-->>ARG: LLMStreamChunk(delta)
@@ -126,7 +126,8 @@ sequenceDiagram
 
 | 故障发生时所处阶段 | 故障类型 | 终态 status | last_reply_delivery | 上抛事件 | 责任 actor |
 |---|---|---|---|---|---|
-| accepted | dispatcher 拒绝（stale / dup） | — (Conv not advanced) | — | `DispatchOutcome.Phase = Rejected*` | dispatcher |
+| accepted → committed | duplicate run start | 不变（terminal duplicate no-op / retry path keeps `REPLY_PRODUCED`） | 不变 | log only or persisted retry handoff | AgentRunGAgent |
+| accepted → committed | stale run age > MaxRunRequestAgeMs | `AgentRunStatus.DROPPED` | `null` | `AgentRunDroppedEvent` + `DeferredLlmReplyDroppedEvent` | AgentRunGAgent |
 | accepted → committed | LLM provider error | `AgentRunStatus.FAILED` | `null` | `AgentRunFailedEvent` + `ConversationContinueFailedEvent` | AgentRunGAgent |
 | accepted → committed | run age > MaxRunRequestAgeMs | `AgentRunStatus.DROPPED` | `null` | `AgentRunDroppedEvent` + `DeferredLlmReplyDroppedEvent` | AgentRunGAgent |
 | accepted → committed | missing relay reply_token | `AgentRunStatus.DROPPED` | `null` | `AgentRunDroppedEvent` | AgentRunGAgent |
@@ -210,7 +211,6 @@ internal static bool IsTerminal(AgentRunState s) =>
 5. `ReDispatchProducedReplyAsync`：终态 → 取消未来 retry，return
 
 **Stale signal 判定**：
-- 通过 `commandId` 不一致 → 视为 stale
 - 通过 `runId` 不一致 → 视为 stale
 - 通过 `nowMs - request.RequestedAtUnixMs > MaxRunRequestAgeMs` → 视为 stale，但仅在 STARTED 入口检查
 
@@ -224,8 +224,8 @@ internal static bool IsTerminal(AgentRunState s) =>
 - [ ] `agents/Aevatar.GAgents.NyxidChat/Protos/agent_run.proto`：扩 `AgentRunStatus` 加 `REPLY_HANDED_OFF`；`reply_dispatched` 标 `reserved`；加 `cleanup_completed_at`、`reply_produced_at_unix_ms`
 - [ ] `agents/Aevatar.GAgents.Channel.Runtime/Protos/conversation_state.proto`：新增 `ReplyDeliveryStatus` 消息 + `ConversationState.last_reply_delivery` 字段
 - [ ] 新增 domain event：`LlmReplyDeliveredEvent` / `LlmReplyDeliveryFailedEvent`（在 `Aevatar.GAgents.Channel.Runtime`）
-- [ ] `IChannelLlmReplyRunDispatcher.DispatchAsync` 改 `Task<DispatchOutcome>`；新增 `DispatchOutcome` / `DispatchPhase`
-- [ ] `AgentRunDispatcher` 实现按新签名返回 `Accepted{commandId, runActorId, acceptedAtMs}` / `RejectedStale` / `RejectedDuplicate`
+- [x] `IChannelLlmReplyRunDispatcher.DispatchAsync` 返回 plain `Task`；删除 `DispatchOutcome` / `DispatchPhase`
+- [x] `AgentRunDispatcher` 仅创建 run actor 并通过 `IActorDispatchPort.DispatchAsync` handoff；不做 dispatcher-local stale / duplicate admission
 - [ ] `AgentRunGAgent`：
   - [ ] 新增 `IsTerminal()` helper
   - [ ] 替换 cs:114-124 隐式终态判定
@@ -240,7 +240,8 @@ internal static bool IsTerminal(AgentRunState s) =>
   - [ ] 实现 Usage 重排（early-usage buffer + merge to last chunk）
   - [ ] 保证 stream-local 唯一 `IsLast = true` chunk
 - [ ] 测试：
-  - [ ] `DispatchOutcome` 三态各 1 测试
+  - [x] dispatcher handoff 测试：typed `run_id` 派生 actor id / envelope id / dedup operation id
+  - [x] duplicate / stale admission 测试落在 `AgentRunGAgent`
   - [ ] AgentRunGAgent terminal short-circuit 五类 late signal 各 1 测试
   - [ ] `ConversationGAgent` 失败 delivery 路径测试（lark 4xx / 5xx）
   - [ ] `ChatRuntime` Usage 重排测试（provider 中段发 Usage）
@@ -250,7 +251,7 @@ internal static bool IsTerminal(AgentRunState s) =>
 
 下列模式视为契约违反，应在 review 时拒收：
 
-- 调用方依赖 `DispatchAsync` 返回 `Task`（无 `DispatchOutcome`）做后续推进决定
+- 调用方依赖 `DispatchAsync` 正常返回推断 run admitted / committed / delivered
 - 任何 handler 内通过 `_pendingRuns.ContainsKey(runId)` 或类似进程内字典判断 stale
 - 在 `ConversationGAgent` 内直接调用 lark API 但不 raise delivery event
 - `AgentRunGAgent` 在 `Status == DROPPED` 后仍执行 `ScheduleTerminalCleanupAsync` 内部副作用

--- a/docs/canon/lark-reply-completion-semantics.md
+++ b/docs/canon/lark-reply-completion-semantics.md
@@ -6,7 +6,7 @@ owner: eanzhao
 
 # Lark Reply Chain Completion Semantics
 
-ADR-0021 决策的工程参考。本文档面向实现者，给出每个阶段的可观察 state、事件时序、故障矩阵、状态机图与实现 checklist。决策依据见 [`docs/adr/0021-lark-reply-chain-completion-semantics.md`](../adr/0021-lark-reply-chain-completion-semantics.md)。
+ADR-0021 决策的工程参考。本文档面向实现者，给出每个阶段的可观察 state、事件时序、故障矩阵、状态机图与实现 checklist。基础决策见 [`docs/adr/0021-lark-reply-chain-completion-semantics.md`](../adr/0021-lark-reply-chain-completion-semantics.md)；dispatcher plain `Task` handoff 修订见 [`docs/adr/0027-lark-reply-run-dispatcher-plain-task-handoff.md`](../adr/0027-lark-reply-run-dispatcher-plain-task-handoff.md)。
 
 ## 1. 链路与四阶段定位
 
@@ -261,6 +261,7 @@ internal static bool IsTerminal(AgentRunState s) =>
 ## 12. 参考
 
 - ADR-0021 [`docs/adr/0021-lark-reply-chain-completion-semantics.md`](../adr/0021-lark-reply-chain-completion-semantics.md)
+- ADR-0027 [`docs/adr/0027-lark-reply-run-dispatcher-plain-task-handoff.md`](../adr/0027-lark-reply-run-dispatcher-plain-task-handoff.md)
 - Issue #647 / #648 / #649
 - 关联 ADR-0009 channel-bot-callback-architecture（callback 流上下游）
 - 关联 ADR-0014 interactive-reply-abstraction

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Actors/OrleansActorDispatchPort.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Actors/OrleansActorDispatchPort.cs
@@ -7,10 +7,14 @@ namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Actors;
 public sealed class OrleansActorDispatchPort : IActorDispatchPort
 {
     private readonly IGrainFactory _grainFactory;
+    private readonly Aevatar.Foundation.Abstractions.IStreamProvider _streams;
 
-    public OrleansActorDispatchPort(IGrainFactory grainFactory)
+    public OrleansActorDispatchPort(
+        IGrainFactory grainFactory,
+        Aevatar.Foundation.Abstractions.IStreamProvider streams)
     {
         _grainFactory = grainFactory ?? throw new ArgumentNullException(nameof(grainFactory));
+        _streams = streams ?? throw new ArgumentNullException(nameof(streams));
     }
 
     public async Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
@@ -23,8 +27,6 @@ public sealed class OrleansActorDispatchPort : IActorDispatchPort
         if (!await grain.IsInitializedAsync())
             throw new InvalidOperationException($"Actor {actorId} is not initialized.");
 
-        var dispatchEnvelope = envelope.Clone();
-        dispatchEnvelope.EnsureRuntime().EnsureDispatch().PropagateFailure = true;
-        await grain.HandleEnvelopeAsync(dispatchEnvelope.ToByteArray());
+        await _streams.GetStream(actorId).ProduceAsync(envelope.Clone(), ct);
     }
 }

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorTransportDispatchTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorTransportDispatchTests.cs
@@ -5,11 +5,52 @@ using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using System.Reflection;
 
 namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 
 public sealed class OrleansActorTransportDispatchTests
 {
+    [Fact]
+    public async Task DispatchPortAsync_ShouldHandoffViaStreamProvider()
+    {
+        var grain = new RecordingRuntimeActorGrain();
+        var streams = new RecordingStreamProvider();
+        var grainFactory = DispatchProxy.Create<IGrainFactory, SingleRuntimeActorGrainFactory>();
+        ((SingleRuntimeActorGrainFactory)(object)grainFactory).Grain = grain;
+        var dispatchPort = new OrleansActorDispatchPort(
+            grainFactory,
+            streams);
+        var envelope = new EventEnvelope { Payload = Any.Pack(new StringValue { Value = "payload" }) };
+
+        await dispatchPort.DispatchAsync("actor-0", envelope, CancellationToken.None);
+
+        streams.GetProduced("actor-0").Should().ContainSingle();
+        streams.GetProduced("actor-0")[0].Payload!.Unpack<StringValue>().Value.Should().Be("payload");
+        grain.DispatchCount.Should().Be(0);
+        grain.IsInitializedCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DispatchPortAsync_WhenActorIsNotInitialized_ShouldThrowBeforeHandoff()
+    {
+        var grain = new RecordingRuntimeActorGrain { Initialized = false };
+        var streams = new RecordingStreamProvider();
+        var grainFactory = DispatchProxy.Create<IGrainFactory, SingleRuntimeActorGrainFactory>();
+        ((SingleRuntimeActorGrainFactory)(object)grainFactory).Grain = grain;
+        var dispatchPort = new OrleansActorDispatchPort(
+            grainFactory,
+            streams);
+        var envelope = new EventEnvelope { Payload = Any.Pack(new StringValue { Value = "payload" }) };
+
+        var act = () => dispatchPort.DispatchAsync("actor-0", envelope, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Actor actor-0 is not initialized.");
+        streams.GetProduced("actor-0").Should().BeEmpty();
+        grain.DispatchCount.Should().Be(0);
+    }
+
     [Fact]
     public async Task HandleEventAsync_ShouldDispatchViaStreamProvider()
     {
@@ -43,12 +84,18 @@ public sealed class OrleansActorTransportDispatchTests
     private sealed class RecordingRuntimeActorGrain : IRuntimeActorGrain
     {
         public int DispatchCount { get; private set; }
+        public int IsInitializedCallCount { get; private set; }
+        public bool Initialized { get; init; } = true;
 
         public Task<bool> InitializeAgentAsync(string agentTypeName) => Task.FromResult(true);
 
         public Task<bool> InitializeAgentByKindAsync(string kind) => Task.FromResult(true);
 
-        public Task<bool> IsInitializedAsync() => Task.FromResult(true);
+        public Task<bool> IsInitializedAsync()
+        {
+            IsInitializedCallCount++;
+            return Task.FromResult(Initialized);
+        }
 
         public Task HandleEnvelopeAsync(byte[] envelopeBytes)
         {
@@ -78,6 +125,28 @@ public sealed class OrleansActorTransportDispatchTests
         public Task DeactivateAsync() => Task.CompletedTask;
 
         public Task PurgeAsync() => Task.CompletedTask;
+    }
+
+    private class SingleRuntimeActorGrainFactory : DispatchProxy
+    {
+        public IRuntimeActorGrain? Grain { get; set; }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod?.Name == "GetGrain" &&
+                targetMethod.IsGenericMethod &&
+                targetMethod.GetGenericArguments().Length == 1 &&
+                targetMethod.GetGenericArguments()[0] == typeof(IRuntimeActorGrain) &&
+                args is { Length: > 0 } &&
+                args[0] is string actorId &&
+                Grain != null)
+            {
+                actorId.Should().Be("actor-0");
+                return Grain;
+            }
+
+            throw new NotSupportedException($"Unexpected grain factory call: {targetMethod?.Name}");
+        }
     }
 
     private sealed class RecordingStreamProvider : IStreamProvider

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorTransportDispatchTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansActorTransportDispatchTests.cs
@@ -12,6 +12,17 @@ namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 public sealed class OrleansActorTransportDispatchTests
 {
     [Fact]
+    public void Constructor_WhenStreamProviderIsNull_ShouldThrowArgumentNullException()
+    {
+        var grainFactory = DispatchProxy.Create<IGrainFactory, SingleRuntimeActorGrainFactory>();
+
+        var act = () => new OrleansActorDispatchPort(grainFactory, null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("streams");
+    }
+
+    [Fact]
     public async Task DispatchPortAsync_ShouldHandoffViaStreamProvider()
     {
         var grain = new RecordingRuntimeActorGrain();

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDirectDispatchFailurePropagationTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDirectDispatchFailurePropagationTests.cs
@@ -19,12 +19,13 @@ namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 public sealed class OrleansDirectDispatchFailurePropagationTests
 {
     [Fact]
-    public async Task DispatchAsync_ShouldThrow_WhenRuntimeRetryIsDisabled()
+    public async Task DispatchAsync_ShouldReturn_WhenRuntimeRetryIsDisabledAndHandlerFails()
     {
         RetryAwareDirectDispatchAgent.Reset();
         var actorId = $"actor-{Guid.NewGuid():N}";
         var siloPort = ReserveTcpPort();
         var gatewayPort = ReserveTcpPort();
+        var logProbe = new RuntimeRetryLogProbe();
 
         using var envScope = new EnvironmentVariableScope(new Dictionary<string, string?>
         {
@@ -34,7 +35,7 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             ["AEVATAR_TEST_FAIL_EVENT_TYPE_URLS"] = string.Empty,
         });
 
-        var host = await StartSiloHostAsync(siloPort, gatewayPort);
+        var host = await StartSiloHostAsync(siloPort, gatewayPort, logProbe);
 
         try
         {
@@ -43,10 +44,9 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             var dispatchPort = host.Services.GetRequiredService<IActorDispatchPort>();
             var envelope = CreateEnvelope("always-fail-no-retry");
 
-            Func<Task> act = () => dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
-
-            var failure = await act.Should().ThrowAsync<Exception>();
-            failure.Which.ToString().Should().Contain("always-fail-no-retry");
+            await dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
+            await RetryAwareDirectDispatchAgent.WaitForAttemptAsync(envelope.Id, TimeSpan.FromSeconds(20));
+            await logProbe.WaitForRuntimeHandlingFailureAsync(TimeSpan.FromSeconds(20));
             RetryAwareDirectDispatchAgent.GetAttemptCount(envelope.Id).Should().Be(1);
         }
         finally
@@ -57,12 +57,13 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldThrow_WhenRuntimeRetryIsAlreadyExhausted()
+    public async Task DispatchAsync_ShouldReturn_WhenRuntimeRetryIsAlreadyExhaustedAndHandlerFails()
     {
         RetryAwareDirectDispatchAgent.Reset();
         var actorId = $"actor-{Guid.NewGuid():N}";
         var siloPort = ReserveTcpPort();
         var gatewayPort = ReserveTcpPort();
+        var logProbe = new RuntimeRetryLogProbe();
 
         using var envScope = new EnvironmentVariableScope(new Dictionary<string, string?>
         {
@@ -72,7 +73,7 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             ["AEVATAR_TEST_FAIL_EVENT_TYPE_URLS"] = string.Empty,
         });
 
-        var host = await StartSiloHostAsync(siloPort, gatewayPort);
+        var host = await StartSiloHostAsync(siloPort, gatewayPort, logProbe);
 
         try
         {
@@ -88,10 +89,9 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
                 },
             };
 
-            Func<Task> act = () => dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
-
-            var failure = await act.Should().ThrowAsync<Exception>();
-            failure.Which.ToString().Should().Contain("always-fail-retry-exhausted");
+            await dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
+            await RetryAwareDirectDispatchAgent.WaitForAttemptAsync(envelope.Id, TimeSpan.FromSeconds(20));
+            await logProbe.WaitForRuntimeHandlingFailureAsync(TimeSpan.FromSeconds(20));
             RetryAwareDirectDispatchAgent.GetAttemptCount(envelope.Id).Should().Be(1);
         }
         finally
@@ -214,6 +214,8 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
     {
         private readonly TaskCompletionSource<bool> _runtimeRetryScheduledDetected =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<bool> _runtimeHandlingFailureDetected =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public ILogger CreateLogger(string categoryName)
         {
@@ -245,6 +247,8 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             var message = formatter(state, exception);
             if (message.Contains("Runtime envelope retry scheduled", StringComparison.Ordinal))
                 _runtimeRetryScheduledDetected.TrySetResult(true);
+            if (message.Contains("Runtime envelope handling failed after retry exhausted", StringComparison.Ordinal))
+                _runtimeHandlingFailureDetected.TrySetResult(true);
         }
 
         public async Task WaitForRuntimeRetryScheduledAsync(TimeSpan timeout)
@@ -257,6 +261,19 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             {
                 throw new TimeoutException(
                     $"Timed out after {timeout} waiting for runtime retry scheduling to be logged.");
+            }
+        }
+
+        public async Task WaitForRuntimeHandlingFailureAsync(TimeSpan timeout)
+        {
+            try
+            {
+                await _runtimeHandlingFailureDetected.Task.WaitAsync(timeout);
+            }
+            catch (TimeoutException)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {timeout} waiting for runtime handling failure to be logged.");
             }
         }
 
@@ -274,6 +291,8 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
     {
         private static readonly Lock SyncLock = new();
         private static readonly Dictionary<string, int> AttemptsByEnvelopeId = new(StringComparer.Ordinal);
+        private static readonly Dictionary<string, TaskCompletionSource<int>> AttemptSourcesByEnvelopeId =
+            new(StringComparer.Ordinal);
         private static TaskCompletionSource<EventEnvelope> _successfulEnvelopeSource = CreateSuccessSource();
 
         public static void Reset()
@@ -281,6 +300,7 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             lock (SyncLock)
             {
                 AttemptsByEnvelopeId.Clear();
+                AttemptSourcesByEnvelopeId.Clear();
                 _successfulEnvelopeSource = CreateSuccessSource();
             }
         }
@@ -305,6 +325,19 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             {
                 throw new TimeoutException(
                     $"Timed out after {timeout} waiting for successful direct-dispatch retry of '{envelopeId}'.");
+            }
+        }
+
+        public static async Task<int> WaitForAttemptAsync(string envelopeId, TimeSpan timeout)
+        {
+            try
+            {
+                return await GetAttemptSource(envelopeId).Task.WaitAsync(timeout);
+            }
+            catch (TimeoutException)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {timeout} waiting for direct-dispatch attempt of '{envelopeId}'.");
             }
         }
 
@@ -356,8 +389,33 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
         {
             lock (SyncLock)
             {
-                AttemptsByEnvelopeId[envelopeId] = AttemptsByEnvelopeId.GetValueOrDefault(envelopeId, 0) + 1;
+                var attempt = AttemptsByEnvelopeId.GetValueOrDefault(envelopeId, 0) + 1;
+                AttemptsByEnvelopeId[envelopeId] = attempt;
+                GetAttemptSourceUnderLock(envelopeId).TrySetResult(attempt);
             }
+        }
+
+        private static TaskCompletionSource<int> GetAttemptSource(string envelopeId)
+        {
+            lock (SyncLock)
+            {
+                var existingAttempt = AttemptsByEnvelopeId.GetValueOrDefault(envelopeId, 0);
+                var source = GetAttemptSourceUnderLock(envelopeId);
+                if (existingAttempt > 0)
+                    source.TrySetResult(existingAttempt);
+                return source;
+            }
+        }
+
+        private static TaskCompletionSource<int> GetAttemptSourceUnderLock(string envelopeId)
+        {
+            if (!AttemptSourcesByEnvelopeId.TryGetValue(envelopeId, out var source))
+            {
+                source = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                AttemptSourcesByEnvelopeId[envelopeId] = source;
+            }
+
+            return source;
         }
     }
 }

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -373,6 +373,7 @@ public sealed class ConversationGAgentDedupTests
         events[0].EventType.ShouldContain(nameof(NeedsLlmReplyEvent));
         var parsed = NeedsLlmReplyEvent.Parser.ParseFrom(events[0].EventData.Value);
         parsed.CorrelationId.ShouldBe("act-llm");
+        parsed.RunId.ShouldBe("act-llm");
         parsed.Activity.Id.ShouldBe("act-llm");
     }
 
@@ -887,6 +888,7 @@ public sealed class ConversationGAgentDedupTests
 
         dispatcher.Dispatched.Count.ShouldBe(1);
         dispatcher.Dispatched[0].CorrelationId.ShouldBe("act-direct");
+        dispatcher.Dispatched[0].RunId.ShouldBe("act-direct");
         dispatcher.Dispatched[0].TargetActorId.ShouldBe(agent.Id);
     }
 
@@ -958,6 +960,7 @@ public sealed class ConversationGAgentDedupTests
         });
 
         dispatcher.Dispatched.ShouldHaveSingleItem();
+        dispatcher.Dispatched[0].RunId.ShouldBe("corr-route");
         dispatcher.Dispatched[0].TargetRef.ForwardToGagent.ActorId.ShouldBe("target-gagent-1");
         dispatcher.Dispatched[0].ReplyToken.ShouldBe("runtime-only-token");
 
@@ -2206,14 +2209,10 @@ public sealed class ConversationGAgentDedupTests
     {
         public List<NeedsLlmReplyEvent> Dispatched { get; } = [];
 
-        public Task<DispatchOutcome> DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
+        public Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
         {
             Dispatched.Add(request.Clone());
-            return Task.FromResult(new DispatchOutcome(
-                Phase: DispatchPhase.Accepted,
-                CommandId: request.CorrelationId ?? string.Empty,
-                RunActorId: null,
-                AcceptedAtUnixMs: 0));
+            return Task.CompletedTask;
         }
     }
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -27,51 +27,50 @@ public sealed class AgentRunGAgentTests
     public async Task DispatchAsync_ShouldCreateRunActorAndDispatchStartCommand()
     {
         var actorRuntime = new DispatchingActorRuntime();
-        var streamProvider = new RecordingStreamProvider();
+        var dispatchPort = new RecordingActorDispatchPort();
         var dispatcher = new AgentRunDispatcher(
             actorRuntime,
-            streamProvider,
+            dispatchPort,
             NullLogger<AgentRunDispatcher>.Instance);
 
-        var outcome = await dispatcher.DispatchAsync(new NeedsLlmReplyEvent
+        await dispatcher.DispatchAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-dispatch",
+            RunId = "run-dispatch",
             TargetActorId = "conversation-actor",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
             ReplyToken = "relay-token-dispatch",
         }, CancellationToken.None);
 
-        outcome.Phase.Should().Be(DispatchPhase.Accepted);
-        outcome.CommandId.Should().Be("agent-run-start:corr-dispatch");
-        outcome.RunActorId.Should().Be(AgentRunGAgent.BuildActorId("corr-dispatch"));
-        outcome.AcceptedAtUnixMs.Should().BeGreaterThan(0);
-        streamProvider.Produced.Should().ContainSingle();
-        var (actorId, envelope) = streamProvider.Produced.Single();
-        actorId.Should().Be(AgentRunGAgent.BuildActorId("corr-dispatch"));
-        envelope.Id.Should().Be(outcome.CommandId);
-        envelope.Runtime.Deduplication.OperationId.Should().Be(outcome.CommandId);
+        dispatchPort.Dispatches.Should().ContainSingle();
+        var (actorId, envelope) = dispatchPort.Dispatches.Single();
+        actorId.Should().Be(AgentRunGAgent.BuildActorId("run-dispatch"));
+        envelope.Id.Should().Be("agent-run-start:run-dispatch");
+        envelope.Runtime.Deduplication.OperationId.Should().Be("agent-run-start:run-dispatch");
         envelope.Propagation.CorrelationId.Should().Be("corr-dispatch");
         var command = envelope.Payload.Unpack<AgentRunStartRequested>();
+        command.Request.RunId.Should().Be("run-dispatch");
         command.Request.CorrelationId.Should().Be("corr-dispatch");
         command.Request.TargetActorId.Should().Be("conversation-actor");
         command.Request.ReplyToken.Should().Be("relay-token-dispatch");
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldRejectDuplicate_WhenRunActorAlreadyExists()
+    public async Task DispatchAsync_ShouldAcceptDuplicateStarts_ForActorOwnedAdmission()
     {
         var actorRuntime = new DispatchingActorRuntime();
-        var streamProvider = new RecordingStreamProvider();
+        var dispatchPort = new RecordingActorDispatchPort();
         var now = new DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero);
         var dispatcher = new AgentRunDispatcher(
             actorRuntime,
-            streamProvider,
+            dispatchPort,
             NullLogger<AgentRunDispatcher>.Instance,
             new FakeTimeProvider(now));
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-duplicate-dispatch",
+            RunId = "run-duplicate-dispatch",
             TargetActorId = "conversation-actor",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
@@ -79,36 +78,33 @@ public sealed class AgentRunGAgentTests
             RequestedAtUnixMs = now.ToUnixTimeMilliseconds(),
         };
 
-        var outcomes = await Task.WhenAll(
+        await Task.WhenAll(
             dispatcher.DispatchAsync(request, CancellationToken.None),
             dispatcher.DispatchAsync(request.Clone(), CancellationToken.None));
 
-        outcomes.Should().ContainSingle(outcome => outcome.Phase == DispatchPhase.Accepted);
-        var duplicate = outcomes.Should()
-            .ContainSingle(outcome => outcome.Phase == DispatchPhase.RejectedDuplicate)
-            .Subject;
-        duplicate.Phase.Should().Be(DispatchPhase.RejectedDuplicate);
-        duplicate.CommandId.Should().BeEmpty();
-        duplicate.RunActorId.Should().Be(AgentRunGAgent.BuildActorId("corr-duplicate-dispatch"));
-        duplicate.AcceptedAtUnixMs.Should().Be(0);
-        streamProvider.Produced.Should().ContainSingle(
-            "duplicate suppression happens at the dispatcher boundary before enqueueing another start command");
+        dispatchPort.Dispatches.Should().HaveCount(2);
+        dispatchPort.Dispatches.Select(x => x.ActorId)
+            .Should().OnlyContain(id => id == AgentRunGAgent.BuildActorId("run-duplicate-dispatch"));
+        dispatchPort.Dispatches.Select(x => x.Envelope.Id)
+            .Should().OnlyContain(id => id == "agent-run-start:run-duplicate-dispatch");
+        actorRuntime.DestroyedIds.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task DispatchAsync_WhenEnqueueFails_ShouldDestroyCreatedActorSoRetryCanDispatch()
+    public async Task DispatchAsync_WhenDispatchPortFails_ShouldPropagateWithoutDestroyCompensation()
     {
         var actorRuntime = new DispatchingActorRuntime();
-        var streamProvider = new FailingOnceStreamProvider();
+        var dispatchPort = new ThrowingActorDispatchPort();
         var now = new DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero);
         var dispatcher = new AgentRunDispatcher(
             actorRuntime,
-            streamProvider,
+            dispatchPort,
             NullLogger<AgentRunDispatcher>.Instance,
             new FakeTimeProvider(now));
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-retry-after-enqueue-failure",
+            RunId = "run-retry-after-enqueue-failure",
             TargetActorId = "conversation-actor",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
@@ -120,30 +116,26 @@ public sealed class AgentRunGAgentTests
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("simulated enqueue failure");
-        actorRuntime.DestroyedIds.Should()
-            .ContainSingle(id => id == AgentRunGAgent.BuildActorId("corr-retry-after-enqueue-failure"));
-
-        var retry = await dispatcher.DispatchAsync(request.Clone(), CancellationToken.None);
-
-        retry.Phase.Should().Be(DispatchPhase.Accepted);
-        streamProvider.Produced.Should().ContainSingle();
+        actorRuntime.DestroyedIds.Should().BeEmpty();
+        dispatchPort.Dispatches.Should().ContainSingle();
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldRejectStaleWithoutCreatingRunActor()
+    public async Task DispatchAsync_ShouldHandStaleRequestToRunActorAdmission()
     {
         var actorRuntime = new DispatchingActorRuntime();
-        var streamProvider = new RecordingStreamProvider();
+        var dispatchPort = new RecordingActorDispatchPort();
         var now = new DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero);
         var dispatcher = new AgentRunDispatcher(
             actorRuntime,
-            streamProvider,
+            dispatchPort,
             NullLogger<AgentRunDispatcher>.Instance,
             new FakeTimeProvider(now));
 
-        var outcome = await dispatcher.DispatchAsync(new NeedsLlmReplyEvent
+        await dispatcher.DispatchAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-stale-dispatch",
+            RunId = "run-stale-dispatch",
             TargetActorId = "conversation-actor",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
@@ -153,12 +145,9 @@ public sealed class AgentRunGAgentTests
                 .ToUnixTimeMilliseconds(),
         }, CancellationToken.None);
 
-        outcome.Phase.Should().Be(DispatchPhase.RejectedStale);
-        outcome.CommandId.Should().BeEmpty();
-        outcome.RunActorId.Should().BeNull();
-        outcome.AcceptedAtUnixMs.Should().Be(0);
-        streamProvider.Produced.Should().BeEmpty();
-        (await actorRuntime.ExistsAsync(AgentRunGAgent.BuildActorId("corr-stale-dispatch"))).Should().BeFalse();
+        dispatchPort.Dispatches.Should().ContainSingle();
+        dispatchPort.Dispatches.Single().ActorId.Should().Be(AgentRunGAgent.BuildActorId("run-stale-dispatch"));
+        (await actorRuntime.ExistsAsync(AgentRunGAgent.BuildActorId("run-stale-dispatch"))).Should().BeTrue();
     }
 
     [Fact]
@@ -534,6 +523,7 @@ public sealed class AgentRunGAgentTests
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-duplicate",
+            RunId = "run-duplicate",
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
@@ -547,6 +537,7 @@ public sealed class AgentRunGAgentTests
         // REPLY_HANDED_OFF (ADR-0021). The duplicate start must short-circuit on
         // terminal-status check and NOT re-run the LLM or re-dispatch.
         runtime.State.Status.Should().Be(AgentRunStatus.ReplyHandedOff);
+        runtime.State.RunId.Should().Be("run-duplicate");
         replyGenerator.CallCount.Should().Be(1);
         handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
     }
@@ -1426,6 +1417,7 @@ public sealed class AgentRunGAgentTests
         await runtime.HandleStartAsync(new NeedsLlmReplyEvent
         {
             CorrelationId = "corr-stale",
+            RunId = "run-stale",
             TargetActorId = "actor-1",
             RegistrationId = "reg-1",
             Activity = BuildRelayActivity(),
@@ -1434,6 +1426,7 @@ public sealed class AgentRunGAgentTests
         });
 
         replyGenerator.CaptureSucceeded.Should().BeFalse();
+        runtime.State.RunId.Should().Be("run-stale");
         handled.Should().NotBeNull();
         var dropped = handled!.Payload.Unpack<DeferredLlmReplyDroppedEvent>();
         dropped.CorrelationId.Should().Be("corr-stale");
@@ -2022,6 +2015,28 @@ public sealed class AgentRunGAgentTests
         }
     }
 
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Dispatches.Add((actorId, envelope));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ThrowingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Dispatches { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Dispatches.Add((actorId, envelope));
+            throw new InvalidOperationException("simulated enqueue failure");
+        }
+    }
+
     private sealed class FailingOnceGetActorRuntime(params (string Id, IActor Actor)[] actors) : IActorRuntime
     {
         private readonly DispatchingActorRuntime _inner = new(actors);
@@ -2228,98 +2243,6 @@ public sealed class AgentRunGAgentTests
                 },
             }, c);
         }
-    }
-
-    private sealed class RecordingStreamProvider : IStreamProvider
-    {
-        private readonly Dictionary<string, RecordingStream> _streams = new(StringComparer.Ordinal);
-
-        public List<(string StreamId, EventEnvelope Envelope)> Produced =>
-            _streams.Values.SelectMany(stream => stream.Produced.Select(envelope => (stream.StreamId, envelope))).ToList();
-
-        public IStream GetStream(string actorId)
-        {
-            if (!_streams.TryGetValue(actorId, out var stream))
-            {
-                stream = new RecordingStream(actorId);
-                _streams[actorId] = stream;
-            }
-
-            return stream;
-        }
-    }
-
-    private sealed class RecordingStream(string streamId) : IStream
-    {
-        public string StreamId { get; } = streamId;
-
-        public List<EventEnvelope> Produced { get; } = [];
-
-        public Task ProduceAsync<T>(T message, CancellationToken ct = default) where T : IMessage
-        {
-            if (message is EventEnvelope envelope)
-                Produced.Add(envelope.Clone());
-            return Task.CompletedTask;
-        }
-
-        public Task<IAsyncDisposable> SubscribeAsync<T>(Func<T, Task> handler, CancellationToken ct = default)
-            where T : IMessage, new() =>
-            Task.FromResult<IAsyncDisposable>(new NoopAsyncDisposable());
-
-        public Task UpsertRelayAsync(StreamForwardingBinding binding, CancellationToken ct = default) =>
-            Task.CompletedTask;
-
-        public Task RemoveRelayAsync(string targetStreamId, CancellationToken ct = default) =>
-            Task.CompletedTask;
-
-        public Task<IReadOnlyList<StreamForwardingBinding>> ListRelaysAsync(CancellationToken ct = default) =>
-            Task.FromResult<IReadOnlyList<StreamForwardingBinding>>([]);
-    }
-
-    private sealed class FailingOnceStreamProvider : IStreamProvider
-    {
-        private readonly RecordingStreamProvider _inner = new();
-        private bool _failNextProduce = true;
-
-        public List<(string StreamId, EventEnvelope Envelope)> Produced => _inner.Produced;
-
-        public IStream GetStream(string actorId) =>
-            new FailingOnceStream(_inner.GetStream(actorId), this);
-
-        private sealed class FailingOnceStream(IStream inner, FailingOnceStreamProvider owner) : IStream
-        {
-            public string StreamId => inner.StreamId;
-
-            public async Task ProduceAsync<T>(T message, CancellationToken ct = default)
-                where T : IMessage
-            {
-                if (owner._failNextProduce)
-                {
-                    owner._failNextProduce = false;
-                    throw new InvalidOperationException("simulated enqueue failure");
-                }
-
-                await inner.ProduceAsync(message, ct);
-            }
-
-            public Task<IAsyncDisposable> SubscribeAsync<T>(Func<T, Task> handler, CancellationToken ct = default)
-                where T : IMessage, new() =>
-                inner.SubscribeAsync(handler, ct);
-
-            public Task UpsertRelayAsync(StreamForwardingBinding binding, CancellationToken ct = default) =>
-                inner.UpsertRelayAsync(binding, ct);
-
-            public Task RemoveRelayAsync(string targetStreamId, CancellationToken ct = default) =>
-                inner.RemoveRelayAsync(targetStreamId, ct);
-
-            public Task<IReadOnlyList<StreamForwardingBinding>> ListRelaysAsync(CancellationToken ct = default) =>
-                inner.ListRelaysAsync(ct);
-        }
-    }
-
-    private sealed class NoopAsyncDisposable : IAsyncDisposable
-    {
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class RecordingReplyGenerator(Func<bool> captureAction) : IConversationReplyGenerator


### PR DESCRIPTION
## 摘要

iter56 cluster-935 — Phase 9 r5 unanimous(5 rounds + 1 reflector retry-fix narrowing,3/3 plain Task):

- 删 dispatcher in-process admission(违反"中间层状态约束")
- **AgentRunGAgent**(actor)承担 run admission:typed run_id + duplicate detection + stale rejection
- **IActorDispatchPort 用 plain Task DispatchAsync**(无 receipt,CommandId/RunActorId 由 typed run_id 派生)
- 删 `DispatchOutcome` / `DispatchPhase` / dispatcher stale precheck
- ConversationGAgent 保 rehydration stale cleanup
- 不加新 actor type / envelope kind / Projection phase

## 边界

- ACK 诚实:dispatcher 仅 handoff,无 receipt
- 中间层无 admission 状态(per CLAUDE)
- 不依赖外部仓库

## 影响范围

9 files changed,LOC **+153 / -342** net **-189**

## Coverage

- AgentRunDispatcher 90% line
- AgentRunGAgent 93.2% line

## 验证

- `dotnet build aevatar.slnx --nologo` PASS
- `dotnet test aevatar.slnx --nologo --no-build` PASS
- `bash tools/ci/test_stability_guards.sh` PASS
- `bash tools/ci/architecture_guards.sh` PASS
- `bash tools/docs/lint.sh` PASS

Closes #935

🤖 Auto-loop / codex-refactor-loop iter56

⟦AI:AUTO-LOOP⟧
