### PR TITLE
iter89 cluster-089: ES projection store 用 monotonic clock 计 elapsedMs

### DIFF
--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -45,7 +46,10 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
         CancellationToken ct)
     {
         var payload = SerializePayload(readModel, keyValue);
-        var startedAt = DateTimeOffset.UtcNow;
+        // Refactor (iter89/cluster-089-projection-provider-elapsed-clock):
+        // Old: elapsedMs used DateTimeOffset.UtcNow subtraction, so wall-clock changes could skew duration logs.
+        // New: elapsedMs uses a monotonic Stopwatch timestamp; projection clocks remain for semantic timestamps only.
+        var startedAtTimestamp = Stopwatch.GetTimestamp();
 
         try
         {
@@ -55,7 +59,7 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
                 var result = ProjectionWriteResultEvaluator.Evaluate(existing.ReadModel, readModel);
                 if (!result.IsApplied)
                 {
-                    LogWriteSkipped(keyValue, startedAt, result);
+                    LogWriteSkipped(keyValue, startedAtTimestamp, result);
                     return result;
                 }
 
@@ -63,7 +67,7 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
                 using var response = await _httpClient.SendAsync(request, ct);
                 if (response.IsSuccessStatusCode)
                 {
-                    LogWriteCompleted(keyValue, startedAt);
+                    LogWriteCompleted(keyValue, startedAtTimestamp);
                     return ProjectionWriteResult.Applied();
                 }
 
@@ -83,7 +87,7 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
             var reconciledResult = ProjectionWriteResultEvaluator.Evaluate(reconciled.ReadModel, readModel);
             if (!reconciledResult.IsApplied)
             {
-                LogWriteSkipped(keyValue, startedAt, reconciledResult);
+                LogWriteSkipped(keyValue, startedAtTimestamp, reconciledResult);
                 return reconciledResult;
             }
 
@@ -92,7 +96,7 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
         }
         catch (Exception ex)
         {
-            LogWriteFailure(keyValue, startedAt, ex);
+            LogWriteFailure(keyValue, startedAtTimestamp, ex);
             throw;
         }
     }
@@ -182,9 +186,9 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
         return payload.ToJsonString();
     }
 
-    private void LogWriteCompleted(string keyValue, DateTimeOffset startedAt)
+    private void LogWriteCompleted(string keyValue, long startedAtTimestamp)
     {
-        var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+        var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
         _logger.LogInformation(
             "Projection read-model write completed. provider={Provider} readModelType={ReadModelType} key={Key} elapsedMs={ElapsedMs} result={Result}",
             ProviderName,
@@ -194,9 +198,9 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
             ProjectionWriteDisposition.Applied);
     }
 
-    private void LogWriteSkipped(string keyValue, DateTimeOffset startedAt, ProjectionWriteResult result)
+    private void LogWriteSkipped(string keyValue, long startedAtTimestamp, ProjectionWriteResult result)
     {
-        var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+        var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
         _logger.LogInformation(
             "Projection read-model write skipped. provider={Provider} readModelType={ReadModelType} key={Key} elapsedMs={ElapsedMs} result={Result}",
             ProviderName,
@@ -206,9 +210,9 @@ internal sealed class ElasticsearchOptimisticWriter<TReadModel>
             result.Disposition);
     }
 
-    private void LogWriteFailure(string keyValue, DateTimeOffset startedAt, Exception ex)
+    private void LogWriteFailure(string keyValue, long startedAtTimestamp, Exception ex)
     {
-        var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+        var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
         _logger.LogError(
             ex,
             "Projection read-model write failed. provider={Provider} readModelType={ReadModelType} key={Key} elapsedMs={ElapsedMs} result={Result} errorType={ErrorType}",

--- a/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStore.cs
+++ b/src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStore.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -124,7 +125,10 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
         ThrowIfDynamicReadModelWritesUnsupportedForDelete();
 
         var trimmedId = id.Trim();
-        var startedAt = DateTimeOffset.UtcNow;
+        // Refactor (iter89/cluster-089-projection-provider-elapsed-clock):
+        // Old: elapsedMs used DateTimeOffset.UtcNow subtraction, so wall-clock changes could skew duration logs.
+        // New: elapsedMs uses a monotonic Stopwatch timestamp; projection clocks remain for semantic timestamps only.
+        var startedAtTimestamp = Stopwatch.GetTimestamp();
         try
         {
             using var response = await _httpClient.DeleteAsync(
@@ -144,7 +148,7 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
                 result = ResolveDeleteResultFromPayload(payload);
             }
 
-            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+            var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
             _logger.LogInformation(
                 "Projection read-model delete completed. provider={Provider} readModelType={ReadModelType} key={Key} elapsedMs={ElapsedMs} result={Result}",
                 ProviderName,
@@ -156,7 +160,7 @@ public sealed class ElasticsearchProjectionDocumentStore<TReadModel, TKey>
         }
         catch (Exception ex)
         {
-            var elapsedMs = (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds;
+            var elapsedMs = Stopwatch.GetElapsedTime(startedAtTimestamp).TotalMilliseconds;
             _logger.LogError(
                 ex,
                 "Projection read-model delete failed. provider={Provider} readModelType={ReadModelType} key={Key} elapsedMs={ElapsedMs} result={Result} errorType={ErrorType}",

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionElapsedLoggingSourceRegressionTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ElasticsearchProjectionElapsedLoggingSourceRegressionTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+
+namespace Aevatar.CQRS.Projection.Core.Tests;
+
+public sealed class ElasticsearchProjectionElapsedLoggingSourceRegressionTests
+{
+    [Fact]
+    public void ElasticsearchElapsedLoggingSources_ShouldUseMonotonicStopwatchClock()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var elapsedLoggingSources = new[]
+        {
+            "src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchProjectionDocumentStore.cs",
+            "src/Aevatar.CQRS.Projection.Providers.Elasticsearch/Stores/ElasticsearchOptimisticWriter.cs",
+        };
+
+        foreach (var relativePath in elapsedLoggingSources)
+        {
+            var source = File.ReadAllText(Path.Combine(repositoryRoot, relativePath));
+
+            source.Should().NotContain(
+                "DateTimeOffset.UtcNow -",
+                $"{relativePath} elapsedMs logging must not subtract wall-clock timestamps");
+            source.Should().NotContain(
+                "DateTimeOffset.UtcNow.Subtract",
+                $"{relativePath} elapsedMs logging must not subtract wall-clock timestamps");
+            source.Should().Contain(
+                "Stopwatch.GetTimestamp()",
+                $"{relativePath} elapsedMs logging must start from a monotonic timestamp");
+            source.Should().Contain(
+                "Stopwatch.GetElapsedTime(",
+                $"{relativePath} elapsedMs logging must calculate duration from the monotonic timestamp");
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "aevatar.slnx")))
+                return directory.FullName;
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from test base directory.");
+    }
+}


### PR DESCRIPTION
## 摘要

iter89 cluster-089-projection-provider-elapsed-clock(severity:low,rules:RULE-TIMING-MONOTONIC-ELAPSED + RULE-TIMING-CLOCK-INJECTION)。

- **Old**:`ElasticsearchOptimisticWriter` + `ElasticsearchProjectionDocumentStore` 用 `DateTimeOffset.UtcNow` 减法计 elapsedMs(wall-clock 非 monotonic;NTP adjust 时可能负值或跳跃)
- **New**:用 `Stopwatch.GetTimestamp` / `Environment.TickCount64` monotonic 计 elapsed;wall-clock 仅用于 semantic timestamp

2 文件(+22 / -14)。验证 ES projection 编译 + 测试 + `ci/*_guards.sh` pass。

🤖 Auto-loop / codex-refactor-loop iter89

⟦AI:AUTO-LOOP⟧
