### PR TITLE
iter72 cluster-072: 删 Studio obsolete /api/workspace/workflows* legacy surface

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs
@@ -35,19 +35,6 @@ public sealed record WorkflowCommittedSummary(
     int StepCount,
     DateTimeOffset? UpdatedAtUtc = null);
 
-[Obsolete("Use WorkflowDraftSummary or WorkflowCommittedSummary.")]
-public sealed record WorkflowSummary(
-    string WorkflowId,
-    string Name,
-    string Description,
-    string FileName,
-    string FilePath,
-    string DirectoryId,
-    string DirectoryLabel,
-    int StepCount,
-    bool HasLayout,
-    DateTimeOffset UpdatedAtUtc);
-
 public sealed record WorkflowDraftResponse(
     string WorkflowId,
     string Name,
@@ -67,30 +54,7 @@ public sealed record WorkflowCommittedResponse(
     IReadOnlyList<ValidationFinding> Findings,
     DateTimeOffset? UpdatedAtUtc = null);
 
-[Obsolete("Use WorkflowDraftResponse or WorkflowCommittedResponse.")]
-public sealed record WorkflowFileResponse(
-    string WorkflowId,
-    string Name,
-    string FileName,
-    string FilePath,
-    string DirectoryId,
-    string DirectoryLabel,
-    string Yaml,
-    WorkflowDocument? Document,
-    WorkflowLayoutDocument? Layout,
-    IReadOnlyList<ValidationFinding> Findings,
-    DateTimeOffset? UpdatedAtUtc = null);
-
 public sealed record SaveWorkflowDraftRequest(
-    string DirectoryId,
-    string WorkflowName,
-    string? FileName,
-    string Yaml,
-    WorkflowLayoutDocument? Layout = null);
-
-[Obsolete("Use SaveWorkflowDraftRequest.")]
-public sealed record SaveWorkflowFileRequest(
-    string? WorkflowId,
     string DirectoryId,
     string WorkflowName,
     string? FileName,

--- a/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs
@@ -104,25 +104,6 @@ public sealed class WorkspaceService
             .ToList();
     }
 
-    #pragma warning disable CS0618
-    [Obsolete("Use ListDraftsAsync.")]
-    public async Task<IReadOnlyList<WorkflowSummary>> ListWorkflowsAsync(CancellationToken cancellationToken = default)
-    {
-        return (await ListDraftsAsync(cancellationToken))
-            .Select(summary => new WorkflowSummary(
-                summary.WorkflowId,
-                summary.Name,
-                summary.Description,
-                summary.FileName,
-                summary.FilePath,
-                summary.DirectoryId,
-                summary.DirectoryLabel,
-                summary.StepCount,
-                HasLayout: false,
-                summary.UpdatedAtUtc))
-            .ToList();
-    }
-
     public async Task<WorkflowDraftResponse?> GetDraftAsync(string workflowId, CancellationToken cancellationToken = default)
     {
         var workspace = await _queryPort.GetAsync(cancellationToken);
@@ -136,32 +117,6 @@ public sealed class WorkspaceService
         return ToWorkflowDraftResponse(file);
     }
 
-    [Obsolete("Use GetDraftAsync.")]
-    public async Task<WorkflowFileResponse?> GetWorkflowAsync(string workflowId, CancellationToken cancellationToken = default)
-    {
-        var workspace = await _queryPort.GetAsync(cancellationToken);
-        var file = workspace.Drafts.FirstOrDefault(item =>
-            string.Equals(item.WorkflowId, workflowId, StringComparison.Ordinal));
-        if (file is null)
-        {
-            return null;
-        }
-
-        var parse = _yamlDocumentService.Parse(file.Yaml);
-        return new WorkflowFileResponse(
-            file.WorkflowId,
-            file.Name,
-            file.FileName,
-            file.FilePath,
-            file.DirectoryId,
-            file.DirectoryLabel,
-            file.Yaml,
-            parse.Document,
-            Layout: null,
-            parse.Findings,
-            file.UpdatedAtUtc);
-    }
-
     public Task<WorkflowDraftResponse> CreateDraftAsync(
         SaveWorkflowDraftRequest request,
         CancellationToken cancellationToken = default)
@@ -172,25 +127,6 @@ public sealed class WorkspaceService
         SaveWorkflowDraftRequest request,
         CancellationToken cancellationToken = default)
         => SaveDraftAsyncCore(NormalizeRequired(workflowId, nameof(workflowId)), request, cancellationToken);
-
-    [Obsolete("Use CreateDraftAsync or UpdateDraftAsync.")]
-    public Task<WorkflowDraftResponse> SaveWorkflowAsync(
-        SaveWorkflowFileRequest request,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-
-        var nextRequest = new SaveWorkflowDraftRequest(
-            request.DirectoryId,
-            request.WorkflowName,
-            request.FileName,
-            request.Yaml,
-            Layout: null);
-        return string.IsNullOrWhiteSpace(request.WorkflowId)
-            ? CreateDraftAsync(nextRequest, cancellationToken)
-            : UpdateDraftAsync(request.WorkflowId, nextRequest, cancellationToken);
-    }
-    #pragma warning restore CS0618
 
     private async Task<WorkflowDraftResponse> SaveDraftAsyncCore(
         string? workflowId,

--- a/src/Aevatar.Studio.Hosting/Controllers/WorkspaceController.cs
+++ b/src/Aevatar.Studio.Hosting/Controllers/WorkspaceController.cs
@@ -127,49 +127,6 @@ public sealed class WorkspaceController : ControllerBase
         return Ok(await _workspaceService.ListDraftsAsync(cancellationToken));
     }
 
-    #pragma warning disable CS0618
-    [Obsolete("Use /api/workspace/workflow-drafts.")]
-    [HttpGet("workflows")]
-    public async Task<ActionResult<IReadOnlyList<WorkflowSummary>>> ListWorkflows(
-        [FromQuery] string? scopeId,
-        CancellationToken cancellationToken)
-    {
-        var result = await ListDrafts(scopeId, cancellationToken);
-        if (result.Result is OkObjectResult okResult &&
-            okResult.Value is IReadOnlyList<WorkflowDraftSummary> draftSummaries)
-        {
-            return Ok(draftSummaries.Select(static summary => new WorkflowSummary(
-                summary.WorkflowId,
-                summary.Name,
-                summary.Description,
-                summary.FileName,
-                summary.FilePath,
-                summary.DirectoryId,
-                summary.DirectoryLabel,
-                summary.StepCount,
-                HasLayout: false,
-                summary.UpdatedAtUtc)).ToList());
-        }
-
-        if (result.Result is not null)
-        {
-            return result.Result;
-        }
-
-        return Ok(result.Value?.Select(static summary => new WorkflowSummary(
-            summary.WorkflowId,
-            summary.Name,
-            summary.Description,
-            summary.FileName,
-            summary.FilePath,
-            summary.DirectoryId,
-            summary.DirectoryLabel,
-            summary.StepCount,
-            HasLayout: false,
-            summary.UpdatedAtUtc)).ToList() ?? []);
-    }
-    #pragma warning restore CS0618
-
     [HttpGet("workflow-drafts/{workflowId}")]
     public async Task<ActionResult<WorkflowDraftResponse>> GetDraft(
         string workflowId,
@@ -204,34 +161,6 @@ public sealed class WorkspaceController : ControllerBase
 
         return workflow is null ? NotFound() : Ok(workflow);
     }
-
-    #pragma warning disable CS0618
-    [Obsolete("Use /api/workspace/workflow-drafts/{workflowId}.")]
-    [HttpGet("workflows/{workflowId}")]
-    public async Task<ActionResult<WorkflowFileResponse>> GetWorkflow(
-        string workflowId,
-        [FromQuery] string? scopeId,
-        CancellationToken cancellationToken)
-    {
-        var result = await GetDraft(workflowId, scopeId, cancellationToken);
-        if (result.Result is NotFoundResult)
-        {
-            return NotFound();
-        }
-
-        if (result.Result is OkObjectResult okResult && okResult.Value is WorkflowDraftResponse draftFromResult)
-        {
-            return Ok(ToLegacyWorkflowFileResponse(draftFromResult));
-        }
-
-        if (result.Result is ObjectResult objectResult)
-        {
-            return objectResult;
-        }
-
-        return Ok(ToLegacyWorkflowFileResponse(result.Value));
-    }
-    #pragma warning restore CS0618
 
     [HttpPost("workflow-drafts")]
     public async Task<ActionResult<WorkflowDraftResponse>> CreateDraft(
@@ -277,49 +206,6 @@ public sealed class WorkspaceController : ControllerBase
             return BadRequest(new { message = exception.Message });
         }
     }
-
-    #pragma warning disable CS0618
-    [Obsolete("Use POST /api/workspace/workflow-drafts or PUT /api/workspace/workflow-drafts/{workflowId}.")]
-    [HttpPost("workflows")]
-    public async Task<ActionResult<WorkflowFileResponse>> SaveWorkflow(
-        [FromBody] SaveWorkflowFileRequest request,
-        [FromQuery] string? scopeId,
-        CancellationToken cancellationToken)
-    {
-        ActionResult<WorkflowDraftResponse> draftResult = string.IsNullOrWhiteSpace(request.WorkflowId)
-            ? await CreateDraft(
-                new SaveWorkflowDraftRequest(
-                    request.DirectoryId,
-                    request.WorkflowName,
-                    request.FileName,
-                    request.Yaml,
-                    Layout: null),
-                scopeId,
-                cancellationToken)
-            : await UpdateDraft(
-                request.WorkflowId,
-                new SaveWorkflowDraftRequest(
-                    request.DirectoryId,
-                    request.WorkflowName,
-                    request.FileName,
-                    request.Yaml,
-                    Layout: null),
-                scopeId,
-                cancellationToken);
-
-        if (draftResult.Result is OkObjectResult okResult && okResult.Value is WorkflowDraftResponse draftFromResult)
-        {
-            return Ok(ToLegacyWorkflowFileResponse(draftFromResult));
-        }
-
-        if (draftResult.Result is ObjectResult objectResult)
-        {
-            return objectResult;
-        }
-
-        return Ok(ToLegacyWorkflowFileResponse(draftResult.Value));
-    }
-    #pragma warning restore CS0618
 
     [HttpPut("workflow-drafts/{workflowId}")]
     public async Task<ActionResult<WorkflowDraftResponse>> UpdateDraft(
@@ -468,23 +354,4 @@ public sealed class WorkspaceController : ControllerBase
         message = exception.Message,
     };
 
-    #pragma warning disable CS0618
-    private static WorkflowFileResponse ToLegacyWorkflowFileResponse(WorkflowDraftResponse? draft)
-    {
-        ArgumentNullException.ThrowIfNull(draft);
-
-        return new WorkflowFileResponse(
-            draft.WorkflowId,
-            draft.Name,
-            draft.FileName,
-            draft.FilePath,
-            draft.DirectoryId,
-            draft.DirectoryLabel,
-            draft.Yaml,
-            Document: null,
-            Layout: null,
-            Findings: [],
-            draft.UpdatedAtUtc);
-    }
-    #pragma warning restore CS0618
 }


### PR DESCRIPTION
## 摘要

iter72 cluster-072-studio-workflows-legacy-public-surface(severity:medium,rules:R-DELETE-01 + R-API-01)。

- **Old**:WorkspaceController obsolete `[HttpGet/HttpPost("workflows*")]` 3 endpoints(标 `[Obsolete]` 但仍存在)+ WorkspaceService.ListWorkflowsAsync / GetWorkflowAsync / SaveWorkflowAsync + WorkspaceContracts 死 DTOs WorkflowSummary / WorkflowFileResponse / SaveWorkflowFileRequest
- **New**:整链路删除;现行 `workflow-drafts` + committed workflow surface 已替代,grep 无残留消费者

违反:CLAUDE 删除优先 / API 字段单一语义(一个字段只表达一个含义,旧 endpoint + 新 endpoint 同时存在导致双语义)。

## 范围

3 文件改动(-233 行):
- `src/Aevatar.Studio.Hosting/Controllers/WorkspaceController.cs`(-133 行,删 3 obsolete endpoints)
- `src/Aevatar.Studio.Application/Studio/Services/WorkspaceService.cs`(-64 行,删 3 死方法)
- `src/Aevatar.Studio.Application/Studio/Contracts/WorkspaceContracts.cs`(-36 行,删 3 死 DTOs)

`workflow-drafts` surface 不动。

验证:
- `dotnet build src/Aevatar.Studio.Hosting/Aevatar.Studio.Hosting.csproj --nologo` ✅
- `dotnet test test/Aevatar.Studio.Tests/Aevatar.Studio.Tests.csproj --nologo` 591/591 ✅
- `tools/ci/test_stability_guards.sh` ✅
- `tools/ci/architecture_guards.sh` ✅
- 前端 `tsc` 未本地跑(`apps/aevatar-console-web/node_modules` 缺,禁止 install);若 frontend 有残留引用,CI/Vercel 会暴露

## Stacked-PR

Part of iter72 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter72

⟦AI:AUTO-LOOP⟧
