### PR TITLE
iter89 cluster-089: status dashboard probe 注入 TimeProvider/clock

### DIFF
--- a/agents/Aevatar.GAgents.StatusDashboard/DependencyInjection/StatusDashboardServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.StatusDashboard/DependencyInjection/StatusDashboardServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class StatusDashboardServiceCollectionExtensions
         // Default executors — additional executors / freshness sources can be
         // registered with TryAddEnumerable by other modules without touching
         // this extension.
+        services.TryAddSingleton(TimeProvider.System);
         services.AddHttpClient();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthProbeExecutor, HttpStatusProbeExecutor>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthProbeExecutor, ReadmodelFreshnessProbeExecutor>());

--- a/agents/Aevatar.GAgents.StatusDashboard/Executors/HttpStatusProbeExecutor.cs
+++ b/agents/Aevatar.GAgents.StatusDashboard/Executors/HttpStatusProbeExecutor.cs
@@ -37,13 +37,16 @@ public sealed class HttpStatusProbeExecutor : IHealthProbeExecutor
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IConfiguration _configuration;
+    private readonly TimeProvider _timeProvider;
 
     public HttpStatusProbeExecutor(
         IHttpClientFactory httpClientFactory,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        TimeProvider timeProvider)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public string Kind => "http_status";
@@ -134,7 +137,7 @@ public sealed class HttpStatusProbeExecutor : IHealthProbeExecutor
         return fallback;
     }
 
-    private static async Task<HealthProbeOutcome?> ValidateBodyAssertionsAsync(
+    private async Task<HealthProbeOutcome?> ValidateBodyAssertionsAsync(
         HealthProbeTargetDescriptor descriptor,
         HttpResponseMessage response,
         CancellationToken ct)
@@ -233,11 +236,14 @@ public sealed class HttpStatusProbeExecutor : IHealthProbeExecutor
         });
     }
 
-    private static HealthProbeOutcome Failure(string detail, string error) => new()
+    private HealthProbeOutcome Failure(string detail, string error) => new()
     {
         Status = HealthOutcomeStatus.Down,
         Detail = detail,
         ErrorMessage = error,
-        ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        // Refactor (iter89/cluster-089-status-dashboard-probe-clock):
+        // Old: executor failure outcomes sampled DateTimeOffset.UtcNow directly.
+        // New: executor failure observed_at is supplied by the injected TimeProvider.
+        ObservedAt = Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow()),
     };
 }

--- a/agents/Aevatar.GAgents.StatusDashboard/Executors/ReadmodelFreshnessProbeExecutor.cs
+++ b/agents/Aevatar.GAgents.StatusDashboard/Executors/ReadmodelFreshnessProbeExecutor.cs
@@ -17,11 +17,15 @@ namespace Aevatar.GAgents.StatusDashboard.Executors;
 public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
 {
     private readonly Dictionary<string, IReadmodelFreshnessSource> _sources;
+    private readonly TimeProvider _timeProvider;
 
-    public ReadmodelFreshnessProbeExecutor(IEnumerable<IReadmodelFreshnessSource> sources)
+    public ReadmodelFreshnessProbeExecutor(
+        IEnumerable<IReadmodelFreshnessSource> sources,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(sources);
         _sources = sources.ToDictionary(s => s.Name, s => s, StringComparer.OrdinalIgnoreCase);
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
     }
 
     public string Kind => "readmodel_freshness";
@@ -37,7 +41,7 @@ public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
                 Status = HealthOutcomeStatus.Down,
                 Detail = "missing_parameter",
                 ErrorMessage = "Parameter 'Source' is required.",
-                ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAt = NowTimestamp(),
             };
         }
 
@@ -48,7 +52,7 @@ public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
                 Status = HealthOutcomeStatus.Down,
                 Detail = "unknown_source",
                 ErrorMessage = $"No IReadmodelFreshnessSource named '{sourceName}'. Known: {string.Join(",", _sources.Keys)}.",
-                ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAt = NowTimestamp(),
             };
         }
 
@@ -67,7 +71,7 @@ public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
                 Status = HealthOutcomeStatus.Down,
                 Detail = "freshness_source_threw",
                 ErrorMessage = ex.Message,
-                ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAt = NowTimestamp(),
             };
         }
 
@@ -78,13 +82,16 @@ public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
                 Status = HealthOutcomeStatus.Degraded,
                 Detail = $"count_{snapshot.Count}",
                 ErrorMessage = $"Read model has {snapshot.Count} entries; expected at least {minCount}.",
-                ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAt = NowTimestamp(),
             };
         }
 
         if (staleAfter.HasValue && snapshot.LastUpdatedAt.HasValue)
         {
-            var age = DateTimeOffset.UtcNow - snapshot.LastUpdatedAt.Value;
+            // Refactor (iter89/cluster-089-status-dashboard-probe-clock):
+            // Old: freshness age compared the readmodel timestamp against DateTimeOffset.UtcNow.
+            // New: freshness age compares against the injected TimeProvider clock.
+            var age = _timeProvider.GetUtcNow() - snapshot.LastUpdatedAt.Value;
             if (age.TotalSeconds > staleAfter.Value)
             {
                 return new HealthProbeOutcome
@@ -92,7 +99,7 @@ public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
                     Status = HealthOutcomeStatus.Degraded,
                     Detail = $"stale_{(int)age.TotalSeconds}s",
                     ErrorMessage = $"Latest entry is {(int)age.TotalSeconds}s old; threshold {staleAfter}s.",
-                    ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                    ObservedAt = NowTimestamp(),
                 };
             }
         }
@@ -103,6 +110,9 @@ public sealed class ReadmodelFreshnessProbeExecutor : IHealthProbeExecutor
             Detail = $"count_{snapshot.Count}",
         };
     }
+
+    private Timestamp NowTimestamp() =>
+        Timestamp.FromDateTimeOffset(_timeProvider.GetUtcNow());
 
     private static string? ReadParam(HealthProbeTargetDescriptor descriptor, string key)
     {

--- a/agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs
+++ b/agents/Aevatar.GAgents.StatusDashboard/HealthProbeTargetGAgent.cs
@@ -34,6 +34,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
     public async Task HandleConfigureAsync(HealthProbeConfigureCommand command)
     {
         ArgumentNullException.ThrowIfNull(command);
+        var timeProvider = ResolveTimeProvider();
         if (command.Spec == null || string.IsNullOrWhiteSpace(command.Spec.Slug))
         {
             Logger.LogWarning("Ignoring HealthProbeConfigureCommand with missing descriptor for actor {ActorId}", Id);
@@ -52,7 +53,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         await PersistDomainEventAsync(new HealthProbeConfigured
         {
             Spec = command.Spec,
-            ConfiguredAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            ConfiguredAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow()),
         });
 
         await EnsureNextTickAsync(initial: true);
@@ -99,7 +100,11 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
     private async Task<HealthProbeOutcome> ExecuteProbeWithGuardsAsync(HealthProbeTargetDescriptor descriptor)
     {
         var registry = Services.GetService<IHealthProbeExecutorRegistry>();
-        var observedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        var timeProvider = ResolveTimeProvider();
+        // Refactor (iter89/cluster-089-status-dashboard-probe-clock):
+        // Old: sample DateTimeOffset.UtcNow and Stopwatch directly inside the actor.
+        // New: use the injected TimeProvider for observed_at, timeout budget, and monotonic elapsed latency.
+        var observedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow());
 
         if (registry == null)
         {
@@ -125,42 +130,39 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         }
 
         var timeoutMs = descriptor.TimeoutMs > 0 ? descriptor.TimeoutMs : 5_000;
-        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs));
-        var sw = System.Diagnostics.Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeoutMs), timeProvider);
+        var startedAt = timeProvider.GetTimestamp();
         try
         {
             var outcome = await executor.ProbeAsync(descriptor, cts.Token);
-            sw.Stop();
             // Always overwrite latency and observed_at with the in-actor values
             // so executors stay focused on the upstream signal.
-            outcome.LatencyMs = (int)Math.Clamp(sw.ElapsedMilliseconds, 0, int.MaxValue);
-            outcome.ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+            outcome.LatencyMs = ToLatencyMs(timeProvider.GetElapsedTime(startedAt));
+            outcome.ObservedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow());
             return outcome;
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
-            sw.Stop();
             return new HealthProbeOutcome
             {
                 Status = HealthOutcomeStatus.Down,
-                LatencyMs = (int)Math.Clamp(sw.ElapsedMilliseconds, 0, int.MaxValue),
+                LatencyMs = ToLatencyMs(timeProvider.GetElapsedTime(startedAt)),
                 Detail = "timeout",
                 ErrorMessage = $"Probe '{descriptor.ProbeKind}' exceeded {timeoutMs}ms.",
-                ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow()),
             };
         }
         catch (Exception ex)
         {
-            sw.Stop();
             Logger.LogWarning(ex, "Probe '{Kind}' for {Slug} threw unexpectedly",
                 descriptor.ProbeKind, descriptor.Slug);
             return new HealthProbeOutcome
             {
                 Status = HealthOutcomeStatus.Down,
-                LatencyMs = (int)Math.Clamp(sw.ElapsedMilliseconds, 0, int.MaxValue),
+                LatencyMs = ToLatencyMs(timeProvider.GetElapsedTime(startedAt)),
                 Detail = "exception",
                 ErrorMessage = ex.Message,
-                ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+                ObservedAt = Timestamp.FromDateTimeOffset(timeProvider.GetUtcNow()),
             };
         }
     }
@@ -177,6 +179,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
         var dueTime = initial
             ? TimeSpan.FromSeconds(1)
             : TimeSpan.FromSeconds(intervalSeconds);
+        var scheduledFor = ResolveTimeProvider().GetUtcNow().Add(dueTime);
 
         await ScheduleSelfDurableTimeoutAsync(
             callbackId: TickCallbackId,
@@ -184,7 +187,7 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
             evt: new HealthProbeTickRequested
             {
                 Slug = descriptor.Slug,
-                ScheduledFor = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow.Add(dueTime)),
+                ScheduledFor = Timestamp.FromDateTimeOffset(scheduledFor),
             });
     }
 
@@ -268,6 +271,12 @@ public sealed class HealthProbeTargetGAgent : GAgentBase<HealthProbeTargetState>
 
     private static bool IsBefore(Timestamp? timestamp, DateTimeOffset cutoff) =>
         timestamp != null && timestamp.ToDateTimeOffset() < cutoff;
+
+    private TimeProvider ResolveTimeProvider() =>
+        Services.GetService<TimeProvider>() ?? TimeProvider.System;
+
+    private static int ToLatencyMs(TimeSpan elapsed) =>
+        (int)Math.Clamp(elapsed.TotalMilliseconds, 0, int.MaxValue);
 
     private static bool DescriptorsEquivalent(HealthProbeTargetDescriptor? a, HealthProbeTargetDescriptor? b)
     {

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/Aevatar.GAgents.StatusDashboard.Tests.csproj
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/Aevatar.GAgents.StatusDashboard.Tests.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
@@ -176,19 +176,21 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     [Fact]
     public async Task Tick_WhenProbeExceedsTimeout_UsesInjectedClockForCancellationAndOutcome()
     {
+        const int timeoutBudgetMs = 30_000;
+        const int timeoutAdvanceMs = timeoutBudgetMs + 1;
         var startedAt = DateTimeOffset.Parse("2026-05-21T10:10:00Z");
         _timeProvider.SetUtcNow(startedAt);
         await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand
         {
-            Spec = NewDescriptor("nyxid-auth", timeoutMs: 1_000),
+            Spec = NewDescriptor("nyxid-auth", timeoutMs: timeoutBudgetMs),
         });
 
         _executor.WaitForCancellation = true;
         var tickTask = _agent.HandleTickAsync(new HealthProbeTickRequested { Slug = "nyxid-auth" });
         await _executor.ProbeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        var timedOutAt = startedAt.AddMilliseconds(1_001);
-        _timeProvider.Advance(TimeSpan.FromMilliseconds(1_001));
+        var timedOutAt = startedAt.AddMilliseconds(timeoutAdvanceMs);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(timeoutAdvanceMs));
 
         await tickTask.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -197,7 +199,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         _agent.State.LastOutcome.Status.Should().Be(HealthOutcomeStatus.Down);
         _agent.State.LastOutcome.Detail.Should().Be("timeout");
         _agent.State.LastOutcome.ObservedAt.ToDateTimeOffset().Should().Be(timedOutAt);
-        _agent.State.LastOutcome.LatencyMs.Should().Be(1_001);
+        _agent.State.LastOutcome.LatencyMs.Should().Be(timeoutAdvanceMs);
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
@@ -174,6 +174,33 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Tick_WhenProbeExceedsTimeout_UsesInjectedClockForCancellationAndOutcome()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-05-21T10:10:00Z");
+        _timeProvider.SetUtcNow(startedAt);
+        await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand
+        {
+            Spec = NewDescriptor("nyxid-auth", timeoutMs: 1_000),
+        });
+
+        _executor.WaitForCancellation = true;
+        var tickTask = _agent.HandleTickAsync(new HealthProbeTickRequested { Slug = "nyxid-auth" });
+        await _executor.ProbeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var timedOutAt = startedAt.AddMilliseconds(1_001);
+        _timeProvider.Advance(TimeSpan.FromMilliseconds(1_001));
+
+        await tickTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        _executor.Invocations.Should().Be(1);
+        _agent.State.LastOutcome.Should().NotBeNull();
+        _agent.State.LastOutcome.Status.Should().Be(HealthOutcomeStatus.Down);
+        _agent.State.LastOutcome.Detail.Should().Be("timeout");
+        _agent.State.LastOutcome.ObservedAt.ToDateTimeOffset().Should().Be(timedOutAt);
+        _agent.State.LastOutcome.LatencyMs.Should().Be(1_001);
+    }
+
+    [Fact]
     public async Task Tick_RetainsRecentTwoHourOutcomeWindow()
     {
         await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand
@@ -319,20 +346,30 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         public Exception? ThrowOnNextProbe { get; set; }
         public FakeTimeProvider TimeProvider { get; set; } = null!;
         public TimeSpan Delay { get; set; }
+        public bool WaitForCancellation { get; set; }
+        public TaskCompletionSource ProbeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task<HealthProbeOutcome> ProbeAsync(HealthProbeTargetDescriptor descriptor, CancellationToken ct)
+        public async Task<HealthProbeOutcome> ProbeAsync(HealthProbeTargetDescriptor descriptor, CancellationToken ct)
         {
             Invocations++;
+            ProbeStarted.TrySetResult();
             if (ThrowOnNextProbe is { } ex)
             {
                 ThrowOnNextProbe = null;
                 throw ex;
             }
+            if (WaitForCancellation)
+            {
+                var cancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                await using var registration = ct.Register(static state =>
+                    ((TaskCompletionSource)state!).TrySetCanceled(), cancelled);
+                await cancelled.Task;
+            }
             if (Delay > TimeSpan.Zero)
             {
                 TimeProvider.Advance(Delay);
             }
-            return Task.FromResult(NextOutcome);
+            return NextOutcome;
         }
     }
 

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/HealthProbeTargetGAgentTests.cs
@@ -6,7 +6,10 @@ using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.GAgents.StatusDashboard.Executors;
 using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aevatar.GAgents.StatusDashboard.Tests;
 
@@ -17,10 +20,13 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     private FakeExecutor _executor = null!;
     private InMemoryEventStore _eventStore = null!;
     private TrackingCallbackScheduler _scheduler = null!;
+    private FakeTimeProvider _timeProvider = null!;
 
     public async Task InitializeAsync()
     {
         _executor = new FakeExecutor();
+        _timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z"));
+        _executor.TimeProvider = _timeProvider;
         var registry = new HealthProbeExecutorRegistry(new IHealthProbeExecutor[] { _executor });
 
         var services = new ServiceCollection();
@@ -33,6 +39,7 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             typeof(DefaultEventSourcingBehaviorFactory<>));
         services.AddSingleton<IActorRuntimeCallbackScheduler>(_scheduler);
         services.AddSingleton<IHealthProbeExecutorRegistry>(registry);
+        services.AddSingleton<TimeProvider>(_timeProvider);
         _serviceProvider = services.BuildServiceProvider();
 
         _agent = new HealthProbeTargetGAgent
@@ -67,6 +74,18 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         _agent.State.Spec.Should().NotBeNull();
         _agent.State.Spec.Slug.Should().Be("nyxid-auth");
         _agent.State.Spec.IntervalSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task Configure_SchedulesInitialTickFromInjectedClock()
+    {
+        var configuredAt = _timeProvider.GetUtcNow();
+
+        await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand { Spec = NewDescriptor("nyxid-auth") });
+
+        _scheduler.LastScheduledEvent.Should().NotBeNull();
+        var tick = _scheduler.LastScheduledEvent.Should().BeOfType<HealthProbeTickRequested>().Subject;
+        tick.ScheduledFor.ToDateTimeOffset().Should().Be(configuredAt.AddSeconds(1));
     }
 
     [Fact]
@@ -128,6 +147,30 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         _agent.State.LastOutcome.Should().NotBeNull();
         _agent.State.LastOutcome.Status.Should().Be(HealthOutcomeStatus.Ok);
         _agent.State.ConsecutiveFailures.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Tick_StampsObservedAtAndLatencyFromInjectedClock()
+    {
+        await _agent.HandleConfigureAsync(new HealthProbeConfigureCommand
+        {
+            Spec = NewDescriptor("nyxid-auth"),
+        });
+
+        _timeProvider.SetUtcNow(DateTimeOffset.Parse("2026-05-21T10:05:00Z"));
+        _executor.Delay = TimeSpan.FromMilliseconds(250);
+        _executor.NextOutcome = new HealthProbeOutcome
+        {
+            Status = HealthOutcomeStatus.Ok,
+            Detail = "http_200",
+            ObservedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2001-01-01T00:00:00Z")),
+        };
+
+        await _agent.HandleTickAsync(new HealthProbeTickRequested { Slug = "nyxid-auth" });
+
+        _agent.State.LastOutcome.ObservedAt.ToDateTimeOffset()
+            .Should().Be(DateTimeOffset.Parse("2026-05-21T10:05:00.250Z"));
+        _agent.State.LastOutcome.LatencyMs.Should().Be(250);
     }
 
     [Fact]
@@ -274,6 +317,8 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
         public int Invocations { get; private set; }
         public HealthProbeOutcome NextOutcome { get; set; } = new() { Status = HealthOutcomeStatus.Unknown };
         public Exception? ThrowOnNextProbe { get; set; }
+        public FakeTimeProvider TimeProvider { get; set; } = null!;
+        public TimeSpan Delay { get; set; }
 
         public Task<HealthProbeOutcome> ProbeAsync(HealthProbeTargetDescriptor descriptor, CancellationToken ct)
         {
@@ -282,6 +327,10 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
             {
                 ThrowOnNextProbe = null;
                 throw ex;
+            }
+            if (Delay > TimeSpan.Zero)
+            {
+                TimeProvider.Advance(Delay);
             }
             return Task.FromResult(NextOutcome);
         }
@@ -355,10 +404,12 @@ public sealed class HealthProbeTargetGAgentTests : IAsyncLifetime
     private sealed class TrackingCallbackScheduler : IActorRuntimeCallbackScheduler
     {
         public int ScheduledTimeouts { get; private set; }
+        public IMessage? LastScheduledEvent { get; private set; }
 
         public Task<RuntimeCallbackLease> ScheduleTimeoutAsync(RuntimeCallbackTimeoutRequest request, CancellationToken ct = default)
         {
             ScheduledTimeouts++;
+            LastScheduledEvent = request.TriggerEnvelope.Payload.Unpack<HealthProbeTickRequested>();
             return Task.FromResult(new RuntimeCallbackLease(
                 request.ActorId,
                 request.CallbackId,

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/HttpStatusProbeExecutorTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/HttpStatusProbeExecutorTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using Aevatar.GAgents.StatusDashboard.Executors;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aevatar.GAgents.StatusDashboard.Tests;
 
@@ -184,24 +186,27 @@ public sealed class HttpStatusProbeExecutorTests
     [Fact]
     public async Task ReportsMissingUrlAsDown()
     {
-        var executor = NewExecutor(HttpStatusCode.OK, configuration: new Dictionary<string, string?>());
+        var clock = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z"));
+        var executor = NewExecutor(HttpStatusCode.OK, configuration: new Dictionary<string, string?>(), timeProvider: clock);
         var descriptor = NewDescriptor("missing-url", new() { ["ExpectedStatuses"] = "200" });
         var outcome = await executor.ProbeAsync(descriptor, CancellationToken.None);
         outcome.Status.Should().Be(HealthOutcomeStatus.Down);
         outcome.Detail.Should().Be("missing_parameter");
+        outcome.ObservedAt.ToDateTimeOffset().Should().Be(clock.GetUtcNow());
     }
 
     private static HttpStatusProbeExecutor NewExecutor(
         HttpStatusCode status,
         Dictionary<string, string?> configuration,
         Action<HttpRequestMessage>? captureRequest = null,
-        string? responseBody = null)
+        string? responseBody = null,
+        TimeProvider? timeProvider = null)
     {
         var configRoot = new ConfigurationBuilder()
             .AddInMemoryCollection(configuration)
             .Build();
         var factory = new TestHttpClientFactory(new StubHandler(status, captureRequest, responseBody));
-        return new HttpStatusProbeExecutor(factory, configRoot);
+        return new HttpStatusProbeExecutor(factory, configRoot, timeProvider ?? TimeProvider.System);
     }
 
     private static HealthProbeTargetDescriptor NewDescriptor(string slug, Dictionary<string, string> parameters)

--- a/test/Aevatar.GAgents.StatusDashboard.Tests/ReadmodelFreshnessProbeExecutorTests.cs
+++ b/test/Aevatar.GAgents.StatusDashboard.Tests/ReadmodelFreshnessProbeExecutorTests.cs
@@ -1,5 +1,7 @@
 using Aevatar.GAgents.StatusDashboard.Executors;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Aevatar.GAgents.StatusDashboard.Tests;
 
@@ -8,8 +10,9 @@ public sealed class ReadmodelFreshnessProbeExecutorTests
     [Fact]
     public async Task ReturnsOk_WhenCountMeetsMinAndFresh()
     {
-        var source = new FixedFreshnessSource("registrations", count: 5, ageSeconds: 10);
-        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source });
+        var clock = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z"));
+        var source = new FixedFreshnessSource("registrations", count: 5, clock, ageSeconds: 10);
+        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source }, clock);
         var descriptor = NewDescriptor(new()
         {
             ["Source"] = "registrations",
@@ -25,8 +28,9 @@ public sealed class ReadmodelFreshnessProbeExecutorTests
     [Fact]
     public async Task DegradesWhenCountBelowMin()
     {
-        var source = new FixedFreshnessSource("registrations", count: 0);
-        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source });
+        var clock = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z"));
+        var source = new FixedFreshnessSource("registrations", count: 0, clock);
+        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source }, clock);
         var descriptor = NewDescriptor(new()
         {
             ["Source"] = "registrations",
@@ -41,8 +45,9 @@ public sealed class ReadmodelFreshnessProbeExecutorTests
     [Fact]
     public async Task DegradesWhenStale()
     {
-        var source = new FixedFreshnessSource("registrations", count: 3, ageSeconds: 600);
-        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source });
+        var clock = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z"));
+        var source = new FixedFreshnessSource("registrations", count: 3, clock, ageSeconds: 600);
+        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source }, clock);
         var descriptor = NewDescriptor(new()
         {
             ["Source"] = "registrations",
@@ -51,14 +56,16 @@ public sealed class ReadmodelFreshnessProbeExecutorTests
 
         var outcome = await executor.ProbeAsync(descriptor, CancellationToken.None);
         outcome.Status.Should().Be(HealthOutcomeStatus.Degraded);
-        outcome.Detail.Should().StartWith("stale_");
+        outcome.Detail.Should().Be("stale_600s");
+        outcome.ObservedAt.ToDateTimeOffset().Should().Be(clock.GetUtcNow());
     }
 
     [Fact]
     public async Task ReturnsDown_WhenUnknownSource()
     {
-        var source = new FixedFreshnessSource("registrations", count: 5);
-        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source });
+        var clock = new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z"));
+        var source = new FixedFreshnessSource("registrations", count: 5, clock);
+        var executor = new ReadmodelFreshnessProbeExecutor(new[] { source }, clock);
         var descriptor = NewDescriptor(new() { ["Source"] = "nothing-here" });
 
         var outcome = await executor.ProbeAsync(descriptor, CancellationToken.None);
@@ -70,7 +77,9 @@ public sealed class ReadmodelFreshnessProbeExecutorTests
     public async Task ReturnsDown_WhenSourceThrows()
     {
         var source = new ThrowingFreshnessSource("registrations");
-        var executor = new ReadmodelFreshnessProbeExecutor(new IReadmodelFreshnessSource[] { source });
+        var executor = new ReadmodelFreshnessProbeExecutor(
+            new IReadmodelFreshnessSource[] { source },
+            new FakeTimeProvider(DateTimeOffset.Parse("2026-05-21T10:00:00Z")));
         var descriptor = NewDescriptor(new() { ["Source"] = "registrations" });
 
         var outcome = await executor.ProbeAsync(descriptor, CancellationToken.None);
@@ -94,14 +103,14 @@ public sealed class ReadmodelFreshnessProbeExecutorTests
         return d;
     }
 
-    private sealed class FixedFreshnessSource(string name, int count, int? ageSeconds = null)
+    private sealed class FixedFreshnessSource(string name, int count, TimeProvider timeProvider, int? ageSeconds = null)
         : IReadmodelFreshnessSource
     {
         public string Name => name;
         public Task<ReadmodelFreshnessSnapshot> GetFreshnessAsync(CancellationToken ct) =>
             Task.FromResult(new ReadmodelFreshnessSnapshot(
                 count,
-                ageSeconds.HasValue ? DateTimeOffset.UtcNow.AddSeconds(-ageSeconds.Value) : null));
+                ageSeconds.HasValue ? timeProvider.GetUtcNow().AddSeconds(-ageSeconds.Value) : null));
     }
 
     private sealed class ThrowingFreshnessSource(string name) : IReadmodelFreshnessSource


### PR DESCRIPTION
## 摘要

iter89 cluster-089-status-dashboard-probe-clock(severity:medium,rules:RULE-TIMING-CLOCK-INJECTION + RULE-TIMING-MONOTONIC-ELAPSED)。

8 文件改动(+132/-40):
- 3 个 probe executor + HealthProbeTargetGAgent 接 TimeProvider
- 一致从 clock 拿 observed_at / scheduled_for / freshness age / timeout budget / monotonic elapsed
- DI 注册 + 3 测试改 fake clock

验证:StatusDashboard 编译 + 测试 pass + `ci/*_guards.sh` pass。

🤖 Auto-loop / codex-refactor-loop iter89

⟦AI:AUTO-LOOP⟧
