### PR TITLE
iter73 cluster-073: durable callback envelope sanitize runtime credentials(reply_token)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -356,7 +356,7 @@ public sealed partial class ConversationGAgent
                 CardId = cardId ?? string.Empty,
                 CardMessageId = cardMessageId ?? string.Empty,
                 CommandId = commandId ?? string.Empty,
-                Activity = activity?.Clone(),
+                Activity = CloneForDurableState(activity),
                 FinalText = finalText ?? string.Empty,
                 LastFlushedText = lastFlushedText ?? string.Empty,
                 FiredAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -341,6 +341,9 @@ public sealed partial class ConversationGAgent
         string? lastFlushedText,
         CancellationToken ct)
     {
+        // Refactor (iter73/cluster-073-durable-callback-runtime-credentials):
+        //   Old pattern: durable callback envelope clones full command/chunk payload, may embed transient runtime credentials (reply_token)
+        //   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
         await ScheduleSelfDurableTimeoutAsync(
             BuildLarkCardOperationTimeoutCallbackId(correlationId, operation, generation),
             StreamingFailureUpdateTimeout,
@@ -353,7 +356,6 @@ public sealed partial class ConversationGAgent
                 CardId = cardId ?? string.Empty,
                 CardMessageId = cardMessageId ?? string.Empty,
                 CommandId = commandId ?? string.Empty,
-                Chunk = chunk?.Clone(),
                 Activity = activity?.Clone(),
                 FinalText = finalText ?? string.Empty,
                 LastFlushedText = lastFlushedText ?? string.Empty,
@@ -1012,7 +1014,7 @@ public sealed partial class ConversationGAgent
                         InFlight = null,
                         PendingAccumulatedText = null,
                     });
-                await ContinueLarkCardCoalescedWorkAsync(correlationId, recovered, evt.Chunk);
+                await ContinueLarkCardCoalescedWorkAsync(correlationId, recovered, sourceChunk: null);
                 return;
             }
 
@@ -1222,8 +1224,6 @@ public sealed partial class ConversationGAgent
                     LarkCardStreamingPhase.CreationFailed,
                     terminalReason: "create_timeout",
                     fieldUpdate: s => s with { InFlight = null });
-                if (evt.Chunk is not null)
-                    await HandleNyxRelayStreamingChunkCoreAsync(ToTextStreamChunk(evt.Chunk));
                 return;
             case LarkCardOperationPhase.Stream:
             {
@@ -1237,7 +1237,7 @@ public sealed partial class ConversationGAgent
                         InFlight = null,
                         PendingAccumulatedText = null,
                     });
-                await ContinueLarkCardCoalescedWorkAsync(correlationId, recovered, evt.Chunk);
+                await ContinueLarkCardCoalescedWorkAsync(correlationId, recovered, sourceChunk: null);
                 return;
             }
             case LarkCardOperationPhase.Finalize:

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -304,6 +304,12 @@ message LarkCardOperationCompletedEvent {
 }
 
 message LarkCardOperationTimeoutFiredEvent {
+  // Refactor (iter73/cluster-073-durable-callback-runtime-credentials):
+  //   Old pattern: durable callback envelope clones full command/chunk payload, may embed transient runtime credentials (reply_token)
+  //   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
+  reserved 8;
+  reserved "chunk";
+
   string correlation_id = 1;
   LarkCardOperationPhase operation = 2;
   int64 sequence = 3;
@@ -311,7 +317,6 @@ message LarkCardOperationTimeoutFiredEvent {
   string card_id = 5;
   string card_message_id = 6;
   string command_id = 7;
-  LlmReplyCardStreamChunkEvent chunk = 8;
   aevatar.gagents.channel.abstractions.ChatActivity activity = 9;
   string final_text = 10;
   string last_flushed_text = 11;

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -19,6 +19,9 @@ namespace Aevatar.GAgents.NyxidChat;
 // Refactor (iter20/cluster-004):
 //   Old pattern: ConversationGAgent 持有 actor token registry + 可见回复状态部分仅在内存
 //   New principle: 删 actor token registry,credentials runtime-only,可见回复 lifecycle 持久到 ConversationGAgent state
+// Refactor (iter73/cluster-073-durable-callback-runtime-credentials):
+//   Old pattern: durable callback envelope clones full command/chunk payload, may embed transient runtime credentials (reply_token)
+//   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
 public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 {
     public const string ActorIdPrefix = "channel-agent-run:";
@@ -234,6 +237,40 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         catch (Exception ex)
         {
             await FailAfterUnexpectedExceptionAsync(request, command.RunId, ex);
+        }
+    }
+
+    [EventHandler]
+    public async Task HandleOutputDispatchRetryAsync(AgentRunOutputDispatchRetryRequested command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (!IsCurrentOutputDispatchRetry(command))
+            return;
+
+        var request = BuildOutputDispatchRetryRequest(command);
+        if (command.RequiresRuntimeReplyToken)
+        {
+            _logger.LogWarning(
+                "Dropping durable output-dispatch retry without runtime reply_token: runId={RunId} correlation={CorrelationId}",
+                command.RunId,
+                command.CorrelationId);
+            await PersistFailedAsync(
+                request,
+                command.RunId,
+                "missing_relay_reply_token_for_durable_retry",
+                "Durable output-dispatch retry cannot rehydrate runtime-only relay reply_token.");
+            return;
+        }
+
+        try
+        {
+            await ReDispatchProducedReplyAsync(request, command.RunId);
+        }
+        catch (AgentRunOutputDispatchException ex)
+        {
+            if (!await TryHandleOutputDispatchFailureAsync(request, command.RunId, ex))
+                throw;
         }
     }
 
@@ -754,9 +791,15 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
                 BuildTimeoutRequest(
                     BuildOutputDispatchRetryCallbackId(runId),
                     OutputDispatchRetryDelay,
-                    new AgentRunStartRequested
+                    new AgentRunOutputDispatchRetryRequested
                     {
-                        Request = request.Clone(),
+                        RunId = runId,
+                        CorrelationId = request.CorrelationId,
+                        TargetActorId = request.TargetActorId,
+                        Attempt = State.GenerationAttempt,
+                        Generation = Math.Max(1, State.GenerationAttempt),
+                        RequestedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+                        RequiresRuntimeReplyToken = IsRelayRequest(request),
                     }),
                 ct: CancellationToken.None);
             return true;
@@ -833,6 +876,57 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
                 runId,
                 Id);
         }
+    }
+
+    private bool IsCurrentOutputDispatchRetry(AgentRunOutputDispatchRetryRequested command)
+    {
+        if (IsTerminal())
+            return false;
+
+        if (State.Status is not AgentRunStatus.ReplyProduced)
+            return false;
+
+        if (!string.IsNullOrWhiteSpace(State.RunId) &&
+            !string.Equals(State.RunId, command.RunId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(State.CorrelationId) &&
+            !string.Equals(State.CorrelationId, command.CorrelationId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return command.Attempt <= 0 || State.GenerationAttempt == command.Attempt;
+    }
+
+    private NeedsLlmReplyEvent BuildOutputDispatchRetryRequest(AgentRunOutputDispatchRetryRequested command) =>
+        new()
+        {
+            RunId = command.RunId ?? string.Empty,
+            CorrelationId = NormalizeOptional(command.CorrelationId) ?? State.CorrelationId ?? string.Empty,
+            TargetActorId = NormalizeOptional(command.TargetActorId) ?? State.TargetActorId ?? string.Empty,
+            Activity = BuildOutputDispatchRetryActivity(command),
+        };
+
+    private ChatActivity? BuildOutputDispatchRetryActivity(AgentRunOutputDispatchRetryRequested command)
+    {
+        var correlationId = NormalizeOptional(command.CorrelationId) ?? NormalizeOptional(State.CorrelationId);
+        if (correlationId is null)
+            return null;
+
+        return new ChatActivity
+        {
+            Id = correlationId,
+            OutboundDelivery = command.RequiresRuntimeReplyToken
+                ? new OutboundDeliveryContext
+                {
+                    CorrelationId = correlationId,
+                    ReplyMessageId = correlationId,
+                }
+                : null,
+        };
     }
 
     private RuntimeCallbackTimeoutRequest BuildTimeoutRequest(

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -898,6 +898,15 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             return false;
         }
 
+        if (!string.IsNullOrWhiteSpace(State.TargetActorId) &&
+            !string.Equals(State.TargetActorId, command.TargetActorId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (command.Generation > 0 && State.GenerationAttempt != command.Generation)
+            return false;
+
         return command.Attempt <= 0 || State.GenerationAttempt == command.Attempt;
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -68,9 +68,24 @@ message AgentRunGAgentState {
 
 // Transient command for the run actor. The nested NeedsLlmReplyEvent may carry
 // a short-lived relay reply_token; AgentRunGAgent must never persist that
-// credential into AgentRunGAgentState or any AgentRun*Event.
+// credential into AgentRunGAgentState, AgentRun*Event facts, or durable
+// scheduler callback payloads.
 message AgentRunStartRequested {
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 1;
+}
+
+// Durable output-dispatch retry signal emitted by the callback scheduler.
+// Refactor (iter73/cluster-073-durable-callback-runtime-credentials):
+//   Old pattern: durable callback envelope clones full command/chunk payload, may embed transient runtime credentials (reply_token)
+//   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
+message AgentRunOutputDispatchRetryRequested {
+  string run_id = 1;
+  string correlation_id = 2;
+  string target_actor_id = 3;
+  int32 attempt = 4;
+  int64 generation = 5;
+  int64 requested_at_unix_ms = 6;
+  bool requires_runtime_reply_token = 7;
 }
 
 message AgentRunCleanupRequested {

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/DurableCallbackEnvelopeCredentialGuard.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/DurableCallbackEnvelopeCredentialGuard.cs
@@ -49,8 +49,12 @@ internal static class DurableCallbackEnvelopeCredentialGuard
         {
             if (IsRuntimeCredentialField(field))
             {
-                violationPath = string.Concat(path, ".", field.Name);
-                return true;
+                var credentialValue = field.Accessor.GetValue(message);
+                if (!IsDefaultCredentialValue(credentialValue))
+                {
+                    violationPath = string.Concat(path, ".", field.Name);
+                    return true;
+                }
             }
 
             if (field.FieldType != FieldType.Message && !field.IsMap)
@@ -122,17 +126,6 @@ internal static class DurableCallbackEnvelopeCredentialGuard
     {
         var keyField = field.MessageType.FindFieldByNumber(1);
         var valueField = field.MessageType.FindFieldByNumber(2);
-        if (keyField is not null && IsRuntimeCredentialField(keyField))
-        {
-            violationPath = string.Concat(path, ".key");
-            return true;
-        }
-
-        if (valueField is not null && IsRuntimeCredentialField(valueField))
-        {
-            violationPath = string.Concat(path, ".value");
-            return true;
-        }
 
         if (valueField?.FieldType != FieldType.Message)
         {
@@ -327,5 +320,25 @@ internal static class DurableCallbackEnvelopeCredentialGuard
                string.Equals(name, "reply_token_expires_at_unix_ms", StringComparison.Ordinal) ||
                string.Equals(name, "nyx_user_access_token", StringComparison.Ordinal) ||
                name.EndsWith("_token", StringComparison.Ordinal);
+    }
+
+    private static bool IsDefaultCredentialValue(object? value)
+    {
+        return value switch
+        {
+            null => true,
+            string stringValue => string.IsNullOrEmpty(stringValue),
+            ByteString bytes => bytes.Length == 0,
+            int intValue => intValue == 0,
+            long longValue => longValue == 0,
+            uint uintValue => uintValue == 0,
+            ulong ulongValue => ulongValue == 0,
+            float floatValue => floatValue == 0,
+            double doubleValue => doubleValue == 0,
+            bool boolValue => !boolValue,
+            System.Enum enumValue => Convert.ToInt64(enumValue) == 0,
+            IEnumerable enumerable => !enumerable.Cast<object>().Any(),
+            _ => false,
+        };
     }
 }

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/DurableCallbackEnvelopeCredentialGuard.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/DurableCallbackEnvelopeCredentialGuard.cs
@@ -1,0 +1,331 @@
+using System.Collections;
+using System.Reflection;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Google.Protobuf.Reflection;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains.Callbacks;
+
+internal static class DurableCallbackEnvelopeCredentialGuard
+{
+    private const string TypeUrlPrefix = "type.googleapis.com/";
+    private const int MaxDepth = 64;
+    private static readonly object DescriptorIndexLock = new();
+    private static Dictionary<string, MessageDescriptor>? DescriptorIndex;
+
+    public static void ThrowIfContainsRuntimeCredential(EventEnvelope envelope)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ThrowIfContainsRuntimeCredential(envelope, nameof(EventEnvelope));
+    }
+
+    internal static void ThrowIfContainsRuntimeCredential(IMessage message, string rootPath)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+
+        if (TryFindRuntimeCredential(message, rootPath, depth: 0, out var violationPath))
+        {
+            throw new InvalidOperationException(
+                $"Durable callback trigger envelope contains runtime credential field '{violationPath}'. " +
+                "Callback payloads must carry stable actor-owned identifiers only.");
+        }
+    }
+
+    private static bool TryFindRuntimeCredential(
+        IMessage message,
+        string path,
+        int depth,
+        out string violationPath)
+    {
+        if (depth > MaxDepth)
+        {
+            violationPath = path;
+            return false;
+        }
+
+        foreach (var field in message.Descriptor.Fields.InFieldNumberOrder())
+        {
+            if (IsRuntimeCredentialField(field))
+            {
+                violationPath = string.Concat(path, ".", field.Name);
+                return true;
+            }
+
+            if (field.FieldType != FieldType.Message && !field.IsMap)
+                continue;
+
+            var value = field.Accessor.GetValue(message);
+            var fieldPath = string.Concat(path, ".", field.Name);
+            if (TryFindRuntimeCredentialInValue(field, value, fieldPath, depth + 1, out violationPath))
+                return true;
+        }
+
+        violationPath = string.Empty;
+        return false;
+    }
+
+    private static bool TryFindRuntimeCredentialInValue(
+        FieldDescriptor field,
+        object? value,
+        string path,
+        int depth,
+        out string violationPath)
+    {
+        if (value is null)
+        {
+            violationPath = string.Empty;
+            return false;
+        }
+
+        if (field.IsMap)
+        {
+            if (TryFindRuntimeCredentialInMap(field, value, path, depth, out violationPath))
+                return true;
+
+            violationPath = string.Empty;
+            return false;
+        }
+
+        if (field.IsRepeated)
+        {
+            var index = 0;
+            foreach (var item in (IEnumerable)value)
+            {
+                if (item is IMessage repeatedMessage &&
+                    TryFindRuntimeCredentialMessage(repeatedMessage, string.Concat(path, "[", index, "]"), depth, out violationPath))
+                {
+                    return true;
+                }
+
+                index++;
+            }
+
+            violationPath = string.Empty;
+            return false;
+        }
+
+        if (value is IMessage nestedMessage)
+            return TryFindRuntimeCredentialMessage(nestedMessage, path, depth, out violationPath);
+
+        violationPath = string.Empty;
+        return false;
+    }
+
+    private static bool TryFindRuntimeCredentialInMap(
+        FieldDescriptor field,
+        object mapValue,
+        string path,
+        int depth,
+        out string violationPath)
+    {
+        var keyField = field.MessageType.FindFieldByNumber(1);
+        var valueField = field.MessageType.FindFieldByNumber(2);
+        if (keyField is not null && IsRuntimeCredentialField(keyField))
+        {
+            violationPath = string.Concat(path, ".key");
+            return true;
+        }
+
+        if (valueField is not null && IsRuntimeCredentialField(valueField))
+        {
+            violationPath = string.Concat(path, ".value");
+            return true;
+        }
+
+        if (valueField?.FieldType != FieldType.Message)
+        {
+            violationPath = string.Empty;
+            return false;
+        }
+
+        foreach (var entry in (IEnumerable)mapValue)
+        {
+            var entryType = entry.GetType();
+            var key = entryType.GetProperty("Key")?.GetValue(entry);
+            var value = entryType.GetProperty("Value")?.GetValue(entry);
+            if (value is IMessage nestedMessage &&
+                TryFindRuntimeCredentialMessage(
+                    nestedMessage,
+                    string.Concat(path, "[", key?.ToString() ?? "<null>", "]"),
+                    depth,
+                    out violationPath))
+            {
+                return true;
+            }
+        }
+
+        violationPath = string.Empty;
+        return false;
+    }
+
+    private static bool TryFindRuntimeCredentialMessage(
+        IMessage message,
+        string path,
+        int depth,
+        out string violationPath)
+    {
+        if (message is Any any)
+            return TryFindRuntimeCredentialInAny(any, path, depth, out violationPath);
+
+        return TryFindRuntimeCredential(message, path, depth, out violationPath);
+    }
+
+    private static bool TryFindRuntimeCredentialInAny(Any any, string path, int depth, out string violationPath)
+    {
+        if (ResolveAnyDescriptor(any) is not { } descriptor)
+        {
+            violationPath = string.Empty;
+            return false;
+        }
+
+        var unpacked = descriptor.Parser.ParseFrom(any.Value) as IMessage;
+        if (unpacked is null)
+        {
+            violationPath = string.Empty;
+            return false;
+        }
+
+        return TryFindRuntimeCredential(unpacked, string.Concat(path, "<", descriptor.FullName, ">"), depth, out violationPath);
+    }
+
+    private static MessageDescriptor? ResolveAnyDescriptor(Any any)
+    {
+        if (string.IsNullOrWhiteSpace(any.TypeUrl))
+            return null;
+
+        var fullName = any.TypeUrl.StartsWith(TypeUrlPrefix, StringComparison.Ordinal)
+            ? any.TypeUrl[TypeUrlPrefix.Length..]
+            : any.TypeUrl[(any.TypeUrl.LastIndexOf('/') + 1)..];
+        return ResolveDescriptor(fullName);
+    }
+
+    private static MessageDescriptor? ResolveDescriptor(string fullName)
+    {
+        lock (DescriptorIndexLock)
+        {
+            DescriptorIndex ??= BuildDescriptorIndex();
+            if (DescriptorIndex.TryGetValue(fullName, out var descriptor))
+                return descriptor;
+
+            DescriptorIndex = BuildDescriptorIndex();
+            return DescriptorIndex.GetValueOrDefault(fullName);
+        }
+    }
+
+    private static Dictionary<string, MessageDescriptor> BuildDescriptorIndex()
+    {
+        var descriptors = new Dictionary<string, MessageDescriptor>(StringComparer.Ordinal);
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(static assembly => !assembly.IsDynamic).ToArray();
+        foreach (var assembly in assemblies)
+        {
+            foreach (var fileDescriptor in EnumerateFileDescriptors(assembly))
+                IndexFileDescriptor(fileDescriptor, descriptors);
+        }
+
+        foreach (var assembly in assemblies)
+        {
+            foreach (var messageDescriptor in EnumerateMessageDescriptors(assembly))
+                IndexMessageDescriptor(messageDescriptor, descriptors);
+        }
+
+        return descriptors;
+    }
+
+    private static IEnumerable<FileDescriptor> EnumerateFileDescriptors(Assembly assembly)
+    {
+        System.Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(static type => type is not null).Cast<System.Type>().ToArray();
+        }
+
+        foreach (var type in types)
+        {
+            var property = type.GetProperty(
+                "Descriptor",
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            if (property?.PropertyType != typeof(FileDescriptor))
+                continue;
+
+            if (property.GetValue(null) is FileDescriptor descriptor)
+                yield return descriptor;
+        }
+    }
+
+    private static IEnumerable<MessageDescriptor> EnumerateMessageDescriptors(Assembly assembly)
+    {
+        System.Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types.Where(static type => type is not null).Cast<System.Type>().ToArray();
+        }
+
+        foreach (var type in types)
+        {
+            if (!typeof(IMessage).IsAssignableFrom(type))
+                continue;
+
+            var property = type.GetProperty(
+                "Descriptor",
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            if (property?.PropertyType != typeof(MessageDescriptor))
+                continue;
+
+            var descriptor = TryGetMessageDescriptor(property);
+            if (descriptor is not null)
+                yield return descriptor;
+        }
+    }
+
+    private static MessageDescriptor? TryGetMessageDescriptor(PropertyInfo property)
+    {
+        try
+        {
+            return property.GetValue(null) as MessageDescriptor;
+        }
+        catch (TargetInvocationException)
+        {
+            return null;
+        }
+        catch (TypeInitializationException)
+        {
+            return null;
+        }
+    }
+
+    private static void IndexFileDescriptor(
+        FileDescriptor fileDescriptor,
+        IDictionary<string, MessageDescriptor> descriptors)
+    {
+        foreach (var message in fileDescriptor.MessageTypes)
+            IndexMessageDescriptor(message, descriptors);
+    }
+
+    private static void IndexMessageDescriptor(
+        MessageDescriptor message,
+        IDictionary<string, MessageDescriptor> descriptors)
+    {
+        descriptors[message.FullName] = message;
+        foreach (var nested in message.NestedTypes)
+            IndexMessageDescriptor(nested, descriptors);
+    }
+
+    private static bool IsRuntimeCredentialField(FieldDescriptor field)
+    {
+        var name = field.Name;
+        return string.Equals(name, "reply_token", StringComparison.Ordinal) ||
+               string.Equals(name, "reply_token_expires_at_unix_ms", StringComparison.Ordinal) ||
+               string.Equals(name, "nyx_user_access_token", StringComparison.Ordinal) ||
+               name.EndsWith("_token", StringComparison.Ordinal);
+    }
+}

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs
@@ -9,6 +9,9 @@ namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains.Callbacks;
 
 public sealed class RuntimeCallbackSchedulerGrain : Grain, IRuntimeCallbackSchedulerGrain, IRemindable
 {
+    // Refactor (iter73/cluster-073-durable-callback-runtime-credentials):
+    //   Old pattern: durable callback envelope clones full command/chunk payload, may embed transient runtime credentials (reply_token)
+    //   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
     private const string ReminderNamePrefix = "runtime-callback:";
     private const string SchedulerStateName = "runtime-callback-scheduler-v2";
     private const int SchedulerSlotEpoch = RuntimeCallbackSlotEpoch.OrleansSchedulerV2;

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs
@@ -120,6 +120,7 @@ public sealed class RuntimeCallbackSchedulerGrain : Grain, IRuntimeCallbackSched
         ArgumentNullException.ThrowIfNull(triggerEnvelope);
         ArgumentNullException.ThrowIfNull(triggerEnvelope.Payload);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(dueTimeMs, 0);
+        DurableCallbackEnvelopeCredentialGuard.ThrowIfContainsRuntimeCredential(triggerEnvelope);
     }
 
     private async Task<long> ResetExistingCallbackAndGetNextGenerationAsync(string callbackId)

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/Aevatar.Foundation.Runtime.Hosting.Tests.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Runtime.Hosting\Aevatar.Foundation.Runtime.Hosting.csproj" />
     <ProjectReference Include="..\..\agents\Aevatar.GAgents.Scheduled\Aevatar.GAgents.Scheduled.csproj" />
+    <ProjectReference Include="..\..\agents\Aevatar.GAgents.Channel.Runtime\Aevatar.GAgents.Channel.Runtime.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests.cs
@@ -1,0 +1,198 @@
+using System.Net;
+using System.Net.Sockets;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains.Callbacks;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Hosting;
+
+namespace Aevatar.Foundation.Runtime.Hosting.Tests;
+
+public sealed class RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests
+{
+    [Fact]
+    public async Task ScheduleTimeoutAsync_ShouldPersistSanitizedLarkCardTimeoutAndRejectRuntimeCredential()
+    {
+        var host = await StartSiloHostAsync();
+
+        try
+        {
+            var grain = ResolveSchedulerGrain(host, "credential-guard-lark-card");
+            var sanitized = CreateEnvelope("evt-lark-sanitized", CreateLarkCardTimeout(nyxUserAccessToken: string.Empty));
+            var unsanitized = CreateEnvelope("evt-lark-unsanitized", CreateLarkCardTimeout(nyxUserAccessToken: "runtime-user-token"));
+
+            var generation = await grain.ScheduleTimeoutAsync("lark-card-sanitized", sanitized, dueTimeMs: 60000);
+            generation.Should().Be(1);
+
+            var act = () => grain.ScheduleTimeoutAsync("lark-card-unsanitized", unsanitized, dueTimeMs: 60000);
+
+            await act.Should()
+                .ThrowAsync<InvalidOperationException>()
+                .WithMessage("*nyx_user_access_token*");
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ScheduleTimeoutAsync_ShouldPersistSanitizedNyxRelayTextTimeoutAndRejectRuntimeCredential()
+    {
+        var host = await StartSiloHostAsync();
+
+        try
+        {
+            var grain = ResolveSchedulerGrain(host, "credential-guard-nyx-relay");
+            var sanitized = CreateEnvelope(
+                "evt-nyx-relay-sanitized",
+                CreateNyxRelayTimeout(replyToken: string.Empty, replyTokenExpiresAtUnixMs: 0));
+            var unsanitized = CreateEnvelope(
+                "evt-nyx-relay-unsanitized",
+                CreateNyxRelayTimeout(
+                    replyToken: "runtime-reply-token",
+                    replyTokenExpiresAtUnixMs: DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds()));
+
+            var generation = await grain.ScheduleTimeoutAsync("nyx-relay-sanitized", sanitized, dueTimeMs: 60000);
+            generation.Should().Be(1);
+
+            var act = () => grain.ScheduleTimeoutAsync("nyx-relay-unsanitized", unsanitized, dueTimeMs: 60000);
+
+            await act.Should()
+                .ThrowAsync<InvalidOperationException>()
+                .WithMessage("*reply_token*");
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    private static IRuntimeCallbackSchedulerGrain ResolveSchedulerGrain(IHost host, string actorId) =>
+        host.Services.GetRequiredService<IGrainFactory>().GetGrain<IRuntimeCallbackSchedulerGrain>(actorId);
+
+    private static async Task<IHost> StartSiloHostAsync()
+    {
+        var siloPort = ReserveTcpPort();
+        var gatewayPort = ReserveTcpPort();
+        var host = Host.CreateDefaultBuilder()
+            .UseOrleans(siloBuilder =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: siloPort,
+                    gatewayPort: gatewayPort,
+                    serviceId: $"aevatar-runtime-callback-credential-guard-service-{Guid.NewGuid():N}",
+                    clusterId: $"aevatar-runtime-callback-credential-guard-cluster-{Guid.NewGuid():N}");
+                siloBuilder.AddAevatarFoundationRuntimeOrleans(options =>
+                {
+                    options.StreamBackend = AevatarOrleansRuntimeOptions.StreamBackendInMemory;
+                    options.PersistenceBackend = AevatarOrleansRuntimeOptions.PersistenceBackendInMemory;
+                });
+            })
+            .Build();
+
+        await host.StartAsync();
+        return host;
+    }
+
+    private static int ReserveTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private static EventEnvelope CreateEnvelope(string id, IMessage payload) => new()
+    {
+        Id = id,
+        Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        Payload = Any.Pack(payload),
+        Route = EnvelopeRouteSemantics.CreateDirect("test", "credential-guard-actor"),
+    };
+
+    private static LarkCardOperationTimeoutFiredEvent CreateLarkCardTimeout(string nyxUserAccessToken) => new()
+    {
+        CorrelationId = "corr-lark-card",
+        Operation = LarkCardOperationPhase.Finalize,
+        Sequence = 1,
+        OperationGeneration = 1,
+        CardId = "card-1",
+        CardMessageId = "om-card-1",
+        CommandId = "cmd-1",
+        Activity = CreateActivity(nyxUserAccessToken),
+        FinalText = "final text",
+        LastFlushedText = "final",
+        FiredAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+    };
+
+    private static NyxRelayTextOperationTimeoutFiredEvent CreateNyxRelayTimeout(
+        string replyToken,
+        long replyTokenExpiresAtUnixMs) => new()
+    {
+        CorrelationId = "corr-nyx-relay",
+        Operation = NyxRelayTextOperationKind.Interim,
+        Sequence = 1,
+        OperationGeneration = 1,
+        Chunk = new LlmReplyStreamChunkEvent
+        {
+            CorrelationId = "corr-nyx-relay",
+            RegistrationId = "reg-1",
+            Activity = CreateActivity(nyxUserAccessToken: string.Empty),
+            AccumulatedText = "hello",
+            ChunkAtUnixMs = 42,
+            ReplyToken = replyToken,
+            ReplyTokenExpiresAtUnixMs = replyTokenExpiresAtUnixMs,
+        },
+        CurrentPlatformMessageId = "om-current",
+        CommandId = "cmd-1",
+        FinalText = "final text",
+        LastFlushedText = "final",
+        EditCount = 1,
+        FiredAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+    };
+
+    private static ChatActivity CreateActivity(string nyxUserAccessToken) => new()
+    {
+        Id = "activity-1",
+        Type = ActivityType.Message,
+        ChannelId = new ChannelId { Value = "lark" },
+        Bot = new BotInstanceId { Value = "lark-bot" },
+        Conversation = new ConversationReference
+        {
+            Channel = new ChannelId { Value = "lark" },
+            Bot = new BotInstanceId { Value = "lark-bot" },
+            Scope = ConversationScope.Group,
+            CanonicalKey = "conv:lark:group",
+        },
+        Content = new MessageContent { Text = "user question" },
+        OutboundDelivery = new OutboundDeliveryContext
+        {
+            ReplyMessageId = "relay-message-1",
+            CorrelationId = "corr-1",
+        },
+        TransportExtras = new TransportExtras
+        {
+            NyxMessageId = "nyx-message-1",
+            NyxAgentApiKeyId = "nyx-agent-key-1",
+            NyxPlatform = "lark",
+            NyxConversationId = "oc-1",
+            NyxUserAccessToken = nyxUserAccessToken,
+            NyxPlatformMessageId = "om-1",
+            NyxLarkUnionId = "on-1",
+            NyxLarkChatId = "oc-lark-1",
+            NyxRegistrationScopeId = "scope-1",
+            NyxSenderUserId = "user-1",
+        },
+    };
+}

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests.cs
@@ -5,15 +5,20 @@ using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains.Callbacks;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using Aevatar.Foundation.Runtime.Callbacks;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.Runtime;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Orleans;
 using Orleans.Hosting;
+using Orleans.Runtime;
+using Orleans.Runtime.Hosting;
+using Orleans.Storage;
 
 namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 
@@ -33,11 +38,23 @@ public sealed class RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests
             var generation = await grain.ScheduleTimeoutAsync("lark-card-sanitized", sanitized, dueTimeMs: 60000);
             generation.Should().Be(1);
 
+            var stateAfterSanitized = await ReadSchedulerStateAsync(host, grain);
+            stateAfterSanitized.ReminderCallbacks.Should().ContainSingle();
+            stateAfterSanitized.ReminderCallbacks.Should().ContainKey("lark-card-sanitized");
+            var persistedLarkCard = stateAfterSanitized.ReminderCallbacks["lark-card-sanitized"];
+            persistedLarkCard.TriggerEnvelope.Payload
+                .Unpack<LarkCardOperationTimeoutFiredEvent>()
+                .Activity.TransportExtras.NyxUserAccessToken.Should().BeEmpty();
+
             var act = () => grain.ScheduleTimeoutAsync("lark-card-unsanitized", unsanitized, dueTimeMs: 60000);
 
             await act.Should()
                 .ThrowAsync<InvalidOperationException>()
                 .WithMessage("*nyx_user_access_token*");
+
+            var stateAfterRejected = await ReadSchedulerStateAsync(host, grain);
+            stateAfterRejected.ReminderCallbacks.Should().HaveCount(stateAfterSanitized.ReminderCallbacks.Count);
+            stateAfterRejected.ReminderCallbacks.Should().NotContainKey("lark-card-unsanitized");
         }
         finally
         {
@@ -66,11 +83,23 @@ public sealed class RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests
             var generation = await grain.ScheduleTimeoutAsync("nyx-relay-sanitized", sanitized, dueTimeMs: 60000);
             generation.Should().Be(1);
 
+            var stateAfterSanitized = await ReadSchedulerStateAsync(host, grain);
+            stateAfterSanitized.ReminderCallbacks.Should().ContainSingle();
+            stateAfterSanitized.ReminderCallbacks.Should().ContainKey("nyx-relay-sanitized");
+            var persistedNyxRelay = stateAfterSanitized.ReminderCallbacks["nyx-relay-sanitized"];
+            persistedNyxRelay.TriggerEnvelope.Payload
+                .Unpack<NyxRelayTextOperationTimeoutFiredEvent>()
+                .Chunk.ReplyToken.Should().BeEmpty();
+
             var act = () => grain.ScheduleTimeoutAsync("nyx-relay-unsanitized", unsanitized, dueTimeMs: 60000);
 
             await act.Should()
                 .ThrowAsync<InvalidOperationException>()
                 .WithMessage("*reply_token*");
+
+            var stateAfterRejected = await ReadSchedulerStateAsync(host, grain);
+            stateAfterRejected.ReminderCallbacks.Should().HaveCount(stateAfterSanitized.ReminderCallbacks.Count);
+            stateAfterRejected.ReminderCallbacks.Should().NotContainKey("nyx-relay-unsanitized");
         }
         finally
         {
@@ -81,6 +110,14 @@ public sealed class RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests
 
     private static IRuntimeCallbackSchedulerGrain ResolveSchedulerGrain(IHost host, string actorId) =>
         host.Services.GetRequiredService<IGrainFactory>().GetGrain<IRuntimeCallbackSchedulerGrain>(actorId);
+
+    private static async Task<RuntimeCallbackSchedulerState> ReadSchedulerStateAsync(
+        IHost host,
+        IRuntimeCallbackSchedulerGrain grain)
+    {
+        var storage = host.Services.GetRequiredService<TestRuntimeCallbackSchedulerStateStorage>();
+        return storage.ReadSchedulerState(grain.GetGrainId());
+    }
 
     private static async Task<IHost> StartSiloHostAsync()
     {
@@ -98,6 +135,14 @@ public sealed class RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests
                 {
                     options.StreamBackend = AevatarOrleansRuntimeOptions.StreamBackendInMemory;
                     options.PersistenceBackend = AevatarOrleansRuntimeOptions.PersistenceBackendInMemory;
+                });
+                siloBuilder.ConfigureServices(services =>
+                {
+                    services.RemoveAllKeyed<IGrainStorage>(OrleansRuntimeConstants.GrainStateStorageName);
+                    services.AddSingleton<TestRuntimeCallbackSchedulerStateStorage>();
+                    services.AddGrainStorage<TestRuntimeCallbackSchedulerStateStorage>(
+                        OrleansRuntimeConstants.GrainStateStorageName,
+                        (sp, _) => sp.GetRequiredService<TestRuntimeCallbackSchedulerStateStorage>());
                 });
             })
             .Build();
@@ -195,4 +240,53 @@ public sealed class RuntimeCallbackSchedulerGrainCredentialGuardIntegrationTests
             NyxSenderUserId = "user-1",
         },
     };
+
+    private sealed class TestRuntimeCallbackSchedulerStateStorage : IGrainStorage
+    {
+        private const string SchedulerStateName = "runtime-callback-scheduler-v2";
+        private readonly Dictionary<(string StateName, GrainId GrainId), object> _states = new();
+
+        public Task ReadStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+        {
+            if (_states.TryGetValue((stateName, grainId), out var state))
+            {
+                grainState.State = CloneState((T)state);
+                grainState.RecordExists = true;
+                grainState.ETag = string.Empty;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task WriteStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+        {
+            _states[(stateName, grainId)] = CloneState(grainState.State)
+                ?? throw new InvalidOperationException("Runtime callback scheduler state cannot be null.");
+            grainState.RecordExists = true;
+            grainState.ETag = string.Empty;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearStateAsync<T>(string stateName, GrainId grainId, IGrainState<T> grainState)
+        {
+            _states.Remove((stateName, grainId));
+            grainState.RecordExists = false;
+            grainState.ETag = string.Empty;
+            return Task.CompletedTask;
+        }
+
+        public RuntimeCallbackSchedulerState ReadSchedulerState(GrainId grainId)
+        {
+            var state = _states[(SchedulerStateName, grainId)];
+            return ((RuntimeCallbackSchedulerState)state).Clone();
+        }
+
+        private static T CloneState<T>(T state)
+        {
+            if (state is IDeepCloneable<T> cloneable)
+                return cloneable.Clone();
+
+            return state;
+        }
+    }
 }

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerStateProtoTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/RuntimeCallbackSchedulerStateProtoTests.cs
@@ -5,8 +5,10 @@ using Aevatar.Foundation.Runtime.Callbacks;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains.Callbacks;
 using FluentAssertions;
 using Google.Protobuf;
+using Google.Protobuf.Reflection;
 using Google.Protobuf.WellKnownTypes;
 using Orleans.Runtime;
+using Aevatar.Workflow.Core;
 
 namespace Aevatar.Foundation.Runtime.Hosting.Tests;
 
@@ -200,6 +202,75 @@ public sealed class RuntimeCallbackSchedulerStateProtoTests
     }
 
     [Fact]
+    public async Task RuntimeCallbackSchedulerGrain_ShouldRejectCredentialEnvelopeBeforePersistingTypedState()
+    {
+        var persistentState =
+            DispatchProxy.Create<IPersistentState<RuntimeCallbackSchedulerState>, RuntimeCallbackPersistentStateProxy>();
+        var grain = new RuntimeCallbackSchedulerGrain(persistentState);
+        var envelope = CreateEnvelope(
+            "evt-credential",
+            new NeedsCredentialPayload
+            {
+                ReplyToken = "runtime-reply-token",
+            });
+
+        var act = () => grain.ScheduleTimeoutAsync("credential-callback", envelope, dueTimeMs: 100);
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*reply_token*");
+        persistentState.State.ReminderCallbacks.Should().BeEmpty();
+        ((RuntimeCallbackPersistentStateProxy)(object)persistentState).WriteCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void DurableCallbackEnvelopeCredentialGuard_ShouldWalkNestedRepeatedAndMapMessages()
+    {
+        var repeatedPayload = new EventStoreCommitResult
+        {
+            CommittedEvents =
+            {
+                new StateEvent
+                {
+                    EventData = Any.Pack(new NeedsCredentialPayload
+                    {
+                        ReplyToken = "runtime-reply-token",
+                    }),
+                },
+            },
+        };
+        var mapPayload = new WorkflowRunState
+        {
+            PendingChildRunIdsByParentRunId =
+            {
+                ["parent"] = new WorkflowRunState.Types.ChildRunIdSet
+                {
+                    ChildRunIds = { "child-1" },
+                },
+            },
+            ExecutionStates =
+            {
+                ["credential"] = Any.Pack(new NeedsCredentialPayload
+                {
+                    ReplyToken = "runtime-reply-token",
+                }),
+            },
+        };
+
+        var repeatedAct = () => DurableCallbackEnvelopeCredentialGuard.ThrowIfContainsRuntimeCredential(
+            CreateEnvelope("evt-repeated", repeatedPayload));
+        var mapAct = () => DurableCallbackEnvelopeCredentialGuard.ThrowIfContainsRuntimeCredential(
+            CreateEnvelope("evt-map", mapPayload));
+
+        repeatedAct.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*committed_events[0].event_data*aevatar.foundation.runtime.hosting.tests.NeedsCredentialPayload*.reply_token*");
+        mapAct.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*execution_states[credential]*aevatar.foundation.runtime.hosting.tests.NeedsCredentialPayload*.reply_token*");
+    }
+
+    [Fact]
     public void RuntimeCallbackSchedulerGrainBoundary_ShouldAcceptTypedEventEnvelope()
     {
         var scheduleTimeout = typeof(IRuntimeCallbackSchedulerGrain).GetMethod(
@@ -274,10 +345,13 @@ public sealed class RuntimeCallbackSchedulerStateProtoTests
             .WithInnerException<ArgumentOutOfRangeException>();
     }
 
-    private static EventEnvelope CreateEnvelope(string id) => new()
+    private static EventEnvelope CreateEnvelope(string id) =>
+        CreateEnvelope(id, new StringValue { Value = "payload" });
+
+    private static EventEnvelope CreateEnvelope(string id, IMessage payload) => new()
     {
         Id = id,
-        Payload = Any.Pack(new StringValue { Value = "payload" }),
+        Payload = Any.Pack(payload),
         Route = EnvelopeRouteSemantics.CreateDirect("actor-1", "actor-1"),
     };
 
@@ -342,4 +416,81 @@ public sealed class RuntimeCallbackSchedulerStateProtoTests
             return type.IsValueType ? Activator.CreateInstance(type) : null;
         }
     }
+}
+
+public sealed partial class NeedsCredentialPayload : IMessage<NeedsCredentialPayload>
+{
+    private static readonly MessageParser<NeedsCredentialPayload> MessageParser =
+        new(() => new NeedsCredentialPayload());
+
+    public static MessageParser<NeedsCredentialPayload> Parser => MessageParser;
+
+    public static MessageDescriptor Descriptor =>
+        NeedsCredentialPayloadReflection.Descriptor.MessageTypes[0];
+
+    MessageDescriptor IMessage.Descriptor => Descriptor;
+
+    public string ReplyToken { get; set; } = string.Empty;
+
+    public NeedsCredentialPayload()
+    {
+    }
+
+    public NeedsCredentialPayload(NeedsCredentialPayload other)
+    {
+        ReplyToken = other.ReplyToken;
+    }
+
+    public NeedsCredentialPayload Clone() => new(this);
+
+    public bool Equals(NeedsCredentialPayload? other) =>
+        other is not null && string.Equals(ReplyToken, other.ReplyToken, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => Equals(obj as NeedsCredentialPayload);
+
+    public override int GetHashCode() => ReplyToken.GetHashCode(StringComparison.Ordinal);
+
+    public void WriteTo(CodedOutputStream output)
+    {
+        if (ReplyToken.Length != 0)
+        {
+            output.WriteRawTag(10);
+            output.WriteString(ReplyToken);
+        }
+    }
+
+    public int CalculateSize() =>
+        ReplyToken.Length == 0 ? 0 : 1 + CodedOutputStream.ComputeStringSize(ReplyToken);
+
+    public void MergeFrom(NeedsCredentialPayload other)
+    {
+        if (other.ReplyToken.Length != 0)
+            ReplyToken = other.ReplyToken;
+    }
+
+    public void MergeFrom(CodedInputStream input)
+    {
+        uint tag;
+        while ((tag = input.ReadTag()) != 0)
+        {
+            if (tag == 10)
+                ReplyToken = input.ReadString();
+            else
+                input.SkipLastField();
+        }
+    }
+}
+
+public static class NeedsCredentialPayloadReflection
+{
+    private static readonly FileDescriptor FileDescriptor = FileDescriptor.FromGeneratedCode(
+        Convert.FromBase64String(
+            "CiN0ZXN0X25lZWRzX2NyZWRlbnRpYWxfcGF5bG9hZC5wcm90bxIoYWV2YXRhci5mb3VuZGF0aW9uLnJ1bnRpbWUuaG9zdGluZy50ZXN0cyItChZOZWVkc0NyZWRlbnRpYWxQYXlsb2FkEhMKC3JlcGx5X3Rva2VuGAEgASgJYgZwcm90bzM="),
+        [],
+        new GeneratedClrTypeInfo(
+            null,
+            null,
+            [new GeneratedClrTypeInfo(typeof(NeedsCredentialPayload), NeedsCredentialPayload.Parser, ["ReplyToken"], null, null, null, null)]));
+
+    public static FileDescriptor Descriptor => FileDescriptor;
 }

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -2423,7 +2423,7 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task HandleLarkCardOperationTimeoutFiredAsync_CreateTimeout_FallsBackToTextEdit()
+    public async Task HandleLarkCardOperationTimeoutFiredAsync_CreateTimeout_DoesNotPersistCredentialChunk()
     {
         var text = new RecordingTurnRunner
         {
@@ -2443,16 +2443,14 @@ public sealed class ConversationGAgentDedupTests
             Operation = LarkCardOperationPhase.Create,
             Sequence = lifecycle.LarkCardInFlightSequence,
             OperationGeneration = lifecycle.LarkCardOperationGeneration,
-            Chunk = CreateCardStreamChunk("act-card-timeout", "relay-msg-1", "hello"),
             CommandId = "llm-reply:act-card-timeout",
             FiredAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
         });
-        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
 
-        text.StreamChunkCount.ShouldBe(1);
+        text.StreamChunkCount.ShouldBe(0);
         agent.State.ActiveReplyLifecycles.ShouldContain(x =>
-            x.Mode == ConversationReplyLifecycleMode.NyxRelayText &&
-            x.Phase == ConversationReplyLifecyclePhase.TextPlaceholderSent);
+            x.Mode == ConversationReplyLifecycleMode.LarkCard &&
+            x.Phase == ConversationReplyLifecyclePhase.LarkCardCreationFailed);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Aevatar.GAgents.ChannelRuntime.Tests.csproj
@@ -28,6 +28,8 @@
     <ProjectReference Include="..\..\src\Aevatar.CQRS.Core\Aevatar.CQRS.Core.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Core\Aevatar.Foundation.Core.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Runtime.Implementations.Orleans\Aevatar.Foundation.Runtime.Implementations.Orleans.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming\Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming.csproj" />
     <ProjectReference Include="..\..\src\workflow\Aevatar.Workflow.Application.Abstractions\Aevatar.Workflow.Application.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -35,6 +37,9 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Orleans.Client" />
+    <PackageReference Include="Microsoft.Orleans.Server" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.ChatRouting.Abstractions;
@@ -1150,15 +1151,75 @@ public sealed class AgentRunGAgentTests
         handled.Should().BeEmpty();
 
         var retry = scheduler.Timeouts.Should().ContainSingle(
-            timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunStartRequested.Descriptor)).Subject;
+            timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunOutputDispatchRetryRequested.Descriptor)).Subject;
         retry.ActorId.Should().Be(runtime.Id);
         retry.DueTime.Should().Be(AgentRunGAgent.OutputDispatchRetryDelay);
-        var retryCommand = retry.TriggerEnvelope.Payload.Unpack<AgentRunStartRequested>();
+        var retryCommand = retry.TriggerEnvelope.Payload.Unpack<AgentRunOutputDispatchRetryRequested>();
+        retryCommand.RunId.Should().Be("corr-retry-ready");
+        retryCommand.CorrelationId.Should().Be("corr-retry-ready");
+        retryCommand.TargetActorId.Should().Be("actor-1");
+        Encoding.UTF8.GetString(retry.TriggerEnvelope.ToByteArray()).Should().NotContain("relay-token-retry-ready");
 
-        await runtime.HandleStartAsync(retryCommand);
+        await runtime.HandleOutputDispatchRetryAsync(retryCommand);
 
-        // After the retry the same persisted reply is delivered — but the LLM was not
-        // re-invoked. Status promoted to REPLY_HANDED_OFF by ApplyReplyDispatched (ADR-0021).
+        // Durable retry cannot rehydrate runtime-only relay reply_token, so it is
+        // explicitly non-retryable after reconciling the produced reply from state.
+        runtime.State.Status.Should().Be(AgentRunStatus.Failed);
+        runtime.State.ErrorCode.Should().Be("missing_relay_reply_token_for_durable_retry");
+        replyGenerator.CallCount.Should().Be(1);
+        handled.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleOutputDispatchRetryAsync_ForNonRelay_ReDispatchesPersistedReplyWithoutRerunningLlm()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var scheduler = new RecordingCallbackScheduler();
+        var publisher = new DispatchingEventPublisher(actorRuntime)
+        {
+            FailNextSend = true,
+        };
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "ok" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            eventPublisher: publisher,
+            callbackScheduler: scheduler);
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-nonrelay-retry-ready",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = new ChatActivity
+            {
+                Id = "msg-nonrelay-retry-ready",
+                Content = new MessageContent { Text = "hello" },
+            },
+        };
+
+        await runtime.HandleStartAsync(request);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
+        replyGenerator.CallCount.Should().Be(1);
+        handled.Should().BeEmpty();
+
+        var retryCommand = scheduler.Timeouts.Should().ContainSingle(
+                timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunOutputDispatchRetryRequested.Descriptor))
+            .Subject.TriggerEnvelope.Payload.Unpack<AgentRunOutputDispatchRetryRequested>();
+
+        await runtime.HandleOutputDispatchRetryAsync(retryCommand);
+
         runtime.State.Status.Should().Be(AgentRunStatus.ReplyHandedOff);
         replyGenerator.CallCount.Should().Be(1);
         handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
@@ -1205,14 +1266,14 @@ public sealed class AgentRunGAgentTests
         replyGenerator.CallCount.Should().Be(0);
 
         var retryCommand = scheduler.Timeouts.Should().ContainSingle(
-                timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunStartRequested.Descriptor))
-            .Subject.TriggerEnvelope.Payload.Unpack<AgentRunStartRequested>();
+                timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunOutputDispatchRetryRequested.Descriptor))
+            .Subject.TriggerEnvelope.Payload.Unpack<AgentRunOutputDispatchRetryRequested>();
 
-        await runtime.HandleStartAsync(retryCommand);
+        await runtime.HandleOutputDispatchRetryAsync(retryCommand);
 
-        runtime.State.Status.Should().Be(AgentRunStatus.Dropped);
+        runtime.State.Status.Should().Be(AgentRunStatus.Started);
         replyGenerator.CallCount.Should().Be(0);
-        handled.Should().ContainSingle(e => e.Payload.Is(DeferredLlmReplyDroppedEvent.Descriptor));
+        handled.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1226,6 +1226,70 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleOutputDispatchRetryAsync_WhenTargetActorIdOrGenerationDoesNotMatch_DropsStaleRetry()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var handled = new List<EventEnvelope>();
+        actor.When(x => x.HandleEventAsync(Arg.Any<EventEnvelope>(), Arg.Any<CancellationToken>()))
+            .Do(call => handled.Add(call.Arg<EventEnvelope>()));
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var scheduler = new RecordingCallbackScheduler();
+        var publisher = new DispatchingEventPublisher(actorRuntime)
+        {
+            FailNextSend = true,
+        };
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "ok" };
+        var runtime = CreateRunAgent(
+            actorRuntime,
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            eventPublisher: publisher,
+            callbackScheduler: scheduler);
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-stale-retry-ready",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = new ChatActivity
+            {
+                Id = "msg-stale-retry-ready",
+                Content = new MessageContent { Text = "hello" },
+            },
+        };
+
+        await runtime.HandleStartAsync(request);
+
+        var retryCommand = scheduler.Timeouts.Should().ContainSingle(
+                timeout => timeout.TriggerEnvelope.Payload.Is(AgentRunOutputDispatchRetryRequested.Descriptor))
+            .Subject.TriggerEnvelope.Payload.Unpack<AgentRunOutputDispatchRetryRequested>();
+
+        var wrongTarget = retryCommand.Clone();
+        wrongTarget.TargetActorId = "actor-2";
+        await runtime.HandleOutputDispatchRetryAsync(wrongTarget);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
+        handled.Should().BeEmpty();
+
+        var wrongGeneration = retryCommand.Clone();
+        wrongGeneration.Generation = retryCommand.Generation + 1;
+        await runtime.HandleOutputDispatchRetryAsync(wrongGeneration);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyProduced);
+        handled.Should().BeEmpty();
+
+        await runtime.HandleOutputDispatchRetryAsync(retryCommand);
+
+        runtime.State.Status.Should().Be(AgentRunStatus.ReplyHandedOff);
+        handled.Should().ContainSingle(e => e.Payload.Is(LlmReplyReadyEvent.Descriptor));
+    }
+
+    [Fact]
     public async Task HandleStartAsync_ShouldScheduleRetry_WhenDropSignalIsNotAccepted()
     {
         var actor = Substitute.For<IActor>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -118,8 +118,74 @@ public sealed class LarkCardOperationSignalTests
 
         var persistedText = Encoding.UTF8.GetString(scheduled.TriggerEnvelope.ToByteArray());
         persistedText.Should().NotContain("runtime-token-corr-card-timeout-token");
+        persistedText.Should().NotContain("runtime-user-access-token-corr-card-timeout-token");
         persistedText.Should().NotContain("reply_token");
         persistedText.Should().NotContain("reply_token_expires_at_unix_ms");
+    }
+
+    [Fact]
+    public async Task HandleLlmReplyReadyAsync_FinalizeTimeoutPayload_StripsActivityRuntimeRelayCredentials()
+    {
+        var scheduler = new RecordingCallbackScheduler();
+        var agent = CreateAgent(
+            "conv-lark-card-finalize-timeout-sanitize",
+            new RecordingCardRunner(),
+            new RecordingActorDispatchPort(),
+            new InMemoryEventStore(),
+            scheduler);
+        var chunk = CreateCardStreamChunk("corr-card-finalize-token", "relay-msg-1", "hello");
+
+        await agent.HandleEventAsync(Envelope(agent.Id, chunk));
+        var lifecycle = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleEventAsync(Envelope(agent.Id,
+            new LarkCardOperationCompletedEvent
+            {
+                OperationId = "corr-card-finalize-token:create:1:1",
+                CorrelationId = "corr-card-finalize-token",
+                Operation = LarkCardOperationPhase.Create,
+                Sequence = lifecycle.LarkCardInFlightSequence,
+                OperationGeneration = lifecycle.LarkCardOperationGeneration,
+                State = LarkCardOperationResultState.Succeeded,
+                Chunk = chunk.Clone(),
+                RawResult = new LarkCardOperationRawResult
+                {
+                    CardId = "card_ok",
+                    CardMessageId = "om_card_msg",
+                },
+            }));
+        scheduler.Timeouts.Clear();
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "corr-card-finalize-token",
+            RegistrationId = "reg-1",
+            SourceActorId = "agent-run",
+            Activity = chunk.Activity.Clone(),
+            Outbound = new MessageContent { Text = "final text" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReplyToken = "runtime-ready-token-corr-card-finalize-token",
+            ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeMilliseconds(),
+            ReadyAtUnixMs = 100,
+        });
+
+        var scheduled = scheduler.Timeouts.Should().ContainSingle().Subject;
+        var timeout = scheduled.TriggerEnvelope.Payload.Unpack<LarkCardOperationTimeoutFiredEvent>();
+        timeout.Operation.Should().Be(LarkCardOperationPhase.Finalize);
+        timeout.Activity.TransportExtras.NyxUserAccessToken.Should().BeEmpty();
+        timeout.Activity.TransportExtras.NyxAgentApiKeyId.Should().Be("nyx-key-corr-card-finalize-token");
+        timeout.Activity.TransportExtras.NyxPlatform.Should().Be("lark");
+        timeout.Activity.TransportExtras.NyxConversationId.Should().Be("oc-corr-card-finalize-token");
+        timeout.Activity.TransportExtras.NyxPlatformMessageId.Should().Be("om-corr-card-finalize-token");
+        timeout.Activity.TransportExtras.NyxLarkUnionId.Should().Be("on-corr-card-finalize-token");
+        timeout.Activity.TransportExtras.NyxLarkChatId.Should().Be("oc-lark-corr-card-finalize-token");
+        timeout.Activity.TransportExtras.NyxRegistrationScopeId.Should().Be("scope-corr-card-finalize-token");
+        timeout.Activity.TransportExtras.NyxSenderUserId.Should().Be("user-corr-card-finalize-token");
+
+        var persistedText = Encoding.UTF8.GetString(scheduled.TriggerEnvelope.ToByteArray());
+        persistedText.Should().NotContain("runtime-user-access-token-corr-card-finalize-token");
+        persistedText.Should().NotContain("runtime-ready-token-corr-card-finalize-token");
+        persistedText.Should().NotContain("nyx_user_access_token");
+        persistedText.Should().NotContain("reply_token");
     }
 
     private static ConversationGAgent CreateAgent(
@@ -214,6 +280,18 @@ public sealed class LarkCardOperationSignalTests
                 {
                     ReplyMessageId = replyMessageId,
                     CorrelationId = correlationId,
+                },
+                TransportExtras = new TransportExtras
+                {
+                    NyxUserAccessToken = "runtime-user-access-token-" + correlationId,
+                    NyxAgentApiKeyId = "nyx-key-" + correlationId,
+                    NyxPlatform = "lark",
+                    NyxConversationId = "oc-" + correlationId,
+                    NyxPlatformMessageId = "om-" + correlationId,
+                    NyxLarkUnionId = "on-" + correlationId,
+                    NyxLarkChatId = "oc-lark-" + correlationId,
+                    NyxRegistrationScopeId = "scope-" + correlationId,
+                    NyxSenderUserId = "user-" + correlationId,
                 },
             },
             AccumulatedText = accumulatedText,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
@@ -96,17 +97,43 @@ public sealed class LarkCardOperationSignalTests
         completed.SentActivityId.Should().Be("lark-card-stream:om_orphan");
     }
 
+    [Fact]
+    public async Task HandleLlmReplyCardStreamChunkAsync_ScheduledTimeoutPayload_StripsRuntimeRelayCredentials()
+    {
+        var scheduler = new RecordingCallbackScheduler();
+        var agent = CreateAgent(
+            "conv-lark-card-timeout-sanitize",
+            new RecordingCardRunner(),
+            new RecordingActorDispatchPort(),
+            new InMemoryEventStore(),
+            scheduler);
+
+        await agent.HandleEventAsync(Envelope("conv-lark-card-timeout-sanitize",
+            CreateCardStreamChunk("corr-card-timeout-token", "relay-msg-1", "hello")));
+
+        var scheduled = scheduler.Timeouts.Should().ContainSingle().Subject;
+        var timeout = scheduled.TriggerEnvelope.Payload.Unpack<LarkCardOperationTimeoutFiredEvent>();
+        timeout.CorrelationId.Should().Be("corr-card-timeout-token");
+        timeout.Operation.Should().Be(LarkCardOperationPhase.Create);
+
+        var persistedText = Encoding.UTF8.GetString(scheduled.TriggerEnvelope.ToByteArray());
+        persistedText.Should().NotContain("runtime-token-corr-card-timeout-token");
+        persistedText.Should().NotContain("reply_token");
+        persistedText.Should().NotContain("reply_token_expires_at_unix_ms");
+    }
+
     private static ConversationGAgent CreateAgent(
         string id,
         IConversationCardTurnRunner cardRunner,
         IActorDispatchPort dispatch,
-        IEventStore store)
+        IEventStore store,
+        IActorRuntimeCallbackScheduler? callbackScheduler = null)
     {
         var services = new ServiceCollection()
             .AddSingleton(store)
             .AddSingleton(dispatch)
             .AddSingleton(cardRunner)
-            .AddSingleton<IActorRuntimeCallbackScheduler, NoopCallbackScheduler>()
+            .AddSingleton(callbackScheduler ?? new NoopCallbackScheduler())
             .AddSingleton<EventSourcingRuntimeOptions>()
             .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
             .BuildServiceProvider();
@@ -245,6 +272,44 @@ public sealed class LarkCardOperationSignalTests
             var envelope = await _dispatched.Task.WaitAsync(TimeSpan.FromSeconds(5));
             return envelope.Payload.Unpack<T>();
         }
+    }
+
+    private sealed class RecordingCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        public List<RuntimeCallbackTimeoutRequest> Timeouts { get; } = [];
+
+        public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Timeouts.Add(new RuntimeCallbackTimeoutRequest
+            {
+                ActorId = request.ActorId,
+                CallbackId = request.CallbackId,
+                TriggerEnvelope = request.TriggerEnvelope.Clone(),
+                DueTime = request.DueTime,
+                DeliveryMode = request.DeliveryMode,
+            });
+            return Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                Timeouts.Count,
+                RuntimeCallbackBackend.InMemory));
+        }
+
+        public Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                1,
+                RuntimeCallbackBackend.InMemory));
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default) => Task.CompletedTask;
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default) => Task.CompletedTask;
     }
 
     private sealed class InMemoryEventStore : IEventStore

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -100,18 +100,18 @@ public sealed class LarkCardOperationSignalTests
     [Fact]
     public async Task HandleLlmReplyCardStreamChunkAsync_ScheduledTimeoutPayload_StripsRuntimeRelayCredentials()
     {
-        var scheduler = new RecordingCallbackScheduler();
+        await using var callbackHarness = await RuntimeCallbackSchedulerGrainTestHarness.StartAsync();
         var agent = CreateAgent(
             "conv-lark-card-timeout-sanitize",
             new RecordingCardRunner(),
             new RecordingActorDispatchPort(),
             new InMemoryEventStore(),
-            scheduler);
+            callbackHarness.Scheduler);
 
         await agent.HandleEventAsync(Envelope("conv-lark-card-timeout-sanitize",
             CreateCardStreamChunk("corr-card-timeout-token", "relay-msg-1", "hello")));
 
-        var scheduled = scheduler.Timeouts.Should().ContainSingle().Subject;
+        var scheduled = callbackHarness.Timeouts.Should().ContainSingle().Subject;
         var timeout = scheduled.TriggerEnvelope.Payload.Unpack<LarkCardOperationTimeoutFiredEvent>();
         timeout.CorrelationId.Should().Be("corr-card-timeout-token");
         timeout.Operation.Should().Be(LarkCardOperationPhase.Create);
@@ -186,6 +186,15 @@ public sealed class LarkCardOperationSignalTests
         persistedText.Should().NotContain("runtime-ready-token-corr-card-finalize-token");
         persistedText.Should().NotContain("nyx_user_access_token");
         persistedText.Should().NotContain("reply_token");
+
+        await using var callbackHarness = await RuntimeCallbackSchedulerGrainTestHarness.StartAsync();
+        await callbackHarness.Scheduler.ScheduleTimeoutAsync(new RuntimeCallbackTimeoutRequest
+        {
+            ActorId = agent.Id,
+            CallbackId = "lark-card-finalize-timeout-sanitized",
+            TriggerEnvelope = scheduled.TriggerEnvelope.Clone(),
+            DueTime = TimeSpan.FromMinutes(1),
+        });
     }
 
     private static ConversationGAgent CreateAgent(

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayTextOperationTimeoutPayloadTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayTextOperationTimeoutPayloadTests.cs
@@ -18,12 +18,12 @@ public sealed class NyxRelayTextOperationTimeoutPayloadTests
     [Fact]
     public async Task HandleLlmReplyStreamChunkAsync_ScheduledTimeoutPayload_StripsRuntimeRelayCredentials()
     {
-        var scheduler = new RecordingCallbackScheduler();
-        var agent = CreateAgent("conv-nyx-timeout-sanitize", scheduler);
+        await using var callbackHarness = await RuntimeCallbackSchedulerGrainTestHarness.StartAsync();
+        var agent = CreateAgent("conv-nyx-timeout-sanitize", callbackHarness.Scheduler);
 
         await agent.HandleLlmReplyStreamChunkAsync(CreateStreamChunk());
 
-        var scheduled = scheduler.Timeouts.Should().ContainSingle().Subject;
+        var scheduled = callbackHarness.Timeouts.Should().ContainSingle().Subject;
         var timeout = scheduled.TriggerEnvelope.Payload.Unpack<NyxRelayTextOperationTimeoutFiredEvent>();
         timeout.Chunk.Should().NotBeNull();
         timeout.Chunk.ReplyToken.Should().BeEmpty();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/RuntimeCallbackSchedulerGrainTestHarness.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/RuntimeCallbackSchedulerGrainTestHarness.cs
@@ -1,0 +1,147 @@
+using System.Net;
+using System.Net.Sockets;
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains.Callbacks;
+using Aevatar.Foundation.Runtime.Implementations.Orleans.Streaming;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Orleans;
+using Orleans.Hosting;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+internal sealed class RuntimeCallbackSchedulerGrainTestHarness : IAsyncDisposable
+{
+    private readonly IHost _host;
+    private readonly List<RuntimeCallbackTimeoutRequest> _timeouts = [];
+
+    private RuntimeCallbackSchedulerGrainTestHarness(IHost host)
+    {
+        _host = host;
+    }
+
+    public IActorRuntimeCallbackScheduler Scheduler { get; private set; } = null!;
+
+    public List<RuntimeCallbackTimeoutRequest> Timeouts => _timeouts;
+
+    public static async Task<RuntimeCallbackSchedulerGrainTestHarness> StartAsync()
+    {
+        var siloPort = ReserveTcpPort();
+        var gatewayPort = ReserveTcpPort();
+        var host = Host.CreateDefaultBuilder()
+            .UseOrleans(siloBuilder =>
+            {
+                siloBuilder.UseLocalhostClustering(
+                    siloPort: siloPort,
+                    gatewayPort: gatewayPort,
+                    serviceId: $"aevatar-channel-runtime-callback-test-service-{Guid.NewGuid():N}",
+                    clusterId: $"aevatar-channel-runtime-callback-test-cluster-{Guid.NewGuid():N}");
+                siloBuilder.AddAevatarFoundationRuntimeOrleans(options =>
+                {
+                    options.StreamBackend = AevatarOrleansRuntimeOptions.StreamBackendInMemory;
+                    options.PersistenceBackend = AevatarOrleansRuntimeOptions.PersistenceBackendInMemory;
+                });
+            })
+            .Build();
+
+        await host.StartAsync();
+        var harness = new RuntimeCallbackSchedulerGrainTestHarness(host);
+        harness.Scheduler = new GrainBackedCallbackScheduler(
+            host.Services.GetRequiredService<IGrainFactory>(),
+            harness._timeouts);
+        return harness;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _host.StopAsync();
+        _host.Dispose();
+    }
+
+    private static int ReserveTcpPort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private sealed class GrainBackedCallbackScheduler : IActorRuntimeCallbackScheduler
+    {
+        private readonly IGrainFactory _grainFactory;
+        private readonly List<RuntimeCallbackTimeoutRequest> _timeouts;
+
+        public GrainBackedCallbackScheduler(
+            IGrainFactory grainFactory,
+            List<RuntimeCallbackTimeoutRequest> timeouts)
+        {
+            _grainFactory = grainFactory;
+            _timeouts = timeouts;
+        }
+
+        public async Task<RuntimeCallbackLease> ScheduleTimeoutAsync(
+            RuntimeCallbackTimeoutRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            _timeouts.Add(new RuntimeCallbackTimeoutRequest
+            {
+                ActorId = request.ActorId,
+                CallbackId = request.CallbackId,
+                TriggerEnvelope = request.TriggerEnvelope.Clone(),
+                DueTime = request.DueTime,
+                DeliveryMode = request.DeliveryMode,
+            });
+            var generation = await _grainFactory
+                .GetGrain<IRuntimeCallbackSchedulerGrain>(request.ActorId)
+                .ScheduleTimeoutAsync(
+                    request.CallbackId,
+                    request.TriggerEnvelope.Clone(),
+                    checked((int)request.DueTime.TotalMilliseconds),
+                    request.DeliveryMode);
+
+            return new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                generation,
+                RuntimeCallbackBackend.Dedicated);
+        }
+
+        public async Task<RuntimeCallbackLease> ScheduleTimerAsync(
+            RuntimeCallbackTimerRequest request,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            var generation = await _grainFactory
+                .GetGrain<IRuntimeCallbackSchedulerGrain>(request.ActorId)
+                .ScheduleTimerAsync(
+                    request.CallbackId,
+                    request.TriggerEnvelope.Clone(),
+                    checked((int)request.DueTime.TotalMilliseconds),
+                    checked((int)request.Period.TotalMilliseconds),
+                    request.DeliveryMode);
+
+            return new RuntimeCallbackLease(
+                request.ActorId,
+                request.CallbackId,
+                generation,
+                RuntimeCallbackBackend.Dedicated);
+        }
+
+        public Task CancelAsync(RuntimeCallbackLease lease, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return _grainFactory
+                .GetGrain<IRuntimeCallbackSchedulerGrain>(lease.ActorId)
+                .CancelAsync(lease.CallbackId, lease.Generation, lease.SlotEpoch);
+        }
+
+        public Task PurgeActorAsync(string actorId, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return _grainFactory
+                .GetGrain<IRuntimeCallbackSchedulerGrain>(actorId)
+                .PurgeAsync();
+        }
+    }
+}


### PR DESCRIPTION
## 摘要

iter73 cluster-073-durable-callback-runtime-credentials(severity:high,rules:serialization-protobuf-runtime-callback-payload + actor-callback-signal-only)。

- **Old**:Durable callback envelopes Clone 整 command/chunk payload 持久化到 scheduler,可能 embed transient runtime credentials(`reply_token` / `reply_token_expires_at_unix_ms`)。AgentRunGAgent retry schedule `AgentRunStartRequested{Request=request.Clone()}` 整 payload 持久化;LarkCard timeout schedule `LarkCardOperationTimeoutFiredEvent{Chunk=chunk.Clone()}` 含 reply_token chunk
- **New**:Durable callback payload **只**带 stable identifier(`run_id` / `correlation_id` / `target_actor_id` / `attempt` / `generation`)和 actor-owned lease key;actor fire 时 reconcile actor state,从持久态拿 produced payload;runtime-only credential 缺失则 mark non-retryable

违反:CLAUDE「核心语义强类型」「Protobuf 序列化」「不持久化 runtime-only credential」「自我对账事件」「不依赖外部仓库」(NyxID 给的 reply_token 是 external runtime credential,本仓库不持久化)。

## 范围

8 文件改动(+268 / -27):
- `agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs`(retry 路径重写,callback 用 typed AgentRunRetrySignal stable IDs;fire 时 reconcile)
- `agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto`(加 AgentRunRetrySignal message,去 nested NeedsLlmReplyEvent)
- `agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto`(LarkCard timeout event sanitize chunk)
- `agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs`(schedule 前 sanitize)
- `src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/Callbacks/RuntimeCallbackSchedulerGrain.cs`(envelope sanitization guard — reflection 扫 reply_token 类字段)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs`(reconcile-from-state + non-retryable path 覆盖)
- `test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs`(sanitize 覆盖)
- `test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs`(adapt)

**不修改 NyxID**(外部仓库)。

验证:Channel.Runtime + NyxidChat 编译 ✅ + 3 测试项目 pass + 两个 `ci/*_guards.sh` pass。

## Stacked-PR

Part of iter73 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter73

⟦AI:AUTO-LOOP⟧
