### PR TITLE
iter74 cluster-074: 删 team members Host-side 100-page fanout,改 readmodel typed team filter

### DIFF
--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberQueryPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberQueryPort.cs
@@ -9,6 +9,9 @@ namespace Aevatar.Studio.Application.Studio.Abstractions;
 /// </summary>
 public interface IStudioMemberQueryPort
 {
+    // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+    //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+    //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
     Task<StudioMemberRosterResponse> ListAsync(
         string scopeId,
         StudioMemberRosterPageRequest? page = null,

--- a/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs
@@ -132,9 +132,13 @@ public sealed record StudioMemberRosterResponse(
     IReadOnlyList<StudioMemberSummaryResponse> Members,
     string? NextPageToken = null);
 
+// Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+//   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+//   New principle: ReadModel query port owns scope_id+team_id filter before pagination
 public sealed record StudioMemberRosterPageRequest(
     int? PageSize = null,
-    string? PageToken = null);
+    string? PageToken = null,
+    string? TeamId = null);
 
 public sealed record CreateStudioMemberRequest(
     string DisplayName,

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
@@ -25,6 +25,9 @@ namespace Aevatar.Studio.Hosting.Endpoints;
 /// </summary>
 internal static class StudioTeamEndpoints
 {
+    // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+    //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+    //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
     public static void Map(IEndpointRouteBuilder app)
     {
         ArgumentNullException.ThrowIfNull(app);
@@ -297,15 +300,9 @@ internal static class StudioTeamEndpoints
     /// filtered by <c>team_id</c> (ADR-0017 §HTTP endpoints) — the team read
     /// model never mirrors the roster.
     ///
-    /// For v1 this iterates the scope's roster and filters in-process. The
-    /// member query port today doesn't expose a typed <c>team_id</c> filter,
-    /// so the filter happens after the read model returns. A typed filter on
-    /// the query port is a follow-up that does not change the wire shape.
-    ///
-    /// To avoid silent empty pages when team members are spread across
-    /// scope-level pages, this method iterates scope pages until enough
-    /// team-filtered results are collected. The returned page token is
-    /// the scope-level cursor of the page where collection stopped.
+    /// The member query port owns the typed <c>team_id</c> filter and applies
+    /// it before pagination, so sparse team members across a scope still page
+    /// by team membership rather than by the unfiltered scope roster.
     /// </summary>
     internal static async Task<IResult> HandleListMembersAsync(
         HttpContext http,
@@ -326,41 +323,12 @@ internal static class StudioTeamEndpoints
             // with empty roster".
             _ = await teamService.GetAsync(scopeId, teamId, ct);
 
-            const int defaultPageSize = 50;
-            const int maxScopePageIterations = 100;
+            var page = new StudioMemberRosterPageRequest(
+                PageSize: pageSize,
+                PageToken: pageToken,
+                TeamId: teamId);
 
-            var effectivePageSize = pageSize ?? defaultPageSize;
-            var filtered = new List<Aevatar.Studio.Application.Studio.Contracts.StudioMemberSummaryResponse>();
-            var nextCursor = string.IsNullOrWhiteSpace(pageToken) ? null : pageToken;
-            string? finalNextPageToken = null;
-            var iterations = 0;
-
-            while (filtered.Count < effectivePageSize && iterations < maxScopePageIterations)
-            {
-                iterations++;
-                var page = new StudioMemberRosterPageRequest(effectivePageSize, nextCursor);
-                var roster = await memberService.ListAsync(scopeId, page, ct);
-
-                foreach (var member in roster.Members)
-                {
-                    if (string.Equals(member.TeamId, teamId, StringComparison.Ordinal))
-                        filtered.Add(member);
-                }
-
-                if (string.IsNullOrWhiteSpace(roster.NextPageToken))
-                {
-                    finalNextPageToken = null;
-                    break;
-                }
-
-                nextCursor = roster.NextPageToken;
-                finalNextPageToken = nextCursor;
-            }
-
-            return Results.Ok(new StudioMemberRosterResponse(
-                ScopeId: scopeId,
-                Members: filtered,
-                NextPageToken: finalNextPageToken));
+            return Results.Ok(await memberService.ListAsync(scopeId, page, ct));
         }
         catch (StudioTeamNotFoundException ex)
         {

--- a/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs
+++ b/src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs
@@ -1,5 +1,6 @@
 using Aevatar.CQRS.Projection.Stores.Abstractions;
 using Aevatar.GAgents.StudioMember;
+using Aevatar.GAgents.StudioTeam;
 using Aevatar.Studio.Application.Studio.Abstractions;
 using Aevatar.Studio.Application.Studio.Contracts;
 using Aevatar.Studio.Projection.ReadModels;
@@ -20,6 +21,9 @@ namespace Aevatar.Studio.Projection.QueryPorts;
 /// </summary>
 public sealed class ProjectionStudioMemberQueryPort : IStudioMemberQueryPort
 {
+    // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+    //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+    //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
     public const int MaxRosterPageSize = 200;
 
     private readonly IProjectionDocumentReader<StudioMemberCurrentStateDocument, string> _documentReader;
@@ -40,17 +44,32 @@ public sealed class ProjectionStudioMemberQueryPort : IStudioMemberQueryPort
         if (requestedPageSize <= 0 || requestedPageSize > MaxRosterPageSize)
             requestedPageSize = MaxRosterPageSize;
 
+        var filters = new List<ProjectionDocumentFilter>
+        {
+            new()
+            {
+                FieldPath = "scope_id",
+                Operator = ProjectionDocumentFilterOperator.Eq,
+                Value = ProjectionDocumentValue.FromString(normalizedScopeId),
+            },
+        };
+
+        var normalizedTeamId = string.IsNullOrWhiteSpace(page?.TeamId)
+            ? null
+            : StudioTeamConventions.NormalizeTeamId(page.TeamId);
+        if (normalizedTeamId != null)
+        {
+            filters.Add(new ProjectionDocumentFilter
+            {
+                FieldPath = "team_id",
+                Operator = ProjectionDocumentFilterOperator.Eq,
+                Value = ProjectionDocumentValue.FromString(normalizedTeamId),
+            });
+        }
+
         var query = new ProjectionDocumentQuery
         {
-            Filters =
-            [
-                new ProjectionDocumentFilter
-                {
-                    FieldPath = "scope_id",
-                    Operator = ProjectionDocumentFilterOperator.Eq,
-                    Value = ProjectionDocumentValue.FromString(normalizedScopeId),
-                },
-            ],
+            Filters = filters,
             Take = requestedPageSize,
             Cursor = string.IsNullOrWhiteSpace(page?.PageToken) ? null : page!.PageToken,
         };

--- a/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs
@@ -20,6 +20,9 @@ namespace Aevatar.Studio.Tests;
 /// </summary>
 public sealed class ProjectionStudioMemberQueryPortTests
 {
+    // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+    //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+    //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
     private const string ScopeId = "scope-1";
 
     [Fact]
@@ -118,6 +121,41 @@ public sealed class ProjectionStudioMemberQueryPortTests
         reader.LastQuery.Cursor.Should().Be("cursor-1");
         roster.NextPageToken.Should().Be("cursor-next");
         roster.Members.Select(m => m.MemberId).Should().BeEquivalentTo("m-1", "m-2");
+    }
+
+    [Fact]
+    public async Task ListAsync_ShouldApplyTeamFilterBeforePagination()
+    {
+        var inOtherTeamA = NewDocument(scopeId: ScopeId, memberId: "m-other-1", teamId: "other-team");
+        var inTeamA = NewDocument(scopeId: ScopeId, memberId: "m-team-1", teamId: "team-1");
+        var inOtherScope = NewDocument(scopeId: "scope-other", memberId: "m-foreign", teamId: "team-1");
+        var inOtherTeamB = NewDocument(scopeId: ScopeId, memberId: "m-other-2", teamId: "other-team");
+        var inTeamB = NewDocument(scopeId: ScopeId, memberId: "m-team-2", teamId: "team-1");
+        var reader = new StubDocumentReader([inOtherTeamA, inTeamA, inOtherScope, inOtherTeamB, inTeamB])
+        {
+            NextCursor = "team-cursor-2",
+        };
+        var port = new ProjectionStudioMemberQueryPort(reader);
+
+        var roster = await port.ListAsync(
+            ScopeId,
+            new StudioMemberRosterPageRequest(PageSize: 2, PageToken: "team-cursor-1", TeamId: " team-1 "));
+
+        reader.LastQuery.Should().NotBeNull();
+        reader.LastQuery!.Cursor.Should().Be("team-cursor-1");
+        reader.LastQuery.Take.Should().Be(2);
+        reader.LastQuery.Filters.Any(f =>
+            string.Equals(f.FieldPath, "scope_id", StringComparison.Ordinal) &&
+            f.Value.RawValue is string scope &&
+            string.Equals(scope, ScopeId, StringComparison.Ordinal))
+            .Should().BeTrue();
+        reader.LastQuery.Filters.Any(f =>
+            string.Equals(f.FieldPath, "team_id", StringComparison.Ordinal) &&
+            f.Value.RawValue is string team &&
+            string.Equals(team, "team-1", StringComparison.Ordinal))
+            .Should().BeTrue();
+        roster.Members.Select(m => m.MemberId).Should().ContainInOrder("m-team-1", "m-team-2");
+        roster.NextPageToken.Should().Be("team-cursor-2");
     }
 
     [Fact]
@@ -231,7 +269,8 @@ public sealed class ProjectionStudioMemberQueryPortTests
         StudioMemberLifecycleStage lifecycle = StudioMemberLifecycleStage.Created,
         bool includeImplementationRef = false,
         bool includeLastBinding = false,
-        bool includeBindingStatus = false)
+        bool includeBindingStatus = false,
+        string? teamId = null)
     {
         var actorId = StudioMemberConventions.BuildActorId(scopeId, memberId);
         var publishedServiceId = StudioMemberConventions.BuildPublishedServiceId(memberId);
@@ -274,6 +313,9 @@ public sealed class ProjectionStudioMemberQueryPortTests
             doc.BindingCurrentStatus = StudioMemberBindingRunStatusNames.PlatformBindingPending;
             doc.BindingUpdatedAt = now;
         }
+
+        if (teamId != null)
+            doc.TeamId = teamId;
 
         return doc;
     }
@@ -325,6 +367,9 @@ public sealed class ProjectionStudioMemberQueryPortTests
     private sealed class StubDocumentReader
         : IProjectionDocumentReader<StudioMemberCurrentStateDocument, string>
     {
+        // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+        //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+        //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
         private readonly Dictionary<string, StudioMemberCurrentStateDocument> _byId;
         public ProjectionDocumentQuery? LastQuery { get; private set; }
         public string? NextCursor { get; init; }
@@ -345,14 +390,21 @@ public sealed class ProjectionStudioMemberQueryPortTests
         {
             LastQuery = query;
 
-            // Honor the scope_id filter the query port issues.
+            // Honor the readmodel filters before pagination, matching store
+            // semantics that the query port relies on.
             var scopeFilter = query.Filters.FirstOrDefault(
                 f => string.Equals(f.FieldPath, "scope_id", StringComparison.Ordinal));
+            var teamFilter = query.Filters.FirstOrDefault(
+                f => string.Equals(f.FieldPath, "team_id", StringComparison.Ordinal));
 
             IEnumerable<StudioMemberCurrentStateDocument> items = _byId.Values;
             if (scopeFilter != null && scopeFilter.Value.RawValue is string scope)
             {
                 items = items.Where(d => string.Equals(d.ScopeId, scope, StringComparison.Ordinal));
+            }
+            if (teamFilter != null && teamFilter.Value.RawValue is string team)
+            {
+                items = items.Where(d => d.HasTeamId && string.Equals(d.TeamId, team, StringComparison.Ordinal));
             }
 
             return Task.FromResult(new ProjectionDocumentQueryResult<StudioMemberCurrentStateDocument>

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
@@ -14,6 +14,9 @@ namespace Aevatar.Studio.Tests;
 
 public sealed class StudioTeamEndpointTests
 {
+    // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+    //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+    //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
     private const string ScopeId = "scope-1";
     private const string TeamId = "t-1";
 
@@ -381,7 +384,10 @@ public sealed class StudioTeamEndpointTests
     public async Task HandleListMembersAsync_ShouldReturn200_WithFilteredMembers()
     {
         var teamService = new InMemoryTeamService(NewSummary());
-        var memberService = new InMemoryMemberService(TeamId);
+        var memberService = new InMemoryMemberService(TeamId, [
+            NewMember("m-1", TeamId),
+            NewMember("m-2", "other-team"),
+        ]);
         var result = await InvokeTeamHandle(
             "HandleListMembersAsync",
             CreateAuthenticatedContext(ScopeId),
@@ -394,6 +400,43 @@ public sealed class StudioTeamEndpointTests
             CancellationToken.None);
 
         GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task HandleListMembersAsync_ShouldDelegateTypedTeamFilter_WhenTeamMembersAreSparseAcrossScope()
+    {
+        var teamService = new InMemoryTeamService(NewSummary());
+        var memberService = new InMemoryMemberService(TeamId, [
+            NewMember("m-team-1", TeamId),
+            NewMember("m-team-2", TeamId),
+        ])
+        {
+            NextPageToken = "team-cursor-2",
+        };
+
+        var result = await InvokeTeamHandle(
+            "HandleListMembersAsync",
+            CreateAuthenticatedContext(ScopeId),
+            ScopeId,
+            TeamId,
+            teamService,
+            memberService,
+            (int?)2,
+            "team-cursor-1",
+            CancellationToken.None);
+
+        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        teamService.GetCalls.Should().Be(1);
+        memberService.ListCalls.Should().Be(1);
+        memberService.LastPage.Should().Be(new StudioMemberRosterPageRequest(
+            PageSize: 2,
+            PageToken: "team-cursor-1",
+            TeamId: TeamId));
+
+        var ok = result.Should().BeOfType<Ok<StudioMemberRosterResponse>>().Subject;
+        ok.Value!.Members.Select(member => member.MemberId)
+            .Should().ContainInOrder("m-team-1", "m-team-2");
+        ok.Value.NextPageToken.Should().Be("team-cursor-2");
     }
 
     [Fact]
@@ -425,6 +468,22 @@ public sealed class StudioTeamEndpointTests
             MemberCount: 0,
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
             UpdatedAt: DateTimeOffset.UtcNow);
+
+    private static StudioMemberSummaryResponse NewMember(string memberId, string? teamId) =>
+        new(
+            MemberId: memberId,
+            ScopeId: ScopeId,
+            DisplayName: memberId,
+            Description: string.Empty,
+            ImplementationKind: MemberImplementationKindNames.Workflow,
+            LifecycleStage: MemberLifecycleStageNames.Created,
+            PublishedServiceId: $"member-{memberId}",
+            LastBoundRevisionId: null,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow)
+        {
+            TeamId = teamId,
+        };
 
     private static HttpContext CreateAuthenticatedContext(string scopeId)
     {
@@ -462,9 +521,13 @@ public sealed class StudioTeamEndpointTests
 
     private sealed class InMemoryTeamService : IStudioTeamService
     {
+        // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+        //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+        //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
         private readonly StudioTeamSummaryResponse _summary;
         public List<SetStudioTeamEntryMemberRequest> SetEntryRequests { get; } = [];
         public int ClearEntryCalls { get; private set; }
+        public int GetCalls { get; private set; }
 
         public InMemoryTeamService(StudioTeamSummaryResponse summary) => _summary = summary;
 
@@ -477,8 +540,11 @@ public sealed class StudioTeamEndpointTests
             Task.FromResult(new StudioTeamRosterResponse(scopeId, [_summary]));
 
         public Task<StudioTeamSummaryResponse> GetAsync(
-            string scopeId, string teamId, CancellationToken ct = default) =>
-            Task.FromResult(_summary);
+            string scopeId, string teamId, CancellationToken ct = default)
+        {
+            GetCalls++;
+            return Task.FromResult(_summary);
+        }
 
         public Task<StudioTeamSummaryResponse> UpdateAsync(
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default) =>
@@ -536,8 +602,21 @@ public sealed class StudioTeamEndpointTests
 
     private sealed class InMemoryMemberService : IStudioMemberService
     {
+        // Refactor (iter74/cluster-074-studio-team-members-query-fanout):
+        //   Old pattern: Host loops scope roster pages + Host-side TeamId filter
+        //   New principle: ReadModel query port owns scope_id+team_id filter before pagination
         private readonly string? _teamId;
-        public InMemoryMemberService(string? teamId) => _teamId = teamId;
+        private readonly IReadOnlyList<StudioMemberSummaryResponse>? _members;
+
+        public int ListCalls { get; private set; }
+        public StudioMemberRosterPageRequest? LastPage { get; private set; }
+        public string? NextPageToken { get; init; }
+
+        public InMemoryMemberService(string? teamId, IReadOnlyList<StudioMemberSummaryResponse>? members = null)
+        {
+            _teamId = teamId;
+            _members = members;
+        }
 
         public Task<StudioMemberSummaryResponse> CreateAsync(
             string scopeId, CreateStudioMemberRequest request, CancellationToken ct = default) =>
@@ -546,6 +625,12 @@ public sealed class StudioTeamEndpointTests
         public Task<StudioMemberRosterResponse> ListAsync(
             string scopeId, StudioMemberRosterPageRequest? page = null, CancellationToken ct = default)
         {
+            ListCalls++;
+            LastPage = page;
+
+            if (_members != null)
+                return Task.FromResult(new StudioMemberRosterResponse(scopeId, _members, NextPageToken));
+
             var members = new List<StudioMemberSummaryResponse>
             {
                 new(MemberId: "m-1", ScopeId: scopeId, DisplayName: "M1", Description: "",
@@ -559,7 +644,7 @@ public sealed class StudioTeamEndpointTests
                     PublishedServiceId: "member-m-2", LastBoundRevisionId: null,
                     CreatedAt: DateTimeOffset.UtcNow, UpdatedAt: DateTimeOffset.UtcNow) { TeamId = "other-team" },
             };
-            return Task.FromResult(new StudioMemberRosterResponse(scopeId, members));
+            return Task.FromResult(new StudioMemberRosterResponse(scopeId, members, NextPageToken));
         }
 
         public Task<StudioMemberDetailResponse> GetAsync(


### PR DESCRIPTION
## 摘要

iter74 cluster-074-studio-team-members-query-fanout(severity:medium,rules:CLAUDE.query-readmodel-only + CLAUDE.readmodel-consumption-scene)。

- **Old**:`StudioTeamEndpoints.cs:338-358` 在 Host 里循环最多 100 个 scope-level roster pages,每页用 `member.TeamId == teamId` 在 Host 过滤直到填满一页。`IStudioMemberQueryPort.ListAsync(scopeId, page)` 只暴露 scope-level 分页,无 team filter
- **New**:`IStudioMemberQueryPort` 暴露 typed TeamId filter(`MemberContracts` page request 加 TeamId);`ProjectionStudioMemberQueryPort` 在 `ProjectionDocumentQuery.Filters` 应用 `scope_id + team_id` **before pagination**;endpoint 不再 query-time aggregate

违反:CLAUDE「查询始终走 readmodel」「readmodel 按需创建并服务声明消费场景」(消费场景 `/teams/{teamId}/members` 已存在,但 readmodel query shape 缺 stable team_id filter,强迫 query-time aggregation)。

## 范围

6 文件改动(+191 / -60):
- `src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberQueryPort.cs`(typed team filter API)
- `src/Aevatar.Studio.Application/Studio/Contracts/MemberContracts.cs`(page request 加 TeamId)
- `src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs`(去 100-page loop,直接 typed query)
- `src/Aevatar.Studio.Projection/QueryPorts/ProjectionStudioMemberQueryPort.cs`(filters 加 scope_id+team_id)
- `test/Aevatar.Studio.Tests/StudioMemberQueryPortTests.cs`(typed filter 覆盖)
- `test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs`(分页语义验证 — team 跨 scope 稀疏分布)

team existence check(单次 `teamService.GetAsync`)保留。

验证:Studio build + Aevatar.Studio.Tests pass + typed team filter 测试覆盖 + 两个 `ci/*_guards.sh` pass。

## Stacked-PR

Part of iter74 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter74

⟦AI:AUTO-LOOP⟧
