### PR TITLE
抽出 AgentRun typed 生成执行器

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -1,4 +1,3 @@
-using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Attributes;
@@ -8,7 +7,6 @@ using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
@@ -41,40 +39,29 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
     internal static readonly TimeSpan TerminalCleanupDelay = TimeSpan.FromMinutes(5);
     private const string TerminalCleanupCallbackPrefix = "agent-run-terminal-cleanup";
+    private const string GenerationTimeoutCallbackPrefix = "agent-run-generation-timeout";
     internal static readonly TimeSpan OutputDispatchTimeout = TimeSpan.FromSeconds(10);
     internal static readonly TimeSpan OutputDispatchRetryDelay = TimeSpan.FromSeconds(5);
     private const string OutputDispatchRetryCallbackPrefix = "agent-run-output-dispatch-retry";
 
     private readonly IActorRuntime _actorRuntime;
-    private readonly IActorDispatchPort _actorDispatchPort;
-    private readonly IConversationReplyGenerator _replyGenerator;
-    private readonly IInteractiveReplyCollector? _interactiveReplyCollector;
+    private readonly IAgentRunReplyGenerationExecutorPort _generationExecutor;
     private readonly Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? _relayOptions;
-    private readonly INyxIdRelayScopeResolver? _scopeResolver;
-    private readonly IUserConfigQueryPort? _userConfigQueryPort;
     private readonly IActorRuntimeCallbackScheduler? _callbackScheduler;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<AgentRunGAgent> _logger;
 
     public AgentRunGAgent(
         IActorRuntime actorRuntime,
-        IActorDispatchPort actorDispatchPort,
-        IConversationReplyGenerator replyGenerator,
-        IInteractiveReplyCollector? interactiveReplyCollector,
+        IAgentRunReplyGenerationExecutorPort generationExecutor,
         Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
         ILogger<AgentRunGAgent> logger,
-        INyxIdRelayScopeResolver? scopeResolver = null,
-        IUserConfigQueryPort? userConfigQueryPort = null,
         IActorRuntimeCallbackScheduler? callbackScheduler = null,
         TimeProvider? timeProvider = null)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
-        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
-        _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
-        _interactiveReplyCollector = interactiveReplyCollector;
+        _generationExecutor = generationExecutor ?? throw new ArgumentNullException(nameof(generationExecutor));
         _relayOptions = relayOptions;
-        _scopeResolver = scopeResolver;
-        _userConfigQueryPort = userConfigQueryPort;
         _callbackScheduler = callbackScheduler;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -90,6 +77,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         StateTransitionMatcher
             .Match(current, evt)
             .On<AgentRunStartedEvent>(ApplyStarted)
+            .On<AgentRunReplyGenerationRequestedEvent>(ApplyReplyGenerationRequested)
             .On<AgentRunReplyProducedEvent>(ApplyReplyProduced)
             .On<AgentRunReplyDispatchedEvent>(ApplyReplyDispatched)
             .On<AgentRunDroppedEvent>(ApplyDropped)
@@ -163,6 +151,15 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             return;
         }
 
+        if (State.Status is AgentRunStatus.ReplyGenerationRequested)
+        {
+            _logger.LogInformation(
+                "Ignoring duplicate agent run start while reply generation is already requested: runId={RunId} correlation={CorrelationId}",
+                runId,
+                request.CorrelationId);
+            return;
+        }
+
         if (string.IsNullOrWhiteSpace(State.RunId))
         {
             await PersistDomainEventAsync(new AgentRunStartedEvent
@@ -176,7 +173,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         try
         {
-            await ProcessAsync(request, runId);
+            await RequestReplyGenerationAsync(request, runId);
         }
         catch (AgentRunOutputDispatchException ex)
         {
@@ -193,6 +190,95 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         {
             await FailAfterUnexpectedExceptionAsync(request, runId, ex);
         }
+    }
+
+    [EventHandler]
+    public async Task HandleReplyGenerationCompletedAsync(AgentRunReplyGenerationCompleted command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!IsCurrentGenerationContinuation(command.RunId, command.CorrelationId, command.Attempt))
+            return;
+
+        var request = command.Request?.Clone() ?? new NeedsLlmReplyEvent
+        {
+            CorrelationId = command.CorrelationId,
+            TargetActorId = command.TargetActorId,
+            RunId = command.RunId,
+        };
+        ApplyTargetRefOverrides(request);
+        if (string.IsNullOrWhiteSpace(request.TargetActorId))
+            request.TargetActorId = command.TargetActorId;
+
+        try
+        {
+            await ProduceAndDispatchAsync(
+                request,
+                command.RunId,
+                command.ReplyText ?? string.Empty,
+                command.Outbound,
+                command.TerminalState,
+                command.ErrorCode ?? string.Empty,
+                command.ErrorSummary ?? string.Empty);
+        }
+        catch (AgentRunOutputDispatchException ex)
+        {
+            if (await TryHandleOutputDispatchFailureAsync(request, command.RunId, ex))
+                return;
+
+            await PersistFailedAsync(
+                request,
+                command.RunId,
+                "agent_run_output_dispatch_failed",
+                ex.Message);
+        }
+        catch (Exception ex)
+        {
+            await FailAfterUnexpectedExceptionAsync(request, command.RunId, ex);
+        }
+    }
+
+    [EventHandler]
+    public async Task HandleReplyGenerationFailedAsync(AgentRunReplyGenerationFailed command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!IsCurrentGenerationContinuation(command.RunId, command.CorrelationId, command.Attempt))
+            return;
+
+        var request = command.Request?.Clone() ?? new NeedsLlmReplyEvent
+        {
+            CorrelationId = command.CorrelationId,
+            TargetActorId = command.TargetActorId,
+            RunId = command.RunId,
+        };
+        ApplyTargetRefOverrides(request);
+        if (string.IsNullOrWhiteSpace(request.TargetActorId))
+            request.TargetActorId = command.TargetActorId;
+
+        await PersistFailedAsync(
+            request,
+            command.RunId,
+            NormalizeOptional(command.ErrorCode) ?? "agent_run_generation_failed",
+            command.ErrorSummary ?? string.Empty);
+    }
+
+    [EventHandler]
+    public async Task HandleReplyGenerationTimedOutAsync(AgentRunReplyGenerationTimedOut command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        if (!IsCurrentGenerationContinuation(command.RunId, command.CorrelationId, command.Attempt))
+            return;
+
+        await PersistDomainEventAsync(new AgentRunFailedEvent
+        {
+            RunId = command.RunId,
+            CorrelationId = command.CorrelationId,
+            TargetActorId = command.TargetActorId,
+            ErrorCode = "llm_reply_timeout",
+            ErrorSummary = $"LLM reply generation exceeded {(int)ResolveFallbackTimeout().TotalSeconds}s budget.",
+            FailedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        });
+
+        await ScheduleTerminalCleanupAsync(command.RunId);
     }
 
     [EventHandler]
@@ -233,10 +319,10 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         await _actorRuntime.DestroyAsync(Id, CancellationToken.None);
     }
 
-    private async Task ProcessAsync(NeedsLlmReplyEvent request, string runId)
+    private async Task RequestReplyGenerationAsync(NeedsLlmReplyEvent request, string runId)
     {
         _logger.LogInformation(
-            "Processing agent run LLM reply request: runId={RunId} correlation={CorrelationId} target={TargetActorId}",
+            "Requesting agent run LLM reply generation: runId={RunId} correlation={CorrelationId} target={TargetActorId}",
             runId,
             request.CorrelationId,
             request.TargetActorId);
@@ -282,159 +368,25 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         await EnsureTargetActorAsync(request.TargetActorId);
 
-        string replyText;
-        MessageContent? outboundIntent = null;
-        var terminalState = LlmReplyTerminalState.Completed;
-        var errorCode = string.Empty;
-        var errorSummary = string.Empty;
-        using TurnStreamingReplySink? streamingSink = TryBuildStreamingSink(request, request.TargetActorId);
-        var streamingState = TryBuildStreamingReplyState(streamingSink, request);
-
-        IReadOnlyDictionary<string, string> effectiveMetadata;
-        using (var metadataCts = new CancellationTokenSource(MetadataBuildBudget))
+        var requestedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+        var attempt = Math.Max(1, State.GenerationAttempt + 1);
+        await PersistDomainEventAsync(new AgentRunReplyGenerationRequestedEvent
         {
-            try
-            {
-                effectiveMetadata = await BuildEffectiveMetadataAsync(request, metadataCts.Token);
-            }
-            catch (OperationCanceledException ex) when (metadataCts.IsCancellationRequested)
-            {
-                _logger.LogWarning(
-                    ex,
-                    "Deferred LLM reply metadata build timed out after {TimeoutSeconds}s: runId={RunId} correlation={CorrelationId}",
-                    (int)MetadataBuildBudget.TotalSeconds,
-                    runId,
-                    request.CorrelationId);
-                replyText = "Sorry, I couldn't load your model preferences in time. Please try again.";
-                terminalState = LlmReplyTerminalState.Failed;
-                errorCode = "llm_reply_metadata_timeout";
-                errorSummary = $"Metadata enrichment exceeded {(int)MetadataBuildBudget.TotalSeconds}s budget.";
-                await FinalizeFailureStreamingSinkAsync(streamingState, replyText, outboundIntent);
-                await ProduceAndDispatchAsync(request, runId, replyText, outboundIntent, terminalState, errorCode, errorSummary);
-                return;
-            }
-        }
+            RunId = runId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            RequestedAtUnixMs = requestedAtUnixMs,
+            Attempt = attempt,
+        });
 
-        var fallbackTimeout = ResolveFallbackTimeout();
-        using var timeoutCts = fallbackTimeout > TimeSpan.Zero
-            ? new CancellationTokenSource(fallbackTimeout)
-            : new CancellationTokenSource();
-
-        try
-        {
-            IDisposable? interactiveReplyScope = null;
-            try
-            {
-                if (ShouldCaptureInteractiveReply(request.Activity))
-                    interactiveReplyScope = _interactiveReplyCollector?.BeginScope();
-
-                // ADR-0021 §6 / canon §8 actor-edge closeout: the generator returns a
-                // single ConversationReplyResult per run carrying aggregated Usage and the
-                // last FinishReason. Round-internal terminal markers no longer leak past
-                // ChatRuntime, so this is the lone closeout observation point.
-                var replyResult = await _replyGenerator.GenerateReplyAsync(
-                    request.Activity,
-                    effectiveMetadata,
-                    streamingState,
-                    timeoutCts.Token);
-                replyText = replyResult.Text ?? string.Empty;
-                if (replyResult.Usage is not null || !string.IsNullOrEmpty(replyResult.FinishReason))
-                {
-                    _logger.LogInformation(
-                        "LLM reply closeout: runId={RunId} correlation={CorrelationId} promptTokens={Prompt} completionTokens={Completion} totalTokens={Total} finishReason={FinishReason}",
-                        runId,
-                        request.CorrelationId,
-                        replyResult.Usage?.PromptTokens,
-                        replyResult.Usage?.CompletionTokens,
-                        replyResult.Usage?.TotalTokens,
-                        replyResult.FinishReason ?? "(none)");
-                }
-                outboundIntent = _interactiveReplyCollector?.TryTake();
-            }
-            finally
-            {
-                interactiveReplyScope?.Dispose();
-            }
-
-            if (streamingState is not null &&
-                outboundIntent is null &&
-                !string.IsNullOrWhiteSpace(replyText))
-            {
-                await streamingState.FinalizeAsync(replyText, CancellationToken.None);
-            }
-
-            if (outboundIntent is null && string.IsNullOrWhiteSpace(replyText))
-            {
-                terminalState = LlmReplyTerminalState.Failed;
-                errorCode = "empty_reply";
-                errorSummary = "Reply generator returned an empty response.";
-                replyText = "Sorry, I wasn't able to generate a response. Please try again.";
-            }
-        }
-        catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested)
-        {
-            terminalState = LlmReplyTerminalState.Failed;
-            errorCode = "llm_reply_timeout";
-            errorSummary = $"LLM reply generation exceeded {(int)fallbackTimeout.TotalSeconds}s budget.";
-            replyText = "Sorry, this took too long to process - the model or one of its tools didn't " +
-                        "respond in time. Please try again, or rephrase the request.";
-            _logger.LogWarning(
-                ex,
-                "Deferred LLM reply timed out after {TimeoutSeconds}s: runId={RunId} correlation={CorrelationId}",
-                (int)fallbackTimeout.TotalSeconds,
+        await ScheduleGenerationTimeoutAsync(request, runId, attempt);
+        await _generationExecutor.StartAsync(
+            new AgentRunReplyGenerationExecutionRequest(
                 runId,
-                request.CorrelationId);
-        }
-        catch (Exception ex)
-        {
-            terminalState = LlmReplyTerminalState.Failed;
-            errorCode = "llm_reply_failed";
-            errorSummary = ex.Message;
-            replyText = NyxIdRelayErrorClassifier.Classify(ex.Message);
-            _logger.LogWarning(
-                ex,
-                "Deferred LLM reply generation failed: runId={RunId} correlation={CorrelationId}",
-                runId,
-                request.CorrelationId);
-        }
-
-        if (terminalState == LlmReplyTerminalState.Failed)
-        {
-            // Streaming-sink failure finalize: when the LLM run terminates with a fallback
-            // text (timeout / classifier / empty reply), surface that text on the live
-            // streaming card/edit message before the LlmReplyReadyEvent lands. Carried over
-            // from feature/lark-bot's dispatch hardening.
-            await FinalizeFailureStreamingSinkAsync(streamingState, replyText, outboundIntent);
-        }
-
-        await ProduceAndDispatchAsync(
-            request,
-            runId,
-            replyText,
-            outboundIntent,
-            terminalState,
-            errorCode,
-            errorSummary);
-    }
-
-    private async Task FinalizeFailureStreamingSinkAsync(
-        StreamingReplyRunState? streamingState,
-        string replyText,
-        MessageContent? outboundIntent)
-    {
-        if (streamingState is not null &&
-            outboundIntent is null &&
-            !string.IsNullOrWhiteSpace(replyText))
-        {
-            try
-            {
-                await streamingState.FinalizeAsync(replyText, CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to finalize streaming failure text for agent run {ActorId}", Id);
-            }
-        }
+                Id,
+                attempt,
+                request.Clone()),
+            CancellationToken.None);
     }
 
     /// <summary>
@@ -694,235 +646,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         }
     }
 
-    private TurnStreamingReplySink? TryBuildStreamingSink(NeedsLlmReplyEvent request, string targetActorId)
-    {
-        if (_relayOptions is not { StreamingRepliesEnabled: true })
-            return null;
-        if (request.Activity?.OutboundDelivery is not
-            {
-                ReplyMessageId.Length: > 0,
-                CorrelationId.Length: > 0,
-            })
-        {
-            return null;
-        }
-        if (string.IsNullOrWhiteSpace(request.CorrelationId))
-            return null;
-
-        var cardMode = _relayOptions.StreamingCardKitEnabled;
-        return new TurnStreamingReplySink(
-            _actorDispatchPort,
-            targetActorId,
-            request.CorrelationId,
-            request.RegistrationId,
-            request.Activity.Clone(),
-            request.ReplyToken,
-            request.ReplyTokenExpiresAtUnixMs,
-            _timeProvider,
-            _logger,
-            cardMode);
-    }
-
-    private StreamingReplyRunState? TryBuildStreamingReplyState(TurnStreamingReplySink? sink, NeedsLlmReplyEvent request)
-    {
-        if (sink is null || _relayOptions is null)
-            return null;
-
-        var cardMode = _relayOptions.StreamingCardKitEnabled;
-        var throttle = TimeSpan.FromMilliseconds(Math.Max(0, cardMode
-            ? _relayOptions.StreamingCardKitFlushIntervalMs
-            : _relayOptions.StreamingFlushIntervalMs));
-        var maxInterimChunks = cardMode
-            ? int.MaxValue
-            : Math.Max(0, _relayOptions.StreamingMaxInterimChunks);
-
-        return new StreamingReplyRunState(sink, throttle, maxInterimChunks, _timeProvider);
-    }
-
-    /// <summary>
-    /// Actor-owned coalescing state for one generated reply stream.
-    /// </summary>
-    /// <remarks>
-    /// Refactor (iter15/cluster-027-streaming-reply-timer-business-dispatch):
-    ///   Old pattern: timer callback directly inspects/mutates pending business output and dispatches actor command from callback thread
-    ///   New principle: this run flow owns throttling, duplicate suppression, interim caps, and final flush ordering before dispatch; throttled deltas never block the actor turn.
-    /// </remarks>
-    private sealed class StreamingReplyRunState : IStreamingReplySink
-    {
-        private readonly TurnStreamingReplySink _sink;
-        private readonly TimeSpan _throttle;
-        private readonly int _maxInterimChunks;
-        private readonly TimeProvider _timeProvider;
-        private string _lastEmittedText = string.Empty;
-        private DateTimeOffset _lastEmitAt = DateTimeOffset.MinValue;
-        private int _chunksEmitted;
-        private string _pendingText = string.Empty;
-
-        public StreamingReplyRunState(
-            TurnStreamingReplySink sink,
-            TimeSpan throttle,
-            int maxInterimChunks,
-            TimeProvider timeProvider)
-        {
-            _sink = sink;
-            _throttle = throttle < TimeSpan.Zero ? TimeSpan.Zero : throttle;
-            _maxInterimChunks = maxInterimChunks < 0 ? 0 : maxInterimChunks;
-            _timeProvider = timeProvider;
-        }
-
-        public Task OnDeltaAsync(string accumulatedText, CancellationToken ct) =>
-            TryDispatchAsync(accumulatedText, isFinal: false, ct);
-
-        public Task FinalizeAsync(string finalText, CancellationToken ct) =>
-            TryDispatchAsync(finalText, isFinal: true, ct);
-
-        private async Task TryDispatchAsync(string text, bool isFinal, CancellationToken ct)
-        {
-            if (string.IsNullOrWhiteSpace(text))
-                return;
-
-            if (string.Equals(text, _lastEmittedText, StringComparison.Ordinal))
-            {
-                if (isFinal || string.Equals(text, _pendingText, StringComparison.Ordinal))
-                    ClearPending();
-                return;
-            }
-
-            if (!isFinal && _chunksEmitted >= _maxInterimChunks)
-            {
-                StashPending(text);
-                return;
-            }
-
-            if (!isFinal)
-            {
-                var elapsed = _timeProvider.GetUtcNow() - _lastEmitAt;
-                if (elapsed < _throttle)
-                {
-                    StashPending(text);
-                    return;
-                }
-            }
-
-            await _sink.DispatchAsync(text, ct).ConfigureAwait(false);
-            if (_sink.ChunksEmitted > _chunksEmitted)
-            {
-                _lastEmittedText = text;
-                _lastEmitAt = _timeProvider.GetUtcNow();
-                _chunksEmitted = _sink.ChunksEmitted;
-                if (isFinal || string.Equals(_pendingText, text, StringComparison.Ordinal))
-                    ClearPending();
-            }
-        }
-
-        private void StashPending(string text)
-        {
-            _pendingText = text;
-        }
-
-        private void ClearPending()
-        {
-            _pendingText = string.Empty;
-        }
-    }
-
-    private async Task<IReadOnlyDictionary<string, string>> BuildEffectiveMetadataAsync(
-        NeedsLlmReplyEvent request,
-        CancellationToken ct)
-    {
-        var routedModel = NormalizeOptional(request.TargetRef?.ForwardToModel?.ModelName);
-        var metadata = new Dictionary<string, string>(request.Metadata, StringComparer.Ordinal);
-
-        await ApplyBotOwnerLlmConfigAsync(request, metadata, ct);
-        if (routedModel is not null)
-            metadata[LLMRequestMetadataKeys.ModelOverride] = routedModel;
-
-        var userAccessToken = request.Activity?.TransportExtras?.NyxUserAccessToken?.Trim();
-        if (!string.IsNullOrWhiteSpace(userAccessToken))
-        {
-            metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = userAccessToken;
-            metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = userAccessToken;
-        }
-
-        return metadata;
-    }
-
-    private async Task ApplyBotOwnerLlmConfigAsync(
-        NeedsLlmReplyEvent request,
-        IDictionary<string, string> metadata,
-        CancellationToken ct)
-    {
-        if (_scopeResolver is null || _userConfigQueryPort is null)
-            return;
-
-        var apiKeyId = request.Activity?.Bot?.Value?.Trim();
-        if (string.IsNullOrWhiteSpace(apiKeyId))
-            return;
-
-        string? scopeId;
-        try
-        {
-            scopeId = await _scopeResolver.ResolveScopeIdByApiKeyAsync(apiKeyId, ct);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to resolve bot owner scope id for LLM config: runId={RunId} correlation={CorrelationId} apiKeyId={ApiKeyId}",
-                Id,
-                request.CorrelationId,
-                apiKeyId);
-            return;
-        }
-
-        if (string.IsNullOrWhiteSpace(scopeId))
-        {
-            _logger.LogDebug(
-                "No bot owner scope id resolved for LLM config: runId={RunId} correlation={CorrelationId} apiKeyId={ApiKeyId}",
-                Id,
-                request.CorrelationId,
-                apiKeyId);
-            return;
-        }
-
-        try
-        {
-            var config = await _userConfigQueryPort.GetAsync(scopeId, ct);
-            if (!string.IsNullOrWhiteSpace(config.DefaultModel))
-                metadata[LLMRequestMetadataKeys.ModelOverride] = config.DefaultModel.Trim();
-            if (!string.IsNullOrWhiteSpace(config.PreferredLlmRoute))
-                metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = config.PreferredLlmRoute.Trim();
-            if (config.MaxToolRounds > 0)
-                metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride] =
-                    config.MaxToolRounds.ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-            _logger.LogInformation(
-                "Applied bot owner LLM config: runId={RunId} correlation={CorrelationId} scopeId={ScopeId} model={Model} route={Route}",
-                Id,
-                request.CorrelationId,
-                scopeId,
-                string.IsNullOrWhiteSpace(config.DefaultModel) ? "<server-default>" : config.DefaultModel,
-                string.IsNullOrWhiteSpace(config.PreferredLlmRoute) ? "<server-default>" : config.PreferredLlmRoute);
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(
-                ex,
-                "Failed to load bot owner LLM config: runId={RunId} correlation={CorrelationId} scopeId={ScopeId}",
-                Id,
-                request.CorrelationId,
-                scopeId);
-        }
-    }
-
     private TimeSpan ResolveFallbackTimeout()
     {
         if (_relayOptions is null)
@@ -1045,6 +768,41 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         }
     }
 
+    private async Task ScheduleGenerationTimeoutAsync(NeedsLlmReplyEvent request, string runId, int attempt)
+    {
+        if (_callbackScheduler is null)
+            return;
+
+        var fallbackTimeout = ResolveFallbackTimeout();
+        if (fallbackTimeout <= TimeSpan.Zero)
+            return;
+
+        try
+        {
+            await _callbackScheduler.ScheduleTimeoutAsync(
+                BuildTimeoutRequest(
+                    BuildGenerationTimeoutCallbackId(runId, attempt),
+                    fallbackTimeout,
+                    new AgentRunReplyGenerationTimedOut
+                    {
+                        RunId = runId,
+                        CorrelationId = request.CorrelationId,
+                        TargetActorId = request.TargetActorId,
+                        TimedOutAtUnixMs = _timeProvider.GetUtcNow().Add(fallbackTimeout).ToUnixTimeMilliseconds(),
+                        Attempt = attempt,
+                    }),
+                ct: CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to schedule agent run generation timeout: runId={RunId} actorId={ActorId}",
+                runId,
+                Id);
+        }
+    }
+
     private RuntimeCallbackTimeoutRequest BuildTimeoutRequest(
         string callbackId,
         TimeSpan dueTime,
@@ -1085,6 +843,16 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         return $"{OutputDispatchRetryCallbackPrefix}:{new string(chars)}";
     }
 
+    private static string BuildGenerationTimeoutCallbackId(string runId, int attempt)
+    {
+        var normalized = NormalizeOptional(runId) ?? "unknown";
+        var chars = normalized
+            .Select(static ch => char.IsLetterOrDigit(ch) || ch is '-' or '_' ? ch : '_')
+            .Take(96)
+            .ToArray();
+        return $"{GenerationTimeoutCallbackPrefix}:{new string(chars)}:{attempt}";
+    }
+
     private async Task EnsureTargetActorAsync(string targetActorId)
     {
         if (string.IsNullOrWhiteSpace(targetActorId))
@@ -1093,6 +861,29 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         var actor = await _actorRuntime.GetAsync(targetActorId);
         if (actor is null)
             await _actorRuntime.CreateAsync<ConversationGAgent>(targetActorId, CancellationToken.None);
+    }
+
+    private bool IsCurrentGenerationContinuation(string runId, string correlationId, int attempt)
+    {
+        if (IsTerminal())
+            return false;
+
+        if (State.Status is not AgentRunStatus.ReplyGenerationRequested)
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(State.RunId) &&
+            !string.Equals(State.RunId, runId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(State.CorrelationId) &&
+            !string.Equals(State.CorrelationId, correlationId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return attempt <= 0 || State.GenerationAttempt == attempt;
     }
 
     /// <summary>
@@ -1109,11 +900,9 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
     ///     <see cref="NeedsLlmReplyEvent.TargetActorId"/>. The reply is
     ///     dispatched to the forwarded actor; <c>EnsureTargetActorAsync</c>
     ///     creates it as a <c>ConversationGAgent</c> if missing.</item>
-    ///   <item><c>ForwardToModel.model_name</c> → sets
-    ///     <c>metadata[LLMRequestMetadataKeys.ModelOverride]</c>. The chat
-    ///     route policy is more specific than the bot owner's default model,
-    ///     so it intentionally overwrites a bot-owner-config-supplied model
-    ///     when both are present.</item>
+    ///   <item><c>ForwardToModel.model_name</c> → the generation executor maps
+    ///     this typed route decision into LLM metadata before invoking the
+    ///     provider.</item>
     ///   <item><c>Reject</c> → resolver-side already failed the turn before
     ///     the run was dispatched; this method shouldn't see it.</item>
     ///   <item>Anything else / no TargetRef → no-op (resolver returned
@@ -1149,7 +938,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
                         "Chat-route override: pinning LLM model to {Model} (correlation={CorrelationId})",
                         routedModel,
                         request.CorrelationId);
-                    request.Metadata[LLMRequestMetadataKeys.ModelOverride] = routedModel;
                 }
                 break;
             default:
@@ -1160,21 +948,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         }
     }
 
-    private bool ShouldCaptureInteractiveReply(ChatActivity? activity)
-    {
-        if (_interactiveReplyCollector is null)
-            return false;
-
-        if (_relayOptions is { InteractiveRepliesEnabled: false })
-            return false;
-
-        return activity?.OutboundDelivery is
-        {
-            ReplyMessageId.Length: > 0,
-            CorrelationId.Length: > 0,
-        };
-    }
-
     private static AgentRunGAgentState ApplyStarted(AgentRunGAgentState current, AgentRunStartedEvent evt)
     {
         var next = current.Clone();
@@ -1183,6 +956,20 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         next.TargetActorId = evt.TargetActorId;
         next.Status = AgentRunStatus.Started;
         next.StartedAtUnixMs = evt.StartedAtUnixMs;
+        return next;
+    }
+
+    private static AgentRunGAgentState ApplyReplyGenerationRequested(
+        AgentRunGAgentState current,
+        AgentRunReplyGenerationRequestedEvent evt)
+    {
+        var next = current.Clone();
+        next.RunId = string.IsNullOrWhiteSpace(next.RunId) ? evt.RunId : next.RunId;
+        next.CorrelationId = string.IsNullOrWhiteSpace(next.CorrelationId) ? evt.CorrelationId : next.CorrelationId;
+        next.TargetActorId = string.IsNullOrWhiteSpace(next.TargetActorId) ? evt.TargetActorId : next.TargetActorId;
+        next.Status = AgentRunStatus.ReplyGenerationRequested;
+        next.GenerationRequestedAtUnixMs = evt.RequestedAtUnixMs;
+        next.GenerationAttempt = evt.Attempt;
         return next;
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -268,6 +268,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         if (!IsCurrentGenerationContinuation(command.RunId, command.CorrelationId, command.Attempt))
             return;
 
+        await DispatchGenerationTimeoutDropNotificationAsync(command);
+
         await PersistDomainEventAsync(new AgentRunFailedEvent
         {
             RunId = command.RunId,
@@ -685,6 +687,36 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         {
             throw new AgentRunOutputDispatchException(
                 $"Failed to send deferred LLM reply drop event to conversation actor '{request.TargetActorId}' (reason '{reason}').",
+                ex);
+        }
+    }
+
+    private async Task DispatchGenerationTimeoutDropNotificationAsync(AgentRunReplyGenerationTimedOut command)
+    {
+        if (string.IsNullOrWhiteSpace(command.TargetActorId) ||
+            string.IsNullOrWhiteSpace(command.CorrelationId))
+        {
+            return;
+        }
+
+        var dropped = new DeferredLlmReplyDroppedEvent
+        {
+            CorrelationId = command.CorrelationId,
+            Reason = "llm_reply_timeout",
+            DroppedAtUnixMs = command.TimedOutAtUnixMs > 0
+                ? command.TimedOutAtUnixMs
+                : _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+        };
+
+        try
+        {
+            using var outputCts = new CancellationTokenSource(OutputDispatchTimeout);
+            await SendToAsync(command.TargetActorId, dropped, outputCts.Token);
+        }
+        catch (Exception ex)
+        {
+            throw new AgentRunOutputDispatchException(
+                $"Failed to send agent run generation timeout drop event to conversation actor '{command.TargetActorId}'.",
                 ex);
         }
     }

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -1,0 +1,538 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.NyxIdRelay;
+using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationExecutorPort
+{
+    private const string PublisherActorId = "agent-run-reply-generation-executor";
+    private readonly IActorDispatchPort _actorDispatchPort;
+    private readonly IConversationReplyGenerator _replyGenerator;
+    private readonly IInteractiveReplyCollector? _interactiveReplyCollector;
+    private readonly Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? _relayOptions;
+    private readonly INyxIdRelayScopeResolver? _scopeResolver;
+    private readonly IUserConfigQueryPort? _userConfigQueryPort;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<AgentRunReplyGenerationExecutor> _logger;
+
+    public AgentRunReplyGenerationExecutor(
+        IActorDispatchPort actorDispatchPort,
+        IConversationReplyGenerator replyGenerator,
+        IInteractiveReplyCollector? interactiveReplyCollector,
+        Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
+        ILogger<AgentRunReplyGenerationExecutor> logger,
+        INyxIdRelayScopeResolver? scopeResolver = null,
+        IUserConfigQueryPort? userConfigQueryPort = null,
+        TimeProvider? timeProvider = null)
+    {
+        _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
+        _interactiveReplyCollector = interactiveReplyCollector;
+        _relayOptions = relayOptions;
+        _scopeResolver = scopeResolver;
+        _userConfigQueryPort = userConfigQueryPort;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task StartAsync(AgentRunReplyGenerationExecutionRequest request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ct.ThrowIfCancellationRequested();
+        var workItem = request with { Request = request.Request.Clone() };
+        _ = Task.Run(() => ExecuteAndReportAsync(workItem), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    private async Task ExecuteAndReportAsync(AgentRunReplyGenerationExecutionRequest workItem)
+    {
+        try
+        {
+            var completed = await ExecuteAsync(workItem).ConfigureAwait(false);
+            await DispatchToRunActorAsync(workItem.RunActorId, completed, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Agent run reply generation executor failed before completion: runId={RunId} correlation={CorrelationId}",
+                workItem.RunId,
+                workItem.Request.CorrelationId);
+            var failed = new AgentRunReplyGenerationFailed
+            {
+                RunId = workItem.RunId,
+                CorrelationId = workItem.Request.CorrelationId,
+                TargetActorId = workItem.Request.TargetActorId,
+                ErrorCode = "agent_run_generation_executor_failed",
+                ErrorSummary = ex.Message,
+                FailedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+                Attempt = workItem.Attempt,
+                Request = workItem.Request.Clone(),
+            };
+            try
+            {
+                await DispatchToRunActorAsync(workItem.RunActorId, failed, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception dispatchEx)
+            {
+                _logger.LogError(
+                    dispatchEx,
+                    "Failed to dispatch agent run generation failure command: runId={RunId} actorId={ActorId}",
+                    workItem.RunId,
+                    workItem.RunActorId);
+            }
+        }
+    }
+
+    internal async Task<AgentRunReplyGenerationCompleted> ExecuteAsync(
+        AgentRunReplyGenerationExecutionRequest workItem)
+    {
+        var request = workItem.Request.Clone();
+        string replyText;
+        MessageContent? outboundIntent = null;
+        var terminalState = LlmReplyTerminalState.Completed;
+        var errorCode = string.Empty;
+        var errorSummary = string.Empty;
+        using TurnStreamingReplySink? streamingSink = TryBuildStreamingSink(request, request.TargetActorId);
+        var streamingState = TryBuildStreamingReplyState(streamingSink);
+
+        IReadOnlyDictionary<string, string> effectiveMetadata;
+        using (var metadataCts = new CancellationTokenSource(AgentRunGAgent.MetadataBuildBudget))
+        {
+            try
+            {
+                effectiveMetadata = await BuildEffectiveMetadataAsync(request, metadataCts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex) when (metadataCts.IsCancellationRequested)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Deferred LLM reply metadata build timed out after {TimeoutSeconds}s: runId={RunId} correlation={CorrelationId}",
+                    (int)AgentRunGAgent.MetadataBuildBudget.TotalSeconds,
+                    workItem.RunId,
+                    request.CorrelationId);
+                replyText = "Sorry, I couldn't load your model preferences in time. Please try again.";
+                terminalState = LlmReplyTerminalState.Failed;
+                errorCode = "llm_reply_metadata_timeout";
+                errorSummary =
+                    $"Metadata enrichment exceeded {(int)AgentRunGAgent.MetadataBuildBudget.TotalSeconds}s budget.";
+                await FinalizeFailureStreamingSinkAsync(streamingState, replyText, outboundIntent)
+                    .ConfigureAwait(false);
+                return BuildCompleted(workItem, request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+            }
+        }
+
+        var fallbackTimeout = ResolveFallbackTimeout();
+        using var timeoutCts = fallbackTimeout > TimeSpan.Zero
+            ? new CancellationTokenSource(fallbackTimeout)
+            : new CancellationTokenSource();
+
+        try
+        {
+            IDisposable? interactiveReplyScope = null;
+            try
+            {
+                if (ShouldCaptureInteractiveReply(request.Activity))
+                    interactiveReplyScope = _interactiveReplyCollector?.BeginScope();
+
+                var replyResult = await _replyGenerator.GenerateReplyAsync(
+                        request.Activity!,
+                        effectiveMetadata,
+                        streamingState,
+                        timeoutCts.Token)
+                    .ConfigureAwait(false);
+                replyText = replyResult.Text ?? string.Empty;
+                if (replyResult.Usage is not null || !string.IsNullOrEmpty(replyResult.FinishReason))
+                {
+                    _logger.LogInformation(
+                        "LLM reply closeout: runId={RunId} correlation={CorrelationId} promptTokens={Prompt} completionTokens={Completion} totalTokens={Total} finishReason={FinishReason}",
+                        workItem.RunId,
+                        request.CorrelationId,
+                        replyResult.Usage?.PromptTokens,
+                        replyResult.Usage?.CompletionTokens,
+                        replyResult.Usage?.TotalTokens,
+                        replyResult.FinishReason ?? "(none)");
+                }
+
+                outboundIntent = _interactiveReplyCollector?.TryTake();
+            }
+            finally
+            {
+                interactiveReplyScope?.Dispose();
+            }
+
+            if (streamingState is not null &&
+                outboundIntent is null &&
+                !string.IsNullOrWhiteSpace(replyText))
+            {
+                await streamingState.FinalizeAsync(replyText, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+
+            if (outboundIntent is null && string.IsNullOrWhiteSpace(replyText))
+            {
+                terminalState = LlmReplyTerminalState.Failed;
+                errorCode = "empty_reply";
+                errorSummary = "Reply generator returned an empty response.";
+                replyText = "Sorry, I wasn't able to generate a response. Please try again.";
+            }
+        }
+        catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested)
+        {
+            terminalState = LlmReplyTerminalState.Failed;
+            errorCode = "llm_reply_timeout";
+            errorSummary = $"LLM reply generation exceeded {(int)fallbackTimeout.TotalSeconds}s budget.";
+            replyText = "Sorry, this took too long to process - the model or one of its tools didn't " +
+                        "respond in time. Please try again, or rephrase the request.";
+            _logger.LogWarning(
+                ex,
+                "Deferred LLM reply timed out after {TimeoutSeconds}s: runId={RunId} correlation={CorrelationId}",
+                (int)fallbackTimeout.TotalSeconds,
+                workItem.RunId,
+                request.CorrelationId);
+        }
+        catch (Exception ex)
+        {
+            terminalState = LlmReplyTerminalState.Failed;
+            errorCode = "llm_reply_failed";
+            errorSummary = ex.Message;
+            replyText = NyxIdRelayErrorClassifier.Classify(ex.Message);
+            _logger.LogWarning(
+                ex,
+                "Deferred LLM reply generation failed: runId={RunId} correlation={CorrelationId}",
+                workItem.RunId,
+                request.CorrelationId);
+        }
+
+        if (terminalState == LlmReplyTerminalState.Failed)
+        {
+            await FinalizeFailureStreamingSinkAsync(streamingState, replyText, outboundIntent)
+                .ConfigureAwait(false);
+        }
+
+        return BuildCompleted(workItem, request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+    }
+
+    private AgentRunReplyGenerationCompleted BuildCompleted(
+        AgentRunReplyGenerationExecutionRequest workItem,
+        NeedsLlmReplyEvent request,
+        string replyText,
+        MessageContent? outboundIntent,
+        LlmReplyTerminalState terminalState,
+        string errorCode,
+        string errorSummary)
+    {
+        var completed = new AgentRunReplyGenerationCompleted
+        {
+            RunId = workItem.RunId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            ReplyText = replyText ?? string.Empty,
+            TerminalState = terminalState,
+            ErrorCode = errorCode,
+            ErrorSummary = errorSummary,
+            CompletedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+            Attempt = workItem.Attempt,
+            Request = request.Clone(),
+        };
+        if (outboundIntent is not null)
+            completed.Outbound = outboundIntent.Clone();
+        return completed;
+    }
+
+    private async Task DispatchToRunActorAsync<TCommand>(
+        string runActorId,
+        TCommand command,
+        CancellationToken ct)
+        where TCommand : IMessage
+    {
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
+            Payload = Any.Pack(command),
+            Route = EnvelopeRouteSemantics.CreateDirect(PublisherActorId, runActorId),
+        };
+        await _actorDispatchPort.DispatchAsync(runActorId, envelope, ct).ConfigureAwait(false);
+    }
+
+    private async Task FinalizeFailureStreamingSinkAsync(
+        StreamingReplyRunState? streamingState,
+        string replyText,
+        MessageContent? outboundIntent)
+    {
+        if (streamingState is not null &&
+            outboundIntent is null &&
+            !string.IsNullOrWhiteSpace(replyText))
+        {
+            try
+            {
+                await streamingState.FinalizeAsync(replyText, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to finalize streaming failure text for agent run");
+            }
+        }
+    }
+
+    private TurnStreamingReplySink? TryBuildStreamingSink(NeedsLlmReplyEvent request, string targetActorId)
+    {
+        if (_relayOptions is not { StreamingRepliesEnabled: true })
+            return null;
+        if (request.Activity?.OutboundDelivery is not
+            {
+                ReplyMessageId.Length: > 0,
+                CorrelationId.Length: > 0,
+            })
+        {
+            return null;
+        }
+        if (string.IsNullOrWhiteSpace(request.CorrelationId))
+            return null;
+
+        var cardMode = _relayOptions.StreamingCardKitEnabled;
+        return new TurnStreamingReplySink(
+            _actorDispatchPort,
+            targetActorId,
+            request.CorrelationId,
+            request.RegistrationId,
+            request.Activity.Clone(),
+            request.ReplyToken,
+            request.ReplyTokenExpiresAtUnixMs,
+            _timeProvider,
+            _logger,
+            cardMode);
+    }
+
+    private StreamingReplyRunState? TryBuildStreamingReplyState(TurnStreamingReplySink? sink)
+    {
+        if (sink is null || _relayOptions is null)
+            return null;
+
+        var cardMode = _relayOptions.StreamingCardKitEnabled;
+        var throttle = TimeSpan.FromMilliseconds(Math.Max(0, cardMode
+            ? _relayOptions.StreamingCardKitFlushIntervalMs
+            : _relayOptions.StreamingFlushIntervalMs));
+        var maxInterimChunks = cardMode
+            ? int.MaxValue
+            : Math.Max(0, _relayOptions.StreamingMaxInterimChunks);
+
+        return new StreamingReplyRunState(sink, throttle, maxInterimChunks, _timeProvider);
+    }
+
+    private async Task<IReadOnlyDictionary<string, string>> BuildEffectiveMetadataAsync(
+        NeedsLlmReplyEvent request,
+        CancellationToken ct)
+    {
+        var routedModel = NormalizeOptional(request.TargetRef?.ForwardToModel?.ModelName);
+        var metadata = new Dictionary<string, string>(request.Metadata, StringComparer.Ordinal);
+
+        await ApplyBotOwnerLlmConfigAsync(request, metadata, ct).ConfigureAwait(false);
+        if (routedModel is not null)
+            metadata[LLMRequestMetadataKeys.ModelOverride] = routedModel;
+
+        var userAccessToken = request.Activity?.TransportExtras?.NyxUserAccessToken?.Trim();
+        if (!string.IsNullOrWhiteSpace(userAccessToken))
+        {
+            metadata[LLMRequestMetadataKeys.NyxIdAccessToken] = userAccessToken;
+            metadata[LLMRequestMetadataKeys.NyxIdOrgToken] = userAccessToken;
+        }
+
+        return metadata;
+    }
+
+    private async Task ApplyBotOwnerLlmConfigAsync(
+        NeedsLlmReplyEvent request,
+        IDictionary<string, string> metadata,
+        CancellationToken ct)
+    {
+        if (_scopeResolver is null || _userConfigQueryPort is null)
+            return;
+
+        var apiKeyId = request.Activity?.Bot?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(apiKeyId))
+            return;
+
+        string? scopeId;
+        try
+        {
+            scopeId = await _scopeResolver.ResolveScopeIdByApiKeyAsync(apiKeyId, ct)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to resolve bot owner scope id for LLM config: correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                request.CorrelationId,
+                apiKeyId);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(scopeId))
+        {
+            _logger.LogDebug(
+                "No bot owner scope id resolved for LLM config: correlation={CorrelationId} apiKeyId={ApiKeyId}",
+                request.CorrelationId,
+                apiKeyId);
+            return;
+        }
+
+        try
+        {
+            var config = await _userConfigQueryPort.GetAsync(scopeId, ct).ConfigureAwait(false);
+            if (!string.IsNullOrWhiteSpace(config.DefaultModel))
+                metadata[LLMRequestMetadataKeys.ModelOverride] = config.DefaultModel.Trim();
+            if (!string.IsNullOrWhiteSpace(config.PreferredLlmRoute))
+                metadata[LLMRequestMetadataKeys.NyxIdRoutePreference] = config.PreferredLlmRoute.Trim();
+            if (config.MaxToolRounds > 0)
+                metadata[LLMRequestMetadataKeys.MaxToolRoundsOverride] =
+                    config.MaxToolRounds.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+            _logger.LogInformation(
+                "Applied bot owner LLM config: correlation={CorrelationId} scopeId={ScopeId} model={Model} route={Route}",
+                request.CorrelationId,
+                scopeId,
+                string.IsNullOrWhiteSpace(config.DefaultModel) ? "<server-default>" : config.DefaultModel,
+                string.IsNullOrWhiteSpace(config.PreferredLlmRoute) ? "<server-default>" : config.PreferredLlmRoute);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to load bot owner LLM config: correlation={CorrelationId} scopeId={ScopeId}",
+                request.CorrelationId,
+                scopeId);
+        }
+    }
+
+    private TimeSpan ResolveFallbackTimeout()
+    {
+        if (_relayOptions is null)
+            return TimeSpan.FromSeconds(AgentRunGAgent.FallbackTimeoutSecondsDefault);
+        var configured = _relayOptions.ResponseTimeoutSeconds;
+        if (configured <= 0)
+            return TimeSpan.Zero;
+        return TimeSpan.FromSeconds(configured);
+    }
+
+    private bool ShouldCaptureInteractiveReply(ChatActivity? activity)
+    {
+        if (_interactiveReplyCollector is null)
+            return false;
+
+        if (_relayOptions is { InteractiveRepliesEnabled: false })
+            return false;
+
+        return activity?.OutboundDelivery is
+        {
+            ReplyMessageId.Length: > 0,
+            CorrelationId.Length: > 0,
+        };
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+
+    private sealed class StreamingReplyRunState : IStreamingReplySink
+    {
+        private readonly TurnStreamingReplySink _sink;
+        private readonly TimeSpan _throttle;
+        private readonly int _maxInterimChunks;
+        private readonly TimeProvider _timeProvider;
+        private string _lastEmittedText = string.Empty;
+        private DateTimeOffset _lastEmitAt = DateTimeOffset.MinValue;
+        private int _chunksEmitted;
+        private string _pendingText = string.Empty;
+
+        public StreamingReplyRunState(
+            TurnStreamingReplySink sink,
+            TimeSpan throttle,
+            int maxInterimChunks,
+            TimeProvider timeProvider)
+        {
+            _sink = sink;
+            _throttle = throttle < TimeSpan.Zero ? TimeSpan.Zero : throttle;
+            _maxInterimChunks = maxInterimChunks < 0 ? 0 : maxInterimChunks;
+            _timeProvider = timeProvider;
+        }
+
+        public Task OnDeltaAsync(string accumulatedText, CancellationToken ct) =>
+            TryDispatchAsync(accumulatedText, isFinal: false, ct);
+
+        public Task FinalizeAsync(string finalText, CancellationToken ct) =>
+            TryDispatchAsync(finalText, isFinal: true, ct);
+
+        private async Task TryDispatchAsync(string text, bool isFinal, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return;
+
+            if (string.Equals(text, _lastEmittedText, StringComparison.Ordinal))
+            {
+                if (isFinal || string.Equals(text, _pendingText, StringComparison.Ordinal))
+                    ClearPending();
+                return;
+            }
+
+            if (!isFinal && _chunksEmitted >= _maxInterimChunks)
+            {
+                StashPending(text);
+                return;
+            }
+
+            if (!isFinal)
+            {
+                var elapsed = _timeProvider.GetUtcNow() - _lastEmitAt;
+                if (elapsed < _throttle)
+                {
+                    StashPending(text);
+                    return;
+                }
+            }
+
+            await _sink.DispatchAsync(text, ct).ConfigureAwait(false);
+            if (_sink.ChunksEmitted > _chunksEmitted)
+            {
+                _lastEmittedText = text;
+                _lastEmitAt = _timeProvider.GetUtcNow();
+                _chunksEmitted = _sink.ChunksEmitted;
+                if (isFinal || string.Equals(_pendingText, text, StringComparison.Ordinal))
+                    ClearPending();
+            }
+        }
+
+        private void StashPending(string text)
+        {
+            _pendingText = text;
+        }
+
+        private void ClearPending()
+        {
+            _pendingText = string.Empty;
+        }
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
@@ -1,0 +1,14 @@
+using Aevatar.GAgents.Channel.Runtime;
+
+namespace Aevatar.GAgents.NyxidChat;
+
+public interface IAgentRunReplyGenerationExecutorPort
+{
+    Task StartAsync(AgentRunReplyGenerationExecutionRequest request, CancellationToken ct);
+}
+
+public sealed record AgentRunReplyGenerationExecutionRequest(
+    string RunId,
+    string RunActorId,
+    int Attempt,
+    NeedsLlmReplyEvent Request);

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -82,6 +82,7 @@ public static class ServiceCollectionExtensions
             }));
         }
         services.TryAddSingleton<IConversationReplyGenerator, NyxIdConversationReplyGenerator>();
+        services.TryAddSingleton<IAgentRunReplyGenerationExecutorPort, AgentRunReplyGenerationExecutor>();
         services.TryAddSingleton<IVoiceDemoAgentCommandPort, VoiceDemoAgentCommandPort>();
 
         // ─── LLM-call middleware that injects channel context into LLM requests ───

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -26,6 +26,12 @@ enum AgentRunStatus {
   // ConversationGAgentState.last_reply_delivery; REPLY_HANDED_OFF is a
   // necessary-not-sufficient precondition. See ADR-0021.
   AGENT_RUN_STATUS_REPLY_HANDED_OFF = 5;
+  // The run actor has committed the generation request and handed the
+  // transient LLM/tool/streaming work to the stateless generation executor.
+  // Duplicate starts in this status must not start a second executor. The
+  // executor reports back through typed completion/failure commands; the run
+  // actor remains the sole owner of produced/dispatched/terminal facts.
+  AGENT_RUN_STATUS_REPLY_GENERATION_REQUESTED = 6;
 }
 
 message AgentRunGAgentState {
@@ -53,6 +59,11 @@ message AgentRunGAgentState {
   // marks the run as finalized (chain.finalized) — late ready/dropped/failed
   // /cleanup signals must no-op from this point.
   int64 cleanup_completed_at_unix_ms = 13;
+  // Generation stage request facts. Runtime-only credentials remain outside
+  // this state; the values here only gate duplicate starts and stale
+  // completion/timeout continuations.
+  int64 generation_requested_at_unix_ms = 14;
+  int32 generation_attempt = 15;
 }
 
 // Transient command for the run actor. The nested NeedsLlmReplyEvent may carry
@@ -88,6 +99,61 @@ message AgentRunReplyProducedEvent {
   // external API calls and incur duplicate billing).
   string reply_text = 8;
   aevatar.gagents.channel.abstractions.MessageContent outbound = 9;
+}
+
+// Persisted after admission gates pass and before the transient generation
+// executor is asked to start. This event intentionally carries no reply_token,
+// user access token, Activity, or other runtime-only credentials.
+message AgentRunReplyGenerationRequestedEvent {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  int64 requested_at_unix_ms = 4;
+  int32 attempt = 5;
+}
+
+// Transient command sent back by the stateless generation executor after it
+// has produced an immutable reply payload. The nested request may still carry
+// command-only credentials such as reply_token; AgentRunGAgent must use them
+// only for the accepted-only LlmReplyReadyEvent handoff and must never persist
+// them into AgentRunGAgentState or AgentRun*Event facts.
+message AgentRunReplyGenerationCompleted {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  string reply_text = 4;
+  aevatar.gagents.channel.abstractions.MessageContent outbound = 5;
+  aevatar.gagents.channel.runtime.LlmReplyTerminalState terminal_state = 6;
+  string error_code = 7;
+  string error_summary = 8;
+  int64 completed_at_unix_ms = 9;
+  int32 attempt = 10;
+  aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 11;
+}
+
+// Transient command for executor failures that did not produce a normal reply
+// payload. It is not a persisted fact; the run actor converts it into its
+// existing failed/produced terminal facts.
+message AgentRunReplyGenerationFailed {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  string error_code = 4;
+  string error_summary = 5;
+  int64 failed_at_unix_ms = 6;
+  int32 attempt = 7;
+  aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 8;
+}
+
+// Transient timeout signal emitted by the callback scheduler. It carries only
+// stable identifiers so runtime-only credentials are never written into the
+// scheduler backend.
+message AgentRunReplyGenerationTimedOut {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  int64 timed_out_at_unix_ms = 4;
+  int32 attempt = 5;
 }
 
 // Persisted after the LlmReplyReadyEvent has been successfully delivered to

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -328,6 +328,69 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleReplyGenerationTimedOutAsync_WhenSchedulerBeatsExecutor_NotifiesConversationAndIgnoresLateCompletion()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var scheduler = new RecordingCallbackScheduler();
+        var generationExecutor = new PausedReplyGenerationExecutor();
+        var runtime = CreateRunAgentWithExecutor(
+            actorRuntime,
+            generationExecutor,
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+                ResponseTimeoutSeconds = 1,
+            },
+            callbackScheduler: scheduler);
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-generation-timeout-race",
+            RunId = "run-generation-timeout-race",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-generation-timeout-race",
+        });
+
+        var timeout = scheduler.Timeouts.Should().ContainSingle(
+            timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunReplyGenerationTimedOut.Descriptor)).Subject;
+
+        await runtime.HandleReplyGenerationTimedOutAsync(
+            timeout.TriggerEnvelope.Payload.Unpack<AgentRunReplyGenerationTimedOut>());
+
+        runtime.State.Status.Should().Be(AgentRunStatus.Failed);
+        runtime.State.ErrorCode.Should().Be("llm_reply_timeout");
+        handled.Should().ContainSingle(e => e.Payload.Is(DeferredLlmReplyDroppedEvent.Descriptor));
+        var dropped = handled.Single().Payload.Unpack<DeferredLlmReplyDroppedEvent>();
+        dropped.CorrelationId.Should().Be("corr-generation-timeout-race");
+        dropped.Reason.Should().Be("llm_reply_timeout");
+
+        await runtime.HandleReplyGenerationCompletedAsync(new AgentRunReplyGenerationCompleted
+        {
+            RunId = "run-generation-timeout-race",
+            CorrelationId = "corr-generation-timeout-race",
+            TargetActorId = "actor-1",
+            ReplyText = "late executor reply",
+            TerminalState = LlmReplyTerminalState.Completed,
+            CompletedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Attempt = generationExecutor.Starts.Single().Attempt,
+            Request = generationExecutor.Starts.Single().Request.Clone(),
+        });
+
+        runtime.State.Status.Should().Be(AgentRunStatus.Failed);
+        runtime.State.ProducedReplyText.Should().BeEmpty();
+        handled.Should().ContainSingle(e => e.Payload.Is(DeferredLlmReplyDroppedEvent.Descriptor));
+        handled.Should().NotContain(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
+    }
+
+    [Fact]
     public async Task ProduceAndDispatch_WhenPersistDispatchedFails_DoesNotDeliverDuplicateFallbackReply()
     {
         // Once DispatchReadyEventAsync delivers the reply to the conversation actor, the user

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -262,6 +262,72 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleStartAsync_WhenAccepted_PersistsGenerationRequestedAndHandsOffToExecutor()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var generationExecutor = new PausedReplyGenerationExecutor();
+        var runtime = CreateRunAgentWithExecutor(
+            actorRuntime,
+            generationExecutor,
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            });
+
+        await runtime.HandleStartAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-generation-requested",
+            RunId = "run-generation-requested",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-generation-requested",
+        });
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyGenerationRequested);
+        runtime.State.GenerationAttempt.Should().Be(1);
+        runtime.State.GenerationRequestedAtUnixMs.Should().BeGreaterThan(0);
+        generationExecutor.Starts.Should().ContainSingle();
+        generationExecutor.Starts[0].RunId.Should().Be("run-generation-requested");
+        generationExecutor.Starts[0].RunActorId.Should().Be(runtime.Id);
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_WhenGenerationRequested_DoesNotStartSecondExecutor()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var generationExecutor = new PausedReplyGenerationExecutor();
+        var runtime = CreateRunAgentWithExecutor(
+            actorRuntime,
+            generationExecutor,
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            });
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-generation-duplicate",
+            RunId = "run-generation-duplicate",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-generation-duplicate",
+        };
+
+        await runtime.HandleStartAsync(request);
+        await runtime.HandleStartAsync(request.Clone());
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyGenerationRequested);
+        generationExecutor.Starts.Should().ContainSingle();
+    }
+
+    [Fact]
     public async Task ProduceAndDispatch_WhenPersistDispatchedFails_DoesNotDeliverDuplicateFallbackReply()
     {
         // Once DispatchReadyEventAsync delivers the reply to the conversation actor, the user
@@ -1875,15 +1941,39 @@ public sealed class AgentRunGAgentTests
         IActorRuntimeCallbackScheduler? callbackScheduler = null)
     {
         var dispatchPort = actorRuntime as IActorDispatchPort ?? Substitute.For<IActorDispatchPort>();
-        var agent = new AgentRunGAgent(
-            actorRuntime,
+        var generationExecutor = new RecordingReplyGenerationExecutor(
             dispatchPort,
             replyGenerator,
             collector,
             relayOptions,
-            NullLogger<AgentRunGAgent>.Instance,
             scopeResolver,
-            userConfigQueryPort,
+            userConfigQueryPort);
+        var agent = new AgentRunGAgent(
+            actorRuntime,
+            generationExecutor,
+            relayOptions,
+            NullLogger<AgentRunGAgent>.Instance,
+            callbackScheduler);
+        SetId(agent, AgentRunGAgent.BuildActorId(Guid.NewGuid().ToString("N")));
+        generationExecutor.Bind(agent);
+        agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
+            InvokeAgentTransition(agent, current, evt));
+        agent.EventPublisher = eventPublisher ?? new DispatchingEventPublisher(actorRuntime);
+        return agent;
+    }
+
+    private static AgentRunGAgent CreateRunAgentWithExecutor(
+        IActorRuntime actorRuntime,
+        IAgentRunReplyGenerationExecutorPort generationExecutor,
+        Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions relayOptions,
+        IEventPublisher? eventPublisher = null,
+        IActorRuntimeCallbackScheduler? callbackScheduler = null)
+    {
+        var agent = new AgentRunGAgent(
+            actorRuntime,
+            generationExecutor,
+            relayOptions,
+            NullLogger<AgentRunGAgent>.Instance,
             callbackScheduler);
         SetId(agent, AgentRunGAgent.BuildActorId(Guid.NewGuid().ToString("N")));
         agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
@@ -2023,6 +2113,59 @@ public sealed class AgentRunGAgentTests
         {
             Dispatches.Add((actorId, envelope));
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class PausedReplyGenerationExecutor : IAgentRunReplyGenerationExecutorPort
+    {
+        public List<AgentRunReplyGenerationExecutionRequest> Starts { get; } = [];
+
+        public Task StartAsync(AgentRunReplyGenerationExecutionRequest request, CancellationToken ct)
+        {
+            Starts.Add(request with { Request = request.Request.Clone() });
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingReplyGenerationExecutor : IAgentRunReplyGenerationExecutorPort
+    {
+        private readonly AgentRunReplyGenerationExecutor _inner;
+        private AgentRunGAgent? _agent;
+
+        public RecordingReplyGenerationExecutor(
+            IActorDispatchPort dispatchPort,
+            IConversationReplyGenerator replyGenerator,
+            IInteractiveReplyCollector? collector,
+            Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions relayOptions,
+            INyxIdRelayScopeResolver? scopeResolver,
+            IUserConfigQueryPort? userConfigQueryPort)
+        {
+            _inner = new AgentRunReplyGenerationExecutor(
+                dispatchPort,
+                replyGenerator,
+                collector,
+                relayOptions,
+                NullLogger<AgentRunReplyGenerationExecutor>.Instance,
+                scopeResolver,
+                userConfigQueryPort);
+            DispatchPort = dispatchPort;
+        }
+
+        public IActorDispatchPort DispatchPort { get; }
+
+        public List<AgentRunReplyGenerationExecutionRequest> Starts { get; } = [];
+
+        public void Bind(AgentRunGAgent agent)
+        {
+            _agent = agent;
+        }
+
+        public async Task StartAsync(AgentRunReplyGenerationExecutionRequest request, CancellationToken ct)
+        {
+            Starts.Add(request with { Request = request.Request.Clone() });
+            var completed = await _inner.ExecuteAsync(request);
+            var agent = _agent ?? throw new InvalidOperationException("AgentRunGAgent test executor was not bound.");
+            await agent.HandleReplyGenerationCompletedAsync(completed);
         }
     }
 


### PR DESCRIPTION
## 问题

#947 要求修复 AgentRunGAgent 在 actor turn 内直接执行 metadata enrichment、LLM/tool streaming generation 和 streaming chunk dispatch 的结构问题。r5 共识是保留 AgentRunGAgent 作为唯一 run fact owner，只抽出单一 typed stateless generation executor，accepted-only 的 LlmReplyReadyEvent handoff 继续留在 AgentRunGAgent。

## 方案

- 新增 `IAgentRunReplyGenerationExecutorPort` 与 `AgentRunReplyGenerationExecutor`，把 metadata 构建、LLM reply generation、interactive intent capture、streaming chunk/finalize、generation failure classification 移出 `AgentRunGAgent`。
- 在 `agent_run.proto` 增加 `ReplyGenerationRequested` 状态与 typed requested/completed/failed/timed-out continuation payload。
- `AgentRunGAgent` 改为 admission/drop/stale gate 后持久化 generation requested fact，只做 accepted-only executor handoff；completion/failure/timeout 回到 actor 后再由 actor 持久化 produced/dispatched/failed/cleanup facts。
- 保留 output dispatch retry、terminal cleanup、drop notification 与 `LlmReplyReadyEvent SendToAsync` 在 AgentRunGAgent 内，不新增 actor type、envelope kind、projection phase 或第二 output executor stage。
- 更新 `AgentRunGAgentTests`，覆盖 requested handoff、duplicate requested 不二次启动 executor，并保持原有 ready handoff、streaming、metadata、retry、token echo 行为。

## 验证

- `dotnet test test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj --no-restore --nologo --filter AgentRunGAgentTests`
- `bash tools/ci/architecture_guards.sh`
- `bash tools/ci/test_stability_guards.sh`
- `dotnet build aevatar.slnx --nologo`

IMPLEMENT_DONE:cluster-069-agentrun-typed-executor:ok
⟦AI:AUTO-LOOP⟧
