### PR TITLE
iter74 cluster-074: Voice WS endpoint 改 transport completion task,去 Task.Delay(500) 轮询

### DIFF
--- a/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs
@@ -52,6 +52,9 @@ public static class VoicePresenceEndpoints
     {
         ArgumentNullException.ThrowIfNull(resolveSession);
 
+        // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+        //   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+        //   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
         return endpoints.Map(pattern, async (HttpContext ctx) =>
         {
             if (!ctx.WebSockets.IsWebSocketRequest)
@@ -82,7 +85,7 @@ public static class VoicePresenceEndpoints
             {
                 await session.AttachTransportAsync(transport, ctx.RequestAborted);
                 attached = true;
-                await WaitUntilClosedAsync(ws, ctx.RequestAborted);
+                await WaitUntilClosedAsync(transport, ctx.RequestAborted);
             }
             catch (VoiceRemoteAudioTransportUnavailableException)
             {
@@ -367,12 +370,14 @@ public static class VoicePresenceEndpoints
         }
     }
 
-    private static async Task WaitUntilClosedAsync(WebSocket ws, CancellationToken ct)
+    // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+    //   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+    //   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
+    private static async Task WaitUntilClosedAsync(WebSocketVoiceTransport transport, CancellationToken ct)
     {
         try
         {
-            while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
-                await Task.Delay(500, ct);
+            await transport.Completion.WaitAsync(ct);
         }
         catch (OperationCanceledException)
         {

--- a/src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs
@@ -37,7 +37,15 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         if (pcm16.IsEmpty) return;
-        await _ws.SendAsync(pcm16, WebSocketMessageType.Binary, endOfMessage: true, ct);
+        try
+        {
+            await _ws.SendAsync(pcm16, WebSocketMessageType.Binary, endOfMessage: true, ct);
+        }
+        catch
+        {
+            _completion.TrySetResult();
+            throw;
+        }
     }
 
     public async Task SendControlAsync(VoiceControlFrame frame, CancellationToken ct)
@@ -46,7 +54,15 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
         ArgumentNullException.ThrowIfNull(frame);
         var json = ControlJsonWriter.Format(frame);
         var bytes = Encoding.UTF8.GetBytes(json);
-        await _ws.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, endOfMessage: true, ct);
+        try
+        {
+            await _ws.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, endOfMessage: true, ct);
+        }
+        catch
+        {
+            _completion.TrySetResult();
+            throw;
+        }
     }
 
     // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):

--- a/src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs
+++ b/src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs
@@ -10,6 +10,9 @@ namespace Aevatar.Foundation.VoicePresence.Transport;
 /// Wraps a raw <see cref="WebSocket"/> into <see cref="IVoiceTransport"/>.
 /// Binary messages = PCM16 audio. Text messages = JSON-encoded VoiceControlFrame.
 /// </summary>
+// Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+//   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+//   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
 public sealed class WebSocketVoiceTransport : IVoiceTransport
 {
     private const int ReceiveBufferSize = 8 * 1024;
@@ -17,12 +20,18 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
     private static readonly JsonParser ControlJsonReader = new(JsonParser.Settings.Default);
 
     private readonly WebSocket _ws;
+    private readonly TaskCompletionSource _completion =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private bool _disposed;
 
     public WebSocketVoiceTransport(WebSocket ws)
     {
         _ws = ws ?? throw new ArgumentNullException(nameof(ws));
+        if (_ws.State != WebSocketState.Open)
+            _completion.TrySetResult();
     }
+
+    public Task Completion => _completion.Task;
 
     public async Task SendAudioAsync(ReadOnlyMemory<byte> pcm16, CancellationToken ct)
     {
@@ -40,46 +49,58 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
         await _ws.SendAsync(bytes.AsMemory(), WebSocketMessageType.Text, endOfMessage: true, ct);
     }
 
+    // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+    //   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+    //   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
     public async IAsyncEnumerable<VoiceTransportFrame> ReceiveFramesAsync(
         [EnumeratorCancellation] CancellationToken ct)
     {
         var buffer = new byte[ReceiveBufferSize];
-
-        while (_ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
+        try
         {
-            int totalBytes;
-            WebSocketMessageType messageType;
-            try
+            while (_ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
             {
-                (totalBytes, messageType, buffer) = await ReceiveFullMessageAsync(buffer, ct);
-            }
-            catch (WebSocketException)
-            {
-                yield break;
-            }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
-            {
-                yield break;
-            }
+                int totalBytes;
+                WebSocketMessageType messageType;
+                try
+                {
+                    (totalBytes, messageType, buffer) = await ReceiveFullMessageAsync(buffer, ct);
+                }
+                catch (WebSocketException)
+                {
+                    yield break;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    yield break;
+                }
 
-            if (messageType == WebSocketMessageType.Close)
-                yield break;
+                if (messageType == WebSocketMessageType.Close)
+                    yield break;
 
-            if (messageType == WebSocketMessageType.Binary)
-            {
-                var audio = new byte[totalBytes];
-                buffer.AsSpan(0, totalBytes).CopyTo(audio);
-                yield return VoiceTransportFrame.Audio(audio);
+                if (messageType == WebSocketMessageType.Binary)
+                {
+                    var audio = new byte[totalBytes];
+                    buffer.AsSpan(0, totalBytes).CopyTo(audio);
+                    yield return VoiceTransportFrame.Audio(audio);
+                }
+                else if (messageType == WebSocketMessageType.Text)
+                {
+                    var frame = TryParseControlFrame(buffer, totalBytes);
+                    if (frame != null)
+                        yield return VoiceTransportFrame.ControlFrame(frame);
+                }
             }
-            else if (messageType == WebSocketMessageType.Text)
-            {
-                var frame = TryParseControlFrame(buffer, totalBytes);
-                if (frame != null)
-                    yield return VoiceTransportFrame.ControlFrame(frame);
-            }
+        }
+        finally
+        {
+            _completion.TrySetResult();
         }
     }
 
+    // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+    //   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+    //   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
     public async ValueTask DisposeAsync()
     {
         if (_disposed) return;
@@ -99,6 +120,7 @@ public sealed class WebSocketVoiceTransport : IVoiceTransport
         }
 
         _ws.Dispose();
+        _completion.TrySetResult();
     }
 
     private async Task<(int TotalBytes, WebSocketMessageType MessageType, byte[] Buffer)>

--- a/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs
@@ -51,6 +51,9 @@ public static class PolicyAwareVoiceEndpoints
         [FromServices] IUserAgentCatalogQueryPort userAgentCatalog,
         [FromServices] IVoicePresenceSessionResolver sessionResolver)
     {
+        // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+        //   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+        //   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
         if (!http.WebSockets.IsWebSocketRequest)
         {
             http.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -120,7 +123,7 @@ public static class PolicyAwareVoiceEndpoints
         {
             await AttachWithTimeoutAsync(session, transport, options.AttachTimeout, http.RequestAborted);
             attached = true;
-            await WaitUntilClosedAsync(ws, options.WebSocketCloseWaitTimeout, http.RequestAborted);
+            await WaitUntilClosedAsync(transport, options.WebSocketCloseWaitTimeout, http.RequestAborted);
         }
         catch when (!attached)
         {
@@ -363,8 +366,11 @@ public static class PolicyAwareVoiceEndpoints
         await session.AttachTransportAsync(transport, timeoutCts.Token).WaitAsync(timeoutCts.Token);
     }
 
+    // Refactor (iter74/cluster-074-voice-ws-request-polling-close-wait):
+    //   Old pattern: while ws.State == Open { Task.Delay(500) } polling to keep request alive
+    //   New principle: Transport owns close notification; endpoint awaits completion task without periodic sleep
     private static async Task WaitUntilClosedAsync(
-        WebSocket ws,
+        WebSocketVoiceTransport transport,
         TimeSpan timeout,
         CancellationToken ct)
     {
@@ -376,8 +382,7 @@ public static class PolicyAwareVoiceEndpoints
             timeoutCts?.CancelAfter(timeout);
             var waitToken = timeoutCts?.Token ?? ct;
 
-            while (ws.State == WebSocketState.Open && !waitToken.IsCancellationRequested)
-                await Task.Delay(500, waitToken);
+            await transport.Completion.WaitAsync(waitToken);
         }
         catch (OperationCanceledException)
         {

--- a/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
+++ b/test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs
@@ -310,7 +310,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
     }
 
     [Fact]
-    public async Task PolicyAwareVoice_WhenLeaseAcceptedPendingAttach_ShouldAttachAndTimeoutCloseWait()
+    public async Task PolicyAwareVoice_WhenLeaseAcceptedPendingAttach_ShouldAttachAndDetachWhenSocketCloses()
     {
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
         var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
@@ -319,10 +319,12 @@ public sealed class PolicyAwareVoiceEndpointsTests
         var session = new VoicePresenceSession(
             isInitialized: static () => true,
             isTransportAttached: static () => false,
-            attachTransportAsync: (_, _) =>
+            attachTransportAsync: async (transport, ct) =>
             {
                 attached++;
-                return Task.CompletedTask;
+                await foreach (var _ in transport.ReceiveFramesAsync(ct))
+                {
+                }
             },
             detachTransportAsync: (_, _) =>
             {
@@ -332,11 +334,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
             pcmSampleRateHz: 24000);
         var resolver = RecordingVoiceSessionResolver.PendingAttach(session);
         var socket = new FakeWebSocket(WebSocketState.Open);
-        using var app = CreatePolicyAwareApp(
-            policyPort,
-            catalog,
-            resolver,
-            options => options.WebSocketCloseWaitTimeout = TimeSpan.FromMilliseconds(1));
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
         var context = CreateVoiceContext(app, "/ws/voice");
         var wsFeature = new FakeHttpWebSocketFeature(socket);
         context.Features.Set<IHttpWebSocketFeature>(wsFeature);
@@ -350,7 +348,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
     }
 
     [Fact]
-    public async Task PolicyAwareVoice_TypedResolutionLeaseAcceptedPendingAttach_ShouldAcceptAttachAndReleaseAfterCloseWaitTimeout()
+    public async Task PolicyAwareVoice_TypedResolutionLeaseAcceptedPendingAttach_ShouldAcceptAttachAndReleaseAfterSocketClose()
     {
         var policyPort = StaticPolicyPort.For(new ChatRoutePolicySnapshot(ForwardToGAgent("voice-agent"), []));
         var catalog = new RecordingCatalogQueryPort(allowedActorIds: ["voice-agent"]);
@@ -359,10 +357,12 @@ public sealed class PolicyAwareVoiceEndpointsTests
         var session = new VoicePresenceSession(
             isInitialized: static () => true,
             isTransportAttached: static () => false,
-            attachTransportAsync: (_, _) =>
+            attachTransportAsync: async (transport, ct) =>
             {
                 attached++;
-                return Task.CompletedTask;
+                await foreach (var _ in transport.ReceiveFramesAsync(ct))
+                {
+                }
             },
             detachTransportAsync: (_, _) =>
             {
@@ -372,11 +372,7 @@ public sealed class PolicyAwareVoiceEndpointsTests
             pcmSampleRateHz: 24000);
         var resolver = RecordingVoiceSessionResolver.PendingAttach(session);
         var socket = new FakeWebSocket(WebSocketState.Open);
-        using var app = CreatePolicyAwareApp(
-            policyPort,
-            catalog,
-            resolver,
-            options => options.WebSocketCloseWaitTimeout = TimeSpan.FromMilliseconds(1));
+        using var app = CreatePolicyAwareApp(policyPort, catalog, resolver);
         var context = CreateVoiceContext(app, "/ws/voice");
         var wsFeature = new FakeHttpWebSocketFeature(socket);
         context.Features.Set<IHttpWebSocketFeature>(wsFeature);

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs
@@ -39,9 +39,7 @@ public class VoicePresenceEndpointsTests
         context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(socket));
         context.Request.RouteValues["actorId"] = "agent-1";
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
-        context.RequestAborted = cts.Token;
-
+        socket.CompleteReceiveClose();
         await GetVoiceEndpoint(app).RequestDelegate!(context);
 
         resolver.RequestedActorIds.ShouldContain("agent-1");
@@ -62,9 +60,7 @@ public class VoicePresenceEndpointsTests
         context.Request.RouteValues["actorId"] = "agent-1";
         context.Request.QueryString = new QueryString("?module=voice_presence_openai");
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
-        context.RequestAborted = cts.Token;
-
+        socket.CompleteReceiveClose();
         await GetVoiceEndpoint(app).RequestDelegate!(context);
 
         resolver.RequestedActorIds.ShouldContain("agent-1");
@@ -147,9 +143,7 @@ public class VoicePresenceEndpointsTests
         context.Features.Set<IHttpWebSocketFeature>(new FakeHttpWebSocketFeature(socket));
         context.Request.RouteValues["actorId"] = "agent-1";
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
-        context.RequestAborted = cts.Token;
-
+        socket.CompleteReceiveClose();
         await GetVoiceEndpoint(app).RequestDelegate!(context);
 
         module.HasVolatileTransportLease.ShouldBeFalse();
@@ -240,9 +234,7 @@ public class VoicePresenceEndpointsTests
         context.Request.RouteValues["moduleName"] = "voice_presence_openai";
         context.Request.QueryString = new QueryString("?module=voice_presence_minicpm");
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(20));
-        context.RequestAborted = cts.Token;
-
+        socket.CompleteReceiveClose();
         await GetVoiceEndpoint(app, "/voice/{actorId}/{moduleName}").RequestDelegate!(context);
 
         resolver.Requests.ShouldContain(request =>

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWebSocketTestSupport.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWebSocketTestSupport.cs
@@ -21,6 +21,8 @@ internal sealed class FakeWebSocket : WebSocket
 {
     private readonly Queue<ReceiveFrame> _frames = [];
     private readonly bool _keepOpenUntilCancelledWhenEmpty;
+    private readonly TaskCompletionSource _closeWhenEmpty =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private WebSocketState _state;
 
     public FakeWebSocket(WebSocketState state, bool keepOpenUntilCancelledWhenEmpty = false)
@@ -51,6 +53,8 @@ internal sealed class FakeWebSocket : WebSocket
 
     public void EnqueueReceive(WebSocketMessageType messageType, byte[] data, bool endOfMessage = true) =>
         _frames.Enqueue(new ReceiveFrame(messageType, data, endOfMessage));
+
+    public void CompleteReceiveClose() => _closeWhenEmpty.TrySetResult();
 
     public override void Abort()
     {
@@ -103,9 +107,7 @@ internal sealed class FakeWebSocket : WebSocket
         {
             if (_keepOpenUntilCancelledWhenEmpty)
             {
-                var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                using var registration = cancellationToken.Register(() => gate.TrySetResult());
-                await gate.Task;
+                await _closeWhenEmpty.Task.WaitAsync(cancellationToken);
             }
 
             _state = WebSocketState.CloseReceived;

--- a/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWebSocketTestSupport.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWebSocketTestSupport.cs
@@ -35,6 +35,8 @@ internal sealed class FakeWebSocket : WebSocket
 
     public bool ThrowOnClose { get; set; }
 
+    public Exception? SendException { get; set; }
+
     public bool Disposed { get; private set; }
 
     public int CloseCalls { get; private set; }
@@ -130,6 +132,8 @@ internal sealed class FakeWebSocket : WebSocket
     {
         cancellationToken.ThrowIfCancellationRequested();
         _ = endOfMessage;
+        if (SendException != null)
+            throw SendException;
 
         if (messageType == WebSocketMessageType.Text)
         {
@@ -143,6 +147,28 @@ internal sealed class FakeWebSocket : WebSocket
         }
 
         return Task.CompletedTask;
+    }
+
+    public override ValueTask SendAsync(
+        ReadOnlyMemory<byte> buffer,
+        WebSocketMessageType messageType,
+        WebSocketMessageFlags flags,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (SendException != null)
+            throw SendException;
+
+        if (messageType == WebSocketMessageType.Text)
+        {
+            SentTexts.Add(Encoding.UTF8.GetString(buffer.Span));
+        }
+        else if (messageType == WebSocketMessageType.Binary)
+        {
+            SentBinaries.Add(buffer.ToArray());
+        }
+
+        return ValueTask.CompletedTask;
     }
 
     private readonly record struct ReceiveFrame(

--- a/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
@@ -118,6 +118,54 @@ public class WebSocketVoiceTransportTests
     }
 
     [Fact]
+    public async Task Completion_should_finish_when_audio_send_fails_with_websocket_exception()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open)
+        {
+            SendException = new WebSocketException("send failed"),
+        };
+        await using var transport = new WebSocketVoiceTransport(socket);
+
+        await Should.ThrowAsync<WebSocketException>(() =>
+            transport.SendAudioAsync(new byte[] { 1 }, CancellationToken.None));
+
+        transport.Completion.IsCompleted.ShouldBeTrue();
+        await transport.Completion;
+    }
+
+    [Fact]
+    public async Task Completion_should_finish_when_control_send_is_cancelled()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        await using var transport = new WebSocketVoiceTransport(socket);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Should.ThrowAsync<OperationCanceledException>(() =>
+            transport.SendControlAsync(new VoiceControlFrame(), cts.Token));
+
+        transport.Completion.IsCompleted.ShouldBeTrue();
+        await transport.Completion;
+    }
+
+    [Fact]
+    public async Task Completion_should_finish_when_send_observes_server_abort()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open)
+        {
+            SendException = new ObjectDisposedException(nameof(FakeWebSocket)),
+        };
+        await using var transport = new WebSocketVoiceTransport(socket);
+        socket.Abort();
+
+        await Should.ThrowAsync<ObjectDisposedException>(() =>
+            transport.SendAudioAsync(new byte[] { 1 }, CancellationToken.None));
+
+        transport.Completion.IsCompleted.ShouldBeTrue();
+        await transport.Completion;
+    }
+
+    [Fact]
     public async Task DisposeAsync_should_close_open_socket_and_swallow_close_failures()
     {
         var openSocket = new FakeWebSocket(WebSocketState.Open);

--- a/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs
@@ -103,6 +103,21 @@ public class WebSocketVoiceTransportTests
     }
 
     [Fact]
+    public async Task Completion_should_finish_when_receive_loop_observes_close()
+    {
+        var socket = new FakeWebSocket(WebSocketState.Open);
+        var transport = new WebSocketVoiceTransport(socket);
+
+        var frames = new List<VoiceTransportFrame>();
+        await foreach (var frame in transport.ReceiveFramesAsync(CancellationToken.None))
+            frames.Add(frame);
+
+        frames.Count.ShouldBe(0);
+        await transport.Completion;
+        await transport.DisposeAsync();
+    }
+
+    [Fact]
     public async Task DisposeAsync_should_close_open_socket_and_swallow_close_failures()
     {
         var openSocket = new FakeWebSocket(WebSocketState.Open);


### PR DESCRIPTION
## 摘要

iter74 cluster-074-voice-ws-request-polling-close-wait(severity:medium,rules:AGENTS.actor-delay-timeout-eventized + CLAUDE.actor-delay-timeout-eventized)。

- **Old**:`VoicePresenceEndpoints.cs:370-375` + `PolicyAwareVoiceEndpoints.cs:366-380` 用 `while (ws.State == Open) { Task.Delay(500) }` 轮询保持 HTTP request 存活;close 检测 quantized 500ms,burning request delegate
- **New**:`WebSocketVoiceTransport` 暴露 awaitable completion task(transport lifecycle contract);endpoint **await transport completion**,无周期 sleep,close 检测即时

违反:CLAUDE「延迟/超时事件化:统一异步等待 -> 发布内部事件 -> Actor 内消费;禁止回调线程直接改状态」「回调只发信号」。

## 范围

7 文件改动(+106 / -69):
- `src/Aevatar.Foundation.VoicePresence/Hosting/VoicePresenceEndpoints.cs`(去 polling,await transport.Completion)
- `src/Aevatar.Foundation.VoicePresence/Transport/WebSocketVoiceTransport.cs`(加 Task Completion + receive/send 终止时完成)
- `src/Aevatar.Mainnet.Host.Api/Voice/PolicyAwareVoiceEndpoints.cs`(同 pattern,去 polling)
- `test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceEndpointsTests.cs`(更新,deterministic awaiter)
- `test/Aevatar.Foundation.VoicePresence.Tests/WebSocketVoiceTransportTests.cs`(完成 task 覆盖)
- `test/Aevatar.Foundation.VoicePresence.Tests/VoicePresenceWebSocketTestSupport.cs`(test support 加 mock completion)
- `test/Aevatar.ChatRouting.Voice.Integration.Tests/PolicyAwareVoiceEndpointsTests.cs`(同)

endpoint 仍只负责 attach/detach + protocol status mapping,不引入 actor state in Host。测试用 TaskCompletionSource mock transport close,无 Task.Delay。

验证:Foundation.VoicePresence + Mainnet.Host.Api 编译 ✅ + 3 测试项目 pass + 两个 `ci/*_guards.sh` pass。

## Stacked-PR

Part of iter74 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter74

⟦AI:AUTO-LOOP⟧
