### PR TITLE
iter89 cluster-089: Workflow modules 用 context clock + monotonic elapsed

### DIFF
--- a/src/workflow/Aevatar.Workflow.Abstractions/Execution/IWorkflowExecutionContext.cs
+++ b/src/workflow/Aevatar.Workflow.Abstractions/Execution/IWorkflowExecutionContext.cs
@@ -10,6 +10,18 @@ public interface IWorkflowExecutionContext
 {
     string RunId { get; }
 
+    // Refactor (iter89/cluster-089-workflow-module-clock-state):
+    //   Old: Workflow modules read process wall clock directly for TTLs,
+    //        timeout stamps, buffered signal eviction, and elapsed metrics.
+    //   New: Workflow modules consume injected execution context time for
+    //        business timestamps and monotonic elapsed APIs for durations.
+    DateTimeOffset UtcNow => TimeProvider.System.GetUtcNow();
+
+    long GetTimestamp() => TimeProvider.System.GetTimestamp();
+
+    TimeSpan GetElapsedTime(long startingTimestamp) =>
+        TimeProvider.System.GetElapsedTime(startingTimestamp);
+
     TState LoadState<TState>(string scopeKey)
         where TState : class, IMessage<TState>, new();
 

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionContextAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionContextAdapter.cs
@@ -36,6 +36,15 @@ internal sealed class WorkflowExecutionContextAdapter : IWorkflowExecutionContex
 
     public ILogger Logger => _inner.Logger;
 
+    // Refactor (iter89/cluster-089-workflow-module-clock-state):
+    //   Old: Workflow modules used process wall clock/Stopwatch directly.
+    //   New: Modules consume the workflow execution context clock so tests
+    //        and runtimes can inject business time and monotonic duration.
+    public DateTimeOffset UtcNow => Clock.GetUtcNow();
+
+    private TimeProvider Clock =>
+        _inner.Services.GetService(typeof(TimeProvider)) as TimeProvider ?? TimeProvider.System;
+
     public static WorkflowExecutionContextAdapter Create(
         IEventHandlerContext context,
         IWorkflowExecutionStateHost stateHost)
@@ -44,6 +53,11 @@ internal sealed class WorkflowExecutionContextAdapter : IWorkflowExecutionContex
         ArgumentNullException.ThrowIfNull(stateHost);
         return new WorkflowExecutionContextAdapter(context, stateHost);
     }
+
+    public long GetTimestamp() => Clock.GetTimestamp();
+
+    public TimeSpan GetElapsedTime(long startingTimestamp) =>
+        Clock.GetElapsedTime(startingTimestamp);
 
     public TState LoadState<TState>(string scopeKey)
         where TState : class, IMessage<TState>, new()

--- a/src/workflow/Aevatar.Workflow.Core/Modules/CacheModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/CacheModule.cs
@@ -32,7 +32,10 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
             var request = payload.Unpack<StepRequestEvent>();
             if (request.StepType != "cache") return;
             var runId = WorkflowRunIdNormalizer.Normalize(request.RunId);
-            var now = DateTimeOffset.UtcNow;
+            // Refactor (iter89/cluster-089-workflow-module-clock-state):
+            //   Old: Cache TTL checks read DateTimeOffset.UtcNow directly.
+            //   New: Cache business time comes from the workflow context clock.
+            var now = ctx.UtcNow;
             var state = WorkflowExecutionStateAccess.Load<CacheModuleState>(ctx, ModuleStateKey);
 
             var cacheKey = request.Parameters.GetValueOrDefault("cache_key", request.Input ?? "");
@@ -115,7 +118,7 @@ public sealed class CacheModule : IEventModule<IWorkflowExecutionContext>
                 state.CacheEntries[cacheKey] = new CacheEntryState
                 {
                     Value = evt.Output ?? string.Empty,
-                    ExpiresAt = WorkflowTimestampCodec.ToTimestamp(DateTimeOffset.UtcNow.AddSeconds(pending.TtlSeconds)),
+                    ExpiresAt = WorkflowTimestampCodec.ToTimestamp(ctx.UtcNow.AddSeconds(pending.TtlSeconds)),
                 };
             }
             await SaveStateAsync(state, ctx, ct);

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -116,7 +115,12 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             }
         }
 
-        var sw = Stopwatch.StartNew();
+        // Refactor (iter89/cluster-089-workflow-module-clock-state):
+        //   Old: Connector elapsed metadata used Stopwatch directly inside
+        //        the module.
+        //   New: Connector duration is measured through the workflow context
+        //        monotonic elapsed API.
+        var startedAt = ctx.GetTimestamp();
         var attempts = Math.Max(1, retry + 1);
         ConnectorResponse? response = null;
         Exception? lastError = null;
@@ -166,7 +170,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             }
         }
 
-        sw.Stop();
+        var durationMs = ctx.GetElapsedTime(startedAt).TotalMilliseconds;
         if (response is { Success: true })
         {
             var resolvedOutput = response.Output ?? string.Empty;
@@ -186,7 +190,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
                 Success = true,
                 Output = resolvedOutput,
             };
-            AppendBaseMetadata(ok, connector, connectorName, operation, attempts, timeoutMs, sw.Elapsed.TotalMilliseconds);
+            AppendBaseMetadata(ok, connector, connectorName, operation, attempts, timeoutMs, durationMs);
             foreach (var (key, value) in response.Metadata)
                 ok.Annotations[key] = value;
             await ctx.PublishAsync(ok, TopologyAudience.Self, ct);
@@ -210,7 +214,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
                 Success = true,
                 Output = request.Input,
             };
-            AppendBaseMetadata(continued, connector, connectorName, operation, attempts, timeoutMs, sw.Elapsed.TotalMilliseconds);
+            AppendBaseMetadata(continued, connector, connectorName, operation, attempts, timeoutMs, durationMs);
             continued.Annotations["connector.continued_on_error"] = "true";
             continued.Annotations["connector.error"] = errorText ?? "";
             await ctx.PublishAsync(continued, TopologyAudience.Self, ct);
@@ -224,7 +228,7 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             Success = false,
             Error = errorText ?? "connector call failed",
         };
-        AppendBaseMetadata(failed, connector, connectorName, operation, attempts, timeoutMs, sw.Elapsed.TotalMilliseconds);
+        AppendBaseMetadata(failed, connector, connectorName, operation, attempts, timeoutMs, durationMs);
         await ctx.PublishAsync(failed, TopologyAudience.Self, ct);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/WaitSignalModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/WaitSignalModule.cs
@@ -50,7 +50,12 @@ public sealed class WaitSignalModule : IEventModule<IWorkflowExecutionContext>
             var timeoutMs = ResolveTimeoutMs(request.Parameters);
             var pendingKey = new PendingSignalKey(runId, signalName, stepId);
             var state = WorkflowExecutionStateAccess.Load<WaitSignalModuleState>(ctx, ModuleStateKey);
-            var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            // Refactor (iter89/cluster-089-workflow-module-clock-state):
+            //   Old: wait_signal used process wall clock for buffered signal
+            //        eviction and received timestamps.
+            //   New: wait_signal uses the workflow execution context clock for
+            //        business-time buffer state.
+            var nowMs = ctx.UtcNow.ToUnixTimeMilliseconds();
             PruneExpiredBufferedSignals(state, nowMs);
 
             if (TryConsumeBufferedSignal(state, pendingKey, nowMs, out var buffered))
@@ -168,7 +173,7 @@ public sealed class WaitSignalModule : IEventModule<IWorkflowExecutionContext>
 
         var signal = payload.Unpack<SignalReceivedEvent>();
         var stateForSignal = WorkflowExecutionStateAccess.Load<WaitSignalModuleState>(ctx, ModuleStateKey);
-        var signalNowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var signalNowMs = ctx.UtcNow.ToUnixTimeMilliseconds();
         PruneExpiredBufferedSignals(stateForSignal, signalNowMs);
         if (!TryResolvePending(stateForSignal, signal, out var resolvedKey, out var pendingStateForSignal))
         {

--- a/src/workflow/Aevatar.Workflow.Core/README.md
+++ b/src/workflow/Aevatar.Workflow.Core/README.md
@@ -39,6 +39,12 @@
 - callback fired 事件能在 actor 内完成对账
 - 不再依赖模块私有 `Dictionary/HashSet`
 
+// Refactor (iter89/cluster-089-workflow-module-clock-state):
+//   Old: modules read process wall clock for cache TTL, signal buffer eviction,
+//        timeout stamps, and connector elapsed metadata.
+//   New: modules use `IWorkflowExecutionContext.UtcNow` for workflow business
+//        time and `GetTimestamp/GetElapsedTime` for monotonic duration metrics.
+
 ## 关键模块语义
 
 - `WorkflowExecutionKernel`

--- a/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/ConnectorCallModuleCoverageTests.cs
@@ -88,6 +88,7 @@ public sealed class ConnectorCallModuleCoverageTests
 
         var module = new ConnectorCallModule(new RegistryBackedWorkflowConnectorResolver(registry));
         var ctx = CreateContext();
+        ctx.SetNextElapsedTime(TimeSpan.FromMilliseconds(1234.56));
         var request = new StepRequestEvent
         {
             StepId = "s-retry",
@@ -113,6 +114,7 @@ public sealed class ConnectorCallModuleCoverageTests
         completed.Output.Should().Be("ok");
         completed.Annotations["connector.attempts"].Should().Be("2");
         completed.Annotations["connector.name"].Should().Be("retryable");
+        completed.Annotations["connector.duration_ms"].Should().Be("1234.56");
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
@@ -39,6 +39,22 @@ internal sealed class TestEventHandlerContext : IEventHandlerContext, IWorkflowE
         : _fallbackRuntimeContext;
 
     private readonly WorkflowExecutionRuntimeContext _fallbackRuntimeContext = new();
+    private TimeSpan? _nextElapsedTime;
+
+    public DateTimeOffset UtcNow { get; set; } = DateTimeOffset.UtcNow;
+
+    public long GetTimestamp() => 1;
+
+    public TimeSpan GetElapsedTime(long startingTimestamp)
+    {
+        _ = startingTimestamp;
+        return _nextElapsedTime ?? TimeSpan.Zero;
+    }
+
+    public void SetNextElapsedTime(TimeSpan elapsedTime)
+    {
+        _nextElapsedTime = elapsedTime;
+    }
 
     public TState LoadState<TState>(string scopeKey)
         where TState : class, IMessage<TState>, new()
@@ -163,7 +179,7 @@ internal sealed class TestEventHandlerContext : IEventHandlerContext, IWorkflowE
         var envelope = new EventEnvelope
         {
             Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Timestamp = Timestamp.FromDateTimeOffset(UtcNow),
             Payload = Any.Pack(callback.Event),
             Route = EnvelopeRouteSemantics.CreateTopologyPublication(publisherId ?? AgentId, TopologyAudience.Self),
         };
@@ -179,7 +195,7 @@ internal sealed class TestEventHandlerContext : IEventHandlerContext, IWorkflowE
             CallbackId = callback.CallbackId,
             Generation = callback.Generation,
             FireIndex = 0,
-            FiredAtUnixTimeMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            FiredAtUnixTimeMs = UtcNow.ToUnixTimeMilliseconds(),
         };
         return envelope;
     }

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -473,6 +473,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
     {
         var module = new CacheModule();
         var ctx = CreateContext();
+        ctx.UtcNow = DateTimeOffset.Parse("2026-05-20T10:00:00Z");
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -497,6 +498,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         childDispatch.TargetRole.Should().Be("worker");
         var childStepId = childDispatch.StepId;
         ctx.Published.Clear();
+        ctx.UtcNow = ctx.UtcNow.AddMinutes(30);
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -543,6 +545,25 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         hitCompletion.Success.Should().BeTrue();
         hitCompletion.Output.Should().Be("cached-value");
         hitCompletion.Annotations["cache.hit"].Should().Be("true");
+
+        ctx.Published.Clear();
+        ctx.UtcNow = DateTimeOffset.Parse("2026-05-20T11:30:01Z");
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "cache-4",
+                StepType = "cache",
+                Input = "after-expiry",
+                Parameters =
+                {
+                    ["cache_key"] = "k1",
+                    ["child_step_type"] = "transform",
+                },
+            }),
+            ctx,
+            CancellationToken.None);
+
+        ctx.Published.Select(x => x.evt).OfType<StepRequestEvent>().Should().ContainSingle(x => x.StepId.StartsWith("cache-4_cached_", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -125,6 +125,8 @@ public sealed class WorkflowExecutionContextAdapterTests
         adapter.InboundEnvelope.Should().BeSameAs(inner.InboundEnvelope);
         adapter.Services.Should().BeSameAs(inner.Services);
         adapter.Logger.Should().BeSameAs(inner.Logger);
+        adapter.UtcNow.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+        adapter.GetElapsedTime(adapter.GetTimestamp()).Should().BeGreaterThanOrEqualTo(TimeSpan.Zero);
 
         await adapter.PublishAsync(new StringValue { Value = "published" }, TopologyAudience.Self, CancellationToken.None);
         await adapter.SendToAsync("child-1", new Int32Value { Value = 3 }, CancellationToken.None);
@@ -169,8 +171,26 @@ public sealed class WorkflowExecutionContextAdapterTests
         inner.Canceled.Should().ContainSingle(x => x.CallbackId == "cancel-me");
     }
 
+    [Fact]
+    public void ClockApis_ShouldUseInjectedTimeProvider()
+    {
+        var timeProvider = new ManualTimeProvider(DateTimeOffset.Parse("2026-05-20T10:00:00Z"));
+        var services = new SingleServiceProvider(typeof(TimeProvider), timeProvider);
+        var adapter = WorkflowExecutionContextAdapter.Create(
+            new RecordingEventHandlerContext { ServicesOverride = services },
+            new RecordingStateHost());
+
+        var startedAt = adapter.GetTimestamp();
+        timeProvider.Advance(TimeSpan.FromMilliseconds(42));
+
+        adapter.UtcNow.Should().Be(DateTimeOffset.Parse("2026-05-20T10:00:00.042Z"));
+        adapter.GetElapsedTime(startedAt).Should().Be(TimeSpan.FromMilliseconds(42));
+    }
+
     private sealed class RecordingEventHandlerContext : IEventHandlerContext
     {
+        private readonly IServiceProvider _defaultServices = new NullServiceProvider();
+
         public EventEnvelope InboundEnvelope { get; } = new()
         {
             Id = Guid.NewGuid().ToString("N"),
@@ -181,7 +201,9 @@ public sealed class WorkflowExecutionContextAdapterTests
 
         public IAgent Agent { get; } = new StubAgent("agent-1");
 
-        public IServiceProvider Services { get; } = new NullServiceProvider();
+        public IServiceProvider Services => ServicesOverride ?? _defaultServices;
+
+        public IServiceProvider? ServicesOverride { get; init; }
 
         public ILogger Logger { get; } = NullLogger.Instance;
 
@@ -300,6 +322,30 @@ public sealed class WorkflowExecutionContextAdapterTests
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(global::System.Type serviceType) => null;
+    }
+
+    private sealed class SingleServiceProvider(global::System.Type serviceType, object service) : IServiceProvider
+    {
+        public object? GetService(global::System.Type requestedServiceType) =>
+            requestedServiceType == serviceType ? service : null;
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = utcNow;
+        private long _timestamp;
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public override long GetTimestamp() => _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public void Advance(TimeSpan elapsed)
+        {
+            _utcNow = _utcNow.Add(elapsed);
+            _timestamp += elapsed.Ticks;
+        }
     }
 
     private sealed record RecordedCallback(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WaitSignalModuleTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WaitSignalModuleTests.cs
@@ -83,7 +83,10 @@ public sealed class WaitSignalModuleTests
         var context = new RecordingEventHandlerContext(
             new EmptyServiceProvider(),
             new StubAgent("workflow-early"),
-            NullLogger.Instance);
+            NullLogger.Instance)
+        {
+            UtcNow = DateTimeOffset.Parse("2026-05-20T10:00:00Z"),
+        };
 
         await module.HandleAsync(
             Envelope(new SignalReceivedEvent
@@ -96,7 +99,8 @@ public sealed class WaitSignalModuleTests
             context,
             CancellationToken.None);
 
-        context.Published.Select(item => item.Event).OfType<WorkflowSignalBufferedEvent>().Should().ContainSingle();
+        var bufferedEvent = context.Published.Select(item => item.Event).OfType<WorkflowSignalBufferedEvent>().Should().ContainSingle().Subject;
+        bufferedEvent.ReceivedAtUnixTimeMs.Should().Be(context.UtcNow.ToUnixTimeMilliseconds());
 
         await module.HandleAsync(
             Envelope(new StepRequestEvent
@@ -171,6 +175,15 @@ public sealed class WaitSignalModuleTests
         public IServiceProvider Services { get; }
         public ILogger Logger { get; }
         public string RunId => AgentId;
+        public DateTimeOffset UtcNow { get; set; } = DateTimeOffset.UtcNow;
+
+        public long GetTimestamp() => 1;
+
+        public TimeSpan GetElapsedTime(long startingTimestamp)
+        {
+            _ = startingTimestamp;
+            return TimeSpan.Zero;
+        }
 
         public TState LoadState<TState>(string scopeKey)
             where TState : class, IMessage<TState>, new()


### PR DESCRIPTION
## 摘要

iter89 cluster-089-workflow-module-clock-state(severity:medium,rules:RULE-TIMING-CLOCK-INJECTION + RULE-TIMING-MONOTONIC-ELAPSED)。

11 文件(+157/-15):
- IWorkflowExecutionContext + adapter 暴露 Clock
- CacheModule / ConnectorCallModule / WaitSignalModule 用 context.Clock
- 测试 fake clock 验证

🤖 Auto-loop / codex-refactor-loop iter89

⟦AI:AUTO-LOOP⟧
