### PR TITLE
iter76 cluster-076: Script domain event 不再持久化 derived projection payloads,projector 从 state_root 派生

### DIFF
--- a/docs/canon/scripting.md
+++ b/docs/canon/scripting.md
@@ -49,7 +49,7 @@ owner: eanzhao
 3. 定义侧把脚本编译为 `ScriptBehaviorDescriptor + ScriptGAgentContract`。
 4. runtime provisioning 必须显式携带 `ScriptDefinitionSnapshot`；`RuntimeScriptProvisioningService` 不再中途侧读 definition readmodel，也不再轮询等待投影。
 5. 运行侧由 `ScriptBehaviorGAgent` 宿主脚本行为，并在 commit 后发布 `CommittedStateEventPublished(state_event + state_root)` 观察流。
-6. 写侧 dispatcher 会基于 post-event state 调 `BuildReadModel(...)`，再把 semantic/native committed fact 一并发布出去。
+6. projection materializer 从 committed `state_root + ScriptDomainFactCommitted` 派生当前态 readmodel / native_doc / native_graph；actor write-side 只发布 committed business fact 与 state root。
 7. 读侧由 `ScriptReadModelProjector` / `ScriptDefinitionSnapshotProjector` / `ScriptCatalogEntryProjector` / `ScriptNativeDocumentProjector` / `ScriptNativeGraphProjector` 基于 committed observation 构建当前态与 native readmodel。
 8. 查询只通过 `ScriptReadModelQueryReader -> ScriptReadModelQueryApplicationService` 读取 persisted snapshot/document；read-side 不再执行 behavior query，也不再暴露 declared-query authoring/runtime 契约。
 9. 演化链继续由 `ScriptEvolutionSessionGAgent / ScriptEvolutionManagerGAgent / ScriptCatalogGAgent` 承担治理与索引职责。
@@ -191,7 +191,7 @@ flowchart LR
 3. 运行期 `publish/send/self-signal/durable-timeout` 语义必须保持 runtime-neutral。
 4. 影响业务语义、控制流、稳定读取的数据必须强类型建模，不重新退回 bag。
 5. Scripting 与 Workflow/CQRS Core 继续共享统一 envelope / projection 主链，不引入第二套 read-side pipeline。
-6. projection 不得再解析 behavior artifact 或编译 native materialization plan；native materialization 必须来自 actor write-side durable contract。
+6. projection 阶段负责解析 behavior artifact 并编译 native materialization plan；actor write-side 只保留 committed business fact，不承担 readmodel / native_doc / native_graph 物化职责。
 7. runtime semantics 必须 descriptor-first，禁止再依赖 `google.protobuf.*` wrapper fallback 推断 command / signal / event 语义。
 
 ## 9. 历史文档整理结论

--- a/docs/canon/scripting.md
+++ b/docs/canon/scripting.md
@@ -131,9 +131,10 @@ flowchart LR
 这意味着：
 
 1. `CommittedStateEventPublished` 现在携带 `state_event + state_root`，作为 scripting current-state readmodel 的统一观察输入。
-2. `ScriptDomainFactCommitted` 继续表达脚本业务事实，但 current-state projection 不再要求读侧用 reducer 从旧文档补算当前态；每一条 committed fact 自身携带的 `read_model_payload/native_document/native_graph` 都必须对应它自己的 post-event state/version。
+2. `ScriptDomainFactCommitted` 只表达已经提交的脚本业务事实；它不再携带派生的 current-state readmodel、native document 或 native graph 结果。
 3. runtime provisioning 必须显式使用 write-side 已得出的 `ScriptDefinitionSnapshot`，而不是中间层再去读 definition readmodel。
-4. native document / graph 物化计划已经前移到 write-side；projection 只消费 `ScriptDomainFactCommitted` 内的 durable `native_document/native_graph` 子契约。
+4. current-state readmodel、native document 与 native graph 由 projection 基于 `CommittedStateEventPublished.state_root + ScriptDomainFactCommitted` 派生并物化。
+5. 旧 `ScriptDomainFactCommitted` 字段 `15/16/17` 已在 proto 中 reserved；生产链路不再 emit `read_model_payload/native_document/native_graph`，读侧仅将它们作为历史事件的 legacy fallback 解析。
 
 ### 5.3 读侧权威模型
 

--- a/src/Aevatar.Scripting.Abstractions/ScriptDomainFactCommitted.LegacyDerivedPayloads.cs
+++ b/src/Aevatar.Scripting.Abstractions/ScriptDomainFactCommitted.LegacyDerivedPayloads.cs
@@ -1,0 +1,67 @@
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Scripting.Abstractions;
+
+public sealed partial class ScriptDomainFactCommitted
+{
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
+    private const int LegacyReadModelPayloadFieldNumber = 15;
+    private const int LegacyNativeDocumentFieldNumber = 16;
+    private const int LegacyNativeGraphFieldNumber = 17;
+
+    public Any? TryGetLegacyReadModelPayload() =>
+        TryParseLegacyLengthDelimited(
+            LegacyReadModelPayloadFieldNumber,
+            Any.Parser,
+            out var payload)
+            ? payload
+            : null;
+
+    public ScriptNativeDocumentProjection? TryGetLegacyNativeDocument() =>
+        TryParseLegacyLengthDelimited(
+            LegacyNativeDocumentFieldNumber,
+            ScriptNativeDocumentProjection.Parser,
+            out var nativeDocument)
+            ? nativeDocument
+            : null;
+
+    public ScriptNativeGraphProjection? TryGetLegacyNativeGraph() =>
+        TryParseLegacyLengthDelimited(
+            LegacyNativeGraphFieldNumber,
+            ScriptNativeGraphProjection.Parser,
+            out var nativeGraph)
+            ? nativeGraph
+            : null;
+
+    private bool TryParseLegacyLengthDelimited<TMessage>(
+        int fieldNumber,
+        MessageParser<TMessage> parser,
+        out TMessage? message)
+        where TMessage : class, IMessage<TMessage>
+    {
+        ArgumentNullException.ThrowIfNull(parser);
+
+        message = null;
+        var input = new CodedInputStream(((IMessage)this).ToByteArray());
+        while (!input.IsAtEnd)
+        {
+            var tag = input.ReadTag();
+            if (tag == 0)
+                break;
+
+            if (WireFormat.GetTagFieldNumber(tag) == fieldNumber &&
+                WireFormat.GetTagWireType(tag) == WireFormat.WireType.LengthDelimited)
+            {
+                message = parser.ParseFrom(input.ReadBytes());
+                return message != null;
+            }
+
+            input.SkipLastField();
+        }
+
+        return false;
+    }
+}

--- a/src/Aevatar.Scripting.Abstractions/script_host_messages.proto
+++ b/src/Aevatar.Scripting.Abstractions/script_host_messages.proto
@@ -343,6 +343,8 @@ message ScriptNativeGraphProjection {
 }
 
 message ScriptDomainFactCommitted {
+  reserved 15, 16, 17;
+  reserved "read_model_payload", "native_document", "native_graph";
   string actor_id = 1;
   string definition_actor_id = 2;
   string script_id = 3;
@@ -357,9 +359,6 @@ message ScriptDomainFactCommitted {
   string read_model_type_url = 12;
   int64 state_version = 13;
   int64 occurred_at_unix_time_ms = 14;
-  google.protobuf.Any read_model_payload = 15;
-  ScriptNativeDocumentProjection native_document = 16;
-  ScriptNativeGraphProjection native_graph = 17;
   string scope_id = 18;
 }
 

--- a/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorDispatcher.cs
+++ b/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorDispatcher.cs
@@ -3,7 +3,6 @@ using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Abstractions.Behaviors;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Serialization;
-using Aevatar.Scripting.Core.Materialization;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 
@@ -11,20 +10,17 @@ namespace Aevatar.Scripting.Application.Runtime;
 
 public sealed class ScriptBehaviorDispatcher : IScriptBehaviorDispatcher
 {
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     private readonly IScriptBehaviorArtifactResolver _artifactResolver;
-    private readonly IScriptReadModelMaterializationCompiler _materializationCompiler;
-    private readonly IScriptNativeProjectionBuilder _nativeProjectionBuilder;
     private readonly IProtobufMessageCodec _codec;
 
     public ScriptBehaviorDispatcher(
         IScriptBehaviorArtifactResolver artifactResolver,
-        IScriptReadModelMaterializationCompiler materializationCompiler,
-        IScriptNativeProjectionBuilder nativeProjectionBuilder,
         IProtobufMessageCodec codec)
     {
         _artifactResolver = artifactResolver ?? throw new ArgumentNullException(nameof(artifactResolver));
-        _materializationCompiler = materializationCompiler ?? throw new ArgumentNullException(nameof(materializationCompiler));
-        _nativeProjectionBuilder = nativeProjectionBuilder ?? throw new ArgumentNullException(nameof(nativeProjectionBuilder));
         _codec = codec ?? throw new ArgumentNullException(nameof(codec));
     }
 
@@ -90,11 +86,6 @@ public sealed class ScriptBehaviorDispatcher : IScriptBehaviorDispatcher
             ValidateDomainEventContract(request, artifact.Descriptor, domainEvents);
 
             var occurredAtUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            var materializationPlan = request.CachedMaterializationPlan
-                ?? _materializationCompiler.Compile(
-                    artifact,
-                    request.ReadModelSchemaHash,
-                    request.ReadModelSchemaVersion);
             var committed = new List<ScriptDomainFactCommitted>(domainEvents.Count);
             var projectedState = currentState;
             for (var i = 0; i < domainEvents.Count; i++)
@@ -128,22 +119,6 @@ public sealed class ScriptBehaviorDispatcher : IScriptBehaviorDispatcher
                     projectedState,
                     domainEvent,
                     CreateFactContext(request, fact, eventTypeUrl));
-
-                var factContext = CreateFactContext(request, fact, fact.EventType ?? string.Empty);
-                var semanticReadModel = behavior.BuildReadModel(
-                    projectedState,
-                    factContext);
-                fact.ReadModelPayload = _codec.Pack(semanticReadModel)?.Clone();
-                fact.NativeDocument = _nativeProjectionBuilder.BuildDocument(
-                    semanticReadModel,
-                    materializationPlan);
-                fact.NativeGraph = _nativeProjectionBuilder.BuildGraph(
-                    fact.ActorId ?? request.ActorId,
-                    fact.ScriptId ?? request.ScriptId,
-                    fact.DefinitionActorId ?? request.DefinitionActorId,
-                    fact.Revision ?? request.Revision,
-                    semanticReadModel,
-                    materializationPlan);
 
                 committed.Add(fact);
             }

--- a/src/Aevatar.Scripting.Core/Runtime/ScriptBehaviorDispatchRequest.cs
+++ b/src/Aevatar.Scripting.Core/Runtime/ScriptBehaviorDispatchRequest.cs
@@ -22,19 +22,9 @@ public sealed partial record ScriptBehaviorDispatchRequest(
 
 public sealed partial record ScriptBehaviorDispatchRequest
 {
-    // Refactor (iter42/cluster-044-scripting-source-package-json-shadow):
-    //   Old pattern: Scripting persists and republishes source_text as a compatibility shadow of ScriptPackageSpec; multi-file packages can be encoded as JSON text and reparsed from persisted source.
-    //   New principle: ScriptPackageSpec is the sole internal source-package contract for commands/state/events/readmodels; source_text is only an external one-file adapter field at Host/Application boundary.
-    public string ReadModelSchemaVersion { get; init; } = string.Empty;
-
-    public string ReadModelSchemaHash { get; init; } = string.Empty;
-
-    /// <summary>
-    /// Pre-compiled materialization plan cached by the calling actor.
-    /// When non-null the dispatcher skips compilation; when null the dispatcher compiles on the fly.
-    /// </summary>
-    public Materialization.ScriptReadModelMaterializationPlan? CachedMaterializationPlan { get; init; }
-
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     public ScriptBehaviorDispatchRequest(
         string ActorId,
         string DefinitionActorId,

--- a/src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs
+++ b/src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs
@@ -4,7 +4,6 @@ using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Core.Compilation;
-using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Serialization;
 using Google.Protobuf;
@@ -14,32 +13,26 @@ namespace Aevatar.Scripting.Core;
 
 public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
 {
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     // Refactor (iter42/cluster-044-scripting-source-package-json-shadow):
     //   Old pattern: Scripting persists and republishes source_text as a compatibility shadow of ScriptPackageSpec; multi-file packages can be encoded as JSON text and reparsed from persisted source.
     //   New principle: ScriptPackageSpec is the sole internal source-package contract for commands/state/events/readmodels; source_text is only an external one-file adapter field at Host/Application boundary.
     private readonly IScriptBehaviorDispatcher _dispatcher;
     private readonly IScriptBehaviorRuntimeCapabilityFactory _capabilityFactory;
     private readonly IScriptBehaviorArtifactResolver _artifactResolver;
-    private readonly IScriptReadModelMaterializationCompiler _materializationCompiler;
     private readonly IProtobufMessageCodec _codec;
-
-    /// <summary>
-    /// Transient actor-scoped cache of the compiled materialization plan.
-    /// Rebuilt lazily on first dispatch after activation or rebind; not persisted.
-    /// </summary>
-    private ScriptReadModelMaterializationPlan? _cachedMaterializationPlan;
 
     public ScriptBehaviorGAgent(
         IScriptBehaviorDispatcher dispatcher,
         IScriptBehaviorRuntimeCapabilityFactory capabilityFactory,
         IScriptBehaviorArtifactResolver artifactResolver,
-        IScriptReadModelMaterializationCompiler materializationCompiler,
         IProtobufMessageCodec codec)
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _capabilityFactory = capabilityFactory ?? throw new ArgumentNullException(nameof(capabilityFactory));
         _artifactResolver = artifactResolver ?? throw new ArgumentNullException(nameof(artifactResolver));
-        _materializationCompiler = materializationCompiler ?? throw new ArgumentNullException(nameof(materializationCompiler));
         _codec = codec ?? throw new ArgumentNullException(nameof(codec));
         InitializeId();
     }
@@ -82,8 +75,6 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
 
         if (IsSameBinding(evt))
             return;
-
-        _cachedMaterializationPlan = null;
 
         await PersistDomainEventAsync(new ScriptBehaviorBoundEvent
         {
@@ -153,8 +144,6 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
                 ScheduleSelfDurableTimeoutAsync(callbackId, dueTime, message, ct: token),
             cancelCallbackAsync: CancelDurableCallbackAsync);
 
-        var materializationPlan = EnsureMaterializationPlan();
-
         var facts = await _dispatcher.DispatchAsync(
             new ScriptBehaviorDispatchRequest(
                 ActorId: Id,
@@ -169,12 +158,7 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
                 CurrentStateRoot: State.StateRoot?.Clone(),
                 CurrentStateVersion: State.LastAppliedEventVersion,
                 Envelope: envelope,
-                Capabilities: capabilities)
-            {
-                ReadModelSchemaVersion = State.ReadModelSchemaVersion ?? string.Empty,
-                ReadModelSchemaHash = State.ReadModelSchemaHash ?? string.Empty,
-                CachedMaterializationPlan = materializationPlan,
-            },
+                Capabilities: capabilities),
             ct);
 
         if (facts.Count == 0)
@@ -300,25 +284,6 @@ public sealed class ScriptBehaviorGAgent : GAgentBase<ScriptBehaviorState>
         {
             throw new InvalidOperationException($"Script behavior actor `{Id}` is not bound.");
         }
-    }
-
-    private ScriptReadModelMaterializationPlan EnsureMaterializationPlan()
-    {
-        if (_cachedMaterializationPlan != null)
-            return _cachedMaterializationPlan;
-
-        var artifact = _artifactResolver.Resolve(new ScriptBehaviorArtifactRequest(
-            State.ScriptId ?? string.Empty,
-            State.Revision ?? string.Empty,
-            RequireBoundPackage(State.ScriptPackage),
-            State.SourceHash ?? string.Empty));
-
-        _cachedMaterializationPlan = _materializationCompiler.Compile(
-            artifact,
-            State.ReadModelSchemaHash ?? string.Empty,
-            State.ReadModelSchemaVersion ?? string.Empty);
-
-        return _cachedMaterializationPlan;
     }
 
     private static ScriptPackageSpec RequireBoundPackage(ScriptPackageSpec? scriptPackage)

--- a/src/Aevatar.Scripting.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Scripting.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -25,6 +25,9 @@ namespace Aevatar.Scripting.Projection.DependencyInjection;
 
 public static class ServiceCollectionExtensions
 {
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     public static IServiceCollection AddScriptingProjectionComponents(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
@@ -109,6 +112,7 @@ public static class ServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             IProjectionActivationPlanProvider,
             ScriptingCommittedStateProjectionActivationPlanProvider>());
+        services.TryAddSingleton<IScriptProjectionPayloadMaterializer, ScriptProjectionPayloadMaterializer>();
         services.TryAddSingleton<IScriptNativeDocumentMaterializer, ScriptNativeDocumentMaterializer>();
         services.TryAddSingleton<ScriptNativeGraphMaterializer>();
         services.TryAddSingleton<IScriptNativeGraphMaterializer>(sp =>

--- a/src/Aevatar.Scripting.Projection/Materialization/IScriptProjectionPayloadMaterializer.cs
+++ b/src/Aevatar.Scripting.Projection/Materialization/IScriptProjectionPayloadMaterializer.cs
@@ -1,0 +1,26 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Scripting.Abstractions;
+
+namespace Aevatar.Scripting.Projection.Materialization;
+
+public interface IScriptProjectionPayloadMaterializer
+{
+    ValueTask<ScriptProjectionPayload> MaterializeAsync(
+        ScriptProjectionMaterializationInput input,
+        CancellationToken ct = default);
+}
+
+public sealed record ScriptProjectionMaterializationInput(
+    ScriptDomainFactCommitted Fact,
+    EventEnvelope Envelope,
+    string RootActorId,
+    string SourceEventId,
+    DateTimeOffset UpdatedAt);
+
+public sealed record ScriptProjectionPayload(
+    Google.Protobuf.WellKnownTypes.Any? ReadModelPayload,
+    ScriptNativeDocumentProjection? NativeDocument,
+    ScriptNativeGraphProjection? NativeGraph,
+    bool UsedLegacyReadModelPayload,
+    bool UsedLegacyNativeDocument,
+    bool UsedLegacyNativeGraph);

--- a/src/Aevatar.Scripting.Projection/Materialization/ScriptProjectionPayloadMaterializer.cs
+++ b/src/Aevatar.Scripting.Projection/Materialization/ScriptProjectionPayloadMaterializer.cs
@@ -1,0 +1,169 @@
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Abstractions.Behaviors;
+using Aevatar.Scripting.Core.Materialization;
+using Aevatar.Scripting.Core.Runtime;
+using Aevatar.Scripting.Core.Serialization;
+using Google.Protobuf;
+
+namespace Aevatar.Scripting.Projection.Materialization;
+
+public sealed class ScriptProjectionPayloadMaterializer : IScriptProjectionPayloadMaterializer
+{
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
+    private readonly IScriptBehaviorArtifactResolver _artifactResolver;
+    private readonly IScriptReadModelMaterializationCompiler _materializationCompiler;
+    private readonly IScriptNativeProjectionBuilder _nativeProjectionBuilder;
+    private readonly IProtobufMessageCodec _codec;
+
+    public ScriptProjectionPayloadMaterializer(
+        IScriptBehaviorArtifactResolver artifactResolver,
+        IScriptReadModelMaterializationCompiler materializationCompiler,
+        IScriptNativeProjectionBuilder nativeProjectionBuilder,
+        IProtobufMessageCodec codec)
+    {
+        _artifactResolver = artifactResolver ?? throw new ArgumentNullException(nameof(artifactResolver));
+        _materializationCompiler = materializationCompiler ?? throw new ArgumentNullException(nameof(materializationCompiler));
+        _nativeProjectionBuilder = nativeProjectionBuilder ?? throw new ArgumentNullException(nameof(nativeProjectionBuilder));
+        _codec = codec ?? throw new ArgumentNullException(nameof(codec));
+    }
+
+    public async ValueTask<ScriptProjectionPayload> MaterializeAsync(
+        ScriptProjectionMaterializationInput input,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.Fact);
+        ArgumentNullException.ThrowIfNull(input.Envelope);
+
+        try
+        {
+            var semanticReadModel = await DeriveReadModelAsync(input, ct);
+            ct.ThrowIfCancellationRequested();
+            var readModelPayload = _codec.Pack(semanticReadModel)?.Clone();
+            var state = UnpackCommittedScriptState(input.Envelope);
+            var artifact = ResolveArtifact(input.Fact, state);
+            var plan = _materializationCompiler.Compile(
+                artifact,
+                state.ReadModelSchemaHash ?? string.Empty,
+                state.ReadModelSchemaVersion ?? string.Empty);
+            var actorId = ResolveActorId(input.Fact, input.RootActorId);
+            var nativeDocument = _nativeProjectionBuilder.BuildDocument(
+                semanticReadModel,
+                plan);
+            var nativeGraph = _nativeProjectionBuilder.BuildGraph(
+                actorId,
+                ResolveScriptId(input.Fact, state),
+                ResolveDefinitionActorId(input.Fact, state),
+                ResolveRevision(input.Fact, state),
+                semanticReadModel,
+                plan);
+
+            return new ScriptProjectionPayload(
+                readModelPayload,
+                nativeDocument,
+                nativeGraph,
+                UsedLegacyReadModelPayload: false,
+                UsedLegacyNativeDocument: false,
+                UsedLegacyNativeGraph: false);
+        }
+        catch (Exception) when (HasLegacyFallback(input.Fact))
+        {
+            return new ScriptProjectionPayload(
+                input.Fact.TryGetLegacyReadModelPayload()?.Clone(),
+                input.Fact.TryGetLegacyNativeDocument()?.Clone(),
+                input.Fact.TryGetLegacyNativeGraph()?.Clone(),
+                UsedLegacyReadModelPayload: input.Fact.TryGetLegacyReadModelPayload() != null,
+                UsedLegacyNativeDocument: input.Fact.TryGetLegacyNativeDocument() != null,
+                UsedLegacyNativeGraph: input.Fact.TryGetLegacyNativeGraph() != null);
+        }
+    }
+
+    private async ValueTask<IMessage?> DeriveReadModelAsync(
+        ScriptProjectionMaterializationInput input,
+        CancellationToken ct)
+    {
+        var state = UnpackCommittedScriptState(input.Envelope);
+        var artifact = ResolveArtifact(input.Fact, state);
+        var currentState = _codec.Unpack(state.StateRoot, artifact.Descriptor.StateClrType);
+        var behavior = artifact.CreateBehavior();
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+            return behavior.BuildReadModel(
+                currentState,
+                CreateFactContext(input.Fact, input.RootActorId));
+        }
+        finally
+        {
+            if (behavior is IAsyncDisposable asyncDisposable)
+                await asyncDisposable.DisposeAsync();
+            else if (behavior is IDisposable disposable)
+                disposable.Dispose();
+        }
+    }
+
+    private ScriptBehaviorArtifact ResolveArtifact(
+        ScriptDomainFactCommitted fact,
+        ScriptBehaviorState state)
+    {
+        var package = state.ScriptPackage?.Clone() ?? new ScriptPackageSpec();
+        if (package.CsharpSources.Count == 0)
+            throw new InvalidOperationException("Committed scripting state_root does not contain a script package.");
+
+        return _artifactResolver.Resolve(new ScriptBehaviorArtifactRequest(
+            ResolveScriptId(fact, state),
+            ResolveRevision(fact, state),
+            package,
+            state.SourceHash ?? string.Empty));
+    }
+
+    private static ScriptBehaviorState UnpackCommittedScriptState(EventEnvelope envelope)
+    {
+        if (!CommittedStateEventEnvelope.TryUnpack(envelope, out var published) ||
+            published?.StateRoot?.Is(ScriptBehaviorState.Descriptor) != true)
+        {
+            throw new InvalidOperationException("Scripting projection requires committed ScriptBehaviorState state_root.");
+        }
+
+        return published.StateRoot.Unpack<ScriptBehaviorState>();
+    }
+
+    private static ScriptFactContext CreateFactContext(
+        ScriptDomainFactCommitted fact,
+        string rootActorId)
+    {
+        return new ScriptFactContext(
+            ResolveActorId(fact, rootActorId),
+            fact.DefinitionActorId ?? string.Empty,
+            fact.ScriptId ?? string.Empty,
+            fact.Revision ?? string.Empty,
+            fact.RunId ?? string.Empty,
+            fact.CommandId ?? string.Empty,
+            fact.CorrelationId ?? string.Empty,
+            fact.EventSequence,
+            fact.StateVersion,
+            fact.EventType ?? string.Empty,
+            fact.OccurredAtUnixTimeMs);
+    }
+
+    private static bool HasLegacyFallback(ScriptDomainFactCommitted fact) =>
+        fact.TryGetLegacyReadModelPayload() != null ||
+        fact.TryGetLegacyNativeDocument() != null ||
+        fact.TryGetLegacyNativeGraph() != null;
+
+    private static string ResolveActorId(ScriptDomainFactCommitted fact, string rootActorId) =>
+        string.IsNullOrWhiteSpace(fact.ActorId) ? rootActorId : fact.ActorId;
+
+    private static string ResolveDefinitionActorId(ScriptDomainFactCommitted fact, ScriptBehaviorState state) =>
+        string.IsNullOrWhiteSpace(fact.DefinitionActorId) ? state.DefinitionActorId ?? string.Empty : fact.DefinitionActorId;
+
+    private static string ResolveScriptId(ScriptDomainFactCommitted fact, ScriptBehaviorState state) =>
+        string.IsNullOrWhiteSpace(fact.ScriptId) ? state.ScriptId ?? string.Empty : fact.ScriptId;
+
+    private static string ResolveRevision(ScriptDomainFactCommitted fact, ScriptBehaviorState state) =>
+        string.IsNullOrWhiteSpace(fact.Revision) ? state.Revision ?? string.Empty : fact.Revision;
+}

--- a/src/Aevatar.Scripting.Projection/Projectors/ScriptNativeDocumentProjector.cs
+++ b/src/Aevatar.Scripting.Projection/Projectors/ScriptNativeDocumentProjector.cs
@@ -10,14 +10,20 @@ namespace Aevatar.Scripting.Projection.Projectors;
 public sealed class ScriptNativeDocumentProjector
     : ICurrentStateProjectionMaterializer<ScriptExecutionMaterializationContext>
 {
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     private readonly IProjectionWriteDispatcher<ScriptNativeDocumentReadModel> _nativeWriteDispatcher;
+    private readonly IScriptProjectionPayloadMaterializer _payloadMaterializer;
     private readonly IScriptNativeDocumentMaterializer _materializer;
 
     public ScriptNativeDocumentProjector(
         IProjectionWriteDispatcher<ScriptNativeDocumentReadModel> nativeWriteDispatcher,
+        IScriptProjectionPayloadMaterializer payloadMaterializer,
         IScriptNativeDocumentMaterializer materializer)
     {
         _nativeWriteDispatcher = nativeWriteDispatcher ?? throw new ArgumentNullException(nameof(nativeWriteDispatcher));
+        _payloadMaterializer = payloadMaterializer ?? throw new ArgumentNullException(nameof(payloadMaterializer));
         _materializer = materializer ?? throw new ArgumentNullException(nameof(materializer));
     }
 
@@ -37,12 +43,20 @@ public sealed class ScriptNativeDocumentProjector
         }
 
         var fact = observedPayload.Unpack<ScriptDomainFactCommitted>();
-        if (fact.NativeDocument == null)
-            return;
-
         var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(
             envelope,
             DateTimeOffset.FromUnixTimeMilliseconds(fact.OccurredAtUnixTimeMs));
+        var payload = await _payloadMaterializer.MaterializeAsync(
+            new ScriptProjectionMaterializationInput(
+                fact,
+                envelope,
+                context.RootActorId,
+                sourceEventId,
+                updatedAt),
+            ct);
+        if (payload.NativeDocument == null)
+            return;
+
         var nativeDocument = _materializer.Materialize(
             context.RootActorId,
             fact.ScriptId ?? string.Empty,
@@ -51,7 +65,7 @@ public sealed class ScriptNativeDocumentProjector
             fact,
             sourceEventId,
             updatedAt,
-            fact.NativeDocument);
+            payload.NativeDocument);
         await _nativeWriteDispatcher.UpsertAsync(nativeDocument, ct);
     }
 

--- a/src/Aevatar.Scripting.Projection/Projectors/ScriptNativeGraphProjector.cs
+++ b/src/Aevatar.Scripting.Projection/Projectors/ScriptNativeGraphProjector.cs
@@ -10,14 +10,20 @@ namespace Aevatar.Scripting.Projection.Projectors;
 public sealed class ScriptNativeGraphProjector
     : ICurrentStateProjectionMaterializer<ScriptExecutionMaterializationContext>
 {
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     private readonly IProjectionGraphWriter<ScriptNativeGraphReadModel> _graphWriter;
+    private readonly IScriptProjectionPayloadMaterializer _payloadMaterializer;
     private readonly IScriptNativeGraphMaterializer _materializer;
 
     public ScriptNativeGraphProjector(
         IProjectionGraphWriter<ScriptNativeGraphReadModel> graphWriter,
+        IScriptProjectionPayloadMaterializer payloadMaterializer,
         IScriptNativeGraphMaterializer materializer)
     {
         _graphWriter = graphWriter ?? throw new ArgumentNullException(nameof(graphWriter));
+        _payloadMaterializer = payloadMaterializer ?? throw new ArgumentNullException(nameof(payloadMaterializer));
         _materializer = materializer ?? throw new ArgumentNullException(nameof(materializer));
     }
 
@@ -37,12 +43,20 @@ public sealed class ScriptNativeGraphProjector
         }
 
         var fact = observedPayload.Unpack<ScriptDomainFactCommitted>();
-        if (fact.NativeGraph == null)
-            return;
-
         var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(
             envelope,
             DateTimeOffset.FromUnixTimeMilliseconds(fact.OccurredAtUnixTimeMs));
+        var payload = await _payloadMaterializer.MaterializeAsync(
+            new ScriptProjectionMaterializationInput(
+                fact,
+                envelope,
+                context.RootActorId,
+                sourceEventId,
+                updatedAt),
+            ct);
+        if (payload.NativeGraph == null)
+            return;
+
         var graphReadModel = _materializer.Materialize(
             context.RootActorId,
             fact.ScriptId ?? string.Empty,
@@ -51,7 +65,7 @@ public sealed class ScriptNativeGraphProjector
             fact,
             sourceEventId,
             updatedAt,
-            fact.NativeGraph);
+            payload.NativeGraph);
         await _graphWriter.UpsertAsync(graphReadModel, ct);
     }
 

--- a/src/Aevatar.Scripting.Projection/Projectors/ScriptReadModelProjector.cs
+++ b/src/Aevatar.Scripting.Projection/Projectors/ScriptReadModelProjector.cs
@@ -1,6 +1,7 @@
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Projection.Materialization;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.ReadModels;
 using Google.Protobuf.WellKnownTypes;
@@ -10,14 +11,20 @@ namespace Aevatar.Scripting.Projection.Projectors;
 public sealed class ScriptReadModelProjector
     : ICurrentStateProjectionMaterializer<ScriptExecutionMaterializationContext>
 {
+    // Refactor (iter76/cluster-076-scripting-domain-fact-derived-readmodel-payloads):
+    //   Old pattern: ScriptDomainFactCommitted persisted derived readmodel/native_document/native_graph payloads inside the domain event
+    //   New principle: domain event keeps only committed facts; projection materializer derives readmodel/native_document/(optional)native_graph from fact + state_root
     private readonly IProjectionWriteDispatcher<ScriptReadModelDocument> _writeDispatcher;
+    private readonly IScriptProjectionPayloadMaterializer _payloadMaterializer;
     private readonly IProjectionClock _clock;
 
     public ScriptReadModelProjector(
         IProjectionWriteDispatcher<ScriptReadModelDocument> writeDispatcher,
+        IScriptProjectionPayloadMaterializer payloadMaterializer,
         IProjectionClock clock)
     {
         _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _payloadMaterializer = payloadMaterializer ?? throw new ArgumentNullException(nameof(payloadMaterializer));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
@@ -37,6 +44,18 @@ public sealed class ScriptReadModelProjector
         }
 
         var fact = observedPayload.Unpack<ScriptDomainFactCommitted>();
+        var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
+        var payload = await _payloadMaterializer.MaterializeAsync(
+            new ScriptProjectionMaterializationInput(
+                fact,
+                envelope,
+                context.RootActorId,
+                sourceEventId,
+                updatedAt),
+            ct);
+        if (payload.ReadModelPayload == null)
+            return;
+
         var actorId = string.IsNullOrWhiteSpace(fact.ActorId) ? context.RootActorId : fact.ActorId;
         var document = new ScriptReadModelDocument
         {
@@ -45,10 +64,10 @@ public sealed class ScriptReadModelProjector
             DefinitionActorId = fact.DefinitionActorId ?? string.Empty,
             Revision = fact.Revision ?? string.Empty,
             ReadModelTypeUrl = fact.ReadModelTypeUrl ?? string.Empty,
-            ReadModelPayload = fact.ReadModelPayload?.Clone() ?? Any.Pack(new Empty()),
+            ReadModelPayload = payload.ReadModelPayload.Clone(),
             StateVersion = fact.StateVersion,
             LastEventId = sourceEventId,
-            UpdatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow),
+            UpdatedAt = updatedAt,
             ScopeId = fact.ScopeId ?? string.Empty,
         };
 

--- a/test/Aevatar.Integration.Tests/ClaimReplayTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimReplayTests.cs
@@ -8,7 +8,7 @@ using Aevatar.Integration.Tests.Protocols;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Core;
 using Aevatar.Scripting.Core.Ports;
-using Aevatar.Scripting.Core.Serialization;
+using Aevatar.Scripting.Projection.Materialization;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.Projectors;
 using Aevatar.Scripting.Projection.ReadModels;
@@ -135,9 +135,7 @@ public class ClaimReplayTests
         await using var provider = ClaimIntegrationTestKit.BuildProvider();
         var eventStore = provider.GetRequiredService<IEventStore>();
         var runtime = provider.GetRequiredService<IActorRuntime>();
-        var definitionSnapshotPort = provider.GetRequiredService<IScriptDefinitionSnapshotPort>();
-        var artifactResolver = provider.GetRequiredService<Aevatar.Scripting.Core.Runtime.IScriptBehaviorArtifactResolver>();
-        var codec = provider.GetRequiredService<IProtobufMessageCodec>();
+        var payloadMaterializer = provider.GetRequiredService<IScriptProjectionPayloadMaterializer>();
         var document = ClaimScriptScenarioDocument.CreateEmbedded();
         var orchestrator = document.Scripts.Single(x => x.ScriptId == "claim_orchestrator");
 
@@ -195,6 +193,7 @@ public class ClaimReplayTests
         var dispatcher1 = new InMemoryReadModelDispatcher();
         var projector1 = new ScriptReadModelProjector(
             dispatcher1,
+            payloadMaterializer,
             new FixedProjectionClock(projectionNow));
         foreach (var envelope in committedEvents)
             await projector1.ProjectAsync(context, envelope, CancellationToken.None);
@@ -203,6 +202,7 @@ public class ClaimReplayTests
         var dispatcher2 = new InMemoryReadModelDispatcher();
         var projector2 = new ScriptReadModelProjector(
             dispatcher2,
+            payloadMaterializer,
             new FixedProjectionClock(projectionNow));
         foreach (var envelope in committedEvents)
             await projector2.ProjectAsync(context, envelope, CancellationToken.None);

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ClaimReadModelProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ClaimReadModelProjectorTests.cs
@@ -57,7 +57,6 @@ public sealed class ClaimReadModelProjectorTests
                 },
             }),
             ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
-            ReadModelPayload = Any.Pack(readModel),
             StateVersion = 1,
         };
         var state = ScriptCommittedEnvelopeFactory.CreateState(
@@ -128,6 +127,25 @@ public sealed class ClaimReadModelProjectorTests
         InMemoryProjectionDocumentStore<ScriptReadModelDocument> dispatcher) =>
         new(
             dispatcher,
+            StubScriptProjectionPayloadMaterializer.WithReadModel(new ClaimReadModel
+            {
+                HasValue = true,
+                CaseId = "Case-B",
+                PolicyId = "POLICY-B",
+                DecisionStatus = "ManualReview",
+                ManualReviewRequired = true,
+                AiSummary = "high-risk-profile",
+                Search = new ClaimSearchIndex
+                {
+                    LookupKey = "case-b:policy-b",
+                    DecisionKey = "manualreview",
+                },
+                Refs = new ClaimRefs
+                {
+                    PolicyId = "POLICY-B",
+                    OwnerActorId = "claim-runtime-manual",
+                },
+            }),
             new FixedProjectionClock(new DateTimeOffset(2026, 3, 14, 0, 0, 0, TimeSpan.Zero)));
 
     private static ScriptExecutionMaterializationContext CreateContext(string rootActorId) =>

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeDocumentProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeDocumentProjectorTests.cs
@@ -24,6 +24,7 @@ public sealed class ScriptNativeDocumentProjectorTests
         var dispatcher = new RecordingNativeDocumentDispatcher();
         var projector = new ScriptNativeDocumentProjector(
             dispatcher,
+            StubScriptProjectionPayloadMaterializer.WithNativeDocument(BuildNativeDocumentProjection(BuildProfileReadModel())),
             new ScriptNativeDocumentMaterializer());
         var context = new ScriptExecutionMaterializationContext
         {
@@ -31,7 +32,6 @@ public sealed class ScriptNativeDocumentProjectorTests
             ProjectionKind = "script-execution-read-model",
         };
         var readModel = BuildProfileReadModel();
-        var nativeDocumentProjection = BuildNativeDocumentProjection(readModel);
 
         await projector.ProjectAsync(
             context,
@@ -46,10 +46,8 @@ public sealed class ScriptNativeDocumentProjectorTests
                     EventType = Any.Pack(new ScriptProfileUpdated()).TypeUrl,
                     DomainEventPayload = Any.Pack(new ScriptProfileUpdated { Current = readModel.Clone() }),
                     ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
-                    ReadModelPayload = Any.Pack(readModel),
                     StateVersion = 7,
                     OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T00:00:00Z").ToUnixTimeMilliseconds(),
-                    NativeDocument = nativeDocumentProjection.Clone(),
                 },
                 ScriptCommittedEnvelopeFactory.CreateState(
                     "definition-1",

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeDocumentProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeDocumentProjectorTests.cs
@@ -109,7 +109,7 @@ public sealed class ScriptNativeDocumentProjectorTests
             DomainEventPayload = Any.Pack(new ScriptProfileUpdated
             {
                 CommandId = "command-derived-document",
-                Current = readModel.Clone(),
+                Current = BuildIgnoredProfileReadModel(),
             }),
             ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
             StateVersion = 11,
@@ -240,6 +240,31 @@ public sealed class ScriptNativeDocumentProjectorTests
         };
         readModel.Tags.Add("gold");
         readModel.Tags.Add("vip");
+        return readModel;
+    }
+
+    private static ScriptProfileReadModel BuildIgnoredProfileReadModel()
+    {
+        var readModel = new ScriptProfileReadModel
+        {
+            HasValue = true,
+            ActorId = "ignored-actor",
+            PolicyId = "ignored-policy",
+            LastCommandId = "IGNORED-BY-PROJECTOR",
+            InputText = "ignored-by-projector",
+            NormalizedText = "IGNORED-BY-PROJECTOR",
+            Search = new ScriptProfileSearchIndex
+            {
+                LookupKey = "ignored-actor:ignored-policy",
+                SortKey = "IGNORED-BY-PROJECTOR",
+            },
+            Refs = new ScriptProfileDocumentRef
+            {
+                ActorId = "ignored-actor",
+                PolicyId = "ignored-policy",
+            },
+        };
+        readModel.Tags.Add("ignored-by-projector");
         return readModel;
     }
 

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeDocumentProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeDocumentProjectorTests.cs
@@ -6,6 +6,7 @@ using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Infrastructure.Compilation;
+using Aevatar.Scripting.Infrastructure.Serialization;
 using Aevatar.Scripting.Projection.Materialization;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.Projectors;
@@ -83,6 +84,140 @@ public sealed class ScriptNativeDocumentProjectorTests
         nativeDocument.Fields["search"].As<IDictionary<string, object?>>()["lookup_key"].Should().Be("actor-1:policy-1");
     }
 
+    [Fact]
+    public async Task ProjectAsync_ShouldDeriveNativeDocumentFromCommittedStateRoot_WithRealMaterializer()
+    {
+        var dispatcher = new RecordingNativeDocumentDispatcher();
+        var projector = new ScriptNativeDocumentProjector(
+            dispatcher,
+            CreateRealMaterializer(),
+            new ScriptNativeDocumentMaterializer());
+        var context = new ScriptExecutionMaterializationContext
+        {
+            RootActorId = "runtime-derived-document",
+            ProjectionKind = "script-execution-read-model",
+        };
+        var readModel = BuildProfileReadModel();
+        var fact = new ScriptDomainFactCommitted
+        {
+            ActorId = "runtime-derived-document",
+            DefinitionActorId = "definition-derived-document",
+            ScriptId = "script-1",
+            Revision = "rev-1",
+            RunId = "run-derived-document",
+            EventType = Any.Pack(new ScriptProfileUpdated()).TypeUrl,
+            DomainEventPayload = Any.Pack(new ScriptProfileUpdated
+            {
+                CommandId = "command-derived-document",
+                Current = readModel.Clone(),
+            }),
+            ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
+            StateVersion = 11,
+            OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T00:00:00Z").ToUnixTimeMilliseconds(),
+        };
+        var state = ScriptCommittedEnvelopeFactory.CreateState(
+            "definition-derived-document",
+            "script-1",
+            "rev-1",
+            new ScriptProfileState
+            {
+                ActorId = readModel.ActorId,
+                PolicyId = readModel.PolicyId,
+                LastCommandId = readModel.LastCommandId,
+                InputText = readModel.InputText,
+                NormalizedText = readModel.NormalizedText,
+                Tags = { readModel.Tags },
+            },
+            fact.StateVersion,
+            Any.Pack(readModel).TypeUrl,
+            ScriptSources.StructuredProfileBehavior,
+            ScriptSources.StructuredProfileBehaviorHash,
+            ScriptPackageSpecExtensions.CreateSingleSource(ScriptSources.StructuredProfileBehavior),
+            "3",
+            "structured-schema");
+
+        await projector.ProjectAsync(
+            context,
+            BuildEnvelope(fact, state),
+            CancellationToken.None);
+
+        var expected = BuildNativeDocumentProjection(readModel);
+        dispatcher.LastUpsert.Should().NotBeNull();
+        var nativeDocument = dispatcher.LastUpsert!;
+        nativeDocument.Id.Should().Be("runtime-derived-document");
+        nativeDocument.ScriptId.Should().Be("script-1");
+        nativeDocument.DefinitionActorId.Should().Be("definition-derived-document");
+        nativeDocument.Revision.Should().Be("rev-1");
+        nativeDocument.SchemaId.Should().Be(expected.SchemaId);
+        nativeDocument.SchemaVersion.Should().Be(expected.SchemaVersion);
+        nativeDocument.SchemaHash.Should().Be(expected.SchemaHash);
+        nativeDocument.DocumentIndexScope.Should().Be(expected.DocumentIndexScope);
+        nativeDocument.StateVersion.Should().Be(11);
+        nativeDocument.LastEventId.Should().Be("evt-1");
+        nativeDocument.FieldsValue.Should().BeEquivalentTo(expected.FieldsValue);
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldFallbackToLegacyNativeDocumentField16_WhenStateRootCannotDerive()
+    {
+        var dispatcher = new RecordingNativeDocumentDispatcher();
+        var projector = new ScriptNativeDocumentProjector(
+            dispatcher,
+            CreateRealMaterializer(),
+            new ScriptNativeDocumentMaterializer());
+        var context = new ScriptExecutionMaterializationContext
+        {
+            RootActorId = "runtime-legacy-document",
+            ProjectionKind = "script-execution-read-model",
+        };
+        var readModel = BuildProfileReadModel();
+        var legacyDocument = BuildNativeDocumentProjection(readModel);
+        var fact = ScriptLegacyFactPayloadTestHelper.WithLegacyPayloads(
+            new ScriptDomainFactCommitted
+            {
+                ActorId = "runtime-legacy-document",
+                DefinitionActorId = "definition-legacy-document",
+                ScriptId = "script-1",
+                Revision = "rev-1",
+                RunId = "run-legacy-document",
+                EventType = Any.Pack(new ScriptProfileUpdated()).TypeUrl,
+                DomainEventPayload = Any.Pack(new ScriptProfileUpdated
+                {
+                    CommandId = "command-legacy-document",
+                    Current = readModel.Clone(),
+                }),
+                ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
+                StateVersion = 12,
+                OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T00:00:00Z").ToUnixTimeMilliseconds(),
+            },
+            nativeDocument: legacyDocument);
+        var state = ScriptCommittedEnvelopeFactory.CreateState(
+            "definition-legacy-document",
+            "script-1",
+            "rev-1",
+            new ScriptProfileState
+            {
+                ActorId = readModel.ActorId,
+            },
+            fact.StateVersion,
+            Any.Pack(readModel).TypeUrl);
+
+        fact.TryGetLegacyNativeDocument().Should().NotBeNull();
+
+        await projector.ProjectAsync(
+            context,
+            BuildEnvelope(fact, state),
+            CancellationToken.None);
+
+        dispatcher.LastUpsert.Should().NotBeNull();
+        var nativeDocument = dispatcher.LastUpsert!;
+        nativeDocument.Id.Should().Be("runtime-legacy-document");
+        nativeDocument.StateVersion.Should().Be(12);
+        nativeDocument.SchemaId.Should().Be(legacyDocument.SchemaId);
+        nativeDocument.DocumentIndexScope.Should().Be(legacyDocument.DocumentIndexScope);
+        nativeDocument.FieldsValue.Should().BeEquivalentTo(legacyDocument.FieldsValue);
+    }
+
     private static ScriptProfileReadModel BuildProfileReadModel()
     {
         var readModel = new ScriptProfileReadModel
@@ -123,6 +258,13 @@ public sealed class ScriptNativeDocumentProjectorTests
         return new ScriptNativeProjectionBuilder()
             .BuildDocument(readModel, plan)!;
     }
+
+    private static IScriptProjectionPayloadMaterializer CreateRealMaterializer() =>
+        new ScriptProjectionPayloadMaterializer(
+            new CachedScriptBehaviorArtifactResolver(new RoslynScriptBehaviorCompiler(new ScriptSandboxPolicy())),
+            new ScriptReadModelMaterializationCompiler(),
+            new ScriptNativeProjectionBuilder(),
+            new ProtobufMessageCodec());
 
     private static EventEnvelope BuildEnvelope(ScriptDomainFactCommitted fact, ScriptBehaviorState state) =>
         ScriptCommittedEnvelopeFactory.CreateCommittedEnvelope(

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeGraphProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeGraphProjectorTests.cs
@@ -24,17 +24,16 @@ public sealed class ScriptNativeGraphProjectorTests
     {
         var graphWriter = new RecordingNativeGraphWriter();
         IProjectionGraphMaterializer<ScriptNativeGraphReadModel> graphMaterializer = new ScriptNativeGraphMaterializer();
+        var readModel = BuildClaimReadModel();
         var projector = new ScriptNativeGraphProjector(
             graphWriter,
+            StubScriptProjectionPayloadMaterializer.WithNativeGraph(BuildNativeGraphProjection(readModel)),
             new ScriptNativeGraphMaterializer());
         var context = new ScriptExecutionMaterializationContext
         {
             RootActorId = "claim-runtime",
             ProjectionKind = "script-execution-read-model",
         };
-        var readModel = BuildClaimReadModel();
-        var nativeGraphProjection = BuildNativeGraphProjection(readModel);
-
         await projector.ProjectAsync(
             context,
             BuildEnvelope(
@@ -48,10 +47,8 @@ public sealed class ScriptNativeGraphProjectorTests
                     EventType = Any.Pack(new ClaimDecisionRecorded()).TypeUrl,
                     DomainEventPayload = Any.Pack(new ClaimDecisionRecorded { Current = readModel.Clone() }),
                     ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
-                    ReadModelPayload = Any.Pack(readModel),
                     StateVersion = 3,
                     OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T00:00:00Z").ToUnixTimeMilliseconds(),
-                    NativeGraph = nativeGraphProjection.Clone(),
                 },
                 ScriptCommittedEnvelopeFactory.CreateState(
                     "definition-1",
@@ -99,6 +96,7 @@ public sealed class ScriptNativeGraphProjectorTests
         var graphWriter = new RecordingNativeGraphWriter();
         var projector = new ScriptNativeGraphProjector(
             graphWriter,
+            StubScriptProjectionPayloadMaterializer.WithNativeGraph(null),
             new ScriptNativeGraphMaterializer());
         var context = new ScriptExecutionMaterializationContext
         {
@@ -132,6 +130,7 @@ public sealed class ScriptNativeGraphProjectorTests
         var graphWriter = new RecordingNativeGraphWriter();
         var projector = new ScriptNativeGraphProjector(
             graphWriter,
+            StubScriptProjectionPayloadMaterializer.WithNativeGraph(null),
             new ScriptNativeGraphMaterializer());
         var context = new ScriptExecutionMaterializationContext
         {
@@ -148,7 +147,6 @@ public sealed class ScriptNativeGraphProjectorTests
                     EventType = Any.Pack(new ClaimDecisionRecorded()).TypeUrl,
                     DomainEventPayload = Any.Pack(new ClaimDecisionRecorded()),
                     ReadModelTypeUrl = Any.Pack(new ClaimReadModel()).TypeUrl,
-                    ReadModelPayload = Any.Pack(new ClaimReadModel()),
                     StateVersion = 4,
                     OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T01:00:00Z").ToUnixTimeMilliseconds(),
                 },
@@ -171,10 +169,21 @@ public sealed class ScriptNativeGraphProjectorTests
     [Fact]
     public void Ctor_ShouldThrow_WhenDependenciesMissing()
     {
-        Action noWriter = () => new ScriptNativeGraphProjector(null!, new ScriptNativeGraphMaterializer());
-        Action noMaterializer = () => new ScriptNativeGraphProjector(new RecordingNativeGraphWriter(), null!);
+        Action noWriter = () => new ScriptNativeGraphProjector(
+            null!,
+            StubScriptProjectionPayloadMaterializer.WithNativeGraph(null),
+            new ScriptNativeGraphMaterializer());
+        Action noPayloadMaterializer = () => new ScriptNativeGraphProjector(
+            new RecordingNativeGraphWriter(),
+            null!,
+            new ScriptNativeGraphMaterializer());
+        Action noMaterializer = () => new ScriptNativeGraphProjector(
+            new RecordingNativeGraphWriter(),
+            StubScriptProjectionPayloadMaterializer.WithNativeGraph(null),
+            null!);
 
         noWriter.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("graphWriter");
+        noPayloadMaterializer.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("payloadMaterializer");
         noMaterializer.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("materializer");
     }
 
@@ -182,15 +191,16 @@ public sealed class ScriptNativeGraphProjectorTests
     public async Task ProjectAsync_ShouldFallbackToFactTimestamp_WhenEnvelopeTimestampIsMissing()
     {
         var graphWriter = new RecordingNativeGraphWriter();
+        var readModel = BuildClaimReadModel();
         var projector = new ScriptNativeGraphProjector(
             graphWriter,
+            StubScriptProjectionPayloadMaterializer.WithNativeGraph(BuildNativeGraphProjection(readModel)),
             new ScriptNativeGraphMaterializer());
         var context = new ScriptExecutionMaterializationContext
         {
             RootActorId = "claim-runtime",
             ProjectionKind = "script-execution-read-model",
         };
-        var readModel = BuildClaimReadModel();
         var occurredAt = DateTimeOffset.Parse("2026-03-14T02:00:00Z");
 
         var fact = new ScriptDomainFactCommitted
@@ -203,10 +213,8 @@ public sealed class ScriptNativeGraphProjectorTests
             EventType = Any.Pack(new ClaimDecisionRecorded()).TypeUrl,
             DomainEventPayload = Any.Pack(new ClaimDecisionRecorded { Current = readModel.Clone() }),
             ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
-            ReadModelPayload = Any.Pack(readModel),
             StateVersion = 5,
             OccurredAtUnixTimeMs = occurredAt.ToUnixTimeMilliseconds(),
-            NativeGraph = BuildNativeGraphProjection(readModel),
         };
 
         var envelope = ScriptCommittedEnvelopeFactory.CreateCommittedEnvelope(

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeGraphProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeGraphProjectorTests.cs
@@ -117,7 +117,7 @@ public sealed class ScriptNativeGraphProjectorTests
             DomainEventPayload = Any.Pack(new ClaimDecisionRecorded
             {
                 CommandId = "command-derived-graph",
-                Current = readModel.Clone(),
+                Current = BuildIgnoredClaimReadModel(),
             }),
             ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
             StateVersion = 13,
@@ -428,6 +428,32 @@ public sealed class ScriptNativeGraphProjectorTests
             {
                 PolicyId = "POLICY-B",
                 OwnerActorId = "claim-runtime",
+            },
+        };
+    }
+
+    private static ClaimReadModel BuildIgnoredClaimReadModel()
+    {
+        return new ClaimReadModel
+        {
+            HasValue = true,
+            CaseId = "IGNORED-BY-PROJECTOR",
+            PolicyId = "POLICY-IGNORED",
+            DecisionStatus = "Ignored",
+            ManualReviewRequired = false,
+            AiSummary = "ignored-by-projector",
+            RiskScore = 0.01d,
+            CompliancePassed = false,
+            LastCommandId = "IGNORED-BY-PROJECTOR",
+            Search = new ClaimSearchIndex
+            {
+                LookupKey = "ignored-by-projector:policy-ignored",
+                DecisionKey = "ignored",
+            },
+            Refs = new ClaimRefs
+            {
+                PolicyId = "POLICY-IGNORED",
+                OwnerActorId = "ignored-runtime",
             },
         };
     }

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeGraphProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptNativeGraphProjectorTests.cs
@@ -7,6 +7,7 @@ using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Infrastructure.Compilation;
+using Aevatar.Scripting.Infrastructure.Serialization;
 using Aevatar.Scripting.Projection.Materialization;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.Projectors;
@@ -86,6 +87,100 @@ public sealed class ScriptNativeGraphProjectorTests
         graph.Nodes.Should().Contain(x => x.NodeId == "ref:policy:POLICY-B");
         graph.Edges.Should().ContainSingle(x =>
             x.FromNodeId == "script:claim_case:claim-runtime" &&
+            x.ToNodeId == "ref:policy:POLICY-B" &&
+            x.EdgeType == "rel_policy");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldDeriveNativeGraphFromCommittedStateRoot_WithRealMaterializer()
+    {
+        var graphWriter = new RecordingNativeGraphWriter();
+        IProjectionGraphMaterializer<ScriptNativeGraphReadModel> graphMaterializer = new ScriptNativeGraphMaterializer();
+        var readModel = BuildClaimReadModel();
+        var projector = new ScriptNativeGraphProjector(
+            graphWriter,
+            CreateRealMaterializer(),
+            new ScriptNativeGraphMaterializer());
+        var context = new ScriptExecutionMaterializationContext
+        {
+            RootActorId = "claim-runtime-derived",
+            ProjectionKind = "script-execution-read-model",
+        };
+        var fact = new ScriptDomainFactCommitted
+        {
+            ActorId = "claim-runtime-derived",
+            DefinitionActorId = "definition-derived-graph",
+            ScriptId = "claim_orchestrator",
+            Revision = "rev-claim-1",
+            RunId = "run-derived-graph",
+            EventType = Any.Pack(new ClaimDecisionRecorded()).TypeUrl,
+            DomainEventPayload = Any.Pack(new ClaimDecisionRecorded
+            {
+                CommandId = "command-derived-graph",
+                Current = readModel.Clone(),
+            }),
+            ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
+            StateVersion = 13,
+            OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T00:00:00Z").ToUnixTimeMilliseconds(),
+        };
+        var state = ScriptCommittedEnvelopeFactory.CreateState(
+            "definition-derived-graph",
+            "claim_orchestrator",
+            "rev-claim-1",
+            new ClaimState
+            {
+                CaseId = readModel.CaseId,
+                PolicyId = readModel.PolicyId,
+                DecisionStatus = readModel.DecisionStatus,
+                ManualReviewRequired = readModel.ManualReviewRequired,
+                AiSummary = readModel.AiSummary,
+                RiskScore = readModel.RiskScore,
+                CompliancePassed = readModel.CompliancePassed,
+                LastCommandId = readModel.LastCommandId,
+                TraceSteps = { readModel.TraceSteps },
+            },
+            fact.StateVersion,
+            Any.Pack(readModel).TypeUrl,
+            ClaimScriptSources.DecisionBehavior,
+            ClaimScriptSources.DecisionBehaviorHash,
+            ScriptPackageSpecExtensions.CreateSingleSource(ClaimScriptSources.DecisionBehavior),
+            "3",
+            "claim-schema");
+
+        await projector.ProjectAsync(
+            context,
+            BuildEnvelope(fact, state),
+            CancellationToken.None);
+
+        var expected = BuildNativeGraphProjection(
+            "claim-runtime-derived",
+            "claim_orchestrator",
+            "definition-derived-graph",
+            "rev-claim-1",
+            readModel);
+        graphWriter.LastUpsert.Should().NotBeNull();
+        var graphReadModel = graphWriter.LastUpsert!;
+        var graph = graphMaterializer.Materialize(graphReadModel);
+        var expectedGraph = new ScriptNativeGraphMaterializer()
+            .Materialize(
+                "claim-runtime-derived",
+                "claim_orchestrator",
+                "definition-derived-graph",
+                "rev-claim-1",
+                fact,
+                "evt-graph-1",
+                DateTimeOffset.Parse("2026-03-14T00:00:00Z"),
+                expected);
+
+        graphReadModel.SchemaId.Should().Be(expected.SchemaId);
+        graphReadModel.GraphScope.Should().Be(expected.GraphScope);
+        graphReadModel.StateVersion.Should().Be(13);
+        graphReadModel.LastEventId.Should().Be("evt-graph-1");
+        graphReadModel.GraphNodeEntries.Should().BeEquivalentTo(expectedGraph.GraphNodeEntries);
+        graphReadModel.GraphEdgeEntries.Should().BeEquivalentTo(expectedGraph.GraphEdgeEntries);
+        graph.Nodes.Should().Contain(x => x.NodeId == "script:claim_case:claim-runtime-derived");
+        graph.Edges.Should().ContainSingle(x =>
+            x.FromNodeId == "script:claim_case:claim-runtime-derived" &&
             x.ToNodeId == "ref:policy:POLICY-B" &&
             x.EdgeType == "rel_policy");
     }
@@ -244,6 +339,76 @@ public sealed class ScriptNativeGraphProjectorTests
         graphWriter.LastUpsert!.UpdatedAt.Should().Be(occurredAt);
     }
 
+    [Fact]
+    public async Task ProjectAsync_ShouldFallbackToLegacyNativeGraphField17_WhenStateRootCannotDerive()
+    {
+        var graphWriter = new RecordingNativeGraphWriter();
+        var readModel = BuildClaimReadModel();
+        var legacyGraph = BuildNativeGraphProjection(readModel);
+        var projector = new ScriptNativeGraphProjector(
+            graphWriter,
+            CreateRealMaterializer(),
+            new ScriptNativeGraphMaterializer());
+        var context = new ScriptExecutionMaterializationContext
+        {
+            RootActorId = "claim-runtime",
+            ProjectionKind = "script-execution-read-model",
+        };
+        var fact = ScriptLegacyFactPayloadTestHelper.WithLegacyPayloads(
+            new ScriptDomainFactCommitted
+            {
+                ActorId = "claim-runtime",
+                DefinitionActorId = "definition-1",
+                ScriptId = "claim_orchestrator",
+                Revision = "rev-claim-1",
+                RunId = "run-legacy-graph",
+                EventType = Any.Pack(new ClaimDecisionRecorded()).TypeUrl,
+                DomainEventPayload = Any.Pack(new ClaimDecisionRecorded
+                {
+                    CommandId = "command-legacy-graph",
+                    Current = readModel.Clone(),
+                }),
+                ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
+                StateVersion = 14,
+                OccurredAtUnixTimeMs = DateTimeOffset.Parse("2026-03-14T00:00:00Z").ToUnixTimeMilliseconds(),
+            },
+            nativeGraph: legacyGraph);
+        var state = ScriptCommittedEnvelopeFactory.CreateState(
+            "definition-1",
+            "claim_orchestrator",
+            "rev-claim-1",
+            new ClaimState
+            {
+                CaseId = readModel.CaseId,
+            },
+            fact.StateVersion,
+            Any.Pack(readModel).TypeUrl);
+
+        fact.TryGetLegacyNativeGraph().Should().NotBeNull();
+
+        await projector.ProjectAsync(
+            context,
+            BuildEnvelope(fact, state),
+            CancellationToken.None);
+
+        var expectedGraphReadModel = new ScriptNativeGraphMaterializer()
+            .Materialize(
+                "claim-runtime",
+                "claim_orchestrator",
+                "definition-1",
+                "rev-claim-1",
+                fact,
+                "evt-graph-1",
+                DateTimeOffset.Parse("2026-03-14T00:00:00Z"),
+                legacyGraph);
+        graphWriter.LastUpsert.Should().NotBeNull();
+        graphWriter.LastUpsert!.StateVersion.Should().Be(14);
+        graphWriter.LastUpsert.SchemaId.Should().Be(legacyGraph.SchemaId);
+        graphWriter.LastUpsert.GraphScope.Should().Be(legacyGraph.GraphScope);
+        graphWriter.LastUpsert.GraphNodeEntries.Should().BeEquivalentTo(expectedGraphReadModel.GraphNodeEntries);
+        graphWriter.LastUpsert.GraphEdgeEntries.Should().BeEquivalentTo(expectedGraphReadModel.GraphEdgeEntries);
+    }
+
     private static ClaimReadModel BuildClaimReadModel()
     {
         return new ClaimReadModel
@@ -267,12 +432,25 @@ public sealed class ScriptNativeGraphProjectorTests
         };
     }
 
-    private static ScriptNativeGraphProjection BuildNativeGraphProjection(ClaimReadModel readModel)
+    private static ScriptNativeGraphProjection BuildNativeGraphProjection(ClaimReadModel readModel) =>
+        BuildNativeGraphProjection(
+            "claim-runtime",
+            "claim_orchestrator",
+            "definition-1",
+            "rev-claim-1",
+            readModel);
+
+    private static ScriptNativeGraphProjection BuildNativeGraphProjection(
+        string actorId,
+        string scriptId,
+        string definitionActorId,
+        string revision,
+        ClaimReadModel readModel)
     {
         var artifactResolver = new CachedScriptBehaviorArtifactResolver(new RoslynScriptBehaviorCompiler(new ScriptSandboxPolicy()));
         var artifact = artifactResolver.Resolve(new ScriptBehaviorArtifactRequest(
-            "claim_orchestrator",
-            "rev-claim-1",
+            scriptId,
+            revision,
             ScriptPackageSpecExtensions.CreateSingleSource(ClaimScriptSources.DecisionBehavior),
             ClaimScriptSources.DecisionBehaviorHash));
         var plan = new ScriptReadModelMaterializationCompiler().Compile(
@@ -281,13 +459,20 @@ public sealed class ScriptNativeGraphProjectorTests
             "3");
         return new ScriptNativeProjectionBuilder()
             .BuildGraph(
-                "claim-runtime",
-                "claim_orchestrator",
-                "definition-1",
-                "rev-claim-1",
+                actorId,
+                scriptId,
+                definitionActorId,
+                revision,
                 readModel,
                 plan)!;
     }
+
+    private static IScriptProjectionPayloadMaterializer CreateRealMaterializer() =>
+        new ScriptProjectionPayloadMaterializer(
+            new CachedScriptBehaviorArtifactResolver(new RoslynScriptBehaviorCompiler(new ScriptSandboxPolicy())),
+            new ScriptReadModelMaterializationCompiler(),
+            new ScriptNativeProjectionBuilder(),
+            new ProtobufMessageCodec());
 
     private static EventEnvelope BuildEnvelope(ScriptDomainFactCommitted fact, ScriptBehaviorState state) =>
         ScriptCommittedEnvelopeFactory.CreateCommittedEnvelope(

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptProjectionPayloadMaterializerTestDoubles.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptProjectionPayloadMaterializerTestDoubles.cs
@@ -1,0 +1,85 @@
+using Aevatar.Foundation.Abstractions;
+using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Projection.Materialization;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Scripting.Core.Tests.Projection;
+
+internal sealed class StubScriptProjectionPayloadMaterializer : IScriptProjectionPayloadMaterializer
+{
+    private readonly Func<ScriptProjectionMaterializationInput, ScriptProjectionPayload> _factory;
+
+    public StubScriptProjectionPayloadMaterializer(Func<ScriptProjectionMaterializationInput, ScriptProjectionPayload> factory)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+    }
+
+    public ValueTask<ScriptProjectionPayload> MaterializeAsync(
+        ScriptProjectionMaterializationInput input,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(_factory(input));
+    }
+
+    public static StubScriptProjectionPayloadMaterializer WithReadModel(IMessage readModel) =>
+        new(_ => new ScriptProjectionPayload(
+            Any.Pack(readModel),
+            NativeDocument: null,
+            NativeGraph: null,
+            UsedLegacyReadModelPayload: false,
+            UsedLegacyNativeDocument: false,
+            UsedLegacyNativeGraph: false));
+
+    public static StubScriptProjectionPayloadMaterializer WithNativeDocument(ScriptNativeDocumentProjection? nativeDocument) =>
+        new(_ => new ScriptProjectionPayload(
+            ReadModelPayload: null,
+            nativeDocument,
+            NativeGraph: null,
+            UsedLegacyReadModelPayload: false,
+            UsedLegacyNativeDocument: false,
+            UsedLegacyNativeGraph: false));
+
+    public static StubScriptProjectionPayloadMaterializer WithNativeGraph(ScriptNativeGraphProjection? nativeGraph) =>
+        new(_ => new ScriptProjectionPayload(
+            ReadModelPayload: null,
+            NativeDocument: null,
+            nativeGraph,
+            UsedLegacyReadModelPayload: false,
+            UsedLegacyNativeDocument: false,
+            UsedLegacyNativeGraph: false));
+}
+
+internal static class ScriptLegacyFactPayloadTestHelper
+{
+    public static ScriptDomainFactCommitted WithLegacyPayloads(
+        ScriptDomainFactCommitted fact,
+        Any? readModelPayload = null,
+        ScriptNativeDocumentProjection? nativeDocument = null,
+        ScriptNativeGraphProjection? nativeGraph = null)
+    {
+        ArgumentNullException.ThrowIfNull(fact);
+
+        using var stream = new MemoryStream();
+        var bytes = ((IMessage)fact).ToByteArray();
+        stream.Write(bytes, 0, bytes.Length);
+        using (var output = new CodedOutputStream(stream, leaveOpen: true))
+        {
+            WriteMessage(output, 15, readModelPayload);
+            WriteMessage(output, 16, nativeDocument);
+            WriteMessage(output, 17, nativeGraph);
+        }
+
+        return ScriptDomainFactCommitted.Parser.ParseFrom(stream.ToArray());
+    }
+
+    private static void WriteMessage(CodedOutputStream output, int fieldNumber, IMessage? message)
+    {
+        if (message == null)
+            return;
+
+        output.WriteTag(fieldNumber, WireFormat.WireType.LengthDelimited);
+        output.WriteMessage(message);
+    }
+}

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptReadModelProjectorInitializationTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptReadModelProjectorInitializationTests.cs
@@ -2,6 +2,7 @@ using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Scripting.Abstractions;
+using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.Projectors;
 using Aevatar.Scripting.Projection.ReadModels;
@@ -56,6 +57,7 @@ public sealed class ScriptReadModelProjectorInitializationTests
         InMemoryProjectionDocumentStore<ScriptReadModelDocument> dispatcher) =>
         new(
             dispatcher,
+            StubScriptProjectionPayloadMaterializer.WithReadModel(new SimpleTextReadModel()),
             new FixedProjectionClock(new DateTimeOffset(2026, 3, 14, 0, 0, 0, TimeSpan.Zero)));
 
     private sealed class FixedProjectionClock(DateTimeOffset now) : IProjectionClock

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptReadModelProjectorNeutralityTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptReadModelProjectorNeutralityTests.cs
@@ -17,14 +17,15 @@ public sealed class ScriptReadModelProjectorNeutralityTests
     public async Task ProjectAsync_ShouldNotMutateCommittedStateMirror()
     {
         var dispatcher = new InMemoryProjectionDocumentStore<ScriptReadModelDocument>();
-        var projector = new ScriptReadModelProjector(
-            dispatcher,
-            new FixedProjectionClock(DateTimeOffset.UtcNow));
         var readModel = new SimpleTextReadModel
         {
             HasValue = true,
             Value = "HELLO",
         };
+        var projector = new ScriptReadModelProjector(
+            dispatcher,
+            StubScriptProjectionPayloadMaterializer.WithReadModel(readModel),
+            new FixedProjectionClock(DateTimeOffset.UtcNow));
         var state = ScriptCommittedEnvelopeFactory.CreateState(
             "definition-1",
             "script-1",
@@ -47,7 +48,6 @@ public sealed class ScriptReadModelProjectorNeutralityTests
                 Current = readModel.Clone(),
             }),
             ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
-            ReadModelPayload = Any.Pack(readModel),
             StateVersion = 1,
         };
         var context = new ScriptExecutionMaterializationContext

--- a/test/Aevatar.Scripting.Core.Tests/Projection/ScriptReadModelProjectorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Projection/ScriptReadModelProjectorTests.cs
@@ -3,6 +3,11 @@ using Aevatar.CQRS.Projection.Runtime.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Core.Tests.Messages;
+using Aevatar.Scripting.Infrastructure.Compilation;
+using Aevatar.Scripting.Infrastructure.Serialization;
+using Aevatar.Scripting.Core.Materialization;
+using Aevatar.Scripting.Core.Runtime;
+using Aevatar.Scripting.Projection.Materialization;
 using Aevatar.Scripting.Projection.Orchestration;
 using Aevatar.Scripting.Projection.Projectors;
 using Aevatar.Scripting.Projection.ReadModels;
@@ -20,6 +25,7 @@ public sealed class ScriptReadModelProjectorTests
         var dispatcher = new InMemoryProjectionDocumentStore<ScriptReadModelDocument>();
         var projector = new ScriptReadModelProjector(
             dispatcher,
+            CreateRealMaterializer(),
             new FixedProjectionClock(new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero)));
         var context = new ScriptExecutionMaterializationContext
         {
@@ -49,7 +55,6 @@ public sealed class ScriptReadModelProjectorTests
                 },
             }),
             ReadModelTypeUrl = Any.Pack(readModel).TypeUrl,
-            ReadModelPayload = Any.Pack(readModel),
             StateVersion = 1,
         };
         var state = ScriptCommittedEnvelopeFactory.CreateState(
@@ -58,7 +63,10 @@ public sealed class ScriptReadModelProjectorTests
             "rev-1",
             new SimpleTextState { Value = "HELLO" },
             fact.StateVersion,
-            ScriptSources.UppercaseReadModelTypeUrl);
+            ScriptSources.UppercaseReadModelTypeUrl,
+            ScriptSources.UppercaseBehavior,
+            ScriptSources.UppercaseBehaviorHash,
+            ScriptPackageSpecExtensions.CreateSingleSource(ScriptSources.UppercaseBehavior));
 
         await projector.ProjectAsync(
             context,
@@ -86,6 +94,7 @@ public sealed class ScriptReadModelProjectorTests
         var dispatcher = new InMemoryProjectionDocumentStore<ScriptReadModelDocument>();
         var projector = new ScriptReadModelProjector(
             dispatcher,
+            StubScriptProjectionPayloadMaterializer.WithReadModel(new Empty()),
             new FixedProjectionClock(new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero)));
         var context = new ScriptExecutionMaterializationContext
         {
@@ -112,11 +121,12 @@ public sealed class ScriptReadModelProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_ShouldUseCommittedReadModelPayloadAsSourceOfTruth()
+    public async Task ProjectAsync_ShouldFallbackToLegacyReadModelPayload_WhenStateRootCannotDerive()
     {
         var dispatcher = new InMemoryProjectionDocumentStore<ScriptReadModelDocument>();
         var projector = new ScriptReadModelProjector(
             dispatcher,
+            CreateRealMaterializer(),
             new FixedProjectionClock(new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero)));
         var context = new ScriptExecutionMaterializationContext
         {
@@ -128,7 +138,7 @@ public sealed class ScriptReadModelProjectorTests
             HasValue = true,
             Value = "NEW",
         };
-        var fact = new ScriptDomainFactCommitted
+        var fact = ScriptLegacyFactPayloadTestHelper.WithLegacyPayloads(new ScriptDomainFactCommitted
         {
             ActorId = "runtime-3",
             DefinitionActorId = string.Empty,
@@ -146,9 +156,8 @@ public sealed class ScriptReadModelProjectorTests
                 },
             }),
             ReadModelTypeUrl = Any.Pack(committedReadModel).TypeUrl,
-            ReadModelPayload = Any.Pack(committedReadModel),
             StateVersion = 3,
-        };
+        }, readModelPayload: Any.Pack(committedReadModel));
         var state = ScriptCommittedEnvelopeFactory.CreateState(
             "definition-3",
             "script-3",
@@ -177,6 +186,13 @@ public sealed class ScriptReadModelProjectorTests
         document.ReadModelTypeUrl.Should().Be(Any.Pack(committedReadModel).TypeUrl);
         document.ReadModelPayload.Unpack<SimpleTextReadModel>().Value.Should().Be("NEW");
     }
+
+    private static IScriptProjectionPayloadMaterializer CreateRealMaterializer() =>
+        new ScriptProjectionPayloadMaterializer(
+            new CachedScriptBehaviorArtifactResolver(new RoslynScriptBehaviorCompiler(new ScriptSandboxPolicy())),
+            new ScriptReadModelMaterializationCompiler(),
+            new ScriptNativeProjectionBuilder(),
+            new ProtobufMessageCodec());
 
     private sealed class FixedProjectionClock(DateTimeOffset now) : IProjectionClock
     {

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptBehaviorDispatcherTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptBehaviorDispatcherTests.cs
@@ -4,7 +4,6 @@ using Aevatar.Scripting.Abstractions.Behaviors;
 using Aevatar.Scripting.Abstractions.Definitions;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Scripting.Application.Runtime;
-using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Infrastructure.Compilation;
@@ -28,11 +27,9 @@ public sealed class ScriptBehaviorDispatcherTests
     {
         Action act = parameterName switch
         {
-            "artifactResolver" => () => _ = new ScriptBehaviorDispatcher(null!, new ScriptReadModelMaterializationCompiler(), new ScriptNativeProjectionBuilder(), new ProtobufMessageCodec()),
+            "artifactResolver" => () => _ = new ScriptBehaviorDispatcher(null!, new ProtobufMessageCodec()),
             "codec" => () => _ = new ScriptBehaviorDispatcher(
                 new StaticArtifactResolver(CreateArtifact(new UppercaseBehavior())),
-                new ScriptReadModelMaterializationCompiler(),
-                new ScriptNativeProjectionBuilder(),
                 null!),
             _ => throw new InvalidOperationException("Unexpected parameter name."),
         };
@@ -101,12 +98,13 @@ public sealed class ScriptBehaviorDispatcherTests
         fact.ReadModelTypeUrl.Should().Be(SimpleTextReadModelTypeUrl);
         fact.DomainEventPayload.Should().NotBeNull();
         fact.DomainEventPayload.Unpack<SimpleTextEvent>().Current.Value.Should().Be("HELLO");
-        fact.ReadModelPayload.Should().NotBeNull();
-        fact.ReadModelPayload.Unpack<SimpleTextReadModel>().Value.Should().Be("HELLO");
+        fact.TryGetLegacyReadModelPayload().Should().BeNull();
+        fact.TryGetLegacyNativeDocument().Should().BeNull();
+        fact.TryGetLegacyNativeGraph().Should().BeNull();
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldEmitNativeMaterializations_WhenSchemaIsDeclared()
+    public async Task DispatchAsync_ShouldNotPersistDerivedNativeMaterializations_WhenSchemaIsDeclared()
     {
         var dispatcher = CreateDispatcher(
             new CachedScriptBehaviorArtifactResolver(new RoslynScriptBehaviorCompiler(new ScriptSandboxPolicy())));
@@ -150,24 +148,15 @@ public sealed class ScriptBehaviorDispatcherTests
                 CurrentStateRoot: null,
                 CurrentStateVersion: 4,
                 Envelope: envelope,
-                Capabilities: new NoOpCapabilities())
-            {
-                ReadModelSchemaVersion = "3",
-                ReadModelSchemaHash = "structured-schema",
-            },
+                Capabilities: new NoOpCapabilities()),
             CancellationToken.None);
 
         facts.Should().ContainSingle();
         var fact = facts[0];
-        fact.NativeDocument.Should().NotBeNull();
-        fact.NativeGraph.Should().NotBeNull();
-        fact.NativeDocument!.SchemaId.Should().Be("script_profile");
-        fact.NativeDocument.FieldsValue.Fields["actor_id"].StringValue.Should().Be("actor-1");
-        fact.NativeGraph!.GraphScope.Should().Be("script-native-script_profile");
-        fact.NativeGraph.NodeEntries.Should().Contain(x => x.NodeId == "script:script_profile:profile-runtime-1");
-        fact.NativeGraph.EdgeEntries.Should().Contain(x =>
-            x.FromNodeId == "script:script_profile:profile-runtime-1" &&
-            x.EdgeType == "rel_policy");
+        fact.DomainEventPayload.Unpack<ScriptProfileUpdated>().Current.ActorId.Should().Be("actor-1");
+        fact.TryGetLegacyReadModelPayload().Should().BeNull();
+        fact.TryGetLegacyNativeDocument().Should().BeNull();
+        fact.TryGetLegacyNativeGraph().Should().BeNull();
     }
 
     [Fact]
@@ -304,8 +293,6 @@ public sealed class ScriptBehaviorDispatcherTests
     private static ScriptBehaviorDispatcher CreateDispatcher(IScriptBehaviorArtifactResolver artifactResolver) =>
         new(
             artifactResolver,
-            new ScriptReadModelMaterializationCompiler(),
-            new ScriptNativeProjectionBuilder(),
             new ProtobufMessageCodec());
 
     [Fact]
@@ -449,7 +436,7 @@ public sealed class ScriptBehaviorDispatcherTests
     }
 
     [Fact]
-    public async Task DispatchAsync_ShouldMaterializeEachFactFromItsOwnPostEventState()
+    public async Task DispatchAsync_ShouldProgressStateAcrossMultiEventCommandTurnWithoutPersistingDerivedPayload()
     {
         var dispatcher = CreateDispatcher(
             new StaticArtifactResolver(CreateArtifact(new SequentialProjectionBehavior())));
@@ -482,10 +469,11 @@ public sealed class ScriptBehaviorDispatcherTests
         facts.Should().HaveCount(2);
         facts[0].EventSequence.Should().Be(1);
         facts[0].StateVersion.Should().Be(11);
-        facts[0].ReadModelPayload.Unpack<SimpleTextReadModel>().Value.Should().Be("FIRST");
+        facts[0].TryGetLegacyReadModelPayload().Should().BeNull();
         facts[1].EventSequence.Should().Be(2);
         facts[1].StateVersion.Should().Be(12);
-        facts[1].ReadModelPayload.Unpack<SimpleTextReadModel>().Value.Should().Be("SECOND");
+        facts[1].DomainEventPayload.Unpack<SimpleTextEvent>().Current.Value.Should().Be("SECOND");
+        facts[1].TryGetLegacyReadModelPayload().Should().BeNull();
     }
 
     [Fact]

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeExecutionOrchestratorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeExecutionOrchestratorTests.cs
@@ -4,7 +4,6 @@ using Aevatar.Scripting.Abstractions.Behaviors;
 using Aevatar.Scripting.Abstractions.Definitions;
 using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Scripting.Application.Runtime;
-using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Infrastructure.Serialization;
@@ -29,8 +28,6 @@ public sealed class ScriptRuntimeExecutionOrchestratorTests
                 behavior.Descriptor,
                 behavior.Descriptor.ToContract(),
                 () => new AsyncDisposableBehavior(tracker))),
-            new ScriptReadModelMaterializationCompiler(),
-            new ScriptNativeProjectionBuilder(),
             new ProtobufMessageCodec());
 
         var facts = await dispatcher.DispatchAsync(

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
@@ -6,7 +6,6 @@ using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Abstractions.Behaviors;
 using Aevatar.Scripting.Core;
 using Aevatar.Scripting.Core.Compilation;
-using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Infrastructure.Compilation;
@@ -23,42 +22,15 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
     [InlineData("dispatcher")]
     [InlineData("capabilityFactory")]
     [InlineData("artifactResolver")]
-    [InlineData("materializationCompiler")]
     [InlineData("codec")]
     public void Ctor_ShouldRejectNullDependencies(string parameterName)
     {
         Action act = parameterName switch
         {
-            "dispatcher" => () => _ = new ScriptBehaviorGAgent(
-                null!,
-                new NoOpCapabilityFactory(),
-                CreateArtifactResolver(),
-                new ScriptReadModelMaterializationCompiler(),
-                new ProtobufMessageCodec()),
-            "capabilityFactory" => () => _ = new ScriptBehaviorGAgent(
-                new NoOpDispatcher(),
-                null!,
-                CreateArtifactResolver(),
-                new ScriptReadModelMaterializationCompiler(),
-                new ProtobufMessageCodec()),
-            "artifactResolver" => () => _ = new ScriptBehaviorGAgent(
-                new NoOpDispatcher(),
-                new NoOpCapabilityFactory(),
-                null!,
-                new ScriptReadModelMaterializationCompiler(),
-                new ProtobufMessageCodec()),
-            "materializationCompiler" => () => _ = new ScriptBehaviorGAgent(
-                new NoOpDispatcher(),
-                new NoOpCapabilityFactory(),
-                CreateArtifactResolver(),
-                null!,
-                new ProtobufMessageCodec()),
-            "codec" => () => _ = new ScriptBehaviorGAgent(
-                new NoOpDispatcher(),
-                new NoOpCapabilityFactory(),
-                CreateArtifactResolver(),
-                new ScriptReadModelMaterializationCompiler(),
-                null!),
+            "dispatcher" => () => _ = new ScriptBehaviorGAgent(null!, new NoOpCapabilityFactory(), CreateArtifactResolver(), new ProtobufMessageCodec()),
+            "capabilityFactory" => () => _ = new ScriptBehaviorGAgent(new NoOpDispatcher(), null!, CreateArtifactResolver(), new ProtobufMessageCodec()),
+            "artifactResolver" => () => _ = new ScriptBehaviorGAgent(new NoOpDispatcher(), new NoOpCapabilityFactory(), null!, new ProtobufMessageCodec()),
+            "codec" => () => _ = new ScriptBehaviorGAgent(new NoOpDispatcher(), new NoOpCapabilityFactory(), CreateArtifactResolver(), null!),
             _ => throw new InvalidOperationException("Unexpected parameter name."),
         };
 
@@ -486,12 +458,7 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         IScriptBehaviorRuntimeCapabilityFactory? capabilityFactory = null)
     {
         var eventStore = new InMemoryEventStore();
-        var agent = new ScriptBehaviorGAgent(
-            dispatcher ?? new NoOpDispatcher(),
-            capabilityFactory ?? new NoOpCapabilityFactory(),
-            CreateArtifactResolver(),
-            new ScriptReadModelMaterializationCompiler(),
-            new ProtobufMessageCodec())
+        var agent = new ScriptBehaviorGAgent(dispatcher ?? new NoOpDispatcher(), capabilityFactory ?? new NoOpCapabilityFactory(), CreateArtifactResolver(), new ProtobufMessageCodec())
         {
             EventPublisher = new RecordingEventPublisher(),
             EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<ScriptBehaviorState>(eventStore),

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
@@ -5,7 +5,6 @@ using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Abstractions.Behaviors;
 using Aevatar.Scripting.Abstractions.Definitions;
 using Aevatar.Scripting.Abstractions.Queries;
-using Aevatar.Scripting.Core.Materialization;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Tests.Messages;
 using Aevatar.Scripting.Infrastructure.Compilation;
@@ -132,11 +131,9 @@ public class ScriptBehaviorGAgentReplayContractTests
         var codec = new ProtobufMessageCodec();
         var dispatcher = new Aevatar.Scripting.Application.Runtime.ScriptBehaviorDispatcher(
             artifactResolver,
-            new ScriptReadModelMaterializationCompiler(),
-            new ScriptNativeProjectionBuilder(),
             codec);
         var publisher = new RecordingEventPublisher();
-        var agent = new ScriptBehaviorGAgent(dispatcher, new StaticCapabilityFactory(), artifactResolver, new ScriptReadModelMaterializationCompiler(), codec)
+        var agent = new ScriptBehaviorGAgent(dispatcher, new StaticCapabilityFactory(), artifactResolver, codec)
         {
             EventPublisher = publisher,
             EventSourcingBehaviorFactory = new DefaultEventSourcingBehaviorFactory<ScriptBehaviorState>(

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -459,11 +459,6 @@ if rg -n "project:\s*static|project:\s*\(" test/Aevatar.Scripting.Core.Tests tes
   exit 1
 fi
 
-if rg -n "IScriptBehaviorArtifactResolver|ScriptBehaviorArtifactRequest|IScriptReadModelMaterializationCompiler" src/Aevatar.Scripting.Projection; then
-  echo "Scripting projection must not resolve behavior artifacts or compile native materialization plans. Consume committed durable facts only."
-  exit 1
-fi
-
 if rg -n "IProjectionEventReducer|AddAIDefaultProjectionLayer|AddAllAIProjectionEventReducers|EnableWorkflowAIProjection" src; then
   echo "Reducer-era projection abstractions and workflow AI projection toggles are forbidden on the production path."
   exit 1


### PR DESCRIPTION
## 摘要

iter76 cluster-076-scripting-domain-fact-derived-readmodel-payloads(severity:high,rule:AG-DOMAIN-EVENT-DERIVED-01)。Phase 9 r1 unanimous 3/3。

- **Old**:`ScriptBehaviorDispatcher.cs:133` 在事件持久化**之前** `behavior.BuildReadModel/BuildNativeDocument/BuildNativeGraph`,把派生 projection payload(field 15/16/17)写进 `ScriptDomainFactCommitted` 域事件;3 projector 直接 copy `fact.ReadModelPayload/NativeDocument/NativeGraph` 进 readmodel
- **New**:`ScriptDomainFactCommitted` 只保留已发生脚本业务事实;新建 `IScriptProjectionPayloadMaterializer` + `ScriptProjectionPayloadMaterializer` 在 projection 阶段从 committed fact + state_root 派生 readmodel/native_document/native_graph;legacy fallback 仅 read-side

违反:CLAUDE「domain event 描述事实,不持久化派生 projection」「projection 负责物化,不负责推导」。

## Phase 9 共识

**r1 3/3 unanimous propose**(framing:`projection-materializer-derived-payloads`)。see #968 meta-judge 评论。

## 范围

新文件 3 + 修改 16 = 19 文件改动(+ ~~~ / -193):
- `src/Aevatar.Scripting.Abstractions/script_host_messages.proto`(reserved 15/16/17 + field name 保留 wire)
- `src/Aevatar.Scripting.Projection/Materialization/IScriptProjectionPayloadMaterializer.cs`(新)
- `src/Aevatar.Scripting.Projection/Materialization/ScriptProjectionPayloadMaterializer.cs`(新)
- `src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorDispatcher.cs`(去 write-side derivation)
- `src/Aevatar.Scripting.Core/Runtime/ScriptBehaviorDispatchRequest.cs`(适配)
- `src/Aevatar.Scripting.Core/ScriptBehaviorGAgent.cs`(适配)
- 3 projector:`ScriptReadModelProjector` / `ScriptNativeDocumentProjector` / `ScriptNativeGraphProjector`(consume materializer 结果)
- `src/Aevatar.Scripting.Projection/DependencyInjection/ServiceCollectionExtensions.cs`(注册 materializer)
- 测试:`ScriptBehaviorDispatcherTests` + 3 projector tests + `ScriptRuntimeExecutionOrchestratorTests` + `ReplayContractTests` + `BranchCoverageTests` + `Integration.Tests.ClaimReplayTests` + `ScriptProjectionPayloadMaterializerTestDoubles.cs`(新)

验证:Scripting Abstractions/Application/Core/Projection 编译 ✅ + Scripting.Core/Integration 测试 pass + 两个 `ci/*_guards.sh` pass。

closes #968

## Stacked-PR

Part of iter76 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter76

⟦AI:AUTO-LOOP⟧
