### PR TITLE
iter87 cluster-087: connector registry IAsyncDisposable + dispose-on-replace/shutdown

### DIFF
--- a/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPConnector.cs
@@ -19,8 +19,11 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
     private readonly string? _defaultTool;
     private readonly HashSet<string> _allowedTools;
     private readonly HashSet<string> _allowedInputKeys;
+    private readonly CancellationTokenSource _disposeCts = new();
     private volatile Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>? _tools;
     private readonly ILogger _logger;
+    private readonly bool _ownsClientManager;
+    private int _disposed;
 
     public MCPConnector(
         string name,
@@ -38,6 +41,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         _allowedTools = new HashSet<string>(allowedTools ?? [], StringComparer.OrdinalIgnoreCase);
         _allowedInputKeys = new HashSet<string>(allowedInputKeys ?? [], StringComparer.OrdinalIgnoreCase);
         _clientManager = clientManager ?? new MCPClientManager(logger);
+        _ownsClientManager = clientManager == null;
         _logger = logger ?? NullLogger.Instance;
     }
 
@@ -136,6 +140,8 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
     {
         while (true)
         {
+            ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+
             var current = _tools;
             if (TryGetReusableTask(current, out var cached))
                 return cached;
@@ -146,7 +152,7 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
             // New: publish a non-started Lazy<Task<T>> first; ExecutionAndPublication lets only the
             // winning Lazy start discovery, while losing Lazy instances are never evaluated.
             var candidate = new Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>(
-                () => ConnectAndIndexToolsAsync(ct),
+                () => ConnectAndIndexToolsAsync(ct, _disposeCts.Token),
                 LazyThreadSafetyMode.ExecutionAndPublication);
             var winner = Interlocked.CompareExchange(ref _tools, candidate, current);
             if (ReferenceEquals(winner, current))
@@ -176,17 +182,53 @@ public sealed class MCPConnector : IConnector, IAsyncDisposable
         return true;
     }
 
-    private async Task<IReadOnlyDictionary<string, IAgentTool>> ConnectAndIndexToolsAsync(CancellationToken ct)
+    private async Task<IReadOnlyDictionary<string, IAgentTool>> ConnectAndIndexToolsAsync(
+        CancellationToken requestCt,
+        CancellationToken disposeCt)
     {
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(requestCt, disposeCt);
+        var ct = linkedCts.Token;
         var discovered = await _clientManager.ConnectAndDiscoverAsync(_serverConfig, ct);
         return discovered.ToFrozenDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase);
     }
 
     /// <inheritdoc />
-    public ValueTask DisposeAsync() =>
-        _clientManager is IAsyncDisposable disposable
-            ? disposable.DisposeAsync()
-            : ValueTask.CompletedTask;
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        await _disposeCts.CancelAsync();
+        var toolsTask = TryGetCreatedToolsTask(_tools);
+        if (toolsTask != null)
+        {
+            try
+            {
+                await toolsTask;
+            }
+            catch
+            {
+                // Discovery may be canceled or faulted while shutdown is releasing the transport.
+            }
+        }
+
+        if (_ownsClientManager && _clientManager is IAsyncDisposable disposableClientManager)
+            await disposableClientManager.DisposeAsync();
+
+        // Refactor (iter87/cluster-087):
+        //   Old pattern: remote MCP HttpClient was transferred into connector config but only connected sessions were disposed.
+        //   New principle: connector lifecycle releases owned transport resources even when disposed before first connect.
+        if (_serverConfig.OwnsHttpClient)
+            _serverConfig.HttpClient?.Dispose();
+
+        _disposeCts.Dispose();
+    }
+
+    private static Task<IReadOnlyDictionary<string, IAgentTool>>? TryGetCreatedToolsTask(
+        Lazy<Task<IReadOnlyDictionary<string, IAgentTool>>>? current)
+    {
+        return current is { IsValueCreated: true } ? current.Value : null;
+    }
 
     private static bool TryValidatePayloadKeys(string payload, HashSet<string> allowedKeys, out string error)
     {

--- a/src/Aevatar.AI.ToolProviders.MCP/MCPServerConfig.cs
+++ b/src/Aevatar.AI.ToolProviders.MCP/MCPServerConfig.cs
@@ -27,6 +27,9 @@ public sealed class MCPServerConfig
 
     /// <summary>可选的远程 MCP 专用 HttpClient。</summary>
     public HttpClient? HttpClient { get; init; }
+
+    /// <summary>Whether connector lifecycle owns <see cref="HttpClient"/>.</summary>
+    public bool OwnsHttpClient { get; init; }
 }
 
 /// <summary>MCP Tools 选项。</summary>

--- a/src/Aevatar.Bootstrap.Extensions.AI/Connectors/MCPConnectorBuilder.cs
+++ b/src/Aevatar.Bootstrap.Extensions.AI/Connectors/MCPConnectorBuilder.cs
@@ -63,6 +63,7 @@ public sealed class MCPConnectorBuilder : IConnectorBuilder
             Environment = entry.MCP.Environment,
             AdditionalHeaders = entry.MCP.AdditionalHeaders,
             HttpClient = transportHttpClient,
+            OwnsHttpClient = transportHttpClient != null,
         };
 
         connector = new MCPConnector(

--- a/src/Aevatar.Bootstrap/ConnectorRegistration.cs
+++ b/src/Aevatar.Bootstrap/ConnectorRegistration.cs
@@ -7,11 +7,12 @@ namespace Aevatar.Bootstrap;
 
 public static class ConnectorRegistration
 {
-    public static int RegisterConnectors(
+    public static async Task<int> RegisterConnectorsAsync(
         IConnectorRegistry registry,
         IEnumerable<IConnectorBuilder> connectorBuilders,
         ILogger logger,
-        string? connectorsJsonPath = null)
+        string? connectorsJsonPath = null,
+        CancellationToken ct = default)
     {
         var entries = AevatarConnectorConfig.LoadConnectors(connectorsJsonPath);
         if (entries.Count == 0)
@@ -33,7 +34,12 @@ public static class ConnectorRegistration
             if (!builder.TryBuild(entry, logger, out var connector) || connector == null)
                 continue;
 
-            registry.Register(connector);
+            // Refactor (iter87/cluster-087):
+            //   Old pattern: startup-built disposable MCP connectors were stored in a sync registry with no shutdown owner.
+            //   New principle: bootstrap-created connectors enter the registry as owned lifecycle resources.
+            await registry.RegisterAsync(
+                global::Aevatar.Foundation.Abstractions.Connectors.ConnectorRegistration.Owned(connector),
+                ct);
             added++;
         }
 

--- a/src/Aevatar.Bootstrap/Hosting/ConnectorBootstrapHostedService.cs
+++ b/src/Aevatar.Bootstrap/Hosting/ConnectorBootstrapHostedService.cs
@@ -10,6 +10,8 @@ public sealed class ConnectorBootstrapHostedService : IHostedService
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<ConnectorBootstrapHostedService> _logger;
+    private IConnectorRegistry? _registry;
+    private int _disposeStarted;
 
     public ConnectorBootstrapHostedService(
         IServiceProvider serviceProvider,
@@ -31,6 +33,7 @@ public sealed class ConnectorBootstrapHostedService : IHostedService
             return;
         }
 
+        _registry = registry;
         var connectorBuilders = scope.ServiceProvider.GetServices<IConnectorBuilder>();
         await ConnectorRegistration.RegisterConnectorsAsync(registry, connectorBuilders, _logger, ct: cancellationToken);
 
@@ -39,5 +42,14 @@ public sealed class ConnectorBootstrapHostedService : IHostedService
             _logger.LogInformation("Connectors loaded: {Count} [{Names}]", names.Count, string.Join(", ", names));
     }
 
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
+            return;
+
+        var registry = _registry;
+        if (registry is not null)
+            await registry.DisposeAsync();
+    }
 }

--- a/src/Aevatar.Bootstrap/Hosting/ConnectorBootstrapHostedService.cs
+++ b/src/Aevatar.Bootstrap/Hosting/ConnectorBootstrapHostedService.cs
@@ -19,7 +19,7 @@ public sealed class ConnectorBootstrapHostedService : IHostedService
         _logger = logger;
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -28,17 +28,15 @@ public sealed class ConnectorBootstrapHostedService : IHostedService
         if (registry == null)
         {
             _logger.LogDebug("Skip connector bootstrap because IConnectorRegistry is not registered.");
-            return Task.CompletedTask;
+            return;
         }
 
         var connectorBuilders = scope.ServiceProvider.GetServices<IConnectorBuilder>();
-        ConnectorRegistration.RegisterConnectors(registry, connectorBuilders, _logger);
+        await ConnectorRegistration.RegisterConnectorsAsync(registry, connectorBuilders, _logger, ct: cancellationToken);
 
         var names = registry.ListNames();
         if (names.Count > 0)
             _logger.LogInformation("Connectors loaded: {Count} [{Names}]", names.Count, string.Join(", ", names));
-
-        return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/Aevatar.Foundation.Abstractions/Connectors/IConnector.cs
+++ b/src/Aevatar.Foundation.Abstractions/Connectors/IConnector.cs
@@ -73,14 +73,52 @@ public sealed class ConnectorResponse
 /// <summary>
 /// Registry for named connectors.
 /// </summary>
-public interface IConnectorRegistry
+public interface IConnectorRegistry : IAsyncDisposable
 {
     /// <summary>Registers or replaces a connector by name.</summary>
-    void Register(IConnector connector);
+    ValueTask RegisterAsync(ConnectorRegistration registration, CancellationToken ct = default);
 
     /// <summary>Resolves a connector by name.</summary>
     bool TryGet(string name, out IConnector? connector);
 
     /// <summary>Returns all registered connector names.</summary>
     IReadOnlyList<string> ListNames();
+}
+
+/// <summary>
+/// Connector registration ownership.
+/// </summary>
+public enum ConnectorOwnership
+{
+    /// <summary>The registry owns the connector and disposes it on replacement or registry shutdown.</summary>
+    RegistryOwned,
+
+    /// <summary>The caller or DI owns the connector lifetime.</summary>
+    ExternallyOwned,
+}
+
+/// <summary>
+/// Connector registration entry with explicit lifecycle ownership.
+/// </summary>
+public sealed class ConnectorRegistration
+{
+    private ConnectorRegistration(IConnector connector, ConnectorOwnership ownership)
+    {
+        Connector = connector ?? throw new ArgumentNullException(nameof(connector));
+        Ownership = ownership;
+    }
+
+    /// <summary>Connector instance to register by <see cref="IConnector.Name"/>.</summary>
+    public IConnector Connector { get; }
+
+    /// <summary>Lifecycle owner for the connector instance.</summary>
+    public ConnectorOwnership Ownership { get; }
+
+    /// <summary>Creates a registry-owned connector registration.</summary>
+    public static ConnectorRegistration Owned(IConnector connector) =>
+        new(connector, ConnectorOwnership.RegistryOwned);
+
+    /// <summary>Creates an externally owned connector registration.</summary>
+    public static ConnectorRegistration External(IConnector connector) =>
+        new(connector, ConnectorOwnership.ExternallyOwned);
 }

--- a/src/workflow/Aevatar.Workflow.Core/Connectors/ConfiguredConnectorRegistry.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Connectors/ConfiguredConnectorRegistry.cs
@@ -20,20 +20,49 @@ namespace Aevatar.Workflow.Core.Connectors;
 /// </summary>
 public sealed class ConfiguredConnectorRegistry : IConnectorRegistry
 {
-    private ImmutableDictionary<string, IConnector> _connectors =
-        ImmutableDictionary.Create<string, IConnector>(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim _mutationGate = new(1, 1);
+    private ImmutableDictionary<string, ConnectorSlot> _connectors =
+        ImmutableDictionary.Create<string, ConnectorSlot>(StringComparer.OrdinalIgnoreCase);
+    private bool _disposed;
+    private int _disposeStarted;
 
     /// <inheritdoc />
-    public void Register(IConnector connector)
+    public async ValueTask RegisterAsync(ConnectorRegistration registration, CancellationToken ct = default)
     {
-        _connectors = _connectors.SetItem(connector.Name, connector);
+        ArgumentNullException.ThrowIfNull(registration);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposeStarted) != 0, this);
+
+        ConnectorSlot? previousSlot = null;
+        await _mutationGate.WaitAsync(ct);
+        try
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            var connector = registration.Connector;
+            if (_connectors.TryGetValue(connector.Name, out var existing))
+                previousSlot = existing;
+
+            // Refactor (iter87/cluster-087):
+            //   Old pattern: Register replaced a disposable connector in-place, leaving MCP HttpClient/session resources with no owner.
+            //   New principle: registry-owned connector slots are async lifecycle entries; replacement swaps first, then awaits old disposal.
+            _connectors = _connectors.SetItem(
+                connector.Name,
+                new ConnectorSlot(connector, registration.Ownership));
+        }
+        finally
+        {
+            _mutationGate.Release();
+        }
+
+        if (previousSlot is not null && !ReferenceEquals(previousSlot.Connector, registration.Connector))
+            await DisposeSlotAsync(previousSlot);
     }
 
     /// <inheritdoc />
     public bool TryGet(string name, out IConnector? connector)
     {
         var ok = _connectors.TryGetValue(name, out var found);
-        connector = found;
+        connector = found?.Connector;
         return ok;
     }
 
@@ -42,4 +71,57 @@ public sealed class ConfiguredConnectorRegistry : IConnectorRegistry
     {
         return _connectors.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
     }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
+            return;
+
+        ImmutableDictionary<string, ConnectorSlot> snapshot;
+
+        await _mutationGate.WaitAsync();
+        try
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            snapshot = _connectors;
+            _connectors = ImmutableDictionary.Create<string, ConnectorSlot>(StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            _mutationGate.Release();
+        }
+
+        var disposedConnectors = new HashSet<IConnector>(ReferenceEqualityComparer.Instance);
+        foreach (var slot in snapshot.Values)
+        {
+            if (!disposedConnectors.Add(slot.Connector))
+                continue;
+
+            await DisposeSlotAsync(slot);
+        }
+
+        _mutationGate.Dispose();
+    }
+
+    private static async ValueTask DisposeSlotAsync(ConnectorSlot slot)
+    {
+        if (slot.Ownership != ConnectorOwnership.RegistryOwned)
+            return;
+
+        switch (slot.Connector)
+        {
+            case IAsyncDisposable asyncDisposable:
+                await asyncDisposable.DisposeAsync();
+                break;
+            case IDisposable disposable:
+                disposable.Dispose();
+                break;
+        }
+    }
+
+    private sealed record ConnectorSlot(IConnector Connector, ConnectorOwnership Ownership);
 }

--- a/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
+++ b/test/Aevatar.AI.Tests/AIComponentCoverageTests.cs
@@ -812,6 +812,27 @@ public class AIComponentCoverageTests
         await manager.DisposeAsync();
     }
 
+    [Fact]
+    public async Task MCPConnector_DisposeAsync_BeforeConnect_ShouldDisposeOwnedRemoteHttpClient()
+    {
+        var handler = new RecordingDisposeHandler();
+        var client = new HttpClient(handler);
+        var connector = new MCPConnector(
+            name: "mcp-owned-http",
+            serverConfig: new MCPServerConfig
+            {
+                Name = "server-owned-http",
+                Url = "https://example.com/mcp",
+                HttpClient = client,
+                OwnsHttpClient = true,
+            });
+
+        await connector.DisposeAsync();
+        await connector.DisposeAsync();
+
+        handler.DisposeCount.Should().Be(1);
+    }
+
     private static async IAsyncEnumerable<ChatResponseUpdate> Stream(IEnumerable<string> parts)
     {
         foreach (var part in parts)
@@ -1060,5 +1081,26 @@ public class AIComponentCoverageTests
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken) =>
             onSend(request);
+    }
+
+    private sealed class RecordingDisposeHandler : HttpMessageHandler
+    {
+        public int DisposeCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _ = request;
+            _ = cancellationToken;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                DisposeCount++;
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj
+++ b/test/Aevatar.Bootstrap.Tests/Aevatar.Bootstrap.Tests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\Aevatar.Configuration\Aevatar.Configuration.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Foundation.Abstractions\Aevatar.Foundation.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Aevatar.Hosting\Aevatar.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\workflow\Aevatar.Workflow.Core\Aevatar.Workflow.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/test/Aevatar.Bootstrap.Tests/ConnectorAndHostingCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/ConnectorAndHostingCoverageTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ConnectorRegistryEntry = Aevatar.Foundation.Abstractions.Connectors.ConnectorRegistration;
 
 namespace Aevatar.Bootstrap.Tests;
 
@@ -401,7 +402,7 @@ public class ConnectorAndHostingCoverageTests
     }
 
     [Fact]
-    public void ConnectorRegistration_ShouldBuildSupportedConnectorsOnly()
+    public async Task ConnectorRegistration_ShouldBuildSupportedConnectorsOnly()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"connector-reg-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
@@ -430,7 +431,7 @@ public class ConnectorAndHostingCoverageTests
             var logger = NullLogger.Instance;
             var builders = new IConnectorBuilder[] { new HttpConnectorBuilder() };
 
-            var added = ConnectorRegistration.RegisterConnectors(registry, builders, logger, filePath);
+            var added = await ConnectorRegistration.RegisterConnectorsAsync(registry, builders, logger, filePath);
 
             added.Should().Be(1);
             registry.ListNames().Should().ContainSingle().Which.Should().Be("valid_http");
@@ -479,7 +480,7 @@ public class ConnectorAndHostingCoverageTests
             services.AddSingleton<IConnectorRegistry, InMemoryConnectorRegistry>();
             services.AddSingleton<IConnectorBuilder, HttpConnectorBuilder>();
 
-            using var provider = services.BuildServiceProvider();
+            await using var provider = services.BuildServiceProvider();
             var service = new ConnectorBootstrapHostedService(
                 provider,
                 NullLogger<ConnectorBootstrapHostedService>.Instance);
@@ -749,7 +750,12 @@ public class ConnectorAndHostingCoverageTests
     {
         private readonly Dictionary<string, IConnector> _connectors = new(StringComparer.OrdinalIgnoreCase);
 
-        public void Register(IConnector connector) => _connectors[connector.Name] = connector;
+        public ValueTask RegisterAsync(ConnectorRegistryEntry registration, CancellationToken ct = default)
+        {
+            _ = ct;
+            _connectors[registration.Connector.Name] = registration.Connector;
+            return ValueTask.CompletedTask;
+        }
 
         public bool TryGet(string name, out IConnector? connector)
         {
@@ -759,6 +765,8 @@ public class ConnectorAndHostingCoverageTests
         }
 
         public IReadOnlyList<string> ListNames() => _connectors.Keys.OrderBy(x => x, StringComparer.Ordinal).ToList();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class RecordingHttpClientFactory(Func<string, HttpClient> clientFactory) : IHttpClientFactory

--- a/test/Aevatar.Bootstrap.Tests/ConnectorAndHostingCoverageTests.cs
+++ b/test/Aevatar.Bootstrap.Tests/ConnectorAndHostingCoverageTests.cs
@@ -6,6 +6,7 @@ using Aevatar.Bootstrap.Connectors;
 using Aevatar.Bootstrap.Hosting;
 using Aevatar.Configuration;
 using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Workflow.Core.Connectors;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -443,6 +444,51 @@ public class ConnectorAndHostingCoverageTests
     }
 
     [Fact]
+    public async Task ConnectorRegistration_ShouldRegisterBootstrapConnectorsAsRegistryOwned()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"connector-ownership-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var filePath = Path.Combine(tempDir, "connectors.json");
+
+        File.WriteAllText(filePath,
+            """
+            {
+              "connectors": [
+                {
+                  "name": "owned_connector",
+                  "type": "recording"
+                }
+              ]
+            }
+            """);
+
+        try
+        {
+            await using var registry = new ConfiguredConnectorRegistry();
+            var connector = new RecordingConnector("owned_connector", "recording");
+            var builders = new IConnectorBuilder[] { new RecordingConnectorBuilder("recording", connector) };
+
+            var added = await ConnectorRegistration.RegisterConnectorsAsync(
+                registry,
+                builders,
+                NullLogger.Instance,
+                filePath);
+
+            added.Should().Be(1);
+            registry.TryGet("owned_connector", out var resolved).Should().BeTrue();
+            resolved.Should().BeSameAs(connector);
+
+            await registry.DisposeAsync();
+
+            connector.DisposeCount.Should().Be(1);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task ConnectorBootstrapHostedService_ShouldSkipWithoutRegistryAndLoadWithRegistry()
     {
         var servicesWithoutRegistry = new ServiceCollection();
@@ -489,6 +535,51 @@ public class ConnectorAndHostingCoverageTests
 
             var registry = provider.GetRequiredService<IConnectorRegistry>();
             registry.ListNames().Should().Contain("h1");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, previousHome);
+            Directory.Delete(tempHome, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ConnectorBootstrapHostedService_StopAsync_ShouldDisposeRegistryOwnedConnectors()
+    {
+        var tempHome = Path.Combine(Path.GetTempPath(), $"connector-stop-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempHome);
+        var previousHome = Environment.GetEnvironmentVariable(AevatarPaths.HomeEnv);
+        Environment.SetEnvironmentVariable(AevatarPaths.HomeEnv, tempHome);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempHome, "connectors.json"),
+                """
+                {
+                  "connectors": [
+                    {
+                      "name": "owned_stop_connector",
+                      "type": "recording"
+                    }
+                  ]
+                }
+                """);
+
+            var connector = new RecordingConnector("owned_stop_connector", "recording");
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<IConnectorRegistry, ConfiguredConnectorRegistry>();
+            services.AddSingleton<IConnectorBuilder>(new RecordingConnectorBuilder("recording", connector));
+
+            await using var provider = services.BuildServiceProvider();
+            var service = new ConnectorBootstrapHostedService(
+                provider,
+                NullLogger<ConnectorBootstrapHostedService>.Instance);
+
+            await service.StartAsync(CancellationToken.None);
+            await service.StopAsync(CancellationToken.None);
+
+            connector.DisposeCount.Should().Be(1);
         }
         finally
         {
@@ -743,6 +834,41 @@ public class ConnectorAndHostingCoverageTests
             _ = cancellationToken;
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(scheme, token);
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingConnectorBuilder(string type, IConnector connector) : IConnectorBuilder
+    {
+        public string Type { get; } = type;
+
+        public bool TryBuild(ConnectorConfigEntry entry, ILogger logger, out IConnector? builtConnector)
+        {
+            _ = entry;
+            _ = logger;
+            builtConnector = connector;
+            return true;
+        }
+    }
+
+    private sealed class RecordingConnector(string name, string type) : IConnector, IAsyncDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public string Name { get; } = name;
+
+        public string Type { get; } = type;
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            return Task.FromResult(new ConnectorResponse { Success = true });
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/test/Aevatar.Integration.Tests/ConnectorCallIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallIntegrationTests.cs
@@ -20,7 +20,7 @@ public class ConnectorCallIntegrationTests
     public async Task ConnectorCall_ShouldInvokeRegisteredConnector_AndPublishMetadata()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new FakeConnector("fake_connector", "echo://done"));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FakeConnector("fake_connector", "echo://done")));
         await using var env = BuildEnvironment(registry);
 
         const string yaml = """
@@ -80,7 +80,7 @@ public class ConnectorCallIntegrationTests
     public async Task ConnectorCall_WhenConnectorFailsAndContinue_ShouldKeepInput()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new FakeFailConnector("unstable_connector"));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FakeFailConnector("unstable_connector")));
         await using var env = BuildEnvironment(registry);
 
         const string yaml = """
@@ -109,7 +109,7 @@ public class ConnectorCallIntegrationTests
     public async Task ConnectorCall_WhenRoleHasConnectorsAllowlist_AndConnectorInList_ShouldSucceed()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new FakeConnector("allowed_connector", "ok"));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FakeConnector("allowed_connector", "ok")));
         await using var env = BuildEnvironment(registry);
 
         const string yaml = """
@@ -140,7 +140,7 @@ public class ConnectorCallIntegrationTests
     public async Task ConnectorCall_WhenRoleHasConnectorsAllowlist_AndConnectorNotInList_ShouldFailStep()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new FakeConnector("other_connector", "ok"));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FakeConnector("other_connector", "ok")));
         await using var env = BuildEnvironment(registry);
 
         const string yaml = """

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -84,7 +84,7 @@ public sealed class ConnectorCallModuleCoverageTests
     {
         var registry = new ConfiguredConnectorRegistry();
         var connector = new ThrowThenSuccessConnector("retryable");
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
 
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var ctx = CreateContext();
@@ -119,7 +119,7 @@ public sealed class ConnectorCallModuleCoverageTests
     public async Task HandleAsync_WhenTimeoutAndContinue_ShouldKeepInput()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new DelayConnector("slow"));
+        await registry.RegisterAsync(ConnectorRegistration.External(new DelayConnector("slow")));
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var ctx = CreateContext();
         var request = new StepRequestEvent
@@ -150,7 +150,7 @@ public sealed class ConnectorCallModuleCoverageTests
     {
         var registry = new ConfiguredConnectorRegistry();
         var connector = new EchoConnector("secure");
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var agent = new TestWorkflowRunAgent("connector-module-test-agent", "run-secure");
         var services = new ServiceCollection().BuildServiceProvider();
@@ -199,7 +199,7 @@ public sealed class ConnectorCallModuleCoverageTests
     {
         var registry = new ConfiguredConnectorRegistry();
         var connector = new EchoConnector("secure-json");
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var agent = new TestWorkflowRunAgent("connector-module-test-agent-json", "run-secure-json");
         var services = new ServiceCollection().BuildServiceProvider();
@@ -240,7 +240,7 @@ public sealed class ConnectorCallModuleCoverageTests
     public async Task HandleAsync_WhenAssertResponsePathPassesAndPassThroughEnabled_ShouldKeepOriginalInput()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new FixedResponseConnector("validator", """{"valid":true}"""));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FixedResponseConnector("validator", """{"valid":true}""")));
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var ctx = CreateContext();
         var request = new StepRequestEvent
@@ -267,7 +267,7 @@ public sealed class ConnectorCallModuleCoverageTests
     public async Task HandleAsync_WhenAssertResponsePathFails_ShouldPublishFailure()
     {
         var registry = new ConfiguredConnectorRegistry();
-        registry.Register(new FixedResponseConnector("validator", """{"valid":false}"""));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FixedResponseConnector("validator", """{"valid":false}""")));
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var ctx = CreateContext();
         var request = new StepRequestEvent

--- a/test/Aevatar.Integration.Tests/ConnectorRegistryDisposalTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorRegistryDisposalTests.cs
@@ -1,0 +1,88 @@
+using Aevatar.Foundation.Abstractions.Connectors;
+using Aevatar.Workflow.Core.Connectors;
+using FluentAssertions;
+
+namespace Aevatar.Integration.Tests;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "ConnectorRegistry")]
+public sealed class ConnectorRegistryDisposalTests
+{
+    [Fact]
+    public async Task RegisterAsync_WhenOwnedConnectorIsReplaced_ShouldDisposePreviousConnector()
+    {
+        var registry = new ConfiguredConnectorRegistry();
+        var previous = new RecordingConnector("mcp");
+        var current = new RecordingConnector("mcp");
+
+        await registry.RegisterAsync(ConnectorRegistration.Owned(previous));
+        await registry.RegisterAsync(ConnectorRegistration.Owned(current));
+
+        previous.DisposeCount.Should().Be(1);
+        current.DisposeCount.Should().Be(0);
+        registry.TryGet("mcp", out var resolved).Should().BeTrue();
+        resolved.Should().BeSameAs(current);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldDisposeCurrentOwnedConnectorsAndClearRegistry()
+    {
+        var registry = new ConfiguredConnectorRegistry();
+        var first = new RecordingConnector("first");
+        var second = new RecordingConnector("second");
+
+        await registry.RegisterAsync(ConnectorRegistration.Owned(first));
+        await registry.RegisterAsync(ConnectorRegistration.Owned(second));
+        await registry.DisposeAsync();
+        await registry.DisposeAsync();
+
+        first.DisposeCount.Should().Be(1);
+        second.DisposeCount.Should().Be(1);
+        registry.ListNames().Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ShouldNotDisposeExternallyOwnedConnectors()
+    {
+        var registry = new ConfiguredConnectorRegistry();
+        var external = new RecordingConnector("external");
+
+        await registry.RegisterAsync(ConnectorRegistration.External(external));
+        await registry.DisposeAsync();
+
+        external.DisposeCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_AfterDispose_ShouldThrow()
+    {
+        var registry = new ConfiguredConnectorRegistry();
+        await registry.DisposeAsync();
+
+        var act = async () => await registry.RegisterAsync(ConnectorRegistration.Owned(new RecordingConnector("late")));
+
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+
+    private sealed class RecordingConnector(string name) : IConnector, IAsyncDisposable
+    {
+        public int DisposeCount { get; private set; }
+
+        public string Name { get; } = name;
+
+        public string Type => "test";
+
+        public Task<ConnectorResponse> ExecuteAsync(ConnectorRequest request, CancellationToken ct = default)
+        {
+            _ = request;
+            _ = ct;
+            return Task.FromResult(new ConnectorResponse { Success = true });
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/test/Aevatar.Workflow.Core.Tests/Extensions/WorkflowBridgeExtensionRegistrationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Extensions/WorkflowBridgeExtensionRegistrationTests.cs
@@ -33,7 +33,7 @@ public sealed class WorkflowBridgeExtensionRegistrationTests
     }
 
     [Fact]
-    public void AddWorkflowBridgeExtensions_ShouldRegisterTelegramGetUpdatesExternalLinkTransportFactory()
+    public async Task AddWorkflowBridgeExtensions_ShouldRegisterTelegramGetUpdatesExternalLinkTransportFactory()
     {
         var services = new ServiceCollection();
         services.AddSingleton<IConnectorRegistry, EmptyConnectorRegistry>();
@@ -42,7 +42,7 @@ public sealed class WorkflowBridgeExtensionRegistrationTests
 
         services.AddWorkflowBridgeExtensions();
 
-        using var provider = services.BuildServiceProvider();
+        await using var provider = services.BuildServiceProvider();
 
         var factories = provider.GetServices<IExternalLinkTransportFactory>();
         var factory = factories.Should().ContainSingle(x =>
@@ -53,9 +53,11 @@ public sealed class WorkflowBridgeExtensionRegistrationTests
 
     private sealed class EmptyConnectorRegistry : IConnectorRegistry
     {
-        public void Register(IConnector connector)
+        public ValueTask RegisterAsync(ConnectorRegistration registration, CancellationToken ct = default)
         {
-            _ = connector;
+            _ = registration;
+            _ = ct;
+            return ValueTask.CompletedTask;
         }
 
         public bool TryGet(string name, out IConnector? connector)
@@ -66,5 +68,7 @@ public sealed class WorkflowBridgeExtensionRegistrationTests
         }
 
         public IReadOnlyList<string> ListNames() => [];
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramBridgeGAgentTests.cs
@@ -26,7 +26,7 @@ public sealed class TelegramBridgeGAgentTests
             Output = """{"ok":true,"result":{"text":"telegram-ok"}}""",
         });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramBridgeGAgent(
             new NoopActorRuntime(),
@@ -100,7 +100,7 @@ public sealed class TelegramBridgeGAgentTests
             Output = """{"ok":true,"result":{"text":"telegram-ok"}}""",
         });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramBridgeGAgent(
             new NoopActorRuntime(),
@@ -135,7 +135,7 @@ public sealed class TelegramBridgeGAgentTests
             Output = """{"ok":true,"result":{"text":"ok"}}""",
         });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramBridgeGAgent(
             new NoopActorRuntime(),
@@ -173,7 +173,7 @@ public sealed class TelegramBridgeGAgentTests
                 Output = "raw-telegram-output",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramBridgeGAgent(
             new NoopActorRuntime(),
@@ -244,7 +244,7 @@ public sealed class TelegramBridgeGAgentTests
                 Output = """{"ok":true,"result":{"text":"ok"}}""",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramUserBridgeGAgent(
             new NoopActorRuntime(),
@@ -280,7 +280,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new RecordingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var runtime = new NoopActorRuntime();
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramBridgeGAgent(
@@ -490,7 +490,7 @@ public sealed class TelegramBridgeGAgentTests
                 Output = """{"ok":true,"result":[]}""",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -593,7 +593,7 @@ public sealed class TelegramBridgeGAgentTests
                 Output = """{"ok":true,"result":[]}""",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -633,7 +633,7 @@ public sealed class TelegramBridgeGAgentTests
                     """{"ok":true,"result":[{"update_id":201,"message":{"chat":{"id":"10001"},"from":{"id":"2002","username":"openclaw_bot"},"text":"[AEVATAR_STREAM_REPLY] bootstrap-reply"}}]}""",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -677,7 +677,7 @@ public sealed class TelegramBridgeGAgentTests
                     """{"ok":true,"result":[{"update_id":301,"message":{"chat":{"id":"10001"},"from":{"id":"2002"},"text":"[AEVATAR_STREAM_REPLY] no-username-reply"}}]}""",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -714,7 +714,7 @@ public sealed class TelegramBridgeGAgentTests
             Output = """{"ok":false,"description":"telegram denied getUpdates"}""",
         });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -773,7 +773,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new HangingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -805,7 +805,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new HangingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var scheduler = new RecordingRuntimeCallbackScheduler();
         var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher, scheduler);
@@ -837,7 +837,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new HangingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
 
@@ -871,7 +871,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new RecordingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -900,7 +900,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new RecordingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramWaitReplyGAgent(
             new NoopActorRuntime(),
@@ -937,7 +937,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new HangingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
 
@@ -965,7 +965,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new HangingConnector();
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
 
@@ -999,7 +999,7 @@ public sealed class TelegramBridgeGAgentTests
     {
         var connector = new AsyncFaultingConnector(new InvalidOperationException("remote fault"));
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var (agent, dispatch) = await CreateActivatedWaitReplyAgentAsync(registry, publisher);
 
@@ -1039,7 +1039,7 @@ public sealed class TelegramBridgeGAgentTests
                 Output = """{"ok":true,"result":{"text":"telegram-user-ok"}}""",
             });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var publisher = new RecordingEventPublisher();
         var agent = new TelegramUserBridgeGAgent(
             new NoopActorRuntime(),
@@ -1256,11 +1256,18 @@ public sealed class TelegramBridgeGAgentTests
     {
         private readonly Dictionary<string, IConnector> _connectors = new(StringComparer.OrdinalIgnoreCase);
 
-        public void Register(IConnector connector) => _connectors[connector.Name] = connector;
+        public ValueTask RegisterAsync(ConnectorRegistration registration, CancellationToken ct = default)
+        {
+            _ = ct;
+            _connectors[registration.Connector.Name] = registration.Connector;
+            return ValueTask.CompletedTask;
+        }
 
         public bool TryGet(string name, out IConnector? connector) => _connectors.TryGetValue(name, out connector);
 
         public IReadOnlyList<string> ListNames() => _connectors.Keys.ToList();
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class RecordingEventPublisher : IEventPublisher

--- a/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/TelegramGetUpdatesExternalLinkTransportTests.cs
@@ -19,7 +19,7 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
             Output = """{"ok":true,"result":[]}""",
         });
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(connector);
+        await registry.RegisterAsync(ConnectorRegistration.External(connector));
         var transport = CreateTransport(registry);
         var sink = new RecordingExternalLinkSignalSink();
         transport.SignalSink = sink;
@@ -68,7 +68,7 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
     public async Task SendAsync_WhenConnectorThrowsSynchronously_ShouldPublishFailureResult()
     {
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(new ThrowingConnector(new InvalidOperationException("sync broke")));
+        await registry.RegisterAsync(ConnectorRegistration.External(new ThrowingConnector(new InvalidOperationException("sync broke"))));
         var transport = CreateTransport(registry);
         var sink = new RecordingExternalLinkSignalSink();
         transport.SignalSink = sink;
@@ -84,7 +84,7 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
     public async Task SendAsync_WhenConnectorFaultsAsynchronously_ShouldPublishFailureResult()
     {
         var registry = new InMemoryConnectorRegistry();
-        registry.Register(new FaultingConnector(new InvalidOperationException("async broke")));
+        await registry.RegisterAsync(ConnectorRegistration.External(new FaultingConnector(new InvalidOperationException("async broke"))));
         var transport = CreateTransport(registry);
         var sink = new RecordingExternalLinkSignalSink();
         transport.SignalSink = sink;
@@ -223,8 +223,15 @@ public sealed class TelegramGetUpdatesExternalLinkTransportTests
     {
         private readonly Dictionary<string, IConnector> _connectors = new(StringComparer.OrdinalIgnoreCase);
 
-        public void Register(IConnector connector) => _connectors[connector.Name] = connector;
+        public ValueTask RegisterAsync(ConnectorRegistration registration, CancellationToken ct = default)
+        {
+            _ = ct;
+            _connectors[registration.Connector.Name] = registration.Connector;
+            return ValueTask.CompletedTask;
+        }
+
         public bool TryGet(string name, out IConnector? connector) => _connectors.TryGetValue(name, out connector);
         public IReadOnlyList<string> ListNames() => _connectors.Keys.ToList();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## 摘要

iter87 cluster-087-mcp-connector-registry-disposal(severity:medium,Phase 9 r1 3/3 consensus `registry-as-async-owner-with-dispose-on-replace`)。

- **Old**:`ConfiguredConnectorRegistry` 不接管 disposable MCP connector → HttpClient/transport leak
- **New**:`IConnector` + `ConfiguredConnectorRegistry` 实 `IAsyncDisposable`;register/replace path `await old.DisposeAsync`;`ConnectorBootstrapHostedService` 在 shutdown 时 dispose all

15 文件改动(+359/-59):
- IConnector contract / ConfiguredConnectorRegistry / MCPConnector + Builder / ConnectorBootstrapHostedService / 等
- 新 ConnectorRegistryDisposalTests 覆盖

closes #988

🤖 Auto-loop / codex-refactor-loop iter87

⟦AI:AUTO-LOOP⟧
