### PR TITLE
iter57 cluster-065: Lark CardKit Task.Run signal-only + actor-side rich continuation (#939)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -295,6 +295,13 @@ public sealed partial class ConversationGAgent
         long generation) =>
         $"conversation-lark-card:{correlationId}:{operation}:{generation}";
 
+    private static string BuildLarkCardOperationId(
+        string correlationId,
+        LarkCardOperationPhase operation,
+        long sequence,
+        long generation) =>
+        $"{correlationId}:{operation}:{sequence}:{generation}";
+
     private static EventEnvelope CreateLarkCardContinuationEnvelope(string actorId, IMessage evt, string correlationId) =>
         new()
         {
@@ -383,7 +390,7 @@ public sealed partial class ConversationGAgent
         long generation,
         ConversationTurnRuntimeContext runtimeContext)
     {
-        LarkCardCreateContinuationEvent continuation;
+        LarkCardOperationCompletedEvent signal;
         try
         {
             var result = await runner.RunCardCreateAsync(
@@ -392,25 +399,37 @@ public sealed partial class ConversationGAgent
                     runtimeContext,
                     CancellationToken.None)
                 .ConfigureAwait(false);
-            continuation = ToCreateContinuation(correlationId, sequence, generation, chunk, result);
+            signal = new LarkCardOperationCompletedEvent
+            {
+                OperationId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Create, sequence, generation),
+                CorrelationId = correlationId,
+                Operation = LarkCardOperationPhase.Create,
+                Sequence = sequence,
+                OperationGeneration = generation,
+                State = result.Success
+                    ? LarkCardOperationResultState.Succeeded
+                    : LarkCardOperationResultState.Failed,
+                RawResult = ToRawResult(result),
+                Chunk = chunk,
+            };
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Card create executor threw. correlation={CorrelationId}", correlationId);
-            continuation = new LarkCardCreateContinuationEvent
+            signal = new LarkCardOperationCompletedEvent
             {
+                OperationId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Create, sequence, generation),
                 CorrelationId = correlationId,
+                Operation = LarkCardOperationPhase.Create,
                 Sequence = sequence,
                 OperationGeneration = generation,
+                State = LarkCardOperationResultState.Faulted,
+                RawResult = ToRawFault(ex),
                 Chunk = chunk,
-                Success = false,
-                ErrorCode = $"create_threw:{ex.GetType().Name}",
-                ErrorSummary = ex.Message,
-                CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             };
         }
 
-        await DispatchLarkCardContinuationAsync(continuation, correlationId, CancellationToken.None)
+        await DispatchLarkCardContinuationAsync(signal, correlationId, CancellationToken.None)
             .ConfigureAwait(false);
     }
 
@@ -444,7 +463,7 @@ public sealed partial class ConversationGAgent
         long generation,
         ConversationTurnRuntimeContext runtimeContext)
     {
-        LarkCardStreamContinuationEvent continuation;
+        LarkCardOperationCompletedEvent signal;
         try
         {
             var result = await runner.RunCardStreamAsync(
@@ -455,27 +474,41 @@ public sealed partial class ConversationGAgent
                     runtimeContext,
                     CancellationToken.None)
                 .ConfigureAwait(false);
-            continuation = ToStreamContinuation(correlationId, sequence, generation, cardId, streamingElementId, chunk, result);
+            signal = new LarkCardOperationCompletedEvent
+            {
+                OperationId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Stream, sequence, generation),
+                CorrelationId = correlationId,
+                Operation = LarkCardOperationPhase.Stream,
+                Sequence = sequence,
+                OperationGeneration = generation,
+                State = result.Success
+                    ? LarkCardOperationResultState.Succeeded
+                    : LarkCardOperationResultState.Failed,
+                RawResult = ToRawResult(result),
+                CardId = cardId,
+                StreamingElementId = streamingElementId,
+                Chunk = chunk,
+            };
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Card stream executor threw. correlation={CorrelationId}, seq={Sequence}", correlationId, sequence);
-            continuation = new LarkCardStreamContinuationEvent
+            signal = new LarkCardOperationCompletedEvent
             {
+                OperationId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Stream, sequence, generation),
                 CorrelationId = correlationId,
+                Operation = LarkCardOperationPhase.Stream,
                 Sequence = sequence,
                 OperationGeneration = generation,
+                State = LarkCardOperationResultState.Faulted,
+                RawResult = ToRawFault(ex),
                 CardId = cardId,
                 StreamingElementId = streamingElementId,
                 Chunk = chunk,
-                Success = false,
-                ErrorCode = $"stream_threw:{ex.GetType().Name}",
-                ErrorSummary = ex.Message,
-                CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             };
         }
 
-        await DispatchLarkCardContinuationAsync(continuation, correlationId, CancellationToken.None)
+        await DispatchLarkCardContinuationAsync(signal, correlationId, CancellationToken.None)
             .ConfigureAwait(false);
     }
 
@@ -522,7 +555,7 @@ public sealed partial class ConversationGAgent
         long generation,
         ConversationTurnRuntimeContext runtimeContext)
     {
-        LarkCardFinalizeContinuationEvent continuation;
+        LarkCardOperationCompletedEvent signal;
         try
         {
             var result = await runner.RunCardFinalizeAsync(
@@ -535,120 +568,86 @@ public sealed partial class ConversationGAgent
                     runtimeContext,
                     CancellationToken.None)
                 .ConfigureAwait(false);
-            continuation = ToFinalizeContinuation(
-                correlationId,
-                sequence,
-                generation,
-                cardId,
-                cardMessageId,
-                commandId,
-                activityForToken,
-                finalText,
-                lastFlushedText,
-                result);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Card finalize executor threw. correlation={CorrelationId}", correlationId);
-            continuation = new LarkCardFinalizeContinuationEvent
+            signal = new LarkCardOperationCompletedEvent
             {
+                OperationId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Finalize, sequence, generation),
                 CorrelationId = correlationId,
+                Operation = LarkCardOperationPhase.Finalize,
                 Sequence = sequence,
                 OperationGeneration = generation,
+                State = result.Success
+                    ? LarkCardOperationResultState.Succeeded
+                    : LarkCardOperationResultState.Failed,
+                RawResult = ToRawResult(result),
                 CardId = cardId,
                 CardMessageId = cardMessageId,
                 CommandId = commandId,
                 Activity = activityForToken,
                 FinalText = finalText,
                 LastFlushedText = lastFlushedText,
-                Success = false,
-                FinalTextWritten = false,
-                ErrorCode = $"finalize_threw:{ex.GetType().Name}",
-                ErrorSummary = ex.Message,
-                CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Card finalize executor threw. correlation={CorrelationId}", correlationId);
+            signal = new LarkCardOperationCompletedEvent
+            {
+                OperationId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Finalize, sequence, generation),
+                CorrelationId = correlationId,
+                Operation = LarkCardOperationPhase.Finalize,
+                Sequence = sequence,
+                OperationGeneration = generation,
+                State = LarkCardOperationResultState.Faulted,
+                RawResult = ToRawFault(ex),
+                CardId = cardId,
+                CardMessageId = cardMessageId,
+                CommandId = commandId,
+                Activity = activityForToken,
+                FinalText = finalText,
+                LastFlushedText = lastFlushedText,
             };
         }
 
-        await DispatchLarkCardContinuationAsync(continuation, correlationId, CancellationToken.None)
+        await DispatchLarkCardContinuationAsync(signal, correlationId, CancellationToken.None)
             .ConfigureAwait(false);
     }
 
-    private static LarkCardCreateContinuationEvent ToCreateContinuation(
-        string correlationId,
-        long sequence,
-        long generation,
-        LlmReplyCardStreamChunkEvent chunk,
-        ConversationCardCreateResult result) =>
+    private static LarkCardOperationRawResult ToRawResult(ConversationCardCreateResult result) =>
         new()
         {
-            CorrelationId = correlationId,
-            Sequence = sequence,
-            OperationGeneration = generation,
-            Chunk = chunk,
-            Success = result.Success,
             CardId = result.CardId ?? string.Empty,
             CardMessageId = result.CardMessageId ?? string.Empty,
             IsRateLimited = result.IsRateLimited,
             IsTableLimitExceeded = result.IsTableLimitExceeded,
             IsCardUnavailable = result.IsCardUnavailable,
             IsPostSendFailure = result.IsPostSendFailure,
-            ErrorCode = result.ErrorCode ?? string.Empty,
-            ErrorSummary = result.ErrorSummary ?? string.Empty,
-            CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            RawErrorCode = result.ErrorCode ?? string.Empty,
+            RawErrorSummary = result.ErrorSummary ?? string.Empty,
         };
 
-    private static LarkCardStreamContinuationEvent ToStreamContinuation(
-        string correlationId,
-        long sequence,
-        long generation,
-        string cardId,
-        string streamingElementId,
-        LlmReplyCardStreamChunkEvent chunk,
-        ConversationCardStreamResult result) =>
+    private static LarkCardOperationRawResult ToRawResult(ConversationCardStreamResult result) =>
         new()
         {
-            CorrelationId = correlationId,
-            Sequence = sequence,
-            OperationGeneration = generation,
-            CardId = cardId,
-            StreamingElementId = streamingElementId,
-            Chunk = chunk,
-            Success = result.Success,
             IsRateLimited = result.IsRateLimited,
             IsTableLimitExceeded = result.IsTableLimitExceeded,
             IsCardUnavailable = result.IsCardUnavailable,
-            ErrorCode = result.ErrorCode ?? string.Empty,
-            ErrorSummary = result.ErrorSummary ?? string.Empty,
-            CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            RawErrorCode = result.ErrorCode ?? string.Empty,
+            RawErrorSummary = result.ErrorSummary ?? string.Empty,
         };
 
-    private static LarkCardFinalizeContinuationEvent ToFinalizeContinuation(
-        string correlationId,
-        long sequence,
-        long generation,
-        string cardId,
-        string cardMessageId,
-        string commandId,
-        ChatActivity activity,
-        string finalText,
-        string lastFlushedText,
-        ConversationCardFinalizeResult result) =>
+    private static LarkCardOperationRawResult ToRawResult(ConversationCardFinalizeResult result) =>
         new()
         {
-            CorrelationId = correlationId,
-            Sequence = sequence,
-            OperationGeneration = generation,
-            CardId = cardId,
-            CardMessageId = cardMessageId,
-            CommandId = commandId,
-            Activity = activity,
-            FinalText = finalText,
-            LastFlushedText = lastFlushedText,
-            Success = result.Success,
             FinalTextWritten = result.FinalTextWritten,
-            ErrorCode = result.ErrorCode ?? string.Empty,
-            ErrorSummary = result.ErrorSummary ?? string.Empty,
-            CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            RawErrorCode = result.ErrorCode ?? string.Empty,
+            RawErrorSummary = result.ErrorSummary ?? string.Empty,
+        };
+
+    private static LarkCardOperationRawResult ToRawFault(Exception ex) =>
+        new()
+        {
+            ExceptionType = ex.GetType().Name,
+            ExceptionMessage = ex.Message,
         };
 
     private static bool MatchesLarkCardInFlight(
@@ -881,9 +880,30 @@ public sealed partial class ConversationGAgent
     }
 
     [EventHandler]
-    public async Task HandleLarkCardCreateContinuationAsync(LarkCardCreateContinuationEvent evt)
+    public async Task HandleLarkCardOperationCompletedAsync(LarkCardOperationCompletedEvent evt)
     {
         ArgumentNullException.ThrowIfNull(evt);
+        switch (evt.Operation)
+        {
+            case LarkCardOperationPhase.Create:
+                await HandleLarkCardCreateCompletionAsync(evt);
+                return;
+            case LarkCardOperationPhase.Stream:
+                await HandleLarkCardStreamCompletionAsync(evt);
+                return;
+            case LarkCardOperationPhase.Finalize:
+                await HandleLarkCardFinalizeCompletionAsync(evt);
+                return;
+            default:
+                Logger.LogDebug(
+                    "Ignoring Lark card operation signal with unspecified operation. operationId={OperationId}",
+                    evt.OperationId);
+                return;
+        }
+    }
+
+    private async Task HandleLarkCardCreateCompletionAsync(LarkCardOperationCompletedEvent evt)
+    {
         var correlationId = NormalizeOptional(evt.CorrelationId);
         if (correlationId is null)
             return;
@@ -892,25 +912,26 @@ public sealed partial class ConversationGAgent
         if (!MatchesLarkCardInFlight(state, LarkCardOperationPhase.Create, evt.Sequence, evt.OperationGeneration))
             return;
 
-        if (!evt.Success)
+        var result = ToCreateResult(evt);
+        if (!result.Success)
         {
-            if (evt.IsPostSendFailure)
+            if (result.IsPostSendFailure)
             {
                 Logger.LogWarning(
                     "Card post-send failure; terminating turn without text-edit fallback. correlation={CorrelationId}, code={ErrorCode}, cardId={CardId}",
                     evt.CorrelationId,
-                    evt.ErrorCode,
-                    evt.CardId);
+                    result.ErrorCode,
+                    result.CardId);
                 var terminated = await TransitionLarkCardStreamingPhaseAsync(
                     correlationId,
                     state,
                     LarkCardStreamingPhase.Terminated,
-                    terminalReason: $"create_post_send_failed:{evt.ErrorCode}",
+                    terminalReason: $"create_post_send_failed:{result.ErrorCode}",
                     fieldUpdate: s => s with
                     {
-                        CardId = NormalizeOptional(evt.CardId),
-                        CardMessageId = NormalizeOptional(evt.CardMessageId),
-                        OriginalCardId = NormalizeOptional(evt.CardId),
+                        CardId = NormalizeOptional(result.CardId),
+                        CardMessageId = NormalizeOptional(result.CardMessageId),
+                        OriginalCardId = NormalizeOptional(result.CardId),
                         InFlight = null,
                     });
                 await PersistCardStreamedCompletionAsync(
@@ -925,15 +946,15 @@ public sealed partial class ConversationGAgent
             Logger.LogInformation(
                 "Card create failed; falling back to text-edit for the rest of this turn. correlation={CorrelationId}, code={ErrorCode}, rateLimited={RateLimited}, tableLimit={TableLimit}, cardUnavailable={CardUnavailable}",
                 evt.CorrelationId,
-                evt.ErrorCode,
-                evt.IsRateLimited,
-                evt.IsTableLimitExceeded,
-                evt.IsCardUnavailable);
+                result.ErrorCode,
+                result.IsRateLimited,
+                result.IsTableLimitExceeded,
+                result.IsCardUnavailable);
             await TransitionLarkCardStreamingPhaseAsync(
                 correlationId,
                 state,
                 LarkCardStreamingPhase.CreationFailed,
-                terminalReason: $"create_failed:{evt.ErrorCode}",
+                terminalReason: $"create_failed:{result.ErrorCode}",
                 fieldUpdate: s => s with { InFlight = null });
             if (evt.Chunk is not null)
                 await HandleNyxRelayStreamingChunkCoreAsync(ToTextStreamChunk(evt.Chunk));
@@ -947,9 +968,9 @@ public sealed partial class ConversationGAgent
             LarkCardStreamingPhase.Streaming,
             fieldUpdate: s => s with
             {
-                CardId = NormalizeOptional(evt.CardId),
-                CardMessageId = NormalizeOptional(evt.CardMessageId),
-                OriginalCardId = NormalizeOptional(evt.CardId),
+                CardId = NormalizeOptional(result.CardId),
+                CardMessageId = NormalizeOptional(result.CardMessageId),
+                OriginalCardId = NormalizeOptional(result.CardId),
                 LastFlushedText = accumulatedText,
                 Sequence = evt.Sequence,
                 InFlight = null,
@@ -958,10 +979,8 @@ public sealed partial class ConversationGAgent
         await ContinueLarkCardCoalescedWorkAsync(correlationId, streaming, evt.Chunk);
     }
 
-    [EventHandler]
-    public async Task HandleLarkCardStreamContinuationAsync(LarkCardStreamContinuationEvent evt)
+    private async Task HandleLarkCardStreamCompletionAsync(LarkCardOperationCompletedEvent evt)
     {
-        ArgumentNullException.ThrowIfNull(evt);
         var correlationId = NormalizeOptional(evt.CorrelationId);
         if (correlationId is null)
             return;
@@ -975,9 +994,10 @@ public sealed partial class ConversationGAgent
                 evt.CardId))
             return;
 
-        if (!evt.Success)
+        var result = ToStreamResult(evt);
+        if (!result.Success)
         {
-            if (evt.IsRateLimited)
+            if (result.IsRateLimited)
             {
                 Logger.LogDebug(
                     "Card stream rate-limited; dropping frame. correlation={CorrelationId}, seq={Sequence}",
@@ -996,17 +1016,17 @@ public sealed partial class ConversationGAgent
                 return;
             }
 
-            if (evt.IsTableLimitExceeded || evt.IsCardUnavailable)
+            if (result.IsTableLimitExceeded || result.IsCardUnavailable)
             {
                 Logger.LogWarning(
                     "Card stream terminal failure; ending turn. correlation={CorrelationId}, code={ErrorCode}",
                     evt.CorrelationId,
-                    evt.ErrorCode);
+                    result.ErrorCode);
                 var terminated = await TransitionLarkCardStreamingPhaseAsync(
                     correlationId,
                     state,
                     LarkCardStreamingPhase.Terminated,
-                    terminalReason: $"stream_failed:{evt.ErrorCode}",
+                    terminalReason: $"stream_failed:{result.ErrorCode}",
                     fieldUpdate: s => s with { InFlight = null });
                 await PersistCardStreamedCompletionAsync(
                     correlationId,
@@ -1020,7 +1040,7 @@ public sealed partial class ConversationGAgent
             Logger.LogInformation(
                 "Card stream non-terminal failure; continuing. correlation={CorrelationId}, code={ErrorCode}",
                 evt.CorrelationId,
-                evt.ErrorCode);
+                result.ErrorCode);
             var continued = await TransitionLarkCardStreamingPhaseAsync(
                 correlationId,
                 state,
@@ -1052,10 +1072,8 @@ public sealed partial class ConversationGAgent
         await ContinueLarkCardCoalescedWorkAsync(correlationId, updated, evt.Chunk);
     }
 
-    [EventHandler]
-    public async Task HandleLarkCardFinalizeContinuationAsync(LarkCardFinalizeContinuationEvent evt)
+    private async Task HandleLarkCardFinalizeCompletionAsync(LarkCardOperationCompletedEvent evt)
     {
-        ArgumentNullException.ThrowIfNull(evt);
         var correlationId = NormalizeOptional(evt.CorrelationId);
         if (correlationId is null)
             return;
@@ -1069,10 +1087,11 @@ public sealed partial class ConversationGAgent
                 evt.CardId))
             return;
 
+        var result = ToFinalizeResult(evt);
         var finalText = state.PendingFinalizeText ?? evt.FinalText ?? string.Empty;
         var commandId = state.PendingFinalizeCommandId ?? evt.CommandId ?? BuildLlmReplyCommandId(correlationId);
-        var visibleText = evt.FinalTextWritten ? finalText : state.LastFlushedText;
-        if (evt.Success)
+        var visibleText = result.FinalTextWritten ? finalText : state.LastFlushedText;
+        if (result.Success)
         {
             await TransitionLarkCardStreamingPhaseAsync(
                 correlationId,
@@ -1086,12 +1105,12 @@ public sealed partial class ConversationGAgent
             Logger.LogWarning(
                 "Card finalize failed; persisting partial. correlation={CorrelationId}, code={ErrorCode}",
                 evt.CorrelationId,
-                evt.ErrorCode);
+                result.ErrorCode);
             await TransitionLarkCardStreamingPhaseAsync(
                 correlationId,
                 state,
                 LarkCardStreamingPhase.Terminated,
-                terminalReason: $"finalize_failed:{evt.ErrorCode}",
+                terminalReason: $"finalize_failed:{result.ErrorCode}",
                 fieldUpdate: s => s with { InFlight = null });
         }
 
@@ -1101,6 +1120,85 @@ public sealed partial class ConversationGAgent
             evt.Activity,
             state.CardMessageId ?? evt.CardMessageId ?? string.Empty,
             visibleText);
+    }
+
+    private static ConversationCardCreateResult ToCreateResult(LarkCardOperationCompletedEvent evt)
+    {
+        var raw = evt.RawResult ?? new LarkCardOperationRawResult();
+        if (evt.State == LarkCardOperationResultState.Succeeded)
+            return ConversationCardCreateResult.Succeeded(raw.CardId, raw.CardMessageId);
+
+        if (evt.State == LarkCardOperationResultState.Faulted)
+            return ConversationCardCreateResult.Failed(
+                BuildFaultErrorCode(LarkCardOperationPhase.Create, raw),
+                raw.ExceptionMessage);
+
+        return raw.IsPostSendFailure
+            ? ConversationCardCreateResult.PostSendFailed(
+                raw.CardId,
+                raw.CardMessageId,
+                raw.RawErrorCode,
+                raw.RawErrorSummary,
+                raw.IsRateLimited,
+                raw.IsTableLimitExceeded,
+                raw.IsCardUnavailable)
+            : ConversationCardCreateResult.Failed(
+                raw.RawErrorCode,
+                raw.RawErrorSummary,
+                raw.IsRateLimited,
+                raw.IsTableLimitExceeded,
+                raw.IsCardUnavailable);
+    }
+
+    private static ConversationCardStreamResult ToStreamResult(LarkCardOperationCompletedEvent evt)
+    {
+        var raw = evt.RawResult ?? new LarkCardOperationRawResult();
+        if (evt.State == LarkCardOperationResultState.Succeeded)
+            return ConversationCardStreamResult.Succeeded();
+
+        return ConversationCardStreamResult.Failed(
+            evt.State == LarkCardOperationResultState.Faulted
+                ? BuildFaultErrorCode(LarkCardOperationPhase.Stream, raw)
+                : raw.RawErrorCode,
+            evt.State == LarkCardOperationResultState.Faulted
+                ? raw.ExceptionMessage
+                : raw.RawErrorSummary,
+            raw.IsRateLimited,
+            raw.IsTableLimitExceeded,
+            raw.IsCardUnavailable);
+    }
+
+    private static ConversationCardFinalizeResult ToFinalizeResult(LarkCardOperationCompletedEvent evt)
+    {
+        var raw = evt.RawResult ?? new LarkCardOperationRawResult();
+        if (evt.State == LarkCardOperationResultState.Succeeded)
+            return ConversationCardFinalizeResult.Succeeded();
+
+        return ConversationCardFinalizeResult.Failed(
+            evt.State == LarkCardOperationResultState.Faulted
+                ? BuildFaultErrorCode(LarkCardOperationPhase.Finalize, raw)
+                : raw.RawErrorCode,
+            evt.State == LarkCardOperationResultState.Faulted
+                ? raw.ExceptionMessage
+                : raw.RawErrorSummary,
+            raw.FinalTextWritten);
+    }
+
+    private static string BuildFaultErrorCode(
+        LarkCardOperationPhase operation,
+        LarkCardOperationRawResult raw)
+    {
+        var operationName = operation switch
+        {
+            LarkCardOperationPhase.Create => "create",
+            LarkCardOperationPhase.Stream => "stream",
+            LarkCardOperationPhase.Finalize => "finalize",
+            _ => "unknown",
+        };
+        var exceptionType = string.IsNullOrWhiteSpace(raw.ExceptionType)
+            ? "Exception"
+            : raw.ExceptionType;
+        return $"{operationName}_threw:{exceptionType}";
     }
 
     [EventHandler]

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -244,57 +244,48 @@ message LlmReplyCardStreamChunkEvent {
   int64 reply_token_expires_at_unix_ms = 7;
 }
 
-// Refactor (iter47/issue-878-actor-turn-inline-timeouts):
-//   Old pattern: ConversationGAgent created CancellationTokenSource around CardKit calls inside actor turn and continued business branches synchronously.
-//   New principle: Card operations are typed continuation events (correlationId+sequence+card id); stateless executor runs CardKit outside actor turn; self-timeout events handle deadlines; actor turn reconciles stale keys serially per correlation.
-message LarkCardCreateContinuationEvent {
-  string correlation_id = 1;
-  int64 sequence = 2;
-  int64 operation_generation = 3;
-  LlmReplyCardStreamChunkEvent chunk = 4;
-  bool success = 5;
-  string card_id = 6;
-  string card_message_id = 7;
-  bool is_rate_limited = 8;
-  bool is_table_limit_exceeded = 9;
-  bool is_card_unavailable = 10;
-  bool is_post_send_failure = 11;
-  string error_code = 12;
-  string error_summary = 13;
-  int64 completed_at_unix_ms = 14;
+// Refactor (iter57/cluster-065-lark-card-signal-only):
+//   Old pattern: Lark CardKit Task.Run helpers built rich create/stream/finalize continuation
+//   payloads outside the actor turn, including timestamps, error codes, and lifecycle field
+//   mapping. New principle: helpers only report the typed operation signal and minimal raw
+//   external result; ConversationGAgent handlers interpret it against actor-owned state.
+enum LarkCardOperationResultState {
+  LARK_CARD_OPERATION_RESULT_STATE_UNSPECIFIED = 0;
+  LARK_CARD_OPERATION_RESULT_STATE_SUCCEEDED = 1;
+  LARK_CARD_OPERATION_RESULT_STATE_FAILED = 2;
+  LARK_CARD_OPERATION_RESULT_STATE_FAULTED = 3;
 }
 
-message LarkCardStreamContinuationEvent {
-  string correlation_id = 1;
-  int64 sequence = 2;
-  int64 operation_generation = 3;
-  string card_id = 4;
-  string streaming_element_id = 5;
-  LlmReplyCardStreamChunkEvent chunk = 6;
-  bool success = 7;
-  bool is_rate_limited = 8;
-  bool is_table_limit_exceeded = 9;
-  bool is_card_unavailable = 10;
-  string error_code = 11;
-  string error_summary = 12;
-  int64 completed_at_unix_ms = 13;
+message LarkCardOperationRawResult {
+  string card_id = 1;
+  string card_message_id = 2;
+  bool is_rate_limited = 3;
+  bool is_table_limit_exceeded = 4;
+  bool is_card_unavailable = 5;
+  bool is_post_send_failure = 6;
+  bool final_text_written = 7;
+  string raw_error_code = 8;
+  string raw_error_summary = 9;
+  string exception_type = 10;
+  string exception_message = 11;
 }
 
-message LarkCardFinalizeContinuationEvent {
-  string correlation_id = 1;
-  int64 sequence = 2;
-  int64 operation_generation = 3;
-  string card_id = 4;
-  string card_message_id = 5;
-  string command_id = 6;
-  aevatar.gagents.channel.abstractions.ChatActivity activity = 7;
-  string final_text = 8;
-  string last_flushed_text = 9;
-  bool success = 10;
-  bool final_text_written = 11;
-  string error_code = 12;
-  string error_summary = 13;
-  int64 completed_at_unix_ms = 14;
+message LarkCardOperationCompletedEvent {
+  string operation_id = 1;
+  string correlation_id = 2;
+  LarkCardOperationPhase operation = 3;
+  int64 sequence = 4;
+  int64 operation_generation = 5;
+  LarkCardOperationResultState state = 6;
+  LarkCardOperationRawResult raw_result = 7;
+  LlmReplyCardStreamChunkEvent chunk = 8;
+  aevatar.gagents.channel.abstractions.ChatActivity activity = 9;
+  string command_id = 10;
+  string final_text = 11;
+  string last_flushed_text = 12;
+  string card_id = 13;
+  string card_message_id = 14;
+  string streaming_element_id = 15;
 }
 
 message LarkCardOperationTimeoutFiredEvent {

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -2311,7 +2311,7 @@ public sealed class ConversationGAgentDedupTests
     // ─── Lark CardKit card-mode streaming tests ───
 
     [Fact]
-    public async Task HandleLarkCardCreateContinuationAsync_TypedContinuationFlow_MaterializesStreamingState()
+    public async Task HandleLarkCardOperationCompletedAsync_TypedSignalFlow_MaterializesStreamingState()
     {
         var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-card-flow");
 
@@ -2323,16 +2323,14 @@ public sealed class ConversationGAgentDedupTests
         lifecycle.LarkCardInFlightOperation.ShouldBe(LarkCardOperationPhase.Create);
         lifecycle.LarkCardInFlightSequence.ShouldBe(1);
 
-        await agent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-flow",
-            Sequence = lifecycle.LarkCardInFlightSequence,
-            OperationGeneration = lifecycle.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-flow", "relay-msg-1", "hello"),
-            Success = true,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-flow",
+            lifecycle.LarkCardInFlightSequence,
+            lifecycle.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-flow", "relay-msg-1", "hello"),
+            success: true,
+            cardId: "card_xyz",
+            cardMessageId: "om_card_msg"));
 
         lifecycle = agent.State.ActiveReplyLifecycles.Single();
         lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.LarkCardStreaming);
@@ -2375,36 +2373,32 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleLarkCardStreamContinuationAsync_StaleKey_DoesNotMutateLifecycle()
+    public async Task HandleLarkCardOperationCompletedAsync_StaleKey_DoesNotMutateLifecycle()
     {
         var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-card-stale");
 
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-stale", "relay-msg-1", "first"));
         var createLifecycle = agent.State.ActiveReplyLifecycles.Single();
-        await agent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-stale",
-            Sequence = createLifecycle.LarkCardInFlightSequence,
-            OperationGeneration = createLifecycle.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-stale", "relay-msg-1", "first"),
-            Success = true,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-stale",
+            createLifecycle.LarkCardInFlightSequence,
+            createLifecycle.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-stale", "relay-msg-1", "first"),
+            success: true,
+            cardId: "card_xyz",
+            cardMessageId: "om_card_msg"));
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-stale", "relay-msg-1", "second"));
         var active = agent.State.ActiveReplyLifecycles.Single();
 
-        await agent.HandleLarkCardStreamContinuationAsync(new LarkCardStreamContinuationEvent
-        {
-            CorrelationId = "act-card-stale",
-            Sequence = active.LarkCardInFlightSequence,
-            OperationGeneration = active.LarkCardOperationGeneration + 99,
-            CardId = "card_xyz",
-            Chunk = CreateCardStreamChunk("act-card-stale", "relay-msg-1", "stale"),
-            Success = true,
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardStreamCompletion(
+            "act-card-stale",
+            active.LarkCardInFlightSequence,
+            active.LarkCardOperationGeneration + 99,
+            "card_xyz",
+            CreateCardStreamChunk("act-card-stale", "relay-msg-1", "stale"),
+            success: true));
 
         var unchanged = agent.State.ActiveReplyLifecycles.Single();
         unchanged.LastFlushedText.ShouldBe("first");
@@ -2413,23 +2407,21 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleLarkCardStreamContinuationAsync_SerialCoalescing_UsesLatestPendingText()
+    public async Task HandleLarkCardOperationCompletedAsync_SerialCoalescing_UsesLatestPendingText()
     {
         var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-card-coalesce");
 
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "first"));
         var createLifecycle = agent.State.ActiveReplyLifecycles.Single();
-        await agent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-coalesce",
-            Sequence = createLifecycle.LarkCardInFlightSequence,
-            OperationGeneration = createLifecycle.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "first"),
-            Success = true,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-coalesce",
+            createLifecycle.LarkCardInFlightSequence,
+            createLifecycle.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "first"),
+            success: true,
+            cardId: "card_xyz",
+            cardMessageId: "om_card_msg"));
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "second"));
         await agent.HandleLlmReplyCardStreamChunkAsync(
@@ -2437,16 +2429,13 @@ public sealed class ConversationGAgentDedupTests
         var streamLifecycle = agent.State.ActiveReplyLifecycles.Single();
         streamLifecycle.PendingAccumulatedText.ShouldBe("third");
 
-        await agent.HandleLarkCardStreamContinuationAsync(new LarkCardStreamContinuationEvent
-        {
-            CorrelationId = "act-card-coalesce",
-            Sequence = streamLifecycle.LarkCardInFlightSequence,
-            OperationGeneration = streamLifecycle.LarkCardOperationGeneration,
-            CardId = "card_xyz",
-            StreamingElementId = "streaming_main",
-            Chunk = CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "second"),
-            Success = true,
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardStreamCompletion(
+            "act-card-coalesce",
+            streamLifecycle.LarkCardInFlightSequence,
+            streamLifecycle.LarkCardOperationGeneration,
+            "card_xyz",
+            CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "second"),
+            success: true));
 
         var followUp = agent.State.ActiveReplyLifecycles.Single();
         followUp.LastFlushedText.ShouldBe("second");
@@ -2455,16 +2444,13 @@ public sealed class ConversationGAgentDedupTests
         followUp.LarkCardInFlightOperation.ShouldBe(LarkCardOperationPhase.Stream);
         followUp.LarkCardInFlightSequence.ShouldBe(3);
 
-        await agent.HandleLarkCardStreamContinuationAsync(new LarkCardStreamContinuationEvent
-        {
-            CorrelationId = "act-card-coalesce",
-            Sequence = followUp.LarkCardInFlightSequence,
-            OperationGeneration = followUp.LarkCardOperationGeneration,
-            CardId = "card_xyz",
-            StreamingElementId = "streaming_main",
-            Chunk = CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "third"),
-            Success = true,
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardStreamCompletion(
+            "act-card-coalesce",
+            followUp.LarkCardInFlightSequence,
+            followUp.LarkCardOperationGeneration,
+            "card_xyz",
+            CreateCardStreamChunk("act-card-coalesce", "relay-msg-1", "third"),
+            success: true));
 
         var coalesced = agent.State.ActiveReplyLifecycles.Single();
         coalesced.LastFlushedText.ShouldBe("third");
@@ -2487,19 +2473,17 @@ public sealed class ConversationGAgentDedupTests
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-postsend", "relay-msg-1", "hello"));
         var lifecycle = agent.State.ActiveReplyLifecycles.Single();
-        await agent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-postsend",
-            Sequence = lifecycle.LarkCardInFlightSequence,
-            OperationGeneration = lifecycle.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-postsend", "relay-msg-1", "hello"),
-            Success = false,
-            CardId = "card_orphan",
-            CardMessageId = "om_orphan",
-            IsPostSendFailure = true,
-            ErrorCode = "card_first_stream_failed",
-            ErrorSummary = "stream rejected",
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-postsend",
+            lifecycle.LarkCardInFlightSequence,
+            lifecycle.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-postsend", "relay-msg-1", "hello"),
+            success: false,
+            cardId: "card_orphan",
+            cardMessageId: "om_orphan",
+            isPostSendFailure: true,
+            errorCode: "card_first_stream_failed",
+            errorSummary: "stream rejected"));
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-postsend", "relay-msg-1", "hello world"));
 
@@ -2520,16 +2504,14 @@ public sealed class ConversationGAgentDedupTests
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-finalize", "relay-msg-1", "complete answer"));
         var create = agent.State.ActiveReplyLifecycles.Single();
-        await agent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-finalize",
-            Sequence = create.LarkCardInFlightSequence,
-            OperationGeneration = create.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-finalize", "relay-msg-1", "complete answer"),
-            Success = true,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-finalize",
+            create.LarkCardInFlightSequence,
+            create.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-finalize", "relay-msg-1", "complete answer"),
+            success: true,
+            cardId: "card_xyz",
+            cardMessageId: "om_card_msg"));
 
         var ready = new LlmReplyReadyEvent
         {
@@ -2543,20 +2525,18 @@ public sealed class ConversationGAgentDedupTests
         };
         await agent.HandleLlmReplyReadyAsync(ready);
         var finalize = agent.State.ActiveReplyLifecycles.Single();
-        await agent.HandleLarkCardFinalizeContinuationAsync(new LarkCardFinalizeContinuationEvent
-        {
-            CorrelationId = "act-card-finalize",
-            Sequence = finalize.LarkCardInFlightSequence,
-            OperationGeneration = finalize.LarkCardOperationGeneration,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-            CommandId = "llm-reply:act-card-finalize",
-            Activity = CreateRelayActivity("act-card-finalize", "relay-msg-1"),
-            FinalText = "complete answer",
-            LastFlushedText = "complete answer",
-            Success = true,
-            FinalTextWritten = true,
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardFinalizeCompletion(
+            "act-card-finalize",
+            finalize.LarkCardInFlightSequence,
+            finalize.LarkCardOperationGeneration,
+            "card_xyz",
+            "om_card_msg",
+            "llm-reply:act-card-finalize",
+            CreateRelayActivity("act-card-finalize", "relay-msg-1"),
+            "complete answer",
+            "complete answer",
+            success: true,
+            finalTextWritten: true));
 
         var events = await store.GetEventsAsync(agent.Id);
         events.Last().EventType.ShouldContain(nameof(ConversationTurnCompletedEvent));
@@ -2574,29 +2554,24 @@ public sealed class ConversationGAgentDedupTests
         await firstAgent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-reactivate", "relay-msg-1", "first"));
         var create = firstAgent.State.ActiveReplyLifecycles.Single();
-        await firstAgent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-reactivate",
-            Sequence = create.LarkCardInFlightSequence,
-            OperationGeneration = create.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-reactivate", "relay-msg-1", "first"),
-            Success = true,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-        });
+        await firstAgent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-reactivate",
+            create.LarkCardInFlightSequence,
+            create.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-reactivate", "relay-msg-1", "first"),
+            success: true,
+            cardId: "card_xyz",
+            cardMessageId: "om_card_msg"));
         await firstAgent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-reactivate", "relay-msg-1", "second"));
         var stream = firstAgent.State.ActiveReplyLifecycles.Single();
-        await firstAgent.HandleLarkCardStreamContinuationAsync(new LarkCardStreamContinuationEvent
-        {
-            CorrelationId = "act-card-reactivate",
-            Sequence = stream.LarkCardInFlightSequence,
-            OperationGeneration = stream.LarkCardOperationGeneration,
-            CardId = "card_xyz",
-            StreamingElementId = "streaming_main",
-            Chunk = CreateCardStreamChunk("act-card-reactivate", "relay-msg-1", "second"),
-            Success = true,
-        });
+        await firstAgent.HandleLarkCardOperationCompletedAsync(CreateCardStreamCompletion(
+            "act-card-reactivate",
+            stream.LarkCardInFlightSequence,
+            stream.LarkCardOperationGeneration,
+            "card_xyz",
+            CreateCardStreamChunk("act-card-reactivate", "relay-msg-1", "second"),
+            success: true));
 
         var lifecycle = firstAgent.State.ActiveReplyLifecycles.Single();
         lifecycle.Mode.ShouldBe(ConversationReplyLifecycleMode.LarkCard);
@@ -2621,20 +2596,18 @@ public sealed class ConversationGAgentDedupTests
         });
         var finalize = secondAgent.State.ActiveReplyLifecycles.Single();
         finalize.LarkCardInFlightSequence.ShouldBe(3);
-        await secondAgent.HandleLarkCardFinalizeContinuationAsync(new LarkCardFinalizeContinuationEvent
-        {
-            CorrelationId = "act-card-reactivate",
-            Sequence = finalize.LarkCardInFlightSequence,
-            OperationGeneration = finalize.LarkCardOperationGeneration,
-            CardId = "card_xyz",
-            CardMessageId = "om_card_msg",
-            CommandId = "llm-reply:act-card-reactivate",
-            Activity = CreateRelayActivity("act-card-reactivate", "relay-msg-1"),
-            FinalText = "third",
-            LastFlushedText = "second",
-            Success = true,
-            FinalTextWritten = true,
-        });
+        await secondAgent.HandleLarkCardOperationCompletedAsync(CreateCardFinalizeCompletion(
+            "act-card-reactivate",
+            finalize.LarkCardInFlightSequence,
+            finalize.LarkCardOperationGeneration,
+            "card_xyz",
+            "om_card_msg",
+            "llm-reply:act-card-reactivate",
+            CreateRelayActivity("act-card-reactivate", "relay-msg-1"),
+            "third",
+            "second",
+            success: true,
+            finalTextWritten: true));
 
         secondAgent.State.ActiveReplyLifecycles.ShouldBeEmpty();
         var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(
@@ -2660,17 +2633,15 @@ public sealed class ConversationGAgentDedupTests
         await agent.HandleLlmReplyCardStreamChunkAsync(
             CreateCardStreamChunk("act-card-fb-final", "relay-msg-1", "complete answer"));
         var lifecycle = agent.State.ActiveReplyLifecycles.Single();
-        await agent.HandleLarkCardCreateContinuationAsync(new LarkCardCreateContinuationEvent
-        {
-            CorrelationId = "act-card-fb-final",
-            Sequence = lifecycle.LarkCardInFlightSequence,
-            OperationGeneration = lifecycle.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-fb-final", "relay-msg-1", "complete answer"),
-            Success = false,
-            IsRateLimited = true,
-            ErrorCode = "card_create_failed",
-            ErrorSummary = "down",
-        });
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-fb-final",
+            lifecycle.LarkCardInFlightSequence,
+            lifecycle.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-fb-final", "relay-msg-1", "complete answer"),
+            success: false,
+            isRateLimited: true,
+            errorCode: "card_create_failed",
+            errorSummary: "down"));
 
         var ready = new LlmReplyReadyEvent
         {
@@ -2701,6 +2672,117 @@ public sealed class ConversationGAgentDedupTests
             ChunkAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             ReplyToken = "runtime-token-" + correlationId,
             ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+        };
+
+    private static LarkCardOperationCompletedEvent CreateCardCreateCompletion(
+        string correlationId,
+        long sequence,
+        long generation,
+        LlmReplyCardStreamChunkEvent chunk,
+        bool success,
+        string cardId = "",
+        string cardMessageId = "",
+        bool isRateLimited = false,
+        bool isTableLimitExceeded = false,
+        bool isCardUnavailable = false,
+        bool isPostSendFailure = false,
+        string errorCode = "",
+        string errorSummary = "") =>
+        new()
+        {
+            OperationId = $"{correlationId}:create:{sequence}:{generation}",
+            CorrelationId = correlationId,
+            Operation = LarkCardOperationPhase.Create,
+            Sequence = sequence,
+            OperationGeneration = generation,
+            State = success
+                ? LarkCardOperationResultState.Succeeded
+                : LarkCardOperationResultState.Failed,
+            Chunk = chunk,
+            RawResult = new LarkCardOperationRawResult
+            {
+                CardId = cardId,
+                CardMessageId = cardMessageId,
+                IsRateLimited = isRateLimited,
+                IsTableLimitExceeded = isTableLimitExceeded,
+                IsCardUnavailable = isCardUnavailable,
+                IsPostSendFailure = isPostSendFailure,
+                RawErrorCode = errorCode,
+                RawErrorSummary = errorSummary,
+            },
+        };
+
+    private static LarkCardOperationCompletedEvent CreateCardStreamCompletion(
+        string correlationId,
+        long sequence,
+        long generation,
+        string cardId,
+        LlmReplyCardStreamChunkEvent chunk,
+        bool success,
+        bool isRateLimited = false,
+        bool isTableLimitExceeded = false,
+        bool isCardUnavailable = false,
+        string errorCode = "",
+        string errorSummary = "") =>
+        new()
+        {
+            OperationId = $"{correlationId}:stream:{sequence}:{generation}",
+            CorrelationId = correlationId,
+            Operation = LarkCardOperationPhase.Stream,
+            Sequence = sequence,
+            OperationGeneration = generation,
+            State = success
+                ? LarkCardOperationResultState.Succeeded
+                : LarkCardOperationResultState.Failed,
+            CardId = cardId,
+            StreamingElementId = "streaming_main",
+            Chunk = chunk,
+            RawResult = new LarkCardOperationRawResult
+            {
+                IsRateLimited = isRateLimited,
+                IsTableLimitExceeded = isTableLimitExceeded,
+                IsCardUnavailable = isCardUnavailable,
+                RawErrorCode = errorCode,
+                RawErrorSummary = errorSummary,
+            },
+        };
+
+    private static LarkCardOperationCompletedEvent CreateCardFinalizeCompletion(
+        string correlationId,
+        long sequence,
+        long generation,
+        string cardId,
+        string cardMessageId,
+        string commandId,
+        ChatActivity activity,
+        string finalText,
+        string lastFlushedText,
+        bool success,
+        bool finalTextWritten,
+        string errorCode = "",
+        string errorSummary = "") =>
+        new()
+        {
+            OperationId = $"{correlationId}:finalize:{sequence}:{generation}",
+            CorrelationId = correlationId,
+            Operation = LarkCardOperationPhase.Finalize,
+            Sequence = sequence,
+            OperationGeneration = generation,
+            State = success
+                ? LarkCardOperationResultState.Succeeded
+                : LarkCardOperationResultState.Failed,
+            CardId = cardId,
+            CardMessageId = cardMessageId,
+            CommandId = commandId,
+            Activity = activity,
+            FinalText = finalText,
+            LastFlushedText = lastFlushedText,
+            RawResult = new LarkCardOperationRawResult
+            {
+                FinalTextWritten = finalTextWritten,
+                RawErrorCode = errorCode,
+                RawErrorSummary = errorSummary,
+            },
         };
 
     private sealed class RecordingCardTurnRunner : IConversationCardTurnRunner

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -1,0 +1,365 @@
+using System.Reflection;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class LarkCardOperationSignalTests
+{
+    [Fact]
+    public async Task LarkCardCreateTaskRun_DispatchesSignalOnlyPayload()
+    {
+        var dispatch = new RecordingActorDispatchPort();
+        var runner = new RecordingCardRunner
+        {
+            CreateResult = ConversationCardCreateResult.PostSendFailed(
+                "card_orphan",
+                "om_orphan",
+                "card_first_stream_failed",
+                "stream rejected",
+                isRateLimited: true),
+        };
+        var agent = CreateAgent("conv-lark-card-signal-only", runner, dispatch, new InMemoryEventStore());
+
+        await agent.HandleEventAsync(Envelope("conv-lark-card-signal-only",
+            CreateCardStreamChunk("corr-signal-only", "relay-msg-1", "hello")));
+
+        var signal = await dispatch.WaitForPayloadAsync<LarkCardOperationCompletedEvent>();
+
+        signal.Operation.Should().Be(LarkCardOperationPhase.Create);
+        signal.OperationId.Should().StartWith("corr-signal-only:");
+        signal.OperationId.Should().EndWith(":1:1");
+        signal.State.Should().Be(LarkCardOperationResultState.Failed);
+        signal.RawResult.CardId.Should().Be("card_orphan");
+        signal.RawResult.CardMessageId.Should().Be("om_orphan");
+        signal.RawResult.RawErrorCode.Should().Be("card_first_stream_failed");
+        signal.RawResult.RawErrorSummary.Should().Be("stream rejected");
+        signal.RawResult.IsRateLimited.Should().BeTrue();
+        signal.RawResult.IsPostSendFailure.Should().BeTrue();
+        signal.Should().BeEquivalentTo(signal.Clone());
+    }
+
+    [Fact]
+    public async Task LarkCardOperationCompleted_ActorReconstructsRichContinuation()
+    {
+        var store = new InMemoryEventStore();
+        var agent = CreateAgent(
+            "conv-lark-card-reconstruct",
+            new RecordingCardRunner(),
+            new RecordingActorDispatchPort(),
+            store);
+
+        await agent.HandleEventAsync(Envelope("conv-lark-card-reconstruct",
+            CreateCardStreamChunk("corr-reconstruct", "relay-msg-1", "hello")));
+        var lifecycle = agent.State.ActiveReplyLifecycles.Single();
+
+        await agent.HandleEventAsync(Envelope("conv-lark-card-reconstruct",
+            new LarkCardOperationCompletedEvent
+            {
+                OperationId = "corr-reconstruct:create:1:1",
+                CorrelationId = "corr-reconstruct",
+                Operation = LarkCardOperationPhase.Create,
+                Sequence = lifecycle.LarkCardInFlightSequence,
+                OperationGeneration = lifecycle.LarkCardOperationGeneration,
+                State = LarkCardOperationResultState.Failed,
+                Chunk = CreateCardStreamChunk("corr-reconstruct", "relay-msg-1", "hello"),
+                RawResult = new LarkCardOperationRawResult
+                {
+                    CardId = "card_orphan",
+                    CardMessageId = "om_orphan",
+                    IsPostSendFailure = true,
+                    RawErrorCode = "card_first_stream_failed",
+                    RawErrorSummary = "stream rejected",
+                },
+            }));
+
+        var events = await store.GetEventsAsync(agent.Id);
+        var changed = events
+            .Where(e => e.EventType == ConversationReplyLifecycleChangedEvent.Descriptor.FullName)
+            .Select(e => ConversationReplyLifecycleChangedEvent.Parser.ParseFrom(e.EventData.Value))
+            .Last();
+        changed.Lifecycle.Phase.Should().Be(ConversationReplyLifecyclePhase.LarkCardTerminated);
+        changed.Lifecycle.CardId.Should().Be("card_orphan");
+        changed.Lifecycle.CardMessageId.Should().Be("om_orphan");
+        changed.Lifecycle.TerminalReason.Should().Be("create_post_send_failed:card_first_stream_failed");
+
+        var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events.Last().EventData.Value);
+        completed.SentActivityId.Should().Be("lark-card-stream:om_orphan");
+    }
+
+    private static ConversationGAgent CreateAgent(
+        string id,
+        IConversationCardTurnRunner cardRunner,
+        IActorDispatchPort dispatch,
+        IEventStore store)
+    {
+        var services = new ServiceCollection()
+            .AddSingleton(store)
+            .AddSingleton(dispatch)
+            .AddSingleton(cardRunner)
+            .AddSingleton<IActorRuntimeCallbackScheduler, NoopCallbackScheduler>()
+            .AddSingleton<EventSourcingRuntimeOptions>()
+            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
+            .BuildServiceProvider();
+
+        var agent = new ConversationGAgent
+        {
+            Services = services,
+            EventPublisher = new NoopEventPublisher(),
+            EventSourcingBehaviorFactory =
+                services.GetRequiredService<IEventSourcingBehaviorFactory<ConversationGAgentState>>(),
+        };
+        SetId(agent, id);
+        agent.ActivateAsync().GetAwaiter().GetResult();
+        return agent;
+    }
+
+    private static EventEnvelope Envelope(string actorId, IMessage payload) =>
+        new()
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(payload),
+            Route = EnvelopeRouteSemantics.CreateDirect("test", actorId),
+            Propagation = new EnvelopePropagation
+            {
+                CorrelationId = payload switch
+                {
+                    LlmReplyCardStreamChunkEvent chunk => chunk.CorrelationId,
+                    LarkCardOperationCompletedEvent signal => signal.CorrelationId,
+                    _ => string.Empty,
+                },
+            },
+        };
+
+    private static void SetId(object agent, string id)
+    {
+        var current = agent.GetType();
+        while (current is not null)
+        {
+            var setIdMethod = current.GetMethod(
+                "SetId",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (setIdMethod is not null)
+            {
+                setIdMethod.Invoke(agent, [id]);
+                return;
+            }
+
+            current = current.BaseType;
+        }
+
+        throw new InvalidOperationException("Unable to set agent id via reflection.");
+    }
+
+    private static LlmReplyCardStreamChunkEvent CreateCardStreamChunk(
+        string correlationId,
+        string replyMessageId,
+        string accumulatedText) =>
+        new()
+        {
+            CorrelationId = correlationId,
+            RegistrationId = "reg-1",
+            Activity = new ChatActivity
+            {
+                Id = correlationId,
+                Type = ActivityType.Message,
+                ChannelId = new ChannelId { Value = "lark" },
+                Bot = new BotInstanceId { Value = "lark-bot" },
+                Conversation = new ConversationReference
+                {
+                    Channel = new ChannelId { Value = "lark" },
+                    Bot = new BotInstanceId { Value = "lark-bot" },
+                    Scope = ConversationScope.Group,
+                    CanonicalKey = "conv:lark:grp",
+                },
+                Content = new MessageContent { Text = "user question" },
+                OutboundDelivery = new OutboundDeliveryContext
+                {
+                    ReplyMessageId = replyMessageId,
+                    CorrelationId = correlationId,
+                },
+            },
+            AccumulatedText = accumulatedText,
+            ChunkAtUnixMs = 42,
+            ReplyToken = "runtime-token-" + correlationId,
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+        };
+
+    private sealed class RecordingCardRunner : IConversationCardTurnRunner
+    {
+        public ConversationCardCreateResult CreateResult { get; init; } =
+            ConversationCardCreateResult.Succeeded("card_ok", "om_card_msg");
+
+        public Task<ConversationCardCreateResult> RunCardCreateAsync(
+            LlmReplyCardStreamChunkEvent chunk,
+            string streamingElementId,
+            ConversationTurnRuntimeContext runtimeContext,
+            CancellationToken ct) =>
+            Task.FromResult(CreateResult);
+
+        public Task<ConversationCardStreamResult> RunCardStreamAsync(
+            LlmReplyCardStreamChunkEvent chunk,
+            string cardId,
+            string elementId,
+            long sequence,
+            ConversationTurnRuntimeContext runtimeContext,
+            CancellationToken ct) =>
+            Task.FromResult(ConversationCardStreamResult.Succeeded());
+
+        public Task<ConversationCardFinalizeResult> RunCardFinalizeAsync(
+            ChatActivity referenceActivity,
+            string cardId,
+            string elementId,
+            string finalText,
+            bool finalTextDiffersFromLastFlushed,
+            long sequence,
+            ConversationTurnRuntimeContext runtimeContext,
+            CancellationToken ct) =>
+            Task.FromResult(ConversationCardFinalizeResult.Succeeded());
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        private readonly TaskCompletionSource<EventEnvelope> _dispatched =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            _dispatched.TrySetResult(envelope.Clone());
+            return Task.CompletedTask;
+        }
+
+        public async Task<T> WaitForPayloadAsync<T>()
+            where T : IMessage<T>, new()
+        {
+            var envelope = await _dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            return envelope.Payload.Unpack<T>();
+        }
+    }
+
+    private sealed class InMemoryEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+            {
+                stream = [];
+                _events[agentId] = stream;
+            }
+
+            var currentVersion = stream.Count == 0 ? 0 : stream[^1].Version;
+            if (currentVersion != expectedVersion)
+                throw new EventStoreOptimisticConcurrencyException(
+                    agentId,
+                    expectedVersion,
+                    currentVersion);
+
+            var appended = events.Select(x => x.Clone()).ToList();
+            stream.AddRange(appended);
+            var latest = stream.Count == 0 ? 0 : stream[^1].Version;
+            return Task.FromResult(new EventStoreCommitResult
+            {
+                AgentId = agentId,
+                LatestVersion = latest,
+                CommittedEvents = { appended.Select(x => x.Clone()) },
+            });
+        }
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult<IReadOnlyList<StateEvent>>([]);
+
+            IReadOnlyList<StateEvent> result = fromVersion.HasValue
+                ? stream.Where(x => x.Version > fromVersion.Value).Select(x => x.Clone()).ToList()
+                : stream.Select(x => x.Clone()).ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (!_events.TryGetValue(agentId, out var stream) || stream.Count == 0)
+                return Task.FromResult(0L);
+            return Task.FromResult(stream[^1].Version);
+        }
+
+        public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (toVersion <= 0 || !_events.TryGetValue(agentId, out var stream))
+                return Task.FromResult(0L);
+
+            var before = stream.Count;
+            stream.RemoveAll(x => x.Version <= toVersion);
+            return Task.FromResult((long)(before - stream.Count));
+        }
+    }
+
+    private sealed class NoopCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class NoopEventPublisher : IEventPublisher
+    {
+        public Task PublishAsync<TEvent>(
+            TEvent evt,
+            TopologyAudience audience = TopologyAudience.Children,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage =>
+            Task.CompletedTask;
+
+        public Task SendToAsync<TEvent>(
+            string targetActorId,
+            TEvent evt,
+            CancellationToken ct = default,
+            EventEnvelope? sourceEnvelope = null,
+            EventEnvelopePublishOptions? options = null)
+            where TEvent : IMessage =>
+            Task.CompletedTask;
+    }
+}

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -1272,18 +1272,47 @@ if [ -f "${lark_card_streaming_file}" ]; then
     awk '
       /private async Task ExecuteLarkCard(Create|Stream|Finalize)OperationAsync/ {
         in_helper = 1
+        body_started = 0
         brace_depth = 0
+        completed_signal_pending = 0
+        completed_signal_depth = -1
       }
       in_helper {
         line = $0
-        opens = gsub(/\{/, "{", line)
-        closes = gsub(/\}/, "}", line)
-        brace_depth += opens - closes
-        if ($0 ~ /LarkCard(Create|Stream|Finalize)ContinuationEvent|To(Create|Stream|Finalize)Continuation|CompletedAtUnixMs|DateTimeOffset\.UtcNow\.ToUnixTimeMilliseconds\(\)|ErrorCode[[:space:]]*=|\$"(create|stream|finalize)_threw|CardMessageId[[:space:]]*=|FinalTextWritten[[:space:]]*=/) {
+        hard_forbidden = "LarkCard(Create|Stream|Finalize)ContinuationEvent|To(Create|Stream|Finalize)Continuation|CompletedAtUnixMs|DateTimeOffset\\.UtcNow\\.ToUnixTimeMilliseconds\\(\\)|ErrorCode[[:space:]]*=|\\$\"(create|stream|finalize)_threw"
+        lifecycle_mapping = "CardMessageId[[:space:]]*=|FinalTextWritten[[:space:]]*="
+        inside_completed_signal = completed_signal_depth >= 0 || line ~ /new[[:space:]]+LarkCardOperationCompletedEvent/
+
+        if (body_started && line ~ hard_forbidden) {
           print FILENAME ":" FNR ":" $0
         }
-        if (brace_depth == 0 && FNR > 1) {
+        if (body_started && !inside_completed_signal && line ~ lifecycle_mapping) {
+          print FILENAME ":" FNR ":" $0
+        }
+
+        if (line ~ /new[[:space:]]+LarkCardOperationCompletedEvent/) {
+          completed_signal_pending = 1
+        }
+
+        opens = gsub(/\{/, "{", line)
+        closes = gsub(/\}/, "}", line)
+        if (!body_started && opens > 0) {
+          body_started = 1
+        }
+        brace_depth += opens - closes
+
+        if (completed_signal_pending && opens > 0) {
+          completed_signal_depth = brace_depth
+          completed_signal_pending = 0
+        }
+        if (completed_signal_depth >= 0 && brace_depth < completed_signal_depth) {
+          completed_signal_depth = -1
+        }
+        if (body_started && brace_depth == 0) {
           in_helper = 0
+          body_started = 0
+          completed_signal_pending = 0
+          completed_signal_depth = -1
         }
       }
     ' "${lark_card_streaming_file}"

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -1260,6 +1260,41 @@ if [ -n "${command_side_readmodel_violations}" ]; then
   exit 1
 fi
 
+# Refactor (iter57/cluster-065-lark-card-signal-only):
+#   Old pattern: ConversationGAgent Lark CardKit Task.Run helpers built rich business
+#   continuation payloads outside the actor turn.
+#   New principle: helpers only dispatch LarkCardOperationCompletedEvent with minimal raw
+#   operation result; actor handlers own error-code interpretation, timestamps, and lifecycle
+#   field mapping.
+lark_card_streaming_file="agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs"
+if [ -f "${lark_card_streaming_file}" ]; then
+  lark_card_taskrun_helper_report="$(
+    awk '
+      /private async Task ExecuteLarkCard(Create|Stream|Finalize)OperationAsync/ {
+        in_helper = 1
+        brace_depth = 0
+      }
+      in_helper {
+        line = $0
+        opens = gsub(/\{/, "{", line)
+        closes = gsub(/\}/, "}", line)
+        brace_depth += opens - closes
+        if ($0 ~ /LarkCard(Create|Stream|Finalize)ContinuationEvent|To(Create|Stream|Finalize)Continuation|CompletedAtUnixMs|DateTimeOffset\.UtcNow\.ToUnixTimeMilliseconds\(\)|ErrorCode[[:space:]]*=|\$"(create|stream|finalize)_threw|CardMessageId[[:space:]]*=|FinalTextWritten[[:space:]]*=/) {
+          print FILENAME ":" FNR ":" $0
+        }
+        if (brace_depth == 0 && FNR > 1) {
+          in_helper = 0
+        }
+      }
+    ' "${lark_card_streaming_file}"
+  )"
+  if [ -n "${lark_card_taskrun_helper_report}" ]; then
+    echo "${lark_card_taskrun_helper_report}"
+    echo "ConversationGAgent Lark CardKit Task.Run helpers must stay signal-only: no rich continuation types, business error-code strings, timestamps, or lifecycle field mapping in ExecuteLarkCard*OperationAsync."
+    exit 1
+  fi
+fi
+
 check_orchestration_class_guard() {
   local file_path="$1"
   local max_non_empty_lines="$2"


### PR DESCRIPTION
## 摘要

iter57 cluster-065(severity:high)— Lark CardKit Task.Run signal-only + actor-side rich continuation

- **Old**:`ConversationGAgent.LarkCardStreaming.cs:367,426,494` 三个 `Task.Run` helper 在 actor turn 外构造 rich continuation(错误码 classification、summary、card_id mapping、timestamps),违反 "Actor 单线程事实边界"
- **New**:helper 改 signal-only(`operation_id + minimal raw result`),所有 rich continuation 在 actor handler 拼装;新增 typed `LarkCardOperationCompletedEvent` proto event

违反:CLAUDE.md「Actor 设计 / 生命周期 / 执行模型 — 回调只发信号」「业务推进内聚」

## Phase 9 共识链路

| Round | Verdict |
|---|---|
| r1 | converge:in-file narrowing vs scheduler port |
| r2 | converge:signal-only Task.Run vs scheduler |
| r3 | escalate:stalled:no-progress |
| **reflector r1** | **`META_RESOLVED:retry-fix`**(CLAUDE "回调只发信号" 已覆盖 signal-only,narrow 到 rich continuation 构造点) |
| r4 | **`META_JUDGE_DONE:consensus:structural`** ✅ |

详见 issue #939。

## Scope

- `agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs`(+/− major)
- `agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto`(新 LarkCardOperationCompletedEvent typed event)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs`(新)
- `test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs`
- `tools/ci/architecture_guards.sh`(新增 source guard)

5 files changed, +886 / −315。

local PASS:architecture_guards + test_stability_guards + LarkCard unit tests(2 passed)

closes #939

🤖 Generated with [Claude Code](https://claude.ai/code) via codex-refactor-loop iter57

⟦AI:AUTO-LOOP⟧
