### PR TITLE
iter75 cluster-075: forwarded Responses 走 LlmSessionGAgent + readmodel,Host 降为 protocol render

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -44,6 +44,9 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aevatar.Mainnet.Host.Api.Hosting;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public static class MainnetHostBuilderExtensions
 {
     public static WebApplicationBuilder AddAevatarMainnetHost(
@@ -121,6 +124,7 @@ public static class MainnetHostBuilderExtensions
         builder.Services.TryAddSingleton<IResponsesCallerScopeResolver, NyxIdResponsesCallerScopeResolver>();
         builder.Services.TryAddSingleton<IResponsesChatRouteDecisionPort, ResponsesChatRouteDecisionPort>();
         builder.Services.TryAddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
+        builder.Services.TryAddSingleton<ResponsesForwardedCompletionRecorder>();
         builder.Services.TryAddSingleton<IMessagesCommandFacade, MessagesCommandFacade>();
         builder.Services.TryAddSingleton<IResponsesModelsAggregator, NyxIdResponsesModelsAggregator>();
         // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):

--- a/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Hosting/MainnetHostBuilderExtensions.cs
@@ -125,6 +125,7 @@ public static class MainnetHostBuilderExtensions
         builder.Services.TryAddSingleton<IResponsesChatRouteDecisionPort, ResponsesChatRouteDecisionPort>();
         builder.Services.TryAddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.TryAddSingleton<ResponsesForwardedCompletionRecorder>();
+        builder.Services.TryAddSingleton<IResponsesForwardingApplicationService, ResponsesForwardingApplicationService>();
         builder.Services.TryAddSingleton<IMessagesCommandFacade, MessagesCommandFacade>();
         builder.Services.TryAddSingleton<IResponsesModelsAggregator, NyxIdResponsesModelsAggregator>();
         // Refactor (iter26/cluster-026-responses-route-user-catalog-cache):

--- a/src/Aevatar.Mainnet.Host.Api/Responses/AGUIEventToResponsesSseAdapter.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/AGUIEventToResponsesSseAdapter.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.Presentation.AGUI;
 using Microsoft.AspNetCore.Http;
 
@@ -19,6 +20,9 @@ namespace Aevatar.Mainnet.Host.Api.Responses;
 ///   2. Each AGUI event is forwarded via <see cref="WriteAsync"/>
 ///   3. Caller calls <see cref="WriteCompletedAsync"/> when the run finishes
 /// </summary>
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 internal sealed class AGUIEventToResponsesSseAdapter
 {
     private readonly HttpResponse _response;
@@ -27,10 +31,7 @@ internal sealed class AGUIEventToResponsesSseAdapter
     private readonly JsonSerializerOptions _jsonOptions;
     private int _sequenceNumber;
     private int _nextOutputIndex;
-    private readonly StringBuilder _aggregatedText = new();
     private readonly Dictionary<string, int> _toolCallOutputIndex = new(StringComparer.Ordinal);
-    private readonly Dictionary<string, string> _toolCallNames = new(StringComparer.Ordinal);
-    private readonly List<(string ToolCallId, string ToolName, string? Result)> _completedToolCalls = new();
 
     public AGUIEventToResponsesSseAdapter(
         HttpResponse response,
@@ -44,12 +45,7 @@ internal sealed class AGUIEventToResponsesSseAdapter
         _jsonOptions = jsonOptions ?? throw new ArgumentNullException(nameof(jsonOptions));
     }
 
-    public string AggregatedText => _aggregatedText.ToString();
-
     public bool HasFailed { get; private set; }
-
-    public IReadOnlyList<(string ToolCallId, string ToolName, string? Result)> CompletedToolCalls =>
-        _completedToolCalls;
 
     /// <summary>
     /// Emit the initial `response.created` + `response.output_item.added` (in-progress
@@ -102,7 +98,6 @@ internal sealed class AGUIEventToResponsesSseAdapter
                     var delta = evt.TextMessageContent?.Delta ?? string.Empty;
                     if (delta.Length == 0)
                         return;
-                    _aggregatedText.Append(delta);
                     await WriteFrameAsync(
                         "response.output_text.delta",
                         new
@@ -131,7 +126,6 @@ internal sealed class AGUIEventToResponsesSseAdapter
                         return;
                     var outputIndex = _nextOutputIndex++;
                     _toolCallOutputIndex[toolCall.ToolCallId] = outputIndex;
-                    _toolCallNames[toolCall.ToolCallId] = toolCall.ToolName ?? string.Empty;
                     break;
                 }
             case AGUIEvent.EventOneofCase.ToolCallEnd:
@@ -141,8 +135,6 @@ internal sealed class AGUIEventToResponsesSseAdapter
                         return;
                     if (!_toolCallOutputIndex.ContainsKey(toolCall.ToolCallId))
                         return;
-                    var toolName = _toolCallNames.GetValueOrDefault(toolCall.ToolCallId, string.Empty);
-                    _completedToolCalls.Add((toolCall.ToolCallId, toolName, toolCall.Result));
                     break;
                 }
             case AGUIEvent.EventOneofCase.RunError:
@@ -182,13 +174,17 @@ internal sealed class AGUIEventToResponsesSseAdapter
     /// Emit the closing frames: `response.output_text.done`, `response.output_item.done`,
     /// per-tool-call output items, then `response.completed`.
     /// </summary>
+    // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+    //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+    //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
     public async Task WriteCompletedAsync(
+        LlmSessionCompletionSnapshot completion,
         Func<string, object> buildCompletedMessageItem,
-        Func<(string ToolCallId, string ToolName, string? Result), object> buildFunctionCallItem,
-        Func<string, object> buildCompletedResponse,
+        Func<LlmSessionCompletedToolCallSnapshot, object> buildFunctionCallItem,
+        Func<LlmSessionCompletionSnapshot, object> buildCompletedResponse,
         CancellationToken ct)
     {
-        var completedText = _aggregatedText.ToString();
+        var completedText = completion.OutputText;
 
         // Always close the in-progress message item that WriteCreatedAsync opened
         // — Responses SSE requires every `output_item.added` to pair with an
@@ -217,9 +213,9 @@ internal sealed class AGUIEventToResponsesSseAdapter
             },
             ct);
 
-        foreach (var toolCall in _completedToolCalls)
+        foreach (var toolCall in completion.ToolCalls)
         {
-            var outputIndex = _toolCallOutputIndex.GetValueOrDefault(toolCall.ToolCallId, _nextOutputIndex++);
+            var outputIndex = _toolCallOutputIndex.GetValueOrDefault(toolCall.CallId, _nextOutputIndex++);
             var item = buildFunctionCallItem(toolCall);
             await WriteFrameAsync(
                 "response.output_item.added",
@@ -248,7 +244,7 @@ internal sealed class AGUIEventToResponsesSseAdapter
             new
             {
                 type = "response.completed",
-                response = buildCompletedResponse(completedText),
+                response = buildCompletedResponse(completion),
                 sequence_number = ++_sequenceNumber,
             },
             ct);

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -400,7 +400,6 @@ internal static partial class ResponsesApiEndpoints
         response.Headers.CacheControl = "no-store";
         response.Headers.Pragma = "no-cache";
         response.Headers["X-Accel-Buffering"] = "no";
-        await response.StartAsync(ct);
 
         // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
         //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
@@ -410,13 +409,15 @@ internal static partial class ResponsesApiEndpoints
             normalized.ResponseId,
             normalized.MessageItemId,
             JsonOptions);
-        await adapter.WriteCreatedAsync(
-            BuildCreatedResponse(normalized, createdAt),
-            BuildOutputMessage(normalized.MessageItemId, "in_progress", text: null),
-            ct);
 
         try
         {
+            await response.StartAsync(ct);
+            await adapter.WriteCreatedAsync(
+                BuildCreatedResponse(normalized, createdAt),
+                BuildOutputMessage(normalized.MessageItemId, "in_progress", text: null),
+                ct);
+
             var result = await forwardingService.ForwardAsync(
                 forwardPlan,
                 bearerToken,
@@ -469,17 +470,36 @@ internal static partial class ResponsesApiEndpoints
                     usage: null),
                 ct);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
-            // Client aborted; nothing to forward.
+            await forwardingService.RecordForwardedFailureAsync(
+                forwardPlan,
+                "request_timeout",
+                "Request timed out.",
+                CancellationToken.None);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "AGUI-backed stream rendering failed for response {ResponseId}", normalized.ResponseId);
-            await adapter.WriteFailureAsync(
+            await forwardingService.RecordForwardedFailureAsync(
+                forwardPlan,
                 "gagent_invocation_failed",
                 "GAgent invocation failed mid-stream.",
-                ct);
+                CancellationToken.None);
+            try
+            {
+                await adapter.WriteFailureAsync(
+                    "gagent_invocation_failed",
+                    "GAgent invocation failed mid-stream.",
+                    ct);
+            }
+            catch (Exception writeEx)
+            {
+                logger.LogWarning(
+                    writeEx,
+                    "Failed to write AGUI-backed stream failure frame for response {ResponseId}",
+                    normalized.ResponseId);
+            }
         }
     }
 

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -19,6 +19,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Mainnet.Host.Api.Responses;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 internal static partial class ResponsesApiEndpoints
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -45,6 +48,7 @@ internal static partial class ResponsesApiEndpoints
         HttpContext http,
         ResponsesCreateRequest request,
         [FromServices] IResponsesCommandFacade commandFacade,
+        [FromServices] ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
         [FromServices] ITeamEntryMemberResolver teamEntryMemberResolver,
         [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
         [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
@@ -54,6 +58,7 @@ internal static partial class ResponsesApiEndpoints
         ArgumentNullException.ThrowIfNull(http);
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(commandFacade);
+        ArgumentNullException.ThrowIfNull(forwardedCompletionRecorder);
         ArgumentNullException.ThrowIfNull(teamEntryMemberResolver);
         ArgumentNullException.ThrowIfNull(memberPublishedServiceResolver);
         ArgumentNullException.ThrowIfNull(staticGAgentStreamInvocationPort);
@@ -86,7 +91,9 @@ internal static partial class ResponsesApiEndpoints
                 http,
                 result.Forward.Normalized,
                 result.Forward.CallerScope,
+                result.Forward,
                 result.Forward.Action.ForwardToTeam,
+                forwardedCompletionRecorder,
                 teamEntryMemberResolver,
                 staticGAgentStreamInvocationPort,
                 logger,
@@ -99,7 +106,9 @@ internal static partial class ResponsesApiEndpoints
                 http,
                 result.Forward.Normalized,
                 result.Forward.CallerScope,
+                result.Forward,
                 result.Forward.Action.ForwardToGagent,
+                forwardedCompletionRecorder,
                 memberPublishedServiceResolver,
                 staticGAgentStreamInvocationPort,
                 logger,
@@ -335,7 +344,9 @@ internal static partial class ResponsesApiEndpoints
         HttpContext http,
         NormalizedResponsesRequest normalized,
         ResponsesCallerScope callerScope,
+        ResponsesForwardCommandResult forwardPlan,
         ForwardToTeam forwardToTeam,
+        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
         ITeamEntryMemberResolver teamEntryMemberResolver,
         IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         ILogger logger,
@@ -383,7 +394,7 @@ internal static partial class ResponsesApiEndpoints
             SessionId: normalized.ResponseId,
             Headers: BuildStaticGAgentInvocationHeaders(http, normalized, callerScope));
         var invocationRequest = new StaticGAgentStreamInvocationRequest(identity, endpointId, input);
-        var createdAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var createdAt = forwardPlan.CreatedAt.ToUnixTimeSeconds();
 
         if (normalized.Stream)
         {
@@ -392,6 +403,8 @@ internal static partial class ResponsesApiEndpoints
                 normalized,
                 createdAt,
                 invocationRequest,
+                forwardedCompletionRecorder,
+                forwardPlan,
                 staticGAgentStreamInvocationPort,
                 logger,
                 ct);
@@ -402,6 +415,8 @@ internal static partial class ResponsesApiEndpoints
             normalized,
             createdAt,
             invocationRequest,
+            forwardedCompletionRecorder,
+            forwardPlan,
             staticGAgentStreamInvocationPort,
             logger,
             ct);
@@ -427,7 +442,9 @@ internal static partial class ResponsesApiEndpoints
         HttpContext http,
         NormalizedResponsesRequest normalized,
         ResponsesCallerScope callerScope,
+        ResponsesForwardCommandResult forwardPlan,
         ForwardToGAgent forwardToGAgent,
+        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
         IMemberPublishedServiceResolver memberPublishedServiceResolver,
         IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         ILogger logger,
@@ -471,7 +488,7 @@ internal static partial class ResponsesApiEndpoints
             SessionId: normalized.ResponseId,
             Headers: BuildStaticGAgentInvocationHeaders(http, normalized, callerScope));
         var invocationRequest = new StaticGAgentStreamInvocationRequest(identity, DefaultGAgentChatEndpointId, input);
-        var createdAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var createdAt = forwardPlan.CreatedAt.ToUnixTimeSeconds();
 
         if (normalized.Stream)
         {
@@ -480,6 +497,8 @@ internal static partial class ResponsesApiEndpoints
                 normalized,
                 createdAt,
                 invocationRequest,
+                forwardedCompletionRecorder,
+                forwardPlan,
                 staticGAgentStreamInvocationPort,
                 logger,
                 ct);
@@ -490,6 +509,8 @@ internal static partial class ResponsesApiEndpoints
             normalized,
             createdAt,
             invocationRequest,
+            forwardedCompletionRecorder,
+            forwardPlan,
             staticGAgentStreamInvocationPort,
             logger,
             ct);
@@ -528,6 +549,8 @@ internal static partial class ResponsesApiEndpoints
         NormalizedResponsesRequest normalized,
         long createdAt,
         StaticGAgentStreamInvocationRequest invocationRequest,
+        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
+        ResponsesForwardCommandResult forwardPlan,
         IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         ILogger logger,
         CancellationToken ct)
@@ -539,11 +562,15 @@ internal static partial class ResponsesApiEndpoints
         response.Headers["X-Accel-Buffering"] = "no";
         await response.StartAsync(ct);
 
+        // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+        //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+        //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
         var adapter = new AGUIEventToResponsesSseAdapter(
             response,
             normalized.ResponseId,
             normalized.MessageItemId,
             JsonOptions);
+        var completionCollector = forwardedCompletionRecorder.CreateCollector(forwardPlan);
         await adapter.WriteCreatedAsync(
             BuildCreatedResponse(normalized, createdAt),
             BuildOutputMessage(normalized.MessageItemId, "in_progress", text: null),
@@ -553,7 +580,11 @@ internal static partial class ResponsesApiEndpoints
         {
             var result = await staticGAgentStreamInvocationPort.InvokeAsync(
                 invocationRequest,
-                emitAsync: adapter.WriteAsync,
+                emitAsync: async (evt, token) =>
+                {
+                    await completionCollector.ObserveAsync(evt, token);
+                    await adapter.WriteAsync(evt, token);
+                },
                 onAcceptedAsync: null,
                 ct);
             if (!result.Succeeded)
@@ -569,6 +600,18 @@ internal static partial class ResponsesApiEndpoints
             {
                 if (!adapter.HasFailed)
                 {
+                    await completionCollector.CommitFailureAndReadAsync(
+                        "gagent_invocation_failed",
+                        "GAgent invocation failed.",
+                        CancellationToken.None);
+                }
+                else
+                {
+                    await completionCollector.CommitAndReadAsync(CancellationToken.None);
+                }
+
+                if (!adapter.HasFailed)
+                {
                     await adapter.WriteFailureAsync(
                         "gagent_invocation_failed",
                         "GAgent invocation failed.",
@@ -577,25 +620,37 @@ internal static partial class ResponsesApiEndpoints
                 return;
             }
 
+            var completionResult = await completionCollector.CommitAndReadAsync(ct);
+            if (completionResult.Error is not null)
+            {
+                await adapter.WriteFailureAsync(
+                    completionResult.Error.Code,
+                    completionResult.Error.Message,
+                    ct);
+                return;
+            }
+
+            var completion = completionResult.Snapshot!.Completion!;
             await adapter.WriteCompletedAsync(
+                completion,
                 buildCompletedMessageItem: text => BuildOutputMessage(normalized.MessageItemId, "completed", text),
                 buildFunctionCallItem: tool => BuildFunctionCallOutputItem(new ToolCall
                 {
-                    Id = tool.ToolCallId,
+                    Id = tool.CallId,
                     Name = tool.ToolName,
-                    ArgumentsJson = tool.Result ?? "{}",
+                    ArgumentsJson = tool.ResultJson ?? "{}",
                 }),
-                buildCompletedResponse: text => BuildCompletedResponse(
+                buildCompletedResponse: snapshot => BuildCompletedResponse(
                     normalized,
                     createdAt,
-                    DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-                    text,
-                    adapter.CompletedToolCalls
-                        .Select(tc => new ToolCall
+                    snapshot.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    snapshot.OutputText,
+                    snapshot.ToolCalls
+                        .Select(static tc => new ToolCall
                         {
-                            Id = tc.ToolCallId,
+                            Id = tc.CallId,
                             Name = tc.ToolName,
-                            ArgumentsJson = tc.Result ?? "{}",
+                            ArgumentsJson = tc.ResultJson ?? "{}",
                         })
                         .ToArray(),
                     usage: null),
@@ -640,51 +695,17 @@ internal static partial class ResponsesApiEndpoints
         NormalizedResponsesRequest normalized,
         long createdAt,
         StaticGAgentStreamInvocationRequest invocationRequest,
+        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
+        ResponsesForwardCommandResult forwardPlan,
         IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
         ILogger logger,
         CancellationToken ct)
     {
-        var aggregatedText = new StringBuilder();
-        var completedToolCalls = new List<ToolCall>();
-        var toolCallNames = new Dictionary<string, string>(StringComparer.Ordinal);
-        string? failureCode = null;
-        string? failureMessage = null;
+        var completionCollector = forwardedCompletionRecorder.CreateCollector(forwardPlan);
 
-        async ValueTask EmitAsync(AGUIEvent evt, CancellationToken token)
+        ValueTask EmitAsync(AGUIEvent evt, CancellationToken token)
         {
-            switch (evt.EventCase)
-            {
-                case AGUIEvent.EventOneofCase.TextMessageContent:
-                    var delta = evt.TextMessageContent?.Delta;
-                    if (!string.IsNullOrEmpty(delta))
-                        aggregatedText.Append(delta);
-                    break;
-                case AGUIEvent.EventOneofCase.ToolCallStart:
-                    if (!string.IsNullOrWhiteSpace(evt.ToolCallStart?.ToolCallId))
-                        toolCallNames[evt.ToolCallStart.ToolCallId] = evt.ToolCallStart.ToolName ?? string.Empty;
-                    break;
-                case AGUIEvent.EventOneofCase.ToolCallEnd:
-                    var endId = evt.ToolCallEnd?.ToolCallId;
-                    if (string.IsNullOrWhiteSpace(endId))
-                        break;
-                    var name = toolCallNames.GetValueOrDefault(endId!, string.Empty);
-                    completedToolCalls.Add(new ToolCall
-                    {
-                        Id = endId!,
-                        Name = name,
-                        ArgumentsJson = evt.ToolCallEnd?.Result ?? "{}",
-                    });
-                    break;
-                case AGUIEvent.EventOneofCase.RunError:
-                    failureCode = string.IsNullOrWhiteSpace(evt.RunError?.Code)
-                        ? "gagent_invocation_failed"
-                        : evt.RunError!.Code;
-                    failureMessage = string.IsNullOrWhiteSpace(evt.RunError?.Message)
-                        ? "GAgent invocation failed."
-                        : evt.RunError!.Message;
-                    break;
-            }
-            await ValueTask.CompletedTask;
+            return completionCollector.ObserveAsync(evt, token);
         }
 
         try
@@ -701,12 +722,20 @@ internal static partial class ResponsesApiEndpoints
                     result.StartError.ToString().ToLowerInvariant(),
                     "GAgent invocation could not be started.");
             }
-            if (failureMessage is not null || result.CompletionStatus == GAgentDraftRunCompletionStatus.Failed)
+            if (result.CompletionStatus == GAgentDraftRunCompletionStatus.Failed &&
+                !completionCollector.HasFailureEvent)
             {
+                var failure = await completionCollector.CommitFailureAndReadAsync(
+                    "gagent_invocation_failed",
+                    "GAgent invocation failed.",
+                    ct);
+                if (failure.Error is not null)
+                    return ToErrorResult(failure.Error.StatusCode, failure.Error.Code, failure.Error.Message);
+                var failedCompletion = failure.Snapshot!.Completion!;
                 return ToErrorResult(
                     StatusCodes.Status500InternalServerError,
-                    failureCode ?? "gagent_invocation_failed",
-                    failureMessage ?? "GAgent invocation failed.");
+                    failedCompletion.FailureCode ?? "gagent_invocation_failed",
+                    failedCompletion.FailureMessage ?? "GAgent invocation failed.");
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -736,12 +765,33 @@ internal static partial class ResponsesApiEndpoints
                 "GAgent invocation failed.");
         }
 
+        var completionResult = await completionCollector.CommitAndReadAsync(ct);
+        if (completionResult.Error is not null)
+            return ToErrorResult(
+                completionResult.Error.StatusCode,
+                completionResult.Error.Code,
+                completionResult.Error.Message);
+
+        var completion = completionResult.Snapshot!.Completion!;
+        if (!string.IsNullOrWhiteSpace(completion.FailureCode))
+            return ToErrorResult(
+                StatusCodes.Status500InternalServerError,
+                completion.FailureCode!,
+                completion.FailureMessage ?? "GAgent invocation failed.");
+
         var completed = BuildCompletedResponse(
             normalized,
             createdAt,
-            DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            aggregatedText.ToString(),
-            completedToolCalls,
+            completion.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            completion.OutputText,
+            completion.ToolCalls
+                .Select(static tc => new ToolCall
+                {
+                    Id = tc.CallId,
+                    Name = tc.ToolName,
+                    ArgumentsJson = tc.ResultJson ?? "{}",
+                })
+                .ToArray(),
             usage: null);
         return Results.Json(completed, statusCode: StatusCodes.Status200OK);
     }

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -1,15 +1,8 @@
 using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.ChatRouting.Abstractions;
-using Aevatar.Foundation.Abstractions.Connectors;
-using Aevatar.GAgentService.Abstractions;
-using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Responses;
-using Aevatar.GAgentService.Abstractions.ScopeGAgents;
-using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Responses;
-using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.Presentation.AGUI;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -48,20 +41,14 @@ internal static partial class ResponsesApiEndpoints
         HttpContext http,
         ResponsesCreateRequest request,
         [FromServices] IResponsesCommandFacade commandFacade,
-        [FromServices] ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
-        [FromServices] ITeamEntryMemberResolver teamEntryMemberResolver,
-        [FromServices] IMemberPublishedServiceResolver memberPublishedServiceResolver,
-        [FromServices] IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
+        [FromServices] IResponsesForwardingApplicationService forwardingService,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(http);
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(commandFacade);
-        ArgumentNullException.ThrowIfNull(forwardedCompletionRecorder);
-        ArgumentNullException.ThrowIfNull(teamEntryMemberResolver);
-        ArgumentNullException.ThrowIfNull(memberPublishedServiceResolver);
-        ArgumentNullException.ThrowIfNull(staticGAgentStreamInvocationPort);
+        ArgumentNullException.ThrowIfNull(forwardingService);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         var bearerToken = ExtractBearerToken(http);
@@ -92,10 +79,8 @@ internal static partial class ResponsesApiEndpoints
                 result.Forward.Normalized,
                 result.Forward.CallerScope,
                 result.Forward,
-                result.Forward.Action.ForwardToTeam,
-                forwardedCompletionRecorder,
-                teamEntryMemberResolver,
-                staticGAgentStreamInvocationPort,
+                forwardingService,
+                bearerToken,
                 logger,
                 ct);
         }
@@ -107,10 +92,8 @@ internal static partial class ResponsesApiEndpoints
                 result.Forward.Normalized,
                 result.Forward.CallerScope,
                 result.Forward,
-                result.Forward.Action.ForwardToGagent,
-                forwardedCompletionRecorder,
-                memberPublishedServiceResolver,
-                staticGAgentStreamInvocationPort,
+                forwardingService,
+                bearerToken,
                 logger,
                 ct);
         }
@@ -330,70 +313,16 @@ internal static partial class ResponsesApiEndpoints
             ct);
     }
 
-    /// <summary>
-    /// Handle a <see cref="ChatRouteAction.ForwardToTeam"/> decision: resolve the
-    /// team's entry member to a Studio published service, invoke it as an
-    /// ephemeral GAgent run via <see cref="IStaticGAgentStreamInvocationPort{TFrame}"/>,
-    /// and map the AGUI event stream back to OpenAI Responses (SSE or JSON).
-    ///
-    /// Bypasses LLM session/provider/llmRequest entirely — the response id
-    /// the caller sees is the normalized response id; per-turn run lifecycle
-    /// belongs to the team entry member's actor.
-    /// </summary>
     private static async Task<IResult> HandleForwardToTeamAsync(
         HttpContext http,
         NormalizedResponsesRequest normalized,
         ResponsesCallerScope callerScope,
         ResponsesForwardCommandResult forwardPlan,
-        ForwardToTeam forwardToTeam,
-        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
-        ITeamEntryMemberResolver teamEntryMemberResolver,
-        IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
+        IResponsesForwardingApplicationService forwardingService,
+        string bearerToken,
         ILogger logger,
         CancellationToken ct)
     {
-        var teamId = forwardToTeam.TeamId?.Trim() ?? string.Empty;
-        var endpointId = forwardToTeam.EndpointId?.Trim() ?? string.Empty;
-        if (teamId.Length == 0)
-            return ToErrorResult(
-                StatusCodes.Status500InternalServerError,
-                "chat_route_invalid",
-                "ForwardToTeam decision missing team_id.");
-        if (endpointId.Length == 0)
-            return ToErrorResult(
-                StatusCodes.Status500InternalServerError,
-                "chat_route_invalid",
-                "ForwardToTeam decision missing endpoint_id.");
-
-        // ForwardToTeam.scope_id is reserved for future cross-scope routing;
-        // v1 stamps the caller's ingress scope and ignores conflicting overrides.
-        var scopeId = callerScope.ScopeId;
-
-        TeamEntryMemberResolution resolution;
-        try
-        {
-            resolution = await teamEntryMemberResolver.ResolveAsync(scopeId, teamId, ct);
-        }
-        catch (TeamEntryMemberResolutionException ex)
-        {
-            return ToErrorResult(
-                ResolveTeamEntryHttpStatusCode(ex.Code),
-                ex.Code,
-                ex.Message);
-        }
-
-        var identity = new ServiceIdentity
-        {
-            TenantId = resolution.ScopeId,
-            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
-            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
-            ServiceId = resolution.PublishedServiceId,
-        };
-        var input = new StaticGAgentStreamInvocationInput(
-            Prompt: normalized.Prompt ?? string.Empty,
-            SessionId: normalized.ResponseId,
-            Headers: BuildStaticGAgentInvocationHeaders(http, normalized, callerScope));
-        var invocationRequest = new StaticGAgentStreamInvocationRequest(identity, endpointId, input);
         var createdAt = forwardPlan.CreatedAt.ToUnixTimeSeconds();
 
         if (normalized.Stream)
@@ -402,10 +331,9 @@ internal static partial class ResponsesApiEndpoints
                 http.Response,
                 normalized,
                 createdAt,
-                invocationRequest,
-                forwardedCompletionRecorder,
                 forwardPlan,
-                staticGAgentStreamInvocationPort,
+                forwardingService,
+                bearerToken,
                 logger,
                 ct);
             return Results.Empty;
@@ -414,80 +342,23 @@ internal static partial class ResponsesApiEndpoints
         return await CollectAGuiBackedResponseAsync(
             normalized,
             createdAt,
-            invocationRequest,
-            forwardedCompletionRecorder,
             forwardPlan,
-            staticGAgentStreamInvocationPort,
+            forwardingService,
+            bearerToken,
             logger,
             ct);
     }
 
-    /// <summary>
-    /// Handle a <see cref="ChatRouteAction.ForwardToGagent"/> decision on the LLM
-    /// facade: resolve <see cref="ForwardToGAgent.ActorId"/> as a Studio
-    /// <c>memberId</c> via <see cref="IMemberPublishedServiceResolver"/>, then
-    /// invoke the resulting published service via
-    /// <see cref="IStaticGAgentStreamInvocationPort{TFrame}"/> and map AGUI events
-    /// back to OpenAI Responses (SSE or JSON).
-    ///
-    /// Endpoint selection: ForwardToGAgent has no <c>endpoint_id</c> field, so the
-    /// caller is steered toward the default chat endpoint
-    /// (<see cref="DefaultGAgentChatEndpointId"/>). This matches the contract a
-    /// chat-route policy author can reasonably express through ForwardToGAgent —
-    /// a single named GAgent run with no per-rule endpoint customization. Authors
-    /// who need an explicit endpoint should switch to ForwardToTeam (which does
-    /// carry endpoint_id) or to a direct Studio invoke URL.
-    /// </summary>
     private static async Task<IResult> HandleForwardToGAgentAsync(
         HttpContext http,
         NormalizedResponsesRequest normalized,
         ResponsesCallerScope callerScope,
         ResponsesForwardCommandResult forwardPlan,
-        ForwardToGAgent forwardToGAgent,
-        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
-        IMemberPublishedServiceResolver memberPublishedServiceResolver,
-        IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
+        IResponsesForwardingApplicationService forwardingService,
+        string bearerToken,
         ILogger logger,
         CancellationToken ct)
     {
-        var memberId = forwardToGAgent.ActorId?.Trim() ?? string.Empty;
-        if (memberId.Length == 0)
-            return ToErrorResult(
-                StatusCodes.Status500InternalServerError,
-                "chat_route_invalid",
-                "ForwardToGAgent decision missing actor_id.");
-
-        MemberPublishedServiceResolution resolution;
-        try
-        {
-            resolution = await memberPublishedServiceResolver.ResolveAsync(
-                new MemberPublishedServiceResolveRequest(callerScope.ScopeId, memberId),
-                ct);
-        }
-        catch (InvalidOperationException ex)
-        {
-            // The resolver's normalization (empty / disallowed separator chars in
-            // memberId) raises InvalidOperationException. Surface as a structured
-            // 400 so the caller sees a real error code, not the resolver's bare
-            // message bubbling up through generic exception handling.
-            return ToErrorResult(
-                StatusCodes.Status400BadRequest,
-                "chat_route_invalid",
-                ex.Message);
-        }
-
-        var identity = new ServiceIdentity
-        {
-            TenantId = resolution.ScopeId,
-            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
-            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
-            ServiceId = resolution.PublishedServiceId,
-        };
-        var input = new StaticGAgentStreamInvocationInput(
-            Prompt: normalized.Prompt ?? string.Empty,
-            SessionId: normalized.ResponseId,
-            Headers: BuildStaticGAgentInvocationHeaders(http, normalized, callerScope));
-        var invocationRequest = new StaticGAgentStreamInvocationRequest(identity, DefaultGAgentChatEndpointId, input);
         var createdAt = forwardPlan.CreatedAt.ToUnixTimeSeconds();
 
         if (normalized.Stream)
@@ -496,10 +367,9 @@ internal static partial class ResponsesApiEndpoints
                 http.Response,
                 normalized,
                 createdAt,
-                invocationRequest,
-                forwardedCompletionRecorder,
                 forwardPlan,
-                staticGAgentStreamInvocationPort,
+                forwardingService,
+                bearerToken,
                 logger,
                 ct);
             return Results.Empty;
@@ -508,50 +378,20 @@ internal static partial class ResponsesApiEndpoints
         return await CollectAGuiBackedResponseAsync(
             normalized,
             createdAt,
-            invocationRequest,
-            forwardedCompletionRecorder,
             forwardPlan,
-            staticGAgentStreamInvocationPort,
+            forwardingService,
+            bearerToken,
             logger,
             ct);
-    }
-
-    /// <summary>
-    /// Default endpoint id used when ForwardToGAgent forwards to a single Studio
-    /// member without naming an explicit endpoint. Members published by Studio's
-    /// member-first authoring flow expose this as their canonical chat entry.
-    /// </summary>
-    internal const string DefaultGAgentChatEndpointId = "chat";
-
-    private static Dictionary<string, string> BuildStaticGAgentInvocationHeaders(
-        HttpContext http,
-        NormalizedResponsesRequest normalized,
-        ResponsesCallerScope callerScope)
-    {
-        var headers = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            [LLMRequestMetadataKeys.RequestId] = normalized.ResponseId,
-            [ChannelMetadataKeys.RegistrationScopeId] = callerScope.ScopeId,
-        };
-
-        var bearerToken = ExtractBearerToken(http);
-        if (!string.IsNullOrWhiteSpace(bearerToken))
-        {
-            headers[LLMRequestMetadataKeys.NyxIdAccessToken] = bearerToken;
-            headers[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
-        }
-
-        return headers;
     }
 
     private static async Task WriteAGuiBackedResponseStreamAsync(
         HttpResponse response,
         NormalizedResponsesRequest normalized,
         long createdAt,
-        StaticGAgentStreamInvocationRequest invocationRequest,
-        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
         ResponsesForwardCommandResult forwardPlan,
-        IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
+        IResponsesForwardingApplicationService forwardingService,
+        string bearerToken,
         ILogger logger,
         CancellationToken ct)
     {
@@ -570,7 +410,6 @@ internal static partial class ResponsesApiEndpoints
             normalized.ResponseId,
             normalized.MessageItemId,
             JsonOptions);
-        var completionCollector = forwardedCompletionRecorder.CreateCollector(forwardPlan);
         await adapter.WriteCreatedAsync(
             BuildCreatedResponse(normalized, createdAt),
             BuildOutputMessage(normalized.MessageItemId, "in_progress", text: null),
@@ -578,59 +417,33 @@ internal static partial class ResponsesApiEndpoints
 
         try
         {
-            var result = await staticGAgentStreamInvocationPort.InvokeAsync(
-                invocationRequest,
-                emitAsync: async (evt, token) =>
-                {
-                    await completionCollector.ObserveAsync(evt, token);
-                    await adapter.WriteAsync(evt, token);
-                },
-                onAcceptedAsync: null,
+            var result = await forwardingService.ForwardAsync(
+                forwardPlan,
+                bearerToken,
+                async (evt, token) => await adapter.WriteAsync(evt, token),
                 ct);
-            if (!result.Succeeded)
+            if (result.Error is not null)
             {
-                await adapter.WriteFailureAsync(
-                    result.StartError.ToString().ToLowerInvariant(),
-                    "GAgent invocation could not be started.",
-                    ct);
+                if (!adapter.HasFailed)
+                {
+                    await adapter.WriteFailureAsync(result.Error.Code, result.Error.Message, ct);
+                }
                 return;
             }
 
-            if (adapter.HasFailed || result.CompletionStatus == GAgentDraftRunCompletionStatus.Failed)
+            var completion = result.Snapshot!.Completion!;
+            if (!string.IsNullOrWhiteSpace(completion.FailureCode))
             {
                 if (!adapter.HasFailed)
                 {
-                    await completionCollector.CommitFailureAndReadAsync(
-                        "gagent_invocation_failed",
-                        "GAgent invocation failed.",
-                        CancellationToken.None);
-                }
-                else
-                {
-                    await completionCollector.CommitAndReadAsync(CancellationToken.None);
-                }
-
-                if (!adapter.HasFailed)
-                {
                     await adapter.WriteFailureAsync(
-                        "gagent_invocation_failed",
-                        "GAgent invocation failed.",
+                        completion.FailureCode!,
+                        completion.FailureMessage ?? "GAgent invocation failed.",
                         ct);
                 }
                 return;
             }
 
-            var completionResult = await completionCollector.CommitAndReadAsync(ct);
-            if (completionResult.Error is not null)
-            {
-                await adapter.WriteFailureAsync(
-                    completionResult.Error.Code,
-                    completionResult.Error.Message,
-                    ct);
-                return;
-            }
-
-            var completion = completionResult.Snapshot!.Completion!;
             await adapter.WriteCompletedAsync(
                 completion,
                 buildCompletedMessageItem: text => BuildOutputMessage(normalized.MessageItemId, "completed", text),
@@ -660,17 +473,9 @@ internal static partial class ResponsesApiEndpoints
         {
             // Client aborted; nothing to forward.
         }
-        catch (InvalidOperationException ex) when (IsServiceNotFoundException(ex))
-        {
-            logger.LogWarning(ex, "AGUI-backed stream invocation resolved to unknown service for response {ResponseId}", normalized.ResponseId);
-            await adapter.WriteFailureAsync(
-                "gagent_target_not_found",
-                ex.Message,
-                ct);
-        }
         catch (Exception ex)
         {
-            logger.LogError(ex, "AGUI-backed stream invocation failed for response {ResponseId}", normalized.ResponseId);
+            logger.LogError(ex, "AGUI-backed stream rendering failed for response {ResponseId}", normalized.ResponseId);
             await adapter.WriteFailureAsync(
                 "gagent_invocation_failed",
                 "GAgent invocation failed mid-stream.",
@@ -678,135 +483,57 @@ internal static partial class ResponsesApiEndpoints
         }
     }
 
-    /// <summary>
-    /// Recognizes the <see cref="InvalidOperationException"/> raised by the
-    /// service-invocation resolution layer when the resolved
-    /// <c>publishedServiceId</c> isn't registered as a Studio service. The
-    /// resolver layer doesn't define a typed exception for this case (it's
-    /// raised from <c>ServiceInvocationResolutionService.ResolveAsync</c> with
-    /// a deterministic message prefix), so we match by message shape. Keeps
-    /// chat-route policy authors out of the generic 500 bucket.
-    /// </summary>
-    private static bool IsServiceNotFoundException(InvalidOperationException ex) =>
-        ex.Message.StartsWith("Service '", StringComparison.Ordinal) &&
-        ex.Message.Contains("was not found", StringComparison.Ordinal);
-
     private static async Task<IResult> CollectAGuiBackedResponseAsync(
         NormalizedResponsesRequest normalized,
         long createdAt,
-        StaticGAgentStreamInvocationRequest invocationRequest,
-        ResponsesForwardedCompletionRecorder forwardedCompletionRecorder,
         ResponsesForwardCommandResult forwardPlan,
-        IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
+        IResponsesForwardingApplicationService forwardingService,
+        string bearerToken,
         ILogger logger,
         CancellationToken ct)
     {
-        var completionCollector = forwardedCompletionRecorder.CreateCollector(forwardPlan);
-
-        ValueTask EmitAsync(AGUIEvent evt, CancellationToken token)
-        {
-            return completionCollector.ObserveAsync(evt, token);
-        }
-
         try
         {
-            var result = await staticGAgentStreamInvocationPort.InvokeAsync(
-                invocationRequest,
-                emitAsync: EmitAsync,
-                onAcceptedAsync: null,
-                ct);
-            if (!result.Succeeded)
-            {
-                return ToErrorResult(
-                    StatusCodes.Status502BadGateway,
-                    result.StartError.ToString().ToLowerInvariant(),
-                    "GAgent invocation could not be started.");
-            }
-            if (result.CompletionStatus == GAgentDraftRunCompletionStatus.Failed &&
-                !completionCollector.HasFailureEvent)
-            {
-                var failure = await completionCollector.CommitFailureAndReadAsync(
-                    "gagent_invocation_failed",
-                    "GAgent invocation failed.",
-                    ct);
-                if (failure.Error is not null)
-                    return ToErrorResult(failure.Error.StatusCode, failure.Error.Code, failure.Error.Message);
-                var failedCompletion = failure.Snapshot!.Completion!;
+            var result = await forwardingService.ForwardAsync(forwardPlan, bearerToken, onEventAsync: null, ct);
+            if (result.Error is not null)
+                return ToErrorResult(result.Error.StatusCode, result.Error.Code, result.Error.Message);
+
+            var completion = result.Snapshot!.Completion!;
+            if (!string.IsNullOrWhiteSpace(completion.FailureCode))
                 return ToErrorResult(
                     StatusCodes.Status500InternalServerError,
-                    failedCompletion.FailureCode ?? "gagent_invocation_failed",
-                    failedCompletion.FailureMessage ?? "GAgent invocation failed.");
-            }
+                    completion.FailureCode!,
+                    completion.FailureMessage ?? "GAgent invocation failed.");
+
+            var completed = BuildCompletedResponse(
+                normalized,
+                createdAt,
+                completion.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                completion.OutputText,
+                completion.ToolCalls
+                    .Select(static tc => new ToolCall
+                    {
+                        Id = tc.CallId,
+                        Name = tc.ToolName,
+                        ArgumentsJson = tc.ResultJson ?? "{}",
+                    })
+                    .ToArray(),
+                usage: null);
+            return Results.Json(completed, statusCode: StatusCodes.Status200OK);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             return Results.StatusCode(StatusCodes.Status408RequestTimeout);
         }
-        catch (InvalidOperationException ex) when (IsServiceNotFoundException(ex))
-        {
-            // The static port's resolution service throws InvalidOperationException
-            // with "Service '<...>' was not found." when ForwardToTeam/ForwardToGAgent
-            // resolves to a publishedServiceId that isn't actually registered as a
-            // Studio service (e.g. chat-route policy points at a member that was
-            // never bound). Surface as structured 404 so chat-route authors can
-            // distinguish "configured wrong" from "service crashed".
-            logger.LogWarning(ex, "AGUI-backed invocation resolved to unknown service for response {ResponseId}", normalized.ResponseId);
-            return ToErrorResult(
-                StatusCodes.Status404NotFound,
-                "gagent_target_not_found",
-                ex.Message);
-        }
         catch (Exception ex)
         {
-            logger.LogError(ex, "AGUI-backed invocation failed for response {ResponseId}", normalized.ResponseId);
+            logger.LogError(ex, "AGUI-backed response rendering failed for response {ResponseId}", normalized.ResponseId);
             return ToErrorResult(
                 StatusCodes.Status500InternalServerError,
                 "gagent_invocation_failed",
                 "GAgent invocation failed.");
         }
-
-        var completionResult = await completionCollector.CommitAndReadAsync(ct);
-        if (completionResult.Error is not null)
-            return ToErrorResult(
-                completionResult.Error.StatusCode,
-                completionResult.Error.Code,
-                completionResult.Error.Message);
-
-        var completion = completionResult.Snapshot!.Completion!;
-        if (!string.IsNullOrWhiteSpace(completion.FailureCode))
-            return ToErrorResult(
-                StatusCodes.Status500InternalServerError,
-                completion.FailureCode!,
-                completion.FailureMessage ?? "GAgent invocation failed.");
-
-        var completed = BuildCompletedResponse(
-            normalized,
-            createdAt,
-            completion.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-            completion.OutputText,
-            completion.ToolCalls
-                .Select(static tc => new ToolCall
-                {
-                    Id = tc.CallId,
-                    Name = tc.ToolName,
-                    ArgumentsJson = tc.ResultJson ?? "{}",
-                })
-                .ToArray(),
-            usage: null);
-        return Results.Json(completed, statusCode: StatusCodes.Status200OK);
     }
-
-    private static int ResolveTeamEntryHttpStatusCode(string code) =>
-        code switch
-        {
-            TeamEntryMemberErrorCodes.TeamNotFound => StatusCodes.Status404NotFound,
-            TeamEntryMemberErrorCodes.EntryMemberNotFound => StatusCodes.Status404NotFound,
-            TeamEntryMemberErrorCodes.TeamArchived => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberNotConfigured => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberMismatch => StatusCodes.Status409Conflict,
-            TeamEntryMemberErrorCodes.EntryMemberNotReady => StatusCodes.Status503ServiceUnavailable,
-            _ => StatusCodes.Status400BadRequest,
-        };
 
     private static ResponsesResponseSnapshot BuildCreatedResponse(
         NormalizedResponsesRequest normalized,

--- a/src/platform/Aevatar.GAgentService.Abstractions/Ports/ILlmSessionRegistrationPort.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Ports/ILlmSessionRegistrationPort.cs
@@ -2,6 +2,9 @@ using Aevatar.GAgentService.Abstractions.Queries;
 
 namespace Aevatar.GAgentService.Abstractions.Ports;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public interface ILlmSessionRegistrationPort
 {
     Task<LlmSessionRegistrationResult> RegisterAsync(
@@ -18,6 +21,12 @@ public interface ILlmSessionRegistrationPort
         string sessionActorId,
         string responseId,
         LlmSessionForwardedToolCall call,
+        CancellationToken ct = default);
+
+    Task RecordCompletionAsync(
+        string sessionActorId,
+        string responseId,
+        LlmSessionCompletion completion,
         CancellationToken ct = default);
 
     Task ReceiveForwardedToolResultAsync(

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -60,11 +60,26 @@ message LlmSessionForwardedToolCall {
   google.protobuf.Timestamp resolved_at = 10;
 }
 
+message LlmSessionCompletedToolCall {
+  string call_id = 1;
+  string tool_name = 2;
+  google.protobuf.Value result = 3;
+}
+
+message LlmSessionCompletion {
+  string output_text = 1;
+  repeated LlmSessionCompletedToolCall tool_calls = 2;
+  google.protobuf.Timestamp completed_at = 3;
+  string failure_code = 4;
+  string failure_message = 5;
+}
+
 message LlmSessionState {
   LlmSessionRecord record = 1;
   int64 last_applied_event_version = 2;
   string last_event_id = 3;
   repeated LlmSessionForwardedToolCall forwarded_tool_calls = 4;
+  LlmSessionCompletion completion = 5;
 }
 
 message RegisterResponseSessionRequested {
@@ -85,6 +100,16 @@ message LlmSessionStatusUpdatedEvent {
   string response_id = 1;
   LlmSessionStatus status = 2;
   google.protobuf.Timestamp updated_at = 3;
+}
+
+message RecordResponseSessionCompletionRequested {
+  string response_id = 1;
+  LlmSessionCompletion completion = 2;
+}
+
+message LlmSessionCompletionRecordedEvent {
+  string response_id = 1;
+  LlmSessionCompletion completion = 2;
 }
 
 message ExpireResponseSessionRequested {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/LlmSessionSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/LlmSessionSnapshot.cs
@@ -2,6 +2,9 @@ using Aevatar.GAgentService.Abstractions;
 
 namespace Aevatar.GAgentService.Abstractions.Queries;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed record LlmSessionSnapshot(
     string ResponseId,
     string ScopeId,
@@ -15,8 +18,12 @@ public sealed record LlmSessionSnapshot(
     string ActorId,
     long StateVersion,
     string LastEventId,
-    IReadOnlyList<LlmSessionForwardedToolCallSnapshot>? ForwardedToolCalls = null);
+    IReadOnlyList<LlmSessionForwardedToolCallSnapshot>? ForwardedToolCalls = null,
+    LlmSessionCompletionSnapshot? Completion = null);
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed record LlmSessionForwardedToolCallSnapshot(
     string CallId,
     string ToolName,
@@ -28,3 +35,21 @@ public sealed record LlmSessionForwardedToolCallSnapshot(
     DateTimeOffset? EmittedAt,
     DateTimeOffset? ReceivedAt,
     DateTimeOffset? ResolvedAt);
+
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+public sealed record LlmSessionCompletionSnapshot(
+    string OutputText,
+    IReadOnlyList<LlmSessionCompletedToolCallSnapshot> ToolCalls,
+    DateTimeOffset? CompletedAt,
+    string? FailureCode,
+    string? FailureMessage);
+
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+public sealed record LlmSessionCompletedToolCallSnapshot(
+    string CallId,
+    string ToolName,
+    string? ResultJson);

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -203,10 +203,16 @@ public sealed record ResponsesCreateCommandResult(
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Forward-to-team/GAgent decisions were endpoint locals interleaved with provider-session setup.
 //   New principle: Forwarding is a typed command result so Host can invoke boundary AGUI rendering without owning route policy.
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed record ResponsesForwardCommandResult(
     NormalizedResponsesRequest Normalized,
     ResponsesCallerScope CallerScope,
-    ChatRouteAction Action);
+    ChatRouteAction Action,
+    LlmSessionRegistrationResult Session,
+    LlmSessionSnapshot? PreviousSnapshot,
+    DateTimeOffset CreatedAt);
 
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Completed Responses JSON shape was built from endpoint execution locals.

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -334,6 +334,12 @@ public interface IResponsesForwardingApplicationService
         string bearerToken,
         Func<AGUIEvent, CancellationToken, ValueTask>? onEventAsync = null,
         CancellationToken ct = default);
+
+    Task<ResponsesForwardingResult> RecordForwardedFailureAsync(
+        ResponsesForwardCommandResult plan,
+        string code,
+        string message,
+        CancellationToken ct = default);
 }
 
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -3,6 +3,7 @@ using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.Presentation.AGUI;
 
 namespace Aevatar.GAgentService.Application.Responses;
 
@@ -214,6 +215,17 @@ public sealed record ResponsesForwardCommandResult(
     LlmSessionSnapshot? PreviousSnapshot,
     DateTimeOffset CreatedAt);
 
+public sealed record ResponsesForwardingResult(
+    ResponsesCommandError? Error,
+    LlmSessionSnapshot? Snapshot)
+{
+    public static ResponsesForwardingResult FromError(int statusCode, string code, string message) =>
+        new(new ResponsesCommandError(statusCode, code, message), null);
+
+    public static ResponsesForwardingResult FromSnapshot(LlmSessionSnapshot snapshot) =>
+        new(null, snapshot);
+}
+
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Completed Responses JSON shape was built from endpoint execution locals.
 //   New principle: Application exposes the completed command data; Host maps it to the external Responses protocol.
@@ -312,6 +324,15 @@ public interface IResponsesCommandFacade
     Task<ResponsesStreamCommandResult> StreamAsync(
         ResponsesCreateCommandPlan plan,
         Func<string, CancellationToken, ValueTask> onTextDelta,
+        CancellationToken ct = default);
+}
+
+public interface IResponsesForwardingApplicationService
+{
+    Task<ResponsesForwardingResult> ForwardAsync(
+        ResponsesForwardCommandResult plan,
+        string bearerToken,
+        Func<AGUIEvent, CancellationToken, ValueTask>? onEventAsync = null,
         CancellationToken ct = default);
 }
 

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -12,6 +12,9 @@ namespace Aevatar.GAgentService.Application.Responses;
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Mainnet Host endpoints owned normalization, target resolution, session registration, tool persistence, and LLM command execution inline.
 //   New principle: Application owns the Responses command lifecycle as a typed facade; Host maps HTTP/SSE/JSON frames around these command plans and results.
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed class ResponsesCommandFacade(
     ILLMProviderFactory providerFactory,
     IResponsesCallerScopeResolver callerScopeResolver,
@@ -56,12 +59,6 @@ public sealed class ResponsesCommandFacade(
                 routedModelResult.Error.StatusCode,
                 routedModelResult.Error.Code,
                 routedModelResult.Error.Message);
-        if (routedModelResult.ForwardAction is not null)
-            return ResponsesCreateCommandResult.FromForward(new ResponsesForwardCommandResult(
-                normalized,
-                callerScope,
-                routedModelResult.ForwardAction));
-
         var continuation = await PrepareContinuationAsync(normalized, callerScope, ct);
         if (continuation.Error is not null)
             return ResponsesCreateCommandResult.FromError(
@@ -78,6 +75,18 @@ public sealed class ResponsesCommandFacade(
                 sessionResult.Error.StatusCode,
                 sessionResult.Error.Code,
                 sessionResult.Error.Message);
+
+        // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+        //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+        //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+        if (routedModelResult.ForwardAction is not null)
+            return ResponsesCreateCommandResult.FromForward(new ResponsesForwardCommandResult(
+                normalized,
+                callerScope,
+                routedModelResult.ForwardAction,
+                sessionResult.Session!,
+                continuation.PreviousSnapshot,
+                createdAt));
 
         var prepared = await BuildExecutionPlanAsync(
             normalized,

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardedCompletionRecorder.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardedCompletionRecorder.cs
@@ -1,0 +1,191 @@
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.Presentation.AGUI;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgentService.Application.Responses;
+
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+public sealed class ResponsesForwardedCompletionRecorder
+{
+    private readonly ILlmSessionRegistrationPort _sessionRegistrationPort;
+    private readonly ILlmSessionQueryPort _sessionQueryPort;
+
+    public ResponsesForwardedCompletionRecorder(
+        ILlmSessionRegistrationPort sessionRegistrationPort,
+        ILlmSessionQueryPort sessionQueryPort)
+    {
+        _sessionRegistrationPort = sessionRegistrationPort ?? throw new ArgumentNullException(nameof(sessionRegistrationPort));
+        _sessionQueryPort = sessionQueryPort ?? throw new ArgumentNullException(nameof(sessionQueryPort));
+    }
+
+    public async Task<ResponsesForwardedCompletionRecordResult> RecordAsync(
+        ResponsesForwardCommandResult plan,
+        IEnumerable<AGUIEvent> events,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(events);
+
+        var completion = BuildCompletion(events, DateTimeOffset.UtcNow);
+        return await CommitAndReadAsync(plan, completion, ct);
+    }
+
+    public ResponsesForwardedCompletionCollector CreateCollector(ResponsesForwardCommandResult plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        return new ResponsesForwardedCompletionCollector(this, plan);
+    }
+
+    public async Task<ResponsesForwardedCompletionRecordResult> CommitAndReadAsync(
+        ResponsesForwardCommandResult plan,
+        LlmSessionCompletion completion,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(completion);
+
+        await _sessionRegistrationPort.RecordCompletionAsync(
+            plan.Session.ActorId,
+            plan.Session.ResponseId,
+            completion,
+            ct);
+
+        var snapshot = await _sessionQueryPort.GetByResponseIdAsync(plan.Session.ResponseId, ct);
+        if (snapshot?.Completion is null)
+        {
+            return ResponsesForwardedCompletionRecordResult.FromError(new ResponsesCommandError(
+                503,
+                "response_completion_not_observed",
+                "Forwarded response completion was committed but is not yet visible in the read model."));
+        }
+
+        return ResponsesForwardedCompletionRecordResult.FromSnapshot(snapshot);
+    }
+
+    public static LlmSessionCompletion BuildCompletion(
+        IEnumerable<AGUIEvent> events,
+        DateTimeOffset completedAt)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        var completion = new LlmSessionCompletion
+        {
+            CompletedAt = Timestamp.FromDateTimeOffset(completedAt),
+        };
+        var toolStarts = new List<(string ToolCallId, string ToolName)>();
+
+        foreach (var evt in events)
+        {
+            switch (evt.EventCase)
+            {
+                case AGUIEvent.EventOneofCase.TextMessageContent:
+                    completion.OutputText += evt.TextMessageContent?.Delta ?? string.Empty;
+                    break;
+                case AGUIEvent.EventOneofCase.ToolCallStart:
+                    if (!string.IsNullOrWhiteSpace(evt.ToolCallStart?.ToolCallId))
+                    {
+                        toolStarts.Add((
+                            evt.ToolCallStart.ToolCallId.Trim(),
+                            evt.ToolCallStart.ToolName?.Trim() ?? string.Empty));
+                    }
+                    break;
+                case AGUIEvent.EventOneofCase.ToolCallEnd:
+                    var end = evt.ToolCallEnd;
+                    if (end is null || string.IsNullOrWhiteSpace(end.ToolCallId))
+                        break;
+                    var toolName = toolStarts.LastOrDefault(x =>
+                        string.Equals(x.ToolCallId, end.ToolCallId.Trim(), StringComparison.Ordinal)).ToolName;
+                    completion.ToolCalls.Add(new LlmSessionCompletedToolCall
+                    {
+                        CallId = end.ToolCallId.Trim(),
+                        ToolName = toolName ?? string.Empty,
+                        Result = ResponsesJsonValues.ParseBoundaryPayload(
+                            string.IsNullOrWhiteSpace(end.Result) ? "{}" : end.Result),
+                    });
+                    break;
+                case AGUIEvent.EventOneofCase.RunError:
+                    completion.FailureCode = string.IsNullOrWhiteSpace(evt.RunError?.Code)
+                        ? "gagent_invocation_failed"
+                        : evt.RunError!.Code;
+                    completion.FailureMessage = string.IsNullOrWhiteSpace(evt.RunError?.Message)
+                        ? "GAgent invocation failed."
+                        : evt.RunError!.Message;
+                    break;
+            }
+        }
+
+        return completion;
+    }
+
+    public static LlmSessionCompletion BuildFailureCompletion(
+        string code,
+        string message,
+        DateTimeOffset completedAt) =>
+        new()
+        {
+            CompletedAt = Timestamp.FromDateTimeOffset(completedAt),
+            FailureCode = string.IsNullOrWhiteSpace(code) ? "gagent_invocation_failed" : code,
+            FailureMessage = string.IsNullOrWhiteSpace(message) ? "GAgent invocation failed." : message,
+        };
+}
+
+public sealed record ResponsesForwardedCompletionRecordResult(
+    ResponsesCommandError? Error,
+    LlmSessionSnapshot? Snapshot)
+{
+    public static ResponsesForwardedCompletionRecordResult FromError(ResponsesCommandError error) =>
+        new(error, null);
+
+    public static ResponsesForwardedCompletionRecordResult FromSnapshot(LlmSessionSnapshot snapshot) =>
+        new(null, snapshot);
+}
+
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+public sealed class ResponsesForwardedCompletionCollector
+{
+    private readonly ResponsesForwardedCompletionRecorder _recorder;
+    private readonly ResponsesForwardCommandResult _plan;
+    private readonly List<AGUIEvent> _events = [];
+
+    internal ResponsesForwardedCompletionCollector(
+        ResponsesForwardedCompletionRecorder recorder,
+        ResponsesForwardCommandResult plan)
+    {
+        _recorder = recorder;
+        _plan = plan;
+    }
+
+    public bool HasFailureEvent { get; private set; }
+
+    public ValueTask ObserveAsync(AGUIEvent evt, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+        ct.ThrowIfCancellationRequested();
+        if (evt.EventCase == AGUIEvent.EventOneofCase.RunError)
+            HasFailureEvent = true;
+        _events.Add(evt.Clone());
+        return ValueTask.CompletedTask;
+    }
+
+    public Task<ResponsesForwardedCompletionRecordResult> CommitAndReadAsync(CancellationToken ct = default) =>
+        _recorder.RecordAsync(_plan, _events, ct);
+
+    public Task<ResponsesForwardedCompletionRecordResult> CommitFailureAndReadAsync(
+        string code,
+        string message,
+        CancellationToken ct = default)
+    {
+        var completion = ResponsesForwardedCompletionRecorder.BuildFailureCompletion(
+            code,
+            message,
+            DateTimeOffset.UtcNow);
+        return _recorder.CommitAndReadAsync(_plan, completion, ct);
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardingApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardingApplicationService.cs
@@ -29,16 +29,16 @@ public sealed class ResponsesForwardingApplicationService(
     {
         ArgumentNullException.ThrowIfNull(plan);
 
-        var target = await BuildInvocationRequestAsync(plan, bearerToken, ct);
-        if (target.Error is not null)
-        {
-            await TryCommitFailureAsync(plan, target.Error.Code, target.Error.Message, CancellationToken.None);
-            return new ResponsesForwardingResult(target.Error, null);
-        }
-
-        var collector = completionRecorder.CreateCollector(plan);
         try
         {
+            var target = await BuildInvocationRequestAsync(plan, bearerToken, ct);
+            if (target.Error is not null)
+            {
+                await TryCommitFailureAsync(plan, target.Error.Code, target.Error.Message, CancellationToken.None);
+                return new ResponsesForwardingResult(target.Error, null);
+            }
+
+            var collector = completionRecorder.CreateCollector(plan);
             var result = await staticGAgentStreamInvocationPort.InvokeAsync(
                 target.Request!,
                 async (evt, token) =>
@@ -75,7 +75,7 @@ public sealed class ResponsesForwardingApplicationService(
                 ? new ResponsesForwardingResult(completion.Error, null)
                 : ResponsesForwardingResult.FromSnapshot(completion.Snapshot!);
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        catch (OperationCanceledException)
         {
             await TryCommitFailureAsync(plan, "request_timeout", "Request timed out.", CancellationToken.None);
             return ResponsesForwardingResult.FromError(408, "request_timeout", "Request timed out.");
@@ -106,6 +106,18 @@ public sealed class ResponsesForwardingApplicationService(
                 "gagent_invocation_failed",
                 "GAgent invocation failed.");
         }
+    }
+
+    public async Task<ResponsesForwardingResult> RecordForwardedFailureAsync(
+        ResponsesForwardCommandResult plan,
+        string code,
+        string message,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        await TryCommitFailureAsync(plan, code, message, ct);
+        return ResponsesForwardingResult.FromError(500, code, message);
     }
 
     private async Task<InvocationRequestResult> BuildInvocationRequestAsync(

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardingApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardingApplicationService.cs
@@ -1,0 +1,286 @@
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.ChatRouting.Abstractions;
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.ScopeGAgents;
+using Aevatar.GAgentService.Abstractions.Services;
+using Aevatar.Presentation.AGUI;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.GAgentService.Application.Responses;
+
+public sealed class ResponsesForwardingApplicationService(
+    ITeamEntryMemberResolver teamEntryMemberResolver,
+    IMemberPublishedServiceResolver memberPublishedServiceResolver,
+    IStaticGAgentStreamInvocationPort<AGUIEvent> staticGAgentStreamInvocationPort,
+    ResponsesForwardedCompletionRecorder completionRecorder,
+    ILogger<ResponsesForwardingApplicationService> logger) : IResponsesForwardingApplicationService
+{
+    private const string DefaultGAgentChatEndpointId = "chat";
+    private const string RegistrationScopeMetadataKey = "scope_id";
+
+    public async Task<ResponsesForwardingResult> ForwardAsync(
+        ResponsesForwardCommandResult plan,
+        string bearerToken,
+        Func<AGUIEvent, CancellationToken, ValueTask>? onEventAsync = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var target = await BuildInvocationRequestAsync(plan, bearerToken, ct);
+        if (target.Error is not null)
+        {
+            await TryCommitFailureAsync(plan, target.Error.Code, target.Error.Message, CancellationToken.None);
+            return new ResponsesForwardingResult(target.Error, null);
+        }
+
+        var collector = completionRecorder.CreateCollector(plan);
+        try
+        {
+            var result = await staticGAgentStreamInvocationPort.InvokeAsync(
+                target.Request!,
+                async (evt, token) =>
+                {
+                    await collector.ObserveAsync(evt, token);
+                    if (onEventAsync != null)
+                        await onEventAsync(evt, token);
+                },
+                onAcceptedAsync: null,
+                ct);
+
+            if (!result.Succeeded)
+            {
+                var code = result.StartError.ToString().ToLowerInvariant();
+                const string message = "GAgent invocation could not be started.";
+                await CommitFailureAsync(plan, code, message, CancellationToken.None);
+                return ResponsesForwardingResult.FromError(502, code, message);
+            }
+
+            if (result.CompletionStatus == GAgentDraftRunCompletionStatus.Failed &&
+                !collector.HasFailureEvent)
+            {
+                var failure = await collector.CommitFailureAndReadAsync(
+                    "gagent_invocation_failed",
+                    "GAgent invocation failed.",
+                    CancellationToken.None);
+                return failure.Error is not null
+                    ? new ResponsesForwardingResult(failure.Error, null)
+                    : ResponsesForwardingResult.FromSnapshot(failure.Snapshot!);
+            }
+
+            var completion = await collector.CommitAndReadAsync(ct);
+            return completion.Error is not null
+                ? new ResponsesForwardingResult(completion.Error, null)
+                : ResponsesForwardingResult.FromSnapshot(completion.Snapshot!);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            await TryCommitFailureAsync(plan, "request_timeout", "Request timed out.", CancellationToken.None);
+            return ResponsesForwardingResult.FromError(408, "request_timeout", "Request timed out.");
+        }
+        catch (InvalidOperationException ex) when (IsServiceNotFoundException(ex))
+        {
+            logger.LogWarning(
+                ex,
+                "AGUI-backed invocation resolved to unknown service for response {ResponseId}",
+                plan.Normalized.ResponseId);
+            var failure = await CommitFailureAsync(
+                plan,
+                "gagent_target_not_found",
+                ex.Message,
+                CancellationToken.None);
+            return ResponsesForwardingResult.FromError(404, "gagent_target_not_found", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "AGUI-backed invocation failed for response {ResponseId}", plan.Normalized.ResponseId);
+            var failure = await CommitFailureAsync(
+                plan,
+                "gagent_invocation_failed",
+                "GAgent invocation failed.",
+                CancellationToken.None);
+            return ResponsesForwardingResult.FromError(
+                500,
+                "gagent_invocation_failed",
+                "GAgent invocation failed.");
+        }
+    }
+
+    private async Task<InvocationRequestResult> BuildInvocationRequestAsync(
+        ResponsesForwardCommandResult plan,
+        string bearerToken,
+        CancellationToken ct)
+    {
+        if (plan.Action.ForwardToTeam is not null)
+            return await BuildForwardToTeamRequestAsync(plan, bearerToken, plan.Action.ForwardToTeam, ct);
+
+        if (plan.Action.ForwardToGagent is not null)
+            return await BuildForwardToGAgentRequestAsync(plan, bearerToken, plan.Action.ForwardToGagent, ct);
+
+        return InvocationRequestResult.FromError(500, "chat_route_invalid", "Forward decision has no forwarding target.");
+    }
+
+    private async Task<InvocationRequestResult> BuildForwardToTeamRequestAsync(
+        ResponsesForwardCommandResult plan,
+        string bearerToken,
+        ForwardToTeam forwardToTeam,
+        CancellationToken ct)
+    {
+        var teamId = forwardToTeam.TeamId?.Trim() ?? string.Empty;
+        var endpointId = forwardToTeam.EndpointId?.Trim() ?? string.Empty;
+        if (teamId.Length == 0)
+            return InvocationRequestResult.FromError(500, "chat_route_invalid", "ForwardToTeam decision missing team_id.");
+        if (endpointId.Length == 0)
+            return InvocationRequestResult.FromError(500, "chat_route_invalid", "ForwardToTeam decision missing endpoint_id.");
+
+        TeamEntryMemberResolution resolution;
+        try
+        {
+            resolution = await teamEntryMemberResolver.ResolveAsync(plan.CallerScope.ScopeId, teamId, ct);
+        }
+        catch (TeamEntryMemberResolutionException ex)
+        {
+            return InvocationRequestResult.FromError(ResolveTeamEntryHttpStatusCode(ex.Code), ex.Code, ex.Message);
+        }
+
+        return InvocationRequestResult.FromRequest(BuildInvocationRequest(
+            plan,
+            bearerToken,
+            resolution.ScopeId,
+            resolution.PublishedServiceId,
+            endpointId));
+    }
+
+    private async Task<InvocationRequestResult> BuildForwardToGAgentRequestAsync(
+        ResponsesForwardCommandResult plan,
+        string bearerToken,
+        ForwardToGAgent forwardToGAgent,
+        CancellationToken ct)
+    {
+        var memberId = forwardToGAgent.ActorId?.Trim() ?? string.Empty;
+        if (memberId.Length == 0)
+            return InvocationRequestResult.FromError(500, "chat_route_invalid", "ForwardToGAgent decision missing actor_id.");
+
+        MemberPublishedServiceResolution resolution;
+        try
+        {
+            resolution = await memberPublishedServiceResolver.ResolveAsync(
+                new MemberPublishedServiceResolveRequest(plan.CallerScope.ScopeId, memberId),
+                ct);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return InvocationRequestResult.FromError(400, "chat_route_invalid", ex.Message);
+        }
+
+        return InvocationRequestResult.FromRequest(BuildInvocationRequest(
+            plan,
+            bearerToken,
+            resolution.ScopeId,
+            resolution.PublishedServiceId,
+            DefaultGAgentChatEndpointId));
+    }
+
+    private static StaticGAgentStreamInvocationRequest BuildInvocationRequest(
+        ResponsesForwardCommandResult plan,
+        string bearerToken,
+        string scopeId,
+        string publishedServiceId,
+        string endpointId)
+    {
+        var identity = new ServiceIdentity
+        {
+            TenantId = scopeId,
+            AppId = ScopeServiceIdentityDefaults.ServiceAppId,
+            Namespace = ScopeServiceIdentityDefaults.ServiceNamespace,
+            ServiceId = publishedServiceId,
+        };
+        var input = new StaticGAgentStreamInvocationInput(
+            Prompt: plan.Normalized.Prompt ?? string.Empty,
+            SessionId: plan.Normalized.ResponseId,
+            Headers: BuildStaticGAgentInvocationHeaders(plan, bearerToken));
+        return new StaticGAgentStreamInvocationRequest(identity, endpointId, input);
+    }
+
+    private static Dictionary<string, string> BuildStaticGAgentInvocationHeaders(
+        ResponsesForwardCommandResult plan,
+        string bearerToken)
+    {
+        var headers = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [LLMRequestMetadataKeys.RequestId] = plan.Normalized.ResponseId,
+            [RegistrationScopeMetadataKey] = plan.CallerScope.ScopeId,
+        };
+
+        if (!string.IsNullOrWhiteSpace(bearerToken))
+        {
+            headers[LLMRequestMetadataKeys.NyxIdAccessToken] = bearerToken;
+            headers[ConnectorRequest.HttpAuthorizationMetadataKey] = $"Bearer {bearerToken}";
+        }
+
+        return headers;
+    }
+
+    private async Task<ResponsesForwardingResult?> CommitFailureAsync(
+        ResponsesForwardCommandResult plan,
+        string code,
+        string message,
+        CancellationToken ct)
+    {
+        var committed = await completionRecorder.CommitAndReadAsync(
+            plan,
+            ResponsesForwardedCompletionRecorder.BuildFailureCompletion(code, message, DateTimeOffset.UtcNow),
+            ct);
+        return committed.Error is not null
+            ? new ResponsesForwardingResult(committed.Error, null)
+            : ResponsesForwardingResult.FromSnapshot(committed.Snapshot!);
+    }
+
+    private async Task TryCommitFailureAsync(
+        ResponsesForwardCommandResult plan,
+        string code,
+        string message,
+        CancellationToken ct)
+    {
+        try
+        {
+            await completionRecorder.CommitAndReadAsync(
+                plan,
+                ResponsesForwardedCompletionRecorder.BuildFailureCompletion(code, message, DateTimeOffset.UtcNow),
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to commit forwarding failure fact for response {ResponseId}", plan.Normalized.ResponseId);
+        }
+    }
+
+    private static int ResolveTeamEntryHttpStatusCode(string code) =>
+        code switch
+        {
+            TeamEntryMemberErrorCodes.TeamNotFound => 404,
+            TeamEntryMemberErrorCodes.EntryMemberNotFound => 404,
+            TeamEntryMemberErrorCodes.TeamArchived => 409,
+            TeamEntryMemberErrorCodes.EntryMemberNotConfigured => 409,
+            TeamEntryMemberErrorCodes.EntryMemberMismatch => 409,
+            TeamEntryMemberErrorCodes.EntryMemberNotReady => 503,
+            _ => 400,
+        };
+
+    private static bool IsServiceNotFoundException(InvalidOperationException ex) =>
+        ex.Message.StartsWith("Service '", StringComparison.Ordinal) &&
+        ex.Message.Contains("was not found", StringComparison.Ordinal);
+
+    private sealed record InvocationRequestResult(
+        StaticGAgentStreamInvocationRequest? Request,
+        ResponsesCommandError? Error)
+    {
+        public static InvocationRequestResult FromRequest(StaticGAgentStreamInvocationRequest request) =>
+            new(request, null);
+
+        public static InvocationRequestResult FromError(int statusCode, string code, string message) =>
+            new(null, new ResponsesCommandError(statusCode, code, message));
+    }
+}

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -7,6 +7,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgentService.Core.GAgents;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
 {
     private static readonly Duration DefaultTtl = Duration.FromTimeSpan(TimeSpan.FromHours(24));
@@ -79,6 +82,39 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             ResponseId = existing.ResponseId,
             Status = command.Status,
             UpdatedAt = command.UpdatedAt ?? Timestamp.FromDateTime(DateTime.UtcNow),
+        });
+    }
+
+    // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+    //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+    //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+    [EventHandler]
+    public async Task HandleRecordCompletionAsync(RecordResponseSessionCompletionRequested command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(command.Completion);
+
+        var existing = EnsureRegisteredSession(command.ResponseId);
+        var completion = NormalizeCompletion(command.Completion.Clone());
+        ValidateCompletion(completion);
+
+        if (State.Completion is { CompletedAt: not null } current)
+        {
+            EnsureExistingCompletionMatches(current, completion);
+            return;
+        }
+
+        if (IsTerminal(existing.Status) &&
+            existing.Status is not (LlmSessionStatus.Completed or LlmSessionStatus.Failed))
+        {
+            throw new InvalidOperationException(
+                $"Response session '{existing.ResponseId}' is {existing.Status} and cannot record completion.");
+        }
+
+        await PersistDomainEventAsync(new LlmSessionCompletionRecordedEvent
+        {
+            ResponseId = existing.ResponseId,
+            Completion = completion,
         });
     }
 
@@ -225,6 +261,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             .Match(current, evt)
             .On<LlmSessionRegisteredEvent>(ApplyRegistered)
             .On<LlmSessionStatusUpdatedEvent>(ApplyStatusUpdated)
+            .On<LlmSessionCompletionRecordedEvent>(ApplyCompletionRecorded)
             .On<LlmSessionForwardedToolCallEmittedEvent>(ApplyForwardedToolCallEmitted)
             .On<LlmSessionForwardedToolResultReceivedEvent>(ApplyForwardedToolResultReceived)
             .On<LlmSessionForwardedToolCallResolvedEvent>(ApplyForwardedToolCallResolved)
@@ -238,6 +275,24 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         next.Record = evt.Record?.Clone() ?? new LlmSessionRecord();
         next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
         next.LastEventId = $"{next.Record.ResponseId}:registered";
+        return next;
+    }
+
+    private static LlmSessionState ApplyCompletionRecorded(
+        LlmSessionState state,
+        LlmSessionCompletionRecordedEvent evt)
+    {
+        var next = state.Clone();
+        if (next.Record == null)
+            next.Record = new LlmSessionRecord();
+
+        next.Completion = evt.Completion?.Clone() ?? new LlmSessionCompletion();
+        next.Record.Status = string.IsNullOrWhiteSpace(next.Completion.FailureCode)
+            ? LlmSessionStatus.Completed
+            : LlmSessionStatus.Failed;
+        next.Record.UpdatedAt = next.Completion.CompletedAt?.Clone() ?? Timestamp.FromDateTime(DateTime.UtcNow);
+        next.LastAppliedEventVersion = state.LastAppliedEventVersion + 1;
+        next.LastEventId = $"{evt.ResponseId}:completion";
         return next;
     }
 
@@ -393,6 +448,42 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
             throw new InvalidOperationException("expiry is required.");
     }
 
+    private static LlmSessionCompletion NormalizeCompletion(LlmSessionCompletion completion)
+    {
+        completion.OutputText ??= string.Empty;
+        completion.FailureCode = NormalizeOptional(completion.FailureCode) ?? string.Empty;
+        completion.FailureMessage = NormalizeOptional(completion.FailureMessage) ?? string.Empty;
+        if (completion.CompletedAt == null)
+            completion.CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow);
+
+        foreach (var toolCall in completion.ToolCalls)
+        {
+            toolCall.CallId = NormalizeRequired(toolCall.CallId);
+            toolCall.ToolName = NormalizeRequired(toolCall.ToolName);
+        }
+
+        return completion;
+    }
+
+    private static void ValidateCompletion(LlmSessionCompletion completion)
+    {
+        if (completion.CompletedAt == null)
+            throw new InvalidOperationException("completed_at is required.");
+        if (!string.IsNullOrWhiteSpace(completion.FailureCode) &&
+            string.IsNullOrWhiteSpace(completion.FailureMessage))
+        {
+            throw new InvalidOperationException("failure_message is required when failure_code is present.");
+        }
+
+        foreach (var toolCall in completion.ToolCalls)
+        {
+            if (string.IsNullOrWhiteSpace(toolCall.CallId))
+                throw new InvalidOperationException("completion tool call_id is required.");
+            if (string.IsNullOrWhiteSpace(toolCall.ToolName))
+                throw new InvalidOperationException("completion tool tool_name is required.");
+        }
+    }
+
     private static void EnsureExistingMatches(
         LlmSessionRecord existing,
         LlmSessionRecord incoming)
@@ -439,6 +530,31 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         {
             throw new InvalidOperationException(
                 $"Forwarded tool call '{existing.CallId}' cannot be rebound to different tool call facts.");
+        }
+    }
+
+    private static void EnsureExistingCompletionMatches(
+        LlmSessionCompletion existing,
+        LlmSessionCompletion incoming)
+    {
+        if (!string.Equals(existing.OutputText, incoming.OutputText, StringComparison.Ordinal) ||
+            !string.Equals(existing.FailureCode, incoming.FailureCode, StringComparison.Ordinal) ||
+            !string.Equals(existing.FailureMessage, incoming.FailureMessage, StringComparison.Ordinal) ||
+            existing.ToolCalls.Count != incoming.ToolCalls.Count)
+        {
+            throw new InvalidOperationException("Response session completion cannot be rebound to different facts.");
+        }
+
+        for (var i = 0; i < existing.ToolCalls.Count; i++)
+        {
+            var existingTool = existing.ToolCalls[i];
+            var incomingTool = incoming.ToolCalls[i];
+            if (!string.Equals(existingTool.CallId, incomingTool.CallId, StringComparison.Ordinal) ||
+                !string.Equals(existingTool.ToolName, incomingTool.ToolName, StringComparison.Ordinal) ||
+                !Equals(existingTool.Result, incomingTool.Result))
+            {
+                throw new InvalidOperationException("Response session completion cannot be rebound to different tool call facts.");
+            }
         }
     }
 

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IResponsesAgentToolStateCommandPort, ResponsesAgentToolStateCommandAdapter>();
         services.TryAddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         services.TryAddSingleton<ResponsesForwardedCompletionRecorder>();
+        services.TryAddSingleton<IResponsesForwardingApplicationService, ResponsesForwardingApplicationService>();
         services.TryAddSingleton<IServiceInvocationDispatcher, DefaultServiceInvocationDispatcher>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceImplementationAdapter, StaticServiceImplementationAdapter>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceImplementationAdapter, ScriptingServiceImplementationAdapter>());

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -37,6 +37,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.GAgentService.Hosting.DependencyInjection;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddGAgentServiceCapability(
@@ -66,6 +69,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ILlmSessionRegistrationPort, LlmSessionRegistrationAdapter>();
         services.TryAddSingleton<IResponsesAgentToolStateCommandPort, ResponsesAgentToolStateCommandAdapter>();
         services.TryAddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
+        services.TryAddSingleton<ResponsesForwardedCompletionRecorder>();
         services.TryAddSingleton<IServiceInvocationDispatcher, DefaultServiceInvocationDispatcher>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceImplementationAdapter, StaticServiceImplementationAdapter>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IServiceImplementationAdapter, ScriptingServiceImplementationAdapter>());

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/LlmSessionRegistrationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/LlmSessionRegistrationAdapter.cs
@@ -14,6 +14,9 @@ namespace Aevatar.GAgentService.Infrastructure.Adapters;
 /// HTTP boundary are parsed into protobuf values here so the actor state never
 /// holds JSON strings.
 /// </summary>
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed class LlmSessionRegistrationAdapter : ILlmSessionRegistrationPort
 {
     private const string PublisherId = "gagent-service.response-sessions";
@@ -119,6 +122,38 @@ public sealed class LlmSessionRegistrationAdapter : ILlmSessionRegistrationPort
             {
                 ResponseId = responseId.Trim(),
                 Call = prepared,
+            }),
+            envelopeId);
+
+        await _dispatchPort.DispatchAsync(sessionActorId, envelope, ct);
+    }
+
+    // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+    //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+    //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+    public async Task RecordCompletionAsync(
+        string sessionActorId,
+        string responseId,
+        LlmSessionCompletion completion,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(sessionActorId))
+            throw new ArgumentException("sessionActorId is required.", nameof(sessionActorId));
+        if (string.IsNullOrWhiteSpace(responseId))
+            throw new ArgumentException("responseId is required.", nameof(responseId));
+        ArgumentNullException.ThrowIfNull(completion);
+
+        var prepared = completion.Clone();
+        if (prepared.CompletedAt == null)
+            prepared.CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow);
+
+        var envelopeId = $"{responseId}:completion";
+        var envelope = CreateEnvelope(
+            sessionActorId,
+            Any.Pack(new RecordResponseSessionCompletionRequested
+            {
+                ResponseId = responseId.Trim(),
+                Completion = prepared,
             }),
             envelopeId);
 

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionCurrentStateProjector.cs
@@ -8,6 +8,9 @@ using Aevatar.GAgentService.Projection.ReadModels;
 
 namespace Aevatar.GAgentService.Projection.Projectors;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed class LlmSessionCurrentStateProjector
     : ICurrentStateProjectionMaterializer<LlmSessionCurrentStateProjectionContext>
 {
@@ -82,6 +85,28 @@ public sealed class LlmSessionCurrentStateProjector
                 ResolvedAt = call.ResolvedAt?.ToDateTimeOffset(),
             })
             .ToArray();
+        // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+        //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+        //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+        if (state.Completion != null)
+        {
+            document.Completion = new LlmSessionCompletionReadModel
+            {
+                OutputText = state.Completion.OutputText ?? string.Empty,
+                CompletedAt = state.Completion.CompletedAt?.ToDateTimeOffset(),
+                FailureCode = state.Completion.FailureCode ?? string.Empty,
+                FailureMessage = state.Completion.FailureMessage ?? string.Empty,
+            };
+            foreach (var call in state.Completion.ToolCalls)
+            {
+                document.Completion.ToolCalls.Add(new LlmSessionCompletedToolCallReadModel
+                {
+                    CallId = call.CallId ?? string.Empty,
+                    ToolName = call.ToolName ?? string.Empty,
+                    Result = call.Result?.Clone(),
+                });
+            }
+        }
 
         await _writeDispatcher.UpsertAsync(document, ct);
     }

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/LlmSessionQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/LlmSessionQueryReader.cs
@@ -8,6 +8,9 @@ using Aevatar.GAgentService.Projection.ReadModels;
 
 namespace Aevatar.GAgentService.Projection.Queries;
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed class LlmSessionQueryReader : ILlmSessionQueryPort
 {
     private readonly IProjectionDocumentReader<LlmSessionCurrentStateReadModel, string> _documentStore;
@@ -58,7 +61,29 @@ public sealed class LlmSessionQueryReader : ILlmSessionQueryPort
                     call.EmittedAt,
                     call.ReceivedAt,
                     call.ResolvedAt))
-                .ToArray());
+                .ToArray(),
+            MapCompletion(readModel.Completion));
+
+    // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+    //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+    //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+    private static LlmSessionCompletionSnapshot? MapCompletion(LlmSessionCompletionReadModel? completion)
+    {
+        if (completion is null || completion.CompletedAt is null)
+            return null;
+
+        return new LlmSessionCompletionSnapshot(
+            completion.OutputText ?? string.Empty,
+            completion.ToolCalls
+                .Select(static tool => new LlmSessionCompletedToolCallSnapshot(
+                    tool.CallId,
+                    tool.ToolName,
+                    ResponsesJsonValues.ToBoundaryJson(tool.Result)))
+                .ToArray(),
+            completion.CompletedAt,
+            string.IsNullOrWhiteSpace(completion.FailureCode) ? null : completion.FailureCode,
+            string.IsNullOrWhiteSpace(completion.FailureMessage) ? null : completion.FailureMessage);
+    }
 
     /// <summary>
     /// For Expired calls without a caller-provided result, the boundary

--- a/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/ReadModels/ServiceProjectionReadModels.Partial.cs
@@ -232,6 +232,9 @@ public sealed partial class GAgentRunTerminalReadModel : IProjectionReadModel<GA
     }
 }
 
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
 public sealed partial class LlmSessionCurrentStateReadModel : IProjectionReadModel<LlmSessionCurrentStateReadModel>
 {
     public DateTimeOffset CreatedAt
@@ -283,6 +286,24 @@ public sealed partial class LlmSessionForwardedToolCallReadModel
     {
         get => ServiceProjectionReadModelSupport.ToNullableDateTimeOffset(ResolvedAtUtcValue);
         set => ResolvedAtUtcValue = ServiceProjectionReadModelSupport.ToNullableTimestamp(value);
+    }
+}
+
+// Refactor (iter75/cluster-075-responses-agui-host-completion-state):
+//   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
+//   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+public sealed partial class LlmSessionCompletionReadModel
+{
+    public DateTimeOffset? CompletedAt
+    {
+        get => ServiceProjectionReadModelSupport.ToNullableDateTimeOffset(CompletedAtUtcValue);
+        set => CompletedAtUtcValue = ServiceProjectionReadModelSupport.ToNullableTimestamp(value);
+    }
+
+    public IList<LlmSessionCompletedToolCallReadModel> ToolCalls
+    {
+        get => ToolCallEntries;
+        set => ServiceProjectionReadModelSupport.ReplaceCollection(ToolCallEntries, value);
     }
 }
 

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -237,6 +237,7 @@ message LlmSessionCurrentStateReadModel {
   google.protobuf.Timestamp cancelled_at_utc_value = 13;
   int64 ttl_seconds = 14;
   repeated LlmSessionForwardedToolCallReadModel forwarded_tool_call_entries = 15;
+  LlmSessionCompletionReadModel completion = 16;
 }
 
 message LlmSessionForwardedToolCallReadModel {
@@ -250,6 +251,20 @@ message LlmSessionForwardedToolCallReadModel {
   google.protobuf.Timestamp emitted_at_utc_value = 8;
   google.protobuf.Timestamp received_at_utc_value = 9;
   google.protobuf.Timestamp resolved_at_utc_value = 10;
+}
+
+message LlmSessionCompletedToolCallReadModel {
+  string call_id = 1;
+  string tool_name = 2;
+  google.protobuf.Value result = 3;
+}
+
+message LlmSessionCompletionReadModel {
+  string output_text = 1;
+  repeated LlmSessionCompletedToolCallReadModel tool_call_entries = 2;
+  google.protobuf.Timestamp completed_at_utc_value = 3;
+  string failure_code = 4;
+  string failure_message = 5;
 }
 
 // --- ResponsesAgentToolStateCurrentStateReadModel ---

--- a/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
@@ -301,6 +301,13 @@ public sealed class MessagesCommandFacadeTests
             CancellationToken ct = default) =>
             Task.CompletedTask;
 
+        public Task RecordCompletionAsync(
+            string sessionActorId,
+            string responseId,
+            LlmSessionCompletion completion,
+            CancellationToken ct = default) =>
+            Task.CompletedTask;
+
         public Task ReceiveForwardedToolResultAsync(
             string sessionActorId,
             string responseId,

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -5,6 +5,7 @@ using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Application.Responses;
+using Aevatar.Presentation.AGUI;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -240,6 +241,37 @@ public sealed class ResponsesCommandFacadeTests
         sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
     }
 
+    [Fact]
+    public async Task ForwardAsync_WhenTargetResolutionIsCancelled_ShouldRecordFailureCompletion()
+    {
+        var sessions = new RecordingSessionPort();
+        var queryPort = new RecordingSessionQueryPort
+        {
+            Snapshot = BuildSnapshot("resp_forward", "scope-1"),
+        };
+        var forwarding = new ResponsesForwardingApplicationService(
+            teamEntryMemberResolver: new CancellingTeamEntryMemberResolver(),
+            memberPublishedServiceResolver: new StaticMemberPublishedServiceResolver("unused"),
+            staticGAgentStreamInvocationPort: new RecordingStaticGAgentStreamInvocationPort(),
+            completionRecorder: new ResponsesForwardedCompletionRecorder(sessions, queryPort),
+            logger: NullLogger<ResponsesForwardingApplicationService>.Instance);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await forwarding.ForwardAsync(
+            BuildForwardPlan(ForwardToTeamAction("team-1", "chat")),
+            "token",
+            onEventAsync: null,
+            cts.Token);
+
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            408,
+            "request_timeout",
+            "Request timed out."));
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.FailureCode.Should().Be("request_timeout");
+    }
+
     private static ResponsesCommandFacade CreateFacade(
         IResponsesCompletionApplicationService? completionService = null,
         ILlmSessionRegistrationPort? sessionPort = null,
@@ -301,6 +333,25 @@ public sealed class ResponsesCommandFacadeTests
             1,
             "event-1");
 
+    private static ResponsesForwardCommandResult BuildForwardPlan(ChatRouteAction action) =>
+        new(
+            new NormalizedResponsesRequest(
+                "resp_forward",
+                "msg_forward",
+                "model",
+                "hello",
+                true,
+                null,
+                null,
+                null,
+                [],
+                []),
+            new ResponsesCallerScope("scope-1", "owner-1", LlmSessionOriginKind.ApiKey),
+            action,
+            new LlmSessionRegistrationResult("actor-resp_forward", "resp_forward"),
+            null,
+            DateTimeOffset.UtcNow);
+
     private static ChatRouteAction ForwardToModelAction(string modelName) => new()
     {
         ForwardToModel = new ForwardToModel { ModelName = modelName },
@@ -309,6 +360,11 @@ public sealed class ResponsesCommandFacadeTests
     private static ChatRouteAction ForwardToGAgentAction(string actorId) => new()
     {
         ForwardToGagent = new ForwardToGAgent { ActorId = actorId },
+    };
+
+    private static ChatRouteAction ForwardToTeamAction(string teamId, string endpointId) => new()
+    {
+        ForwardToTeam = new ForwardToTeam { TeamId = teamId, EndpointId = endpointId },
     };
 
     private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
@@ -470,5 +526,39 @@ public sealed class ResponsesCommandFacadeTests
 
         public Task<LlmSessionSnapshot?> GetByResponseIdAsync(string responseId, CancellationToken ct = default) =>
             Task.FromResult(Snapshot);
+    }
+
+    private sealed class CancellingTeamEntryMemberResolver : ITeamEntryMemberResolver
+    {
+        public Task<TeamEntryMemberResolution> ResolveAsync(
+            string scopeId,
+            string teamId,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            throw new OperationCanceledException(ct);
+        }
+    }
+
+    private sealed class StaticMemberPublishedServiceResolver(string publishedServiceId)
+        : IMemberPublishedServiceResolver
+    {
+        public Task<MemberPublishedServiceResolution> ResolveAsync(
+            MemberPublishedServiceResolveRequest request,
+            CancellationToken ct = default) =>
+            Task.FromResult(new MemberPublishedServiceResolution(
+                request.ScopeId,
+                request.MemberId,
+                publishedServiceId));
+    }
+
+    private sealed class RecordingStaticGAgentStreamInvocationPort : IStaticGAgentStreamInvocationPort<AGUIEvent>
+    {
+        public Task<StaticGAgentStreamInvocationResult> InvokeAsync(
+            StaticGAgentStreamInvocationRequest request,
+            Func<AGUIEvent, CancellationToken, ValueTask> emitAsync,
+            Func<StaticGAgentStreamAcceptedReceipt, CancellationToken, ValueTask>? onAcceptedAsync = null,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("Invocation should not start when target resolution is cancelled.");
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -50,6 +50,34 @@ public sealed class ResponsesCommandFacadeTests
     }
 
     [Fact]
+    public async Task CreateAsync_WhenForwardToGAgent_ShouldRegisterSessionBeforeReturningForwardPlan()
+    {
+        var completion = new RecordingCompletionService(new ResponsesCompletionResult("unused", null, []));
+        var sessions = new RecordingSessionPort();
+        var facade = CreateFacade(
+            completionService: completion,
+            sessionPort: sessions,
+            chatRouteDecisionPort: new StaticResponsesChatRouteDecisionPort(ForwardToGAgentAction("member-1")));
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "client-model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), "token");
+
+        result.Error.Should().BeNull();
+        result.Forward.Should().NotBeNull();
+        sessions.Registered.Should().ContainSingle();
+        result.Forward!.Session.ResponseId.Should().Be(sessions.Registered[0].ResponseId);
+        result.Forward.Session.ActorId.Should().Be("actor-" + sessions.Registered[0].ResponseId);
+        completion.LastRequest.Should().BeNull("forwarded Responses bypass provider execution but must keep session lifecycle");
+    }
+
+    [Fact]
     public async Task CreateAsync_ShouldReturnAuthenticationError_WhenCallerScopeCannotBeResolved()
     {
         var facade = CreateFacade(callerScopeResolver: new ThrowingCallerScopeResolver());
@@ -278,6 +306,11 @@ public sealed class ResponsesCommandFacadeTests
         ForwardToModel = new ForwardToModel { ModelName = modelName },
     };
 
+    private static ChatRouteAction ForwardToGAgentAction(string actorId) => new()
+    {
+        ForwardToGagent = new ForwardToGAgent { ActorId = actorId },
+    };
+
     private sealed class StaticCallerScopeResolver : IResponsesCallerScopeResolver
     {
         public Task<ResponsesCallerScope> ResolveAsync(string nyxIdAccessToken, CancellationToken ct = default) =>
@@ -376,6 +409,8 @@ public sealed class ResponsesCommandFacadeTests
 
         public List<LlmSessionForwardedToolCall> RecordedToolCalls { get; } = [];
 
+        public List<LlmSessionCompletion> RecordedCompletions { get; } = [];
+
         public Exception? UpdateStatusException { get; init; }
 
         public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
@@ -399,6 +434,16 @@ public sealed class ResponsesCommandFacadeTests
             CancellationToken ct = default)
         {
             RecordedToolCalls.Add(call);
+            return Task.CompletedTask;
+        }
+
+        public Task RecordCompletionAsync(
+            string sessionActorId,
+            string responseId,
+            LlmSessionCompletion completion,
+            CancellationToken ct = default)
+        {
+            RecordedCompletions.Add(completion.Clone());
             return Task.CompletedTask;
         }
 

--- a/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Core/LlmSessionGAgentTests.cs
@@ -259,6 +259,158 @@ public sealed class LlmSessionGAgentTests
     }
 
     [Fact]
+    public async Task HandleRecordCompletionAsync_ShouldRecordCompletedFact()
+    {
+        var actor = CreateActor("resp_1");
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_1"),
+        });
+
+        await actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = BuildCompletion("done"),
+        });
+
+        actor.State.Record!.Status.Should().Be(LlmSessionStatus.Completed);
+        actor.State.Completion.Should().NotBeNull();
+        actor.State.Completion!.OutputText.Should().Be("done");
+        actor.State.Completion.ToolCalls.Should().ContainSingle()
+            .Which.CallId.Should().Be("call_done");
+        actor.State.LastAppliedEventVersion.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task HandleRecordCompletionAsync_ShouldRecordFailureFact()
+    {
+        var actor = CreateActor("resp_1");
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_1"),
+        });
+
+        await actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = new LlmSessionCompletion
+            {
+                FailureCode = "gagent_invocation_failed",
+                FailureMessage = "GAgent invocation failed.",
+            },
+        });
+
+        actor.State.Record!.Status.Should().Be(LlmSessionStatus.Failed);
+        actor.State.Completion!.FailureCode.Should().Be("gagent_invocation_failed");
+        actor.State.Completion.FailureMessage.Should().Be("GAgent invocation failed.");
+    }
+
+    [Fact]
+    public async Task HandleRecordCompletionAsync_ShouldIgnoreDuplicateSameFact()
+    {
+        var actor = CreateActor("resp_1");
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_1"),
+        });
+        await actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = BuildCompletion("done"),
+        });
+        var versionAfterFirstCompletion = actor.State.LastAppliedEventVersion;
+
+        await actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = BuildCompletion("done"),
+        });
+
+        actor.State.LastAppliedEventVersion.Should().Be(versionAfterFirstCompletion);
+    }
+
+    [Fact]
+    public async Task HandleRecordCompletionAsync_ShouldRejectDuplicateDifferentFact()
+    {
+        var actor = CreateActor("resp_1");
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_1"),
+        });
+        await actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = BuildCompletion("done"),
+        });
+
+        var act = () => actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = BuildCompletion("different"),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*completion cannot be rebound to different facts*");
+    }
+
+    [Fact]
+    public async Task HandleRecordCompletionAsync_ShouldRejectInvalidCompletion()
+    {
+        var actor = CreateActor("resp_1");
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_1"),
+        });
+
+        var act = () => actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = new LlmSessionCompletion { FailureCode = "failed_without_message" },
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*failure_message is required*");
+    }
+
+    [Theory]
+    [InlineData(LlmSessionStatus.Cancelled)]
+    [InlineData(LlmSessionStatus.Expired)]
+    public async Task HandleRecordCompletionAsync_ShouldRejectAfterTerminalNonCompletionStatus(LlmSessionStatus status)
+    {
+        var actor = CreateActor("resp_1");
+        await actor.HandleRegisterAsync(new RegisterResponseSessionRequested
+        {
+            Record = BuildRecord("resp_1"),
+        });
+        if (status == LlmSessionStatus.Cancelled)
+        {
+            await actor.HandleUpdateStatusAsync(new UpdateResponseSessionStatusRequested
+            {
+                ResponseId = "resp_1",
+                Status = LlmSessionStatus.Cancelled,
+            });
+        }
+        else
+        {
+            var record = actor.State.Record!;
+            await actor.HandleExpireResponseSessionAsync(new ExpireResponseSessionRequested
+            {
+                ResponseId = "resp_1",
+                ObservedAt = Timestamp.FromDateTimeOffset(ResolveExpiry(record).AddSeconds(1)),
+            });
+        }
+
+        var act = () => actor.HandleRecordCompletionAsync(new RecordResponseSessionCompletionRequested
+        {
+            ResponseId = "resp_1",
+            Completion = BuildCompletion("late"),
+        });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*is {status} and cannot record completion*");
+    }
+
+    [Fact]
     public async Task HandleExpireResponseSessionAsync_ShouldExpirePendingToolCallsWithSyntheticError()
     {
         var actor = CreateActor("resp_1");
@@ -320,4 +472,24 @@ public sealed class LlmSessionGAgentTests
             EmittedAt = Timestamp.FromDateTime(DateTime.UtcNow),
             Expiry = Timestamp.FromDateTime(DateTime.UtcNow.AddHours(1)),
         };
+
+    private static LlmSessionCompletion BuildCompletion(string text) =>
+        new()
+        {
+            OutputText = text,
+            CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow),
+            ToolCalls =
+            {
+                new LlmSessionCompletedToolCall
+                {
+                    CallId = "call_done",
+                    ToolName = "get_weather",
+                    Result = ResponsesJsonValues.ParseBoundaryPayload("""{"ok":true}"""),
+                },
+            },
+        };
+
+    private static DateTimeOffset ResolveExpiry(LlmSessionRecord record) =>
+        (record.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow)
+        .Add(record.Ttl?.ToTimeSpan() ?? TimeSpan.FromHours(24));
 }

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/LlmSessionRegistrationAdapterTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/LlmSessionRegistrationAdapterTests.cs
@@ -257,6 +257,77 @@ public sealed class LlmSessionRegistrationAdapterTests
         await act.Should().ThrowAsync<ArgumentException>().Where(ex => ex.ParamName == param);
     }
 
+    [Fact]
+    public async Task RecordCompletionAsync_ShouldDispatchCompletionEnvelope_WithDefaultTimestamp()
+    {
+        var (adapter, _, dispatch) = CreateAdapter();
+        var completion = new LlmSessionCompletion
+        {
+            OutputText = "forwarded done",
+            ToolCalls =
+            {
+                new LlmSessionCompletedToolCall
+                {
+                    CallId = "call-1",
+                    ToolName = "WebFetch",
+                    Result = ResponsesJsonValues.ParseBoundaryPayload("""{"ok":true}"""),
+                },
+            },
+        };
+
+        await adapter.RecordCompletionAsync("actor-1", "resp_1", completion);
+
+        dispatch.Calls.Should().ContainSingle();
+        dispatch.Calls[0].actorId.Should().Be("actor-1");
+        dispatch.Calls[0].envelope.Payload.TypeUrl.Should().Contain("RecordResponseSessionCompletionRequested");
+        var packed = dispatch.Calls[0].envelope.Payload.Unpack<RecordResponseSessionCompletionRequested>();
+        packed.ResponseId.Should().Be("resp_1");
+        packed.Completion.OutputText.Should().Be("forwarded done");
+        packed.Completion.CompletedAt.Should().NotBeNull();
+        packed.Completion.ToolCalls.Should().ContainSingle()
+            .Which.CallId.Should().Be("call-1");
+    }
+
+    [Fact]
+    public async Task RecordCompletionAsync_ShouldPreservePresetTimestamp()
+    {
+        var (adapter, _, dispatch) = CreateAdapter();
+        var preset = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-04-01T00:00:00+00:00"));
+        var completion = new LlmSessionCompletion
+        {
+            OutputText = "done",
+            CompletedAt = preset,
+        };
+
+        await adapter.RecordCompletionAsync("actor-1", "resp_1", completion);
+
+        var packed = dispatch.Calls[0].envelope.Payload.Unpack<RecordResponseSessionCompletionRequested>();
+        packed.Completion.CompletedAt.Should().Be(preset);
+    }
+
+    [Theory]
+    [InlineData("", "resp_1", "sessionActorId")]
+    [InlineData("actor-1", "", "responseId")]
+    public async Task RecordCompletionAsync_ShouldRejectMissingArguments(string actorId, string respId, string param)
+    {
+        var (adapter, _, _) = CreateAdapter();
+        var completion = new LlmSessionCompletion();
+
+        var act = () => adapter.RecordCompletionAsync(actorId, respId, completion);
+
+        await act.Should().ThrowAsync<ArgumentException>().Where(ex => ex.ParamName == param);
+    }
+
+    [Fact]
+    public async Task RecordCompletionAsync_ShouldRejectNullCompletion()
+    {
+        var (adapter, _, _) = CreateAdapter();
+
+        var act = () => adapter.RecordCompletionAsync("actor-1", "resp_1", null!);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
     private static (LlmSessionRegistrationAdapter adapter, RecordingRuntime runtime, RecordingDispatchPort dispatch) CreateAdapter()
     {
         var runtime = new RecordingRuntime();

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionCurrentStateProjectorTests.cs
@@ -48,6 +48,13 @@ public sealed class LlmSessionCurrentStateProjectorTests
         doc.ForwardedToolCalls.Should().ContainSingle();
         doc.ForwardedToolCalls[0].CallId.Should().Be("call_1");
         doc.ForwardedToolCalls[0].Status.Should().Be((int)LlmSessionForwardedToolCallStatus.Received);
+        doc.Completion.Should().NotBeNull();
+        doc.Completion!.OutputText.Should().Be("completed text");
+        doc.Completion.ToolCalls.Should().ContainSingle();
+        doc.Completion.ToolCalls[0].CallId.Should().Be("call_done");
+        ResponsesJsonValues.ToBoundaryJson(doc.Completion.ToolCalls[0].Result)
+            .Should().Be("""{"result":true}""");
+        doc.Completion.FailureCode.Should().BeEmpty();
 
         var snapshot = await reader.GetByResponseIdAsync("resp_1");
         snapshot.Should().NotBeNull();
@@ -55,6 +62,57 @@ public sealed class LlmSessionCurrentStateProjectorTests
         snapshot.Status.Should().Be(LlmSessionStatus.Completed);
         snapshot.ForwardedToolCalls.Should().ContainSingle();
         snapshot.ForwardedToolCalls![0].ResultJson.Should().Be("""{"temperature":28}""");
+        snapshot.Completion.Should().NotBeNull();
+        snapshot.Completion!.OutputText.Should().Be("completed text");
+        snapshot.Completion.ToolCalls.Should().ContainSingle()
+            .Which.ResultJson.Should().Be("""{"result":true}""");
+    }
+
+    [Fact]
+    public async Task QueryReader_ShouldMapCompletionToolResultJson_AndFailureFields()
+    {
+        var store = new RecordingDocumentStore<LlmSessionCurrentStateReadModel>(x => x.Id);
+        var reader = new LlmSessionQueryReader(store);
+        await store.UpsertAsync(new LlmSessionCurrentStateReadModel
+        {
+            Id = LlmSessionIds.BuildKey("resp_failed"),
+            ResponseId = "resp_failed",
+            ScopeId = "user-1",
+            OwnerSubject = "user-1",
+            OriginKind = (int)LlmSessionOriginKind.ApiKey,
+            Status = (int)LlmSessionStatus.Failed,
+            ActorId = ActorId,
+            StateVersion = 4,
+            LastEventId = "evt-failed",
+            CreatedAt = DateTimeOffset.Parse("2026-04-27T01:00:00+00:00"),
+            TtlSeconds = (long)TimeSpan.FromHours(1).TotalSeconds,
+            Completion = new LlmSessionCompletionReadModel
+            {
+                OutputText = "partial",
+                CompletedAt = DateTimeOffset.Parse("2026-04-27T01:01:00+00:00"),
+                FailureCode = "gagent_invocation_failed",
+                FailureMessage = "GAgent invocation failed.",
+                ToolCalls =
+                {
+                    new LlmSessionCompletedToolCallReadModel
+                    {
+                        CallId = "call_failed",
+                        ToolName = "WebFetch",
+                        Result = ResponsesJsonValues.ParseBoundaryPayload("""{"error":"boom"}"""),
+                    },
+                },
+            },
+        });
+
+        var snapshot = await reader.GetByResponseIdAsync("resp_failed");
+
+        snapshot.Should().NotBeNull();
+        snapshot!.Completion.Should().NotBeNull();
+        snapshot.Completion!.OutputText.Should().Be("partial");
+        snapshot.Completion.FailureCode.Should().Be("gagent_invocation_failed");
+        snapshot.Completion.FailureMessage.Should().Be("GAgent invocation failed.");
+        snapshot.Completion.ToolCalls.Should().ContainSingle()
+            .Which.ResultJson.Should().Be("""{"error":"boom"}""");
     }
 
     [Fact]
@@ -157,6 +215,20 @@ public sealed class LlmSessionCurrentStateProjectorTests
             ReceivedAt = Timestamp.FromDateTimeOffset(observedAt.AddMinutes(-1)),
             Expiry = Timestamp.FromDateTimeOffset(observedAt.AddHours(1)),
         });
+        state.Completion = new LlmSessionCompletion
+        {
+            OutputText = "completed text",
+            CompletedAt = Timestamp.FromDateTimeOffset(observedAt),
+            ToolCalls =
+            {
+                new LlmSessionCompletedToolCall
+                {
+                    CallId = "call_done",
+                    ToolName = "get_weather",
+                    Result = ResponsesJsonValues.ParseBoundaryPayload("""{"result":true}"""),
+                },
+            },
+        };
         return new EventEnvelope
         {
             Id = $"outer-{eventId}",

--- a/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
@@ -842,6 +842,12 @@ public sealed class MainnetMessagesEndpointsTests
             LlmSessionForwardedToolCall call,
             CancellationToken ct = default) => Task.CompletedTask;
 
+        public Task RecordCompletionAsync(
+            string sessionActorId,
+            string responseId,
+            LlmSessionCompletion completion,
+            CancellationToken ct = default) => Task.CompletedTask;
+
         public Task ReceiveForwardedToolResultAsync(
             string sessionActorId,
             string responseId,

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -1100,6 +1100,7 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.AddSingleton<ResponsesForwardedCompletionRecorder>();
+        builder.Services.AddSingleton<IResponsesForwardingApplicationService, ResponsesForwardingApplicationService>();
         builder.Services.AddSingleton<IResponsesCallerScopeResolver>(new StubResponsesCallerScopeResolver());
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(StaticChatRoutePolicyQueryPort.ForSnapshot(
             new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
@@ -1169,6 +1170,7 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.AddSingleton<ResponsesForwardedCompletionRecorder>();
+        builder.Services.AddSingleton<IResponsesForwardingApplicationService, ResponsesForwardingApplicationService>();
         builder.Services.AddSingleton<IResponsesCallerScopeResolver>(new StubResponsesCallerScopeResolver());
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(queryPort);
         builder.Services.AddSingleton(new ChatRouteResolver(new StaticChatRouteFallbackProvider(string.Empty)));
@@ -1718,8 +1720,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var memberResolver = StubMemberPublishedServiceResolver.ForPublishedService("published-svc-stream");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.EmittingText("alpha ", "beta");
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1742,6 +1746,8 @@ public sealed class MainnetResponsesEndpointsTests
         body.Should().Contain("event: response.output_text.done");
         body.Should().Contain("\"text\":\"alpha beta\"");
         body.Should().Contain("event: response.completed");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("alpha beta");
         provider.LastRequest.Should().BeNull();
         staticPort.LastRequest!.Identity!.ServiceId.Should().Be("published-svc-stream");
     }
@@ -1759,8 +1765,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var memberResolver = StubMemberPublishedServiceResolver.ForPublishedService("published-svc-run-error");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.EmittingRunError();
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1782,6 +1790,8 @@ public sealed class MainnetResponsesEndpointsTests
         body.Should().NotContain("event: response.completed");
         body.Should().NotContain("team_invocation_failed");
         body.Should().NotContain("Team invocation failed");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be("gagent_invocation_failed");
         provider.LastRequest.Should().BeNull();
     }
 
@@ -1794,8 +1804,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var memberResolver = StubMemberPublishedServiceResolver.ForPublishedService("published-svc-run-error");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.EmittingRunError();
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1814,6 +1826,8 @@ public sealed class MainnetResponsesEndpointsTests
         var err = doc.RootElement.GetProperty("error");
         err.GetProperty("code").GetString().Should().Be("gagent_invocation_failed");
         err.GetProperty("message").GetString().Should().Be("GAgent invocation failed.");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be("gagent_invocation_failed");
         provider.LastRequest.Should().BeNull();
     }
 
@@ -1825,8 +1839,10 @@ public sealed class MainnetResponsesEndpointsTests
             ForwardToGAgentAction(string.Empty),
             []));
         var staticPort = RecordingStaticGAgentStreamInvocationPort.Empty();
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             staticGAgentStreamInvocationPort: staticPort);
 
@@ -1843,6 +1859,8 @@ public sealed class MainnetResponsesEndpointsTests
         using var doc = JsonDocument.Parse(body);
         doc.RootElement.GetProperty("error").GetProperty("code").GetString()
             .Should().Be("chat_route_invalid");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be("chat_route_invalid");
         staticPort.LastRequest.Should().BeNull();
         provider.LastRequest.Should().BeNull();
     }
@@ -1863,8 +1881,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var memberResolver = StubMemberPublishedServiceResolver.Identity();
         var staticPort = ThrowingStaticGAgentStreamInvocationPort.ServiceNotFound("user-1:default:default:ghost-member");
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1883,6 +1903,8 @@ public sealed class MainnetResponsesEndpointsTests
         var err = doc.RootElement.GetProperty("error");
         err.GetProperty("code").GetString().Should().Be("gagent_target_not_found");
         err.GetProperty("message").GetString().Should().Contain("ghost-member");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be("gagent_target_not_found");
         provider.LastRequest.Should().BeNull();
     }
 
@@ -1895,8 +1917,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var memberResolver = StubMemberPublishedServiceResolver.Identity();
         var staticPort = ThrowingStaticGAgentStreamInvocationPort.ServiceNotFound("user-1:default:default:ghost-member");
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1916,6 +1940,8 @@ public sealed class MainnetResponsesEndpointsTests
         body.Should().Contain("event: response.failed");
         body.Should().Contain("\"code\":\"gagent_target_not_found\"");
         body.Should().Contain("ghost-member");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be("gagent_target_not_found");
         provider.LastRequest.Should().BeNull();
     }
 
@@ -1932,8 +1958,10 @@ public sealed class MainnetResponsesEndpointsTests
         var memberResolver = StubMemberPublishedServiceResolver.Throwing(
             "memberId must not contain ':', '/', '\\\\', '?' or '#'.");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.Empty();
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1951,6 +1979,8 @@ public sealed class MainnetResponsesEndpointsTests
         using var doc = JsonDocument.Parse(body);
         doc.RootElement.GetProperty("error").GetProperty("code").GetString()
             .Should().Be("chat_route_invalid");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be("chat_route_invalid");
         staticPort.LastRequest.Should().BeNull();
         provider.LastRequest.Should().BeNull();
     }
@@ -2018,8 +2048,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var teamResolver = StubTeamEntryMemberResolver.ForResolution("published-svc-2");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.EmittingText("alpha ", "beta");
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             teamEntryMemberResolver: teamResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -2042,6 +2074,8 @@ public sealed class MainnetResponsesEndpointsTests
         body.Should().Contain("event: response.output_text.done");
         body.Should().Contain("\"text\":\"alpha beta\"");
         body.Should().Contain("event: response.completed");
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("alpha beta");
         provider.LastRequest.Should().BeNull();
     }
 
@@ -2053,8 +2087,10 @@ public sealed class MainnetResponsesEndpointsTests
             ForwardToTeamAction("missing-team", "chat"),
             []));
         var staticPort = RecordingStaticGAgentStreamInvocationPort.Empty();
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             teamEntryMemberResolver: StubTeamEntryMemberResolver.NotFound(),
             staticGAgentStreamInvocationPort: staticPort);
@@ -2072,6 +2108,8 @@ public sealed class MainnetResponsesEndpointsTests
         using var doc = JsonDocument.Parse(body);
         doc.RootElement.GetProperty("error").GetProperty("code").GetString()
             .Should().Be(TeamEntryMemberErrorCodes.TeamNotFound);
+        responseSessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.FailureCode.Should().Be(TeamEntryMemberErrorCodes.TeamNotFound);
         staticPort.LastRequest.Should().BeNull();
     }
 
@@ -2127,6 +2165,7 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
         builder.Services.AddSingleton<ResponsesForwardedCompletionRecorder>();
+        builder.Services.AddSingleton<IResponsesForwardingApplicationService, ResponsesForwardingApplicationService>();
         builder.Services.AddSingleton(callerScopeResolver ?? new StubResponsesCallerScopeResolver());
         builder.Services.AddSingleton(chatRoutePolicyQueryPort ?? StaticChatRoutePolicyQueryPort.ForSnapshot(
             new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -1099,6 +1099,7 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<ILlmSessionQueryPort>(sessions);
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
+        builder.Services.AddSingleton<ResponsesForwardedCompletionRecorder>();
         builder.Services.AddSingleton<IResponsesCallerScopeResolver>(new StubResponsesCallerScopeResolver());
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(StaticChatRoutePolicyQueryPort.ForSnapshot(
             new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
@@ -1167,6 +1168,7 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<ILlmSessionQueryPort>(sessions);
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
+        builder.Services.AddSingleton<ResponsesForwardedCompletionRecorder>();
         builder.Services.AddSingleton<IResponsesCallerScopeResolver>(new StubResponsesCallerScopeResolver());
         builder.Services.AddSingleton<IChatRoutePolicyQueryPort>(queryPort);
         builder.Services.AddSingleton(new ChatRouteResolver(new StaticChatRouteFallbackProvider(string.Empty)));
@@ -1660,8 +1662,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var memberResolver = StubMemberPublishedServiceResolver.ForPublishedService("published-svc-member-7");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.EmittingText("hello", " ", "agent");
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             memberPublishedServiceResolver: memberResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1676,6 +1680,8 @@ public sealed class MainnetResponsesEndpointsTests
         var body = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        responseSessions.Registered.Should().ContainSingle();
+        responseSessions.RecordedCompletions.Should().ContainSingle();
         provider.LastRequest.Should().BeNull(
             "ForwardToGAgent must bypass the LLM provider entirely");
         staticPort.LastRequest.Should().NotBeNull();
@@ -1699,6 +1705,8 @@ public sealed class MainnetResponsesEndpointsTests
         var content = message.GetProperty("content")[0];
         content.GetProperty("type").GetString().Should().Be("output_text");
         content.GetProperty("text").GetString().Should().Be("hello agent");
+        var snapshot = await responseSessions.GetByResponseIdAsync(root.GetProperty("id").GetString()!);
+        snapshot!.Completion!.OutputText.Should().Be("hello agent");
     }
 
     [Fact]
@@ -1956,8 +1964,10 @@ public sealed class MainnetResponsesEndpointsTests
             []));
         var teamResolver = StubTeamEntryMemberResolver.ForResolution("published-svc-1");
         var staticPort = RecordingStaticGAgentStreamInvocationPort.EmittingText("hel", "lo", " world");
+        var responseSessions = new RecordingResponseSessionStore();
         await using var app = await CreateAppAsync(
             provider,
+            responseSessions,
             chatRoutePolicyQueryPort: queryPort,
             teamEntryMemberResolver: teamResolver,
             staticGAgentStreamInvocationPort: staticPort);
@@ -1972,6 +1982,8 @@ public sealed class MainnetResponsesEndpointsTests
         var body = await response.Content.ReadAsStringAsync();
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, body);
+        responseSessions.Registered.Should().ContainSingle();
+        responseSessions.RecordedCompletions.Should().ContainSingle();
         provider.LastRequest.Should().BeNull(
             "ForwardToTeam must bypass the LLM provider entirely");
         staticPort.LastRequest.Should().NotBeNull();
@@ -1993,6 +2005,8 @@ public sealed class MainnetResponsesEndpointsTests
         var content = message.GetProperty("content")[0];
         content.GetProperty("type").GetString().Should().Be("output_text");
         content.GetProperty("text").GetString().Should().Be("hello world");
+        var snapshot = await responseSessions.GetByResponseIdAsync(root.GetProperty("id").GetString()!);
+        snapshot!.Completion!.OutputText.Should().Be("hello world");
     }
 
     [Fact]
@@ -2112,6 +2126,7 @@ public sealed class MainnetResponsesEndpointsTests
         builder.Services.AddSingleton<ILlmSessionQueryPort>(responseSessions);
         builder.Services.AddSingleton<IResponsesCompletionApplicationService, ResponsesCompletionApplicationService>();
         builder.Services.AddSingleton<IResponsesCommandFacade, ResponsesCommandFacade>();
+        builder.Services.AddSingleton<ResponsesForwardedCompletionRecorder>();
         builder.Services.AddSingleton(callerScopeResolver ?? new StubResponsesCallerScopeResolver());
         builder.Services.AddSingleton(chatRoutePolicyQueryPort ?? StaticChatRoutePolicyQueryPort.ForSnapshot(
             new ChatRoutePolicySnapshot(ForwardToModelAction(string.Empty), [])));
@@ -2638,6 +2653,8 @@ public sealed class MainnetResponsesEndpointsTests
 
         public List<(string ActorId, string ResponseId, LlmSessionForwardedToolCall Call)> ForwardedToolCalls { get; } = [];
 
+        public List<(string ActorId, string ResponseId, LlmSessionCompletion Completion)> RecordedCompletions { get; } = [];
+
         public List<(string ActorId, string ResponseId, string CallId, string SchemaHash, string ResultJson)> ToolResults { get; } = [];
 
         public List<(string ActorId, string ResponseId, string CallId)> ResolvedToolResults { get; } = [];
@@ -2724,6 +2741,40 @@ public sealed class MainnetResponsesEndpointsTests
                     ForwardedToolCalls = calls,
                     StateVersion = current.StateVersion + 1,
                     LastEventId = $"{responseId}:tool:{clone.CallId}:emitted",
+                };
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task RecordCompletionAsync(
+            string sessionActorId,
+            string responseId,
+            LlmSessionCompletion completion,
+            CancellationToken ct = default)
+        {
+            var clone = completion.Clone();
+            RecordedCompletions.Add((sessionActorId, responseId, clone));
+            if (_snapshots.TryGetValue(responseId, out var current))
+            {
+                _snapshots[responseId] = current with
+                {
+                    Status = string.IsNullOrWhiteSpace(clone.FailureCode)
+                        ? LlmSessionStatus.Completed
+                        : LlmSessionStatus.Failed,
+                    StateVersion = current.StateVersion + 1,
+                    LastEventId = $"{responseId}:completion",
+                    Completion = new LlmSessionCompletionSnapshot(
+                        clone.OutputText ?? string.Empty,
+                        clone.ToolCalls
+                            .Select(static call => new LlmSessionCompletedToolCallSnapshot(
+                                call.CallId,
+                                call.ToolName,
+                                ResponsesJsonValues.ToBoundaryJson(call.Result)))
+                            .ToArray(),
+                        clone.CompletedAt?.ToDateTimeOffset(),
+                        string.IsNullOrWhiteSpace(clone.FailureCode) ? null : clone.FailureCode,
+                        string.IsNullOrWhiteSpace(clone.FailureMessage) ? null : clone.FailureMessage),
                 };
             }
 

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -28,6 +28,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Hosting.Tests;
 
@@ -1796,6 +1797,39 @@ public sealed class MainnetResponsesEndpointsTests
     }
 
     [Fact]
+    public async Task PostResponses_WhenStreamingInitialSseWriteIsCancelled_ShouldRecordFailureCompletionBeforeForwarding()
+    {
+        var commandFacade = new StaticResponsesCommandFacade(
+            ResponsesCreateCommandResult.FromForward(BuildForwardPlan(ForwardToGAgentAction("member-stream-cancel"))));
+        var forwardingService = new RecordingForwardingApplicationService();
+        var context = new DefaultHttpContext
+        {
+            Response =
+            {
+                Body = new CancellingWriteStream(),
+            },
+        };
+        context.Request.Headers.Authorization = "Bearer stream-cancel-secret";
+        var request = new ResponsesCreateRequest
+        {
+            Model = "original-model",
+            Input = JsonDocument.Parse("\"stream me\"").RootElement.Clone(),
+            Stream = true,
+        };
+
+        await ResponsesApiEndpoints.HandleCreateResponseAsync(
+            context,
+            request,
+            commandFacade,
+            forwardingService,
+            LoggerFactory.Create(static _ => { }),
+            context.RequestAborted);
+
+        forwardingService.ForwardCalls.Should().Be(0);
+        forwardingService.Failures.Should().ContainSingle().Which.Code.Should().Be("request_timeout");
+    }
+
+    [Fact]
     public async Task PostResponses_WhenForwardToGAgentEmitsRunError_ReturnsFailureInsteadOfCompletedResponse()
     {
         var provider = new RecordingLLMProvider();
@@ -2313,6 +2347,25 @@ public sealed class MainnetResponsesEndpointsTests
         ForwardToTeam = new ForwardToTeam { TeamId = teamId, EndpointId = endpointId },
     };
 
+    private static ResponsesForwardCommandResult BuildForwardPlan(ChatRouteAction action) =>
+        new(
+            new NormalizedResponsesRequest(
+                "resp_forward",
+                "msg_forward",
+                "model",
+                "stream me",
+                true,
+                null,
+                null,
+                null,
+                [],
+                []),
+            new ResponsesCallerScope("user-1", "user-1", LlmSessionOriginKind.ApiKey),
+            action,
+            new LlmSessionRegistrationResult("actor-resp_forward", "resp_forward"),
+            null,
+            DateTimeOffset.UtcNow);
+
     private sealed class StubTeamEntryMemberResolver : ITeamEntryMemberResolver
     {
         private readonly Func<string, string, TeamEntryMemberResolution> _resolve;
@@ -2452,6 +2505,94 @@ public sealed class MainnetResponsesEndpointsTests
                 CompletionStatus: GAgentDraftRunCompletionStatus.RunFinished,
                 CompletionObserved: true);
         }
+    }
+
+    private sealed class StaticResponsesCommandFacade(ResponsesCreateCommandResult createResult) : IResponsesCommandFacade
+    {
+        public Task<ResponsesCreateCommandResult> CreateAsync(
+            ResponsesCommandRequest request,
+            string bearerToken,
+            CancellationToken ct = default) =>
+            Task.FromResult(createResult);
+
+        public Task<ResponsesCancelCommandResult> CancelAsync(
+            string responseId,
+            string bearerToken,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task<ResponsesStreamCommandResult> StreamAsync(
+            ResponsesCreateCommandPlan plan,
+            Func<string, CancellationToken, ValueTask> onTextDelta,
+            CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class RecordingForwardingApplicationService : IResponsesForwardingApplicationService
+    {
+        public int ForwardCalls { get; private set; }
+
+        public List<(ResponsesForwardCommandResult Plan, string Code, string Message)> Failures { get; } = [];
+
+        public Task<ResponsesForwardingResult> ForwardAsync(
+            ResponsesForwardCommandResult plan,
+            string bearerToken,
+            Func<AGUIEvent, CancellationToken, ValueTask>? onEventAsync = null,
+            CancellationToken ct = default)
+        {
+            ForwardCalls++;
+            return Task.FromResult(ResponsesForwardingResult.FromError(
+                500,
+                "unexpected_forward",
+                "Forward should not start after initial SSE write cancellation."));
+        }
+
+        public Task<ResponsesForwardingResult> RecordForwardedFailureAsync(
+            ResponsesForwardCommandResult plan,
+            string code,
+            string message,
+            CancellationToken ct = default)
+        {
+            Failures.Add((plan, code, message));
+            return Task.FromResult(ResponsesForwardingResult.FromError(500, code, message));
+        }
+    }
+
+    private sealed class CancellingWriteStream : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new OperationCanceledException(new CancellationToken(canceled: true));
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException(new OperationCanceledException(new CancellationToken(canceled: true)));
     }
 
     private sealed class ThrowingStaticGAgentStreamInvocationPort : IStaticGAgentStreamInvocationPort<AGUIEvent>


### PR DESCRIPTION
## 摘要

iter75 cluster-075-responses-agui-host-completion-state(severity:high,rules:AG-LAYER-01 + AG-PROJECTION-01 + AG-OBSERVE-01 + AG-READMODEL-01 + AG-MIDSTATE-01)。Phase 9 r1 unanimous 3/3。

- **Old**:`ResponsesCommandFacade.ForwardToTeam/ForwardToGAgent` 在 `RegisterSessionAsync` 之前 return,**跳过** `LlmSessionGAgent` session lifecycle;`ResponsesEndpoints` request 方法里 new `StringBuilder` + `Dictionary<string,string>` + `List<ToolCall>` 累积 AGUI 回调,构造 `response.completed` snapshot
- **New**:forwarded Responses 走 `LlmSessionGAgent` lifecycle + current-state readmodel(typed completion field);Host 只 render `response.completed` from readmodel snapshot;`AGUIEventToResponsesSseAdapter` 不再 owned completion accumulator

违反:CLAUDE「API 仅做宿主与组合,不承载核心业务编排」「查询始终走 readmodel」「禁止中间层维护 entity/actor/workflow-run/session ID 到上下文/事实状态的进程内映射」「actor 即业务实体」。

## Phase 9 共识

**r1 3/3 unanimous propose**(framing:`reuse-llm-session-host-protocol-only`)。see #967 meta-judge 评论。

## 范围

20 文件改动(+749 / -84):
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs`(ForwardTo* 改在 RegisterSession 之后)
- `src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardedCompletionRecorder.cs`(新建)
- `src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs`(typed completion contract)
- `src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto`(typed completion field)
- `src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto`(完成态 read model field)
- `src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionCurrentStateProjector.cs`(物化 completion)
- `src/platform/Aevatar.GAgentService.Projection/Queries/LlmSessionQueryReader.cs`(暴露 completion query)
- `src/platform/Aevatar.GAgentService.Infrastructure/Adapters/LlmSessionRegistrationAdapter.cs`(接入 registration)
- `src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs`(去 Host StringBuilder/Dict/List,改 readmodel render)
- `src/Aevatar.Mainnet.Host.Api/Responses/AGUIEventToResponsesSseAdapter.cs`(streaming 同 pattern)
- 测试:`ResponsesCommandFacadeTests` + `MainnetResponsesEndpointsTests`(验证 forwarded Responses 创 session/readmodel fact + completion render from typed contract)

验证:GAgentService + Mainnet.Host.Api 编译 ✅ + 测试 pass + 两个 `ci/*_guards.sh` pass。

closes #967

## Stacked-PR

Part of iter75 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter75

⟦AI:AUTO-LOOP⟧
