### PR TITLE
iter86 cluster-086: 7 SCE 复用 ElasticsearchProjectionConfiguration + 新 ProjectionDocumentProviderConfiguration helper

### DIFF
--- a/agents/Aevatar.GAgents.StreamingProxy/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.StreamingProxy/ServiceCollectionExtensions.cs
@@ -8,7 +8,6 @@ using Aevatar.CQRS.Core.Interactions;
 using Aevatar.CQRS.Projection.Core.DependencyInjection;
 using Aevatar.CQRS.Projection.Core.Orchestration;
 using Aevatar.CQRS.Projection.Core.Streaming;
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Runtime.Abstractions;
@@ -131,28 +130,19 @@ public static class ServiceCollectionExtensions
             services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<StreamingProxyRoomParticipantsSnapshot, string>)))
             return;
 
-        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
-        var inMemoryEnabled = ResolveOptionalBool(
-            configuration?["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !elasticsearchEnabled);
-        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
-        if (providerCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled for StreamingProxy.");
-        }
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "StreamingProxy");
 
-        if (elasticsearchEnabled)
+        if (documentProvider.ElasticsearchEnabled)
         {
             services.AddElasticsearchDocumentProjectionStore<StreamingProxyChatSessionTerminalSnapshot, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration!),
+                optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration!),
                 metadataFactory: sp => sp
                     .GetRequiredService<IProjectionDocumentMetadataProvider<StreamingProxyChatSessionTerminalSnapshot>>()
                     .Metadata,
                 keySelector: readModel => readModel.Id,
                 keyFormatter: key => key);
             services.AddElasticsearchDocumentProjectionStore<StreamingProxyRoomParticipantsSnapshot, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration!),
+                optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration!),
                 metadataFactory: sp => sp
                     .GetRequiredService<IProjectionDocumentMetadataProvider<StreamingProxyRoomParticipantsSnapshot>>()
                     .Metadata,
@@ -171,42 +161,4 @@ public static class ServiceCollectionExtensions
             defaultSortSelector: readModel => readModel.UpdatedAt.ToDateTimeOffset());
     }
 
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration? configuration)
-    {
-        if (configuration == null)
-            return false;
-
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
-    }
-
-    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
-    {
-        if (string.IsNullOrWhiteSpace(rawValue))
-            return fallbackValue;
-        if (!bool.TryParse(rawValue, out var parsed))
-            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
-
-        return parsed;
-    }
 }

--- a/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/ServiceCollectionExtensions.cs
@@ -21,7 +21,6 @@ using Aevatar.Bootstrap.Extensions.AI.Connectors;
 using Aevatar.Workflow.Application.Abstractions.Workflows;
 using Aevatar.Workflow.Core.Primitives;
 using Aevatar.Configuration;
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
@@ -170,24 +169,15 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
-        var inMemoryEnabled = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !elasticsearchEnabled);
-        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
-        if (providerCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled for VoicePresence.");
-        }
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "VoicePresence");
 
         if (HasAnyVoicePresenceCapabilityReader(services))
             return services;
 
-        if (elasticsearchEnabled)
+        if (documentProvider.ElasticsearchEnabled)
         {
             services.AddElasticsearchDocumentProjectionStore<VoicePresenceCapabilityReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+                optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration),
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<VoicePresenceCapabilityReadModel>>().Metadata,
                 keySelector: static readModel => readModel.Id,
                 keyFormatter: static key => key);
@@ -890,42 +880,6 @@ public static class ServiceCollectionExtensions
         OpenAI,
         DeepSeek,
         NyxId,
-    }
-
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
-    }
-
-    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
-    {
-        if (string.IsNullOrWhiteSpace(rawValue))
-            return fallbackValue;
-        if (!bool.TryParse(rawValue, out var parsed))
-            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
-
-        return parsed;
     }
 
     private sealed record ConfiguredProvider(

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/DependencyInjection/ElasticsearchProjectionConfiguration.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/DependencyInjection/ElasticsearchProjectionConfiguration.cs
@@ -47,7 +47,12 @@ public static class ElasticsearchProjectionConfiguration
         var section = configuration.GetSection(SectionPath);
         var explicitEnabled = section["Enabled"];
         if (!string.IsNullOrWhiteSpace(explicitEnabled))
-            return string.Equals(explicitEnabled.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+        {
+            if (!bool.TryParse(explicitEnabled, out var enabled))
+                throw new InvalidOperationException($"Invalid boolean value '{explicitEnabled}'.");
+
+            return enabled;
+        }
 
         var hasEndpoints = section.GetSection("Endpoints").GetChildren()
             .Any(static x => !string.IsNullOrWhiteSpace(x.Value));

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/DependencyInjection/ProjectionDocumentProviderConfiguration.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/DependencyInjection/ProjectionDocumentProviderConfiguration.cs
@@ -1,0 +1,117 @@
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+
+// Refactor (iter86/cluster-086-projection-provider-config-duplication):
+//   Old pattern: each capability SCE parsed Projection:Document:Providers:* and
+//   rebound ElasticsearchProjectionDocumentStoreOptions with local policy drift.
+//   New principle: shared provider selection and ES typed binding live beside the
+//   provider helper; capability SCEs only register their readmodel document types.
+public static class ProjectionDocumentProviderConfiguration
+{
+    public const string InMemoryEnabledPath = "Projection:Document:Providers:InMemory:Enabled";
+    public const string DenyInMemoryDocumentReadStorePath = "Projection:Policies:DenyInMemoryDocumentReadStore";
+    public const string PolicyEnvironmentPath = "Projection:Policies:Environment";
+
+    public static ProjectionDocumentProviderSelection Resolve(
+        IConfiguration? configuration,
+        string capabilityName,
+        ILogger? logger = null)
+    {
+        var elasticsearchEnabled = ElasticsearchProjectionConfiguration.IsEnabled(
+            configuration,
+            logger,
+            capabilityName);
+        var inMemoryEnabled = ResolveOptionalBool(
+            configuration?[InMemoryEnabledPath],
+            fallbackValue: !elasticsearchEnabled);
+        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
+        if (providerCount != 1)
+        {
+            throw new InvalidOperationException(
+                $"Exactly one document projection provider must be enabled for {capabilityName}. " +
+                "Configure either Projection:Document:Providers:Elasticsearch:Enabled=true or " +
+                "Projection:Document:Providers:InMemory:Enabled=true.");
+        }
+
+        EnforceInMemoryPolicy(configuration, inMemoryEnabled);
+
+        return new ProjectionDocumentProviderSelection(
+            elasticsearchEnabled
+                ? ProjectionDocumentProviderKind.Elasticsearch
+                : ProjectionDocumentProviderKind.InMemory,
+            elasticsearchEnabled,
+            inMemoryEnabled);
+    }
+
+    public static ElasticsearchProjectionDocumentStoreOptions BindRequiredElasticsearchOptions(
+        IConfiguration configuration)
+    {
+        var options = ElasticsearchProjectionConfiguration.BindOptions(configuration);
+        if (options.Endpoints.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"{ElasticsearchProjectionConfiguration.SectionPath} is enabled but Endpoints is empty.");
+        }
+
+        return options;
+    }
+
+    public static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
+    {
+        if (string.IsNullOrWhiteSpace(rawValue))
+            return fallbackValue;
+        if (!bool.TryParse(rawValue, out var parsed))
+            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
+
+        return parsed;
+    }
+
+    private static void EnforceInMemoryPolicy(
+        IConfiguration? configuration,
+        bool inMemoryEnabled)
+    {
+        if (!inMemoryEnabled || configuration is null)
+            return;
+
+        var denyInMemory = ResolveOptionalBool(
+            configuration[DenyInMemoryDocumentReadStorePath],
+            fallbackValue: false);
+        var environment = ResolveRuntimeEnvironment(configuration[PolicyEnvironmentPath]);
+        if (denyInMemory || IsProductionEnvironment(environment))
+        {
+            throw new InvalidOperationException(
+                "InMemory document provider is not allowed by projection policy. " +
+                "Disable Projection:Document:Providers:InMemory:Enabled and configure Elasticsearch.");
+        }
+    }
+
+    private static string ResolveRuntimeEnvironment(string? configuredEnvironment)
+    {
+        if (!string.IsNullOrWhiteSpace(configuredEnvironment))
+            return configuredEnvironment.Trim();
+
+        var dotnetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        if (!string.IsNullOrWhiteSpace(dotnetEnvironment))
+            return dotnetEnvironment.Trim();
+
+        var aspnetEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        return aspnetEnvironment?.Trim() ?? string.Empty;
+    }
+
+    private static bool IsProductionEnvironment(string environment) =>
+        string.Equals(environment, "Production", StringComparison.OrdinalIgnoreCase);
+}
+
+public readonly record struct ProjectionDocumentProviderSelection(
+    ProjectionDocumentProviderKind Kind,
+    bool ElasticsearchEnabled,
+    bool InMemoryEnabled);
+
+public enum ProjectionDocumentProviderKind
+{
+    InMemory,
+    Elasticsearch,
+}

--- a/src/Aevatar.Scripting.Hosting/DependencyInjection/ScriptingProjectionProviderServiceCollectionExtensions.cs
+++ b/src/Aevatar.Scripting.Hosting/DependencyInjection/ScriptingProjectionProviderServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
@@ -22,7 +21,7 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
 
         if (configuration == null)
         {
-            if (HasAllScriptingDocumentReaders(services, DocumentProviderKind.InMemory))
+            if (HasAllScriptingDocumentReaders(services, ProjectionDocumentProviderKind.InMemory))
                 return services;
 
             AddInMemoryDocumentStores(services);
@@ -32,29 +31,15 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
 
         EnsureLegacyProviderOptionsNotUsed(configuration);
 
-        var enableElasticsearchDocument = ResolveElasticsearchDocumentEnabled(configuration);
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "Scripting");
         var enableNeo4jGraph = ResolveNeo4jGraphEnabled(configuration);
-        var enableInMemoryDocument = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !enableElasticsearchDocument);
         var enableInMemoryGraph = ResolveOptionalBool(
             configuration["Projection:Graph:Providers:InMemory:Enabled"],
             fallbackValue: !enableNeo4jGraph);
 
-        EnforceDocumentProviderPolicy(configuration, enableInMemoryDocument);
         EnforceGraphProviderPolicy(configuration, enableInMemoryGraph);
 
-        var documentProviderCount = (enableElasticsearchDocument ? 1 : 0) + (enableInMemoryDocument ? 1 : 0);
-        if (documentProviderCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled. Configure either Projection:Document:Providers:Elasticsearch:Enabled=true or Projection:Document:Providers:InMemory:Enabled=true.");
-        }
-
-        var selectedDocumentProvider = enableElasticsearchDocument
-            ? DocumentProviderKind.Elasticsearch
-            : DocumentProviderKind.InMemory;
-        if (HasAllScriptingDocumentReaders(services, selectedDocumentProvider))
+        if (HasAllScriptingDocumentReaders(services, documentProvider.Kind))
             return services;
 
         var graphProviderCount = (enableNeo4jGraph ? 1 : 0) + (enableInMemoryGraph ? 1 : 0);
@@ -64,7 +49,7 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
                 "Exactly one graph projection provider must be enabled. Configure either Projection:Graph:Providers:Neo4j:Enabled=true or Projection:Graph:Providers:InMemory:Enabled=true.");
         }
 
-        if (enableElasticsearchDocument)
+        if (documentProvider.ElasticsearchEnabled)
         {
             TryAddElasticsearchDocumentStore<ScriptDefinitionSnapshotDocument>(
                 services,
@@ -117,7 +102,7 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
 
     private static bool HasAllScriptingDocumentReaders(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
     {
         return HasDocumentReaderForProvider<ScriptDefinitionSnapshotDocument>(services, providerKind)
                && HasDocumentReaderForProvider<ScriptCatalogEntryDocument>(services, providerKind)
@@ -134,20 +119,20 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
 
     private static bool HasDocumentReaderForProvider<TDocument>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
         return providerKind switch
         {
-            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDocument, string>)),
-            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDocument, string>)),
+            ProjectionDocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDocument, string>)),
+            ProjectionDocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDocument, string>)),
             _ => false,
         };
     }
 
     private static void EnsureCompatibleDocumentReaderProvider<TDocument>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
         if (!HasAnyDocumentReader<TDocument>(services))
@@ -166,12 +151,12 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         Func<TDocument, string?>? indexScopeSelector = null)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.Elasticsearch);
-        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.Elasticsearch))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, ProjectionDocumentProviderKind.Elasticsearch);
+        if (HasDocumentReaderForProvider<TDocument>(services, ProjectionDocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TDocument, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration),
             metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDocument>>().Metadata,
             keySelector: keySelector,
             keyFormatter: static key => key,
@@ -183,8 +168,8 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         Func<TDocument, string> keySelector)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.InMemory);
-        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.InMemory))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, ProjectionDocumentProviderKind.InMemory);
+        if (HasDocumentReaderForProvider<TDocument>(services, ProjectionDocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TDocument, string>(
@@ -205,38 +190,12 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         }
     }
 
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
     private static bool ResolveNeo4jGraphEnabled(IConfiguration configuration)
     {
         var section = configuration.GetSection("Projection:Graph:Providers:Neo4j");
         var explicitEnabled = section["Enabled"];
         var hasUri = (section["Uri"]?.Trim().Length ?? 0) > 0;
         return ResolveOptionalBool(explicitEnabled, hasUri);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
     }
 
     private static Neo4jProjectionGraphStoreOptions BuildNeo4jGraphOptions(
@@ -258,22 +217,6 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         }
 
         return options;
-    }
-
-    private static void EnforceDocumentProviderPolicy(
-        IConfiguration configuration,
-        bool enableInMemoryDocumentProvider)
-    {
-        var denyInMemoryDocumentProvider = ResolveOptionalBool(
-            configuration["Projection:Policies:DenyInMemoryDocumentReadStore"],
-            fallbackValue: false);
-        var environment = ResolveRuntimeEnvironment(configuration["Projection:Policies:Environment"]);
-        if ((denyInMemoryDocumentProvider || IsProductionEnvironment(environment)) && enableInMemoryDocumentProvider)
-        {
-            throw new InvalidOperationException(
-                "InMemory document provider is not allowed by projection policy. " +
-                "Disable Projection:Document:Providers:InMemory:Enabled and configure Elasticsearch.");
-        }
     }
 
     private static void EnforceGraphProviderPolicy(
@@ -319,9 +262,4 @@ public static class ScriptingProjectionProviderServiceCollectionExtensions
         return parsed;
     }
 
-    private enum DocumentProviderKind
-    {
-        InMemory,
-        Elasticsearch,
-    }
 }

--- a/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Hosting/StudioProjectionReadModelServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
@@ -41,24 +40,11 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
-        var inMemoryEnabled = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !elasticsearchEnabled);
-        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
-        if (providerCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled for Studio.");
-        }
-
-        var selectedDocumentProvider = elasticsearchEnabled
-            ? DocumentProviderKind.Elasticsearch
-            : DocumentProviderKind.InMemory;
-        if (HasAllStudioDocumentReaders(services, selectedDocumentProvider))
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "Studio");
+        if (HasAllStudioDocumentReaders(services, documentProvider.Kind))
             return services;
 
-        if (elasticsearchEnabled)
+        if (documentProvider.ElasticsearchEnabled)
         {
             RegisterElasticsearch<RoleCatalogCurrentStateDocument>(services, configuration);
             RegisterElasticsearch<ConnectorCatalogCurrentStateDocument>(services, configuration);
@@ -95,12 +81,12 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         IConfiguration configuration)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
-        EnsureCompatibleDocumentReaderProvider<TDoc>(services, DocumentProviderKind.Elasticsearch);
-        if (HasDocumentReaderForProvider<TDoc>(services, DocumentProviderKind.Elasticsearch))
+        EnsureCompatibleDocumentReaderProvider<TDoc>(services, ProjectionDocumentProviderKind.Elasticsearch);
+        if (HasDocumentReaderForProvider<TDoc>(services, ProjectionDocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TDoc, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration),
             metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDoc>>().Metadata,
             keySelector: readModel => readModel.ActorId,
             keyFormatter: key => key,
@@ -111,8 +97,8 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
         IServiceCollection services)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
-        EnsureCompatibleDocumentReaderProvider<TDoc>(services, DocumentProviderKind.InMemory);
-        if (HasDocumentReaderForProvider<TDoc>(services, DocumentProviderKind.InMemory))
+        EnsureCompatibleDocumentReaderProvider<TDoc>(services, ProjectionDocumentProviderKind.InMemory);
+        if (HasDocumentReaderForProvider<TDoc>(services, ProjectionDocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TDoc, string>(
@@ -123,7 +109,7 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
 
     private static bool HasAllStudioDocumentReaders(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
     {
         return HasDocumentReaderForProvider<RoleCatalogCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<ConnectorCatalogCurrentStateDocument>(services, providerKind)
@@ -146,20 +132,20 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
 
     private static bool HasDocumentReaderForProvider<TDoc>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
         return providerKind switch
         {
-            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDoc, string>)),
-            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDoc, string>)),
+            ProjectionDocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDoc, string>)),
+            ProjectionDocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDoc, string>)),
             _ => false,
         };
     }
 
     private static void EnsureCompatibleDocumentReaderProvider<TDoc>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TDoc : class, IProjectionReadModel<TDoc>, new()
     {
         if (!HasAnyDocumentReader<TDoc>(services))
@@ -169,42 +155,6 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
 
         throw new InvalidOperationException(
             $"Projection document reader for {typeof(TDoc).Name} is already registered with a different provider.");
-    }
-
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
-    }
-
-    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
-    {
-        if (string.IsNullOrWhiteSpace(rawValue))
-            return fallbackValue;
-        if (!bool.TryParse(rawValue, out var parsed))
-            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
-
-        return parsed;
     }
 
     private static TypeRegistry BuildStudioStateTypeRegistry()
@@ -223,9 +173,4 @@ internal static class StudioProjectionReadModelServiceCollectionExtensions
             StudioWorkspaceState.Descriptor);
     }
 
-    private enum DocumentProviderKind
-    {
-        InMemory,
-        Elasticsearch,
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Governance.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Governance.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
 using Aevatar.CQRS.Projection.Stores.Abstractions;
@@ -54,21 +53,12 @@ public static class ServiceCollectionExtensions
 
         if (services.Any(x => x.ServiceType == typeof(IProjectionDocumentReader<ServiceConfigurationReadModel, string>)))
             return services;
-        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
-        var inMemoryEnabled = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !elasticsearchEnabled);
-        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
-        if (providerCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled for GAgentService governance.");
-        }
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "GAgentService governance");
 
-        if (elasticsearchEnabled)
+        if (documentProvider.ElasticsearchEnabled)
         {
             services.AddElasticsearchDocumentProjectionStore<ServiceConfigurationReadModel, string>(
-                optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+                optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration),
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<ServiceConfigurationReadModel>>().Metadata,
                 keySelector: readModel => readModel.Id,
                 keyFormatter: key => key);
@@ -84,39 +74,4 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
-    }
-
-    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
-    {
-        if (string.IsNullOrWhiteSpace(rawValue))
-            return fallbackValue;
-        if (!bool.TryParse(rawValue, out var parsed))
-            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
-
-        return parsed;
-    }
 }

--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
@@ -112,21 +111,8 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
-        var elasticsearchEnabled = ResolveElasticsearchDocumentEnabled(configuration);
-        var inMemoryEnabled = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !elasticsearchEnabled);
-        var providerCount = (elasticsearchEnabled ? 1 : 0) + (inMemoryEnabled ? 1 : 0);
-        if (providerCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled for GAgentService.");
-        }
-
-        var selectedDocumentProvider = elasticsearchEnabled
-            ? DocumentProviderKind.Elasticsearch
-            : DocumentProviderKind.InMemory;
-        if (HasAllGAgentServiceProjectionReaders(services, selectedDocumentProvider))
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "GAgentService");
+        if (HasAllGAgentServiceProjectionReaders(services, documentProvider.Kind))
             return services;
 
         services.TryAddSingleton<
@@ -136,7 +122,7 @@ public static class ServiceCollectionExtensions
             IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>,
             WorkflowCapabilitiesCurrentStateDocumentMetadataProvider>();
 
-        if (elasticsearchEnabled)
+        if (documentProvider.ElasticsearchEnabled)
         {
             TryAddElasticsearchDocumentProjectionStore<ServiceCatalogReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<ServiceRevisionCatalogReadModel>(services, configuration, static readModel => readModel.Id);
@@ -176,7 +162,7 @@ public static class ServiceCollectionExtensions
 
     private static bool HasAllGAgentServiceProjectionReaders(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
     {
         return HasProjectionDocumentReaderForProvider<ServiceCatalogReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<ServiceRevisionCatalogReadModel>(services, providerKind)
@@ -202,20 +188,20 @@ public static class ServiceCollectionExtensions
 
     private static bool HasProjectionDocumentReaderForProvider<TReadModel>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
         return providerKind switch
         {
-            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TReadModel, string>)),
-            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TReadModel, string>)),
+            ProjectionDocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TReadModel, string>)),
+            ProjectionDocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TReadModel, string>)),
             _ => false,
         };
     }
 
     private static void EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
         if (!HasAnyProjectionDocumentReader<TReadModel>(services))
@@ -233,12 +219,12 @@ public static class ServiceCollectionExtensions
         Func<TReadModel, string> keySelector)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
-        EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(services, DocumentProviderKind.Elasticsearch);
-        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, DocumentProviderKind.Elasticsearch))
+        EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(services, ProjectionDocumentProviderKind.Elasticsearch);
+        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, ProjectionDocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TReadModel, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration),
             metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TReadModel>>().Metadata,
             keySelector: keySelector,
             keyFormatter: static key => key);
@@ -249,8 +235,8 @@ public static class ServiceCollectionExtensions
         Func<TReadModel, string> keySelector)
         where TReadModel : class, IProjectionReadModel<TReadModel>, new()
     {
-        EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(services, DocumentProviderKind.InMemory);
-        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, DocumentProviderKind.InMemory))
+        EnsureCompatibleProjectionDocumentReaderProvider<TReadModel>(services, ProjectionDocumentProviderKind.InMemory);
+        if (HasProjectionDocumentReaderForProvider<TReadModel>(services, ProjectionDocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TReadModel, string>(
@@ -259,45 +245,4 @@ public static class ServiceCollectionExtensions
             defaultSortSelector: static readModel => readModel.UpdatedAt);
     }
 
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? string.Empty)
-            .Any(x => x.Length > 0);
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
-    }
-
-    private static bool ResolveOptionalBool(string? rawValue, bool fallbackValue)
-    {
-        if (string.IsNullOrWhiteSpace(rawValue))
-            return fallbackValue;
-        if (!bool.TryParse(rawValue, out var parsed))
-            throw new InvalidOperationException($"Invalid boolean value '{rawValue}'.");
-
-        return parsed;
-    }
-
-    private enum DocumentProviderKind
-    {
-        InMemory,
-        Elasticsearch,
-    }
 }

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using Aevatar.CQRS.Projection.Providers.Elasticsearch.Configuration;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
 using Aevatar.CQRS.Projection.Providers.Elasticsearch.Stores;
 using Aevatar.CQRS.Projection.Providers.InMemory.DependencyInjection;
@@ -23,29 +22,15 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
 
         EnsureLegacyProviderOptionsNotUsed(configuration);
 
-        var enableElasticsearchDocument = ResolveElasticsearchDocumentEnabled(configuration);
+        var documentProvider = ProjectionDocumentProviderConfiguration.Resolve(configuration, "Workflow");
         var enableNeo4jGraph = ResolveNeo4jGraphEnabled(configuration);
-        var enableInMemoryDocument = ResolveOptionalBool(
-            configuration["Projection:Document:Providers:InMemory:Enabled"],
-            fallbackValue: !enableElasticsearchDocument);
         var enableInMemoryGraph = ResolveOptionalBool(
             configuration["Projection:Graph:Providers:InMemory:Enabled"],
             fallbackValue: !enableNeo4jGraph);
 
-        EnforceDocumentProviderPolicy(configuration, enableInMemoryDocument);
         EnforceGraphProviderPolicy(configuration, enableInMemoryGraph);
 
-        var documentProviderCount = (enableElasticsearchDocument ? 1 : 0) + (enableInMemoryDocument ? 1 : 0);
-        if (documentProviderCount != 1)
-        {
-            throw new InvalidOperationException(
-                "Exactly one document projection provider must be enabled. Configure either Projection:Document:Providers:Elasticsearch:Enabled=true or Projection:Document:Providers:InMemory:Enabled=true.");
-        }
-
-        var selectedDocumentProvider = enableElasticsearchDocument
-            ? DocumentProviderKind.Elasticsearch
-            : DocumentProviderKind.InMemory;
-        if (HasAllWorkflowDocumentReaders(services, selectedDocumentProvider))
+        if (HasAllWorkflowDocumentReaders(services, documentProvider.Kind))
             return services;
 
         var graphProviderCount = (enableNeo4jGraph ? 1 : 0) + (enableInMemoryGraph ? 1 : 0);
@@ -55,7 +40,7 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
                 "Exactly one graph projection provider must be enabled. Configure either Projection:Graph:Providers:Neo4j:Enabled=true or Projection:Graph:Providers:InMemory:Enabled=true.");
         }
 
-        if (enableElasticsearchDocument)
+        if (documentProvider.ElasticsearchEnabled)
         {
             AddElasticsearchDocumentStores(services, configuration);
         }
@@ -129,7 +114,7 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
 
     private static bool HasAllWorkflowDocumentReaders(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
     {
         return HasDocumentReaderForProvider<WorkflowExecutionCurrentStateDocument>(services, providerKind)
                && HasDocumentReaderForProvider<WorkflowRunInsightReportDocument>(services, providerKind)
@@ -146,20 +131,20 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
 
     private static bool HasDocumentReaderForProvider<TDocument>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
         return providerKind switch
         {
-            DocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDocument, string>)),
-            DocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDocument, string>)),
+            ProjectionDocumentProviderKind.Elasticsearch => services.Any(x => x.ServiceType == typeof(ElasticsearchProjectionDocumentStore<TDocument, string>)),
+            ProjectionDocumentProviderKind.InMemory => services.Any(x => x.ServiceType == typeof(InMemoryProjectionDocumentStore<TDocument, string>)),
             _ => false,
         };
     }
 
     private static void EnsureCompatibleDocumentReaderProvider<TDocument>(
         IServiceCollection services,
-        DocumentProviderKind providerKind)
+        ProjectionDocumentProviderKind providerKind)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
         if (!HasAnyDocumentReader<TDocument>(services))
@@ -177,12 +162,12 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         Func<TDocument, string> keySelector)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.Elasticsearch);
-        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.Elasticsearch))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, ProjectionDocumentProviderKind.Elasticsearch);
+        if (HasDocumentReaderForProvider<TDocument>(services, ProjectionDocumentProviderKind.Elasticsearch))
             return;
 
         services.AddElasticsearchDocumentProjectionStore<TDocument, string>(
-            optionsFactory: _ => BuildElasticsearchDocumentOptions(configuration),
+            optionsFactory: _ => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration),
             metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<TDocument>>().Metadata,
             keySelector: keySelector,
             keyFormatter: static key => key);
@@ -194,8 +179,8 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         Func<TDocument, object?> defaultSortSelector)
         where TDocument : class, IProjectionReadModel<TDocument>, new()
     {
-        EnsureCompatibleDocumentReaderProvider<TDocument>(services, DocumentProviderKind.InMemory);
-        if (HasDocumentReaderForProvider<TDocument>(services, DocumentProviderKind.InMemory))
+        EnsureCompatibleDocumentReaderProvider<TDocument>(services, ProjectionDocumentProviderKind.InMemory);
+        if (HasDocumentReaderForProvider<TDocument>(services, ProjectionDocumentProviderKind.InMemory))
             return;
 
         services.AddInMemoryDocumentProjectionStore<TDocument, string>(
@@ -218,19 +203,6 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         }
     }
 
-    private static bool ResolveElasticsearchDocumentEnabled(IConfiguration configuration)
-    {
-        var section = configuration.GetSection("Projection:Document:Providers:Elasticsearch");
-        var explicitEnabled = section["Enabled"];
-        var hasEndpoints = section
-            .GetSection("Endpoints")
-            .GetChildren()
-            .Select(x => x.Value?.Trim() ?? "")
-            .Any(x => x.Length > 0);
-
-        return ResolveOptionalBool(explicitEnabled, hasEndpoints);
-    }
-
     private static bool ResolveNeo4jGraphEnabled(IConfiguration configuration)
     {
         var section = configuration.GetSection("Projection:Graph:Providers:Neo4j");
@@ -238,20 +210,6 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         var hasUri = (section["Uri"]?.Trim().Length ?? 0) > 0;
 
         return ResolveOptionalBool(explicitEnabled, hasUri);
-    }
-
-    private static ElasticsearchProjectionDocumentStoreOptions BuildElasticsearchDocumentOptions(
-        IConfiguration configuration)
-    {
-        var options = new ElasticsearchProjectionDocumentStoreOptions();
-        configuration.GetSection("Projection:Document:Providers:Elasticsearch").Bind(options);
-        if (options.Endpoints.Count == 0)
-        {
-            throw new InvalidOperationException(
-                "Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
-        }
-
-        return options;
     }
 
     private static Neo4jProjectionGraphStoreOptions BuildNeo4jGraphOptions(IConfiguration configuration)
@@ -292,24 +250,6 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         }
     }
 
-    private static void EnforceDocumentProviderPolicy(
-        IConfiguration configuration,
-        bool enableInMemoryDocumentProvider)
-    {
-        var denyInMemoryDocumentProvider = ResolveOptionalBool(
-            configuration["Projection:Policies:DenyInMemoryDocumentReadStore"],
-            fallbackValue: false);
-        var environment = ResolveRuntimeEnvironment(configuration["Projection:Policies:Environment"]);
-        var production = IsProductionEnvironment(environment);
-
-        if ((denyInMemoryDocumentProvider || production) && enableInMemoryDocumentProvider)
-        {
-            throw new InvalidOperationException(
-                "InMemory document provider is not allowed by projection policy. " +
-                "Disable Projection:Document:Providers:InMemory:Enabled and configure Elasticsearch.");
-        }
-    }
-
     private static string ResolveRuntimeEnvironment(string? configuredEnvironment)
     {
         if (!string.IsNullOrWhiteSpace(configuredEnvironment))
@@ -339,9 +279,4 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
         return parsed;
     }
 
-    private enum DocumentProviderKind
-    {
-        InMemory,
-        Elasticsearch,
-    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ElasticsearchProjectionConfigurationTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ElasticsearchProjectionConfigurationTests.cs
@@ -166,6 +166,20 @@ public sealed class ElasticsearchProjectionConfigurationTests
     }
 
     [Fact]
+    public void IsEnabled_Throws_WhenExplicitFlagIsInvalid()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "sometimes",
+        });
+
+        Action act = () => ElasticsearchProjectionConfiguration.IsEnabled(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Invalid boolean value 'sometimes'.");
+    }
+
+    [Fact]
     public void BindOptions_NullConfiguration_Throws()
     {
         Action act = () => ElasticsearchProjectionConfiguration.BindOptions(null!);
@@ -203,6 +217,126 @@ public sealed class ElasticsearchProjectionConfigurationTests
         options.Should().NotBeNull();
         options.IndexPrefix.Should().Be("aevatar");
         options.Endpoints.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Resolve_SelectsElasticsearch_WhenExplicitlyEnabledAndInMemoryDefaultIsDisabled()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+            ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://es:9200",
+        });
+
+        var selection = ProjectionDocumentProviderConfiguration.Resolve(configuration, "TestCapability");
+
+        selection.Kind.Should().Be(ProjectionDocumentProviderKind.Elasticsearch);
+        selection.ElasticsearchEnabled.Should().BeTrue();
+        selection.InMemoryEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_SelectsInMemory_WhenElasticsearchDisabledAndInMemoryDefaultIsEnabled()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+        });
+
+        var selection = ProjectionDocumentProviderConfiguration.Resolve(configuration, "TestCapability");
+
+        selection.Kind.Should().Be(ProjectionDocumentProviderKind.InMemory);
+        selection.ElasticsearchEnabled.Should().BeFalse();
+        selection.InMemoryEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Resolve_Throws_WhenBothDocumentProvidersAreEnabled()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+            ["Projection:Document:Providers:InMemory:Enabled"] = "true",
+        });
+
+        Action act = () => ProjectionDocumentProviderConfiguration.Resolve(configuration, "TestCapability");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Exactly one document projection provider must be enabled for TestCapability.*");
+    }
+
+    [Fact]
+    public void Resolve_Throws_WhenInMemoryIsSelectedAndDeniedByPolicy()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+            ["Projection:Policies:DenyInMemoryDocumentReadStore"] = "true",
+        });
+
+        Action act = () => ProjectionDocumentProviderConfiguration.Resolve(configuration, "TestCapability");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("InMemory document provider is not allowed by projection policy.*");
+    }
+
+    [Fact]
+    public void Resolve_Throws_WhenInMemoryIsSelectedInProduction()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+            ["Projection:Policies:Environment"] = "Production",
+        });
+
+        Action act = () => ProjectionDocumentProviderConfiguration.Resolve(configuration, "TestCapability");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("InMemory document provider is not allowed by projection policy.*");
+    }
+
+    [Fact]
+    public void Resolve_Throws_WhenInMemoryFlagIsInvalid()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "false",
+            ["Projection:Document:Providers:InMemory:Enabled"] = "maybe",
+        });
+
+        Action act = () => ProjectionDocumentProviderConfiguration.Resolve(configuration, "TestCapability");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Invalid boolean value 'maybe'.");
+    }
+
+    [Fact]
+    public void BindRequiredElasticsearchOptions_UsesSharedBindingAndRequiresEndpoints()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://es:9200",
+            ["Projection:Document:Providers:Elasticsearch:IndexPrefix"] = "iter86",
+        });
+
+        var options = ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration);
+
+        options.Endpoints.Should().BeEquivalentTo(new[] { "http://es:9200" });
+        options.IndexPrefix.Should().Be("iter86");
+    }
+
+    [Fact]
+    public void BindRequiredElasticsearchOptions_Throws_WhenEnabledButEndpointsAreEmpty()
+    {
+        var configuration = BuildConfiguration(new()
+        {
+            ["Projection:Document:Providers:Elasticsearch:Enabled"] = "true",
+        });
+
+        Action act = () => ProjectionDocumentProviderConfiguration.BindRequiredElasticsearchOptions(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Projection:Document:Providers:Elasticsearch is enabled but Endpoints is empty.");
     }
 
     private static IConfigurationRoot BuildConfiguration(Dictionary<string, string?> values) =>


### PR DESCRIPTION
## 摘要

iter86 cluster-086-projection-provider-config-duplication(severity:medium,rules:CFG-01..04)。

- **Old**:7 SCE 各自 parse `Projection:Document:Providers:Elasticsearch` / bind `ElasticsearchProjectionDocumentStoreOptions` / apply provider 选择 policy 重复(GAgentService / Studio / Workflow / Scripting / StreamingProxy / Bootstrap.AI / Governance)
- **New**:复用现有 `ElasticsearchProjectionConfiguration` + 新建 `ProjectionDocumentProviderConfiguration` 统一封装(provider selection + DenyInMemoryDocumentReadStore policy + bind+validation)

违反:CLAUDE / docs/canon/cqrs-projection.md 第 5 节「Host 组合层按配置仅注册所需 provider」 + 「使用现有 helper」原则。

10 文件改动(+320 / -440,净去重 -120 行,7 SCE 各减 ~70 行):
- ElasticsearchProjectionConfiguration:接口微调
- **ProjectionDocumentProviderConfiguration(新)**:统一 provider selection + policy + bind+validation
- 7 SCE:移除本地复制,改调 shared helper
- ElasticsearchProjectionConfigurationTests +134:回归覆盖 ES / InMemory / policy 一致

验证:7 SCE 编译 + ChannelRuntime.Tests + 各 SCE 测试 pass + `ci/*_guards.sh` pass。

🤖 Auto-loop / codex-refactor-loop iter86

⟦AI:AUTO-LOOP⟧
