### PR TITLE
iter82 cluster-082: Workflow SDK async correctness(ConfigureAwait + WithCancellation + preserve OperationCanceledException)

### DIFF
--- a/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs
@@ -12,6 +12,9 @@ namespace Aevatar.Workflow.Sdk;
 
 public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
 {
+    // Refactor (iter82/cluster-082-workflow-sdk-library-await-cancellation):
+    //   Old pattern: SDK awaits without library-safe ConfigureAwait/WithCancellation; OperationCanceledException wrapped as Transport failure
+    //   New principle: library awaits ConfigureAwait(false), async-enumerable WithCancellation, preserve OperationCanceledException
     private readonly HttpClient _httpClient;
     private readonly IWorkflowChatTransport _chatTransport;
     private readonly JsonSerializerOptions _jsonOptions;
@@ -67,7 +70,9 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         var events = new List<WorkflowEvent>();
         AevatarWorkflowException? runError = null;
 
-        await foreach (var evt in StartRunStreamAsync(request, cancellationToken))
+        await foreach (var evt in StartRunStreamAsync(request, cancellationToken)
+                           .WithCancellation(cancellationToken)
+                           .ConfigureAwait(false))
         {
             events.Add(evt);
             if (evt.IsRunError && runError == null)
@@ -103,7 +108,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
                 feedback = NormalizeOptional(request.Feedback),
                 metadata = request.Metadata,
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<WorkflowSignalResponse> SignalAsync(
@@ -126,15 +131,15 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
                 commandId = NormalizeOptional(request.CommandId),
                 payload = NormalizeOptional(request.Payload),
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<JsonElement>> GetWorkflowCatalogAsync(
         CancellationToken cancellationToken = default)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/workflow-catalog");
-        using var response = await SendAsync(request, cancellationToken);
-        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -172,11 +177,11 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         CancellationToken cancellationToken = default)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/capabilities");
-        using var response = await SendAsync(request, cancellationToken);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return null;
 
-        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             throw WorkflowSdkJson.BuildHttpException(
@@ -211,11 +216,11 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
             $"/api/workflows/{Uri.EscapeDataString(workflowName)}");
-        using var response = await SendAsync(request, cancellationToken);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return null;
 
-        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             throw WorkflowSdkJson.BuildHttpException(
@@ -250,11 +255,11 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
             $"/api/actors/{Uri.EscapeDataString(actorId)}");
-        using var response = await SendAsync(request, cancellationToken);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
             return null;
 
-        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             throw WorkflowSdkJson.BuildHttpException(
@@ -296,8 +301,8 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         using var request = new HttpRequestMessage(
             HttpMethod.Get,
             $"/api/workflow-runs/{Uri.EscapeDataString(workflowRunId)}/timeline-export?take={take}");
-        using var response = await SendAsync(request, cancellationToken);
-        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -340,8 +345,8 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
         {
             Content = JsonContent.Create(requestPayload, options: _jsonOptions),
         };
-        using var response = await SendAsync(request, cancellationToken);
-        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+        using var response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (!response.IsSuccessStatusCode)
         {
@@ -381,7 +386,7 @@ public sealed class AevatarWorkflowClient : IAevatarWorkflowClient
             return await _httpClient.SendAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/workflow/Aevatar.Workflow.Sdk/Session/WorkflowClientSessionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Session/WorkflowClientSessionExtensions.cs
@@ -5,6 +5,9 @@ namespace Aevatar.Workflow.Sdk.Session;
 
 public static class WorkflowClientSessionExtensions
 {
+    // Refactor (iter82/cluster-082-workflow-sdk-library-await-cancellation):
+    //   Old pattern: SDK awaits without library-safe ConfigureAwait/WithCancellation; OperationCanceledException wrapped as Transport failure
+    //   New principle: library awaits ConfigureAwait(false), async-enumerable WithCancellation, preserve OperationCanceledException
     public static async IAsyncEnumerable<WorkflowEvent> StartRunStreamWithTrackingAsync(
         this IAevatarWorkflowClient client,
         ChatRunRequest request,
@@ -15,7 +18,9 @@ public static class WorkflowClientSessionExtensions
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(tracker);
 
-        await foreach (var evt in client.StartRunStreamAsync(request, cancellationToken))
+        await foreach (var evt in client.StartRunStreamAsync(request, cancellationToken)
+                           .WithCancellation(cancellationToken)
+                           .ConfigureAwait(false))
         {
             tracker.Track(evt);
             yield return evt;

--- a/src/workflow/Aevatar.Workflow.Sdk/Streaming/SseChatTransport.cs
+++ b/src/workflow/Aevatar.Workflow.Sdk/Streaming/SseChatTransport.cs
@@ -19,6 +19,9 @@ public interface IWorkflowChatTransport
 
 public sealed class SseChatTransport : IWorkflowChatTransport
 {
+    // Refactor (iter82/cluster-082-workflow-sdk-library-await-cancellation):
+    //   Old pattern: SDK awaits without library-safe ConfigureAwait/WithCancellation; OperationCanceledException wrapped as Transport failure
+    //   New principle: library awaits ConfigureAwait(false), async-enumerable WithCancellation, preserve OperationCanceledException
     public async IAsyncEnumerable<WorkflowEvent> StreamAsync(
         HttpClient httpClient,
         ChatRunRequest request,
@@ -58,7 +61,7 @@ public sealed class SseChatTransport : IWorkflowChatTransport
             response = await httpClient.SendAsync(
                 requestMessage,
                 HttpCompletionOption.ResponseHeadersRead,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -73,7 +76,7 @@ public sealed class SseChatTransport : IWorkflowChatTransport
         {
             if (!response.IsSuccessStatusCode)
             {
-                var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken);
+                var rawPayload = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
                 throw WorkflowSdkJson.BuildHttpException(
                     response.StatusCode,
                     rawPayload,
@@ -83,7 +86,11 @@ public sealed class SseChatTransport : IWorkflowChatTransport
             Stream stream;
             try
             {
-                stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -98,7 +105,7 @@ public sealed class SseChatTransport : IWorkflowChatTransport
                 string? line;
                 try
                 {
-                    line = await reader.ReadLineAsync(cancellationToken);
+                    line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {

--- a/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs
@@ -189,6 +189,18 @@ data: {"type":"STATE_SNAPSHOT","snapshot":{"actorId":"actor-1","projectionComple
     }
 
     [Fact]
+    public async Task GetWorkflowCatalogAsync_WhenSendCanceled_ShouldPropagateCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var client = CreateClient((_, ct) => Task.FromCanceled<HttpResponseMessage>(ct));
+
+        var act = () => client.GetWorkflowCatalogAsync(cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task GetCapabilitiesAsync_ShouldParseCapabilitiesPayload()
     {
         var client = CreateClient((request, _) =>

--- a/test/Aevatar.Workflow.Sdk.Tests/Streaming/SseChatTransportTests.cs
+++ b/test/Aevatar.Workflow.Sdk.Tests/Streaming/SseChatTransportTests.cs
@@ -84,6 +84,35 @@ data: {"type":"STATE_SNAPSHOT","snapshot":{"actorId":"actor-1","projectionComple
     }
 
     [Fact]
+    public async Task StreamAsync_WhenResponseStreamAcquisitionCanceled_ShouldPropagateCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var handler = new TestHttpMessageHandler((_, _) =>
+        {
+            cts.Cancel();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new CancelingStreamContent(),
+            });
+        });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5100") };
+        var transport = new SseChatTransport();
+
+        var act = async () =>
+        {
+            await foreach (var _ in transport.StreamAsync(
+                               client,
+                               new ChatRunRequest { Prompt = "hello", ScopeId = "scope-a", Workflow = "approval" },
+                               CreateJsonOptions(),
+                               cts.Token))
+            {
+            }
+        };
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
     public async Task StreamAsync_ShouldPreserveUnknownFrameFieldsInExtensionData()
     {
         const string ssePayload = """
@@ -123,4 +152,19 @@ data: {"type":"RUN_STARTED","threadId":"actor-1","source":"playground","extra":{
         {
             PropertyNameCaseInsensitive = true,
         };
+
+    private sealed class CancelingStreamContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.CompletedTask;
+
+        protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
+            Task.FromCanceled<Stream>(cancellationToken);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
## 摘要

iter82 cluster-082-workflow-sdk-library-await-cancellation(severity:medium,rules:ASYNC-AWAIT-01/02/03)。

- **Old**:Workflow SDK async methods + async enumerators await HTTP/SSE 没用 `ConfigureAwait(false)` / `WithCancellation`;`SseChatTransport.ReadAsStreamAsync` 路径 catch 把 `OperationCanceledException` 包装为 `AevatarWorkflowException.Transport`
- **New**:SDK library awaits 用 `ConfigureAwait(false)`;async-enumerable 用 `WithCancellation(cancellationToken)`;`OperationCanceledException` 保留为 cancellation(不 wrap)

违反:async/await 库正确性原则。SDK 是 library,不该捕获调用方上下文。

## 范围

5 文件改动(+94 / -21):
- `src/workflow/Aevatar.Workflow.Sdk/AevatarWorkflowClient.cs`(8 处 await + StartRunStreamAsync WithCancellation)
- `src/workflow/Aevatar.Workflow.Sdk/Streaming/SseChatTransport.cs`(4 处 await + ReadAsStreamAsync preserve cancellation)
- `src/workflow/Aevatar.Workflow.Sdk/Session/WorkflowClientSessionExtensions.cs`(async enumerable + WithCancellation)
- `test/Aevatar.Workflow.Sdk.Tests/AevatarWorkflowClientTests.cs`(canceling HttpMessageHandler 断言 cancellation 不被包装)
- `test/Aevatar.Workflow.Sdk.Tests/Streaming/SseChatTransportTests.cs`(hanging SSE stream 断言)

不改 API routes / DTOs / CQRS / workflow runtime。

验证:Workflow.Sdk 编译 ✅ + Workflow.Sdk.Tests pass + 两个 `ci/*_guards.sh` pass。

## Stacked-PR

Part of iter82 batch 1。Base = `auto-refact-dev`。Rollup target = `dev`(via #690)。

🤖 Auto-loop / codex-refactor-loop iter82

⟦AI:AUTO-LOOP⟧
