### PR TITLE
iter79 cluster-079: secure-input suspension typed-first(bool secure + redacted_output)+ Metadata reserved keys legacy

### DIFF
--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -177,6 +177,8 @@ message WorkflowSuspendedEvent
   map<string, string> metadata = 7;
   string content = 8;
   string delivery_target_id = 9;
+  bool secure = 10;
+  string redacted_output = 11;
 }
 message WorkflowResumedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/workflow_run_events.proto
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/workflow_run_events.proto
@@ -183,6 +183,8 @@ message WorkflowHumanInputRequestCustomPayload {
   repeated string options = 8;
   string content = 9;
   string delivery_target_id = 10;
+  bool secure = 11;
+  string redacted_output = 12;
 }
 
 message WorkflowHumanInputResponseCustomPayload {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
@@ -91,6 +91,9 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
                 requestVariableName,
                 timeoutSeconds);
 
+            // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
+            //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
+            //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
             var suspended = new WorkflowSuspendedEvent
             {
                 RunId = runId,
@@ -99,12 +102,10 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
                 Prompt = prompt,
                 TimeoutSeconds = timeoutSeconds,
                 VariableName = requestVariableName,
+                Secure = true,
+                RedactedOutput = requestMaskedOutput,
             };
             WorkflowSuspensionRequestSupport.ApplyDeliveryTarget(suspended, request);
-            suspended.Metadata["variable"] = requestVariableName;
-            suspended.Metadata["secure"] = "true";
-            suspended.Metadata["input_mode"] = "password";
-            suspended.Metadata["redacted_output"] = requestMaskedOutput;
 
             await ctx.PublishAsync(suspended, TopologyAudience.ParentAndChildren, ct);
             return;

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs
@@ -610,9 +610,13 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
 
         var evt = envelope.Payload.Unpack<WorkflowSuspendedEvent>();
         var ts = AGUIEventEnvelopeMappingHelpers.ToUnixMs(envelope.Timestamp);
-        var metadata = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var (key, value) in evt.Metadata)
-            metadata[key] = value;
+        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
+        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        var metadata = WorkflowSuspendedSecureInputMetadata.FilterOpenExtensionMetadata(evt.Metadata);
+        var variableName = WorkflowSuspendedSecureInputMetadata.ResolveVariableName(evt.VariableName, evt.Metadata);
+        var secure = WorkflowSuspendedSecureInputMetadata.ResolveSecure(evt.Secure, evt.Metadata);
+        var redactedOutput = WorkflowSuspendedSecureInputMetadata.ResolveRedactedOutput(evt.RedactedOutput, evt.Metadata);
 
         events =
         [
@@ -629,9 +633,11 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
                         SuspensionType = evt.SuspensionType,
                         Prompt = evt.Prompt,
                         TimeoutSeconds = evt.TimeoutSeconds,
-                        VariableName = evt.VariableName,
+                        VariableName = variableName,
                         Content = evt.Content,
                         DeliveryTargetId = evt.DeliveryTargetId,
+                        Secure = secure,
+                        RedactedOutput = redactedOutput,
                         Metadata = { metadata },
                     }),
                 },
@@ -639,6 +645,46 @@ public sealed class WorkflowSuspendedRunEventEnvelopeMappingHandler : IWorkflowR
         ];
         return true;
     }
+}
+
+internal static class WorkflowSuspendedSecureInputMetadata
+{
+    private static readonly HashSet<string> ReservedLegacyKeys =
+    [
+        "variable",
+        "secure",
+        "input_mode",
+        "redacted_output",
+    ];
+
+    public static Dictionary<string, string> FilterOpenExtensionMetadata(
+        IDictionary<string, string> metadata)
+    {
+        var filtered = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in metadata)
+        {
+            if (!ReservedLegacyKeys.Contains(key))
+                filtered[key] = value;
+        }
+
+        return filtered;
+    }
+
+    public static string ResolveVariableName(string? typedValue, IDictionary<string, string> metadata) =>
+        !string.IsNullOrWhiteSpace(typedValue)
+            ? typedValue
+            : metadata.TryGetValue("variable", out var legacy) ? legacy : string.Empty;
+
+    public static bool ResolveSecure(bool typedValue, IDictionary<string, string> metadata) =>
+        typedValue ||
+        (metadata.TryGetValue("secure", out var legacy) &&
+         bool.TryParse(legacy, out var parsed) &&
+         parsed);
+
+    public static string ResolveRedactedOutput(string? typedValue, IDictionary<string, string> metadata) =>
+        !string.IsNullOrWhiteSpace(typedValue)
+            ? typedValue
+            : metadata.TryGetValue("redacted_output", out var legacy) ? legacy : string.Empty;
 }
 
 public sealed class WorkflowWaitingSignalRunEventEnvelopeMappingHandler : IWorkflowRunEventEnvelopeMappingHandler

--- a/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs
@@ -35,9 +35,10 @@ public sealed class WorkflowHumanInteractionProjector
         if (string.IsNullOrWhiteSpace(evt.DeliveryTargetId))
             return;
 
-        var annotations = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var (key, value) in evt.Metadata)
-            annotations[key] = value;
+        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
+        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        var annotations = BuildAnnotations(evt);
 
         var request = new HumanInteractionRequest
         {
@@ -66,4 +67,21 @@ public sealed class WorkflowHumanInteractionProjector
             "secure_input" => ["submit"],
             _ => Array.Empty<string>(),
         };
+
+    private static Dictionary<string, string> BuildAnnotations(WorkflowSuspendedEvent evt)
+    {
+        var annotations = WorkflowSuspendedSecureInputMetadata.FilterOpenExtensionMetadata(evt.Metadata);
+        var variableName = WorkflowSuspendedSecureInputMetadata.ResolveVariableName(evt.VariableName, evt.Metadata);
+        var secure = WorkflowSuspendedSecureInputMetadata.ResolveSecure(evt.Secure, evt.Metadata);
+        var redactedOutput = WorkflowSuspendedSecureInputMetadata.ResolveRedactedOutput(evt.RedactedOutput, evt.Metadata);
+
+        if (!string.IsNullOrWhiteSpace(variableName))
+            annotations["variable"] = variableName;
+        if (secure)
+            annotations["secure"] = "true";
+        if (!string.IsNullOrWhiteSpace(redactedOutput))
+            annotations["redacted_output"] = redactedOutput;
+
+        return annotations;
+    }
 }

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs
@@ -278,6 +278,10 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
         step.SuspensionTimeoutSeconds = evt.TimeoutSeconds == 0 ? null : evt.TimeoutSeconds;
         step.RequestedVariableName = evt.VariableName ?? string.Empty;
         readModel.CompletionStatus = WorkflowExecutionCompletionStatus.WaitingForSignal;
+        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
+        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        var timelineMetadata = BuildWorkflowSuspendedTimelineMetadata(evt);
         AddTimeline(
             readModel.Timeline,
             observedAt,
@@ -287,7 +291,47 @@ internal static class WorkflowExecutionArtifactMaterializationSupport
             evt.StepId,
             step.StepType,
             eventType,
-            evt.Metadata);
+            timelineMetadata);
+    }
+
+    private static Dictionary<string, string> BuildWorkflowSuspendedTimelineMetadata(WorkflowSuspendedEvent evt)
+    {
+        var metadata = FilterOpenExtensionMetadata(evt.Metadata);
+        var variableName = !string.IsNullOrWhiteSpace(evt.VariableName)
+            ? evt.VariableName
+            : evt.Metadata.TryGetValue("variable", out var legacyVariable) ? legacyVariable : string.Empty;
+        var secure = evt.Secure ||
+                     (evt.Metadata.TryGetValue("secure", out var legacySecure) &&
+                      bool.TryParse(legacySecure, out var parsedSecure) &&
+                      parsedSecure);
+        var redactedOutput = !string.IsNullOrWhiteSpace(evt.RedactedOutput)
+            ? evt.RedactedOutput
+            : evt.Metadata.TryGetValue("redacted_output", out var legacyRedactedOutput)
+                ? legacyRedactedOutput
+                : string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(variableName))
+            metadata["variable"] = variableName;
+        if (secure)
+            metadata["secure"] = "true";
+        if (!string.IsNullOrWhiteSpace(redactedOutput))
+            metadata["redacted_output"] = redactedOutput;
+
+        return metadata;
+    }
+
+    private static Dictionary<string, string> FilterOpenExtensionMetadata(IDictionary<string, string> metadata)
+    {
+        var filtered = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in metadata)
+        {
+            if (key is "variable" or "secure" or "input_mode" or "redacted_output")
+                continue;
+
+            filtered[key] = value;
+        }
+
+        return filtered;
     }
 
     private static void ApplyWaitingForSignal(

--- a/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowCustomEvents.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowCustomEvents.cs
@@ -55,6 +55,8 @@ public sealed record WorkflowHumanInputRequestEventData
     public string? VariableName { get; init; }
     public string? Content { get; init; }
     public string? DeliveryTargetId { get; init; }
+    public bool? Secure { get; init; }
+    public string? RedactedOutput { get; init; }
     public IDictionary<string, string>? Metadata { get; init; }
 }
 
@@ -164,6 +166,34 @@ public static class WorkflowCustomEventParser
             return false;
         }
 
+        // Refactor (iter79/cluster-079-secure-input-suspension-metadata-bag):
+        //   Old pattern: WorkflowSuspendedEvent.Metadata string bag for secure/input_mode/redacted_output/variable
+        //   New principle (delete framing): typed bool secure + string redacted_output + reuse variable_name; Metadata open extension only; reserved keys read-only fallback
+        var rawMetadata = TryReadStringMap(obj, "metadata", "Metadata");
+        var metadata = FilterReservedHumanInputMetadata(rawMetadata);
+        var variableName = WorkflowSdkJson.TryReadString(obj, "variableName", "VariableName");
+        var secure = TryReadBoolean(obj, "secure", "Secure");
+        var redactedOutput = WorkflowSdkJson.TryReadString(obj, "redactedOutput", "RedactedOutput");
+
+        if (string.IsNullOrWhiteSpace(variableName) &&
+            rawMetadata?.TryGetValue("variable", out var legacyVariableName) == true)
+        {
+            variableName = legacyVariableName;
+        }
+
+        if (!secure.HasValue &&
+            rawMetadata?.TryGetValue("secure", out var legacySecure) == true &&
+            bool.TryParse(legacySecure, out var parsedSecure))
+        {
+            secure = parsedSecure;
+        }
+
+        if (string.IsNullOrWhiteSpace(redactedOutput) &&
+            rawMetadata?.TryGetValue("redacted_output", out var legacyRedactedOutput) == true)
+        {
+            redactedOutput = legacyRedactedOutput;
+        }
+
         data = new WorkflowHumanInputRequestEventData
         {
             RunId = WorkflowSdkJson.TryReadString(obj, "runId", "RunId"),
@@ -171,12 +201,31 @@ public static class WorkflowCustomEventParser
             SuspensionType = WorkflowSdkJson.TryReadString(obj, "suspensionType", "SuspensionType"),
             Prompt = WorkflowSdkJson.TryReadString(obj, "prompt", "Prompt"),
             TimeoutSeconds = TryReadInt(obj, "timeoutSeconds", "TimeoutSeconds"),
-            VariableName = WorkflowSdkJson.TryReadString(obj, "variableName", "VariableName"),
+            VariableName = variableName,
             Content = WorkflowSdkJson.TryReadString(obj, "content", "Content"),
             DeliveryTargetId = WorkflowSdkJson.TryReadString(obj, "deliveryTargetId", "DeliveryTargetId"),
-            Metadata = TryReadStringMap(obj, "metadata", "Metadata"),
+            Secure = secure,
+            RedactedOutput = redactedOutput,
+            Metadata = metadata,
         };
         return true;
+    }
+
+    private static Dictionary<string, string>? FilterReservedHumanInputMetadata(IDictionary<string, string>? metadata)
+    {
+        if (metadata == null)
+            return null;
+
+        var filtered = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in metadata)
+        {
+            if (key is "variable" or "secure" or "input_mode" or "redacted_output")
+                continue;
+
+            filtered[key] = value;
+        }
+
+        return filtered;
     }
 
     public static bool TryParseWaitingSignal(WorkflowOutputFrame frame, out WorkflowWaitingSignalEventData data) =>

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -1015,6 +1015,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
                 {
                     ["prompt"] = "provide secret",
                     ["variable"] = "api_key",
+                    ["redacted_output"] = "[api key captured]",
                     ["delivery_target_id"] = "agent-secure-1",
                 },
             }),
@@ -1023,8 +1024,13 @@ public sealed class WorkflowAdditionalModulesCoverageTests
 
         var suspended = ctx.Published.Select(x => x.evt).OfType<WorkflowSuspendedEvent>().Single();
         suspended.SuspensionType.Should().Be("secure_input");
-        suspended.Metadata["secure"].Should().Be("true");
-        suspended.Metadata["variable"].Should().Be("api_key");
+        suspended.VariableName.Should().Be("api_key");
+        suspended.Secure.Should().BeTrue();
+        suspended.RedactedOutput.Should().Be("[api key captured]");
+        suspended.Metadata.Should().NotContainKey("secure");
+        suspended.Metadata.Should().NotContainKey("variable");
+        suspended.Metadata.Should().NotContainKey("input_mode");
+        suspended.Metadata.Should().NotContainKey("redacted_output");
         suspended.Content.Should().BeEmpty();
         suspended.DeliveryTargetId.Should().Be("agent-secure-1");
         ctx.Published.Clear();
@@ -1051,9 +1057,10 @@ public sealed class WorkflowAdditionalModulesCoverageTests
 
         var completed = resumedCtx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Single();
         completed.Success.Should().BeTrue();
-        completed.Output.Should().Be("[secure input captured]");
+        completed.Output.Should().Be("[api key captured]");
         completed.Annotations["secure.input"].Should().Be("true");
         completed.Annotations["secure.variable"].Should().Be("api_key");
+        completed.Annotations["secure.redacted_output"].Should().Be("[api key captured]");
 
         var resumedState = resumedCtx.LoadState<SecureInputModuleState>(SecureInputStateAccess.ModuleStateKey);
         resumedState.Pending.Should().BeEmpty();

--- a/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/EventEnvelopeToAGUIEventMapperTests.cs
@@ -320,6 +320,16 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
             TimeoutSeconds = 1800,
             VariableName = "user_context",
             DeliveryTargetId = "agent-delivery-1",
+            Secure = true,
+            RedactedOutput = "[captured]",
+            Metadata =
+            {
+                ["source"] = "test",
+                ["variable"] = "legacy_variable",
+                ["secure"] = "true",
+                ["input_mode"] = "password",
+                ["redacted_output"] = "[legacy]",
+            },
         }));
         var waiting = CreateMapper().Map(WrapCommitted(new WaitingForSignalEvent
         {
@@ -334,13 +344,50 @@ public sealed class EventEnvelopeToAGUIEventMapperTests
         suspended[0].Custom.Name.Should().Be("aevatar.human_input.request");
         var request = suspended[0].Custom.Payload.Unpack<WorkflowHumanInputRequestCustomPayload>();
         request.VariableName.Should().Be("user_context");
+        request.Secure.Should().BeTrue();
+        request.RedactedOutput.Should().Be("[captured]");
         request.Content.Should().Be("已有上下文");
         request.DeliveryTargetId.Should().Be("agent-delivery-1");
+        request.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("test");
         request.Metadata.Should().NotContainKey("variable");
+        request.Metadata.Should().NotContainKey("secure");
+        request.Metadata.Should().NotContainKey("input_mode");
+        request.Metadata.Should().NotContainKey("redacted_output");
 
         waiting.Should().ContainSingle();
         waiting[0].Custom.Name.Should().Be("aevatar.workflow.waiting_signal");
         waiting[0].Custom.Payload.Unpack<WorkflowWaitingSignalCustomPayload>().RunId.Should().Be("run-expected");
+    }
+
+    [Fact]
+    public void WorkflowSuspended_ShouldFallbackLegacySecureInputMetadataToTypedPayload()
+    {
+        var suspended = CreateMapper().Map(WrapCommitted(new WorkflowSuspendedEvent
+        {
+            RunId = "run-legacy",
+            StepId = "secure-legacy",
+            SuspensionType = "secure_input",
+            Prompt = "provide secret",
+            Metadata =
+            {
+                ["variable"] = "api_key",
+                ["secure"] = "true",
+                ["input_mode"] = "password",
+                ["redacted_output"] = "[legacy captured]",
+                ["source"] = "legacy-test",
+            },
+        }));
+
+        suspended.Should().ContainSingle();
+        var request = suspended[0].Custom.Payload.Unpack<WorkflowHumanInputRequestCustomPayload>();
+        request.VariableName.Should().Be("api_key");
+        request.Secure.Should().BeTrue();
+        request.RedactedOutput.Should().Be("[legacy captured]");
+        request.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("legacy-test");
+        request.Metadata.Should().NotContainKey("variable");
+        request.Metadata.Should().NotContainKey("secure");
+        request.Metadata.Should().NotContainKey("input_mode");
+        request.Metadata.Should().NotContainKey("redacted_output");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
@@ -562,6 +562,48 @@ public sealed class WorkflowExecutionProjectionProjectorTests
     }
 
     [Fact]
+    public void ApplyObservedPayloadToReport_ShouldFallbackLegacyOnlySecureInputMetadata()
+    {
+        var report = new WorkflowRunInsightReportDocument
+        {
+            Id = "root-actor",
+            RootActorId = "root-actor",
+            CommandId = "cmd-legacy-secure",
+        };
+        var timestamp = new DateTimeOffset(2026, 3, 18, 5, 10, 0, TimeSpan.Zero);
+
+        WorkflowExecutionArtifactMaterializationSupport.ApplyObservedPayloadToReport(
+            report,
+            PackStateEvent(
+                new WorkflowSuspendedEvent
+                {
+                    StepId = "secure-input",
+                    SuspensionType = "secure_input",
+                    Prompt = "enter secret",
+                    Metadata =
+                    {
+                        ["variable"] = "api_key",
+                        ["secure"] = "true",
+                        ["input_mode"] = "password",
+                        ["redacted_output"] = "[legacy captured]",
+                        ["source"] = "legacy-test",
+                    },
+                },
+                30,
+                "evt-legacy-secure"),
+            timestamp);
+
+        var suspendedTimeline = report.Timeline.Single(x =>
+            x.Stage == "workflow.suspended" &&
+            x.StepId == "secure-input");
+        suspendedTimeline.Data.Should().ContainKey("source").WhoseValue.Should().Be("legacy-test");
+        suspendedTimeline.Data.Should().ContainKey("variable").WhoseValue.Should().Be("api_key");
+        suspendedTimeline.Data.Should().ContainKey("secure").WhoseValue.Should().Be("true");
+        suspendedTimeline.Data.Should().ContainKey("redacted_output").WhoseValue.Should().Be("[legacy captured]");
+        suspendedTimeline.Data.Should().NotContainKey("input_mode");
+    }
+
+    [Fact]
     public void ApplyObservedPayloadToReport_ShouldHandleWorkflowStoppedEvent()
     {
         var report = new WorkflowRunInsightReportDocument

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionProjectionProjectorTests.cs
@@ -333,9 +333,15 @@ public sealed class WorkflowExecutionProjectionProjectorTests
                     SuspensionType = "human_input",
                     Prompt = "Need approval",
                     VariableName = "approval",
+                    Secure = true,
+                    RedactedOutput = "[captured]",
                     Metadata =
                     {
                         ["channel"] = "ui",
+                        ["variable"] = "legacy_approval",
+                        ["secure"] = "false",
+                        ["input_mode"] = "password",
+                        ["redacted_output"] = "[legacy]",
                     },
                 },
                 6,
@@ -489,7 +495,12 @@ public sealed class WorkflowExecutionProjectionProjectorTests
         report.Timeline.Should().Contain(x => x.Stage == "workflow.start" && x.Message == "command=cmd-1");
         report.Timeline.Should().Contain(x => x.Stage == "step.request" && x.StepId == "step-1");
         report.Timeline.Should().Contain(x => x.Stage == "step.failed" && x.StepId == "step-1");
-        report.Timeline.Should().Contain(x => x.Stage == "workflow.suspended" && x.StepId == "step-1");
+        var suspendedTimeline = report.Timeline.Single(x => x.Stage == "workflow.suspended" && x.StepId == "step-1");
+        suspendedTimeline.Data.Should().ContainKey("channel").WhoseValue.Should().Be("ui");
+        suspendedTimeline.Data.Should().ContainKey("variable").WhoseValue.Should().Be("approval");
+        suspendedTimeline.Data.Should().ContainKey("secure").WhoseValue.Should().Be("true");
+        suspendedTimeline.Data.Should().ContainKey("redacted_output").WhoseValue.Should().Be("[captured]");
+        suspendedTimeline.Data.Should().NotContainKey("input_mode");
         report.Timeline.Should().Contain(x => x.Stage == "signal.waiting" && x.Data["timeout_ms"] == "900");
         report.Timeline.Should().Contain(x => x.Stage == "signal.buffered");
         report.Timeline.Count(x => x.Stage == "tool.call").Should().Be(2);

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowHumanInteractionProjectorTests.cs
@@ -31,7 +31,17 @@ public sealed class WorkflowHumanInteractionProjectorTests
                     Content = "Please review the summary.",
                     DeliveryTargetId = "agent-delivery-1",
                     TimeoutSeconds = 90,
-                    Metadata = { ["source"] = "workflow-test" },
+                    VariableName = "approval_note",
+                    Secure = true,
+                    RedactedOutput = "[captured]",
+                    Metadata =
+                    {
+                        ["source"] = "workflow-test",
+                        ["variable"] = "legacy_variable",
+                        ["secure"] = "false",
+                        ["input_mode"] = "password",
+                        ["redacted_output"] = "[legacy]",
+                    },
                 }),
             },
             CancellationToken.None);
@@ -47,6 +57,50 @@ public sealed class WorkflowHumanInteractionProjectorTests
         call.request.Options.Should().Equal("approve", "reject");
         call.request.TimeoutSeconds.Should().Be(90);
         call.request.Annotations.Should().ContainKey("source").WhoseValue.Should().Be("workflow-test");
+        call.request.Annotations.Should().ContainKey("variable").WhoseValue.Should().Be("approval_note");
+        call.request.Annotations.Should().ContainKey("secure").WhoseValue.Should().Be("true");
+        call.request.Annotations.Should().ContainKey("redacted_output").WhoseValue.Should().Be("[captured]");
+        call.request.Annotations.Should().NotContainKey("input_mode");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldFallbackLegacySecureInputMetadata()
+    {
+        var port = new RecordingHumanInteractionPort();
+        var projector = new WorkflowHumanInteractionProjector(port);
+
+        await projector.ProjectAsync(
+            BuildContext(),
+            new EventEnvelope
+            {
+                Id = "evt-human-legacy-secure",
+                Route = EnvelopeRouteSemantics.CreateObserverPublication("workflow-human-interaction-test"),
+                Payload = Any.Pack(new WorkflowSuspendedEvent
+                {
+                    RunId = "run-legacy",
+                    StepId = "secure-legacy",
+                    SuspensionType = "secure_input",
+                    Prompt = "Need secret",
+                    DeliveryTargetId = "agent-delivery-legacy",
+                    Metadata =
+                    {
+                        ["source"] = "legacy-test",
+                        ["variable"] = "api_key",
+                        ["secure"] = "true",
+                        ["input_mode"] = "password",
+                        ["redacted_output"] = "[legacy captured]",
+                    },
+                }),
+            },
+            CancellationToken.None);
+
+        port.Calls.Should().ContainSingle();
+        var annotations = port.Calls[0].request.Annotations;
+        annotations.Should().ContainKey("source").WhoseValue.Should().Be("legacy-test");
+        annotations.Should().ContainKey("variable").WhoseValue.Should().Be("api_key");
+        annotations.Should().ContainKey("secure").WhoseValue.Should().Be("true");
+        annotations.Should().ContainKey("redacted_output").WhoseValue.Should().Be("[legacy captured]");
+        annotations.Should().NotContainKey("input_mode");
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Sdk.Tests/Session/WorkflowCustomEventParserTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Session/WorkflowCustomEventParserTests.cs
@@ -113,6 +113,29 @@ public sealed class WorkflowCustomEventParserTests
     }
 
     [Fact]
+    public void TryParseHumanInputRequest_ShouldPreferTypedSecureInputOverLegacyMetadata()
+    {
+        var frame = new WorkflowOutputFrame
+        {
+            Type = WorkflowEventTypes.Custom,
+            Name = WorkflowCustomEventNames.HumanInputRequest,
+            Value = ParseObject("""{"runId":"run-1","stepId":"approve","suspensionType":"secure_input","prompt":"approve?","timeoutSeconds":30,"variableName":"decision","secure":true,"redactedOutput":"[captured]","metadata":{"variable":"legacy_decision","secure":"false","input_mode":"password","redacted_output":"[legacy captured]","source":"test"}}"""),
+        };
+
+        var ok = WorkflowCustomEventParser.TryParseHumanInputRequest(frame, out var data);
+
+        ok.Should().BeTrue();
+        data.VariableName.Should().Be("decision");
+        data.Secure.Should().BeTrue();
+        data.RedactedOutput.Should().Be("[captured]");
+        data.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("test");
+        data.Metadata.Should().NotContainKey("variable");
+        data.Metadata.Should().NotContainKey("secure");
+        data.Metadata.Should().NotContainKey("input_mode");
+        data.Metadata.Should().NotContainKey("redacted_output");
+    }
+
+    [Fact]
     public void TryParseHumanInputRequest_ShouldFallbackLegacySecureInputMetadata()
     {
         var frame = new WorkflowOutputFrame

--- a/test/Aevatar.Workflow.Sdk.Tests/Session/WorkflowCustomEventParserTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Session/WorkflowCustomEventParserTests.cs
@@ -90,21 +90,48 @@ public sealed class WorkflowCustomEventParserTests
     }
 
     [Fact]
-    public void TryParseHumanInputRequest_ShouldReturnTypedVariableWithoutMetadataMirror()
+    public void TryParseHumanInputRequest_ShouldReturnTypedSecureInputWithoutMetadataMirror()
     {
         var frame = new WorkflowOutputFrame
         {
             Type = WorkflowEventTypes.Custom,
             Name = WorkflowCustomEventNames.HumanInputRequest,
-            Value = ParseObject("""{"runId":"run-1","stepId":"approve","suspensionType":"human_input","prompt":"approve?","timeoutSeconds":30,"variableName":"decision","metadata":{"secure":"true"}}"""),
+            Value = ParseObject("""{"runId":"run-1","stepId":"approve","suspensionType":"secure_input","prompt":"approve?","timeoutSeconds":30,"variableName":"decision","secure":true,"redactedOutput":"[captured]","metadata":{"source":"test"}}"""),
         };
 
         var ok = WorkflowCustomEventParser.TryParseHumanInputRequest(frame, out var data);
 
         ok.Should().BeTrue();
         data.VariableName.Should().Be("decision");
-        data.Metadata.Should().ContainKey("secure").WhoseValue.Should().Be("true");
+        data.Secure.Should().BeTrue();
+        data.RedactedOutput.Should().Be("[captured]");
+        data.Metadata.Should().ContainKey("source").WhoseValue.Should().Be("test");
         data.Metadata.Should().NotContainKey("variable");
+        data.Metadata.Should().NotContainKey("secure");
+        data.Metadata.Should().NotContainKey("input_mode");
+        data.Metadata.Should().NotContainKey("redacted_output");
+    }
+
+    [Fact]
+    public void TryParseHumanInputRequest_ShouldFallbackLegacySecureInputMetadata()
+    {
+        var frame = new WorkflowOutputFrame
+        {
+            Type = WorkflowEventTypes.Custom,
+            Name = WorkflowCustomEventNames.HumanInputRequest,
+            Value = ParseObject("""{"runId":"run-1","stepId":"approve","suspensionType":"secure_input","prompt":"approve?","timeoutSeconds":30,"metadata":{"variable":"decision","secure":"true","input_mode":"password","redacted_output":"[legacy captured]"}}"""),
+        };
+
+        var ok = WorkflowCustomEventParser.TryParseHumanInputRequest(frame, out var data);
+
+        ok.Should().BeTrue();
+        data.VariableName.Should().Be("decision");
+        data.Secure.Should().BeTrue();
+        data.RedactedOutput.Should().Be("[legacy captured]");
+        data.Metadata.Should().NotContainKey("variable");
+        data.Metadata.Should().NotContainKey("secure");
+        data.Metadata.Should().NotContainKey("input_mode");
+        data.Metadata.Should().NotContainKey("redacted_output");
     }
 
     [Fact]


### PR DESCRIPTION
## 摘要

iter79 cluster-079-secure-input-suspension-metadata-bag(severity:medium,rules:AG-TYPED-CORE-01 + AG-METADATA-NAME-01 + AG-PROTO-TAG-01)。Phase 9 r2 3/3 unanimous(reflector save:r1 split → meta-judge converge:r2 narrow → r2 consensus delete framing)。

- **Old**:`WorkflowSuspendedEvent.Metadata` 写 `secure/input_mode/redacted_output/variable` string bag;AGUI/projection 消费 string key
- **New (delete framing)**:typed `bool secure = 10` + `string redacted_output = 11` 加到 WorkflowSuspendedEvent + WorkflowHumanInputRequestCustomPayload;**reuse 已有** `variable_name`(field 6);**无** input_mode enum;Metadata 仍 open extension(write-side 不再写 4 reserved keys);mapper/projector/SDK typed-first + 旧 Metadata reserved keys 只读 fallback

违反:CLAUDE「核心语义强类型」「Metadata 不承载稳定核心语义」。

## Phase 9 共识

- r1:3 propose 但 direction split(flat/submessage/delete)→ meta-judge converge:r2
- r2:3/3 propose delete framing(flat bool secure + redacted_output,无 input_mode,Metadata legacy)→ unanimous

## 范围

12 文件改动(+330 / -22):
- `src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto`(typed field 10/11)
- `src/workflow/Aevatar.Workflow.Application.Abstractions/Runs/workflow_run_events.proto`(typed field 11/12)
- `src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs`(typed write,删 Metadata 4 reserved keys)
- `src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/EventEnvelopeToWorkflowRunEventMapper.cs`(typed-first + reserved keys filter + legacy fallback)
- `src/workflow/Aevatar.Workflow.Presentation.AGUIAdapter/WorkflowHumanInteractionProjector.cs`(同)
- `src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionArtifactMaterializationSupport.cs`(timeline typed-first)
- `src/workflow/Aevatar.Workflow.Sdk/Contracts/WorkflowCustomEvents.cs`(SDK 加 typed + parser typed-first)
- 测试:WorkflowAdditionalModulesCoverageTests + EventEnvelopeToAGUIEventMapperTests + WorkflowExecutionProjectionProjectorTests + WorkflowHumanInteractionProjectorTests + WorkflowCustomEventParserTests(typed 断言 + legacy fallback 覆盖)

**无新 enum / submessage**;不动 docs/canon;**不**升级 input_mode(write-side 删除 + read-side 不输出)。

验证:Workflow.Abstractions/Application/Core/Presentation/Projection/Sdk 编译 ✅ + 测试 pass + 两个 `ci/*_guards.sh` pass。

closes #974

## Stacked-PR

Part of iter79 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter79

⟦AI:AUTO-LOOP⟧
