### PR TITLE
iter89 cluster-089: ChannelScheduleRunner 注入 IClock + ITimeZoneResolver(actor turn 单次采样)

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/ChannelScheduleCalculator.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ChannelScheduleCalculator.cs
@@ -11,7 +11,7 @@ public static class ChannelScheduleCalculator
 {
     public static bool TryGetNextOccurrence(
         string cronExpression,
-        string? timeZoneId,
+        TimeZoneInfo timeZone,
         DateTimeOffset fromUtc,
         out DateTimeOffset nextRunAtUtc,
         out string? error)
@@ -25,8 +25,7 @@ public static class ChannelScheduleCalculator
             return false;
         }
 
-        if (!TryResolveTimeZone(timeZoneId, out var timeZone, out error))
-            return false;
+        ArgumentNullException.ThrowIfNull(timeZone);
 
         CronExpression expression;
         try
@@ -48,35 +47,6 @@ public static class ChannelScheduleCalculator
 
         nextRunAtUtc = new DateTimeOffset(DateTime.SpecifyKind(nextUtc.Value, DateTimeKind.Utc), TimeSpan.Zero);
         return true;
-    }
-
-    public static bool TryResolveTimeZone(
-        string? timeZoneId,
-        out TimeZoneInfo timeZone,
-        out string? error)
-    {
-        error = null;
-        var normalized = string.IsNullOrWhiteSpace(timeZoneId)
-            ? SkillRunnerDefaults.DefaultTimezone
-            : timeZoneId.Trim();
-
-        try
-        {
-            timeZone = TimeZoneInfo.FindSystemTimeZoneById(normalized);
-            return true;
-        }
-        catch (TimeZoneNotFoundException ex)
-        {
-            timeZone = TimeZoneInfo.Utc;
-            error = ex.Message;
-            return false;
-        }
-        catch (InvalidTimeZoneException ex)
-        {
-            timeZone = TimeZoneInfo.Utc;
-            error = ex.Message;
-            return false;
-        }
     }
 
     public static TimeSpan ComputeDueTime(DateTimeOffset nextRunAtUtc, DateTimeOffset nowUtc)

--- a/agents/Aevatar.GAgents.Scheduled/ChannelScheduleRunner.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ChannelScheduleRunner.cs
@@ -20,6 +20,8 @@ internal sealed class ChannelScheduleRunner
     private readonly Func<DateTimeOffset, Task> _persistNextRunEventAsync;
     private readonly Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> _scheduleTimeoutAsync;
     private readonly Func<RuntimeCallbackLease, CancellationToken, Task> _cancelCallbackAsync;
+    private readonly IClock _clock;
+    private readonly ITimeZoneResolver _timeZoneResolver;
     private readonly ILogger _logger;
     private readonly string _ownerDescription;
 
@@ -32,6 +34,8 @@ internal sealed class ChannelScheduleRunner
         Func<DateTimeOffset, Task> persistNextRunEventAsync,
         Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> scheduleTimeoutAsync,
         Func<RuntimeCallbackLease, CancellationToken, Task> cancelCallbackAsync,
+        IClock? clock,
+        ITimeZoneResolver? timeZoneResolver,
         ILogger logger,
         string ownerDescription)
     {
@@ -41,6 +45,8 @@ internal sealed class ChannelScheduleRunner
         _persistNextRunEventAsync = persistNextRunEventAsync ?? throw new ArgumentNullException(nameof(persistNextRunEventAsync));
         _scheduleTimeoutAsync = scheduleTimeoutAsync ?? throw new ArgumentNullException(nameof(scheduleTimeoutAsync));
         _cancelCallbackAsync = cancelCallbackAsync ?? throw new ArgumentNullException(nameof(cancelCallbackAsync));
+        _clock = clock ?? new SystemClock();
+        _timeZoneResolver = timeZoneResolver ?? new TimeZoneResolver();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _ownerDescription = ownerDescription ?? string.Empty;
     }
@@ -48,36 +54,53 @@ internal sealed class ChannelScheduleRunner
     /// <summary>Revives the schedule after actor activation when the previous run window has lapsed.</summary>
     public Task BootstrapOnActivateAsync(CancellationToken ct)
     {
+        var nowUtc = _clock.UtcNow;
         var schedule = _schedulableSource().Schedule;
         if (!schedule.Enabled || string.IsNullOrWhiteSpace(schedule.Cron))
             return Task.CompletedTask;
 
         var nextRun = schedule.NextRunAt;
-        if (nextRun != null && nextRun.ToDateTimeOffset() > DateTimeOffset.UtcNow)
+        if (nextRun != null && nextRun.ToDateTimeOffset() > nowUtc)
             return Task.CompletedTask;
 
-        return ScheduleNextRunAsync(DateTimeOffset.UtcNow, ct);
+        return ScheduleNextRunAsync(nowUtc, ct);
+    }
+
+    /// <summary>Samples the wall clock once, then computes and schedules the next run.</summary>
+    public Task ScheduleNextRunAsync(CancellationToken ct)
+    {
+        var nowUtc = _clock.UtcNow;
+        return ScheduleNextRunAsync(nowUtc, ct);
     }
 
     /// <summary>Computes the next cron occurrence and (re)places the durable callback lease.</summary>
-    public async Task ScheduleNextRunAsync(DateTimeOffset fromUtc, CancellationToken ct)
+    public async Task ScheduleNextRunAsync(DateTimeOffset sampledUtc, CancellationToken ct)
     {
         var schedule = _schedulableSource().Schedule;
         if (!schedule.Enabled || string.IsNullOrWhiteSpace(schedule.Cron))
             return;
 
-        if (!ChannelScheduleCalculator.TryGetNextOccurrence(
-                schedule.Cron,
-                schedule.Timezone,
-                fromUtc,
-                out var nextRunAtUtc,
-                out var error))
+        // Refactor (iter89/cluster-089-scheduled-runner-wall-clock):
+        //   Old: cron helpers resolved OS timezones directly and due-time used a second DateTimeOffset.UtcNow read.
+        //   New: the runner receives clock/timezone dependencies and pure schedule math uses one sampled actor-turn time.
+        if (!_timeZoneResolver.TryResolve(schedule.Timezone, out var timeZone, out var error))
         {
             _logger.LogWarning("{Owner} could not compute next run: {Error}", _ownerDescription, error);
             return;
         }
 
-        var dueTime = ChannelScheduleCalculator.ComputeDueTime(nextRunAtUtc, DateTimeOffset.UtcNow);
+        if (!ChannelScheduleCalculator.TryGetNextOccurrence(
+                schedule.Cron,
+                timeZone,
+                sampledUtc,
+                out var nextRunAtUtc,
+                out error))
+        {
+            _logger.LogWarning("{Owner} could not compute next run: {Error}", _ownerDescription, error);
+            return;
+        }
+
+        var dueTime = ChannelScheduleCalculator.ComputeDueTime(nextRunAtUtc, sampledUtc);
 
         if (_lease != null)
             await _cancelCallbackAsync(_lease, ct);

--- a/agents/Aevatar.GAgents.Scheduled/DependencyInjection/ScheduledServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Scheduled/DependencyInjection/ScheduledServiceCollectionExtensions.cs
@@ -41,6 +41,8 @@ public static class ScheduledServiceCollectionExtensions
         // ─── Retired-actor cleanup contribution ───
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IRetiredActorSpec, ScheduledRetiredActorSpec>());
+        services.TryAddSingleton<IClock, SystemClock>();
+        services.TryAddSingleton<ITimeZoneResolver, TimeZoneResolver>();
         services.TryAddSingleton<ProjectionActivationPlanDispatcher>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<
             ICommittedStatePublicationHook,

--- a/agents/Aevatar.GAgents.Scheduled/IClock.cs
+++ b/agents/Aevatar.GAgents.Scheduled/IClock.cs
@@ -1,0 +1,17 @@
+namespace Aevatar.GAgents.Scheduled;
+
+/// <summary>
+/// Provides the current UTC wall clock for scheduled-agent decisions.
+/// </summary>
+public interface IClock
+{
+    DateTimeOffset UtcNow { get; }
+}
+
+/// <summary>
+/// Default wall clock backed by the system UTC clock.
+/// </summary>
+public sealed class SystemClock : IClock
+{
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/agents/Aevatar.GAgents.Scheduled/ITimeZoneResolver.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ITimeZoneResolver.cs
@@ -1,0 +1,9 @@
+namespace Aevatar.GAgents.Scheduled;
+
+public interface ITimeZoneResolver
+{
+    bool TryResolve(
+        string? timeZoneId,
+        out TimeZoneInfo timeZone,
+        out string? error);
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -27,6 +27,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 {
     private readonly NyxIdApiClient? _nyxIdApiClient;
     private readonly IOwnerLlmConfigSource? _ownerLlmConfigSource;
+    private readonly IClock _clock;
+    private readonly ITimeZoneResolver _timeZoneResolver;
     // Per-run counter for nyxid_proxy outcomes, populated by the instance-owned
     // NyxIdProxyToolFailureCountingMiddleware appended to the tool-call middleware chain.
     // The runner reads it after each ChatStreamAsync to enforce the safety net for issue
@@ -44,7 +46,9 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IEnumerable<IAgentToolSource>? toolSources = null,
         NyxIdApiClient? nyxIdApiClient = null,
         IOwnerLlmConfigSource? ownerLlmConfigSource = null,
-        IToolApprovalHandler? approvalHandler = null)
+        IToolApprovalHandler? approvalHandler = null,
+        IClock? clock = null,
+        ITimeZoneResolver? timeZoneResolver = null)
         : this(
             BuildToolMiddlewareChain(toolMiddlewares),
             llmProviderFactory,
@@ -54,7 +58,9 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             toolSources,
             nyxIdApiClient,
             ownerLlmConfigSource,
-            approvalHandler)
+            approvalHandler,
+            clock,
+            timeZoneResolver)
     {
     }
 
@@ -67,7 +73,9 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         IEnumerable<IAgentToolSource>? toolSources,
         NyxIdApiClient? nyxIdApiClient,
         IOwnerLlmConfigSource? ownerLlmConfigSource,
-        IToolApprovalHandler? approvalHandler)
+        IToolApprovalHandler? approvalHandler,
+        IClock? clock,
+        ITimeZoneResolver? timeZoneResolver)
         : base(
             llmProviderFactory,
             additionalHooks,
@@ -79,6 +87,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
     {
         _nyxIdApiClient = nyxIdApiClient;
         _ownerLlmConfigSource = ownerLlmConfigSource;
+        _clock = clock ?? new SystemClock();
+        _timeZoneResolver = timeZoneResolver ?? new TimeZoneResolver();
         _toolFailureCounter = toolMiddlewareChain.Counter;
     }
 
@@ -108,6 +118,8 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         }),
         scheduleTimeoutAsync: (id, dueTime, evt, ct) => ScheduleSelfDurableTimeoutAsync(id, dueTime, evt, ct: ct),
         cancelCallbackAsync: (lease, ct) => CancelDurableCallbackAsync(lease, ct),
+        clock: _clock,
+        timeZoneResolver: _timeZoneResolver,
         logger: Logger,
         ownerDescription: $"Skill runner {Id}");
 
@@ -185,7 +197,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
         await PersistDomainEventAsync(initialized);
 
-        await Scheduler.ScheduleNextRunAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+        // Refactor (iter89/cluster-089-scheduled-runner-wall-clock):
+        //   Old: SkillRunnerGAgent sampled DateTimeOffset.UtcNow and cron helper resolved timezone inline.
+        //   New: ChannelScheduleRunner owns injected clock/timezone dependencies and samples once for this turn.
+        await Scheduler.ScheduleNextRunAsync(CancellationToken.None);
         await UpsertRegistryAsync(CancellationToken.None);
     }
 
@@ -198,7 +213,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             return;
         }
 
-        var now = DateTimeOffset.UtcNow;
+        var now = _clock.UtcNow;
         try
         {
             var output = await ExecuteSkillAsync(now, command.Reason, CancellationToken.None);
@@ -286,7 +301,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             });
         }
 
-        await Scheduler.ScheduleNextRunAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+        await Scheduler.ScheduleNextRunAsync(CancellationToken.None);
     }
 
     private async Task<string> ExecuteSkillAsync(DateTimeOffset now, string? reason, CancellationToken ct)

--- a/agents/Aevatar.GAgents.Scheduled/TimeZoneResolver.cs
+++ b/agents/Aevatar.GAgents.Scheduled/TimeZoneResolver.cs
@@ -1,0 +1,36 @@
+namespace Aevatar.GAgents.Scheduled;
+
+/// <summary>
+/// Resolves configured schedule timezone identifiers at the infrastructure boundary.
+/// </summary>
+public sealed class TimeZoneResolver : ITimeZoneResolver
+{
+    public bool TryResolve(
+        string? timeZoneId,
+        out TimeZoneInfo timeZone,
+        out string? error)
+    {
+        error = null;
+        var normalized = string.IsNullOrWhiteSpace(timeZoneId)
+            ? SkillRunnerDefaults.DefaultTimezone
+            : timeZoneId.Trim();
+
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(normalized);
+            return true;
+        }
+        catch (TimeZoneNotFoundException ex)
+        {
+            timeZone = TimeZoneInfo.Utc;
+            error = ex.Message;
+            return false;
+        }
+        catch (InvalidTimeZoneException ex)
+        {
+            timeZone = TimeZoneInfo.Utc;
+            error = ex.Message;
+            return false;
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelScheduleCalculatorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelScheduleCalculatorTests.cs
@@ -13,7 +13,7 @@ public sealed class ChannelScheduleCalculatorTests
 
         var ok = ChannelScheduleCalculator.TryGetNextOccurrence(
             "30 9 * * *",
-            "UTC",
+            TimeZoneInfo.Utc,
             fromUtc,
             out var nextRunAtUtc,
             out var error);
@@ -30,7 +30,7 @@ public sealed class ChannelScheduleCalculatorTests
 
         var ok = ChannelScheduleCalculator.TryGetNextOccurrence(
             "0 9 * * *",
-            "Asia/Singapore",
+            TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore"),
             fromUtc,
             out var nextRunAtUtc,
             out var error);
@@ -43,7 +43,7 @@ public sealed class ChannelScheduleCalculatorTests
     [Fact]
     public void TryResolveTimeZone_ReturnsFalse_ForUnknownTimezone()
     {
-        var ok = ChannelScheduleCalculator.TryResolveTimeZone(
+        var ok = new TimeZoneResolver().TryResolve(
             "Mars/Olympus",
             out var timeZone,
             out var error);

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelScheduleRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelScheduleRunnerTests.cs
@@ -1,0 +1,161 @@
+using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class ChannelScheduleRunnerTests
+{
+    [Fact]
+    public async Task ScheduleNextRunAsync_UsesFakeClockSample_ForDueTimeAndCronBase()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2026, 4, 14, 9, 0, 0, TimeSpan.Zero));
+        var resolver = new FakeTimeZoneResolver(TimeZoneInfo.Utc);
+        var source = new TestSchedulable
+        {
+            Schedule =
+            {
+                Enabled = true,
+                Cron = "30 9 * * *",
+                Timezone = "Custom/Test",
+            },
+        };
+        var scheduled = new List<ScheduledTimeout>();
+        var persisted = new List<DateTimeOffset>();
+        var runner = CreateRunner(source, clock, resolver, scheduled, persisted);
+
+        await runner.ScheduleNextRunAsync(CancellationToken.None);
+
+        clock.ReadCount.Should().Be(1);
+        resolver.RequestedTimezones.Should().ContainSingle().Which.Should().Be("Custom/Test");
+        scheduled.Should().ContainSingle();
+        scheduled[0].DueTime.Should().Be(TimeSpan.FromMinutes(30));
+        persisted.Should().ContainSingle().Which.Should().Be(
+            new DateTimeOffset(2026, 4, 14, 9, 30, 0, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public async Task BootstrapOnActivateAsync_WhenNextRunIsFuture_DoesNotReschedule()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2026, 4, 14, 9, 0, 0, TimeSpan.Zero));
+        var resolver = new FakeTimeZoneResolver(TimeZoneInfo.Utc);
+        var source = new TestSchedulable
+        {
+            Schedule =
+            {
+                Enabled = true,
+                Cron = "30 9 * * *",
+                Timezone = "UTC",
+                NextRunAt = Timestamp.FromDateTimeOffset(
+                    new DateTimeOffset(2026, 4, 14, 9, 30, 0, TimeSpan.Zero)),
+            },
+        };
+        var scheduled = new List<ScheduledTimeout>();
+        var persisted = new List<DateTimeOffset>();
+        var runner = CreateRunner(source, clock, resolver, scheduled, persisted);
+
+        await runner.BootstrapOnActivateAsync(CancellationToken.None);
+
+        clock.ReadCount.Should().Be(1);
+        resolver.RequestedTimezones.Should().BeEmpty();
+        scheduled.Should().BeEmpty();
+        persisted.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BootstrapOnActivateAsync_WhenNextRunElapsed_UsesSameFakeClockSample_ForReschedule()
+    {
+        var clock = new FakeClock(new DateTimeOffset(2026, 4, 14, 9, 0, 0, TimeSpan.Zero));
+        var resolver = new FakeTimeZoneResolver(TimeZoneInfo.Utc);
+        var source = new TestSchedulable
+        {
+            Schedule =
+            {
+                Enabled = true,
+                Cron = "30 9 * * *",
+                Timezone = "UTC",
+                NextRunAt = Timestamp.FromDateTimeOffset(
+                    new DateTimeOffset(2026, 4, 14, 8, 30, 0, TimeSpan.Zero)),
+            },
+        };
+        var scheduled = new List<ScheduledTimeout>();
+        var persisted = new List<DateTimeOffset>();
+        var runner = CreateRunner(source, clock, resolver, scheduled, persisted);
+
+        await runner.BootstrapOnActivateAsync(CancellationToken.None);
+
+        clock.ReadCount.Should().Be(1);
+        scheduled.Should().ContainSingle();
+        scheduled[0].DueTime.Should().Be(TimeSpan.FromMinutes(30));
+        persisted.Should().ContainSingle().Which.Should().Be(
+            new DateTimeOffset(2026, 4, 14, 9, 30, 0, TimeSpan.Zero));
+    }
+
+    private static ChannelScheduleRunner CreateRunner(
+        TestSchedulable source,
+        FakeClock clock,
+        ITimeZoneResolver resolver,
+        List<ScheduledTimeout> scheduled,
+        List<DateTimeOffset> persisted) =>
+        new(
+            callbackId: "trigger",
+            schedulableSource: () => source,
+            triggerFactory: static () => new TriggerSkillRunnerExecutionCommand { Reason = "schedule" },
+            persistNextRunEventAsync: next =>
+            {
+                persisted.Add(next);
+                return Task.CompletedTask;
+            },
+            scheduleTimeoutAsync: (id, dueTime, evt, _) =>
+            {
+                scheduled.Add(new ScheduledTimeout(id, dueTime, evt));
+                return Task.FromResult(new RuntimeCallbackLease(
+                    "actor-1",
+                    id,
+                    scheduled.Count,
+                    RuntimeCallbackBackend.InMemory));
+            },
+            cancelCallbackAsync: (_, _) => Task.CompletedTask,
+            clock: clock,
+            timeZoneResolver: resolver,
+            logger: NullLogger.Instance,
+            ownerDescription: "test runner");
+
+    private sealed class TestSchedulable : ISchedulable
+    {
+        public ScheduleState Schedule { get; } = new();
+    }
+
+    private sealed class FakeClock(DateTimeOffset utcNow) : IClock
+    {
+        public int ReadCount { get; private set; }
+
+        public DateTimeOffset UtcNow
+        {
+            get
+            {
+                ReadCount++;
+                return utcNow;
+            }
+        }
+    }
+
+    private sealed class FakeTimeZoneResolver(TimeZoneInfo timeZone) : ITimeZoneResolver
+    {
+        public List<string?> RequestedTimezones { get; } = [];
+
+        public bool TryResolve(string? timeZoneId, out TimeZoneInfo resolved, out string? error)
+        {
+            RequestedTimezones.Add(timeZoneId);
+            resolved = timeZone;
+            error = null;
+            return true;
+        }
+    }
+
+    private sealed record ScheduledTimeout(string CallbackId, TimeSpan DueTime, IMessage Event);
+}


### PR DESCRIPTION
## 摘要

iter89 cluster-089-scheduled-runner-wall-clock(severity:medium,rules:RULE-TIMING-CLOCK-INJECTION + RULE-TIMING-TIMEZONE)。

- **Old**:SkillRunnerGAgent + cron helper 直接 `DateTimeOffset.UtcNow` + 直接 resolve timezone — 不可测
- **New**:`ChannelScheduleRunner` ctor 接 `IClock` + `ITimeZoneResolver`;actor turn 采样 clock 一次 + pass into pure schedule calc

9 文件改动:
- 新 `IClock` + `ITimeZoneResolver` + `TimeZoneResolver` 实现
- ChannelScheduleCalculator 改 pure
- ChannelScheduleRunner / SkillRunnerGAgent / DI 接入
- ChannelScheduleCalculatorTests 重写 + ChannelScheduleRunnerTests(新)

验证:Scheduled + ChannelRuntime.Tests pass + `ci/*_guards.sh` pass。

🤖 Auto-loop / codex-refactor-loop iter89

⟦AI:AUTO-LOOP⟧
