### PR TITLE
iter80 cluster-081: split event vs state schema,event 描述 transition facts,reducer derive state

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -272,38 +272,40 @@ public sealed partial class ConversationGAgent
         };
 
         if (!string.Equals(current.CardId, updated.CardId, StringComparison.Ordinal))
-            evt.CardId = updated.CardId ?? string.Empty;
+            evt.CardIdAssigned = updated.CardId ?? string.Empty;
         if (!string.Equals(current.CardMessageId, updated.CardMessageId, StringComparison.Ordinal))
-            evt.CardMessageId = updated.CardMessageId ?? string.Empty;
+            evt.CardMessageIdAssigned = updated.CardMessageId ?? string.Empty;
         if (!string.Equals(current.OriginalCardId, updated.OriginalCardId, StringComparison.Ordinal))
-            evt.OriginalCardId = updated.OriginalCardId ?? string.Empty;
+            evt.OriginalCardIdAssigned = updated.OriginalCardId ?? string.Empty;
         if (!string.Equals(current.LastFlushedText, updated.LastFlushedText, StringComparison.Ordinal))
-            evt.LastFlushedText = updated.LastFlushedText ?? string.Empty;
+            evt.FlushedTextDelta = updated.LastFlushedText ?? string.Empty;
         if (current.Sequence != updated.Sequence)
-            evt.Sequence = updated.Sequence;
+            evt.SequenceDelta = updated.Sequence - current.Sequence;
         if (!string.Equals(current.StreamingElementId, updated.StreamingElementId, StringComparison.Ordinal))
-            evt.StreamingElementId = updated.StreamingElementId ?? LarkCardStreamingState.DefaultStreamingElementId;
+            evt.StreamingElementIdSelected = updated.StreamingElementId ?? LarkCardStreamingState.DefaultStreamingElementId;
         if (!string.Equals(current.TerminalReason, updated.TerminalReason, StringComparison.Ordinal))
             evt.TerminalReason = updated.TerminalReason ?? string.Empty;
 
         var currentOperation = current.InFlight?.Operation ?? LarkCardOperationPhase.Unspecified;
         var updatedOperation = updated.InFlight?.Operation ?? LarkCardOperationPhase.Unspecified;
         if (currentOperation != updatedOperation)
-            evt.LarkCardInFlightOperation = updatedOperation;
+            evt.LarkCardOperation = updatedOperation;
 
         var currentSequence = current.InFlight?.Sequence ?? 0;
         var updatedSequence = updated.InFlight?.Sequence ?? 0;
         if (currentSequence != updatedSequence)
-            evt.LarkCardInFlightSequence = updatedSequence;
+            evt.OperationSequence = updatedSequence;
 
-        if (current.OperationGeneration != updated.OperationGeneration)
-            evt.LarkCardOperationGeneration = updated.OperationGeneration;
+        if (current.OperationGeneration != updated.OperationGeneration ||
+            currentOperation != updatedOperation ||
+            currentSequence != updatedSequence)
+            evt.OperationGeneration = updated.OperationGeneration;
         if (!string.Equals(current.PendingAccumulatedText, updated.PendingAccumulatedText, StringComparison.Ordinal))
-            evt.PendingAccumulatedText = updated.PendingAccumulatedText ?? string.Empty;
+            evt.QueuedAccumulatedText = updated.PendingAccumulatedText ?? string.Empty;
         if (!string.Equals(current.PendingFinalizeText, updated.PendingFinalizeText, StringComparison.Ordinal))
-            evt.PendingFinalizeText = updated.PendingFinalizeText ?? string.Empty;
+            evt.FinalizeText = updated.PendingFinalizeText ?? string.Empty;
         if (!string.Equals(current.PendingFinalizeCommandId, updated.PendingFinalizeCommandId, StringComparison.Ordinal))
-            evt.PendingFinalizeCommandId = updated.PendingFinalizeCommandId ?? string.Empty;
+            evt.FinalizeCommandId = updated.PendingFinalizeCommandId ?? string.Empty;
 
         return evt;
     }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -197,9 +197,9 @@ public sealed partial class ConversationGAgent
             _ => false,
         };
 
-    // Refactor (iter20/cluster-004):
-    //   Old pattern: Card phase transitions updated only process-local state.
-    //   New principle: Persist each card lifecycle change through ConversationReplyLifecycleChangedEvent.
+    // Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
+    //   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
+    //   New principle: event describes transition facts; reducer derives current state from event + actor state
     private async Task<LarkCardStreamingState> TransitionLarkCardStreamingPhaseAsync(
         string correlationId,
         LarkCardStreamingState current,
@@ -227,11 +227,8 @@ public sealed partial class ConversationGAgent
                 ? (terminalReason ?? carried.TerminalReason)
                 : carried.TerminalReason,
         };
-        await PersistDomainEventAsync(new ConversationReplyLifecycleChangedEvent
-        {
-            Lifecycle = ToLifecycleState(correlationId, updated),
-            ChangedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        });
+        var changedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await PersistDomainEventAsync(ToLifecycleChangedEvent(correlationId, current, updated, changedAtUnixMs));
         return updated;
     }
 
@@ -259,29 +256,57 @@ public sealed partial class ConversationGAgent
             _ => ConversationReplyLifecyclePhase.Unspecified,
         };
 
-    private static ConversationReplyLifecycleState ToLifecycleState(
+    private static ConversationReplyLifecycleChangedEvent ToLifecycleChangedEvent(
         string correlationId,
-        LarkCardStreamingState state) =>
-        new()
+        LarkCardStreamingState current,
+        LarkCardStreamingState updated,
+        long changedAtUnixMs)
+    {
+        var evt = new ConversationReplyLifecycleChangedEvent
         {
             CorrelationId = correlationId,
             Mode = ConversationReplyLifecycleMode.LarkCard,
-            Phase = ToLifecyclePhase(state.Phase),
-            CardId = state.CardId ?? string.Empty,
-            CardMessageId = state.CardMessageId ?? string.Empty,
-            OriginalCardId = state.OriginalCardId ?? string.Empty,
-            LastFlushedText = state.LastFlushedText ?? string.Empty,
-            Sequence = state.Sequence,
-            StreamingElementId = state.StreamingElementId ?? LarkCardStreamingState.DefaultStreamingElementId,
-            TerminalReason = state.TerminalReason ?? string.Empty,
-            UpdatedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            LarkCardInFlightOperation = state.InFlight?.Operation ?? LarkCardOperationPhase.Unspecified,
-            LarkCardInFlightSequence = state.InFlight?.Sequence ?? 0,
-            LarkCardOperationGeneration = state.OperationGeneration,
-            PendingAccumulatedText = state.PendingAccumulatedText ?? string.Empty,
-            PendingFinalizeText = state.PendingFinalizeText ?? string.Empty,
-            PendingFinalizeCommandId = state.PendingFinalizeCommandId ?? string.Empty,
+            PreviousPhase = ToLifecyclePhase(current.Phase),
+            Phase = ToLifecyclePhase(updated.Phase),
+            ChangedAtUnixMs = changedAtUnixMs,
         };
+
+        if (!string.Equals(current.CardId, updated.CardId, StringComparison.Ordinal))
+            evt.CardId = updated.CardId ?? string.Empty;
+        if (!string.Equals(current.CardMessageId, updated.CardMessageId, StringComparison.Ordinal))
+            evt.CardMessageId = updated.CardMessageId ?? string.Empty;
+        if (!string.Equals(current.OriginalCardId, updated.OriginalCardId, StringComparison.Ordinal))
+            evt.OriginalCardId = updated.OriginalCardId ?? string.Empty;
+        if (!string.Equals(current.LastFlushedText, updated.LastFlushedText, StringComparison.Ordinal))
+            evt.LastFlushedText = updated.LastFlushedText ?? string.Empty;
+        if (current.Sequence != updated.Sequence)
+            evt.Sequence = updated.Sequence;
+        if (!string.Equals(current.StreamingElementId, updated.StreamingElementId, StringComparison.Ordinal))
+            evt.StreamingElementId = updated.StreamingElementId ?? LarkCardStreamingState.DefaultStreamingElementId;
+        if (!string.Equals(current.TerminalReason, updated.TerminalReason, StringComparison.Ordinal))
+            evt.TerminalReason = updated.TerminalReason ?? string.Empty;
+
+        var currentOperation = current.InFlight?.Operation ?? LarkCardOperationPhase.Unspecified;
+        var updatedOperation = updated.InFlight?.Operation ?? LarkCardOperationPhase.Unspecified;
+        if (currentOperation != updatedOperation)
+            evt.LarkCardInFlightOperation = updatedOperation;
+
+        var currentSequence = current.InFlight?.Sequence ?? 0;
+        var updatedSequence = updated.InFlight?.Sequence ?? 0;
+        if (currentSequence != updatedSequence)
+            evt.LarkCardInFlightSequence = updatedSequence;
+
+        if (current.OperationGeneration != updated.OperationGeneration)
+            evt.LarkCardOperationGeneration = updated.OperationGeneration;
+        if (!string.Equals(current.PendingAccumulatedText, updated.PendingAccumulatedText, StringComparison.Ordinal))
+            evt.PendingAccumulatedText = updated.PendingAccumulatedText ?? string.Empty;
+        if (!string.Equals(current.PendingFinalizeText, updated.PendingFinalizeText, StringComparison.Ordinal))
+            evt.PendingFinalizeText = updated.PendingFinalizeText ?? string.Empty;
+        if (!string.Equals(current.PendingFinalizeCommandId, updated.PendingFinalizeCommandId, StringComparison.Ordinal))
+            evt.PendingFinalizeCommandId = updated.PendingFinalizeCommandId ?? string.Empty;
+
+        return evt;
+    }
 
     private IConversationCardTurnRunner ResolveCardRunner() =>
         Services.GetService<IConversationCardTurnRunner>() ?? new NullConversationCardTurnRunner();

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.NyxRelayStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.NyxRelayStreaming.cs
@@ -268,34 +268,36 @@ public sealed partial class ConversationGAgent
         };
 
         if (!string.Equals(current.PlatformMessageId, updated.PlatformMessageId, StringComparison.Ordinal))
-            evt.PlatformMessageId = updated.PlatformMessageId ?? string.Empty;
+            evt.PlatformMessageIdAssigned = updated.PlatformMessageId ?? string.Empty;
         if (!string.Equals(current.LastFlushedText, updated.LastFlushedText, StringComparison.Ordinal))
-            evt.LastFlushedText = updated.LastFlushedText ?? string.Empty;
+            evt.FlushedTextDelta = updated.LastFlushedText ?? string.Empty;
         if (current.EditCount != updated.EditCount)
-            evt.EditCount = updated.EditCount;
+            evt.EditCountDelta = updated.EditCount - current.EditCount;
         if (!string.Equals(current.TerminalReason, updated.TerminalReason, StringComparison.Ordinal))
             evt.TerminalReason = updated.TerminalReason ?? string.Empty;
 
         var currentOperation = current.InFlight?.Operation ?? NyxRelayTextOperationKind.Unspecified;
         var updatedOperation = updated.InFlight?.Operation ?? NyxRelayTextOperationKind.Unspecified;
         if (currentOperation != updatedOperation)
-            evt.NyxRelayInFlightOperation = updatedOperation;
+            evt.NyxRelayOperation = updatedOperation;
 
         var currentSequence = current.InFlight?.Sequence ?? 0;
         var updatedSequence = updated.InFlight?.Sequence ?? 0;
         if (currentSequence != updatedSequence)
-            evt.NyxRelayInFlightSequence = updatedSequence;
+            evt.OperationSequence = updatedSequence;
 
-        if (current.OperationGeneration != updated.OperationGeneration)
-            evt.NyxRelayOperationGeneration = updated.OperationGeneration;
+        if (current.OperationGeneration != updated.OperationGeneration ||
+            currentOperation != updatedOperation ||
+            currentSequence != updatedSequence)
+            evt.OperationGeneration = updated.OperationGeneration;
         if (!string.Equals(current.PendingAccumulatedText, updated.PendingAccumulatedText, StringComparison.Ordinal))
-            evt.PendingAccumulatedText = updated.PendingAccumulatedText ?? string.Empty;
+            evt.QueuedAccumulatedText = updated.PendingAccumulatedText ?? string.Empty;
         if (!string.Equals(current.PendingFinalizeText, updated.PendingFinalizeText, StringComparison.Ordinal))
-            evt.PendingFinalizeText = updated.PendingFinalizeText ?? string.Empty;
+            evt.FinalizeText = updated.PendingFinalizeText ?? string.Empty;
         if (!string.Equals(current.PendingFinalizeCommandId, updated.PendingFinalizeCommandId, StringComparison.Ordinal))
-            evt.PendingFinalizeCommandId = updated.PendingFinalizeCommandId ?? string.Empty;
+            evt.FinalizeCommandId = updated.PendingFinalizeCommandId ?? string.Empty;
         if (current.PendingTerminalState != updated.PendingTerminalState)
-            evt.PendingNyxRelayTerminalState = updated.PendingTerminalState;
+            evt.NyxRelayTerminalState = updated.PendingTerminalState;
 
         return evt;
     }

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.NyxRelayStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.NyxRelayStreaming.cs
@@ -177,9 +177,9 @@ public sealed partial class ConversationGAgent
     /// updated state, and returns it. Illegal transitions are logged at warn level and
     /// return the unchanged current state — actor turns must keep making progress.
     /// </summary>
-    // Refactor (iter20/cluster-004):
-    //   Old pattern: Phase transitions mutated a private in-memory streaming dictionary.
-    //   New principle: Persist every lifecycle phase change as a typed actor event owned by ConversationGAgent.
+    // Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
+    //   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
+    //   New principle: event describes transition facts; reducer derives current state from event + actor state
     private async Task<NyxRelayStreamingState> TransitionNyxRelayStreamingPhaseAsync(
         string correlationId,
         NyxRelayStreamingState current,
@@ -210,11 +210,8 @@ public sealed partial class ConversationGAgent
                 ? (terminalReason ?? carried.TerminalReason)
                 : carried.TerminalReason,
         };
-        await PersistDomainEventAsync(new ConversationReplyLifecycleChangedEvent
-        {
-            Lifecycle = ToLifecycleState(correlationId, updated),
-            ChangedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        });
+        var changedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        await PersistDomainEventAsync(ToLifecycleChangedEvent(correlationId, current, updated, changedAtUnixMs));
         return updated;
     }
 
@@ -255,27 +252,53 @@ public sealed partial class ConversationGAgent
             _ => ConversationReplyLifecyclePhase.TextIdle,
         };
 
-    private static ConversationReplyLifecycleState ToLifecycleState(
+    private static ConversationReplyLifecycleChangedEvent ToLifecycleChangedEvent(
         string correlationId,
-        NyxRelayStreamingState state) =>
-        new()
+        NyxRelayStreamingState current,
+        NyxRelayStreamingState updated,
+        long changedAtUnixMs)
+    {
+        var evt = new ConversationReplyLifecycleChangedEvent
         {
             CorrelationId = correlationId,
             Mode = ConversationReplyLifecycleMode.NyxRelayText,
-            Phase = ToLifecyclePhase(state.Phase),
-            PlatformMessageId = state.PlatformMessageId ?? string.Empty,
-            LastFlushedText = state.LastFlushedText ?? string.Empty,
-            EditCount = state.EditCount,
-            TerminalReason = state.TerminalReason ?? string.Empty,
-            UpdatedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            NyxRelayInFlightOperation = state.InFlight?.Operation ?? NyxRelayTextOperationKind.Unspecified,
-            NyxRelayInFlightSequence = state.InFlight?.Sequence ?? 0,
-            NyxRelayOperationGeneration = state.OperationGeneration,
-            PendingAccumulatedText = state.PendingAccumulatedText ?? string.Empty,
-            PendingFinalizeText = state.PendingFinalizeText ?? string.Empty,
-            PendingFinalizeCommandId = state.PendingFinalizeCommandId ?? string.Empty,
-            PendingNyxRelayTerminalState = state.PendingTerminalState,
+            PreviousPhase = ToLifecyclePhase(current.Phase),
+            Phase = ToLifecyclePhase(updated.Phase),
+            ChangedAtUnixMs = changedAtUnixMs,
         };
+
+        if (!string.Equals(current.PlatformMessageId, updated.PlatformMessageId, StringComparison.Ordinal))
+            evt.PlatformMessageId = updated.PlatformMessageId ?? string.Empty;
+        if (!string.Equals(current.LastFlushedText, updated.LastFlushedText, StringComparison.Ordinal))
+            evt.LastFlushedText = updated.LastFlushedText ?? string.Empty;
+        if (current.EditCount != updated.EditCount)
+            evt.EditCount = updated.EditCount;
+        if (!string.Equals(current.TerminalReason, updated.TerminalReason, StringComparison.Ordinal))
+            evt.TerminalReason = updated.TerminalReason ?? string.Empty;
+
+        var currentOperation = current.InFlight?.Operation ?? NyxRelayTextOperationKind.Unspecified;
+        var updatedOperation = updated.InFlight?.Operation ?? NyxRelayTextOperationKind.Unspecified;
+        if (currentOperation != updatedOperation)
+            evt.NyxRelayInFlightOperation = updatedOperation;
+
+        var currentSequence = current.InFlight?.Sequence ?? 0;
+        var updatedSequence = updated.InFlight?.Sequence ?? 0;
+        if (currentSequence != updatedSequence)
+            evt.NyxRelayInFlightSequence = updatedSequence;
+
+        if (current.OperationGeneration != updated.OperationGeneration)
+            evt.NyxRelayOperationGeneration = updated.OperationGeneration;
+        if (!string.Equals(current.PendingAccumulatedText, updated.PendingAccumulatedText, StringComparison.Ordinal))
+            evt.PendingAccumulatedText = updated.PendingAccumulatedText ?? string.Empty;
+        if (!string.Equals(current.PendingFinalizeText, updated.PendingFinalizeText, StringComparison.Ordinal))
+            evt.PendingFinalizeText = updated.PendingFinalizeText ?? string.Empty;
+        if (!string.Equals(current.PendingFinalizeCommandId, updated.PendingFinalizeCommandId, StringComparison.Ordinal))
+            evt.PendingFinalizeCommandId = updated.PendingFinalizeCommandId ?? string.Empty;
+        if (current.PendingTerminalState != updated.PendingTerminalState)
+            evt.PendingNyxRelayTerminalState = updated.PendingTerminalState;
+
+        return evt;
+    }
 
     private long NextNyxRelayTextOperationGeneration(NyxRelayStreamingState state) =>
         Math.Max(state.OperationGeneration, state.InFlight?.Generation ?? 0) + 1;

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -2290,16 +2290,6 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         ConversationReplyLifecycleChangedEvent evt)
     {
         var next = current.Clone();
-        if (evt.LegacyLifecycleSnapshot is { } legacySnapshot &&
-            !string.IsNullOrWhiteSpace(legacySnapshot.CorrelationId))
-        {
-            var legacyLifecycle = ToReplyLifecycleState(legacySnapshot);
-            UpsertReplyLifecycle(next.ActiveReplyLifecycles, legacyLifecycle);
-            next.LastUpdatedUnixMs = evt.ChangedAtUnixMs > 0
-                ? evt.ChangedAtUnixMs
-                : legacyLifecycle.UpdatedAtUnixMs;
-            return next;
-        }
 
         var normalizedCorrelationId = NormalizeOptional(evt.CorrelationId);
         if (normalizedCorrelationId is null || evt.Mode == ConversationReplyLifecycleMode.Unspecified)
@@ -2319,35 +2309,6 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         return next;
     }
 
-    private static ConversationReplyLifecycleState ToReplyLifecycleState(
-        LegacyConversationReplyLifecycleSnapshot snapshot) =>
-        new()
-        {
-            CorrelationId = snapshot.CorrelationId ?? string.Empty,
-            Mode = snapshot.Mode,
-            Phase = snapshot.Phase,
-            PlatformMessageId = snapshot.PlatformMessageId ?? string.Empty,
-            CardId = snapshot.CardId ?? string.Empty,
-            CardMessageId = snapshot.CardMessageId ?? string.Empty,
-            OriginalCardId = snapshot.OriginalCardId ?? string.Empty,
-            LastFlushedText = snapshot.LastFlushedText ?? string.Empty,
-            EditCount = snapshot.EditCount,
-            Sequence = snapshot.Sequence,
-            StreamingElementId = snapshot.StreamingElementId ?? string.Empty,
-            TerminalReason = snapshot.TerminalReason ?? string.Empty,
-            UpdatedAtUnixMs = snapshot.UpdatedAtUnixMs,
-            LarkCardInFlightOperation = snapshot.LarkCardInFlightOperation,
-            LarkCardInFlightSequence = snapshot.LarkCardInFlightSequence,
-            LarkCardOperationGeneration = snapshot.LarkCardOperationGeneration,
-            PendingAccumulatedText = snapshot.PendingAccumulatedText ?? string.Empty,
-            PendingFinalizeText = snapshot.PendingFinalizeText ?? string.Empty,
-            PendingFinalizeCommandId = snapshot.PendingFinalizeCommandId ?? string.Empty,
-            NyxRelayInFlightOperation = snapshot.NyxRelayInFlightOperation,
-            NyxRelayInFlightSequence = snapshot.NyxRelayInFlightSequence,
-            NyxRelayOperationGeneration = snapshot.NyxRelayOperationGeneration,
-            PendingNyxRelayTerminalState = snapshot.PendingNyxRelayTerminalState,
-        };
-
     private static void ApplyReplyLifecycleTransitionFact(
         ConversationReplyLifecycleState lifecycle,
         ConversationReplyLifecycleChangedEvent evt)
@@ -2355,44 +2316,52 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         if (evt.Phase != ConversationReplyLifecyclePhase.Unspecified)
             lifecycle.Phase = evt.Phase;
 
-        if (evt.HasPlatformMessageId)
-            lifecycle.PlatformMessageId = evt.PlatformMessageId ?? string.Empty;
-        if (evt.HasCardId)
-            lifecycle.CardId = evt.CardId ?? string.Empty;
-        if (evt.HasCardMessageId)
-            lifecycle.CardMessageId = evt.CardMessageId ?? string.Empty;
-        if (evt.HasOriginalCardId)
-            lifecycle.OriginalCardId = evt.OriginalCardId ?? string.Empty;
-        if (evt.HasLastFlushedText)
-            lifecycle.LastFlushedText = evt.LastFlushedText ?? string.Empty;
-        if (evt.HasEditCount)
-            lifecycle.EditCount = evt.EditCount;
-        if (evt.HasSequence)
-            lifecycle.Sequence = evt.Sequence;
-        if (evt.HasStreamingElementId)
-            lifecycle.StreamingElementId = evt.StreamingElementId ?? string.Empty;
+        if (evt.HasPlatformMessageIdAssigned)
+            lifecycle.PlatformMessageId = evt.PlatformMessageIdAssigned ?? string.Empty;
+        if (evt.HasCardIdAssigned)
+            lifecycle.CardId = evt.CardIdAssigned ?? string.Empty;
+        if (evt.HasCardMessageIdAssigned)
+            lifecycle.CardMessageId = evt.CardMessageIdAssigned ?? string.Empty;
+        if (evt.HasOriginalCardIdAssigned)
+            lifecycle.OriginalCardId = evt.OriginalCardIdAssigned ?? string.Empty;
+        if (evt.HasFlushedTextDelta)
+            lifecycle.LastFlushedText = evt.FlushedTextDelta ?? string.Empty;
+        if (evt.HasEditCountDelta)
+            lifecycle.EditCount += evt.EditCountDelta;
+        if (evt.HasSequenceDelta)
+            lifecycle.Sequence += evt.SequenceDelta;
+        if (evt.HasStreamingElementIdSelected)
+            lifecycle.StreamingElementId = evt.StreamingElementIdSelected ?? string.Empty;
         if (evt.HasTerminalReason)
             lifecycle.TerminalReason = evt.TerminalReason ?? string.Empty;
-        if (evt.HasLarkCardInFlightOperation)
-            lifecycle.LarkCardInFlightOperation = evt.LarkCardInFlightOperation;
-        if (evt.HasLarkCardInFlightSequence)
-            lifecycle.LarkCardInFlightSequence = evt.LarkCardInFlightSequence;
-        if (evt.HasLarkCardOperationGeneration)
-            lifecycle.LarkCardOperationGeneration = evt.LarkCardOperationGeneration;
-        if (evt.HasPendingAccumulatedText)
-            lifecycle.PendingAccumulatedText = evt.PendingAccumulatedText ?? string.Empty;
-        if (evt.HasPendingFinalizeText)
-            lifecycle.PendingFinalizeText = evt.PendingFinalizeText ?? string.Empty;
-        if (evt.HasPendingFinalizeCommandId)
-            lifecycle.PendingFinalizeCommandId = evt.PendingFinalizeCommandId ?? string.Empty;
-        if (evt.HasNyxRelayInFlightOperation)
-            lifecycle.NyxRelayInFlightOperation = evt.NyxRelayInFlightOperation;
-        if (evt.HasNyxRelayInFlightSequence)
-            lifecycle.NyxRelayInFlightSequence = evt.NyxRelayInFlightSequence;
-        if (evt.HasNyxRelayOperationGeneration)
-            lifecycle.NyxRelayOperationGeneration = evt.NyxRelayOperationGeneration;
-        if (evt.HasPendingNyxRelayTerminalState)
-            lifecycle.PendingNyxRelayTerminalState = evt.PendingNyxRelayTerminalState;
+        if (evt.HasLarkCardOperation)
+            lifecycle.LarkCardInFlightOperation = evt.LarkCardOperation;
+        if (evt.HasNyxRelayOperation)
+            lifecycle.NyxRelayInFlightOperation = evt.NyxRelayOperation;
+        if (evt.HasOperationSequence)
+        {
+            if (evt.Mode == ConversationReplyLifecycleMode.LarkCard)
+                lifecycle.LarkCardInFlightSequence = evt.OperationSequence;
+            else if (evt.Mode == ConversationReplyLifecycleMode.NyxRelayText)
+                lifecycle.NyxRelayInFlightSequence = evt.OperationSequence;
+        }
+
+        if (evt.HasOperationGeneration)
+        {
+            if (evt.Mode == ConversationReplyLifecycleMode.LarkCard)
+                lifecycle.LarkCardOperationGeneration = evt.OperationGeneration;
+            else if (evt.Mode == ConversationReplyLifecycleMode.NyxRelayText)
+                lifecycle.NyxRelayOperationGeneration = evt.OperationGeneration;
+        }
+
+        if (evt.HasQueuedAccumulatedText)
+            lifecycle.PendingAccumulatedText = evt.QueuedAccumulatedText ?? string.Empty;
+        if (evt.HasFinalizeText)
+            lifecycle.PendingFinalizeText = evt.FinalizeText ?? string.Empty;
+        if (evt.HasFinalizeCommandId)
+            lifecycle.PendingFinalizeCommandId = evt.FinalizeCommandId ?? string.Empty;
+        if (evt.HasNyxRelayTerminalState)
+            lifecycle.PendingNyxRelayTerminalState = evt.NyxRelayTerminalState;
 
         if (evt.ChangedAtUnixMs > 0)
             lifecycle.UpdatedAtUnixMs = evt.ChangedAtUnixMs;

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -2282,22 +2282,120 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         return next;
     }
 
-    // Refactor (iter20/cluster-004):
-    //   Old pattern: ConversationGAgent 持有 actor token registry + 可见回复状态部分仅在内存
-    //   New principle: 删 actor token registry,credentials runtime-only,可见回复 lifecycle 持久到 ConversationGAgent state
+    // Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
+    //   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
+    //   New principle: event describes transition facts; reducer derives current state from event + actor state
     private static ConversationGAgentState ApplyReplyLifecycleChanged(
         ConversationGAgentState current,
         ConversationReplyLifecycleChangedEvent evt)
     {
         var next = current.Clone();
-        if (evt.Lifecycle is null || string.IsNullOrWhiteSpace(evt.Lifecycle.CorrelationId))
+        if (evt.LegacyLifecycleSnapshot is { } legacySnapshot &&
+            !string.IsNullOrWhiteSpace(legacySnapshot.CorrelationId))
+        {
+            var legacyLifecycle = ToReplyLifecycleState(legacySnapshot);
+            UpsertReplyLifecycle(next.ActiveReplyLifecycles, legacyLifecycle);
+            next.LastUpdatedUnixMs = evt.ChangedAtUnixMs > 0
+                ? evt.ChangedAtUnixMs
+                : legacyLifecycle.UpdatedAtUnixMs;
+            return next;
+        }
+
+        var normalizedCorrelationId = NormalizeOptional(evt.CorrelationId);
+        if (normalizedCorrelationId is null || evt.Mode == ConversationReplyLifecycleMode.Unspecified)
             return next;
 
-        UpsertReplyLifecycle(next.ActiveReplyLifecycles, evt.Lifecycle);
+        var lifecycle = FindReplyLifecycle(next.ActiveReplyLifecycles, normalizedCorrelationId, evt.Mode)?.Clone() ??
+                        new ConversationReplyLifecycleState
+                        {
+                            CorrelationId = normalizedCorrelationId,
+                            Mode = evt.Mode,
+                        };
+        ApplyReplyLifecycleTransitionFact(lifecycle, evt);
         next.LastUpdatedUnixMs = evt.ChangedAtUnixMs > 0
             ? evt.ChangedAtUnixMs
-            : evt.Lifecycle.UpdatedAtUnixMs;
+            : lifecycle.UpdatedAtUnixMs;
+        UpsertReplyLifecycle(next.ActiveReplyLifecycles, lifecycle);
         return next;
+    }
+
+    private static ConversationReplyLifecycleState ToReplyLifecycleState(
+        LegacyConversationReplyLifecycleSnapshot snapshot) =>
+        new()
+        {
+            CorrelationId = snapshot.CorrelationId ?? string.Empty,
+            Mode = snapshot.Mode,
+            Phase = snapshot.Phase,
+            PlatformMessageId = snapshot.PlatformMessageId ?? string.Empty,
+            CardId = snapshot.CardId ?? string.Empty,
+            CardMessageId = snapshot.CardMessageId ?? string.Empty,
+            OriginalCardId = snapshot.OriginalCardId ?? string.Empty,
+            LastFlushedText = snapshot.LastFlushedText ?? string.Empty,
+            EditCount = snapshot.EditCount,
+            Sequence = snapshot.Sequence,
+            StreamingElementId = snapshot.StreamingElementId ?? string.Empty,
+            TerminalReason = snapshot.TerminalReason ?? string.Empty,
+            UpdatedAtUnixMs = snapshot.UpdatedAtUnixMs,
+            LarkCardInFlightOperation = snapshot.LarkCardInFlightOperation,
+            LarkCardInFlightSequence = snapshot.LarkCardInFlightSequence,
+            LarkCardOperationGeneration = snapshot.LarkCardOperationGeneration,
+            PendingAccumulatedText = snapshot.PendingAccumulatedText ?? string.Empty,
+            PendingFinalizeText = snapshot.PendingFinalizeText ?? string.Empty,
+            PendingFinalizeCommandId = snapshot.PendingFinalizeCommandId ?? string.Empty,
+            NyxRelayInFlightOperation = snapshot.NyxRelayInFlightOperation,
+            NyxRelayInFlightSequence = snapshot.NyxRelayInFlightSequence,
+            NyxRelayOperationGeneration = snapshot.NyxRelayOperationGeneration,
+            PendingNyxRelayTerminalState = snapshot.PendingNyxRelayTerminalState,
+        };
+
+    private static void ApplyReplyLifecycleTransitionFact(
+        ConversationReplyLifecycleState lifecycle,
+        ConversationReplyLifecycleChangedEvent evt)
+    {
+        if (evt.Phase != ConversationReplyLifecyclePhase.Unspecified)
+            lifecycle.Phase = evt.Phase;
+
+        if (evt.HasPlatformMessageId)
+            lifecycle.PlatformMessageId = evt.PlatformMessageId ?? string.Empty;
+        if (evt.HasCardId)
+            lifecycle.CardId = evt.CardId ?? string.Empty;
+        if (evt.HasCardMessageId)
+            lifecycle.CardMessageId = evt.CardMessageId ?? string.Empty;
+        if (evt.HasOriginalCardId)
+            lifecycle.OriginalCardId = evt.OriginalCardId ?? string.Empty;
+        if (evt.HasLastFlushedText)
+            lifecycle.LastFlushedText = evt.LastFlushedText ?? string.Empty;
+        if (evt.HasEditCount)
+            lifecycle.EditCount = evt.EditCount;
+        if (evt.HasSequence)
+            lifecycle.Sequence = evt.Sequence;
+        if (evt.HasStreamingElementId)
+            lifecycle.StreamingElementId = evt.StreamingElementId ?? string.Empty;
+        if (evt.HasTerminalReason)
+            lifecycle.TerminalReason = evt.TerminalReason ?? string.Empty;
+        if (evt.HasLarkCardInFlightOperation)
+            lifecycle.LarkCardInFlightOperation = evt.LarkCardInFlightOperation;
+        if (evt.HasLarkCardInFlightSequence)
+            lifecycle.LarkCardInFlightSequence = evt.LarkCardInFlightSequence;
+        if (evt.HasLarkCardOperationGeneration)
+            lifecycle.LarkCardOperationGeneration = evt.LarkCardOperationGeneration;
+        if (evt.HasPendingAccumulatedText)
+            lifecycle.PendingAccumulatedText = evt.PendingAccumulatedText ?? string.Empty;
+        if (evt.HasPendingFinalizeText)
+            lifecycle.PendingFinalizeText = evt.PendingFinalizeText ?? string.Empty;
+        if (evt.HasPendingFinalizeCommandId)
+            lifecycle.PendingFinalizeCommandId = evt.PendingFinalizeCommandId ?? string.Empty;
+        if (evt.HasNyxRelayInFlightOperation)
+            lifecycle.NyxRelayInFlightOperation = evt.NyxRelayInFlightOperation;
+        if (evt.HasNyxRelayInFlightSequence)
+            lifecycle.NyxRelayInFlightSequence = evt.NyxRelayInFlightSequence;
+        if (evt.HasNyxRelayOperationGeneration)
+            lifecycle.NyxRelayOperationGeneration = evt.NyxRelayOperationGeneration;
+        if (evt.HasPendingNyxRelayTerminalState)
+            lifecycle.PendingNyxRelayTerminalState = evt.PendingNyxRelayTerminalState;
+
+        if (evt.ChangedAtUnixMs > 0)
+            lifecycle.UpdatedAtUnixMs = evt.ChangedAtUnixMs;
     }
 
     private static ConversationGAgentState ApplyReplyLifecycleCleared(
@@ -2387,6 +2485,14 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         RemoveReplyLifecycle(field, lifecycle.CorrelationId, lifecycle.Mode);
         field.Add(lifecycle.Clone());
     }
+
+    private static ConversationReplyLifecycleState? FindReplyLifecycle(
+        Google.Protobuf.Collections.RepeatedField<ConversationReplyLifecycleState> field,
+        string correlationId,
+        ConversationReplyLifecycleMode mode) =>
+        field.FirstOrDefault(lifecycle =>
+            lifecycle.Mode == mode &&
+            string.Equals(lifecycle.CorrelationId, correlationId, StringComparison.Ordinal));
 
     private static void RemoveReplyLifecycle(
         Google.Protobuf.Collections.RepeatedField<ConversationReplyLifecycleState> field,

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -163,65 +163,32 @@ enum NyxRelayTextOperationKind {
 // Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
 //   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
 //   New principle: event describes transition facts; reducer derives current state from event + actor state
-// Legacy wire-compatible parser for historical ConversationReplyLifecycleChangedEvent.lifecycle = 1 bytes.
-// New writers MUST NOT populate this snapshot; it exists only so old events can replay.
-message LegacyConversationReplyLifecycleSnapshot {
-  string correlation_id = 1;
-  ConversationReplyLifecycleMode mode = 2;
-  ConversationReplyLifecyclePhase phase = 3;
-  string platform_message_id = 4;
-  string card_id = 5;
-  string card_message_id = 6;
-  string original_card_id = 7;
-  string last_flushed_text = 8;
-  int32 edit_count = 9;
-  int64 sequence = 10;
-  string streaming_element_id = 11;
-  string terminal_reason = 12;
-  int64 updated_at_unix_ms = 13;
-  LarkCardOperationPhase lark_card_in_flight_operation = 14;
-  int64 lark_card_in_flight_sequence = 15;
-  int64 lark_card_operation_generation = 16;
-  string pending_accumulated_text = 17;
-  string pending_finalize_text = 18;
-  string pending_finalize_command_id = 19;
-  NyxRelayTextOperationKind nyx_relay_in_flight_operation = 20;
-  int64 nyx_relay_in_flight_sequence = 21;
-  int64 nyx_relay_operation_generation = 22;
-  LlmReplyTerminalState pending_nyx_relay_terminal_state = 23;
-}
-
-// Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
-//   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
-//   New principle: event describes transition facts; reducer derives current state from event + actor state
 message ConversationReplyLifecycleChangedEvent {
-  reserved "lifecycle";
+  reserved 1, 7 to 25;
+  reserved "lifecycle", "legacy_lifecycle_snapshot";
 
-  LegacyConversationReplyLifecycleSnapshot legacy_lifecycle_snapshot = 1;
   int64 changed_at_unix_ms = 2;
   string correlation_id = 3;
   ConversationReplyLifecycleMode mode = 4;
   ConversationReplyLifecyclePhase previous_phase = 5;
   ConversationReplyLifecyclePhase phase = 6;
-  optional string platform_message_id = 7;
-  optional string card_id = 8;
-  optional string card_message_id = 9;
-  optional string original_card_id = 10;
-  optional string last_flushed_text = 11;
-  optional int32 edit_count = 12;
-  optional int64 sequence = 13;
-  optional string streaming_element_id = 14;
-  optional string terminal_reason = 15;
-  optional LarkCardOperationPhase lark_card_in_flight_operation = 16;
-  optional int64 lark_card_in_flight_sequence = 17;
-  optional int64 lark_card_operation_generation = 18;
-  optional string pending_accumulated_text = 19;
-  optional string pending_finalize_text = 20;
-  optional string pending_finalize_command_id = 21;
-  optional NyxRelayTextOperationKind nyx_relay_in_flight_operation = 22;
-  optional int64 nyx_relay_in_flight_sequence = 23;
-  optional int64 nyx_relay_operation_generation = 24;
-  optional LlmReplyTerminalState pending_nyx_relay_terminal_state = 25;
+  optional LarkCardOperationPhase lark_card_operation = 26;
+  optional NyxRelayTextOperationKind nyx_relay_operation = 27;
+  optional int64 operation_sequence = 28;
+  optional int64 operation_generation = 29;
+  optional string platform_message_id_assigned = 30;
+  optional string card_id_assigned = 31;
+  optional string card_message_id_assigned = 32;
+  optional string original_card_id_assigned = 33;
+  optional string flushed_text_delta = 34;
+  optional int32 edit_count_delta = 35;
+  optional int64 sequence_delta = 36;
+  optional string streaming_element_id_selected = 37;
+  optional string terminal_reason = 38;
+  optional string queued_accumulated_text = 39;
+  optional string finalize_text = 40;
+  optional string finalize_command_id = 41;
+  optional LlmReplyTerminalState nyx_relay_terminal_state = 42;
 }
 
 // Refactor (iter20/cluster-004):

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -160,10 +160,12 @@ enum NyxRelayTextOperationKind {
   NYX_RELAY_TEXT_OPERATION_KIND_FINAL = 3;
 }
 
-// Refactor (iter20/cluster-004):
-//   Old pattern: ConversationGAgent 持有 actor token registry + 可见回复状态部分仅在内存
-//   New principle: 删 actor token registry,credentials runtime-only,可见回复 lifecycle 持久到 ConversationGAgent state
-message ConversationReplyLifecycleState {
+// Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
+//   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
+//   New principle: event describes transition facts; reducer derives current state from event + actor state
+// Legacy wire-compatible parser for historical ConversationReplyLifecycleChangedEvent.lifecycle = 1 bytes.
+// New writers MUST NOT populate this snapshot; it exists only so old events can replay.
+message LegacyConversationReplyLifecycleSnapshot {
   string correlation_id = 1;
   ConversationReplyLifecycleMode mode = 2;
   ConversationReplyLifecyclePhase phase = 3;
@@ -189,12 +191,37 @@ message ConversationReplyLifecycleState {
   LlmReplyTerminalState pending_nyx_relay_terminal_state = 23;
 }
 
-// Refactor (iter20/cluster-004):
-//   Old pattern: ConversationGAgent 持有 actor token registry + 可见回复状态部分仅在内存
-//   New principle: 删 actor token registry,credentials runtime-only,可见回复 lifecycle 持久到 ConversationGAgent state
+// Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
+//   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
+//   New principle: event describes transition facts; reducer derives current state from event + actor state
 message ConversationReplyLifecycleChangedEvent {
-  ConversationReplyLifecycleState lifecycle = 1;
+  reserved "lifecycle";
+
+  LegacyConversationReplyLifecycleSnapshot legacy_lifecycle_snapshot = 1;
   int64 changed_at_unix_ms = 2;
+  string correlation_id = 3;
+  ConversationReplyLifecycleMode mode = 4;
+  ConversationReplyLifecyclePhase previous_phase = 5;
+  ConversationReplyLifecyclePhase phase = 6;
+  optional string platform_message_id = 7;
+  optional string card_id = 8;
+  optional string card_message_id = 9;
+  optional string original_card_id = 10;
+  optional string last_flushed_text = 11;
+  optional int32 edit_count = 12;
+  optional int64 sequence = 13;
+  optional string streaming_element_id = 14;
+  optional string terminal_reason = 15;
+  optional LarkCardOperationPhase lark_card_in_flight_operation = 16;
+  optional int64 lark_card_in_flight_sequence = 17;
+  optional int64 lark_card_operation_generation = 18;
+  optional string pending_accumulated_text = 19;
+  optional string pending_finalize_text = 20;
+  optional string pending_finalize_command_id = 21;
+  optional NyxRelayTextOperationKind nyx_relay_in_flight_operation = 22;
+  optional int64 nyx_relay_in_flight_sequence = 23;
+  optional int64 nyx_relay_operation_generation = 24;
+  optional LlmReplyTerminalState pending_nyx_relay_terminal_state = 25;
 }
 
 // Refactor (iter20/cluster-004):

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto
@@ -27,6 +27,35 @@ message ConversationGAgentState {
   repeated ConversationReplyLifecycleState active_reply_lifecycles = 11;
 }
 
+// Refactor (iter80/cluster-081-channel-reply-lifecycle-event-state-schema):
+//   Old pattern: ConversationReplyLifecycleChangedEvent carried full ConversationReplyLifecycleState
+//   New principle: event describes transition facts; reducer derives current state from event + actor state
+message ConversationReplyLifecycleState {
+  string correlation_id = 1;
+  ConversationReplyLifecycleMode mode = 2;
+  ConversationReplyLifecyclePhase phase = 3;
+  string platform_message_id = 4;
+  string card_id = 5;
+  string card_message_id = 6;
+  string original_card_id = 7;
+  string last_flushed_text = 8;
+  int32 edit_count = 9;
+  int64 sequence = 10;
+  string streaming_element_id = 11;
+  string terminal_reason = 12;
+  int64 updated_at_unix_ms = 13;
+  LarkCardOperationPhase lark_card_in_flight_operation = 14;
+  int64 lark_card_in_flight_sequence = 15;
+  int64 lark_card_operation_generation = 16;
+  string pending_accumulated_text = 17;
+  string pending_finalize_text = 18;
+  string pending_finalize_command_id = 19;
+  NyxRelayTextOperationKind nyx_relay_in_flight_operation = 20;
+  int64 nyx_relay_in_flight_sequence = 21;
+  int64 nyx_relay_operation_generation = 22;
+  LlmReplyTerminalState pending_nyx_relay_terminal_state = 23;
+}
+
 // Channel-sink ack tracking for the most recent reply turn. Carries either
 // an in-flight pending marker, a successful delivery (with channel-side
 // message id) or a structured failure. Used by ConversationGAgent to make

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -1596,6 +1596,94 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task NyxRelayStreaming_EmitsTransitionFactsForStartEditAndTerminal()
+    {
+        var runner = new RecordingTurnRunner
+        {
+            StreamChunkResultFactory = (_, currentPmid) =>
+                ConversationStreamChunkResult.Succeeded(currentPmid ?? "om_nyx_emit"),
+        };
+        var dispatch = new RecordingActorDispatchPort();
+        var (agent, store) = CreateAgent(runner, "conv-nyx-emit", dispatchPort: dispatch);
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-nyx-emit", "relay-msg-1", "hello"));
+        var started = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            started,
+            ConversationReplyLifecycleMode.NyxRelayText,
+            "act-nyx-emit",
+            ConversationReplyLifecyclePhase.TextIdle,
+            ConversationReplyLifecyclePhase.TextIdle);
+        started.NyxRelayOperation.ShouldBe(NyxRelayTextOperationKind.Interim);
+        started.OperationSequence.ShouldBe(1);
+        started.OperationGeneration.ShouldBe(1);
+        started.QueuedAccumulatedText.ShouldBe("hello");
+
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        var flushed = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            flushed,
+            ConversationReplyLifecycleMode.NyxRelayText,
+            "act-nyx-emit",
+            ConversationReplyLifecyclePhase.TextIdle,
+            ConversationReplyLifecyclePhase.TextPlaceholderSent);
+        flushed.PlatformMessageIdAssigned.ShouldBe("om_nyx_emit");
+        flushed.FlushedTextDelta.ShouldBe("hello");
+        flushed.NyxRelayOperation.ShouldBe(NyxRelayTextOperationKind.Unspecified);
+        flushed.OperationSequence.ShouldBe(0);
+        flushed.QueuedAccumulatedText.ShouldBeEmpty();
+
+        await agent.HandleLlmReplyStreamChunkAsync(
+            CreateStreamChunk("act-nyx-emit", "relay-msg-1", "hello edited"));
+        var editStarted = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            editStarted,
+            ConversationReplyLifecycleMode.NyxRelayText,
+            "act-nyx-emit",
+            ConversationReplyLifecyclePhase.TextPlaceholderSent,
+            ConversationReplyLifecyclePhase.TextPlaceholderSent);
+        editStarted.NyxRelayOperation.ShouldBe(NyxRelayTextOperationKind.Interim);
+        editStarted.OperationSequence.ShouldBe(1);
+        editStarted.OperationGeneration.ShouldBe(2);
+        editStarted.QueuedAccumulatedText.ShouldBe("hello edited");
+
+        await CompleteNextNyxRelayTextOperationAsync(agent, dispatch);
+        var edited = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            edited,
+            ConversationReplyLifecycleMode.NyxRelayText,
+            "act-nyx-emit",
+            ConversationReplyLifecyclePhase.TextPlaceholderSent,
+            ConversationReplyLifecyclePhase.TextStreaming);
+        edited.FlushedTextDelta.ShouldBe("hello edited");
+        edited.EditCountDelta.ShouldBe(1);
+        edited.NyxRelayOperation.ShouldBe(NyxRelayTextOperationKind.Unspecified);
+        edited.OperationSequence.ShouldBe(0);
+        edited.OperationGeneration.ShouldBe(2);
+        edited.QueuedAccumulatedText.ShouldBeEmpty();
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-nyx-emit",
+            RegistrationId = "reg-1",
+            SourceActorId = "agent-run",
+            Activity = CreateRelayActivity("act-nyx-emit", "relay-msg-1"),
+            Outbound = new MessageContent { Text = "hello edited" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = 100,
+        });
+        var terminated = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            terminated,
+            ConversationReplyLifecycleMode.NyxRelayText,
+            "act-nyx-emit",
+            ConversationReplyLifecyclePhase.TextStreaming,
+            ConversationReplyLifecyclePhase.TextTerminalSucceeded);
+        terminated.TerminalReason.ShouldBe("completed");
+    }
+
+    [Fact]
     public async Task HandleLlmReplyReadyAsync_TextStreamingLifecycleSurvivesReactivation()
     {
         var store = new InMemoryEventStore();
@@ -1658,50 +1746,6 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
-    public async Task ActivateAsync_LegacyReplyLifecycleSnapshotEvent_FallbackReplacesCurrentState()
-    {
-        var store = new InMemoryEventStore();
-        await AppendStateEventAsync(
-            store,
-            "conv-legacy-lifecycle-replay",
-            new ConversationReplyLifecycleChangedEvent
-            {
-                LegacyLifecycleSnapshot = new LegacyConversationReplyLifecycleSnapshot
-                {
-                    CorrelationId = "corr-legacy",
-                    Mode = ConversationReplyLifecycleMode.NyxRelayText,
-                    Phase = ConversationReplyLifecyclePhase.TextStreaming,
-                    PlatformMessageId = "om_legacy",
-                    LastFlushedText = "legacy text",
-                    EditCount = 2,
-                    UpdatedAtUnixMs = 123,
-                    NyxRelayInFlightOperation = NyxRelayTextOperationKind.Interim,
-                    NyxRelayInFlightSequence = 7,
-                    NyxRelayOperationGeneration = 9,
-                    PendingAccumulatedText = "pending legacy",
-                },
-                ChangedAtUnixMs = 456,
-            },
-            1);
-
-        var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-legacy-lifecycle-replay", store: store);
-
-        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
-        lifecycle.CorrelationId.ShouldBe("corr-legacy");
-        lifecycle.Mode.ShouldBe(ConversationReplyLifecycleMode.NyxRelayText);
-        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextStreaming);
-        lifecycle.PlatformMessageId.ShouldBe("om_legacy");
-        lifecycle.LastFlushedText.ShouldBe("legacy text");
-        lifecycle.EditCount.ShouldBe(2);
-        lifecycle.UpdatedAtUnixMs.ShouldBe(123);
-        lifecycle.NyxRelayInFlightOperation.ShouldBe(NyxRelayTextOperationKind.Interim);
-        lifecycle.NyxRelayInFlightSequence.ShouldBe(7);
-        lifecycle.NyxRelayOperationGeneration.ShouldBe(9);
-        lifecycle.PendingAccumulatedText.ShouldBe("pending legacy");
-        agent.State.LastUpdatedUnixMs.ShouldBe(456);
-    }
-
-    [Fact]
     public async Task ActivateAsync_ReplyLifecycleTransitionFacts_DeriveStateAcrossNyxRelayTransitions()
     {
         var store = new InMemoryEventStore();
@@ -1715,10 +1759,9 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.TextIdle,
                 Phase = ConversationReplyLifecyclePhase.TextPlaceholderSent,
                 ChangedAtUnixMs = 100,
-                PlatformMessageId = "om_fact",
-                LastFlushedText = "first",
-                EditCount = 1,
-                NyxRelayOperationGeneration = 1,
+                PlatformMessageIdAssigned = "om_fact",
+                FlushedTextDelta = "first",
+                OperationGeneration = 1,
             },
             1);
         await AppendStateEventAsync(
@@ -1731,14 +1774,14 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.TextPlaceholderSent,
                 Phase = ConversationReplyLifecyclePhase.TextStreaming,
                 ChangedAtUnixMs = 200,
-                LastFlushedText = "second",
-                EditCount = 2,
-                NyxRelayInFlightOperation = NyxRelayTextOperationKind.Final,
-                NyxRelayInFlightSequence = 2,
-                NyxRelayOperationGeneration = 2,
-                PendingFinalizeText = "final",
-                PendingFinalizeCommandId = "cmd-final",
-                PendingNyxRelayTerminalState = LlmReplyTerminalState.Completed,
+                FlushedTextDelta = "second",
+                EditCountDelta = 2,
+                NyxRelayOperation = NyxRelayTextOperationKind.Final,
+                OperationSequence = 2,
+                OperationGeneration = 2,
+                FinalizeText = "final",
+                FinalizeCommandId = "cmd-final",
+                NyxRelayTerminalState = LlmReplyTerminalState.Completed,
             },
             2);
         await AppendStateEventAsync(
@@ -1751,11 +1794,11 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.TextStreaming,
                 Phase = ConversationReplyLifecyclePhase.TextTerminalSucceeded,
                 ChangedAtUnixMs = 300,
-                NyxRelayInFlightOperation = NyxRelayTextOperationKind.Unspecified,
-                NyxRelayInFlightSequence = 0,
-                PendingFinalizeText = string.Empty,
-                PendingFinalizeCommandId = string.Empty,
-                PendingNyxRelayTerminalState = LlmReplyTerminalState.Unspecified,
+                NyxRelayOperation = NyxRelayTextOperationKind.Unspecified,
+                OperationSequence = 0,
+                FinalizeText = string.Empty,
+                FinalizeCommandId = string.Empty,
+                NyxRelayTerminalState = LlmReplyTerminalState.Unspecified,
                 TerminalReason = "completed",
             },
             3);
@@ -2168,6 +2211,27 @@ public sealed class ConversationGAgentDedupTests
             ],
             expectedVersion: version - 1);
 
+    private static ConversationReplyLifecycleChangedEvent LastReplyLifecycleChanged(
+        IReadOnlyList<StateEvent> events) =>
+        events
+            .Where(e => e.EventType == ConversationReplyLifecycleChangedEvent.Descriptor.FullName)
+            .Select(e => ConversationReplyLifecycleChangedEvent.Parser.ParseFrom(e.EventData.Value))
+            .Last();
+
+    private static void AssertReplyLifecycleTransition(
+        ConversationReplyLifecycleChangedEvent evt,
+        ConversationReplyLifecycleMode mode,
+        string correlationId,
+        ConversationReplyLifecyclePhase previousPhase,
+        ConversationReplyLifecyclePhase phase)
+    {
+        evt.Mode.ShouldBe(mode);
+        evt.CorrelationId.ShouldBe(correlationId);
+        evt.PreviousPhase.ShouldBe(previousPhase);
+        evt.Phase.ShouldBe(phase);
+        evt.ChangedAtUnixMs.ShouldBeGreaterThan(0);
+    }
+
     private static (ConversationGAgent agent, IEventStore store) CreateAgent(
         RecordingTurnRunner runner,
         string agentId,
@@ -2545,6 +2609,139 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task LarkCardStreaming_EmitsTransitionFactsForCreateStreamFinalize()
+    {
+        var (agent, store) = CreateAgent(new RecordingTurnRunner(), "conv-card-emit");
+
+        await agent.HandleLlmReplyCardStreamChunkAsync(
+            CreateCardStreamChunk("act-card-emit", "relay-msg-1", "hello"));
+        var createStarted = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            createStarted,
+            ConversationReplyLifecycleMode.LarkCard,
+            "act-card-emit",
+            ConversationReplyLifecyclePhase.Unspecified,
+            ConversationReplyLifecyclePhase.LarkCardCreating);
+        createStarted.LarkCardOperation.ShouldBe(LarkCardOperationPhase.Create);
+        createStarted.OperationSequence.ShouldBe(1);
+        createStarted.OperationGeneration.ShouldBe(1);
+        createStarted.QueuedAccumulatedText.ShouldBe("hello");
+
+        var createLifecycle = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardCreateCompletion(
+            "act-card-emit",
+            createLifecycle.LarkCardInFlightSequence,
+            createLifecycle.LarkCardOperationGeneration,
+            CreateCardStreamChunk("act-card-emit", "relay-msg-1", "hello"),
+            success: true,
+            cardId: "card_emit",
+            cardMessageId: "om_card_emit"));
+        var createFlushed = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            createFlushed,
+            ConversationReplyLifecycleMode.LarkCard,
+            "act-card-emit",
+            ConversationReplyLifecyclePhase.LarkCardCreating,
+            ConversationReplyLifecyclePhase.LarkCardStreaming);
+        createFlushed.CardIdAssigned.ShouldBe("card_emit");
+        createFlushed.CardMessageIdAssigned.ShouldBe("om_card_emit");
+        createFlushed.OriginalCardIdAssigned.ShouldBe("card_emit");
+        createFlushed.FlushedTextDelta.ShouldBe("hello");
+        createFlushed.SequenceDelta.ShouldBe(1);
+        createFlushed.HasStreamingElementIdSelected.ShouldBeFalse();
+        createFlushed.LarkCardOperation.ShouldBe(LarkCardOperationPhase.Unspecified);
+        createFlushed.OperationSequence.ShouldBe(0);
+        createFlushed.QueuedAccumulatedText.ShouldBeEmpty();
+
+        await agent.HandleLlmReplyCardStreamChunkAsync(
+            CreateCardStreamChunk("act-card-emit", "relay-msg-1", "hello edited"));
+        var streamStarted = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            streamStarted,
+            ConversationReplyLifecycleMode.LarkCard,
+            "act-card-emit",
+            ConversationReplyLifecyclePhase.LarkCardStreaming,
+            ConversationReplyLifecyclePhase.LarkCardStreaming);
+        streamStarted.LarkCardOperation.ShouldBe(LarkCardOperationPhase.Stream);
+        streamStarted.OperationSequence.ShouldBe(2);
+        streamStarted.OperationGeneration.ShouldBe(2);
+        streamStarted.QueuedAccumulatedText.ShouldBe("hello edited");
+
+        var streamLifecycle = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardStreamCompletion(
+            "act-card-emit",
+            streamLifecycle.LarkCardInFlightSequence,
+            streamLifecycle.LarkCardOperationGeneration,
+            "card_emit",
+            CreateCardStreamChunk("act-card-emit", "relay-msg-1", "hello edited"),
+            success: true));
+        var streamFlushed = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            streamFlushed,
+            ConversationReplyLifecycleMode.LarkCard,
+            "act-card-emit",
+            ConversationReplyLifecyclePhase.LarkCardStreaming,
+            ConversationReplyLifecyclePhase.LarkCardStreaming);
+        streamFlushed.FlushedTextDelta.ShouldBe("hello edited");
+        streamFlushed.SequenceDelta.ShouldBe(1);
+        streamFlushed.LarkCardOperation.ShouldBe(LarkCardOperationPhase.Unspecified);
+        streamFlushed.OperationSequence.ShouldBe(0);
+        streamFlushed.OperationGeneration.ShouldBe(2);
+        streamFlushed.QueuedAccumulatedText.ShouldBeEmpty();
+
+        await agent.HandleLlmReplyReadyAsync(new LlmReplyReadyEvent
+        {
+            CorrelationId = "act-card-emit",
+            RegistrationId = "reg-1",
+            SourceActorId = "agent-run",
+            Activity = CreateRelayActivity("act-card-emit", "relay-msg-1"),
+            Outbound = new MessageContent { Text = "hello final" },
+            TerminalState = LlmReplyTerminalState.Completed,
+            ReadyAtUnixMs = 100,
+        });
+        var finalizeStarted = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            finalizeStarted,
+            ConversationReplyLifecycleMode.LarkCard,
+            "act-card-emit",
+            ConversationReplyLifecyclePhase.LarkCardStreaming,
+            ConversationReplyLifecyclePhase.LarkCardStreaming);
+        finalizeStarted.LarkCardOperation.ShouldBe(LarkCardOperationPhase.Finalize);
+        finalizeStarted.OperationSequence.ShouldBe(3);
+        finalizeStarted.OperationGeneration.ShouldBe(3);
+        finalizeStarted.FinalizeText.ShouldBe("hello final");
+        finalizeStarted.FinalizeCommandId.ShouldBe("llm:act-card-emit");
+
+        var finalizeLifecycle = agent.State.ActiveReplyLifecycles.Single();
+        await agent.HandleLarkCardOperationCompletedAsync(CreateCardFinalizeCompletion(
+            "act-card-emit",
+            finalizeLifecycle.LarkCardInFlightSequence,
+            finalizeLifecycle.LarkCardOperationGeneration,
+            "card_emit",
+            "om_card_emit",
+            "llm:act-card-emit",
+            CreateRelayActivity("act-card-emit", "relay-msg-1"),
+            "hello final",
+            "hello edited",
+            success: true,
+            finalTextWritten: true));
+        var finalized = LastReplyLifecycleChanged(await store.GetEventsAsync(agent.Id));
+        AssertReplyLifecycleTransition(
+            finalized,
+            ConversationReplyLifecycleMode.LarkCard,
+            "act-card-emit",
+            ConversationReplyLifecyclePhase.LarkCardStreaming,
+            ConversationReplyLifecyclePhase.LarkCardCompleted);
+        finalized.LarkCardOperation.ShouldBe(LarkCardOperationPhase.Unspecified);
+        finalized.OperationSequence.ShouldBe(0);
+        finalized.OperationGeneration.ShouldBe(3);
+        finalized.QueuedAccumulatedText.ShouldBeEmpty();
+        finalized.FinalizeText.ShouldBeEmpty();
+        finalized.FinalizeCommandId.ShouldBeEmpty();
+        finalized.TerminalReason.ShouldBe("completed");
+    }
+
+    [Fact]
     public async Task ActivateAsync_ReplyLifecycleTransitionFacts_DeriveStateAcrossLarkCardTransitions()
     {
         var store = new InMemoryEventStore();
@@ -2558,9 +2755,9 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.Unspecified,
                 Phase = ConversationReplyLifecyclePhase.LarkCardCreating,
                 ChangedAtUnixMs = 100,
-                LarkCardInFlightOperation = LarkCardOperationPhase.Create,
-                LarkCardInFlightSequence = 1,
-                LarkCardOperationGeneration = 1,
+                LarkCardOperation = LarkCardOperationPhase.Create,
+                OperationSequence = 1,
+                OperationGeneration = 1,
             },
             1);
         await AppendStateEventAsync(
@@ -2573,14 +2770,14 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.LarkCardCreating,
                 Phase = ConversationReplyLifecyclePhase.LarkCardStreaming,
                 ChangedAtUnixMs = 200,
-                CardId = "card_fact",
-                CardMessageId = "om_fact",
-                OriginalCardId = "card_fact",
-                LastFlushedText = "hello",
-                Sequence = 1,
-                StreamingElementId = "streaming_main",
-                LarkCardInFlightOperation = LarkCardOperationPhase.Unspecified,
-                LarkCardInFlightSequence = 0,
+                CardIdAssigned = "card_fact",
+                CardMessageIdAssigned = "om_fact",
+                OriginalCardIdAssigned = "card_fact",
+                FlushedTextDelta = "hello",
+                SequenceDelta = 1,
+                StreamingElementIdSelected = "streaming_main",
+                LarkCardOperation = LarkCardOperationPhase.Unspecified,
+                OperationSequence = 0,
             },
             2);
         await AppendStateEventAsync(
@@ -2593,12 +2790,12 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.LarkCardStreaming,
                 Phase = ConversationReplyLifecyclePhase.LarkCardStreaming,
                 ChangedAtUnixMs = 300,
-                PendingAccumulatedText = "queued",
-                PendingFinalizeText = "final",
-                PendingFinalizeCommandId = "cmd-final",
-                LarkCardInFlightOperation = LarkCardOperationPhase.Finalize,
-                LarkCardInFlightSequence = 2,
-                LarkCardOperationGeneration = 2,
+                QueuedAccumulatedText = "queued",
+                FinalizeText = "final",
+                FinalizeCommandId = "cmd-final",
+                LarkCardOperation = LarkCardOperationPhase.Finalize,
+                OperationSequence = 2,
+                OperationGeneration = 2,
             },
             3);
         await AppendStateEventAsync(
@@ -2611,13 +2808,13 @@ public sealed class ConversationGAgentDedupTests
                 PreviousPhase = ConversationReplyLifecyclePhase.LarkCardStreaming,
                 Phase = ConversationReplyLifecyclePhase.LarkCardCompleted,
                 ChangedAtUnixMs = 400,
-                LastFlushedText = "final",
-                Sequence = 2,
-                PendingAccumulatedText = string.Empty,
-                PendingFinalizeText = string.Empty,
-                PendingFinalizeCommandId = string.Empty,
-                LarkCardInFlightOperation = LarkCardOperationPhase.Unspecified,
-                LarkCardInFlightSequence = 0,
+                FlushedTextDelta = "final",
+                SequenceDelta = 1,
+                QueuedAccumulatedText = string.Empty,
+                FinalizeText = string.Empty,
+                FinalizeCommandId = string.Empty,
+                LarkCardOperation = LarkCardOperationPhase.Unspecified,
+                OperationSequence = 0,
                 TerminalReason = "completed",
             },
             4);

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -1658,6 +1658,128 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task ActivateAsync_LegacyReplyLifecycleSnapshotEvent_FallbackReplacesCurrentState()
+    {
+        var store = new InMemoryEventStore();
+        await AppendStateEventAsync(
+            store,
+            "conv-legacy-lifecycle-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                LegacyLifecycleSnapshot = new LegacyConversationReplyLifecycleSnapshot
+                {
+                    CorrelationId = "corr-legacy",
+                    Mode = ConversationReplyLifecycleMode.NyxRelayText,
+                    Phase = ConversationReplyLifecyclePhase.TextStreaming,
+                    PlatformMessageId = "om_legacy",
+                    LastFlushedText = "legacy text",
+                    EditCount = 2,
+                    UpdatedAtUnixMs = 123,
+                    NyxRelayInFlightOperation = NyxRelayTextOperationKind.Interim,
+                    NyxRelayInFlightSequence = 7,
+                    NyxRelayOperationGeneration = 9,
+                    PendingAccumulatedText = "pending legacy",
+                },
+                ChangedAtUnixMs = 456,
+            },
+            1);
+
+        var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-legacy-lifecycle-replay", store: store);
+
+        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycle.CorrelationId.ShouldBe("corr-legacy");
+        lifecycle.Mode.ShouldBe(ConversationReplyLifecycleMode.NyxRelayText);
+        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextStreaming);
+        lifecycle.PlatformMessageId.ShouldBe("om_legacy");
+        lifecycle.LastFlushedText.ShouldBe("legacy text");
+        lifecycle.EditCount.ShouldBe(2);
+        lifecycle.UpdatedAtUnixMs.ShouldBe(123);
+        lifecycle.NyxRelayInFlightOperation.ShouldBe(NyxRelayTextOperationKind.Interim);
+        lifecycle.NyxRelayInFlightSequence.ShouldBe(7);
+        lifecycle.NyxRelayOperationGeneration.ShouldBe(9);
+        lifecycle.PendingAccumulatedText.ShouldBe("pending legacy");
+        agent.State.LastUpdatedUnixMs.ShouldBe(456);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ReplyLifecycleTransitionFacts_DeriveStateAcrossNyxRelayTransitions()
+    {
+        var store = new InMemoryEventStore();
+        await AppendStateEventAsync(
+            store,
+            "conv-nyx-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-nyx-fact",
+                Mode = ConversationReplyLifecycleMode.NyxRelayText,
+                PreviousPhase = ConversationReplyLifecyclePhase.TextIdle,
+                Phase = ConversationReplyLifecyclePhase.TextPlaceholderSent,
+                ChangedAtUnixMs = 100,
+                PlatformMessageId = "om_fact",
+                LastFlushedText = "first",
+                EditCount = 1,
+                NyxRelayOperationGeneration = 1,
+            },
+            1);
+        await AppendStateEventAsync(
+            store,
+            "conv-nyx-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-nyx-fact",
+                Mode = ConversationReplyLifecycleMode.NyxRelayText,
+                PreviousPhase = ConversationReplyLifecyclePhase.TextPlaceholderSent,
+                Phase = ConversationReplyLifecyclePhase.TextStreaming,
+                ChangedAtUnixMs = 200,
+                LastFlushedText = "second",
+                EditCount = 2,
+                NyxRelayInFlightOperation = NyxRelayTextOperationKind.Final,
+                NyxRelayInFlightSequence = 2,
+                NyxRelayOperationGeneration = 2,
+                PendingFinalizeText = "final",
+                PendingFinalizeCommandId = "cmd-final",
+                PendingNyxRelayTerminalState = LlmReplyTerminalState.Completed,
+            },
+            2);
+        await AppendStateEventAsync(
+            store,
+            "conv-nyx-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-nyx-fact",
+                Mode = ConversationReplyLifecycleMode.NyxRelayText,
+                PreviousPhase = ConversationReplyLifecyclePhase.TextStreaming,
+                Phase = ConversationReplyLifecyclePhase.TextTerminalSucceeded,
+                ChangedAtUnixMs = 300,
+                NyxRelayInFlightOperation = NyxRelayTextOperationKind.Unspecified,
+                NyxRelayInFlightSequence = 0,
+                PendingFinalizeText = string.Empty,
+                PendingFinalizeCommandId = string.Empty,
+                PendingNyxRelayTerminalState = LlmReplyTerminalState.Unspecified,
+                TerminalReason = "completed",
+            },
+            3);
+
+        var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-nyx-fact-replay", store: store);
+
+        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycle.CorrelationId.ShouldBe("corr-nyx-fact");
+        lifecycle.Mode.ShouldBe(ConversationReplyLifecycleMode.NyxRelayText);
+        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.TextTerminalSucceeded);
+        lifecycle.PlatformMessageId.ShouldBe("om_fact");
+        lifecycle.LastFlushedText.ShouldBe("second");
+        lifecycle.EditCount.ShouldBe(2);
+        lifecycle.NyxRelayInFlightOperation.ShouldBe(NyxRelayTextOperationKind.Unspecified);
+        lifecycle.NyxRelayInFlightSequence.ShouldBe(0);
+        lifecycle.NyxRelayOperationGeneration.ShouldBe(2);
+        lifecycle.PendingFinalizeText.ShouldBeEmpty();
+        lifecycle.PendingFinalizeCommandId.ShouldBeEmpty();
+        lifecycle.PendingNyxRelayTerminalState.ShouldBe(LlmReplyTerminalState.Unspecified);
+        lifecycle.TerminalReason.ShouldBe("completed");
+        lifecycle.UpdatedAtUnixMs.ShouldBe(300);
+    }
+
+    [Fact]
     public async Task HandleLlmReplyReadyAsync_WhenStreamingDisabled_FallsBackToRunLlmReplyAsync()
     {
         var runner = new RecordingTurnRunner
@@ -2420,6 +2542,106 @@ public sealed class ConversationGAgentDedupTests
         lifecycle.Sequence.ShouldBe(1);
         lifecycle.LastFlushedText.ShouldBe("hello");
         lifecycle.LarkCardInFlightOperation.ShouldBe(LarkCardOperationPhase.Unspecified);
+    }
+
+    [Fact]
+    public async Task ActivateAsync_ReplyLifecycleTransitionFacts_DeriveStateAcrossLarkCardTransitions()
+    {
+        var store = new InMemoryEventStore();
+        await AppendStateEventAsync(
+            store,
+            "conv-card-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-card-fact",
+                Mode = ConversationReplyLifecycleMode.LarkCard,
+                PreviousPhase = ConversationReplyLifecyclePhase.Unspecified,
+                Phase = ConversationReplyLifecyclePhase.LarkCardCreating,
+                ChangedAtUnixMs = 100,
+                LarkCardInFlightOperation = LarkCardOperationPhase.Create,
+                LarkCardInFlightSequence = 1,
+                LarkCardOperationGeneration = 1,
+            },
+            1);
+        await AppendStateEventAsync(
+            store,
+            "conv-card-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-card-fact",
+                Mode = ConversationReplyLifecycleMode.LarkCard,
+                PreviousPhase = ConversationReplyLifecyclePhase.LarkCardCreating,
+                Phase = ConversationReplyLifecyclePhase.LarkCardStreaming,
+                ChangedAtUnixMs = 200,
+                CardId = "card_fact",
+                CardMessageId = "om_fact",
+                OriginalCardId = "card_fact",
+                LastFlushedText = "hello",
+                Sequence = 1,
+                StreamingElementId = "streaming_main",
+                LarkCardInFlightOperation = LarkCardOperationPhase.Unspecified,
+                LarkCardInFlightSequence = 0,
+            },
+            2);
+        await AppendStateEventAsync(
+            store,
+            "conv-card-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-card-fact",
+                Mode = ConversationReplyLifecycleMode.LarkCard,
+                PreviousPhase = ConversationReplyLifecyclePhase.LarkCardStreaming,
+                Phase = ConversationReplyLifecyclePhase.LarkCardStreaming,
+                ChangedAtUnixMs = 300,
+                PendingAccumulatedText = "queued",
+                PendingFinalizeText = "final",
+                PendingFinalizeCommandId = "cmd-final",
+                LarkCardInFlightOperation = LarkCardOperationPhase.Finalize,
+                LarkCardInFlightSequence = 2,
+                LarkCardOperationGeneration = 2,
+            },
+            3);
+        await AppendStateEventAsync(
+            store,
+            "conv-card-fact-replay",
+            new ConversationReplyLifecycleChangedEvent
+            {
+                CorrelationId = "corr-card-fact",
+                Mode = ConversationReplyLifecycleMode.LarkCard,
+                PreviousPhase = ConversationReplyLifecyclePhase.LarkCardStreaming,
+                Phase = ConversationReplyLifecyclePhase.LarkCardCompleted,
+                ChangedAtUnixMs = 400,
+                LastFlushedText = "final",
+                Sequence = 2,
+                PendingAccumulatedText = string.Empty,
+                PendingFinalizeText = string.Empty,
+                PendingFinalizeCommandId = string.Empty,
+                LarkCardInFlightOperation = LarkCardOperationPhase.Unspecified,
+                LarkCardInFlightSequence = 0,
+                TerminalReason = "completed",
+            },
+            4);
+
+        var (agent, _) = CreateAgent(new RecordingTurnRunner(), "conv-card-fact-replay", store: store);
+
+        var lifecycle = agent.State.ActiveReplyLifecycles.ShouldHaveSingleItem();
+        lifecycle.CorrelationId.ShouldBe("corr-card-fact");
+        lifecycle.Mode.ShouldBe(ConversationReplyLifecycleMode.LarkCard);
+        lifecycle.Phase.ShouldBe(ConversationReplyLifecyclePhase.LarkCardCompleted);
+        lifecycle.CardId.ShouldBe("card_fact");
+        lifecycle.CardMessageId.ShouldBe("om_fact");
+        lifecycle.OriginalCardId.ShouldBe("card_fact");
+        lifecycle.LastFlushedText.ShouldBe("final");
+        lifecycle.Sequence.ShouldBe(2);
+        lifecycle.StreamingElementId.ShouldBe("streaming_main");
+        lifecycle.PendingAccumulatedText.ShouldBeEmpty();
+        lifecycle.PendingFinalizeText.ShouldBeEmpty();
+        lifecycle.PendingFinalizeCommandId.ShouldBeEmpty();
+        lifecycle.LarkCardInFlightOperation.ShouldBe(LarkCardOperationPhase.Unspecified);
+        lifecycle.LarkCardInFlightSequence.ShouldBe(0);
+        lifecycle.LarkCardOperationGeneration.ShouldBe(2);
+        lifecycle.TerminalReason.ShouldBe("completed");
+        lifecycle.UpdatedAtUnixMs.ShouldBe(400);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -88,10 +88,11 @@ public sealed class LarkCardOperationSignalTests
             .Where(e => e.EventType == ConversationReplyLifecycleChangedEvent.Descriptor.FullName)
             .Select(e => ConversationReplyLifecycleChangedEvent.Parser.ParseFrom(e.EventData.Value))
             .Last();
-        changed.Lifecycle.Phase.Should().Be(ConversationReplyLifecyclePhase.LarkCardTerminated);
-        changed.Lifecycle.CardId.Should().Be("card_orphan");
-        changed.Lifecycle.CardMessageId.Should().Be("om_orphan");
-        changed.Lifecycle.TerminalReason.Should().Be("create_post_send_failed:card_first_stream_failed");
+        changed.LegacyLifecycleSnapshot.Should().BeNull();
+        changed.Phase.Should().Be(ConversationReplyLifecyclePhase.LarkCardTerminated);
+        changed.CardId.Should().Be("card_orphan");
+        changed.CardMessageId.Should().Be("om_orphan");
+        changed.TerminalReason.Should().Be("create_post_send_failed:card_first_stream_failed");
 
         var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events.Last().EventData.Value);
         completed.SentActivityId.Should().Be("lark-card-stream:om_orphan");

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -88,10 +88,17 @@ public sealed class LarkCardOperationSignalTests
             .Where(e => e.EventType == ConversationReplyLifecycleChangedEvent.Descriptor.FullName)
             .Select(e => ConversationReplyLifecycleChangedEvent.Parser.ParseFrom(e.EventData.Value))
             .Last();
-        changed.LegacyLifecycleSnapshot.Should().BeNull();
+        changed.CorrelationId.Should().Be("corr-reconstruct");
+        changed.Mode.Should().Be(ConversationReplyLifecycleMode.LarkCard);
+        changed.PreviousPhase.Should().Be(ConversationReplyLifecyclePhase.LarkCardCreating);
         changed.Phase.Should().Be(ConversationReplyLifecyclePhase.LarkCardTerminated);
-        changed.CardId.Should().Be("card_orphan");
-        changed.CardMessageId.Should().Be("om_orphan");
+        changed.ChangedAtUnixMs.Should().BeGreaterThan(0);
+        changed.CardIdAssigned.Should().Be("card_orphan");
+        changed.CardMessageIdAssigned.Should().Be("om_orphan");
+        changed.OriginalCardIdAssigned.Should().Be("card_orphan");
+        changed.LarkCardOperation.Should().Be(LarkCardOperationPhase.Unspecified);
+        changed.OperationSequence.Should().Be(0);
+        changed.OperationGeneration.Should().Be(lifecycle.LarkCardOperationGeneration);
         changed.TerminalReason.Should().Be("create_post_send_failed:card_first_stream_failed");
 
         var completed = ConversationTurnCompletedEvent.Parser.ParseFrom(events.Last().EventData.Value);


### PR DESCRIPTION
## 摘要

iter80 cluster-081-channel-reply-lifecycle-event-state-schema(severity:medium,rules:AG-EVENT-STATE-SEPARATION-01 + AG-EVENT-DERIVED-STATE-01)。Phase 9 r1 3/3 unanimous(`split-event-state-with-transition-facts-and-legacy-fallback`)。

- **Old**:`ConversationReplyLifecycleChangedEvent` 直接 carry **整** `ConversationReplyLifecycleState`(含 derived field:last_flushed_text / edit_count / in-flight operation / pending text / pending terminal);`ConversationGAgent.cs:2296` apply replace state wholesale
- **New**:event 携带 **transition facts**(correlation / mode / phase transition / operation generation / terminal reason / timestamp);state schema 在 `conversation_state.proto`(actor-state);applier reducer derive 不 commit snapshot;legacy event 含 full snapshot 时 fallback replace 整 state

违反:CLAUDE「domain event 描述事实」「AggregateState 单独 schema」「event payload 不含 derived state」。

## 范围

7 文件改动(+501 / -68):
- `agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto`(+43):transition fact schema + reserved 旧 state snapshot field
- `agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_state.proto`(+29):ConversationReplyLifecycleState 保留 + 微调
- `ConversationGAgent.cs`(+118):applier reducer + legacy fallback
- `ConversationGAgent.LarkCardStreaming.cs`(+77):emit transition fact
- `ConversationGAgent.NyxRelayStreaming.cs`(+71):同
- `ConversationGAgentDedupTests.cs`(+222):transition fact + reducer derive + legacy fallback + 各 phase transition 覆盖
- `LarkCardOperationSignalTests.cs`(+9):adapt

不重 design Task.Run continuation execution(family covered by prior cluster)。

验证:Channel.Runtime + Channel.Protocol.Tests + ChannelRuntime.Tests 编译 + 测试 pass + 两个 `ci/*_guards.sh` pass。

closes #977

## Stacked-PR

Part of iter80 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter80

⟦AI:AUTO-LOOP⟧
