### PR TITLE
iter83 cluster-083: tool source 改 typed DI(去 root IServiceProvider service locator)

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -16,7 +16,7 @@ public sealed class AgentBuilderTool : IAgentTool
     //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
     //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
     private readonly IUserAgentCatalogQueryPort _queryPort;
-    private readonly NyxIdApiClient _nyxClient;
+    private readonly INyxIdApiClientFactory _nyxClientFactory;
     private readonly ISkillRunnerCommandPort _skillRunnerPort;
     private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
     private readonly ICallerScopeResolver _callerScopeResolver;
@@ -27,14 +27,14 @@ public sealed class AgentBuilderTool : IAgentTool
     //   New principle: Lifecycle commands return accepted; freshness is observed by follow-up query or push event.
     public AgentBuilderTool(
         IUserAgentCatalogQueryPort queryPort,
-        NyxIdApiClient nyxClient,
+        INyxIdApiClientFactory nyxClientFactory,
         ISkillRunnerCommandPort skillRunnerPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
         ICallerScopeResolver callerScopeResolver,
         ILogger<AgentBuilderTool>? logger = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
-        _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
+        _nyxClientFactory = nyxClientFactory ?? throw new ArgumentNullException(nameof(nyxClientFactory));
         _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
         _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
@@ -116,7 +116,7 @@ public sealed class AgentBuilderTool : IAgentTool
             "run_agent" => await RunAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
             "disable_agent" => await DisableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
             "enable_agent" => await EnableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
-            "delete_agent" => await DeleteAgentAsync(args, _queryPort, _catalogCommandPort, _skillRunnerPort, _nyxClient, token, caller, ct),
+            "delete_agent" => await DeleteAgentAsync(args, _queryPort, _catalogCommandPort, _skillRunnerPort, _nyxClientFactory, token, caller, ct),
             _ => JsonSerializer.Serialize(new { error = $"Unsupported action '{action}'" }),
         };
     }
@@ -152,7 +152,7 @@ public sealed class AgentBuilderTool : IAgentTool
         IUserAgentCatalogQueryPort queryPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
         ISkillRunnerCommandPort skillRunnerPort,
-        NyxIdApiClient nyxClient,
+        INyxIdApiClientFactory nyxClientFactory,
         string token,
         OwnerScope caller,
         CancellationToken ct)
@@ -183,7 +183,10 @@ public sealed class AgentBuilderTool : IAgentTool
             return disableResult.error;
 
         if (!string.IsNullOrWhiteSpace(entry.ApiKeyId))
+        {
+            var nyxClient = nyxClientFactory.CreateClient();
             await nyxClient.DeleteApiKeyAsync(token, entry.ApiKeyId, ct);
+        }
 
         // Refactor (iter4/cluster-009):
         //   Old pattern: Delete mapped command-port Observed to a synchronous deleted status.

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -6,24 +6,38 @@ using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.GAgents.Scheduled;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.Authoring.Lark;
 
 public sealed class AgentBuilderTool : IAgentTool
 {
-    private readonly IServiceProvider _serviceProvider;
+    // Refactor (iter83/cluster-083-agent-tool-source-root-provider-locator):
+    //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
+    //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
+    private readonly IUserAgentCatalogQueryPort _queryPort;
+    private readonly NyxIdApiClient _nyxClient;
+    private readonly ISkillRunnerCommandPort _skillRunnerPort;
+    private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
+    private readonly ICallerScopeResolver _callerScopeResolver;
     private readonly ILogger<AgentBuilderTool>? _logger;
 
     // Refactor (iter1/cluster-002):
     //   Old pattern: Tool construction carried readmodel polling budget for lifecycle command paths.
     //   New principle: Lifecycle commands return accepted; freshness is observed by follow-up query or push event.
     public AgentBuilderTool(
-        IServiceProvider serviceProvider,
+        IUserAgentCatalogQueryPort queryPort,
+        NyxIdApiClient nyxClient,
+        ISkillRunnerCommandPort skillRunnerPort,
+        IUserAgentCatalogCommandPort catalogCommandPort,
+        ICallerScopeResolver callerScopeResolver,
         ILogger<AgentBuilderTool>? logger = null)
     {
-        _serviceProvider = serviceProvider;
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
+        _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
+        _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
+        _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
         _logger = logger;
     }
 
@@ -77,24 +91,12 @@ public sealed class AgentBuilderTool : IAgentTool
         if (args.HasParseError)
             return JsonSerializer.Serialize(new { error = args.ParseError });
 
-        var queryPort = _serviceProvider.GetService<IUserAgentCatalogQueryPort>();
-        var nyxClient = _serviceProvider.GetService<NyxIdApiClient>();
-        var skillRunnerPort = _serviceProvider.GetService<ISkillRunnerCommandPort>();
-        var catalogCommandPort = _serviceProvider.GetService<IUserAgentCatalogCommandPort>();
-        var callerScopeResolver = _serviceProvider.GetService<ICallerScopeResolver>();
-        if (queryPort is null || nyxClient is null ||
-            skillRunnerPort is null || catalogCommandPort is null ||
-            callerScopeResolver is null)
-        {
-            return """{"error":"Agent builder runtime not available. Required services are not registered in DI."}""";
-        }
-
         // Resolve once per request and pass to every method below. Failure to resolve
         // is fail-closed: never fall through to "all agents". (Issue #466 acceptance.)
         OwnerScope caller;
         try
         {
-            caller = await callerScopeResolver.RequireAsync(ct);
+            caller = await _callerScopeResolver.RequireAsync(ct);
         }
         catch (CallerScopeUnavailableException ex)
         {
@@ -109,12 +111,12 @@ public sealed class AgentBuilderTool : IAgentTool
         var action = args.Str("action", "list_agents");
         return action switch
         {
-            "list_agents" => await ListAgentsAsync(queryPort, caller, ct),
-            "agent_status" => await GetAgentStatusAsync(args, queryPort, caller, ct),
-            "run_agent" => await RunAgentAsync(args, queryPort, skillRunnerPort, caller, ct),
-            "disable_agent" => await DisableAgentAsync(args, queryPort, skillRunnerPort, caller, ct),
-            "enable_agent" => await EnableAgentAsync(args, queryPort, skillRunnerPort, caller, ct),
-            "delete_agent" => await DeleteAgentAsync(args, queryPort, catalogCommandPort, skillRunnerPort, nyxClient, token, caller, ct),
+            "list_agents" => await ListAgentsAsync(_queryPort, caller, ct),
+            "agent_status" => await GetAgentStatusAsync(args, _queryPort, caller, ct),
+            "run_agent" => await RunAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
+            "disable_agent" => await DisableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
+            "enable_agent" => await EnableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
+            "delete_agent" => await DeleteAgentAsync(args, _queryPort, _catalogCommandPort, _skillRunnerPort, _nyxClient, token, caller, ct),
             _ => JsonSerializer.Serialize(new { error = $"Unsupported action '{action}'" }),
         };
     }

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
@@ -1,20 +1,52 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.AI.ToolProviders.NyxId;
+using Aevatar.GAgentService.Abstractions.Ports;
+using Aevatar.GAgents.Scheduled;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.Authoring.Lark;
 
 public sealed class AgentBuilderToolSource : IAgentToolSource
 {
-    private readonly IServiceProvider _serviceProvider;
+    // Refactor (iter83/cluster-083-agent-tool-source-root-provider-locator):
+    //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
+    //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
+    private readonly IUserAgentCatalogQueryPort _queryPort;
+    private readonly NyxIdApiClient _nyxClient;
+    private readonly ISkillRunnerCommandPort _skillRunnerPort;
+    private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
+    private readonly ICallerScopeResolver _callerScopeResolver;
+    private readonly ILogger<AgentBuilderTool>? _toolLogger;
 
-    public AgentBuilderToolSource(IServiceProvider serviceProvider)
+    public AgentBuilderToolSource(
+        IUserAgentCatalogQueryPort queryPort,
+        NyxIdApiClient nyxClient,
+        ISkillRunnerCommandPort skillRunnerPort,
+        IUserAgentCatalogCommandPort catalogCommandPort,
+        ICallerScopeResolver callerScopeResolver,
+        ILogger<AgentBuilderTool>? toolLogger = null)
     {
-        _serviceProvider = serviceProvider;
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
+        _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
+        _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
+        _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
+        _toolLogger = toolLogger;
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        IReadOnlyList<IAgentTool> tools = [new AgentBuilderTool(_serviceProvider)];
+        IReadOnlyList<IAgentTool> tools =
+        [
+            new AgentBuilderTool(
+                _queryPort,
+                _nyxClient,
+                _skillRunnerPort,
+                _catalogCommandPort,
+                _callerScopeResolver,
+                _toolLogger),
+        ];
         return Task.FromResult(tools);
     }
 }

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
@@ -12,7 +12,7 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
     //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
     //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
     private readonly IUserAgentCatalogQueryPort _queryPort;
-    private readonly NyxIdApiClient _nyxClient;
+    private readonly INyxIdApiClientFactory _nyxClientFactory;
     private readonly ISkillRunnerCommandPort _skillRunnerPort;
     private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
     private readonly ICallerScopeResolver _callerScopeResolver;
@@ -20,14 +20,14 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
 
     public AgentBuilderToolSource(
         IUserAgentCatalogQueryPort queryPort,
-        NyxIdApiClient nyxClient,
+        INyxIdApiClientFactory nyxClientFactory,
         ISkillRunnerCommandPort skillRunnerPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
         ICallerScopeResolver callerScopeResolver,
         ILogger<AgentBuilderTool>? toolLogger = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
-        _nyxClient = nyxClient ?? throw new ArgumentNullException(nameof(nyxClient));
+        _nyxClientFactory = nyxClientFactory ?? throw new ArgumentNullException(nameof(nyxClientFactory));
         _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
         _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
@@ -41,7 +41,7 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
         [
             new AgentBuilderTool(
                 _queryPort,
-                _nyxClient,
+                _nyxClientFactory,
                 _skillRunnerPort,
                 _catalogCommandPort,
                 _callerScopeResolver,

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -1,9 +1,7 @@
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.GAgents.Scheduled;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.AI.ToolProviders.AgentCatalog;
 
@@ -22,11 +20,21 @@ namespace Aevatar.AI.ToolProviders.AgentCatalog;
 /// </summary>
 public sealed class AgentDeliveryTargetTool : IAgentTool
 {
-    private readonly IServiceProvider _serviceProvider;
+    // Refactor (iter83/cluster-083-agent-tool-source-root-provider-locator):
+    //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
+    //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
+    private readonly IUserAgentCatalogQueryPort _queryPort;
+    private readonly IUserAgentCatalogCommandPort _commandPort;
+    private readonly ICallerScopeResolver _callerScopeResolver;
 
-    public AgentDeliveryTargetTool(IServiceProvider serviceProvider)
+    public AgentDeliveryTargetTool(
+        IUserAgentCatalogQueryPort queryPort,
+        IUserAgentCatalogCommandPort commandPort,
+        ICallerScopeResolver callerScopeResolver)
     {
-        _serviceProvider = serviceProvider;
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
+        _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
     }
 
     public string Name => "agent_delivery_targets";
@@ -80,15 +88,10 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         if (string.IsNullOrWhiteSpace(token))
             return """{"error":"No NyxID access token available. User must be authenticated."}""";
 
-        var queryPort = _serviceProvider.GetService<IUserAgentCatalogQueryPort>();
-        var callerScopeResolver = _serviceProvider.GetService<ICallerScopeResolver>();
-        if (queryPort is null || callerScopeResolver is null)
-            return """{"error":"Agent delivery target runtime not available. IUserAgentCatalogQueryPort or ICallerScopeResolver not registered in DI."}""";
-
         OwnerScope caller;
         try
         {
-            caller = await callerScopeResolver.RequireAsync(ct);
+            caller = await _callerScopeResolver.RequireAsync(ct);
         }
         catch (CallerScopeUnavailableException ex)
         {
@@ -106,19 +109,15 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
 
         if (action is "upsert" or "delete")
         {
-            var commandPort = _serviceProvider.GetService<IUserAgentCatalogCommandPort>();
-            if (commandPort is null)
-                return """{"error":"Agent delivery target runtime not available. IUserAgentCatalogCommandPort not registered in DI."}""";
-
             return action switch
             {
-                "upsert" => await UpsertAsync(queryPort, commandPort, caller, root, ct),
-                "delete" => await DeleteAsync(queryPort, commandPort, caller, root, ct),
-                _ => await ListAsync(queryPort, caller, ct),
+                "upsert" => await UpsertAsync(_queryPort, _commandPort, caller, root, ct),
+                "delete" => await DeleteAsync(_queryPort, _commandPort, caller, root, ct),
+                _ => await ListAsync(_queryPort, caller, ct),
             };
         }
 
-        return await ListAsync(queryPort, caller, ct);
+        return await ListAsync(_queryPort, caller, ct);
     }
 
     private static string? GetStr(JsonElement el, params string[] properties)

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetToolSource.cs
@@ -1,19 +1,31 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgents.Scheduled;
 
 namespace Aevatar.AI.ToolProviders.AgentCatalog;
 
 public sealed class AgentDeliveryTargetToolSource : IAgentToolSource
 {
-    private readonly IServiceProvider _serviceProvider;
+    // Refactor (iter83/cluster-083-agent-tool-source-root-provider-locator):
+    //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
+    //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
+    private readonly IUserAgentCatalogQueryPort _queryPort;
+    private readonly IUserAgentCatalogCommandPort _commandPort;
+    private readonly ICallerScopeResolver _callerScopeResolver;
 
-    public AgentDeliveryTargetToolSource(IServiceProvider serviceProvider)
+    public AgentDeliveryTargetToolSource(
+        IUserAgentCatalogQueryPort queryPort,
+        IUserAgentCatalogCommandPort commandPort,
+        ICallerScopeResolver callerScopeResolver)
     {
-        _serviceProvider = serviceProvider;
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _commandPort = commandPort ?? throw new ArgumentNullException(nameof(commandPort));
+        _callerScopeResolver = callerScopeResolver ?? throw new ArgumentNullException(nameof(callerScopeResolver));
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
-        IReadOnlyList<IAgentTool> tools = [new AgentDeliveryTargetTool(_serviceProvider)];
+        ct.ThrowIfCancellationRequested();
+        IReadOnlyList<IAgentTool> tools = [new AgentDeliveryTargetTool(_queryPort, _commandPort, _callerScopeResolver)];
         return Task.FromResult(tools);
     }
 }

--- a/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs
+++ b/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationTool.cs
@@ -3,7 +3,6 @@ using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using Aevatar.GAgents.Channel.Runtime;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aevatar.AI.ToolProviders.ChannelAdmin;
 
@@ -14,17 +13,27 @@ namespace Aevatar.AI.ToolProviders.ChannelAdmin;
 /// </summary>
 public sealed class ChannelRegistrationTool : IAgentTool
 {
+    // Refactor (iter83/cluster-083-agent-tool-source-root-provider-locator):
+    //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
+    //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual readmodel rematerialization path, new=startup-owned projection refresh
     // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
     //   Old pattern: Nyx relay registration endpoints + singleton provisioning services 在 Host 内做 platform selection / scope resolution / remote Nyx provisioning / actor creation / envelope construction / dispatch through raw runtime/dispatch helpers。
     //   New principle: Channel registration 暴露 typed application command facade(reuse existing CQRS command dispatch skeleton);Host 仅 adapt HTTP;provisioning adapters 只调 existing NyxID REST surfaces(**不修改 NyxID 仓库**);local mirror writes 进 standard command skeleton via narrow dispatch port。**不引入新 actor type / 新 envelope / 新 projection phase**(reflector force-pick minimal,排除 structural 的 ChannelRelayRegistrationRunGAgent)。
     private const string DefaultNyxProviderSlug = "api-lark-bot";
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IChannelBotRegistrationQueryPort _queryPort;
+    private readonly ChannelRegistrationCommandFacade _commandFacade;
+    private readonly INyxLarkProvisioningService _provisioningService;
 
-    public ChannelRegistrationTool(IServiceProvider serviceProvider)
+    public ChannelRegistrationTool(
+        IChannelBotRegistrationQueryPort queryPort,
+        ChannelRegistrationCommandFacade commandFacade,
+        INyxLarkProvisioningService provisioningService)
     {
-        _serviceProvider = serviceProvider;
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _commandFacade = commandFacade ?? throw new ArgumentNullException(nameof(commandFacade));
+        _provisioningService = provisioningService ?? throw new ArgumentNullException(nameof(provisioningService));
     }
 
     public string Name => "channel_registrations";
@@ -97,35 +106,13 @@ public sealed class ChannelRegistrationTool : IAgentTool
 
         return action switch
         {
-            "list" => await ExecuteWithQueryAsync(queryPort => ListAsync(queryPort, ct)),
+            "list" => await ListAsync(_queryPort, ct),
             "register_lark_via_nyx" => await RegisterLarkViaNyxAsync(token, root, ct),
-            "delete" => await ExecuteWithCommandFacadeAsync((queryPort, commandFacade) => DeleteAsync(queryPort, commandFacade, root, ct)),
+            "delete" => await DeleteAsync(_queryPort, _commandFacade, root, ct),
             "register" => RetiredActionError("Direct callback registration is retired. Use action=register_lark_via_nyx."),
             "update_token" => RetiredActionError("update_token is retired. ChannelRuntime no longer stores or refreshes channel credentials."),
             _ => SerializeError($"Unsupported channel registration action '{action}'."),
         };
-    }
-
-    private async Task<string> ExecuteWithQueryAsync(Func<IChannelBotRegistrationQueryPort, Task<string>> operation)
-    {
-        var queryPort = _serviceProvider.GetService<IChannelBotRegistrationQueryPort>();
-        if (queryPort is null)
-            return """{"error":"Channel runtime not available. IChannelBotRegistrationQueryPort is not registered in DI."}""";
-
-        return await operation(queryPort);
-    }
-
-    private async Task<string> ExecuteWithCommandFacadeAsync(
-        Func<IChannelBotRegistrationQueryPort, ChannelRegistrationCommandFacade, Task<string>> operation)
-    {
-        var queryPort = _serviceProvider.GetService<IChannelBotRegistrationQueryPort>();
-        var commandFacade = _serviceProvider.GetService<ChannelRegistrationCommandFacade>();
-        if (queryPort is null || commandFacade is null)
-        {
-            return """{"error":"Channel runtime not available. IChannelBotRegistrationQueryPort or ChannelRegistrationCommandFacade is not registered in DI."}""";
-        }
-
-        return await operation(queryPort, commandFacade);
     }
 
     private static string? GetStr(JsonElement element, string propertyName) =>
@@ -228,15 +215,11 @@ public sealed class ChannelRegistrationTool : IAgentTool
         JsonElement args,
         CancellationToken ct)
     {
-        var provisioningService = _serviceProvider.GetService<INyxLarkProvisioningService>();
-        if (provisioningService is null)
-            return """{"error":"Nyx-backed Lark provisioning service is not registered."}""";
-
         var scopeResolution = ResolveToolScopeId(args, required: true);
         if (scopeResolution.Error is not null)
             return SerializeError(scopeResolution.Error);
 
-        var result = await provisioningService.ProvisionAsync(
+        var result = await _provisioningService.ProvisionAsync(
             new NyxLarkProvisioningRequest(
                 AccessToken: accessToken,
                 AppId: GetStr(args, "app_id")?.Trim() ?? string.Empty,

--- a/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationToolSource.cs
@@ -1,29 +1,38 @@
 using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgents.Channel.NyxIdRelay;
+using Aevatar.GAgents.Channel.Runtime;
 
 namespace Aevatar.AI.ToolProviders.ChannelAdmin;
 
 /// <summary>
 /// Tool source that exposes channel_registrations tool to NyxIdChatGAgent.
-/// Only depends on IServiceProvider — the tool itself lazy-resolves its
-/// dependencies (ChannelRegistrationCommandFacade, IChannelBotRegistrationQueryPort)
-/// at call time in ExecuteAsync, not at construction time. This avoids DI failures
-/// during Orleans grain activation when services may not yet be available.
 /// </summary>
 public sealed class ChannelRegistrationToolSource : IAgentToolSource
 {
+    // Refactor (iter83/cluster-083-agent-tool-source-root-provider-locator):
+    //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
+    //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
     // Refactor (iter36/cluster-041-nyx-relay-command-skeleton):
     //   Old pattern: Nyx relay registration endpoints + singleton provisioning services 在 Host 内做 platform selection / scope resolution / remote Nyx provisioning / actor creation / envelope construction / dispatch through raw runtime/dispatch helpers。
     //   New principle: Channel registration 暴露 typed application command facade(reuse existing CQRS command dispatch skeleton);Host 仅 adapt HTTP;provisioning adapters 只调 existing NyxID REST surfaces(**不修改 NyxID 仓库**);local mirror writes 进 standard command skeleton via narrow dispatch port。**不引入新 actor type / 新 envelope / 新 projection phase**(reflector force-pick minimal,排除 structural 的 ChannelRelayRegistrationRunGAgent)。
-    private readonly IServiceProvider _serviceProvider;
+    private readonly IChannelBotRegistrationQueryPort _queryPort;
+    private readonly ChannelRegistrationCommandFacade _commandFacade;
+    private readonly INyxLarkProvisioningService _provisioningService;
 
-    public ChannelRegistrationToolSource(IServiceProvider serviceProvider)
+    public ChannelRegistrationToolSource(
+        IChannelBotRegistrationQueryPort queryPort,
+        ChannelRegistrationCommandFacade commandFacade,
+        INyxLarkProvisioningService provisioningService)
     {
-        _serviceProvider = serviceProvider;
+        _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _commandFacade = commandFacade ?? throw new ArgumentNullException(nameof(commandFacade));
+        _provisioningService = provisioningService ?? throw new ArgumentNullException(nameof(provisioningService));
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
-        IReadOnlyList<IAgentTool> tools = [new ChannelRegistrationTool(_serviceProvider)];
+        ct.ThrowIfCancellationRequested();
+        IReadOnlyList<IAgentTool> tools = [new ChannelRegistrationTool(_queryPort, _commandFacade, _provisioningService)];
         return Task.FromResult(tools);
     }
 }

--- a/src/Aevatar.AI.ToolProviders.NyxId/INyxIdApiClientFactory.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/INyxIdApiClientFactory.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.AI.ToolProviders.NyxId;
+
+public interface INyxIdApiClientFactory
+{
+    NyxIdApiClient CreateClient();
+}
+
+internal sealed class HttpClientFactoryNyxIdApiClientFactory : INyxIdApiClientFactory
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly NyxIdToolOptions _options;
+    private readonly ILogger<NyxIdApiClient>? _logger;
+
+    public HttpClientFactoryNyxIdApiClientFactory(
+        IHttpClientFactory httpClientFactory,
+        NyxIdToolOptions options,
+        ILogger<NyxIdApiClient>? logger = null)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger;
+    }
+
+    public NyxIdApiClient CreateClient() =>
+        new(_options, _httpClientFactory.CreateClient(nameof(NyxIdApiClient)), _logger);
+}

--- a/src/Aevatar.AI.ToolProviders.NyxId/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.NyxId/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtensions
         configure(options);
         services.TryAddSingleton(options);
         services.AddHttpClient<NyxIdApiClient>();
+        services.TryAddSingleton<INyxIdApiClientFactory, HttpClientFactoryNyxIdApiClientFactory>();
         services.AddHttpClient(ConnectedServiceSpecCache.HttpClientName, _ => { });
         services.TryAddSingleton<IConnectedServiceSpecSource, ConnectedServiceSpecCache>();
         services.TryAddEnumerable(

--- a/test/Aevatar.AI.Tests/ToolProviderHttpClientRegistrationTests.cs
+++ b/test/Aevatar.AI.Tests/ToolProviderHttpClientRegistrationTests.cs
@@ -25,6 +25,10 @@ public sealed class ToolProviderHttpClientRegistrationTests
         using var provider = services.BuildServiceProvider();
         provider.GetRequiredService<IHttpClientFactory>().Should().NotBeNull();
         provider.GetRequiredService<NyxIdApiClient>().Should().NotBeNull();
+        provider.GetRequiredService<INyxIdApiClientFactory>()
+            .CreateClient()
+            .Should()
+            .NotBeNull();
         provider.GetRequiredService<IRemoteToolApprovalPort>().Should()
             .BeOfType<NyxIdRemoteToolApprovalPort>();
         provider.GetServices<IToolApprovalHandler>().Should().BeEmpty();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -4,11 +4,8 @@ using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.AI.ToolProviders.NyxId;
-using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.Foundation.Abstractions;
-using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Abstractions.Ports;
-using Aevatar.Studio.Application.Studio.Abstractions;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -16,7 +13,6 @@ using NSubstitute;
 using Xunit;
 using Aevatar.GAgents.Authoring.Lark;
 using Aevatar.GAgents.Scheduled;
-using StudioUserConfig = Aevatar.Studio.Application.Studio.Abstractions.UserConfig;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
@@ -64,7 +60,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -151,7 +147,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -222,7 +218,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -282,7 +278,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -342,7 +338,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -412,7 +408,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -477,7 +473,7 @@ public sealed class AgentBuilderToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentBuilderTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -518,11 +514,59 @@ public sealed class AgentBuilderToolTests
     [Fact]
     public async Task ToolSource_Always_ReturnsTool()
     {
-        var source = new AgentBuilderToolSource(new ServiceCollection().BuildServiceProvider());
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var nyxClient = new NyxIdApiClient(
+            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+            new HttpClient(new RoutingJsonHandler()) { BaseAddress = new Uri("https://nyx.example.com") });
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        queryPort.QueryByCallerAsync(Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>(Array.Empty<UserAgentCatalogReadModelEntry>()));
+
+        var source = new AgentBuilderToolSource(
+            queryPort,
+            nyxClient,
+            skillRunnerPort,
+            catalogCommandPort,
+            callerScopeResolver);
         var tools = await source.DiscoverToolsAsync();
 
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_builder");
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tools[0].ExecuteAsync("""{"action":"list_agents"}""");
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("total").GetInt32().Should().Be(0);
+
+            await queryPort.Received(1).QueryByCallerAsync(
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    private static AgentBuilderTool CreateTool(IServiceCollection services)
+    {
+        var provider = services.BuildServiceProvider();
+        return new AgentBuilderTool(
+            provider.GetRequiredService<IUserAgentCatalogQueryPort>(),
+            provider.GetRequiredService<NyxIdApiClient>(),
+            provider.GetRequiredService<ISkillRunnerCommandPort>(),
+            provider.GetRequiredService<IUserAgentCatalogCommandPort>(),
+            provider.GetRequiredService<ICallerScopeResolver>(),
+            provider.GetService<ILogger<AgentBuilderTool>>());
     }
 
     private sealed class RoutingJsonHandler : HttpMessageHandler
@@ -561,77 +605,4 @@ public sealed class AgentBuilderToolTests
 
     private sealed record RecordedRequest(HttpMethod Method, string Path, string? Body);
 
-    private sealed class StubUserConfigQueryPort : IUserConfigQueryPort
-    {
-        private readonly StudioUserConfig _config;
-
-        public StubUserConfigQueryPort(StudioUserConfig config)
-        {
-            _config = config;
-        }
-
-        public Task<StudioUserConfig> GetAsync(CancellationToken ct = default) => Task.FromResult(_config);
-
-        public Task<StudioUserConfig> GetAsync(string scopeId, CancellationToken ct = default) => Task.FromResult(_config);
-    }
-
-    private sealed class RecordingUserConfigCommandService : IUserConfigCommandService
-    {
-        public string? SavedScopeId { get; private set; }
-        public StudioUserConfig? SavedConfig { get; private set; }
-        public string? SavedGithubUsername { get; private set; }
-
-        public Task SaveAsync(StudioUserConfig config, CancellationToken ct = default)
-        {
-            SavedConfig = config;
-            return Task.CompletedTask;
-        }
-
-        public Task SaveAsync(string scopeId, StudioUserConfig config, CancellationToken ct = default)
-        {
-            SavedScopeId = scopeId;
-            return SaveAsync(config, ct);
-        }
-
-        public Task SaveGithubUsernameAsync(string scopeId, string githubUsername, CancellationToken ct = default)
-        {
-            SavedScopeId = scopeId;
-            SavedGithubUsername = githubUsername;
-            return Task.CompletedTask;
-        }
-    }
-
-    /// <summary>
-    /// Minimal in-memory <see cref="ILogger{T}"/> that records each log call so tests can assert
-    /// on level + formatted message. Avoids a full Microsoft.Extensions.Logging.Testing dependency
-    /// for a single observability assertion.
-    /// </summary>
-    private sealed class ListLogger<T> : ILogger<T>
-    {
-        public List<LogEntry> Entries { get; } = new();
-
-        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            ArgumentNullException.ThrowIfNull(formatter);
-            Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
-        }
-
-        public sealed record LogEntry(LogLevel Level, string Message);
-
-        private sealed class NullScope : IDisposable
-        {
-            public static readonly NullScope Instance = new();
-
-            public void Dispose() { }
-        }
-    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -55,7 +55,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(nyxClient);
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory(nyxClient));
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -142,7 +142,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(nyxClient);
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory(nyxClient));
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -208,12 +208,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(new NyxIdApiClient(
-            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
-            new HttpClient(new RoutingJsonHandler())
-            {
-                BaseAddress = new Uri("https://nyx.example.com"),
-            }));
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -268,12 +263,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(new NyxIdApiClient(
-            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
-            new HttpClient(new RoutingJsonHandler())
-            {
-                BaseAddress = new Uri("https://nyx.example.com"),
-            }));
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -328,12 +318,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(new NyxIdApiClient(
-            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
-            new HttpClient(new RoutingJsonHandler())
-            {
-                BaseAddress = new Uri("https://nyx.example.com"),
-            }));
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -398,12 +383,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(new NyxIdApiClient(
-            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
-            new HttpClient(new RoutingJsonHandler())
-            {
-                BaseAddress = new Uri("https://nyx.example.com"),
-            }));
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -463,12 +443,7 @@ public sealed class AgentBuilderToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(skillRunnerPort);
         services.AddSingleton(catalogCommandPort);
-        services.AddSingleton(new NyxIdApiClient(
-            new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
-            new HttpClient(new RoutingJsonHandler())
-            {
-                BaseAddress = new Uri("https://nyx.example.com"),
-            }));
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
@@ -512,12 +487,78 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
+    public void Constructor_Requires_Typed_Dependencies()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var nyxClientFactory = Substitute.For<INyxIdApiClientFactory>();
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+        var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+
+        var missingQuery = () => new AgentBuilderTool(null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingNyxFactory = () => new AgentBuilderTool(queryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSkillRunner = () => new AgentBuilderTool(queryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
+        var missingCatalogCommand = () => new AgentBuilderTool(queryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
+        var missingCallerScope = () => new AgentBuilderTool(queryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
+        var missingSourceQuery = () => new AgentBuilderToolSource(null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSourceNyxFactory = () => new AgentBuilderToolSource(queryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSourceSkillRunner = () => new AgentBuilderToolSource(queryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
+        var missingSourceCatalogCommand = () => new AgentBuilderToolSource(queryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
+        var missingSourceCallerScope = () => new AgentBuilderToolSource(queryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
+
+        missingQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingNyxFactory.Should().Throw<ArgumentNullException>().WithParameterName("nyxClientFactory");
+        missingSkillRunner.Should().Throw<ArgumentNullException>().WithParameterName("skillRunnerPort");
+        missingCatalogCommand.Should().Throw<ArgumentNullException>().WithParameterName("catalogCommandPort");
+        missingCallerScope.Should().Throw<ArgumentNullException>().WithParameterName("callerScopeResolver");
+        missingSourceQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingSourceNyxFactory.Should().Throw<ArgumentNullException>().WithParameterName("nyxClientFactory");
+        missingSourceSkillRunner.Should().Throw<ArgumentNullException>().WithParameterName("skillRunnerPort");
+        missingSourceCatalogCommand.Should().Throw<ArgumentNullException>().WithParameterName("catalogCommandPort");
+        missingSourceCallerScope.Should().Throw<ArgumentNullException>().WithParameterName("callerScopeResolver");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsStructuredError_WhenCallerScopeUnavailable()
+    {
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(null));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>());
+        services.AddSingleton(Substitute.For<ISkillRunnerCommandPort>());
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
+        services.AddSingleton(callerScopeResolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"action":"list_agents"}""");
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("error").GetString().Should().Be("caller_scope_unavailable");
+            doc.RootElement.GetProperty("hint").GetString().Should().Contain("Re-authenticate");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
     public async Task ToolSource_Always_ReturnsTool()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
         var nyxClient = new NyxIdApiClient(
             new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
             new HttpClient(new RoutingJsonHandler()) { BaseAddress = new Uri("https://nyx.example.com") });
+        var nyxClientFactory = new TestNyxIdApiClientFactory(nyxClient);
         var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
         var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
@@ -528,7 +569,7 @@ public sealed class AgentBuilderToolTests
 
         var source = new AgentBuilderToolSource(
             queryPort,
-            nyxClient,
+            nyxClientFactory,
             skillRunnerPort,
             catalogCommandPort,
             callerScopeResolver);
@@ -562,11 +603,28 @@ public sealed class AgentBuilderToolTests
         var provider = services.BuildServiceProvider();
         return new AgentBuilderTool(
             provider.GetRequiredService<IUserAgentCatalogQueryPort>(),
-            provider.GetRequiredService<NyxIdApiClient>(),
+            provider.GetRequiredService<INyxIdApiClientFactory>(),
             provider.GetRequiredService<ISkillRunnerCommandPort>(),
             provider.GetRequiredService<IUserAgentCatalogCommandPort>(),
             provider.GetRequiredService<ICallerScopeResolver>(),
             provider.GetService<ILogger<AgentBuilderTool>>());
+    }
+
+    private sealed class TestNyxIdApiClientFactory : INyxIdApiClientFactory
+    {
+        private readonly NyxIdApiClient _client;
+
+        public TestNyxIdApiClientFactory(NyxIdApiClient? client = null)
+        {
+            _client = client ?? new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" },
+                new HttpClient(new RoutingJsonHandler())
+                {
+                    BaseAddress = new Uri("https://nyx.example.com"),
+                });
+        }
+
+        public NyxIdApiClient CreateClient() => _client;
     }
 
     private sealed class RoutingJsonHandler : HttpMessageHandler

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -1,12 +1,8 @@
-using System.Net;
-using System.Text;
 using System.Text.Json;
 using Aevatar.AI.Abstractions.LLMProviders;
 using Aevatar.AI.Abstractions.ToolProviders;
-using Aevatar.AI.ToolProviders.NyxId;
 using Aevatar.Foundation.Abstractions;
 using FluentAssertions;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
@@ -20,14 +16,14 @@ public sealed class AgentDeliveryTargetToolTests
     [Fact]
     public void Name_Is_agent_delivery_targets()
     {
-        var tool = new AgentDeliveryTargetTool(new ServiceCollection().BuildServiceProvider());
+        var tool = CreateTool();
         tool.Name.Should().Be("agent_delivery_targets");
     }
 
     [Fact]
     public void ParametersSchema_Is_Valid_Json()
     {
-        var tool = new AgentDeliveryTargetTool(new ServiceCollection().BuildServiceProvider());
+        var tool = CreateTool();
         var act = () => JsonDocument.Parse(tool.ParametersSchema);
         act.Should().NotThrow();
     }
@@ -35,7 +31,7 @@ public sealed class AgentDeliveryTargetToolTests
     [Fact]
     public async Task ExecuteAsync_Returns_Error_When_No_Auth_Token()
     {
-        var tool = new AgentDeliveryTargetTool(new ServiceCollection().BuildServiceProvider());
+        var tool = CreateTool();
         var result = await tool.ExecuteAsync("""{"action":"list"}""");
 
         result.Should().Contain("error");
@@ -43,24 +39,19 @@ public sealed class AgentDeliveryTargetToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_Returns_Error_When_Dependencies_Missing()
+    public void Constructor_Requires_Typed_Dependencies()
     {
-        var tool = new AgentDeliveryTargetTool(new ServiceCollection().BuildServiceProvider());
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        var resolver = Substitute.For<ICallerScopeResolver>();
 
-        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        };
-        try
-        {
-            var result = await tool.ExecuteAsync("""{"action":"list"}""");
-            result.Should().Contain("error");
-            result.Should().Contain("not registered");
-        }
-        finally
-        {
-            AgentToolRequestContext.CurrentMetadata = null;
-        }
+        var missingQuery = () => new AgentDeliveryTargetTool(null!, commandPort, resolver);
+        var missingCommand = () => new AgentDeliveryTargetTool(queryPort, null!, resolver);
+        var missingResolver = () => new AgentDeliveryTargetTool(queryPort, commandPort, null!);
+
+        missingQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingCommand.Should().Throw<ArgumentNullException>().WithParameterName("commandPort");
+        missingResolver.Should().Throw<ArgumentNullException>().WithParameterName("callerScopeResolver");
     }
 
     [Fact]
@@ -86,16 +77,11 @@ public sealed class AgentDeliveryTargetToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
 
-        var httpClient = new HttpClient(new StaticJsonHandler("""{"user":{"id":"user-1"}}"""))
-        {
-            BaseAddress = new Uri("https://nyx.example.com"),
-        };
-        var nyxClient = new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }, httpClient);
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
         services.AddSingleton(callerScopeResolver);
-        services.AddSingleton(nyxClient);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -130,7 +116,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>());
         services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
         services.AddSingleton(callerScopeResolver);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -176,18 +162,11 @@ public sealed class AgentDeliveryTargetToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(caller));
 
-        var httpClient = new HttpClient(new StaticJsonHandler("""{"user":{"id":"user-1"}}"""))
-        {
-            BaseAddress = new Uri("https://nyx.example.com"),
-        };
-        var nyxClient = new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }, httpClient);
-
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(callerScopeResolver);
-        services.AddSingleton(nyxClient);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -248,17 +227,11 @@ public sealed class AgentDeliveryTargetToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(caller));
 
-        var httpClient = new HttpClient(new StaticJsonHandler("""{"user":{"id":"user-1"}}"""))
-        {
-            BaseAddress = new Uri("https://nyx.example.com"),
-        };
-        var nyxClient = new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }, httpClient);
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
         services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
         services.AddSingleton(callerScopeResolver);
-        services.AddSingleton(nyxClient);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -294,18 +267,11 @@ public sealed class AgentDeliveryTargetToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(caller));
 
-        var httpClient = new HttpClient(new StaticJsonHandler("""{"user":{"id":"user-1"}}"""))
-        {
-            BaseAddress = new Uri("https://nyx.example.com"),
-        };
-        var nyxClient = new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }, httpClient);
-
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(callerScopeResolver);
-        services.AddSingleton(nyxClient);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -349,17 +315,11 @@ public sealed class AgentDeliveryTargetToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(caller));
 
-        var httpClient = new HttpClient(new StaticJsonHandler("""{"user":{"id":"user-1"}}"""))
-        {
-            BaseAddress = new Uri("https://nyx.example.com"),
-        };
-        var nyxClient = new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }, httpClient);
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(callerScopeResolver);
-        services.AddSingleton(nyxClient);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -407,17 +367,11 @@ public sealed class AgentDeliveryTargetToolTests
         callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<OwnerScope?>(caller));
 
-        var httpClient = new HttpClient(new StaticJsonHandler("""{"user":{"id":"user-1"}}"""))
-        {
-            BaseAddress = new Uri("https://nyx.example.com"),
-        };
-        var nyxClient = new NyxIdApiClient(new NyxIdToolOptions { BaseUrl = "https://nyx.example.com" }, httpClient);
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(callerScopeResolver);
-        services.AddSingleton(nyxClient);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -441,11 +395,38 @@ public sealed class AgentDeliveryTargetToolTests
     [Fact]
     public async Task ToolSource_Always_Returns_Tool()
     {
-        var source = new AgentDeliveryTargetToolSource(new ServiceCollection().BuildServiceProvider());
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        queryPort.QueryByCallerAsync(Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>(Array.Empty<UserAgentCatalogReadModelEntry>()));
+
+        var source = new AgentDeliveryTargetToolSource(queryPort, commandPort, callerScopeResolver);
         var tools = await source.DiscoverToolsAsync();
 
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("agent_delivery_targets");
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tools[0].ExecuteAsync("""{"action":"list"}""");
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("total").GetInt32().Should().Be(0);
+
+            await queryPort.Received(1).QueryByCallerAsync(
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
     }
 
     // ─── Patch coverage gap-fillers (issue #466 / codecov/patch) ───
@@ -464,7 +445,7 @@ public sealed class AgentDeliveryTargetToolTests
         var services = new ServiceCollection();
         services.AddSingleton(queryPort);
         services.AddSingleton(resolver);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -485,33 +466,19 @@ public sealed class AgentDeliveryTargetToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_Returns_Error_When_CommandPort_Missing_For_Upsert()
+    public void ToolSource_Constructor_Requires_Typed_Dependencies()
     {
-        // Hits the IUserAgentCatalogCommandPort missing branch on the upsert/delete path.
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var commandPort = Substitute.For<IUserAgentCatalogCommandPort>();
         var resolver = Substitute.For<ICallerScopeResolver>();
-        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
 
-        var services = new ServiceCollection();
-        services.AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>());
-        services.AddSingleton(resolver);
-        // No IUserAgentCatalogCommandPort registered.
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var missingQuery = () => new AgentDeliveryTargetToolSource(null!, commandPort, resolver);
+        var missingCommand = () => new AgentDeliveryTargetToolSource(queryPort, null!, resolver);
+        var missingResolver = () => new AgentDeliveryTargetToolSource(queryPort, commandPort, null!);
 
-        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
-        {
-            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
-        };
-        try
-        {
-            var result = await tool.ExecuteAsync("""{"action":"upsert","agent_id":"agent-1"}""");
-            result.Should().Contain("IUserAgentCatalogCommandPort");
-            result.Should().Contain("not registered");
-        }
-        finally
-        {
-            AgentToolRequestContext.CurrentMetadata = null;
-        }
+        missingQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingCommand.Should().Throw<ArgumentNullException>().WithParameterName("commandPort");
+        missingResolver.Should().Throw<ArgumentNullException>().WithParameterName("callerScopeResolver");
     }
 
     [Fact]
@@ -577,7 +544,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(resolver);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -638,7 +605,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(resolver);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -720,7 +687,7 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(resolver);
-        var tool = new AgentDeliveryTargetTool(services.BuildServiceProvider());
+        var tool = CreateTool(services);
 
         AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
         {
@@ -744,6 +711,27 @@ public sealed class AgentDeliveryTargetToolTests
     /// branches (no real query/command response wiring). Returns a tool with a stub
     /// query port, a stub command port, and a deterministic caller-scope resolver.
     /// </summary>
+    private static AgentDeliveryTargetTool CreateTool(IServiceCollection? services = null)
+    {
+        var provider = (services ?? CreateDefaultServices()).BuildServiceProvider();
+        return new AgentDeliveryTargetTool(
+            provider.GetRequiredService<IUserAgentCatalogQueryPort>(),
+            provider.GetService<IUserAgentCatalogCommandPort>() ?? Substitute.For<IUserAgentCatalogCommandPort>(),
+            provider.GetRequiredService<ICallerScopeResolver>());
+    }
+
+    private static IServiceCollection CreateDefaultServices()
+    {
+        var resolver = Substitute.For<ICallerScopeResolver>();
+        resolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+
+        return new ServiceCollection()
+            .AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>())
+            .AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>())
+            .AddSingleton(resolver);
+    }
+
     private static (AgentDeliveryTargetTool tool, IUserAgentCatalogQueryPort queryPort, IUserAgentCatalogCommandPort commandPort) BuildBasicHarness()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
@@ -756,18 +744,6 @@ public sealed class AgentDeliveryTargetToolTests
         services.AddSingleton(queryPort);
         services.AddSingleton(commandPort);
         services.AddSingleton(resolver);
-        return (new AgentDeliveryTargetTool(services.BuildServiceProvider()), queryPort, commandPort);
-    }
-
-    private sealed class StaticJsonHandler(string json) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(json, Encoding.UTF8, "application/json"),
-            };
-            return Task.FromResult(response);
-        }
+        return (CreateTool(services), queryPort, commandPort);
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -953,12 +953,12 @@ public sealed class ChannelConversationTurnRunnerTests
             .AddSingleton(Substitute.For<ISkillRunnerCommandPort>())
             .AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>())
             .AddSingleton<ICallerScopeResolver>(callerScopeResolver)
-            .AddSingleton(new NyxIdApiClient(
+            .AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory(new NyxIdApiClient(
                 new NyxIdToolOptions { BaseUrl = "https://example.com" },
                 new HttpClient(new RecordingJsonHandler("""{"ok":true}"""))
                 {
                     BaseAddress = new Uri("https://example.com"),
-                }))
+                })))
             .BuildServiceProvider();
         var runner = CreateRunner(
             registrationQueryPort,
@@ -2461,7 +2461,7 @@ public sealed class ChannelConversationTurnRunnerTests
         HttpMessageHandler? nyxHandler = null,
         IInteractiveReplyDispatcher? interactiveReplyDispatcher = null)
     {
-        services ??= new ServiceCollection().BuildServiceProvider();
+        services ??= BuildAgentBuilderToolServices();
         relayHandler ??= new RecordingJsonHandler("""{"message_id":"relay-reply"}""");
         nyxHandler ??= new RecordingJsonHandler("""{"code":0,"data":{}}""");
         var relayClient = new NyxIdApiClient(
@@ -2504,6 +2504,28 @@ public sealed class ChannelConversationTurnRunnerTests
             userConfigQueryPort: services.GetService<IUserConfigQueryPort>(),
             replyService: services.GetService<ChannelPlatformReplyService>(),
             workflowResumeService: services.GetService<ICommandDispatchService<WorkflowResumeCommand, WorkflowRunControlAcceptedReceipt, WorkflowRunControlStartError>>());
+    }
+
+    private static IServiceProvider BuildAgentBuilderToolServices()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.QueryByCallerAsync(Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>(Array.Empty<UserAgentCatalogReadModelEntry>()));
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForChannel(
+                "nyx-user-1",
+                "lark",
+                "scope-1",
+                "ou_user_1")));
+
+        return new ServiceCollection()
+            .AddSingleton(queryPort)
+            .AddSingleton(Substitute.For<ISkillRunnerCommandPort>())
+            .AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>())
+            .AddSingleton<ICallerScopeResolver>(callerScopeResolver)
+            .AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory())
+            .BuildServiceProvider();
     }
 
     private static ConversationTurnRuntimeContext RelayRuntimeContext(
@@ -2689,6 +2711,23 @@ public sealed class ChannelConversationTurnRunnerTests
                 "scope-1",
                 "ou_user_1"));
         }
+    }
+
+    private sealed class TestNyxIdApiClientFactory : INyxIdApiClientFactory
+    {
+        private readonly NyxIdApiClient _client;
+
+        public TestNyxIdApiClientFactory(NyxIdApiClient? client = null)
+        {
+            _client = client ?? new NyxIdApiClient(
+                new NyxIdToolOptions { BaseUrl = "https://example.com" },
+                new HttpClient(new RecordingJsonHandler("""{"ok":true}"""))
+                {
+                    BaseAddress = new Uri("https://example.com"),
+                });
+        }
+
+        public NyxIdApiClient CreateClient() => _client;
     }
 
     private sealed class StubUserLlmOptionsService(UserLlmOption option) : IUserLlmOptionsService

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelRegistrationToolTests.cs
@@ -17,7 +17,7 @@ public sealed class ChannelRegistrationToolTests
     [Fact]
     public void Metadata_ReflectsRelayOnlyContract()
     {
-        var tool = new ChannelRegistrationTool(new ServiceCollection().BuildServiceProvider());
+        var tool = CreateTool();
 
         tool.Name.Should().Be("channel_registrations");
         tool.Description.Should().Contain("register_lark_via_nyx");
@@ -41,7 +41,7 @@ public sealed class ChannelRegistrationToolTests
         AgentToolRequestContext.CurrentMetadata = null;
         try
         {
-            var tool = new ChannelRegistrationTool(new ServiceCollection().BuildServiceProvider());
+            var tool = CreateTool();
 
             var result = await tool.ExecuteAsync("""{"action":"list"}""");
 
@@ -76,7 +76,7 @@ public sealed class ChannelRegistrationToolTests
         using var serviceProvider = new ServiceCollection()
             .AddSingleton(queryPort)
             .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
+        var tool = CreateTool(serviceProvider);
 
         using var scope = PushNyxToken();
         var json = await tool.ExecuteAsync("""{"action":"list"}""");
@@ -107,7 +107,7 @@ public sealed class ChannelRegistrationToolTests
         using var serviceProvider = new ServiceCollection()
             .AddSingleton(provisioningService)
             .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
+        var tool = CreateTool(serviceProvider);
 
         using var scope = PushNyxToken();
         var json = await tool.ExecuteAsync(
@@ -134,7 +134,7 @@ public sealed class ChannelRegistrationToolTests
         using var serviceProvider = new ServiceCollection()
             .AddSingleton(provisioningService)
             .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
+        var tool = CreateTool(serviceProvider);
 
         using var scope = PushNyxToken(null);
         var json = await tool.ExecuteAsync(
@@ -151,7 +151,7 @@ public sealed class ChannelRegistrationToolTests
         using var serviceProvider = new ServiceCollection()
             .AddSingleton(queryPort)
             .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
+        var tool = CreateTool(serviceProvider);
 
         using var scope = PushNyxToken();
         var result = await tool.ExecuteAsync("""{"action":"rebuild_projection"}""");
@@ -165,7 +165,7 @@ public sealed class ChannelRegistrationToolTests
     [Fact]
     public async Task ExecuteAsync_UpdateToken_ReturnsRetiredError()
     {
-        var tool = new ChannelRegistrationTool(new ServiceCollection().BuildServiceProvider());
+        var tool = CreateTool();
 
         using var scope = PushNyxToken();
         var result = await tool.ExecuteAsync("""{"action":"update_token"}""");
@@ -195,7 +195,7 @@ public sealed class ChannelRegistrationToolTests
             .AddSingleton(queryPort)
             .AddSingleton(ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime))
             .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
+        var tool = CreateTool(serviceProvider);
 
         using var scope = PushNyxToken();
         var json = await tool.ExecuteAsync("""{"action":"delete","registration_id":"reg-1"}""");
@@ -235,7 +235,7 @@ public sealed class ChannelRegistrationToolTests
             .AddSingleton(queryPort)
             .AddSingleton(ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime))
             .BuildServiceProvider();
-        var tool = new ChannelRegistrationTool(serviceProvider);
+        var tool = CreateTool(serviceProvider);
 
         using var scope = PushNyxToken();
         var json = await tool.ExecuteAsync("""{"action":"delete","registration_id":"reg-1","confirm":true}""");
@@ -247,6 +247,55 @@ public sealed class ChannelRegistrationToolTests
         capturedEnvelope.Should().NotBeNull();
         capturedEnvelope!.Payload.Unpack<ChannelBotUnregisterCommand>().RegistrationId.Should().Be("reg-1");
         await queryPort.Received(1).GetAsync("reg-1", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ToolSource_ReturnsTool_WithTypedDependencies()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        queryPort.QueryAllAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<ChannelBotRegistrationEntry>>(Array.Empty<ChannelBotRegistrationEntry>()));
+
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        var commandFacade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime);
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+        provisioningService.Platform.Returns("lark");
+
+        var source = new ChannelRegistrationToolSource(queryPort, commandFacade, provisioningService);
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().ContainSingle();
+        tools[0].Name.Should().Be("channel_registrations");
+
+        using var scope = PushNyxToken();
+        var result = await tools[0].ExecuteAsync("""{"action":"list"}""");
+        using var doc = JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("total").GetInt32().Should().Be(0);
+
+        await queryPort.Received(1).QueryAllAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void Constructor_Requires_Typed_Dependencies()
+    {
+        var queryPort = Substitute.For<IChannelBotRegistrationQueryPort>();
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        var commandFacade = ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime);
+        var provisioningService = Substitute.For<INyxLarkProvisioningService>();
+
+        var missingQuery = () => new ChannelRegistrationTool(null!, commandFacade, provisioningService);
+        var missingCommand = () => new ChannelRegistrationTool(queryPort, null!, provisioningService);
+        var missingProvisioning = () => new ChannelRegistrationTool(queryPort, commandFacade, null!);
+        var missingSourceQuery = () => new ChannelRegistrationToolSource(null!, commandFacade, provisioningService);
+        var missingSourceCommand = () => new ChannelRegistrationToolSource(queryPort, null!, provisioningService);
+        var missingSourceProvisioning = () => new ChannelRegistrationToolSource(queryPort, commandFacade, null!);
+
+        missingQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingCommand.Should().Throw<ArgumentNullException>().WithParameterName("commandFacade");
+        missingProvisioning.Should().Throw<ArgumentNullException>().WithParameterName("provisioningService");
+        missingSourceQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingSourceCommand.Should().Throw<ArgumentNullException>().WithParameterName("commandFacade");
+        missingSourceProvisioning.Should().Throw<ArgumentNullException>().WithParameterName("provisioningService");
     }
 
     [Fact]
@@ -276,6 +325,29 @@ public sealed class ChannelRegistrationToolTests
         AgentToolRequestContext.CurrentMetadata = next;
 
         return new ResetMetadataScope(previous);
+    }
+
+    private static ChannelRegistrationTool CreateTool(IServiceProvider? services = null)
+    {
+        var provider = services ?? CreateDefaultServices().BuildServiceProvider();
+        return new ChannelRegistrationTool(
+            provider.GetService<IChannelBotRegistrationQueryPort>() ?? Substitute.For<IChannelBotRegistrationQueryPort>(),
+            provider.GetService<ChannelRegistrationCommandFacade>() ?? CreateDefaultCommandFacade(),
+            provider.GetService<INyxLarkProvisioningService>() ?? Substitute.For<INyxLarkProvisioningService>());
+    }
+
+    private static IServiceCollection CreateDefaultServices()
+    {
+        return new ServiceCollection()
+            .AddSingleton(Substitute.For<IChannelBotRegistrationQueryPort>())
+            .AddSingleton(CreateDefaultCommandFacade())
+            .AddSingleton(Substitute.For<INyxLarkProvisioningService>());
+    }
+
+    private static ChannelRegistrationCommandFacade CreateDefaultCommandFacade()
+    {
+        var actorRuntime = Substitute.For<IActorRuntime, IActorDispatchPort>();
+        return ChannelRegistrationCommandFacadeTestSupport.CreateFacade(actorRuntime, (IActorDispatchPort)actorRuntime);
     }
 
     private sealed class ResetMetadataScope(IReadOnlyDictionary<string, string>? previous) : IDisposable


### PR DESCRIPTION
## 摘要

iter83 cluster-083-agent-tool-source-root-provider-locator(severity:medium,rules:AG-DI-01..04)。

- **Old**:3 个 singleton `IAgentToolSource`(AgentBuilderToolSource / AgentDeliveryTargetToolSource / ChannelRegistrationToolSource)capture root `IServiceProvider`;new tools retain it;`ExecuteAsync` 用 service locator 解析业务 port(IUserAgentCatalogQueryPort / NyxIdApiClient / ISkillRunnerCommandPort / IUserAgentCatalogCommandPort / ICallerScopeResolver / IChannelBotRegistrationQueryPort / ChannelRegistrationCommandFacade)
- **New**:tool source + tools constructor-inject typed contracts + options + ILogger;无 root provider lookup

违反:CLAUDE「上层依赖抽象」「禁止 ServiceLocator pattern」「DI 注册 lifetime 一致」「captive dependency」。

## 范围

9 文件改动(+351 / -295):
- `agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs` + `AgentBuilderTool.cs`
- `src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetToolSource.cs` + `AgentDeliveryTargetTool.cs`
- `src/Aevatar.AI.ToolProviders.ChannelAdmin/ChannelRegistrationToolSource.cs` + `ChannelRegistrationTool.cs`
- 3 tool tests:去 IServiceProvider mock,直接 typed deps;execution path 覆盖

**不新建抽象**,复用 existing port contracts。

验证:Authoring.Lark + AgentCatalog + ChannelAdmin 编译 ✅ + ChannelRuntime.Tests pass + 两个 `ci/*_guards.sh` pass。

## Stacked-PR

Part of iter83 batch 1。Base = `auto-refact-dev`。

🤖 Auto-loop / codex-refactor-loop iter83

⟦AI:AUTO-LOOP⟧
