### PR TITLE
iter81 cluster-081 (reflective): direct /v1/responses + /v1/messages 也 record LlmSessionCompletion

### DIFF
--- a/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Messages/MessagesEndpoints.cs
@@ -1,5 +1,7 @@
 using System.Text;
 using System.Text.Json;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.Mainnet.Host.Api.Responses;
 using Microsoft.AspNetCore.Http;
@@ -28,6 +30,9 @@ internal static partial class MessagesApiEndpoints
     // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
     //   Old pattern: Mainnet Minimal API handlers (ResponsesEndpoints / MessagesEndpoints) inject long lists of application/runtime collaborators and perform caller resolution / route / session / LLM orchestration inline.
     //   New principle: Host handlers parse/authenticate HTTP only + delegate to typed Application command/query facade that owns Normalize -> Resolve Target -> Build Context -> Dispatch/Observe lifecycle. SSE rendering stays at the boundary.
+    // Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+    //   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+    //   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
     internal static async Task<IResult> HandleCreateMessageAsync(
         HttpContext http,
         MessagesCreateRequest request,
@@ -151,8 +156,10 @@ internal static partial class MessagesApiEndpoints
             }, ct);
         }
 
+        var sessionCompletion = completion.Completion!;
+        var toolCalls = ToToolCalls(sessionCompletion.ToolCalls);
         var nextBlockIndex = textStarted ? 1 : 0;
-        foreach (var toolCall in completion.ForwardedToolCalls)
+        foreach (var toolCall in toolCalls)
         {
             await WriteSseFrameAsync(response, "content_block_start", new
             {
@@ -184,7 +191,7 @@ internal static partial class MessagesApiEndpoints
             nextBlockIndex++;
         }
 
-        var stopReason = completion.ForwardedToolCalls.Count > 0 ? "tool_use" : "end_turn";
+        var stopReason = toolCalls.Count > 0 ? "tool_use" : "end_turn";
         await WriteSseFrameAsync(response, "message_delta", new
         {
             type = "message_delta",
@@ -195,7 +202,7 @@ internal static partial class MessagesApiEndpoints
             },
             usage = new
             {
-                output_tokens = completion.Usage?.CompletionTokens ?? 0,
+                output_tokens = sessionCompletion.Usage?.CompletionTokens ?? 0,
             },
         }, ct);
 
@@ -207,14 +214,15 @@ internal static partial class MessagesApiEndpoints
 
     private static object BuildCompletedMessage(
         NormalizedMessagesRequest normalized,
-        ResponsesCompletionResult completion)
+        LlmSessionCompletionSnapshot completion)
     {
         var contentBlocks = new List<object>();
-        if (!string.IsNullOrEmpty(completion.Text))
+        if (!string.IsNullOrEmpty(completion.OutputText))
         {
-            contentBlocks.Add(new { type = "text", text = completion.Text });
+            contentBlocks.Add(new { type = "text", text = completion.OutputText });
         }
-        foreach (var toolCall in completion.ForwardedToolCalls)
+        var toolCalls = ToToolCalls(completion.ToolCalls);
+        foreach (var toolCall in toolCalls)
         {
             using var argsDoc = SafeParseJson(toolCall.ArgumentsJson);
             contentBlocks.Add(new
@@ -226,7 +234,7 @@ internal static partial class MessagesApiEndpoints
             });
         }
 
-        var stopReason = completion.ForwardedToolCalls.Count > 0 ? "tool_use" : "end_turn";
+        var stopReason = toolCalls.Count > 0 ? "tool_use" : "end_turn";
         return new
         {
             id = normalized.MessageId,
@@ -243,6 +251,17 @@ internal static partial class MessagesApiEndpoints
             },
         };
     }
+
+    private static IReadOnlyList<ToolCall> ToToolCalls(
+        IReadOnlyList<LlmSessionCompletedToolCallSnapshot> toolCalls) =>
+        toolCalls
+            .Select(static toolCall => new ToolCall
+            {
+                Id = toolCall.CallId,
+                Name = toolCall.ToolName,
+                ArgumentsJson = toolCall.ResultJson ?? "{}",
+            })
+            .ToArray();
 
     private static async Task WriteSseFrameAsync(
         HttpResponse response,

--- a/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
+++ b/src/Aevatar.Mainnet.Host.Api/Responses/ResponsesEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgentService.Abstractions.Responses;
+using Aevatar.GAgentService.Abstractions.Queries;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.Presentation.AGUI;
 using Microsoft.AspNetCore.Builder;
@@ -15,6 +16,9 @@ namespace Aevatar.Mainnet.Host.Api.Responses;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
 internal static partial class ResponsesApiEndpoints
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
@@ -114,10 +118,10 @@ internal static partial class ResponsesApiEndpoints
                 BuildCompletedResponse(
                     result.Completed.Normalized,
                     result.Completed.CreatedAt,
-                    result.Completed.CompletedAt,
-                    result.Completed.OutputText,
-                    result.Completed.ForwardedToolCalls,
-                    result.Completed.Usage is null ? null : MapUsage(result.Completed.Usage)),
+                    result.Completed.Completion.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+                    result.Completed.Completion.OutputText,
+                    ToToolCalls(result.Completed.Completion.ToolCalls),
+                    result.Completed.Completion.Usage is null ? null : MapUsage(result.Completed.Completion.Usage)),
                 statusCode: StatusCodes.Status200OK);
         }
 
@@ -236,7 +240,8 @@ internal static partial class ResponsesApiEndpoints
             return;
         }
 
-        var completedText = completion.OutputText;
+        var sessionCompletion = completion.Completion!;
+        var completedText = sessionCompletion.OutputText;
         await WriteSseFrameAsync(
             response,
             "response.output_text.done",
@@ -264,8 +269,9 @@ internal static partial class ResponsesApiEndpoints
             },
             ct);
 
+        var toolCalls = ToToolCalls(sessionCompletion.ToolCalls);
         var nextOutputIndex = 1;
-        foreach (var toolCall in completion.ForwardedToolCalls)
+        foreach (var toolCall in toolCalls)
         {
             var functionCallItem = BuildFunctionCallOutputItem(toolCall);
             await WriteSseFrameAsync(
@@ -296,10 +302,10 @@ internal static partial class ResponsesApiEndpoints
         var completedResponse = BuildCompletedResponse(
             normalized,
             createdAt,
-            DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            sessionCompletion.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
             completedText,
-            completion.ForwardedToolCalls,
-            completion.Usage is null ? null : MapUsage(completion.Usage));
+            toolCalls,
+            sessionCompletion.Usage is null ? null : MapUsage(sessionCompletion.Usage));
 
         await WriteSseFrameAsync(
             response,
@@ -459,15 +465,8 @@ internal static partial class ResponsesApiEndpoints
                     createdAt,
                     snapshot.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                     snapshot.OutputText,
-                    snapshot.ToolCalls
-                        .Select(static tc => new ToolCall
-                        {
-                            Id = tc.CallId,
-                            Name = tc.ToolName,
-                            ArgumentsJson = tc.ResultJson ?? "{}",
-                        })
-                        .ToArray(),
-                    usage: null),
+                    ToToolCalls(snapshot.ToolCalls),
+                    snapshot.Usage is null ? null : MapUsage(snapshot.Usage)),
                 ct);
         }
         catch (OperationCanceledException)
@@ -530,15 +529,8 @@ internal static partial class ResponsesApiEndpoints
                 createdAt,
                 completion.CompletedAt?.ToUnixTimeSeconds() ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                 completion.OutputText,
-                completion.ToolCalls
-                    .Select(static tc => new ToolCall
-                    {
-                        Id = tc.CallId,
-                        Name = tc.ToolName,
-                        ArgumentsJson = tc.ResultJson ?? "{}",
-                    })
-                    .ToArray(),
-                usage: null);
+                ToToolCalls(completion.ToolCalls),
+                completion.Usage is null ? null : MapUsage(completion.Usage));
             return Results.Json(completed, statusCode: StatusCodes.Status200OK);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -640,6 +632,18 @@ internal static partial class ResponsesApiEndpoints
             OutputTokens = usage.CompletionTokens,
             TotalTokens = usage.TotalTokens,
             OutputTokensDetails = new ResponsesOutputTokensDetails(),
+        };
+
+    private static IReadOnlyList<ToolCall> ToToolCalls(
+        IReadOnlyList<LlmSessionCompletedToolCallSnapshot> toolCalls) =>
+        toolCalls.Select(ToToolCall).ToArray();
+
+    private static ToolCall ToToolCall(LlmSessionCompletedToolCallSnapshot toolCall) =>
+        new()
+        {
+            Id = toolCall.CallId,
+            Name = toolCall.ToolName,
+            ArgumentsJson = toolCall.ResultJson ?? "{}",
         };
 
     private static ResponsesOutputMessage BuildOutputMessage(string id, string status, string? text)

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/llm_sessions.proto
@@ -72,6 +72,13 @@ message LlmSessionCompletion {
   google.protobuf.Timestamp completed_at = 3;
   string failure_code = 4;
   string failure_message = 5;
+  LlmSessionTokenUsage usage = 6;
+}
+
+message LlmSessionTokenUsage {
+  int32 prompt_tokens = 1;
+  int32 completion_tokens = 2;
+  int32 total_tokens = 3;
 }
 
 message LlmSessionState {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/LlmSessionSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/LlmSessionSnapshot.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgentService.Abstractions;
 
 namespace Aevatar.GAgentService.Abstractions.Queries;
@@ -44,7 +45,8 @@ public sealed record LlmSessionCompletionSnapshot(
     IReadOnlyList<LlmSessionCompletedToolCallSnapshot> ToolCalls,
     DateTimeOffset? CompletedAt,
     string? FailureCode,
-    string? FailureMessage);
+    string? FailureMessage,
+    TokenUsage? Usage = null);
 
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed

--- a/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/MessagesCommandFacade.cs
@@ -3,6 +3,7 @@ using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging;
 
@@ -11,11 +12,15 @@ namespace Aevatar.GAgentService.Application.Responses;
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Anthropic Messages Host handler normalized, resolved chat route, registered sessions, classified tools, and built LLM requests inline.
 //   New principle: Application owns the Messages command lifecycle as a typed facade; Host only maps Anthropic HTTP/SSE/JSON frames.
+// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
 public sealed class MessagesCommandFacade(
     IResponsesCallerScopeResolver callerScopeResolver,
     IResponsesChatRouteDecisionPort chatRouteDecisionPort,
     IResponsesRouteResolver routeResolver,
     ILlmSessionRegistrationPort sessionRegistrationPort,
+    ILlmSessionQueryPort sessionQueryPort,
     IResponsesCompletionApplicationService completionService,
     ILLMProviderFactory providerFactory,
     ILogger<MessagesCommandFacade> logger) : IMessagesCommandFacade
@@ -91,11 +96,21 @@ public sealed class MessagesCommandFacade(
                 plan.ToolClassification,
                 onTextDelta,
                 ct);
-            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Completed, ct);
-            return ResponsesStreamCommandResult.FromCompleted(
-                completion.Text,
-                completion.ForwardedToolCalls,
-                completion.Usage);
+            var completionResult = await RecordCompletionAndReadAsync(
+                plan.Session,
+                BuildSessionCompletion(
+                    completion.Text,
+                    completion.ForwardedToolCalls,
+                    completion.Usage,
+                    DateTimeOffset.UtcNow),
+                ct);
+            if (completionResult.Error is not null)
+                return ResponsesStreamCommandResult.FromError(
+                    completionResult.Error.StatusCode,
+                    completionResult.Error.Code,
+                    completionResult.Error.Message);
+
+            return ResponsesStreamCommandResult.FromCompleted(completionResult.Completion!);
         }
         catch (NyxIdAuthenticationRequiredException ex)
         {
@@ -244,8 +259,23 @@ public sealed class MessagesCommandFacade(
                 plan.ToolContextMetadata,
                 plan.ToolClassification,
                 ct);
-            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Completed, ct);
-            return MessagesCreateCommandResult.FromCompleted(new MessagesCreateCompletedCommandResult(plan.Normalized, completion));
+            var completionResult = await RecordCompletionAndReadAsync(
+                plan.Session,
+                BuildSessionCompletion(
+                    completion.Text,
+                    completion.ForwardedToolCalls,
+                    completion.Usage,
+                    DateTimeOffset.UtcNow),
+                ct);
+            if (completionResult.Error is not null)
+                return MessagesCreateCommandResult.FromError(
+                    completionResult.Error.StatusCode,
+                    completionResult.Error.Code,
+                    completionResult.Error.Message);
+
+            return MessagesCreateCommandResult.FromCompleted(new MessagesCreateCompletedCommandResult(
+                plan.Normalized,
+                completionResult.Completion!));
         }
         catch (NyxIdAuthenticationRequiredException ex)
         {
@@ -424,6 +454,80 @@ public sealed class MessagesCommandFacade(
         }
     }
 
+    private async Task<CompletionRecordResult> RecordCompletionAndReadAsync(
+        LlmSessionRegistrationResult session,
+        LlmSessionCompletion completion,
+        CancellationToken ct)
+    {
+        try
+        {
+            await sessionRegistrationPort.RecordCompletionAsync(
+                session.ActorId,
+                session.ResponseId,
+                completion,
+                ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to record llm session completion for message {MessageId}", session.ResponseId);
+            return CompletionRecordResult.FromError(new ResponsesCommandError(
+                500,
+                "response_completion_record_failed",
+                "Failed to record response completion."));
+        }
+
+        var snapshot = await sessionQueryPort.GetByResponseIdAsync(session.ResponseId, ct);
+        if (snapshot?.Completion is null)
+        {
+            return CompletionRecordResult.FromError(new ResponsesCommandError(
+                503,
+                "response_completion_not_observed",
+                "Response completion was committed but is not yet visible in the read model."));
+        }
+
+        return CompletionRecordResult.FromCompletion(snapshot.Completion);
+    }
+
+    private static LlmSessionCompletion BuildSessionCompletion(
+        string outputText,
+        IReadOnlyList<ToolCall> forwardedToolCalls,
+        TokenUsage? usage,
+        DateTimeOffset completedAt)
+    {
+        var completion = new LlmSessionCompletion
+        {
+            OutputText = outputText,
+            CompletedAt = Timestamp.FromDateTimeOffset(completedAt),
+        };
+
+        if (usage is not null)
+        {
+            completion.Usage = new LlmSessionTokenUsage
+            {
+                PromptTokens = usage.PromptTokens,
+                CompletionTokens = usage.CompletionTokens,
+                TotalTokens = usage.TotalTokens,
+            };
+        }
+
+        foreach (var toolCall in forwardedToolCalls)
+        {
+            completion.ToolCalls.Add(new LlmSessionCompletedToolCall
+            {
+                CallId = toolCall.Id,
+                ToolName = toolCall.Name,
+                Result = ResponsesJsonValues.ParseBoundaryPayload(
+                    string.IsNullOrWhiteSpace(toolCall.ArgumentsJson) ? "{}" : toolCall.ArgumentsJson),
+            });
+        }
+
+        return completion;
+    }
+
     private sealed record CallerScopeResult(
         ResponsesCallerScope? Scope,
         ResponsesCommandError? Error);
@@ -441,4 +545,13 @@ public sealed class MessagesCommandFacade(
     private sealed record SessionRegistrationResult(
         LlmSessionRegistrationResult? Session,
         ResponsesCommandError? Error);
+
+    private sealed record CompletionRecordResult(
+        ResponsesCommandError? Error,
+        LlmSessionCompletionSnapshot? Completion)
+    {
+        public static CompletionRecordResult FromError(ResponsesCommandError error) => new(error, null);
+
+        public static CompletionRecordResult FromCompletion(LlmSessionCompletionSnapshot completion) => new(null, completion);
+    }
 }

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandContracts.cs
@@ -232,28 +232,21 @@ public sealed record ResponsesForwardingResult(
 public sealed record ResponsesCreateCompletedCommandResult(
     NormalizedResponsesRequest Normalized,
     long CreatedAt,
-    long CompletedAt,
-    string OutputText,
-    IReadOnlyList<ToolCall> ForwardedToolCalls,
-    TokenUsage? Usage);
+    LlmSessionCompletionSnapshot Completion);
 
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: Streaming completion errors and final data were encoded directly into SSE handler branches.
 //   New principle: Application reports stream execution outcome as typed data; Host renders the appropriate SSE or error frame.
 public sealed record ResponsesStreamCommandResult(
     ResponsesCommandError? Error,
-    string OutputText,
-    IReadOnlyList<ToolCall> ForwardedToolCalls,
-    TokenUsage? Usage)
+    LlmSessionCompletionSnapshot? Completion)
 {
     public static ResponsesStreamCommandResult FromError(int statusCode, string code, string message) =>
-        new(new ResponsesCommandError(statusCode, code, message), string.Empty, [], null);
+        new(new ResponsesCommandError(statusCode, code, message), null);
 
     public static ResponsesStreamCommandResult FromCompleted(
-        string outputText,
-        IReadOnlyList<ToolCall> forwardedToolCalls,
-        TokenUsage? usage) =>
-        new(null, outputText, forwardedToolCalls, usage);
+        LlmSessionCompletionSnapshot completion) =>
+        new(null, completion);
 }
 
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
@@ -304,7 +297,7 @@ public sealed record MessagesCreateCommandResult(
 //   New principle: Application exposes the completed Messages command outcome for the Host protocol mapper.
 public sealed record MessagesCreateCompletedCommandResult(
     NormalizedMessagesRequest Normalized,
-    ResponsesCompletionResult Completion);
+    LlmSessionCompletionSnapshot Completion);
 
 // Refactor (iter35/cluster-037-mainnet-responses-host-orchestration):
 //   Old pattern: /v1/responses endpoints owned command orchestration and called many lower-level collaborators directly.

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesCommandFacade.cs
@@ -15,6 +15,9 @@ namespace Aevatar.GAgentService.Application.Responses;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
 public sealed class ResponsesCommandFacade(
     ILLMProviderFactory providerFactory,
     IResponsesCallerScopeResolver callerScopeResolver,
@@ -59,22 +62,35 @@ public sealed class ResponsesCommandFacade(
                 routedModelResult.Error.StatusCode,
                 routedModelResult.Error.Code,
                 routedModelResult.Error.Message);
-        var continuation = await PrepareContinuationAsync(normalized, callerScope, ct);
+        var createdAt = DateTimeOffset.UtcNow;
+        var continuation = await PrepareContinuationAsync(normalized, callerScope, createdAt, ct);
         if (continuation.Error is not null)
             return ResponsesCreateCommandResult.FromError(
                 continuation.Error.StatusCode,
                 continuation.Error.Code,
                 continuation.Error.Message);
-        if (continuation.AlreadyResolved is not null)
-            return ResponsesCreateCommandResult.FromCompleted(continuation.AlreadyResolved);
-
-        var createdAt = DateTimeOffset.UtcNow;
         var sessionResult = await RegisterSessionAsync(normalized, callerScope, createdAt, ct);
         if (sessionResult.Error is not null)
             return ResponsesCreateCommandResult.FromError(
                 sessionResult.Error.StatusCode,
                 sessionResult.Error.Code,
                 sessionResult.Error.Message);
+        if (continuation.AlreadyResolvedCompletion is not null)
+        {
+            var completionResult = await RecordCompletionAndReadAsync(
+                sessionResult.Session!,
+                continuation.AlreadyResolvedCompletion,
+                ct);
+            return completionResult.Error is not null
+                ? ResponsesCreateCommandResult.FromError(
+                    completionResult.Error.StatusCode,
+                    completionResult.Error.Code,
+                    completionResult.Error.Message)
+                : ResponsesCreateCommandResult.FromCompleted(new ResponsesCreateCompletedCommandResult(
+                    normalized,
+                    createdAt.ToUnixTimeSeconds(),
+                    completionResult.Completion!));
+        }
 
         // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
         //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
@@ -186,11 +202,21 @@ public sealed class ResponsesCommandFacade(
                 DateTimeOffset.UtcNow,
                 ct);
             await TryResolveIncomingToolResultsAsync(plan.PreviousSnapshot, plan.Normalized, ct);
-            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Completed, ct);
-            return ResponsesStreamCommandResult.FromCompleted(
+            var completionResult = await RecordCompletionAndReadAsync(
+                plan.Session,
+                BuildSessionCompletion(
                 completion.Text,
                 completion.ForwardedToolCalls,
-                completion.Usage);
+                    completion.Usage,
+                    DateTimeOffset.UtcNow),
+                ct);
+            if (completionResult.Error is not null)
+                return ResponsesStreamCommandResult.FromError(
+                    completionResult.Error.StatusCode,
+                    completionResult.Error.Code,
+                    completionResult.Error.Message);
+
+            return ResponsesStreamCommandResult.FromCompleted(completionResult.Completion!);
         }
         catch (NyxIdAuthenticationRequiredException ex)
         {
@@ -265,6 +291,7 @@ public sealed class ResponsesCommandFacade(
     private async Task<ContinuationResult> PrepareContinuationAsync(
         NormalizedResponsesRequest normalized,
         ResponsesCallerScope callerScope,
+        DateTimeOffset createdAt,
         CancellationToken ct)
     {
         LlmSessionSnapshot? previousSnapshot = null;
@@ -285,11 +312,16 @@ public sealed class ResponsesCommandFacade(
         }
 
         if (previousSnapshot is not null &&
-            TryBuildAlreadyResolvedToolResultResponse(normalized, previousSnapshot, out var alreadyResolvedResult, out var alreadyResolvedError))
+            TryBuildAlreadyResolvedToolResultCompletion(
+                normalized,
+                previousSnapshot,
+                createdAt,
+                out var alreadyResolvedCompletion,
+                out var alreadyResolvedError))
         {
             return alreadyResolvedError is not null
                 ? ContinuationResult.FromError(alreadyResolvedError)
-                : ContinuationResult.FromAlreadyResolved(alreadyResolvedResult!);
+                : ContinuationResult.FromAlreadyResolved(alreadyResolvedCompletion!);
         }
 
         if (previousSnapshot is not null)
@@ -389,15 +421,24 @@ public sealed class ResponsesCommandFacade(
             var forwardedToolCalls = completion.ForwardedToolCalls;
             await PersistForwardedToolCallsAsync(plan.Session, plan.ToolClassification, forwardedToolCalls, DateTimeOffset.UtcNow, ct);
             await TryResolveIncomingToolResultsAsync(plan.PreviousSnapshot, plan.Normalized, ct);
-            var completedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            await TryUpdateSessionStatusAsync(plan.Session, LlmSessionStatus.Completed, ct);
+            var completionResult = await RecordCompletionAndReadAsync(
+                plan.Session,
+                BuildSessionCompletion(
+                    completion.Text,
+                    forwardedToolCalls,
+                    completion.Usage,
+                    DateTimeOffset.UtcNow),
+                ct);
+            if (completionResult.Error is not null)
+                return ResponsesCreateCommandResult.FromError(
+                    completionResult.Error.StatusCode,
+                    completionResult.Error.Code,
+                    completionResult.Error.Message);
+
             return ResponsesCreateCommandResult.FromCompleted(new ResponsesCreateCompletedCommandResult(
                 plan.Normalized,
                 plan.CreatedAt.ToUnixTimeSeconds(),
-                completedAt,
-                completion.Text,
-                forwardedToolCalls,
-                completion.Usage));
+                completionResult.Completion!));
         }
         catch (NyxIdAuthenticationRequiredException ex)
         {
@@ -687,13 +728,14 @@ public sealed class ResponsesCommandFacade(
         return null;
     }
 
-    private bool TryBuildAlreadyResolvedToolResultResponse(
+    private bool TryBuildAlreadyResolvedToolResultCompletion(
         NormalizedResponsesRequest normalized,
         LlmSessionSnapshot previousSnapshot,
-        out ResponsesCreateCompletedCommandResult? result,
+        DateTimeOffset completedAt,
+        out LlmSessionCompletion? completion,
         out ResponsesCommandError? error)
     {
-        result = null;
+        completion = null;
         error = null;
         if (normalized.ToolResults.Count == 0)
             return false;
@@ -723,12 +765,85 @@ public sealed class ResponsesCommandFacade(
             resolvedOutputs.Add(string.IsNullOrWhiteSpace(call.ResultJson) ? input.Output : call.ResultJson!);
         }
 
-        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var outputText = resolvedOutputs.Count == 1
             ? resolvedOutputs[0]
             : System.Text.Json.JsonSerializer.Serialize(resolvedOutputs);
-        result = new ResponsesCreateCompletedCommandResult(normalized, now, now, outputText, [], null);
+        completion = BuildSessionCompletion(outputText, [], null, completedAt);
         return true;
+    }
+
+    private async Task<CompletionRecordResult> RecordCompletionAndReadAsync(
+        LlmSessionRegistrationResult session,
+        LlmSessionCompletion completion,
+        CancellationToken ct)
+    {
+        try
+        {
+            await responseSessionRegistrationPort.RecordCompletionAsync(
+                session.ActorId,
+                session.ResponseId,
+                completion,
+                ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var correlation = LogAndCorrelate(logger, ex, "session_completion", session.ResponseId);
+            return CompletionRecordResult.FromError(new ResponsesCommandError(
+                500,
+                "response_completion_record_failed",
+                $"Failed to record response completion. Correlation: {correlation}"));
+        }
+
+        var snapshot = await responseSessionQueryPort.GetByResponseIdAsync(session.ResponseId, ct);
+        if (snapshot?.Completion is null)
+        {
+            return CompletionRecordResult.FromError(new ResponsesCommandError(
+                503,
+                "response_completion_not_observed",
+                "Response completion was committed but is not yet visible in the read model."));
+        }
+
+        return CompletionRecordResult.FromCompletion(snapshot.Completion);
+    }
+
+    private static LlmSessionCompletion BuildSessionCompletion(
+        string outputText,
+        IReadOnlyList<ToolCall> forwardedToolCalls,
+        TokenUsage? usage,
+        DateTimeOffset completedAt)
+    {
+        var completion = new LlmSessionCompletion
+        {
+            OutputText = outputText,
+            CompletedAt = Timestamp.FromDateTimeOffset(completedAt),
+        };
+
+        if (usage is not null)
+        {
+            completion.Usage = new LlmSessionTokenUsage
+            {
+                PromptTokens = usage.PromptTokens,
+                CompletionTokens = usage.CompletionTokens,
+                TotalTokens = usage.TotalTokens,
+            };
+        }
+
+        foreach (var toolCall in forwardedToolCalls)
+        {
+            completion.ToolCalls.Add(new LlmSessionCompletedToolCall
+            {
+                CallId = toolCall.Id,
+                ToolName = toolCall.Name,
+                Result = ResponsesJsonValues.ParseBoundaryPayload(
+                    string.IsNullOrWhiteSpace(toolCall.ArgumentsJson) ? "{}" : toolCall.ArgumentsJson),
+            });
+        }
+
+        return completion;
     }
 
     private async Task TryResolveIncomingToolResultsAsync(
@@ -929,13 +1044,13 @@ public sealed class ResponsesCommandFacade(
 
     private sealed record ContinuationResult(
         LlmSessionSnapshot? PreviousSnapshot,
-        ResponsesCreateCompletedCommandResult? AlreadyResolved,
+        LlmSessionCompletion? AlreadyResolvedCompletion,
         ResponsesCommandError? Error)
     {
         public static ContinuationResult FromPrevious(LlmSessionSnapshot? previousSnapshot) =>
             new(previousSnapshot, null, null);
 
-        public static ContinuationResult FromAlreadyResolved(ResponsesCreateCompletedCommandResult alreadyResolved) =>
+        public static ContinuationResult FromAlreadyResolved(LlmSessionCompletion alreadyResolved) =>
             new(null, alreadyResolved, null);
 
         public static ContinuationResult FromError(ResponsesCommandError error) => new(null, null, error);
@@ -944,4 +1059,13 @@ public sealed class ResponsesCommandFacade(
     private sealed record SessionRegistrationResult(
         LlmSessionRegistrationResult? Session,
         ResponsesCommandError? Error);
+
+    private sealed record CompletionRecordResult(
+        ResponsesCommandError? Error,
+        LlmSessionCompletionSnapshot? Completion)
+    {
+        public static CompletionRecordResult FromError(ResponsesCommandError error) => new(error, null);
+
+        public static CompletionRecordResult FromCompletion(LlmSessionCompletionSnapshot completion) => new(null, completion);
+    }
 }

--- a/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
+++ b/src/platform/Aevatar.GAgentService.Core/GAgents/LlmSessionGAgent.cs
@@ -10,6 +10,9 @@ namespace Aevatar.GAgentService.Core.GAgents;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
 public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
 {
     private static readonly Duration DefaultTtl = Duration.FromTimeSpan(TimeSpan.FromHours(24));
@@ -455,6 +458,12 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         completion.FailureMessage = NormalizeOptional(completion.FailureMessage) ?? string.Empty;
         if (completion.CompletedAt == null)
             completion.CompletedAt = Timestamp.FromDateTime(DateTime.UtcNow);
+        if (completion.Usage is not null)
+        {
+            completion.Usage.PromptTokens = Math.Max(0, completion.Usage.PromptTokens);
+            completion.Usage.CompletionTokens = Math.Max(0, completion.Usage.CompletionTokens);
+            completion.Usage.TotalTokens = Math.Max(0, completion.Usage.TotalTokens);
+        }
 
         foreach (var toolCall in completion.ToolCalls)
         {
@@ -540,6 +549,7 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
         if (!string.Equals(existing.OutputText, incoming.OutputText, StringComparison.Ordinal) ||
             !string.Equals(existing.FailureCode, incoming.FailureCode, StringComparison.Ordinal) ||
             !string.Equals(existing.FailureMessage, incoming.FailureMessage, StringComparison.Ordinal) ||
+            !UsageEquals(existing.Usage, incoming.Usage) ||
             existing.ToolCalls.Count != incoming.ToolCalls.Count)
         {
             throw new InvalidOperationException("Response session completion cannot be rebound to different facts.");
@@ -616,6 +626,16 @@ public sealed class LlmSessionGAgent : GAgentBase<LlmSessionState>
 
     private static bool DurationEquals(Duration? left, Duration? right) =>
         left?.ToTimeSpan() == right?.ToTimeSpan();
+
+    private static bool UsageEquals(LlmSessionTokenUsage? left, LlmSessionTokenUsage? right)
+    {
+        if (left is null || right is null)
+            return left is null && right is null;
+
+        return left.PromptTokens == right.PromptTokens &&
+               left.CompletionTokens == right.CompletionTokens &&
+               left.TotalTokens == right.TotalTokens;
+    }
 
     private static string NormalizeRequired(string? value) =>
         NormalizeOptional(value) ?? string.Empty;

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionCurrentStateProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/LlmSessionCurrentStateProjector.cs
@@ -11,6 +11,9 @@ namespace Aevatar.GAgentService.Projection.Projectors;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
 public sealed class LlmSessionCurrentStateProjector
     : ICurrentStateProjectionMaterializer<LlmSessionCurrentStateProjectionContext>
 {
@@ -96,6 +99,14 @@ public sealed class LlmSessionCurrentStateProjector
                 CompletedAt = state.Completion.CompletedAt?.ToDateTimeOffset(),
                 FailureCode = state.Completion.FailureCode ?? string.Empty,
                 FailureMessage = state.Completion.FailureMessage ?? string.Empty,
+                Usage = state.Completion.Usage is null
+                    ? null
+                    : new LlmSessionTokenUsageReadModel
+                    {
+                        PromptTokens = state.Completion.Usage.PromptTokens,
+                        CompletionTokens = state.Completion.Usage.CompletionTokens,
+                        TotalTokens = state.Completion.Usage.TotalTokens,
+                    },
             };
             foreach (var call in state.Completion.ToolCalls)
             {

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/LlmSessionQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/LlmSessionQueryReader.cs
@@ -1,4 +1,5 @@
 using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
@@ -11,6 +12,9 @@ namespace Aevatar.GAgentService.Projection.Queries;
 // Refactor (iter75/cluster-075-responses-agui-host-completion-state):
 //   Old pattern: ForwardToTeam/ForwardToGAgent skipped session lifecycle; Host new'd StringBuilder/Dictionary/List<ToolCall> to synthesize response.completed
 //   New principle: Reuse LlmSessionGAgent for forwarded Responses; Host renders response.completed from typed completion contract / readmodel
+// Refactor (iter81/cluster-081-direct-response-completion-not-session-fact):
+//   Old pattern: direct Responses/Messages held terminal completion in request-local result; LlmSession only marked Completed
+//   New principle: record typed LlmSessionCompletion on session for direct paths; terminal protocol output renders from session contract/readmodel
 public sealed class LlmSessionQueryReader : ILlmSessionQueryPort
 {
     private readonly IProjectionDocumentReader<LlmSessionCurrentStateReadModel, string> _documentStore;
@@ -82,7 +86,13 @@ public sealed class LlmSessionQueryReader : ILlmSessionQueryPort
                 .ToArray(),
             completion.CompletedAt,
             string.IsNullOrWhiteSpace(completion.FailureCode) ? null : completion.FailureCode,
-            string.IsNullOrWhiteSpace(completion.FailureMessage) ? null : completion.FailureMessage);
+            string.IsNullOrWhiteSpace(completion.FailureMessage) ? null : completion.FailureMessage,
+            completion.Usage is null
+                ? null
+                : new TokenUsage(
+                    completion.Usage.PromptTokens,
+                    completion.Usage.CompletionTokens,
+                    completion.Usage.TotalTokens));
     }
 
     /// <summary>

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -265,6 +265,13 @@ message LlmSessionCompletionReadModel {
   google.protobuf.Timestamp completed_at_utc_value = 3;
   string failure_code = 4;
   string failure_message = 5;
+  LlmSessionTokenUsageReadModel usage = 6;
+}
+
+message LlmSessionTokenUsageReadModel {
+  int32 prompt_tokens = 1;
+  int32 completion_tokens = 2;
+  int32 total_tokens = 3;
 }
 
 // --- ResponsesAgentToolStateCurrentStateReadModel ---

--- a/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
@@ -32,6 +32,27 @@ public sealed class MessagesCommandFacadeTests
     }
 
     [Fact]
+    public async Task CreateAsync_WhenCompletionIsCommittedButNotObserved_ShouldReturnServiceUnavailable()
+    {
+        var completion = new RecordingCompletionService(new ResponsesCompletionResult("hello", null, []));
+        var sessions = new RecordingSessionPort
+        {
+            ObserveCompletionInQueryPort = false,
+        };
+        var facade = CreateFacade(completionService: completion, sessionPort: sessions);
+
+        var result = await facade.CreateAsync(BuildRequest("claude-sonnet"), "token");
+
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.OutputText.Should().Be("hello");
+        result.Completed.Should().BeNull();
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            503,
+            "response_completion_not_observed",
+            "Response completion was committed but is not yet visible in the read model."));
+    }
+
+    [Fact]
     public async Task CreateAsync_ShouldReturnStreamPlan_WhenRequestIsStreaming()
     {
         var sessions = new RecordingSessionPort();
@@ -327,6 +348,8 @@ public sealed class MessagesCommandFacadeTests
 
         public List<LlmSessionCompletion> RecordedCompletions { get; } = [];
 
+        public bool ObserveCompletionInQueryPort { get; init; } = true;
+
         public RecordingSessionQueryPort QueryPort { get; } = new();
 
         public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
@@ -370,7 +393,7 @@ public sealed class MessagesCommandFacadeTests
         {
             RecordedCompletions.Add(completion.Clone());
             var current = QueryPort.Snapshot;
-            if (current is not null)
+            if (current is not null && ObserveCompletionInQueryPort)
             {
                 QueryPort.Snapshot = current with
                 {

--- a/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/MessagesCommandFacadeTests.cs
@@ -3,6 +3,8 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,9 +23,10 @@ public sealed class MessagesCommandFacadeTests
         var result = await facade.CreateAsync(BuildRequest("claude-sonnet"), "token");
 
         result.Error.Should().BeNull();
-        result.Completed!.Completion.Text.Should().Be("hello");
+        result.Completed!.Completion.OutputText.Should().Be("hello");
         sessions.Registered.Should().ContainSingle().Which.PreviousResponseId.Should().BeEmpty();
-        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Completed);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.OutputText.Should().Be("hello");
         completion.LastRequest!.Model.Should().Be("claude-sonnet");
         completion.LastRequest.Messages.Should().ContainSingle(message => message.Role == "user" && message.Content == "hello");
     }
@@ -75,6 +78,27 @@ public sealed class MessagesCommandFacadeTests
             "authentication_error",
             "NyxID authentication required for provider 'test-provider'. Please sign in."));
         sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Failed);
+    }
+
+    [Fact]
+    public async Task StreamAsync_ShouldRecordCompletionFact_AndReturnSessionCompletion()
+    {
+        var completion = new RecordingCompletionService(new ResponsesCompletionResult(
+            "message stream done",
+            new TokenUsage(2, 3, 5),
+            []));
+        var sessions = new RecordingSessionPort();
+        sessions.QueryPort.Snapshot = BuildSnapshot("msg_stream");
+        var facade = CreateFacade(completionService: completion, sessionPort: sessions);
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), (_, _) => ValueTask.CompletedTask);
+
+        result.Error.Should().BeNull();
+        result.Completion!.OutputText.Should().Be("message stream done");
+        result.Completion.Usage.Should().Be(new TokenUsage(2, 3, 5));
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.OutputText.Should().Be("message stream done");
+        sessions.UpdatedStatuses.Should().BeEmpty();
     }
 
     [Fact]
@@ -156,15 +180,19 @@ public sealed class MessagesCommandFacadeTests
     private static MessagesCommandFacade CreateFacade(
         IResponsesCompletionApplicationService? completionService = null,
         ILlmSessionRegistrationPort? sessionPort = null,
-        IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null) =>
-        new(
+        IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null)
+    {
+        var effectiveSessionPort = sessionPort ?? new RecordingSessionPort();
+        return new MessagesCommandFacade(
             new StaticCallerScopeResolver(),
             chatRouteDecisionPort ?? new StaticResponsesChatRouteDecisionPort(ForwardToModelAction(string.Empty)),
             new StaticResponsesRouteResolver("route-value"),
-            sessionPort ?? new RecordingSessionPort(),
+            effectiveSessionPort,
+            (effectiveSessionPort as RecordingSessionPort)?.QueryPort ?? new RecordingSessionQueryPort(),
             completionService ?? new RecordingCompletionService(new ResponsesCompletionResult("ok", null, [])),
             new StaticLlmProviderFactory(),
             NullLogger<MessagesCommandFacade>.Instance);
+    }
 
     private static MessagesCreateCommandPlan BuildStreamPlan() =>
         new(
@@ -186,6 +214,21 @@ public sealed class MessagesCommandFacadeTests
             },
             new Dictionary<string, string>(StringComparer.Ordinal),
             new ResponsesToolClassification([], [], [], []));
+
+    private static LlmSessionSnapshot BuildSnapshot(string responseId) =>
+        new(
+            responseId,
+            "scope-1",
+            "owner-1",
+            LlmSessionOriginKind.ApiKey,
+            null,
+            LlmSessionStatus.Accepted,
+            DateTimeOffset.UtcNow,
+            TimeSpan.FromHours(1),
+            null,
+            "actor-" + responseId,
+            1,
+            "event-1");
 
     private static ChatRouteAction ForwardToModelAction(string modelName) => new()
     {
@@ -282,10 +325,28 @@ public sealed class MessagesCommandFacadeTests
 
         public List<(string ActorId, string ResponseId, LlmSessionStatus Status)> UpdatedStatuses { get; } = [];
 
+        public List<LlmSessionCompletion> RecordedCompletions { get; } = [];
+
+        public RecordingSessionQueryPort QueryPort { get; } = new();
+
         public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
         {
             Registered.Add(record);
-            return Task.FromResult(new LlmSessionRegistrationResult("actor-" + record.ResponseId, record.ResponseId));
+            var actorId = "actor-" + record.ResponseId;
+            QueryPort.Snapshot = new LlmSessionSnapshot(
+                record.ResponseId,
+                record.ScopeId,
+                record.OwnerSubject,
+                record.OriginKind,
+                string.IsNullOrWhiteSpace(record.PreviousResponseId) ? null : record.PreviousResponseId,
+                record.Status,
+                record.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow,
+                record.Ttl?.ToTimeSpan() ?? TimeSpan.FromHours(1),
+                record.CancelledAt?.ToDateTimeOffset(),
+                actorId,
+                1,
+                $"{record.ResponseId}:registered");
+            return Task.FromResult(new LlmSessionRegistrationResult(actorId, record.ResponseId));
         }
 
         public Task UpdateStatusAsync(string sessionActorId, string responseId, LlmSessionStatus status, CancellationToken ct = default)
@@ -305,8 +366,43 @@ public sealed class MessagesCommandFacadeTests
             string sessionActorId,
             string responseId,
             LlmSessionCompletion completion,
-            CancellationToken ct = default) =>
-            Task.CompletedTask;
+            CancellationToken ct = default)
+        {
+            RecordedCompletions.Add(completion.Clone());
+            var current = QueryPort.Snapshot;
+            if (current is not null)
+            {
+                QueryPort.Snapshot = current with
+                {
+                    Status = string.IsNullOrWhiteSpace(completion.FailureCode)
+                        ? LlmSessionStatus.Completed
+                        : LlmSessionStatus.Failed,
+                    StateVersion = current.StateVersion + 1,
+                    LastEventId = $"{responseId}:completion",
+                    Completion = ToSnapshot(completion),
+                };
+            }
+            return Task.CompletedTask;
+        }
+
+        private static LlmSessionCompletionSnapshot ToSnapshot(LlmSessionCompletion completion) =>
+            new(
+                completion.OutputText ?? string.Empty,
+                completion.ToolCalls
+                    .Select(static call => new LlmSessionCompletedToolCallSnapshot(
+                        call.CallId,
+                        call.ToolName,
+                        ResponsesJsonValues.ToBoundaryJson(call.Result)))
+                    .ToArray(),
+                completion.CompletedAt?.ToDateTimeOffset(),
+                string.IsNullOrWhiteSpace(completion.FailureCode) ? null : completion.FailureCode,
+                string.IsNullOrWhiteSpace(completion.FailureMessage) ? null : completion.FailureMessage,
+                completion.Usage is null
+                    ? null
+                    : new TokenUsage(
+                        completion.Usage.PromptTokens,
+                        completion.Usage.CompletionTokens,
+                        completion.Usage.TotalTokens));
 
         public Task ReceiveForwardedToolResultAsync(
             string sessionActorId,
@@ -323,5 +419,13 @@ public sealed class MessagesCommandFacadeTests
             string callId,
             CancellationToken ct = default) =>
             Task.CompletedTask;
+    }
+
+    private sealed class RecordingSessionQueryPort : ILlmSessionQueryPort
+    {
+        public LlmSessionSnapshot? Snapshot { get; set; }
+
+        public Task<LlmSessionSnapshot?> GetByResponseIdAsync(string responseId, CancellationToken ct = default) =>
+            Task.FromResult(Snapshot);
     }
 }

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -53,6 +53,35 @@ public sealed class ResponsesCommandFacadeTests
     }
 
     [Fact]
+    public async Task CreateAsync_WhenCompletionIsCommittedButNotObserved_ShouldReturnServiceUnavailable()
+    {
+        var completion = new RecordingCompletionService(new ResponsesCompletionResult("done", null, []));
+        var sessions = new RecordingSessionPort
+        {
+            ObserveCompletionInQueryPort = false,
+        };
+        var facade = CreateFacade(completionService: completion, sessionPort: sessions);
+
+        var result = await facade.CreateAsync(new ResponsesCommandRequest(
+            "client-model",
+            "hello",
+            [],
+            false,
+            null,
+            null,
+            null,
+            []), "token");
+
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.OutputText.Should().Be("done");
+        result.Completed.Should().BeNull();
+        result.Error.Should().BeEquivalentTo(new ResponsesCommandError(
+            503,
+            "response_completion_not_observed",
+            "Response completion was committed but is not yet visible in the read model."));
+    }
+
+    [Fact]
     public async Task CreateAsync_WhenForwardToGAgent_ShouldRegisterSessionBeforeReturningForwardPlan()
     {
         var completion = new RecordingCompletionService(new ResponsesCompletionResult("unused", null, []));
@@ -495,6 +524,8 @@ public sealed class ResponsesCommandFacadeTests
 
         public Exception? UpdateStatusException { get; init; }
 
+        public bool ObserveCompletionInQueryPort { get; init; } = true;
+
         public RecordingSessionQueryPort QueryPort { get; } = new();
 
         public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
@@ -543,7 +574,7 @@ public sealed class ResponsesCommandFacadeTests
         {
             RecordedCompletions.Add(completion.Clone());
             var current = QueryPort.Snapshot;
-            if (current is not null)
+            if (current is not null && ObserveCompletionInQueryPort)
             {
                 QueryPort.Snapshot = current with
                 {

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -4,6 +4,7 @@ using Aevatar.ChatRouting.Abstractions;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.GAgentService.Abstractions.Queries;
+using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.Presentation.AGUI;
 using FluentAssertions;
@@ -39,9 +40,10 @@ public sealed class ResponsesCommandFacadeTests
 
         result.Error.Should().BeNull();
         result.Completed.Should().NotBeNull();
-        result.Completed!.OutputText.Should().Be("done");
+        result.Completed!.Completion.OutputText.Should().Be("done");
         sessions.Registered.Should().ContainSingle().Which.ResponseId.Should().StartWith("resp_");
-        sessions.UpdatedStatuses.Should().ContainSingle().Which.Status.Should().Be(LlmSessionStatus.Completed);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.OutputText.Should().Be("done");
         completion.LastRequest.Should().NotBeNull();
         completion.LastRequest!.Model.Should().Be("gpt-5");
         completion.LastRequest.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
@@ -181,6 +183,27 @@ public sealed class ResponsesCommandFacadeTests
     }
 
     [Fact]
+    public async Task StreamAsync_ShouldRecordCompletionFact_AndReturnSessionCompletion()
+    {
+        var completion = new RecordingCompletionService(new ResponsesCompletionResult(
+            "stream done",
+            new TokenUsage(4, 5, 9),
+            []));
+        var sessions = new RecordingSessionPort();
+        sessions.QueryPort.Snapshot = BuildSnapshot("resp_stream", "scope-1");
+        var facade = CreateFacade(completionService: completion, sessionPort: sessions);
+
+        var result = await facade.StreamAsync(BuildStreamPlan(), (_, _) => ValueTask.CompletedTask);
+
+        result.Error.Should().BeNull();
+        result.Completion!.OutputText.Should().Be("stream done");
+        result.Completion.Usage.Should().Be(new TokenUsage(4, 5, 9));
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.OutputText.Should().Be("stream done");
+        sessions.UpdatedStatuses.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task StreamAsync_ShouldReturnUpstreamError_AndMarkSessionFailed()
     {
         var completion = new RecordingCompletionService(
@@ -278,17 +301,20 @@ public sealed class ResponsesCommandFacadeTests
         ILlmSessionQueryPort? queryPort = null,
         IResponsesCallerScopeResolver? callerScopeResolver = null,
         IResponsesRouteResolver? routeResolver = null,
-        IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null) =>
-        new(
+        IResponsesChatRouteDecisionPort? chatRouteDecisionPort = null)
+    {
+        var effectiveSessionPort = sessionPort ?? new RecordingSessionPort();
+        return new ResponsesCommandFacade(
             new StaticLlmProviderFactory(),
             callerScopeResolver ?? new StaticCallerScopeResolver(),
             chatRouteDecisionPort ?? new StaticResponsesChatRouteDecisionPort(ForwardToModelAction(string.Empty)),
             routeResolver ?? new StaticResponsesRouteResolver(null),
-            sessionPort ?? new RecordingSessionPort(),
-            queryPort ?? new RecordingSessionQueryPort(),
+            effectiveSessionPort,
+            queryPort ?? (effectiveSessionPort as RecordingSessionPort)?.QueryPort ?? new RecordingSessionQueryPort(),
             completionService ?? new RecordingCompletionService(new ResponsesCompletionResult("ok", null, [])),
             [],
             NullLogger<ResponsesCommandFacade>.Instance);
+    }
 
     private static ResponsesCreateCommandPlan BuildStreamPlan() =>
         new(
@@ -469,10 +495,26 @@ public sealed class ResponsesCommandFacadeTests
 
         public Exception? UpdateStatusException { get; init; }
 
+        public RecordingSessionQueryPort QueryPort { get; } = new();
+
         public Task<LlmSessionRegistrationResult> RegisterAsync(LlmSessionRecord record, CancellationToken ct = default)
         {
             Registered.Add(record);
-            return Task.FromResult(new LlmSessionRegistrationResult("actor-" + record.ResponseId, record.ResponseId));
+            var actorId = "actor-" + record.ResponseId;
+            QueryPort.Snapshot = new LlmSessionSnapshot(
+                record.ResponseId,
+                record.ScopeId,
+                record.OwnerSubject,
+                record.OriginKind,
+                string.IsNullOrWhiteSpace(record.PreviousResponseId) ? null : record.PreviousResponseId,
+                record.Status,
+                record.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow,
+                record.Ttl?.ToTimeSpan() ?? TimeSpan.FromHours(1),
+                record.CancelledAt?.ToDateTimeOffset(),
+                actorId,
+                1,
+                $"{record.ResponseId}:registered");
+            return Task.FromResult(new LlmSessionRegistrationResult(actorId, record.ResponseId));
         }
 
         public Task UpdateStatusAsync(string sessionActorId, string responseId, LlmSessionStatus status, CancellationToken ct = default)
@@ -500,8 +542,40 @@ public sealed class ResponsesCommandFacadeTests
             CancellationToken ct = default)
         {
             RecordedCompletions.Add(completion.Clone());
+            var current = QueryPort.Snapshot;
+            if (current is not null)
+            {
+                QueryPort.Snapshot = current with
+                {
+                    Status = string.IsNullOrWhiteSpace(completion.FailureCode)
+                        ? LlmSessionStatus.Completed
+                        : LlmSessionStatus.Failed,
+                    StateVersion = current.StateVersion + 1,
+                    LastEventId = $"{responseId}:completion",
+                    Completion = ToSnapshot(completion),
+                };
+            }
             return Task.CompletedTask;
         }
+
+        private static LlmSessionCompletionSnapshot ToSnapshot(LlmSessionCompletion completion) =>
+            new(
+                completion.OutputText ?? string.Empty,
+                completion.ToolCalls
+                    .Select(static call => new LlmSessionCompletedToolCallSnapshot(
+                        call.CallId,
+                        call.ToolName,
+                        ResponsesJsonValues.ToBoundaryJson(call.Result)))
+                    .ToArray(),
+                completion.CompletedAt?.ToDateTimeOffset(),
+                string.IsNullOrWhiteSpace(completion.FailureCode) ? null : completion.FailureCode,
+                string.IsNullOrWhiteSpace(completion.FailureMessage) ? null : completion.FailureMessage,
+                completion.Usage is null
+                    ? null
+                    : new TokenUsage(
+                        completion.Usage.PromptTokens,
+                        completion.Usage.CompletionTokens,
+                        completion.Usage.TotalTokens));
 
         public Task ReceiveForwardedToolResultAsync(
             string sessionActorId,

--- a/test/Aevatar.GAgentService.Tests/Projection/LlmSessionCurrentStateProjectorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Projection/LlmSessionCurrentStateProjectorTests.cs
@@ -1,3 +1,4 @@
+using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgentService.Abstractions;
@@ -54,6 +55,10 @@ public sealed class LlmSessionCurrentStateProjectorTests
         doc.Completion.ToolCalls[0].CallId.Should().Be("call_done");
         ResponsesJsonValues.ToBoundaryJson(doc.Completion.ToolCalls[0].Result)
             .Should().Be("""{"result":true}""");
+        doc.Completion.Usage.Should().NotBeNull();
+        doc.Completion.Usage!.PromptTokens.Should().Be(10);
+        doc.Completion.Usage.CompletionTokens.Should().Be(11);
+        doc.Completion.Usage.TotalTokens.Should().Be(21);
         doc.Completion.FailureCode.Should().BeEmpty();
 
         var snapshot = await reader.GetByResponseIdAsync("resp_1");
@@ -64,6 +69,7 @@ public sealed class LlmSessionCurrentStateProjectorTests
         snapshot.ForwardedToolCalls![0].ResultJson.Should().Be("""{"temperature":28}""");
         snapshot.Completion.Should().NotBeNull();
         snapshot.Completion!.OutputText.Should().Be("completed text");
+        snapshot.Completion.Usage.Should().Be(new TokenUsage(10, 11, 21));
         snapshot.Completion.ToolCalls.Should().ContainSingle()
             .Which.ResultJson.Should().Be("""{"result":true}""");
     }
@@ -219,6 +225,12 @@ public sealed class LlmSessionCurrentStateProjectorTests
         {
             OutputText = "completed text",
             CompletedAt = Timestamp.FromDateTimeOffset(observedAt),
+            Usage = new LlmSessionTokenUsage
+            {
+                PromptTokens = 10,
+                CompletionTokens = 11,
+                TotalTokens = 21,
+            },
             ToolCalls =
             {
                 new LlmSessionCompletedToolCall

--- a/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetMessagesEndpointsTests.cs
@@ -90,7 +90,10 @@ public sealed class MainnetMessagesEndpointsTests
         // Path B reuses the same LlmSession actor as Path A (no MessagesSessionGAgent).
         sessions.Registered.Should().ContainSingle();
         sessions.Registered[0].ScopeId.Should().Be("user-1");
-        sessions.StatusUpdates.Should().Contain(u => u.Status == LlmSessionStatus.Completed);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("Hi there");
+        (await sessions.GetByResponseIdAsync(root.GetProperty("id").GetString()!))!
+            .Completion!.Usage.Should().Be(new TokenUsage(5, 3, 8));
 
         // System message + user message both flow into the intermediate ChatMessage list.
         provider.LastRequest.Should().NotBeNull();
@@ -156,7 +159,8 @@ public sealed class MainnetMessagesEndpointsTests
         body.Should().Contain("event: message_stop");
         body.Should().NotContain("stream-bearer");
 
-        sessions.StatusUpdates.Should().Contain(u => u.Status == LlmSessionStatus.Completed);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("Hello");
     }
 
     [Fact]
@@ -813,17 +817,33 @@ public sealed class MainnetMessagesEndpointsTests
         ILlmSessionRegistrationPort,
         ILlmSessionQueryPort
     {
+        private readonly Dictionary<string, LlmSessionSnapshot> _snapshots = new(StringComparer.Ordinal);
+
         public List<LlmSessionRecord> Registered { get; } = [];
         public List<(string ActorId, string ResponseId, LlmSessionStatus Status)> StatusUpdates { get; } = [];
+        public List<(string ActorId, string ResponseId, LlmSessionCompletion Completion)> RecordedCompletions { get; } = [];
 
         public Task<LlmSessionRegistrationResult> RegisterAsync(
             LlmSessionRecord record,
             CancellationToken ct = default)
         {
-            Registered.Add(record);
-            return Task.FromResult(new LlmSessionRegistrationResult(
-                ActorId: $"llm-session:{record.ResponseId}",
-                ResponseId: record.ResponseId));
+            var clone = record.Clone();
+            Registered.Add(clone);
+            var actorId = $"llm-session:{clone.ResponseId}";
+            _snapshots[clone.ResponseId] = new LlmSessionSnapshot(
+                clone.ResponseId,
+                clone.ScopeId,
+                clone.OwnerSubject,
+                clone.OriginKind,
+                string.IsNullOrWhiteSpace(clone.PreviousResponseId) ? null : clone.PreviousResponseId,
+                clone.Status,
+                clone.CreatedAt?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow,
+                clone.Ttl?.ToTimeSpan() ?? TimeSpan.Zero,
+                clone.CancelledAt?.ToDateTimeOffset(),
+                actorId,
+                1,
+                $"{clone.ResponseId}:registered");
+            return Task.FromResult(new LlmSessionRegistrationResult(actorId, clone.ResponseId));
         }
 
         public Task UpdateStatusAsync(
@@ -846,7 +866,41 @@ public sealed class MainnetMessagesEndpointsTests
             string sessionActorId,
             string responseId,
             LlmSessionCompletion completion,
-            CancellationToken ct = default) => Task.CompletedTask;
+            CancellationToken ct = default)
+        {
+            var clone = completion.Clone();
+            RecordedCompletions.Add((sessionActorId, responseId, clone));
+            if (_snapshots.TryGetValue(responseId, out var current))
+            {
+                _snapshots[responseId] = current with
+                {
+                    Status = string.IsNullOrWhiteSpace(clone.FailureCode)
+                        ? LlmSessionStatus.Completed
+                        : LlmSessionStatus.Failed,
+                    StateVersion = current.StateVersion + 1,
+                    LastEventId = $"{responseId}:completion",
+                    Completion = new LlmSessionCompletionSnapshot(
+                        clone.OutputText ?? string.Empty,
+                        clone.ToolCalls
+                            .Select(static call => new LlmSessionCompletedToolCallSnapshot(
+                                call.CallId,
+                                call.ToolName,
+                                ResponsesJsonValues.ToBoundaryJson(call.Result)))
+                            .ToArray(),
+                        clone.CompletedAt?.ToDateTimeOffset(),
+                        string.IsNullOrWhiteSpace(clone.FailureCode) ? null : clone.FailureCode,
+                        string.IsNullOrWhiteSpace(clone.FailureMessage) ? null : clone.FailureMessage,
+                        clone.Usage is null
+                            ? null
+                            : new TokenUsage(
+                                clone.Usage.PromptTokens,
+                                clone.Usage.CompletionTokens,
+                                clone.Usage.TotalTokens)),
+                };
+            }
+
+            return Task.CompletedTask;
+        }
 
         public Task ReceiveForwardedToolResultAsync(
             string sessionActorId,
@@ -865,7 +919,7 @@ public sealed class MainnetMessagesEndpointsTests
         public Task<LlmSessionSnapshot?> GetByResponseIdAsync(
             string responseId,
             CancellationToken ct = default) =>
-            Task.FromResult<LlmSessionSnapshot?>(null);
+            Task.FromResult(_snapshots.GetValueOrDefault(responseId));
     }
 
     private sealed class MessagesRecordingResponsesToolProvider : IResponsesToolProvider

--- a/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
+++ b/test/Aevatar.Hosting.Tests/MainnetResponsesEndpointsTests.cs
@@ -98,6 +98,10 @@ public sealed class MainnetResponsesEndpointsTests
             .Be(0);
         root.GetProperty("usage").GetProperty("output_tokens").GetInt32().Should().Be(2);
         root.GetProperty("usage").GetProperty("total_tokens").GetInt32().Should().Be(5);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("pong");
+        (await sessions.GetByResponseIdAsync(responseId))!
+            .Completion!.Usage.Should().Be(new TokenUsage(3, 2, 5));
 
         provider.StreamCallCount.Should().Be(1);
         provider.LastRequest.Should().NotBeNull();
@@ -126,7 +130,8 @@ public sealed class MainnetResponsesEndpointsTests
         sessions.Registered[0].OriginKind.Should().Be(LlmSessionOriginKind.ApiKey);
         var snapshot = await sessions.GetByResponseIdAsync(responseId);
         snapshot!.ActorId.Should().NotContain(responseId);
-        sessions.StatusUpdates.Should().ContainSingle(x => x.Status == LlmSessionStatus.Completed);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("pong");
     }
 
     [Fact]
@@ -175,7 +180,8 @@ public sealed class MainnetResponsesEndpointsTests
         provider.LastRequest.Should().NotBeNull();
         provider.LastRequest!.Metadata.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
         provider.LastRequest.CallerContext!.Credentials!.NyxIdBearer.Should().Be("stream-secret");
-        sessions.StatusUpdates.Should().ContainSingle(x => x.Status == LlmSessionStatus.Completed);
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("pong");
     }
 
     [Fact]
@@ -773,7 +779,9 @@ public sealed class MainnetResponsesEndpointsTests
             .Should()
             .Be("""{"temperature":28}""");
         provider.LastRequest.Should().BeNull();
-        sessions.Registered.Should().BeEmpty();
+        sessions.Registered.Should().ContainSingle();
+        sessions.RecordedCompletions.Should().ContainSingle()
+            .Which.Completion.OutputText.Should().Be("""{"temperature":28}""");
         sessions.ToolResults.Should().BeEmpty();
         sessions.ResolvedToolResults.Should().BeEmpty();
     }
@@ -2954,7 +2962,13 @@ public sealed class MainnetResponsesEndpointsTests
                             .ToArray(),
                         clone.CompletedAt?.ToDateTimeOffset(),
                         string.IsNullOrWhiteSpace(clone.FailureCode) ? null : clone.FailureCode,
-                        string.IsNullOrWhiteSpace(clone.FailureMessage) ? null : clone.FailureMessage),
+                        string.IsNullOrWhiteSpace(clone.FailureMessage) ? null : clone.FailureMessage,
+                        clone.Usage is null
+                            ? null
+                            : new TokenUsage(
+                                clone.Usage.PromptTokens,
+                                clone.Usage.CompletionTokens,
+                                clone.Usage.TotalTokens)),
                 };
             }
 


### PR DESCRIPTION
## 摘要

iter81 cluster-081-direct-response-completion-not-session-fact(reflective audit;severity:high;requires_design:false 复用 #970 合约)。

- **Old**:Direct `/v1/responses` + `/v1/messages` 路径 register `LlmSessionGAgent` 但只 mark `Completed`,terminal text/tool_calls/usage 停留在 request-local `ResponsesCompletionResult` → **从未** call `RecordCompletionAsync` → readmodel 永停 Accepted
- **New**:Direct + forwarded 都 record typed `LlmSessionCompletion` on session;endpoint terminal 协议帧从 session contract/readmodel render

违反:CLAUDE「committed fact 必须可观察」「读写分离 Command→Event Query→ReadModel」「查询走 readmodel」。

## 范围

16 文件改动(+675 / -107):
- proto:typed completion 加 usage(input/output tokens)
- LlmSessionGAgent + Projector + QueryReader:typed completion 物化 + 查询
- ResponsesCommandFacade(StreamAsync + 非 streaming + tool-result):调 RecordCompletionAsync
- MessagesCommandFacade(StreamAsync + 非 streaming):同
- ResponsesEndpoints + MessagesEndpoints:terminal 协议帧从 session readmodel
- 测试 +250:RecordCompletionAsync 调用 + readmodel 暴露 + endpoint terminal 派生

**复用 #970 合约**(LlmSessionCompletion / RecordResponseSessionCompletionRequested / LlmSessionCompletionRecordedEvent),不新建 actor / readmodel。

unchanged:forwarded AGUI(#967/#970)、stream-RPC(#969)、secure input(#974)、workflow subrun(#971)、Channel reply lifecycle(#977)。

验证:GAgentService + Mainnet.Host.Api 编译 ✅ + 测试 pass + 两个 `ci/*_guards.sh` pass。

## Stacked-PR

Part of iter81 batch 1(reflective audit cluster)。Base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop iter81(reflective)

⟦AI:AUTO-LOOP⟧
