### PR TITLE
iter57 cluster-070: 拆分 VoicePresence lease 与 relay pump

### DIFF
--- a/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs
@@ -40,7 +40,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     // Refactor (iter44/issue-866-voice-presence-process-runtime-state):
     //   Old pattern: VoicePresenceModule kept _runtimeState/_userTransport/relay tasks/dispatcher as module fields that participated in active session, transport attach, and provider response decisions outside actor turn.
     //   New principle: RoleGAgent voice runtime state is the only authority for active session / transport attached / lease expiry / provider binding; transport handles are byte-only volatile leases; provider/transport callbacks enqueue typed self-signals only.
-    private VoiceTransportLease? _transportLease;
+    private VoiceTransportRelayPump? _transportPump;
     private Func<IMessage, CancellationToken, Task>? _volatileSelfSignalDispatcher;
 
     public VoicePresenceModule(
@@ -77,7 +77,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
 
     public bool IsInitialized { get; private set; }
 
-    public bool HasVolatileTransportLease => _transportLease != null;
+    public bool HasVolatileTransportLease => _transportPump != null;
 
     public int PcmSampleRateHz =>
         _sessionConfig is { SampleRateHz: > 0 }
@@ -199,7 +199,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     public async ValueTask DisposeAsync()
     {
         IsInitialized = false;
-        await DisposeTransportLeaseAsync();
+        await DisposeTransportPumpAsync();
         _volatileSelfSignalDispatcher = null;
 
         await _provider.DisposeAsync();
@@ -242,9 +242,11 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         string? ownerId,
         Timestamp? leaseExpiresAt)
     {
-        var lease = AttachTransportCore(userTransport, selfEventDispatcher, sessionId, ownerId, leaseExpiresAt);
-        DispatchAttachRequestedFireAndForget(lease, sessionId);
-        StartTransportRelay(lease);
+        if (!string.IsNullOrWhiteSpace(sessionId))
+            throw new InvalidOperationException("Leased voice transport attach must observe attach signal dispatch.");
+
+        var pump = AttachTransportCore(userTransport, selfEventDispatcher, sessionId, ownerId, leaseExpiresAt);
+        StartTransportRelay(pump);
     }
 
     private async Task AttachTransportAndObserveDispatchAsync(
@@ -255,27 +257,27 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         Timestamp? leaseExpiresAt,
         CancellationToken ct)
     {
-        var lease = AttachTransportCore(userTransport, selfEventDispatcher, sessionId, ownerId, leaseExpiresAt);
+        var pump = AttachTransportCore(userTransport, selfEventDispatcher, sessionId, ownerId, leaseExpiresAt);
         if (string.IsNullOrWhiteSpace(sessionId))
         {
-            StartTransportRelay(lease);
+            StartTransportRelay(pump);
             return;
         }
 
         try
         {
-            await lease.DispatchAsync(BuildAttachRequested(lease), ct);
+            await pump.DispatchAsync(BuildAttachRequested(pump.Key), ct);
         }
         catch
         {
-            await DisposeTransportLeaseAsync();
+            await DisposeTransportPumpAsync();
             throw;
         }
 
-        StartTransportRelay(lease);
+        StartTransportRelay(pump);
     }
 
-    private VoiceTransportLease AttachTransportCore(
+    private VoiceTransportRelayPump AttachTransportCore(
         IVoiceTransport userTransport,
         Func<IMessage, CancellationToken, Task> selfEventDispatcher,
         string? sessionId,
@@ -285,44 +287,40 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         ArgumentNullException.ThrowIfNull(userTransport);
         ArgumentNullException.ThrowIfNull(selfEventDispatcher);
 
-        if (_transportLease != null)
+        if (_transportPump != null)
             throw new InvalidOperationException("A voice transport is already attached.");
 
-        var lease = new VoiceTransportLease(
-            string.IsNullOrWhiteSpace(sessionId) ? Guid.NewGuid().ToString("N") : sessionId,
-            ownerId ?? string.Empty,
+        var key = new VoiceTransportRelayKey(
+            string.IsNullOrWhiteSpace(sessionId) ? Guid.NewGuid().ToString("N") : sessionId.Trim(),
+            ownerId?.Trim() ?? string.Empty,
             Guid.NewGuid().ToString("N"),
-            leaseExpiresAt?.Clone(),
+            leaseExpiresAt);
+        var pump = new VoiceTransportRelayPump(
+            key,
             userTransport,
             selfEventDispatcher);
-        _transportLease = lease;
+        _transportPump = pump;
 
-        _provider.OnEvent = (evt, token) => OnProviderEventAsync(evt, lease, token);
-        return lease;
+        _provider.OnEvent = (evt, token) => OnProviderEventAsync(evt, pump.Key, token);
+        return pump;
     }
 
-    private void StartTransportRelay(VoiceTransportLease lease)
+    private void StartTransportRelay(VoiceTransportRelayPump pump)
     {
-        if (lease.RelayTask != null)
+        if (pump.RelayTask != null)
             return;
 
-        lease.RelayTask = RunUserToProviderRelayAsync(lease, lease.Cancellation.Token);
+        pump.RelayTask = RunUserToProviderRelayAsync(pump, pump.Cancellation.Token);
     }
 
-    private static VoiceTransportAttachRequested BuildAttachRequested(VoiceTransportLease lease) =>
+    private static VoiceTransportAttachRequested BuildAttachRequested(VoiceTransportRelayKey key) =>
         new()
         {
-            SessionId = lease.SessionId,
-            OwnerId = lease.OwnerId,
-            TransportLeaseId = lease.TransportLeaseId,
-            LeaseExpiresAt = lease.LeaseExpiresAt?.Clone(),
+            SessionId = key.SessionId,
+            OwnerId = key.OwnerId,
+            TransportLeaseId = key.TransportLeaseId,
+            LeaseExpiresAt = key.LeaseExpiresAt?.Clone(),
         };
-
-    private static void DispatchAttachRequestedFireAndForget(VoiceTransportLease lease, string? requestedSessionId)
-    {
-        if (!string.IsNullOrWhiteSpace(requestedSessionId))
-            lease.DispatchFireAndForget(BuildAttachRequested(lease));
-    }
 
     /// <summary>
     /// Detaches the current transport and stops the relay loops.
@@ -332,44 +330,44 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
     //   New principle: voice capability/session facts 由 actor-owned VoicePresenceCapabilityReadModel 暴露;host resolver 只 obtain lease/session handle;走 existing typed lease command/event flow,no runtime-shape inspection。
     public async Task DetachTransportAsync(IVoiceTransport? expectedTransport = null)
     {
-        var lease = _transportLease;
-        if (lease == null)
+        var pump = _transportPump;
+        if (pump == null)
             return;
 
-        if (expectedTransport != null && !ReferenceEquals(expectedTransport, lease.Transport))
+        if (expectedTransport != null && !ReferenceEquals(expectedTransport, pump.Transport))
             return;
 
-        if (!string.IsNullOrWhiteSpace(lease.SessionId))
+        if (!string.IsNullOrWhiteSpace(pump.Key.SessionId))
         {
-            await lease.DispatchAsync(new VoiceTransportDetachRequested
+            await pump.DispatchAsync(new VoiceTransportDetachRequested
             {
-                SessionId = lease.SessionId,
-                OwnerId = lease.OwnerId,
-                TransportLeaseId = lease.TransportLeaseId,
-                LeaseExpiresAt = lease.LeaseExpiresAt?.Clone(),
+                SessionId = pump.Key.SessionId,
+                OwnerId = pump.Key.OwnerId,
+                TransportLeaseId = pump.Key.TransportLeaseId,
+                LeaseExpiresAt = pump.Key.LeaseExpiresAt?.Clone(),
                 Reason = "host_transport_detached",
             }, CancellationToken.None);
         }
 
-        await DisposeTransportLeaseAsync();
+        await DisposeTransportPumpAsync();
     }
 
-    private async Task RunUserToProviderRelayAsync(VoiceTransportLease lease, CancellationToken ct)
+    private async Task RunUserToProviderRelayAsync(VoiceTransportRelayPump pump, CancellationToken ct)
     {
         try
         {
-            await foreach (var frame in lease.Transport.ReceiveFramesAsync(ct))
+            await foreach (var frame in pump.Transport.ReceiveFramesAsync(ct))
             {
                 if (frame.IsAudio)
                 {
                     if (!frame.AudioPcm16.IsEmpty)
                     {
-                        await lease.DispatchAsync(new VoiceTransportAudioFrameReceived
+                        await pump.DispatchAsync(new VoiceTransportAudioFrameReceived
                         {
-                            SessionId = lease.SessionId,
-                            OwnerId = lease.OwnerId,
-                            TransportLeaseId = lease.TransportLeaseId,
-                            LeaseExpiresAt = lease.LeaseExpiresAt?.Clone(),
+                            SessionId = pump.Key.SessionId,
+                            OwnerId = pump.Key.OwnerId,
+                            TransportLeaseId = pump.Key.TransportLeaseId,
+                            LeaseExpiresAt = pump.Key.LeaseExpiresAt?.Clone(),
                             Pcm16 = ByteString.CopyFrom(frame.AudioPcm16.Span),
                             SampleRateHz = PcmSampleRateHz,
                         }, ct);
@@ -377,12 +375,12 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
                 }
                 else if (frame.Control != null)
                 {
-                    await lease.DispatchAsync(new VoiceTransportControlFrameReceived
+                    await pump.DispatchAsync(new VoiceTransportControlFrameReceived
                     {
-                        SessionId = lease.SessionId,
-                        OwnerId = lease.OwnerId,
-                        TransportLeaseId = lease.TransportLeaseId,
-                        LeaseExpiresAt = lease.LeaseExpiresAt?.Clone(),
+                        SessionId = pump.Key.SessionId,
+                        OwnerId = pump.Key.OwnerId,
+                        TransportLeaseId = pump.Key.TransportLeaseId,
+                        LeaseExpiresAt = pump.Key.LeaseExpiresAt?.Clone(),
                         ControlFrame = frame.Control.Clone(),
                     }, ct);
                 }
@@ -394,30 +392,30 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "User-to-provider relay terminated unexpectedly.");
-            await lease.DispatchAsync(new VoiceTransportRelayStopped
+            await pump.DispatchAsync(new VoiceTransportRelayStopped
             {
-                SessionId = lease.SessionId,
-                OwnerId = lease.OwnerId,
-                TransportLeaseId = lease.TransportLeaseId,
-                LeaseExpiresAt = lease.LeaseExpiresAt?.Clone(),
+                SessionId = pump.Key.SessionId,
+                OwnerId = pump.Key.OwnerId,
+                TransportLeaseId = pump.Key.TransportLeaseId,
+                LeaseExpiresAt = pump.Key.LeaseExpiresAt?.Clone(),
                 Reason = $"error:{ex.Message}",
             }, CancellationToken.None);
         }
     }
 
     private Task OnProviderEventAsync(VoiceProviderEvent evt, CancellationToken ct) =>
-        OnProviderEventAsync(evt, _transportLease, ct);
+        OnProviderEventAsync(evt, _transportPump?.Key, ct);
 
-    private async Task OnProviderEventAsync(VoiceProviderEvent evt, VoiceTransportLease? callbackLease, CancellationToken ct)
+    private async Task OnProviderEventAsync(VoiceProviderEvent evt, VoiceTransportRelayKey? callbackKey, CancellationToken ct)
     {
-        if (callbackLease != null)
+        if (callbackKey != null)
         {
-            await callbackLease.DispatchAsync(new VoiceProviderEventReceived
+            await DispatchSelfEventAsync(new VoiceProviderEventReceived
             {
-                SessionId = callbackLease.SessionId,
-                OwnerId = callbackLease.OwnerId,
-                TransportLeaseId = callbackLease.TransportLeaseId,
-                LeaseExpiresAt = callbackLease.LeaseExpiresAt?.Clone(),
+                SessionId = callbackKey.SessionId,
+                OwnerId = callbackKey.OwnerId,
+                TransportLeaseId = callbackKey.TransportLeaseId,
+                LeaseExpiresAt = callbackKey.LeaseExpiresAt?.Clone(),
                 ProviderEvent = evt.Clone(),
             }, ct);
             return;
@@ -429,57 +427,62 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         }, ct);
     }
 
-    private bool IsActorAcceptedCurrentTransportLease(VoiceTransportLease lease) =>
-        ReferenceEquals(_transportLease, lease) &&
-        lease.IsActorAccepted &&
-        !IsLeaseExpired(lease.LeaseExpiresAt);
-
-    private async Task DisposeTransportLeaseAsync()
+    private async Task DisposeTransportPumpAsync()
     {
-        var lease = _transportLease;
-        _transportLease = null;
+        var pump = _transportPump;
+        _transportPump = null;
         _provider.OnEvent = null;
-        if (lease == null)
+        if (pump == null)
             return;
 
-        await lease.DisposeAsync();
+        await pump.DisposeAsync();
     }
 
-    private sealed class VoiceTransportLease : IAsyncDisposable
+    private sealed class VoiceTransportRelayKey
     {
-        public VoiceTransportLease(
+        public VoiceTransportRelayKey(
             string sessionId,
             string ownerId,
             string transportLeaseId,
-            Timestamp? leaseExpiresAt,
-            IVoiceTransport transport,
-            Func<IMessage, CancellationToken, Task> selfEventDispatcher)
+            Timestamp? leaseExpiresAt)
         {
             SessionId = sessionId;
             OwnerId = ownerId;
             TransportLeaseId = transportLeaseId;
             LeaseExpiresAt = leaseExpiresAt?.Clone();
-            Transport = transport;
-            SelfEventDispatcher = selfEventDispatcher;
         }
 
         public string SessionId { get; }
         public string OwnerId { get; }
         public string TransportLeaseId { get; }
         public Timestamp? LeaseExpiresAt { get; }
+
+        public bool Matches(VoiceProviderEventReceived request) =>
+            string.Equals(SessionId, request.SessionId, StringComparison.Ordinal) &&
+            string.Equals(TransportLeaseId, request.TransportLeaseId, StringComparison.Ordinal) &&
+            string.Equals(OwnerId, request.OwnerId, StringComparison.Ordinal);
+    }
+
+    private sealed class VoiceTransportRelayPump : IAsyncDisposable
+    {
+        public VoiceTransportRelayPump(
+            VoiceTransportRelayKey key,
+            IVoiceTransport transport,
+            Func<IMessage, CancellationToken, Task> selfEventDispatcher)
+        {
+            Key = key;
+            Transport = transport;
+            SelfEventDispatcher = selfEventDispatcher;
+        }
+
+        public VoiceTransportRelayKey Key { get; }
         public IVoiceTransport Transport { get; }
         public Func<IMessage, CancellationToken, Task> SelfEventDispatcher { get; }
         public CancellationTokenSource Cancellation { get; } = new();
         public Task? RelayTask { get; set; }
-        public bool IsActorAccepted { get; set; }
 
         public Task DispatchAsync(IMessage message, CancellationToken ct) =>
             SelfEventDispatcher(message, ct);
-
-        public void DispatchFireAndForget(IMessage message)
-        {
-            _ = DispatchAsync(message, CancellationToken.None);
-        }
 
         public async ValueTask DisposeAsync()
         {
@@ -759,7 +762,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
 
     private async Task DispatchSelfEventAsync(IMessage message, CancellationToken ct)
     {
-        var dispatcher = _transportLease?.SelfEventDispatcher ?? _volatileSelfSignalDispatcher;
+        var dispatcher = _transportPump?.SelfEventDispatcher ?? _volatileSelfSignalDispatcher;
         if (dispatcher == null)
             return;
 
@@ -843,19 +846,15 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         VoiceProviderEventReceived request,
         CancellationToken ct)
     {
-        var lease = _transportLease;
-        if (lease == null ||
-            !string.Equals(lease.SessionId, request.SessionId, StringComparison.Ordinal) ||
-            !string.Equals(lease.TransportLeaseId, request.TransportLeaseId, StringComparison.Ordinal) ||
-            !string.Equals(lease.OwnerId, request.OwnerId, StringComparison.Ordinal) ||
-            !IsActorAcceptedCurrentTransportLease(lease))
+        var pump = _transportPump;
+        if (pump == null || !pump.Key.Matches(request))
         {
             return;
         }
 
         try
         {
-            await lease.Transport.SendAudioAsync(request.ProviderEvent.AudioReceived.Pcm16.Memory, ct);
+            await pump.Transport.SendAudioAsync(request.ProviderEvent.AudioReceived.Pcm16.Memory, ct);
         }
         catch (Exception ex)
         {
@@ -899,14 +898,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         if (state.RemoteAudioSupport == VoiceRemoteAudioSupport.Unspecified)
             state.RemoteAudioSupport = VoiceRemoteAudioSupport.LocalOnly;
 
-        var lease = _transportLease;
-        if (lease != null &&
-            string.Equals(lease.SessionId, request.SessionId, StringComparison.Ordinal) &&
-            string.Equals(lease.TransportLeaseId, request.TransportLeaseId, StringComparison.Ordinal))
-        {
-            lease.IsActorAccepted = true;
-        }
-
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
@@ -926,14 +917,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             return;
 
         ClearTransportLeaseState(state);
-        var lease = _transportLease;
-        if (lease != null &&
-            string.Equals(lease.SessionId, request.SessionId, StringComparison.Ordinal) &&
-            string.Equals(lease.TransportLeaseId, request.TransportLeaseId, StringComparison.Ordinal))
-        {
-            lease.IsActorAccepted = false;
-        }
-
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
@@ -974,14 +957,6 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
             return;
 
         ClearTransportLeaseState(state);
-        var lease = _transportLease;
-        if (lease != null &&
-            string.Equals(lease.SessionId, request.SessionId, StringComparison.Ordinal) &&
-            string.Equals(lease.TransportLeaseId, request.TransportLeaseId, StringComparison.Ordinal))
-        {
-            lease.IsActorAccepted = false;
-        }
-
         await PersistRuntimeStateAsync(ctx, state, ct);
     }
 
@@ -1178,7 +1153,7 @@ public sealed class VoicePresenceModule : ILifecycleAwareEventModule, IRouteBypa
         state.ProviderResponseBindings.Clear();
         state.CancelledProviderResponseIds.Clear();
         state.ActiveProviderResponseId = string.Empty;
-        _provider.OnEvent = _transportLease == null ? null : OnProviderEventAsync;
+        _provider.OnEvent = _transportPump == null ? null : OnProviderEventAsync;
         await PersistRuntimeStateAsync(ctx, state, ct);
         await PublishRemoteOutputAsync(
             new VoiceRemoteTransportOutput

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs
@@ -490,6 +490,9 @@ public class VoicePresenceModuleTests
         moduleSource.ShouldNotContain("Task? _providerToUserRelay", Case.Sensitive);
         moduleSource.ShouldNotContain("TransportAttached = _transportLease", Case.Sensitive);
         moduleSource.ShouldNotContain("TransportAttached = _userTransport", Case.Sensitive);
+        moduleSource.ShouldNotContain("IsActorAccepted", Case.Sensitive);
+        moduleSource.ShouldNotContain("DispatchFireAndForget", Case.Sensitive);
+        moduleSource.ShouldNotContain("VoiceTransportLease", Case.Sensitive);
     }
 
     [Fact]
@@ -994,7 +997,7 @@ public class VoicePresenceModuleTests
         var transport = new RecordingVoiceTransport();
         var dispatched = new List<IMessage>();
         var expiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
-        module.AttachTransport(transport, (message, _) =>
+        await module.AttachTransportAsync(transport, (message, _) =>
         {
             dispatched.Add(message);
             return Task.CompletedTask;
@@ -1054,6 +1057,30 @@ public class VoicePresenceModuleTests
         }), ctx, CancellationToken.None);
 
         transport.SentAudio.ShouldHaveSingleItem().ShouldBe([4, 5]);
+    }
+
+    [Fact]
+    public void Sync_leased_attach_should_reject_fire_and_forget_dispatch_shape()
+    {
+        var module = CreateModule(new RecordingVoiceProvider());
+        var transport = new RecordingVoiceTransport();
+        var dispatched = new List<IMessage>();
+
+        var ex = Should.Throw<InvalidOperationException>(() =>
+            module.AttachTransport(
+                transport,
+                (message, _) =>
+                {
+                    dispatched.Add(message);
+                    return Task.CompletedTask;
+                },
+                "lease-1",
+                "host-1",
+                Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5))));
+
+        ex.Message.ShouldBe("Leased voice transport attach must observe attach signal dispatch.");
+        dispatched.ShouldBeEmpty();
+        module.HasVolatileTransportLease.ShouldBeFalse();
     }
 
     [Fact]
@@ -1489,7 +1516,7 @@ public class VoicePresenceModuleTests
 
         var sendThrowTransport = new ThrowingSendVoiceTransport();
         var dispatched = new List<IMessage>();
-        module.AttachTransport(sendThrowTransport, (message, _) =>
+        await module.AttachTransportAsync(sendThrowTransport, (message, _) =>
         {
             dispatched.Add(message);
             return Task.CompletedTask;

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoiceTransportRelayTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoiceTransportRelayTests.cs
@@ -135,11 +135,12 @@ public class VoiceTransportRelayTests
         ]);
 
         const string transportLeaseId = "transport-1";
+        var leaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5));
         roleAgent.State.VoicePresence["voice_presence"] = new VoicePresenceRuntimeState
         {
             ActiveSessionId = "lease-1",
             ActiveLeaseOwnerId = "host-1",
-            LeaseExpiresAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)),
+            LeaseExpiresAt = leaseExpiresAt.Clone(),
             TransportAttached = true,
             ActiveTransportLeaseId = transportLeaseId,
             Status = VoicePresenceRuntimeStatus.AudioDraining,
@@ -148,16 +149,19 @@ public class VoiceTransportRelayTests
             LastDrainAckResponseId = -1,
             LastDrainAckPlayoutSequence = -1,
         };
-        module.AttachTransport(transport, (message, ct) =>
+        await module.AttachTransportAsync(transport, (message, ct) =>
         {
-            if (message is VoiceTransportAttachRequested)
-                return Task.CompletedTask;
+            if (message is VoiceTransportAttachRequested attach)
+                return module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
+                {
+                    ModuleName = "voice_presence",
+                    TransportAttachRequested = attach,
+                }), ctx, ct);
 
             if (message is VoiceTransportControlFrameReceived control)
             {
-                control.OwnerId = "host-1";
-                control.TransportLeaseId = transportLeaseId;
-                control.LeaseExpiresAt = roleAgent.State.VoicePresence["voice_presence"].LeaseExpiresAt.Clone();
+                control.TransportLeaseId.ShouldNotBe(transportLeaseId);
+                roleAgent.State.VoicePresence["voice_presence"].ActiveTransportLeaseId = control.TransportLeaseId;
                 return module.HandleAsync(CreateEnvelope(new VoiceModuleSignal
                 {
                     ModuleName = "voice_presence",
@@ -166,7 +170,7 @@ public class VoiceTransportRelayTests
             }
 
             return module.HandleAsync(CreateEnvelope(message), ctx, ct);
-        }, "lease-1", "host-1", Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.AddMinutes(5)));
+        }, "lease-1", "host-1", leaseExpiresAt.Clone());
         await transport.WaitUntilConsumed(TimeSpan.FromSeconds(3));
 
         var persistedState = roleAgent.State.VoicePresence["voice_presence"];


### PR DESCRIPTION
## 问题

cluster-070 / #948 指出 `VoicePresenceModule` 的本地 `VoiceTransportLease` 同时承载 actor acceptance、session/owner/expiry lease 事实和本地 relay 生命周期，导致 actor-owned lease fact 与 process-local mirror 混在一起。

## 方案

- 删除本地 actor acceptance mirror：移除 `IsActorAccepted` 与相关本地置位/清理逻辑，provider audio 是否能写回 transport 由 actor turn 中的 `VoicePresenceRuntimeState` 先验收，再只用不可变 transport key 对账本地 pump。
- 删除 fire-and-forget leased attach：带 `sessionId` 的同步 `AttachTransport(...)` 直接拒绝，正式路径必须走 `AttachTransportAsync(...)` 并等待 attach signal dispatch 结果。
- 拆分本地 relay pump：将本地对象收敛为 `VoiceTransportRelayPump` + `VoiceTransportRelayKey`，pump 只持 transport I/O、dispatcher、取消源和 relay task；lease fact 继续在 actor state 中维护。
- 保留 `/ws/voice` endpoint contract、`VoicePresenceSession`、现有 typed signals 和 transport reconciliation keys；未新增 core actor/envelope/proto。

## 影响路径

- `src/Aevatar.Foundation.VoicePresence/Modules/VoicePresenceModule.cs`
- `test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceModuleTests.cs`
- `test/Aevatar.Foundation.VoicePresence.Tests/VoiceTransportRelayTests.cs`

## 验证

- `dotnet test test/Aevatar.Foundation.VoicePresence.Tests/Aevatar.Foundation.VoicePresence.Tests.csproj --no-restore --nologo`
- `bash tools/ci/architecture_guards.sh && bash tools/ci/test_stability_guards.sh && dotnet build aevatar.slnx --nologo`

⟦AI:AUTO-LOOP⟧
