### PR TITLE
iter71 cluster-071: 删 Identity actor no-op ProjectionRebuildRequested events

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -69,6 +69,9 @@ public static class IdentityServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionActivationPlanProvider,
             ChannelIdentityCommittedStateProjectionActivationPlanProvider>());
+        services.TryAddSingleton<
+            IChannelIdentityCommittedStateActivationService,
+            ChannelIdentityCommittedStateActivationService>();
 
         // ─── Per-binding projection (one document per ExternalSubjectRef) ───
         services.AddProjectionMaterializationRuntimeCore<

--- a/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
@@ -18,6 +18,9 @@ namespace Aevatar.GAgents.Channel.Identity;
 /// </summary>
 public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalIdentityBindingState>
 {
+    // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
+    //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
+    //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     /// <inheritdoc />
     /// <remarks>
     /// <see cref="StateTransitionMatcher"/> handles <c>Any</c>-wrapped payloads
@@ -33,7 +36,6 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
             .Match(current, evt)
             .On<ExternalIdentityBoundEvent>(ApplyBound)
             .On<ExternalIdentityBindingRevokedEvent>(ApplyRevoked)
-            .On<ExternalIdentityBindingProjectionRebuildRequestedEvent>(static (state, _) => state)
             .OrCurrent();
 
     // ─── Commands ───
@@ -77,23 +79,8 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
 
         if (!string.IsNullOrEmpty(State.BindingId))
         {
-            // Steady-state branch: persist a no-op rebuild request so the
-            // projector materializes the existing binding into the readmodel.
-            // Without this, a legacy binding actor whose projection scope
-            // was never activated (issue #549 follow-up: the binding scope
-            // missed an EnsureProjectionForActorAsync wiring while every
-            // other GAgent had one) leaves the readmodel empty, the OAuth
-            // callback's readiness wait times out, and binding-required
-            // commands keep re-sending the user back to /init.
-            // Apply is identity, so the binding facts are not mutated by
-            // this event.
-            await PersistDomainEventAsync(new ExternalIdentityBindingProjectionRebuildRequestedEvent
-            {
-                Reason = "commit_already_bound",
-                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            });
             Logger.LogInformation(
-                "CommitBinding discarded: already bound for {Platform}:{Tenant}:{User} (existing={ExistingBindingId}, incoming={IncomingBindingId}); rebuild requested so the projector materializes the existing binding",
+                "CommitBinding discarded: already bound for {Platform}:{Tenant}:{User} (existing={ExistingBindingId}, incoming={IncomingBindingId}); no identity fact changed",
                 cmd.ExternalSubject.Platform,
                 cmd.ExternalSubject.Tenant,
                 cmd.ExternalSubject.ExternalUserId,
@@ -121,10 +108,10 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
     /// Revokes the active binding. When state has no active binding (for
     /// example concurrent /unbind, revoke-after-revoke from
     /// <c>invalid_grant</c>, or remote-side self-heal after projection drift),
-    /// emits a no-op rebuild event so the readmodel is overwritten from the
-    /// actor's authoritative empty state. Caller must have already invoked
-    /// the NyxID-side revoke (or observed <c>invalid_grant</c>) — this command
-    /// only transitions local state.
+    /// leaves actor facts unchanged. Stale readmodel repair belongs to the
+    /// projection lifecycle or maintenance path. Caller must have already
+    /// invoked the NyxID-side revoke (or observed <c>invalid_grant</c>) —
+    /// this command only transitions local state when an active binding exists.
     /// </summary>
     [EventHandler]
     public async Task HandleRevokeBinding(RevokeBindingCommand cmd)
@@ -150,18 +137,8 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
 
         if (string.IsNullOrEmpty(State.BindingId))
         {
-            // Remote revocation self-heal can land here when the actor state
-            // is already empty but the readmodel still contains an old active
-            // binding. Persisting an identity event republishes the committed
-            // state root, allowing the projector to overwrite that stale
-            // document without inventing query-time repair logic.
-            await PersistDomainEventAsync(new ExternalIdentityBindingProjectionRebuildRequestedEvent
-            {
-                Reason = $"revoke_without_active_binding:{reason}",
-                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            });
             Logger.LogInformation(
-                "RevokeBinding found no active binding for {Platform}:{Tenant}:{User}; rebuild requested so the projector materializes the authoritative empty state (reason={Reason})",
+                "RevokeBinding found no active binding for {Platform}:{Tenant}:{User}; no identity fact changed (reason={Reason})",
                 cmd.ExternalSubject.Platform,
                 cmd.ExternalSubject.Tenant,
                 cmd.ExternalSubject.ExternalUserId,

--- a/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs
@@ -86,6 +86,7 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
                 cmd.ExternalSubject.ExternalUserId,
                 State.BindingId,
                 cmd.BindingId);
+            await EnsureCommittedStateActivatedAsync().ConfigureAwait(false);
             return;
         }
 
@@ -143,6 +144,7 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
                 cmd.ExternalSubject.Tenant,
                 cmd.ExternalSubject.ExternalUserId,
                 reason);
+            await EnsureCommittedStateActivatedAsync().ConfigureAwait(false);
             return;
         }
 
@@ -185,6 +187,26 @@ public sealed partial class ExternalIdentityBindingGAgent : GAgentBase<ExternalI
             expected,
             Id);
         return false;
+    }
+
+    private Task EnsureCommittedStateActivatedAsync()
+    {
+        var activation = Services.GetService(typeof(IChannelIdentityCommittedStateActivationService))
+            as IChannelIdentityCommittedStateActivationService;
+        if (activation == null)
+            return Task.CompletedTask;
+
+        var actorId = !string.IsNullOrWhiteSpace(Id)
+            ? Id
+            : State.ExternalSubject?.ToActorId() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(actorId) || EventSourcing == null)
+            return Task.CompletedTask;
+
+        return activation.EnsureExternalIdentityCommittedStateActivatedAsync(
+            actorId,
+            State.Clone(),
+            EventSourcing.CurrentVersion,
+            CancellationToken.None);
     }
 
     // ─── State transitions ───

--- a/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateActivationService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateActivationService.cs
@@ -1,0 +1,127 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.Foundation.Abstractions.Streaming;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.Channel.Identity;
+
+internal sealed class ChannelIdentityCommittedStateActivationService
+    : IChannelIdentityCommittedStateActivationService
+{
+    internal const string ExternalIdentityBindingProjectionKind = "external-identity-binding";
+    internal const string AevatarOAuthClientProjectionKind = "aevatar-oauth-client";
+
+    private readonly IProjectionScopeActivationService<ExternalIdentityBindingMaterializationRuntimeLease> _bindingActivation;
+    private readonly IProjectionScopeActivationService<AevatarOAuthClientMaterializationRuntimeLease> _oauthClientActivation;
+    private readonly IActorDispatchPort _dispatchPort;
+    private readonly IEventStore _eventStore;
+
+    public ChannelIdentityCommittedStateActivationService(
+        IProjectionScopeActivationService<ExternalIdentityBindingMaterializationRuntimeLease> bindingActivation,
+        IProjectionScopeActivationService<AevatarOAuthClientMaterializationRuntimeLease> oauthClientActivation,
+        IActorDispatchPort dispatchPort,
+        IEventStore eventStore)
+    {
+        _bindingActivation = bindingActivation ?? throw new ArgumentNullException(nameof(bindingActivation));
+        _oauthClientActivation = oauthClientActivation ?? throw new ArgumentNullException(nameof(oauthClientActivation));
+        _dispatchPort = dispatchPort ?? throw new ArgumentNullException(nameof(dispatchPort));
+        _eventStore = eventStore ?? throw new ArgumentNullException(nameof(eventStore));
+    }
+
+    public async Task EnsureExternalIdentityCommittedStateActivatedAsync(
+        string actorId,
+        ExternalIdentityBindingState state,
+        long stateVersion,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
+        ArgumentNullException.ThrowIfNull(state);
+
+        await _bindingActivation.EnsureAsync(
+            DurableRequest(actorId, ExternalIdentityBindingProjectionKind),
+            ct).ConfigureAwait(false);
+
+        await DispatchCommittedStateAsync(
+            actorId,
+            ExternalIdentityBindingProjectionKind,
+            state,
+            stateVersion,
+            ct).ConfigureAwait(false);
+    }
+
+    public async Task EnsureAevatarOAuthClientCommittedStateActivatedAsync(
+        string actorId,
+        AevatarOAuthClientState state,
+        long stateVersion,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(actorId);
+        ArgumentNullException.ThrowIfNull(state);
+
+        await _oauthClientActivation.EnsureAsync(
+            DurableRequest(actorId, AevatarOAuthClientProjectionKind),
+            ct).ConfigureAwait(false);
+
+        await DispatchCommittedStateAsync(
+            actorId,
+            AevatarOAuthClientProjectionKind,
+            state,
+            stateVersion,
+            ct).ConfigureAwait(false);
+    }
+
+    private async Task DispatchCommittedStateAsync<TState>(
+        string actorId,
+        string projectionKind,
+        TState state,
+        long stateVersion,
+        CancellationToken ct)
+        where TState : IMessage
+    {
+        if (stateVersion <= 0)
+            return;
+
+        var events = await _eventStore
+            .GetEventsAsync(actorId, stateVersion - 1, ct)
+            .ConfigureAwait(false);
+        var committedEvent = events.LastOrDefault(evt => evt.Version == stateVersion);
+        if (committedEvent == null)
+            return;
+
+        var scopeActorId = ProjectionScopeActorId.Build(new ProjectionRuntimeScopeKey(
+            actorId,
+            projectionKind,
+            ProjectionRuntimeMode.DurableMaterialization));
+
+        var envelope = new EventEnvelope
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = committedEvent.Clone(),
+                StateRoot = Any.Pack(state),
+            }),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication(actorId, ObserverAudience.CommittedFacts),
+        };
+
+        var forwarded = StreamForwardingRules.BuildForwardedEnvelope(
+            envelope,
+            actorId,
+            scopeActorId,
+            StreamForwardingMode.HandleThenForward);
+
+        await _dispatchPort.DispatchAsync(scopeActorId, forwarded, ct).ConfigureAwait(false);
+    }
+
+    private static ProjectionScopeStartRequest DurableRequest(string actorId, string projectionKind) =>
+        new()
+        {
+            RootActorId = actorId,
+            ProjectionKind = projectionKind,
+            Mode = ProjectionRuntimeMode.DurableMaterialization,
+        };
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs
@@ -10,6 +10,9 @@ namespace Aevatar.GAgents.Channel.Identity;
 public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProvider
     : IProjectionActivationPlanProvider
 {
+    // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
+    //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
+    //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     private const string ExternalIdentityBindingProjectionKind = "external-identity-binding";
     private const string AevatarOAuthClientProjectionKind = "aevatar-oauth-client";
 
@@ -42,14 +45,12 @@ public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProvide
 
     private static bool IsExternalIdentityBindingEvent(Any payload) =>
         payload.Is(ExternalIdentityBoundEvent.Descriptor) ||
-        payload.Is(ExternalIdentityBindingRevokedEvent.Descriptor) ||
-        payload.Is(ExternalIdentityBindingProjectionRebuildRequestedEvent.Descriptor);
+        payload.Is(ExternalIdentityBindingRevokedEvent.Descriptor);
 
     private static bool IsAevatarOAuthClientEvent(Any payload) =>
         payload.Is(AevatarOAuthClientProvisionedEvent.Descriptor) ||
         payload.Is(AevatarOAuthClientHmacKeyRotatedEvent.Descriptor) ||
-        payload.Is(AevatarOAuthClientBrokerCapabilityObservedEvent.Descriptor) ||
-        payload.Is(AevatarOAuthClientProjectionRebuildRequestedEvent.Descriptor);
+        payload.Is(AevatarOAuthClientBrokerCapabilityObservedEvent.Descriptor);
 
     private static ProjectionActivationPlan DurablePlan<TLease>(
         string actorId,

--- a/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs
@@ -13,9 +13,6 @@ public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProvide
     // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
     //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
     //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
-    private const string ExternalIdentityBindingProjectionKind = "external-identity-binding";
-    private const string AevatarOAuthClientProjectionKind = "aevatar-oauth-client";
-
     public IEnumerable<ProjectionActivationPlan> GetPlans(CommittedStatePublicationContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -30,14 +27,14 @@ public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProvide
             [
                 DurablePlan<ExternalIdentityBindingMaterializationRuntimeLease>(
                     context.ActorId,
-                    ExternalIdentityBindingProjectionKind),
+                    ChannelIdentityCommittedStateActivationService.ExternalIdentityBindingProjectionKind),
             ],
             var type when type == typeof(AevatarOAuthClientGAgent) &&
                           IsAevatarOAuthClientEvent(payload) =>
             [
                 DurablePlan<AevatarOAuthClientMaterializationRuntimeLease>(
                     context.ActorId,
-                    AevatarOAuthClientProjectionKind),
+                    ChannelIdentityCommittedStateActivationService.AevatarOAuthClientProjectionKind),
             ],
             _ => [],
         };

--- a/agents/Aevatar.GAgents.Channel.Identity/Projection/IChannelIdentityCommittedStateActivationService.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Projection/IChannelIdentityCommittedStateActivationService.cs
@@ -1,0 +1,16 @@
+namespace Aevatar.GAgents.Channel.Identity;
+
+internal interface IChannelIdentityCommittedStateActivationService
+{
+    Task EnsureExternalIdentityCommittedStateActivatedAsync(
+        string actorId,
+        ExternalIdentityBindingState state,
+        long stateVersion,
+        CancellationToken ct = default);
+
+    Task EnsureAevatarOAuthClientCommittedStateActivatedAsync(
+        string actorId,
+        AevatarOAuthClientState state,
+        long stateVersion,
+        CancellationToken ct = default);
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -158,6 +158,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 "Aevatar OAuth client already provisioned: actorId={ActorId}, authority={Authority}; no OAuth client fact changed",
                 Id,
                 cmd.NyxidAuthority);
+            await EnsureCommittedStateActivatedAsync().ConfigureAwait(false);
             return;
         }
 
@@ -659,6 +660,20 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
         // Fall back to a timestamp-derived kid so rotation still uniquely
         // labels the new key even if state has been hand-edited or migrated.
         return $"v{now.ToUnixTimeSeconds()}";
+    }
+
+    private Task EnsureCommittedStateActivatedAsync()
+    {
+        var activation = Services.GetService(typeof(IChannelIdentityCommittedStateActivationService))
+            as IChannelIdentityCommittedStateActivationService;
+        if (activation == null || string.IsNullOrWhiteSpace(Id) || EventSourcing == null)
+            return Task.CompletedTask;
+
+        return activation.EnsureAevatarOAuthClientCommittedStateActivatedAsync(
+            Id,
+            State.Clone(),
+            EventSourcing.CurrentVersion,
+            CancellationToken.None);
     }
 
     // ─── State transitions ───

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs
@@ -21,6 +21,9 @@ namespace Aevatar.GAgents.Channel.Identity;
 /// </summary>
 public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientState>
 {
+    // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
+    //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
+    //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     /// <summary>
     /// Well-known actor id. There is exactly one of these per cluster.
     /// </summary>
@@ -55,7 +58,6 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             .On<AevatarOAuthClientProvisionedEvent>(ApplyProvisioned)
             .On<AevatarOAuthClientHmacKeyRotatedEvent>(ApplyHmacKeyRotated)
             .On<AevatarOAuthClientBrokerCapabilityObservedEvent>(ApplyBrokerCapabilityObserved)
-            .On<AevatarOAuthClientProjectionRebuildRequestedEvent>(static (state, _) => state)
             .On<AevatarOAuthClientProvisioningRetryScheduledEvent>(ApplyProvisioningRetryScheduled)
             .On<AevatarOAuthClientProvisioningRetryClearedEvent>(ApplyProvisioningRetryCleared)
             .On<AevatarOAuthClientDriftReconciledEvent>(static (state, _) => state)
@@ -141,7 +143,7 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
             // Seed HMAC key on first activation against an existing client_id
             // (defence-in-depth against partial state loaded from snapshots).
             // Returning here is intentional: HmacKeyRotatedEvent itself
-            // re-publishes the state root, so the projector materializes the
+            // publishes the committed state root, so the projector materializes the
             // readmodel without needing an additional rebuild trigger.
             if (State.HmacKey.Length == 0)
             {
@@ -151,22 +153,9 @@ public sealed class AevatarOAuthClientGAgent : GAgentBase<AevatarOAuthClientStat
                 return;
             }
 
-            // Steady-state branch: nothing changed at NyxID, but a freshly-
-            // booted silo may have an empty projection (codex PR #539 P1 —
-            // happens after the projection-scope-activation fix is deployed
-            // to a cluster whose actor was already provisioned by an earlier
-            // build that never activated the scope). Persist a no-op rebuild
-            // event so the now-attached projector has a state-root
-            // publication to materialize. Apply is identity, so the OAuth
-            // client facts are not mutated.
-            await PersistDomainEventAsync(new AevatarOAuthClientProjectionRebuildRequestedEvent
-            {
-                Reason = "ensure_already_provisioned",
-                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            });
             await ClearProvisioningRetryAsync("ensure_already_provisioned");
             Logger.LogInformation(
-                "Requested aevatar OAuth client projection rebuild: actorId={ActorId}, authority={Authority}",
+                "Aevatar OAuth client already provisioned: actorId={ActorId}, authority={Authority}; no OAuth client fact changed",
                 Id,
                 cmd.NyxidAuthority);
             return;

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -130,6 +130,14 @@ message RotateAevatarOAuthClientHmacKeyCommand {}
 // broker_capability_enabled on this client.
 message ObserveBrokerCapabilityCommand {}
 
+// Tombstone for the removed projection-only event. Keep its message name and
+// field numbers reserved so old event-store payloads remain replay-safe and
+// future events cannot reuse the same wire shape accidentally.
+message AevatarOAuthClientProjectionRebuildRequestedEvent {
+  reserved 1, 2;
+  reserved "reason", "requested_at";
+}
+
 // Persisted after a failed actor-owned provisioning attempt schedules a
 // durable self-callback for the next retry.
 message AevatarOAuthClientProvisioningRetryScheduledEvent {

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto
@@ -130,15 +130,6 @@ message RotateAevatarOAuthClientHmacKeyCommand {}
 // broker_capability_enabled on this client.
 message ObserveBrokerCapabilityCommand {}
 
-// Persisted when bootstrap needs to re-emit the authoritative state root for
-// the OAuth client projection without changing business state. This repairs a
-// missing/stale readmodel after the projection scope is activated, while
-// keeping rebuild semantics owned by the actor rather than query-time replay.
-message AevatarOAuthClientProjectionRebuildRequestedEvent {
-  string reason = 1;
-  google.protobuf.Timestamp requested_at = 2;
-}
-
 // Persisted after a failed actor-owned provisioning attempt schedules a
 // durable self-callback for the next retry.
 message AevatarOAuthClientProvisioningRetryScheduledEvent {

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
@@ -59,6 +59,14 @@ message ExternalIdentityBindingRevokedEvent {
   string reason = 3;
 }
 
+// Tombstone for the removed projection-only event. Keep its message name and
+// field numbers reserved so old event-store payloads remain replay-safe and
+// future events cannot reuse the same wire shape accidentally.
+message ExternalIdentityBindingProjectionRebuildRequestedEvent {
+  reserved 1, 2;
+  reserved "reason", "requested_at";
+}
+
 // Stateless OAuth `state` token payload (HMAC-sealed, never in grain state).
 // Carries the correlation id, the originating external subject, the PKCE
 // verifier, and the absolute expiry. See ADR-0018 §Implementation Notes #1.

--- a/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
+++ b/agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto
@@ -36,8 +36,8 @@ message CommitBindingCommand {
 
 // Issued by the /unbind handler after a successful NyxID DELETE call, or by
 // the turn path on `invalid_grant` from token-exchange. When state has no
-// active binding, the actor leaves binding facts unchanged but republishes
-// its authoritative state root so stale readmodels can be overwritten.
+// active binding, the actor leaves binding facts unchanged. Stale readmodel
+// repair belongs to projection lifecycle / maintenance, not this command.
 message RevokeBindingCommand {
   aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
   // Free-form reason for audit (e.g. "user_unbind", "nyx_invalid_grant",
@@ -57,18 +57,6 @@ message ExternalIdentityBindingRevokedEvent {
   aevatar.gagents.channel.abstractions.ExternalSubjectRef external_subject = 1;
   google.protobuf.Timestamp revoked_at = 2;
   string reason = 3;
-}
-
-// Persisted when an inbound CommitBindingCommand is discarded because the
-// actor already holds an active binding_id, when RevokeBindingCommand observes
-// already-empty actor state, OR when a deploy needs to re-publish the
-// authoritative state root for a legacy binding actor whose projection scope
-// was never activated. Apply is identity — the binding facts are not mutated.
-// The projector still sees a state-root publication and materializes the
-// authoritative state into the readmodel.
-message ExternalIdentityBindingProjectionRebuildRequestedEvent {
-  string reason = 1;
-  google.protobuf.Timestamp requested_at = 2;
 }
 
 // Stateless OAuth `state` token payload (HMAC-sealed, never in grain state).

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -27,6 +27,9 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 /// </summary>
 public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
 {
+    // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
+    //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
+    //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     private AevatarOAuthClientGAgent _agent = null!;
     private ServiceProvider _serviceProvider = null!;
     private RecordingDcrClient _registrar = null!;
@@ -110,9 +113,9 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _agent.State.ClientId.Should().Be(firstClientId);
         _agent.State.HmacKey.Should().BeEquivalentTo(firstHmacKey);
         _agent.State.Should().BeEquivalentTo(beforeRefreshState,
-            "projection rebuild is a state-root refresh and must not mutate OAuth client facts");
-        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeRefreshVersion + 1,
-            "already-provisioned ensure must re-emit the authoritative state root so an empty projection can materialize");
+            "already-provisioned ensure must not mutate OAuth client facts");
+        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeRefreshVersion,
+            "already-provisioned ensure must not append a projection-only no-op event");
     }
 
     [Fact]
@@ -685,17 +688,17 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
         _registrar.NextClientId = "loser-orphan-client";
         _registrar.OnRegistered = async () =>
         {
-            // Peer's commit is a rebuild request — Apply is identity, so
-            // it does NOT update RedirectUri. State stays drifted after
+            // Peer's commit observes broker capability. It is a real fact,
+            // but it does NOT update RedirectUri. State stays drifted after
             // refresh, the absorber returns false, and actor-owned retry
             // captures the failed attempt.
             var store = _serviceProvider.GetRequiredService<IEventStore>();
             var actorId = _agent.Id;
             var current = await store.GetVersionAsync(actorId);
-            var peerEvent = new AevatarOAuthClientProjectionRebuildRequestedEvent
+            var peerEvent = new AevatarOAuthClientBrokerCapabilityObservedEvent
             {
-                Reason = "peer_rebuild",
-                RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAtUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
             };
             await store.AppendAsync(
                 actorId,
@@ -705,7 +708,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
                     {
                         AgentId = actorId,
                         Version = current + 1,
-                        EventType = AevatarOAuthClientProjectionRebuildRequestedEvent.Descriptor.FullName,
+                        EventType = AevatarOAuthClientBrokerCapabilityObservedEvent.Descriptor.FullName,
                         EventData = Any.Pack(peerEvent),
                         Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
                     },

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs
@@ -34,11 +34,13 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
     private ServiceProvider _serviceProvider = null!;
     private RecordingDcrClient _registrar = null!;
     private IdentityGAgentTestHarness.NoopCallbackScheduler _callbackScheduler = null!;
+    private RecordingCommittedStateActivationService _activation = null!;
 
     public async Task InitializeAsync()
     {
         _registrar = new RecordingDcrClient();
         _callbackScheduler = new IdentityGAgentTestHarness.NoopCallbackScheduler();
+        _activation = new RecordingCommittedStateActivationService();
 
         var services = new ServiceCollection();
         services.AddSingleton<IEventStore, IdentityGAgentTestHarness.InMemoryEventStore>();
@@ -48,6 +50,7 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             typeof(DefaultEventSourcingBehaviorFactory<>));
         services.AddSingleton<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler>(
             _callbackScheduler);
+        services.AddSingleton<IChannelIdentityCommittedStateActivationService>(_activation);
         // The actor resolves the registrar by abstract NyxIdDynamicClientRegistrationClient
         // type; tests inject a recording stub so HandleEnsureProvisioned exercises the
         // full code path without a real HTTP call.
@@ -116,6 +119,10 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             "already-provisioned ensure must not mutate OAuth client facts");
         _agent.EventSourcing!.CurrentVersion.Should().Be(beforeRefreshVersion,
             "already-provisioned ensure must not append a projection-only no-op event");
+        _activation.OAuthClientRequests.Should().ContainSingle(request =>
+            request.ActorId == AevatarOAuthClientGAgent.WellKnownId &&
+            request.State.ClientId == firstClientId &&
+            request.StateVersion == beforeRefreshVersion);
     }
 
     [Fact]
@@ -810,4 +817,31 @@ public sealed class AevatarOAuthClientGAgentTests : IAsyncLifetime
             ?? throw new InvalidOperationException("SetId not found on GAgentBase");
         method.Invoke(agent, new object[] { id });
     }
+
+    private sealed class RecordingCommittedStateActivationService : IChannelIdentityCommittedStateActivationService
+    {
+        public List<OAuthClientActivationRequest> OAuthClientRequests { get; } = [];
+
+        public Task EnsureExternalIdentityCommittedStateActivatedAsync(
+            string actorId,
+            ExternalIdentityBindingState state,
+            long stateVersion,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
+        public Task EnsureAevatarOAuthClientCommittedStateActivatedAsync(
+            string actorId,
+            AevatarOAuthClientState state,
+            long stateVersion,
+            CancellationToken ct = default)
+        {
+            OAuthClientRequests.Add(new OAuthClientActivationRequest(actorId, state.Clone(), stateVersion));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed record OAuthClientActivationRequest(
+        string ActorId,
+        AevatarOAuthClientState State,
+        long StateVersion);
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateActivationServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateActivationServiceTests.cs
@@ -1,0 +1,154 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+public sealed class ChannelIdentityCommittedStateActivationServiceTests
+{
+    [Fact]
+    public async Task EnsureExternalIdentityCommittedStateActivatedAsync_ActivatesScopeAndDispatchesCurrentStateRoot()
+    {
+        var bindingActivation = new RecordingActivationService<ExternalIdentityBindingMaterializationRuntimeLease>(
+            request => new ExternalIdentityBindingMaterializationRuntimeLease(new ExternalIdentityBindingMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+            }));
+        var oauthActivation = new RecordingActivationService<AevatarOAuthClientMaterializationRuntimeLease>(
+            request => new AevatarOAuthClientMaterializationRuntimeLease(new AevatarOAuthClientMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+            }));
+        var dispatch = new RecordingActorDispatchPort();
+        var eventStore = new RecordingEventStore();
+        var service = new ChannelIdentityCommittedStateActivationService(
+            bindingActivation,
+            oauthActivation,
+            dispatch,
+            eventStore);
+        const string actorId = "external-identity-binding:lark:t:u";
+        var state = new ExternalIdentityBindingState
+        {
+            ExternalSubject = new ExternalSubjectRef
+            {
+                Platform = "lark",
+                Tenant = "t",
+                ExternalUserId = "u",
+            },
+            BindingId = "bnd-first",
+            BoundAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+        eventStore.Seed(actorId, new ExternalIdentityBoundEvent
+        {
+            ExternalSubject = state.ExternalSubject.Clone(),
+            BindingId = state.BindingId,
+            BoundAt = state.BoundAt,
+        }, 7);
+
+        await service.EnsureExternalIdentityCommittedStateActivatedAsync(actorId, state, 7);
+
+        bindingActivation.Requests.Should().ContainSingle().Which.Should().BeEquivalentTo(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = actorId,
+                ProjectionKind = "external-identity-binding",
+                Mode = ProjectionRuntimeMode.DurableMaterialization,
+            });
+        dispatch.Envelopes.Should().ContainSingle();
+        var (targetActorId, envelope) = dispatch.Envelopes[0];
+        targetActorId.Should().Be("projection.durable.scope:external-identity-binding:external-identity-binding:lark:t:u");
+        envelope.Route.IsObserverPublication().Should().BeTrue();
+        var published = envelope.Payload.Unpack<CommittedStateEventPublished>();
+        published.StateRoot.Unpack<ExternalIdentityBindingState>().BindingId.Should().Be("bnd-first");
+        published.StateEvent.Version.Should().Be(7);
+        published.StateEvent.EventData.Unpack<ExternalIdentityBoundEvent>()
+            .BindingId.Should().Be("bnd-first");
+    }
+
+    private sealed class RecordingActivationService<TLease> : IProjectionScopeActivationService<TLease>
+        where TLease : class, IProjectionRuntimeLease
+    {
+        private readonly Func<ProjectionScopeStartRequest, TLease> _leaseFactory;
+
+        public RecordingActivationService(Func<ProjectionScopeStartRequest, TLease> leaseFactory)
+        {
+            _leaseFactory = leaseFactory;
+        }
+
+        public List<ProjectionScopeStartRequest> Requests { get; } = [];
+
+        public Task<TLease> EnsureAsync(ProjectionScopeStartRequest request, CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_leaseFactory(request));
+        }
+    }
+
+    private sealed class RecordingActorDispatchPort : IActorDispatchPort
+    {
+        public List<(string ActorId, EventEnvelope Envelope)> Envelopes { get; } = [];
+
+        public Task DispatchAsync(string actorId, EventEnvelope envelope, CancellationToken ct = default)
+        {
+            Envelopes.Add((actorId, envelope));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingEventStore : IEventStore
+    {
+        private readonly Dictionary<string, List<StateEvent>> _events = new(StringComparer.Ordinal);
+
+        public void Seed<TEvent>(string agentId, TEvent evt, long version)
+            where TEvent : IMessage
+        {
+            _events[agentId] =
+            [
+                new StateEvent
+                {
+                    AgentId = agentId,
+                    EventId = $"event-{version}",
+                    EventType = evt.Descriptor.FullName,
+                    EventData = Any.Pack(evt),
+                    Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                    Version = version,
+                },
+            ];
+        }
+
+        public Task<EventStoreCommitResult> AppendAsync(
+            string agentId,
+            IEnumerable<StateEvent> events,
+            long expectedVersion,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<IReadOnlyList<StateEvent>> GetEventsAsync(
+            string agentId,
+            long? fromVersion = null,
+            CancellationToken ct = default)
+        {
+            IReadOnlyList<StateEvent> result = !_events.TryGetValue(agentId, out var events)
+                ? []
+                : events
+                    .Where(evt => !fromVersion.HasValue || evt.Version > fromVersion.Value)
+                    .Select(evt => evt.Clone())
+                    .ToList();
+            return Task.FromResult(result);
+        }
+
+        public Task<long> GetVersionAsync(string agentId, CancellationToken ct = default) =>
+            Task.FromResult(_events.TryGetValue(agentId, out var events) && events.Count > 0 ? events[^1].Version : 0);
+
+        public Task<long> DeleteEventsUpToAsync(string agentId, long toVersion, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateActivationServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateActivationServiceTests.cs
@@ -73,6 +73,69 @@ public sealed class ChannelIdentityCommittedStateActivationServiceTests
             .BindingId.Should().Be("bnd-first");
     }
 
+    [Fact]
+    public async Task EnsureAevatarOAuthClientCommittedStateActivatedAsync_DispatchesOAuthStateRoot()
+    {
+        var bindingActivation = new RecordingActivationService<ExternalIdentityBindingMaterializationRuntimeLease>(
+            request => new ExternalIdentityBindingMaterializationRuntimeLease(new ExternalIdentityBindingMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+            }));
+        var oauthActivation = new RecordingActivationService<AevatarOAuthClientMaterializationRuntimeLease>(
+            request => new AevatarOAuthClientMaterializationRuntimeLease(new AevatarOAuthClientMaterializationContext
+            {
+                RootActorId = request.RootActorId,
+                ProjectionKind = request.ProjectionKind,
+            }));
+        var dispatch = new RecordingActorDispatchPort();
+        var eventStore = new RecordingEventStore();
+        var service = new ChannelIdentityCommittedStateActivationService(
+            bindingActivation,
+            oauthActivation,
+            dispatch,
+            eventStore);
+        const string actorId = AevatarOAuthClientGAgent.WellKnownId;
+        const string clientId = "aevatar-client-first";
+        var state = new AevatarOAuthClientState
+        {
+            ClientId = clientId,
+            ClientIdIssuedAtUnix = 1_700_000_001,
+            NyxidAuthority = "https://nyxid.test",
+            RedirectUri = "https://aevatar.test/api/oauth/nyxid-callback",
+            OauthScope = AevatarOAuthClientScopes.AuthorizationScope,
+        };
+        eventStore.Seed(actorId, new AevatarOAuthClientProvisionedEvent
+        {
+            ClientId = state.ClientId,
+            ClientIdIssuedAtUnix = state.ClientIdIssuedAtUnix,
+            NyxidAuthority = state.NyxidAuthority,
+            RedirectUri = state.RedirectUri,
+            OauthScope = state.OauthScope,
+            PersistedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        }, 11);
+
+        await service.EnsureAevatarOAuthClientCommittedStateActivatedAsync(actorId, state, 11);
+
+        bindingActivation.Requests.Should().BeEmpty();
+        oauthActivation.Requests.Should().ContainSingle().Which.Should().BeEquivalentTo(
+            new ProjectionScopeStartRequest
+            {
+                RootActorId = actorId,
+                ProjectionKind = "aevatar-oauth-client",
+                Mode = ProjectionRuntimeMode.DurableMaterialization,
+            });
+        dispatch.Envelopes.Should().ContainSingle();
+        var (targetActorId, envelope) = dispatch.Envelopes[0];
+        targetActorId.Should().Be("projection.durable.scope:aevatar-oauth-client:aevatar-oauth-client");
+        envelope.Route.IsObserverPublication().Should().BeTrue();
+        var published = envelope.Payload.Unpack<CommittedStateEventPublished>();
+        published.StateRoot.Unpack<AevatarOAuthClientState>().ClientId.Should().Be(clientId);
+        published.StateEvent.Version.Should().Be(11);
+        published.StateEvent.EventData.Unpack<AevatarOAuthClientProvisionedEvent>()
+            .ClientId.Should().Be(clientId);
+    }
+
     private sealed class RecordingActivationService<TLease> : IProjectionScopeActivationService<TLease>
         where TLease : class, IProjectionRuntimeLease
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateProjectionActivationPlanProviderTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateProjectionActivationPlanProviderTests.cs
@@ -9,6 +9,9 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 public sealed class ChannelIdentityCommittedStateProjectionActivationPlanProviderTests
     : ProjectionActivationPlanProviderTestBase
 {
+    // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
+    //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
+    //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     [Fact]
     public void GetPlans_ShouldMapExternalIdentityBindingActor()
     {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
@@ -35,9 +35,11 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
     //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     private ExternalIdentityBindingGAgent _agent = null!;
     private ServiceProvider _serviceProvider = null!;
+    private RecordingCommittedStateActivationService _activation = null!;
 
     public async Task InitializeAsync()
     {
+        _activation = new RecordingCommittedStateActivationService();
         var services = new ServiceCollection();
         services.AddSingleton<IEventStore, InMemoryEventStore>();
         services.AddSingleton<EventSourcingRuntimeOptions>();
@@ -48,6 +50,7 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         // continuation timers; tests register a no-op so the dispatch path
         // is exercised without bringing up a real Orleans cluster.
         services.AddSingleton<Aevatar.Foundation.Abstractions.Runtime.Callbacks.IActorRuntimeCallbackScheduler, NoopCallbackScheduler>();
+        services.AddSingleton<IChannelIdentityCommittedStateActivationService>(_activation);
 
         _serviceProvider = services.BuildServiceProvider();
 
@@ -118,6 +121,10 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         _agent.EventSourcing!.CurrentVersion.Should().Be(
             afterFirstVersion,
             "the discard branch must not append a projection-only no-op event");
+        _activation.ExternalIdentityRequests.Should().ContainSingle(request =>
+            request.ActorId == subject.ToActorId() &&
+            request.State.BindingId == "bnd_first" &&
+            request.StateVersion == afterFirstVersion);
     }
 
     [Fact]
@@ -201,6 +208,8 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         _agent.EventSourcing!.CurrentVersion.Should().Be(
             initialVersion,
             "empty revoke must not append a projection-only no-op event");
+        _activation.ExternalIdentityRequests.Should().BeEmpty(
+            "there is no committed state root to activate before the actor has any committed version");
     }
 
     [Fact]
@@ -357,4 +366,31 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
             return Task.FromResult((long)(before - stream.Count));
         }
     }
+
+    private sealed class RecordingCommittedStateActivationService : IChannelIdentityCommittedStateActivationService
+    {
+        public List<ExternalIdentityActivationRequest> ExternalIdentityRequests { get; } = [];
+
+        public Task EnsureExternalIdentityCommittedStateActivatedAsync(
+            string actorId,
+            ExternalIdentityBindingState state,
+            long stateVersion,
+            CancellationToken ct = default)
+        {
+            ExternalIdentityRequests.Add(new ExternalIdentityActivationRequest(actorId, state.Clone(), stateVersion));
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureAevatarOAuthClientCommittedStateActivatedAsync(
+            string actorId,
+            AevatarOAuthClientState state,
+            long stateVersion,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+    }
+
+    private sealed record ExternalIdentityActivationRequest(
+        string ActorId,
+        ExternalIdentityBindingState State,
+        long StateVersion);
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs
@@ -30,6 +30,9 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
 /// </summary>
 public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
 {
+    // Refactor (iter71/cluster-071-identity-projection-rebuild-events):
+    //   Old pattern: emit no-op ProjectionRebuildRequested event in command handler to trigger projection materialization
+    //   New principle: Identity actor only persists real identity facts; projection materialization owned by projection lifecycle/materializer/bootstrap
     private ExternalIdentityBindingGAgent _agent = null!;
     private ServiceProvider _serviceProvider = null!;
 
@@ -101,13 +104,10 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         });
         var afterFirstVersion = _agent.EventSourcing!.CurrentVersion;
 
-        // Second concurrent /init wins the race after the first one already
+        // Second concurrent /init lands after the first one already
         // committed. The actor MUST keep the existing binding_id and discard
-        // the second one (ADR-0018 §Implementation Notes #2). It also emits
-        // a no-op rebuild event so the projector materializes the existing
-        // binding into the readmodel — necessary on legacy clusters whose
-        // binding projection scope was activated for the first time after
-        // the bind already happened (issue #549 follow-up 2026-05-01).
+        // the second one (ADR-0018 §Implementation Notes #2) without
+        // persisting projection-only events.
         await _agent.HandleCommitBinding(new CommitBindingCommand
         {
             ExternalSubject = subject,
@@ -116,8 +116,8 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
 
         _agent.State.BindingId.Should().Be("bnd_first");
         _agent.EventSourcing!.CurrentVersion.Should().Be(
-            afterFirstVersion + 1,
-            "the discard branch must emit a rebuild event so the projector re-publishes the existing binding's state root");
+            afterFirstVersion,
+            "the discard branch must not append a projection-only no-op event");
     }
 
     [Fact]
@@ -186,8 +186,10 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task HandleRevokeBinding_RequestsProjectionRebuildWhenNoActiveBinding()
+    public async Task HandleRevokeBinding_IsNoOpWhenNoActiveBinding()
     {
+        var initialVersion = _agent.EventSourcing!.CurrentVersion;
+
         await _agent.HandleRevokeBinding(new RevokeBindingCommand
         {
             ExternalSubject = SampleSubject(),
@@ -197,8 +199,8 @@ public class ExternalIdentityBindingGAgentTests : IAsyncLifetime
         _agent.State.BindingId.Should().BeEmpty();
         _agent.State.RevokedAt.Should().BeNull();
         _agent.EventSourcing!.CurrentVersion.Should().Be(
-            1,
-            "a remote-side revoke/self-heal must overwrite any stale active binding readmodel from the actor's empty state");
+            initialVersion,
+            "empty revoke must not append a projection-only no-op event");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

iter71 cluster-071-identity-projection-rebuild-events(severity:high,rule:AG-PROJECTION-COMMITTED-FACTS)。

- **Old**:`ExternalIdentityBindingGAgent` / `AevatarOAuthClientGAgent` 在 CommitBinding/RevokeBinding/Provision 等 command handler 里,若 state 已是 desired 状态,持久化 no-op `*ProjectionRebuildRequestedEvent`,**唯一目的**让 projection 物化 state_root。Projection activation provider 把这些 event 当 trigger 消费。
- **New**:Identity actor 只持久化真业务事实(bound/revoked/provisioned/hmac-rotated/broker-capability-observed/drift-reconciled/retry-scheduled/retry-cleared);state 已 desired 时 idempotent return 不 emit。Projection 物化由 projection lifecycle / materializer / bootstrap 拥有。

违反:CLAUDE「projection 只消费 committed 事实」「projection 负责物化,不负责推导」「正常路径禁止 replay」。

## Phase 9 共识

**r1 unanimous 3/3 propose**(framing:`projection-lifecycle-delete-noop`)。无需多轮迭代,无需 maintainer 介入。see #959 meta-judge 评论。

## 范围

8 文件改动(+49 / -95):
- `agents/Aevatar.GAgents.Channel.Identity/ExternalIdentityBindingGAgent.cs`
- `agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs`
- `agents/Aevatar.GAgents.Channel.Identity/Projection/ChannelIdentityCommittedStateProjectionActivationPlanProvider.cs`
- `agents/Aevatar.GAgents.Channel.Identity/protos/external_identity_binding.proto`(deprecated event message 删,reserved 保留 wire)
- `agents/Aevatar.GAgents.Channel.Identity/protos/aevatar_oauth_client.proto`(同)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ExternalIdentityBindingGAgentTests.cs`(测试断言 idempotent no-op 不 bump version)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientGAgentTests.cs`(同)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/ChannelIdentityCommittedStateProjectionActivationPlanProviderTests.cs`(provider 测试更新)

验证:
- `dotnet build agents/Aevatar.GAgents.Channel.Identity/Aevatar.GAgents.Channel.Identity.csproj --nologo` ✅
- ChannelRuntime Identity tests ✅
- CQRS.Projection.Core tests ✅
- `tools/ci/test_stability_guards.sh` ✅
- `tools/ci/architecture_guards.sh` ✅

## Stacked-PR

Part of iter71 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

closes #959

🤖 Auto-loop / codex-refactor-loop iter71

⟦AI:AUTO-LOOP⟧
