### PR TITLE
iter85 cluster-085: Workflow + role logs 去 raw content,只 emit stable id + len + status + redaction marker

### DIFF
--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -4,7 +4,7 @@
 // Handles ChatRequestEvent:
 // 1. Calls LLM via ChatStreamAsync (streaming)
 // 2. Publishes AG-UI events: TextMessageStart → Content* → ToolCall* → End
-// 3. Logs prompt and full LLM response for observability
+// 3. Logs stable ids, lengths, status, and redaction markers for observability
 // ─────────────────────────────────────────────────────────────
 
 using System.Text;
@@ -689,8 +689,14 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 request.SessionId);
         }
 
-        var promptPreview = BuildRequestPreview(request);
-        Logger.LogInformation("[{Role}] LLM request: {Preview}", RoleName, promptPreview);
+        // iter85/cluster-085: raw prompts belong in gated sensitive traces, not production Information logs.
+        var requestSummary = BuildRequestLogSummary(request);
+        Logger.LogInformation(
+            "[{Role}] LLM request: session={SessionId}, status=started, prompt_len={PromptLen}, input_parts={InputPartCount}, input_redacted=true",
+            RoleName,
+            request.SessionId,
+            requestSummary.PromptLength,
+            requestSummary.InputPartCount);
         var timeoutMs = ResolveLlmTimeoutMs(request);
         var useWorkflowFailureMarker = timeoutMs > 0;
         using var timeoutCts = timeoutMs > 0 ? new CancellationTokenSource(timeoutMs) : null;
@@ -878,26 +884,20 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         }
 
         var response = fullContent.ToString();
-        var responsePreview = response.Length > 300
-            ? response[..300] + "..."
-            : response;
+        // iter85/cluster-085: response/reasoning text is user-facing content; keep raw data in events/artifacts.
         Logger.LogInformation(
-            "[{Role}] LLM response ({Len} chars): {Preview}",
+            "[{Role}] LLM response: session={SessionId}, status=completed, output_len={OutputLen}, output_redacted=true",
             RoleName,
-            response.Length,
-            responsePreview);
+            request.SessionId,
+            response.Length);
 
         if (fullReasoning.Length > 0)
         {
-            var reasoning = fullReasoning.ToString();
-            var reasoningPreview = reasoning.Length > 300
-                ? reasoning[..300] + "..."
-                : reasoning;
             Logger.LogInformation(
-                "[{Role}] LLM reasoning ({Len} chars): {Preview}",
+                "[{Role}] LLM reasoning: session={SessionId}, status=completed, reasoning_len={ReasoningLen}, reasoning_redacted=true",
                 RoleName,
-                reasoning.Length,
-                reasoningPreview);
+                request.SessionId,
+                fullReasoning.Length);
         }
 
         return new SessionReplayRecord(
@@ -1310,16 +1310,10 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         return [ContentPart.TextPart(request.Prompt ?? string.Empty)];
     }
 
-    private static string BuildRequestPreview(ChatRequestEvent request)
-    {
-        var previewSource = string.IsNullOrWhiteSpace(request.Prompt)
-            ? string.Join(", ", ResolveRequestInputParts(request).Select(part => part.Kind.ToString().ToLowerInvariant()))
-            : request.Prompt;
+    private static LLMRequestLogSummary BuildRequestLogSummary(ChatRequestEvent request) =>
+        new(request.Prompt?.Length ?? 0, ResolveRequestInputParts(request).Count);
 
-        return previewSource.Length > 200
-            ? previewSource[..200] + "..."
-            : previewSource;
-    }
+    private readonly record struct LLMRequestLogSummary(int PromptLength, int InputPartCount);
 
     private static bool HaveMatchingInputParts(
         Google.Protobuf.Collections.RepeatedField<ChatContentPart> existing,

--- a/src/Aevatar.AI.Core/RoleGAgent.cs
+++ b/src/Aevatar.AI.Core/RoleGAgent.cs
@@ -689,7 +689,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
                 request.SessionId);
         }
 
-        // iter85/cluster-085: raw prompts belong in gated sensitive traces, not production Information logs.
+        // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+        //   Old pattern: Information log included raw value/prompt/input preview
+        //   New principle: only stable id + length + status + redaction marker
         var requestSummary = BuildRequestLogSummary(request);
         Logger.LogInformation(
             "[{Role}] LLM request: session={SessionId}, status=started, prompt_len={PromptLen}, input_parts={InputPartCount}, input_redacted=true",
@@ -884,7 +886,9 @@ public class RoleGAgent : AIGAgentBase<RoleGAgentState>, IRoleAgent, IVoicePrese
         }
 
         var response = fullContent.ToString();
-        // iter85/cluster-085: response/reasoning text is user-facing content; keep raw data in events/artifacts.
+        // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+        //   Old pattern: Information log included raw value/prompt/input preview
+        //   New principle: only stable id + length + status + redaction marker
         Logger.LogInformation(
             "[{Role}] LLM response: session={SessionId}, status=completed, output_len={OutputLen}, output_redacted=true",
             RoleName,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/AssignModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/AssignModule.cs
@@ -33,7 +33,9 @@ public sealed class AssignModule : IEventModule<IWorkflowExecutionContext>
         // 如果 value 以 $ 开头，表示从 input（上一步输出）中取值
         var resolvedValue = value.StartsWith('$') ? request.Input ?? string.Empty : value;
 
-        // iter85/cluster-085: log only assignment identity and value length; value content remains in workflow state.
+        // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+        //   Old pattern: Information log included raw value/prompt/input preview
+        //   New principle: only stable id + length + status + redaction marker
         ctx.Logger.LogInformation(
             "Assign: run={RunId} step={StepId} target={Target} status=assigned value_len={ValueLen} value_redacted=true",
             request.RunId,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/AssignModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/AssignModule.cs
@@ -33,7 +33,13 @@ public sealed class AssignModule : IEventModule<IWorkflowExecutionContext>
         // 如果 value 以 $ 开头，表示从 input（上一步输出）中取值
         var resolvedValue = value.StartsWith('$') ? request.Input ?? string.Empty : value;
 
-        ctx.Logger.LogInformation("Assign: {Target} = {Value}", target, resolvedValue.Length > 50 ? resolvedValue[..50] + "..." : resolvedValue);
+        // iter85/cluster-085: log only assignment identity and value length; value content remains in workflow state.
+        ctx.Logger.LogInformation(
+            "Assign: run={RunId} step={StepId} target={Target} status=assigned value_len={ValueLen} value_redacted=true",
+            request.RunId,
+            request.StepId,
+            target,
+            resolvedValue.Length);
 
         var completed = new StepCompletedEvent
         {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/HumanApprovalModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/HumanApprovalModule.cs
@@ -64,7 +64,9 @@ public sealed class HumanApprovalModule : IEventModule<IWorkflowExecutionContext
             };
             await SaveStateAsync(state, ctx, ct);
 
-            // iter85/cluster-085: approval prompt text may contain user content; log length only.
+            // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+            //   Old pattern: Information log included raw value/prompt/input preview
+            //   New principle: only stable id + length + status + redaction marker
             ctx.Logger.LogInformation(
                 "HumanApproval: run={RunId} step={StepId} status=suspended prompt_len={PromptLen} prompt_redacted=true timeout={Timeout}s",
                 runId, request.StepId, prompt.Length, timeoutSeconds);

--- a/src/workflow/Aevatar.Workflow.Core/Modules/HumanApprovalModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/HumanApprovalModule.cs
@@ -64,9 +64,10 @@ public sealed class HumanApprovalModule : IEventModule<IWorkflowExecutionContext
             };
             await SaveStateAsync(state, ctx, ct);
 
+            // iter85/cluster-085: approval prompt text may contain user content; log length only.
             ctx.Logger.LogInformation(
-                "HumanApproval: run={RunId} step={StepId} suspended, prompt=\"{Prompt}\", timeout={Timeout}s",
-                runId, request.StepId, prompt, timeoutSeconds);
+                "HumanApproval: run={RunId} step={StepId} status=suspended prompt_len={PromptLen} prompt_redacted=true timeout={Timeout}s",
+                runId, request.StepId, prompt.Length, timeoutSeconds);
 
             var suspended = new WorkflowSuspendedEvent
             {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/HumanInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/HumanInputModule.cs
@@ -66,7 +66,9 @@ public sealed class HumanInputModule : IEventModule<IWorkflowExecutionContext>
             };
             await SaveStateAsync(state, ctx, ct);
 
-            // iter85/cluster-085: prompt text is user content, so Information logs keep only length/status.
+            // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+            //   Old pattern: Information log included raw value/prompt/input preview
+            //   New principle: only stable id + length + status + redaction marker
             ctx.Logger.LogInformation(
                 "HumanInput: run={RunId} step={StepId} status=suspended prompt_len={PromptLen} prompt_redacted=true variable={Var} timeout={Timeout}s",
                 runId, request.StepId, prompt.Length, variable, timeoutSeconds);

--- a/src/workflow/Aevatar.Workflow.Core/Modules/HumanInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/HumanInputModule.cs
@@ -66,9 +66,10 @@ public sealed class HumanInputModule : IEventModule<IWorkflowExecutionContext>
             };
             await SaveStateAsync(state, ctx, ct);
 
+            // iter85/cluster-085: prompt text is user content, so Information logs keep only length/status.
             ctx.Logger.LogInformation(
-                "HumanInput: run={RunId} step={StepId} suspended, prompt=\"{Prompt}\", variable={Var}, timeout={Timeout}s",
-                runId, request.StepId, prompt, variable, timeoutSeconds);
+                "HumanInput: run={RunId} step={StepId} status=suspended prompt_len={PromptLen} prompt_redacted=true variable={Var} timeout={Timeout}s",
+                runId, request.StepId, prompt.Length, variable, timeoutSeconds);
 
             var suspended = new WorkflowSuspendedEvent
             {

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -18,7 +18,9 @@ namespace Aevatar.Workflow.Core.Modules;
 // Refactor (iter30/cluster-030-workflow-step-raw-actor-lifecycle):
 //   Old pattern: WorkflowStepTargetAgentResolver 用 agent_type/agent_id 通过 Type.GetType + AppDomain scan + IRoleAgentTypeResolver 直接 create/link actors,workflow step parameter 暴露 raw CLR lifecycle
 //   New principle: role-level agent_kind 配合 WorkflowRunGAgent runtime lifecycle;step 只用 target_role;删 agent_type/agent_id raw lifecycle 参数 + IWorkflowAgentTypeAliasProvider;Foundation 加 CreateByKindAsync;Bridge 注册 stable kind token
-// Refactor (iter85/cluster-085): Information logs report ids, status, and lengths only; prompt/output content is redacted.
+// Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+//   Old pattern: Information log included raw value/prompt/input preview
+//   New principle: only stable id + length + status + redaction marker
 public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
 {
     private const int DefaultLlmTimeoutMs = 1_800_000;

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -18,6 +18,7 @@ namespace Aevatar.Workflow.Core.Modules;
 // Refactor (iter30/cluster-030-workflow-step-raw-actor-lifecycle):
 //   Old pattern: WorkflowStepTargetAgentResolver 用 agent_type/agent_id 通过 Type.GetType + AppDomain scan + IRoleAgentTypeResolver 直接 create/link actors,workflow step parameter 暴露 raw CLR lifecycle
 //   New principle: role-level agent_kind 配合 WorkflowRunGAgent runtime lifecycle;step 只用 target_role;删 agent_type/agent_id raw lifecycle 参数 + IWorkflowAgentTypeAliasProvider;Foundation 加 CreateByKindAsync;Bridge 注册 stable kind token
+// Refactor (iter85/cluster-085): Information logs report ids, status, and lengths only; prompt/output content is redacted.
 public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
 {
     private const int DefaultLlmTimeoutMs = 1_800_000;
@@ -182,14 +183,12 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             return;
         }
 
-        var outputPreview = (evt.Content ?? string.Empty).Length > 300
-            ? evt.Content![..300] + "..."
-            : evt.Content ?? string.Empty;
         ctx.Logger.LogInformation(
-            "LLMCallModule: step={StepId} completed ({Len} chars): {Preview}",
+            "LLMCallModule: run={RunId} step={StepId} session={SessionId} status=completed output_len={OutputLen} output_redacted=true",
+            pending.RunId,
             pending.StepId,
-            evt.Content?.Length ?? 0,
-            outputPreview);
+            sessionId,
+            evt.Content?.Length ?? 0);
 
         await ctx.PublishAsync(
             new StepCompletedEvent
@@ -226,14 +225,12 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
             return;
         }
 
-        var outputPreview = (evt.Content ?? string.Empty).Length > 300
-            ? evt.Content![..300] + "..."
-            : evt.Content ?? string.Empty;
         ctx.Logger.LogInformation(
-            "LLMCallModule: step={StepId} completed non-streaming ({Len} chars): {Preview}",
+            "LLMCallModule: run={RunId} step={StepId} session={SessionId} status=completed_non_streaming output_len={OutputLen} output_redacted=true",
+            pending.RunId,
             pending.StepId,
-            evt.Content?.Length ?? 0,
-            outputPreview);
+            sessionId,
+            evt.Content?.Length ?? 0);
 
         await ctx.PublishAsync(
             new StepCompletedEvent
@@ -631,7 +628,6 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
         IWorkflowExecutionContext ctx,
         CancellationToken ct)
     {
-        var promptPreview = prompt.Length > 200 ? prompt[..200] + "..." : prompt;
         var chatRequest = new ChatRequestEvent
         {
             Prompt = prompt,
@@ -649,23 +645,25 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
         if (!target.UseSelf)
         {
             ctx.Logger.LogInformation(
-                "LLMCallModule: step={StepId} → SendTo mode={Mode} actor={ActorId} timeout={Timeout}ms prompt=({Len} chars) {Preview}",
+                "LLMCallModule: run={RunId} step={StepId} session={SessionId} status=dispatching mode={Mode} actor={ActorId} timeout={Timeout}ms prompt_len={PromptLen} prompt_redacted=true",
+                WorkflowRunIdNormalizer.Normalize(request.RunId),
                 stepId,
+                sessionId,
                 target.Mode,
                 target.ActorId,
                 timeoutMs,
-                prompt.Length,
-                promptPreview);
+                prompt.Length);
             await ctx.SendToAsync(target.ActorId, chatRequest, ct, dispatchOptions);
             return;
         }
 
         ctx.Logger.LogInformation(
-            "LLMCallModule: step={StepId} → Self timeout={Timeout}ms prompt=({Len} chars) {Preview}",
+            "LLMCallModule: run={RunId} step={StepId} session={SessionId} status=dispatching_self timeout={Timeout}ms prompt_len={PromptLen} prompt_redacted=true",
+            WorkflowRunIdNormalizer.Normalize(request.RunId),
             stepId,
+            sessionId,
             timeoutMs,
-            prompt.Length,
-            promptPreview);
+            prompt.Length);
         await ctx.PublishAsync(chatRequest, TopologyAudience.Self, ct, dispatchOptions);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ParallelFanOutModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ParallelFanOutModule.cs
@@ -107,9 +107,14 @@ public sealed class ParallelFanOutModule : IEventModule<IWorkflowExecutionContex
                 state.Backpressure,
                 BackpressureHelper.ResolveMaxConcurrent(evt.Parameters));
 
-            var inputPreview = evt.Input.Length > 150 ? evt.Input[..150] + "..." : evt.Input;
-            ctx.Logger.LogInformation("ParallelFanOut: step={StepId} fanout to {Count} workers, vote={VoteType}, input=({Len} chars) {Preview}",
-                evt.StepId, count, string.IsNullOrWhiteSpace(voteStepType) ? "(none)" : voteStepType, evt.Input.Length, inputPreview);
+            // iter85/cluster-085: Information telemetry must not carry workflow input previews.
+            ctx.Logger.LogInformation(
+                "ParallelFanOut: run={RunId} step={StepId} status=fanout_dispatching workers={Count} vote={VoteType} input_len={InputLen} input_redacted=true",
+                runId,
+                evt.StepId,
+                count,
+                string.IsNullOrWhiteSpace(voteStepType) ? "(none)" : voteStepType,
+                evt.Input.Length);
 
             var bpApplied = false;
             for (var i = 0; i < count; i++)

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ParallelFanOutModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ParallelFanOutModule.cs
@@ -107,7 +107,9 @@ public sealed class ParallelFanOutModule : IEventModule<IWorkflowExecutionContex
                 state.Backpressure,
                 BackpressureHelper.ResolveMaxConcurrent(evt.Parameters));
 
-            // iter85/cluster-085: Information telemetry must not carry workflow input previews.
+            // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+            //   Old pattern: Information log included raw value/prompt/input preview
+            //   New principle: only stable id + length + status + redaction marker
             ctx.Logger.LogInformation(
                 "ParallelFanOut: run={RunId} step={StepId} status=fanout_dispatching workers={Count} vote={VoteType} input_len={InputLen} input_redacted=true",
                 runId,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SwitchModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SwitchModule.cs
@@ -33,7 +33,9 @@ public sealed class SwitchModule : IEventModule<IWorkflowExecutionContext>
 
         var branchKey = ResolveMatchingBranch(value, request.Parameters);
 
-        // iter85/cluster-085: branch input can be user content; keep only length and resolved branch.
+        // Refactor (iter85/cluster-085-workflow-raw-content-information-logs):
+        //   Old pattern: Information log included raw value/prompt/input preview
+        //   New principle: only stable id + length + status + redaction marker
         ctx.Logger.LogInformation(
             "Switch: run={RunId} step={StepId} status=branch_resolved value_len={ValueLen} value_redacted=true branch={Branch}",
             request.RunId,

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SwitchModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SwitchModule.cs
@@ -33,8 +33,13 @@ public sealed class SwitchModule : IEventModule<IWorkflowExecutionContext>
 
         var branchKey = ResolveMatchingBranch(value, request.Parameters);
 
-        ctx.Logger.LogInformation("Switch {StepId}: on={Value} → branch={Branch}",
-            request.StepId, value.Length > 80 ? value[..80] + "..." : value, branchKey);
+        // iter85/cluster-085: branch input can be user content; keep only length and resolved branch.
+        ctx.Logger.LogInformation(
+            "Switch: run={RunId} step={StepId} status=branch_resolved value_len={ValueLen} value_redacted=true branch={Branch}",
+            request.RunId,
+            request.StepId,
+            value.Length,
+            branchKey);
 
         var completed = new StepCompletedEvent
         {

--- a/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/RoleGAgentStateCoverageTests.cs
@@ -13,6 +13,7 @@ using Aevatar.Foundation.VoicePresence.Abstractions;
 using FluentAssertions;
 using Google.Protobuf;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Aevatar.AI.Tests;
 
@@ -38,9 +39,9 @@ public sealed class RoleGAgentStateCoverageTests
         .GetMethod("ResolveRequestInputParts", BindingFlags.NonPublic | BindingFlags.Static)
         ?? throw new InvalidOperationException("ResolveRequestInputParts not found.");
 
-    private static readonly MethodInfo BuildRequestPreviewMethod = typeof(RoleGAgent)
-        .GetMethod("BuildRequestPreview", BindingFlags.NonPublic | BindingFlags.Static)
-        ?? throw new InvalidOperationException("BuildRequestPreview not found.");
+    private static readonly MethodInfo BuildRequestLogSummaryMethod = typeof(RoleGAgent)
+        .GetMethod("BuildRequestLogSummary", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildRequestLogSummary not found.");
 
     private static readonly MethodInfo DetectPendingApprovalFromHistoryMethod = typeof(RoleGAgent)
         .GetMethod("DetectPendingApprovalFromHistory", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -1012,11 +1013,12 @@ public sealed class RoleGAgentStateCoverageTests
     }
 
     [Fact]
-    public void ResolveRequestInputParts_AndBuildRequestPreview_ShouldRespectPromptAndMediaBranches()
+    public void ResolveRequestInputParts_AndBuildRequestLogSummary_ShouldRespectPromptAndMediaBranches()
     {
+        const string sensitivePrompt = "secret prompt body";
         var multimodalRequest = new ChatRequestEvent
         {
-            Prompt = "describe this",
+            Prompt = sensitivePrompt,
         };
         multimodalRequest.InputParts.Add(new ChatContentPart
         {
@@ -1031,9 +1033,10 @@ public sealed class RoleGAgentStateCoverageTests
         parts[0].Kind.Should().Be(ContentPartKind.Text);
         parts[1].Kind.Should().Be(ContentPartKind.Image);
 
-        InvokePrivateStatic<string>(BuildRequestPreviewMethod, multimodalRequest)
-            .Should()
-            .Be("describe this");
+        var multimodalSummary = InvokePrivateStatic<object>(BuildRequestLogSummaryMethod, multimodalRequest);
+        GetProperty<int>(multimodalSummary, "PromptLength").Should().Be(sensitivePrompt.Length);
+        GetProperty<int>(multimodalSummary, "InputPartCount").Should().Be(2);
+        multimodalSummary.ToString().Should().NotContain(sensitivePrompt);
 
         var promptlessRequest = new ChatRequestEvent();
         promptlessRequest.InputParts.Add(new ChatContentPart
@@ -1042,15 +1045,49 @@ public sealed class RoleGAgentStateCoverageTests
             Name = "clip.mp4",
         });
 
-        InvokePrivateStatic<string>(BuildRequestPreviewMethod, promptlessRequest)
-            .Should()
-            .Be("video");
+        var promptlessSummary = InvokePrivateStatic<object>(BuildRequestLogSummaryMethod, promptlessRequest);
+        GetProperty<int>(promptlessSummary, "PromptLength").Should().Be(0);
+        GetProperty<int>(promptlessSummary, "InputPartCount").Should().Be(1);
+        promptlessSummary.ToString().Should().NotContain("video");
 
         InvokePrivateStatic<IReadOnlyList<ContentPart>>(
                 ResolveRequestInputPartsMethod,
                 new ChatRequestEvent())
             .Should()
             .ContainSingle(x => x.Kind == ContentPartKind.Text && x.Text == string.Empty);
+    }
+
+    [Fact]
+    public async Task HandleChatRequest_ShouldRedactPromptAndResponseContentInInformationLogs()
+    {
+        const string sensitivePrompt = "customer secret prompt";
+        const string sensitiveResponse = "customer secret response";
+        var logger = new RecordingLogger();
+        using var provider = BuildServiceProvider();
+        var agent = CreateRoleAgent(
+            provider,
+            "role-log-redaction",
+            llmProviderFactory: new StubChatProviderFactory((_, _) =>
+                Task.FromResult(new LLMResponse { Content = sensitiveResponse })));
+        agent.Logger = logger;
+        agent.EventPublisher = new TestRecordingEventPublisher();
+        await agent.ActivateAsync();
+
+        await agent.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = sensitivePrompt,
+            SessionId = "session-log-redaction",
+        });
+
+        var messages = logger.Messages.Should().NotBeEmpty().And.Subject;
+        messages.Should().Contain(message =>
+            message.Contains("input_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"prompt_len={sensitivePrompt.Length}", StringComparison.Ordinal));
+        messages.Should().Contain(message =>
+            message.Contains("output_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"output_len={sensitiveResponse.Length}", StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitivePrompt, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveResponse, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1213,9 +1250,13 @@ public sealed class RoleGAgentStateCoverageTests
         IServiceProvider provider,
         string actorId,
         IRemoteToolApprovalPort? remoteToolApprovalPort = null,
-        IEnumerable<IAgentToolSource>? toolSources = null)
+        IEnumerable<IAgentToolSource>? toolSources = null,
+        ILLMProviderFactory? llmProviderFactory = null)
     {
-        var agent = new TestRoleGAgent(remoteToolApprovalPort, toolSources ?? Enumerable.Empty<IAgentToolSource>())
+        var agent = new TestRoleGAgent(
+            llmProviderFactory,
+            remoteToolApprovalPort,
+            toolSources ?? Enumerable.Empty<IAgentToolSource>())
         {
             Services = provider,
             EventSourcingBehaviorFactory = provider.GetRequiredService<IEventSourcingBehaviorFactory<RoleGAgentState>>(),
@@ -1265,10 +1306,36 @@ public sealed class RoleGAgentStateCoverageTests
     }
 
     private sealed class TestRoleGAgent(
+        ILLMProviderFactory? llmProviderFactory,
         IRemoteToolApprovalPort? remoteToolApprovalPort,
         IEnumerable<IAgentToolSource> toolSources)
-        : RoleGAgent(toolSources: toolSources, remoteToolApprovalPort: remoteToolApprovalPort)
+        : RoleGAgent(
+            llmProviderFactory: llmProviderFactory,
+            toolSources: toolSources,
+            remoteToolApprovalPort: remoteToolApprovalPort)
     {
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull =>
+            null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Information)
+                Messages.Add(formatter(state, exception));
+        }
     }
 
     private sealed class StubRemoteApprovalPort(

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -1025,6 +1025,76 @@ public sealed class WorkflowAdditionalModulesCoverageTests
     }
 
     [Fact]
+    public async Task SwitchModule_ShouldRedactSensitiveSwitchInputInInformationLogs()
+    {
+        const string sensitiveSwitchInput = "customer secret switch input route-blue";
+        var logger = new RecordingLogger();
+        var ctx = CreateContext(logger: logger);
+
+        await new SwitchModule().HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "switch-log-redaction",
+                StepType = "switch",
+                RunId = "run-switch-log-redaction",
+                Parameters =
+                {
+                    ["on"] = sensitiveSwitchInput,
+                    ["branch.blue"] = "blue-step",
+                    ["branch._default"] = "fallback-step",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var messages = logger.Messages.Should().NotBeEmpty().And.Subject;
+        messages.Should().Contain(message =>
+            message.Contains("value_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"value_len={sensitiveSwitchInput.Length}", StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveSwitchInput, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task LlmCallModule_ShouldRedactNonStreamingChatResponseInInformationLogs()
+    {
+        const string sensitiveLlmPrompt = "customer secret llm non streaming prompt";
+        const string sensitiveLlmOutput = "customer secret llm non streaming output";
+        var logger = new RecordingLogger();
+        var ctx = CreateContext(logger: logger);
+        var module = new LLMCallModule();
+
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "llm-non-stream-log-redaction",
+                StepType = "llm_call",
+                RunId = "run-llm-non-stream-log-redaction",
+                Input = sensitiveLlmPrompt,
+                TargetRole = "worker_a",
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var sessionId = ctx.Sent.Select(x => x.evt).OfType<ChatRequestEvent>().Single().SessionId;
+        await module.HandleAsync(
+            Envelope(new ChatResponseEvent
+            {
+                SessionId = sessionId,
+                Content = sensitiveLlmOutput,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var messages = logger.Messages.Should().NotBeEmpty().And.Subject;
+        messages.Should().Contain(message =>
+            message.Contains("status=completed_non_streaming", StringComparison.Ordinal) &&
+            message.Contains("output_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"output_len={sensitiveLlmOutput.Length}", StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveLlmPrompt, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveLlmOutput, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task HumanInputModule_ShouldUseRunScopedPendingForSameStepId()
     {
         var module = new HumanInputModule();

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -906,6 +906,125 @@ public sealed class WorkflowAdditionalModulesCoverageTests
     }
 
     [Fact]
+    public async Task WorkflowModules_ShouldRedactRawContentInInformationLogs()
+    {
+        const string sensitiveAssignValue = "customer secret assigned value";
+        const string sensitiveHumanPrompt = "customer secret human prompt";
+        const string sensitiveApprovalPrompt = "customer secret approval prompt";
+        const string sensitiveFanoutInput = "customer secret fanout input";
+        const string sensitiveLlmPrompt = "customer secret llm prompt";
+        const string sensitiveLlmOutput = "customer secret llm output";
+        var logger = new RecordingLogger();
+        var ctx = CreateContext(logger: logger);
+
+        await new AssignModule().HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "assign-log-redaction",
+                StepType = "assign",
+                RunId = "run-log-redaction",
+                Parameters =
+                {
+                    ["target"] = "answer",
+                    ["value"] = sensitiveAssignValue,
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        await new HumanInputModule().HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "human-log-redaction",
+                StepType = "human_input",
+                RunId = "run-log-redaction",
+                Parameters =
+                {
+                    ["prompt"] = sensitiveHumanPrompt,
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        await new HumanApprovalModule().HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "approval-log-redaction",
+                StepType = "human_approval",
+                RunId = "run-log-redaction",
+                Parameters =
+                {
+                    ["prompt"] = sensitiveApprovalPrompt,
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        await new ParallelFanOutModule().HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "parallel-log-redaction",
+                StepType = "parallel",
+                RunId = "run-log-redaction",
+                Input = sensitiveFanoutInput,
+                Parameters =
+                {
+                    ["workers"] = "[\"worker_a\",\"worker_b\"]",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var llmCall = new LLMCallModule();
+        await llmCall.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "llm-log-redaction",
+                StepType = "llm_call",
+                RunId = "run-log-redaction",
+                Input = sensitiveLlmPrompt,
+                TargetRole = "worker_a",
+            }),
+            ctx,
+            CancellationToken.None);
+        var llmSessionId = ctx.Sent.Select(x => x.evt).OfType<ChatRequestEvent>().Single().SessionId;
+        await llmCall.HandleAsync(
+            Envelope(new TextMessageEndEvent
+            {
+                SessionId = llmSessionId,
+                Content = sensitiveLlmOutput,
+            }),
+            ctx,
+            CancellationToken.None);
+
+        var messages = logger.Messages.Should().NotBeEmpty().And.Subject;
+        messages.Should().Contain(message =>
+            message.Contains("value_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"value_len={sensitiveAssignValue.Length}", StringComparison.Ordinal));
+        messages.Should().Contain(message =>
+            message.Contains("prompt_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"prompt_len={sensitiveHumanPrompt.Length}", StringComparison.Ordinal));
+        messages.Should().Contain(message =>
+            message.Contains("prompt_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"prompt_len={sensitiveApprovalPrompt.Length}", StringComparison.Ordinal));
+        messages.Should().Contain(message =>
+            message.Contains("input_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"input_len={sensitiveFanoutInput.Length}", StringComparison.Ordinal));
+        messages.Should().Contain(message =>
+            message.Contains("prompt_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"prompt_len={sensitiveLlmPrompt.Length}", StringComparison.Ordinal));
+        messages.Should().Contain(message =>
+            message.Contains("output_redacted=true", StringComparison.Ordinal) &&
+            message.Contains($"output_len={sensitiveLlmOutput.Length}", StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveAssignValue, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveHumanPrompt, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveApprovalPrompt, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveFanoutInput, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveLlmPrompt, StringComparison.Ordinal));
+        messages.Should().NotContain(message => message.Contains(sensitiveLlmOutput, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task HumanInputModule_ShouldUseRunScopedPendingForSameStepId()
     {
         var module = new HumanInputModule();
@@ -2437,12 +2556,12 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         }
     }
 
-    private static TestEventHandlerContext CreateContext(IServiceProvider? services = null)
+    private static TestEventHandlerContext CreateContext(IServiceProvider? services = null, ILogger? logger = null)
     {
         return new TestEventHandlerContext(
             services ?? new ServiceCollection().AddAevatarWorkflow().BuildServiceProvider(),
             new TestAgent("workflow-advanced-module-test-agent"),
-            NullLogger.Instance);
+            logger ?? NullLogger.Instance);
     }
 
     private static EventEnvelope Envelope(IMessage evt, string? publisherId = null)
@@ -2454,6 +2573,28 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             Payload = Any.Pack(evt),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication(publisherId ?? "test-publisher", TopologyAudience.Self),
         };
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull =>
+            null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Information)
+                Messages.Add(formatter(state, exception));
+        }
     }
 
 }


### PR DESCRIPTION
## 摘要

iter85 cluster-085-workflow-raw-content-information-logs(severity:medium,rule:OBS-PII-LOG-01)。

- **Old**:Workflow Information logs 含 raw prompt/input/output/value preview(ParallelFanOutModule 150-char input / AssignModule value / HumanInputModule prompt / RoleGAgent LLM prompt)
- **New**:Information logs 只 emit RunId/StepId/Target + character counts + redaction marker;raw content 通过 GenAI sensitive-data switch 或 debug artifact

违反:CLAUDE PII/log redaction 原则。参照 GenAIObservabilityMiddleware.EnableSensitiveData boundary。

9 文件改动(+288/-70):
- 7 个 module(ParallelFanOut/Assign/HumanInput/RoleGAgent/LLMCall/Switch/HumanApproval)去 raw preview
- 2 test 项目断言 log 不含 raw content

验证:Workflow.Core + AI.Core + 测试 pass + `ci/*_guards.sh` pass。

🤖 Auto-loop / codex-refactor-loop iter85

⟦AI:AUTO-LOOP⟧
