### PR TITLE
iter90 cluster-090: ScriptBehaviorArtifactResolver bounded MemoryCache + typed key

### DIFF
--- a/src/Aevatar.Scripting.Infrastructure/Aevatar.Scripting.Infrastructure.csproj
+++ b/src/Aevatar.Scripting.Infrastructure/Aevatar.Scripting.Infrastructure.csproj
@@ -13,5 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 </Project>

--- a/src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs
+++ b/src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs
@@ -46,15 +46,15 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         ArgumentNullException.ThrowIfNull(request);
 
         var cacheKey = ScriptBehaviorArtifactCacheKey.From(request);
-        var lazy = GetOrCreateLazy(cacheKey, request);
+        var entry = GetOrCreateEntry(cacheKey, request);
 
         try
         {
-            return lazy.Value;
+            return entry.Value;
         }
         catch
         {
-            RemoveFailedLazy(cacheKey, lazy);
+            RemoveFailedLazy(cacheKey, entry);
             throw;
         }
     }
@@ -64,11 +64,11 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         _artifacts.Dispose();
     }
 
-    private Lazy<ScriptBehaviorArtifact> GetOrCreateLazy(
+    private ArtifactCacheEntry GetOrCreateEntry(
         ScriptBehaviorArtifactCacheKey cacheKey,
         ScriptBehaviorArtifactRequest request)
     {
-        if (_artifacts.TryGetValue(cacheKey, out Lazy<ScriptBehaviorArtifact>? existing) && existing != null)
+        if (_artifacts.TryGetValue(cacheKey, out ArtifactCacheEntry? existing) && existing != null)
             return existing;
 
         lock (_cacheGate)
@@ -76,9 +76,7 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
             if (_artifacts.TryGetValue(cacheKey, out existing) && existing != null)
                 return existing;
 
-            var created = new Lazy<ScriptBehaviorArtifact>(
-                () => CompileOrThrow(request),
-                LazyThreadSafetyMode.ExecutionAndPublication);
+            var created = new ArtifactCacheEntry(() => CompileOrThrow(request));
 
             CompactWhenFull();
             _artifacts.Set(
@@ -103,11 +101,11 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
 
     private void RemoveFailedLazy(
         ScriptBehaviorArtifactCacheKey cacheKey,
-        Lazy<ScriptBehaviorArtifact> failed)
+        ArtifactCacheEntry failed)
     {
         lock (_cacheGate)
         {
-            if (_artifacts.TryGetValue(cacheKey, out Lazy<ScriptBehaviorArtifact>? current) &&
+            if (_artifacts.TryGetValue(cacheKey, out ArtifactCacheEntry? current) &&
                 ReferenceEquals(current, failed))
             {
                 _artifacts.Remove(cacheKey);
@@ -133,24 +131,89 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         _ = reason;
         _ = state;
 
-        if (value is not Lazy<ScriptBehaviorArtifact> lazy || !lazy.IsValueCreated)
+        if (value is not ArtifactCacheEntry entry)
             return;
 
-        try
+        entry.DisposeWhenCreated();
+    }
+
+    private sealed class ArtifactCacheEntry
+    {
+        private readonly object _gate = new();
+        private readonly Lazy<ScriptBehaviorArtifact> _lazy;
+        private ScriptBehaviorArtifact? _artifact;
+        private bool _disposeStarted;
+        private bool _disposeWhenCreated;
+
+        public ArtifactCacheEntry(Func<ScriptBehaviorArtifact> artifactFactory)
         {
-            var dispose = lazy.Value.DisposeAsync();
-            if (!dispose.IsCompletedSuccessfully)
+            _lazy = new Lazy<ScriptBehaviorArtifact>(
+                () =>
+                {
+                    var artifact = artifactFactory();
+                    bool disposeNow;
+                    lock (_gate)
+                    {
+                        _artifact = artifact;
+                        disposeNow = _disposeWhenCreated && !_disposeStarted;
+                        if (disposeNow)
+                            _disposeStarted = true;
+                    }
+
+                    if (disposeNow)
+                        DisposeArtifact(artifact);
+
+                    return artifact;
+                },
+                LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        public ScriptBehaviorArtifact Value => _lazy.Value;
+
+        public void DisposeWhenCreated()
+        {
+            ScriptBehaviorArtifact? artifact;
+            lock (_gate)
             {
-                _ = dispose.AsTask().ContinueWith(
-                    static task => _ = task.Exception,
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
+                if (_disposeWhenCreated)
+                    return;
+
+                _disposeWhenCreated = true;
+                artifact = _artifact;
+                if (artifact == null || _disposeStarted)
+                    return;
+
+                _disposeStarted = true;
+            }
+
+            try
+            {
+                DisposeArtifact(artifact);
+            }
+            catch
+            {
+                // Eviction must not make cache mutation fail; callers already observe compile failures through Resolve.
             }
         }
-        catch
+
+        private static void DisposeArtifact(ScriptBehaviorArtifact artifact)
         {
-            // Eviction must not make cache mutation fail; callers already observe compile failures through Resolve.
+            try
+            {
+                var dispose = artifact.DisposeAsync();
+                if (!dispose.IsCompletedSuccessfully)
+                {
+                    _ = dispose.AsTask().ContinueWith(
+                        static task => _ = task.Exception,
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+            }
+            catch
+            {
+                // Eviction must not make cache mutation fail; callers already observe compile failures through Resolve.
+            }
         }
     }
 

--- a/src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs
+++ b/src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs
@@ -1,5 +1,7 @@
-using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Compilation;
+using Aevatar.Scripting.Core.Runtime;
+using Aevatar.Scripting.Abstractions.Behaviors;
+using Google.Protobuf;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Aevatar.Scripting.Infrastructure.Compilation;
@@ -46,16 +48,23 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         ArgumentNullException.ThrowIfNull(request);
 
         var cacheKey = ScriptBehaviorArtifactCacheKey.From(request);
-        var entry = GetOrCreateEntry(cacheKey, request);
+        while (true)
+        {
+            var entry = GetOrCreateEntry(cacheKey, request);
 
-        try
-        {
-            return entry.Value;
-        }
-        catch
-        {
-            RemoveFailedLazy(cacheKey, entry);
-            throw;
+            try
+            {
+                return entry.LeaseForCaller();
+            }
+            catch (EvictedArtifactCacheEntryDisposedException)
+            {
+                RemoveFailedLazy(cacheKey, entry);
+            }
+            catch
+            {
+                RemoveFailedLazy(cacheKey, entry);
+                throw;
+            }
         }
     }
 
@@ -134,7 +143,7 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         if (value is not ArtifactCacheEntry entry)
             return;
 
-        entry.DisposeWhenCreated();
+        entry.MarkEvicted();
     }
 
     private sealed class ArtifactCacheEntry
@@ -142,8 +151,9 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         private readonly object _gate = new();
         private readonly Lazy<ScriptBehaviorArtifact> _lazy;
         private ScriptBehaviorArtifact? _artifact;
+        private int _referenceCount;
+        private bool _evicted;
         private bool _disposeStarted;
-        private bool _disposeWhenCreated;
 
         public ArtifactCacheEntry(Func<ScriptBehaviorArtifact> artifactFactory)
         {
@@ -151,13 +161,15 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
                 () =>
                 {
                     var artifact = artifactFactory();
-                    bool disposeNow;
+                    bool disposeNow = false;
                     lock (_gate)
                     {
                         _artifact = artifact;
-                        disposeNow = _disposeWhenCreated && !_disposeStarted;
-                        if (disposeNow)
+                        if (_evicted && _referenceCount == 0 && !_disposeStarted)
+                        {
                             _disposeStarted = true;
+                            disposeNow = true;
+                        }
                     }
 
                     if (disposeNow)
@@ -168,32 +180,102 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
                 LazyThreadSafetyMode.ExecutionAndPublication);
         }
 
-        public ScriptBehaviorArtifact Value => _lazy.Value;
-
-        public void DisposeWhenCreated()
+        public ScriptBehaviorArtifact LeaseForCaller()
         {
-            ScriptBehaviorArtifact? artifact;
-            lock (_gate)
-            {
-                if (_disposeWhenCreated)
-                    return;
-
-                _disposeWhenCreated = true;
-                artifact = _artifact;
-                if (artifact == null || _disposeStarted)
-                    return;
-
-                _disposeStarted = true;
-            }
-
+            var callerLease = Retain();
             try
             {
-                DisposeArtifact(artifact);
+                var artifact = _lazy.Value;
+                return new ScriptBehaviorArtifact(
+                    artifact.ScriptId,
+                    artifact.Revision,
+                    artifact.PackageHash,
+                    artifact.Descriptor,
+                    artifact.Contract,
+                    () => CreateBehavior(artifact, callerLease),
+                    callerLease.ReleaseAsync);
             }
             catch
             {
-                // Eviction must not make cache mutation fail; callers already observe compile failures through Resolve.
+                callerLease.Release();
+                throw;
             }
+        }
+
+        public void MarkEvicted()
+        {
+            ScriptBehaviorArtifact? disposeNow = null;
+            lock (_gate)
+            {
+                if (_evicted)
+                    return;
+
+                _evicted = true;
+                if (_artifact != null && _referenceCount == 0 && !_disposeStarted)
+                {
+                    _disposeStarted = true;
+                    disposeNow = _artifact;
+                }
+            }
+
+            if (disposeNow != null)
+                DisposeArtifact(disposeNow);
+        }
+
+        private ArtifactLease Retain()
+        {
+            lock (_gate)
+            {
+                if (_disposeStarted)
+                    throw new EvictedArtifactCacheEntryDisposedException();
+
+                _referenceCount += 1;
+            }
+
+            return new ArtifactLease(this);
+        }
+
+        private IScriptBehaviorBridge CreateBehavior(ScriptBehaviorArtifact artifact, ArtifactLease callerLease)
+        {
+            var behaviorLease = Retain();
+            try
+            {
+                var behavior = artifact.CreateBehavior();
+                callerLease.Release();
+                return new LeasedScriptBehaviorBridge(behavior, behaviorLease);
+            }
+            catch
+            {
+                behaviorLease.Release();
+                callerLease.Release();
+                throw;
+            }
+        }
+
+        private ValueTask ReleaseAsync()
+        {
+            Release();
+            return ValueTask.CompletedTask;
+        }
+
+        private void Release()
+        {
+            ScriptBehaviorArtifact? disposeNow = null;
+            lock (_gate)
+            {
+                if (_referenceCount == 0)
+                    return;
+
+                _referenceCount -= 1;
+                if (_evicted && _referenceCount == 0 && _artifact != null && !_disposeStarted)
+                {
+                    _disposeStarted = true;
+                    disposeNow = _artifact;
+                }
+            }
+
+            if (disposeNow != null)
+                DisposeArtifact(disposeNow);
         }
 
         private static void DisposeArtifact(ScriptBehaviorArtifact artifact)
@@ -215,6 +297,143 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
                 // Eviction must not make cache mutation fail; callers already observe compile failures through Resolve.
             }
         }
+
+        public sealed class ArtifactLease
+        {
+            private readonly ArtifactCacheEntry _owner;
+            private int _released;
+
+            public ArtifactLease(ArtifactCacheEntry owner)
+            {
+                _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+            }
+
+            public ValueTask ReleaseAsync()
+            {
+                Release();
+                return ValueTask.CompletedTask;
+            }
+
+            public void Release()
+            {
+                if (Interlocked.CompareExchange(ref _released, 1, 0) == 0)
+                    _owner.Release();
+            }
+        }
+    }
+
+    private sealed class LeasedScriptBehaviorBridge : IScriptBehaviorBridge, IDisposable, IAsyncDisposable
+    {
+        private readonly IScriptBehaviorBridge _inner;
+        private readonly ArtifactCacheEntry.ArtifactLease _lease;
+        private int _disposed;
+
+        public LeasedScriptBehaviorBridge(IScriptBehaviorBridge inner, ArtifactCacheEntry.ArtifactLease lease)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _lease = lease ?? throw new ArgumentNullException(nameof(lease));
+        }
+
+        public ScriptBehaviorDescriptor Descriptor => _inner.Descriptor;
+
+        public Task<IReadOnlyList<IMessage>> DispatchAsync(
+            IMessage inbound,
+            ScriptDispatchContext context,
+            CancellationToken ct) =>
+            _inner.DispatchAsync(inbound, context, ct);
+
+        public IMessage? ApplyDomainEvent(
+            IMessage? currentState,
+            IMessage domainEvent,
+            ScriptFactContext context) =>
+            _inner.ApplyDomainEvent(currentState, domainEvent, context);
+
+        public IMessage? BuildReadModel(
+            IMessage? currentState,
+            ScriptFactContext context) =>
+            _inner.BuildReadModel(currentState, context);
+
+        public void Dispose()
+        {
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+                return;
+
+            if (_inner is IDisposable disposable)
+            {
+                try
+                {
+                    disposable.Dispose();
+                }
+                finally
+                {
+                    _lease.Release();
+                }
+
+                return;
+            }
+
+            if (_inner is IAsyncDisposable asyncDisposable)
+            {
+                DisposeAsyncBehavior(asyncDisposable, _lease);
+                return;
+            }
+
+            _lease.Release();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+                return;
+
+            try
+            {
+                if (_inner is IAsyncDisposable asyncDisposable)
+                    await asyncDisposable.DisposeAsync();
+                else if (_inner is IDisposable disposable)
+                    disposable.Dispose();
+            }
+            finally
+            {
+                _lease.Release();
+            }
+        }
+
+        private static void DisposeAsyncBehavior(
+            IAsyncDisposable asyncDisposable,
+            ArtifactCacheEntry.ArtifactLease lease)
+        {
+            try
+            {
+                var dispose = asyncDisposable.DisposeAsync();
+                if (dispose.IsCompletedSuccessfully)
+                {
+                    lease.Release();
+                    return;
+                }
+
+                _ = dispose.AsTask().ContinueWith(
+                    static (task, state) =>
+                    {
+                        _ = task.Exception;
+                        ((ArtifactCacheEntry.ArtifactLease)state!).Release();
+                    },
+                    lease,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            catch
+            {
+                lease.Release();
+                throw;
+            }
+        }
+
+    }
+
+    private sealed class EvictedArtifactCacheEntryDisposedException : Exception
+    {
     }
 
     private readonly record struct ScriptBehaviorArtifactCacheKey(

--- a/src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs
+++ b/src/Aevatar.Scripting.Infrastructure/Compilation/CachedScriptBehaviorArtifactResolver.cs
@@ -1,29 +1,118 @@
-using System.Collections.Concurrent;
 using Aevatar.Scripting.Core.Runtime;
 using Aevatar.Scripting.Core.Compilation;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Aevatar.Scripting.Infrastructure.Compilation;
 
-public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifactResolver
+// Refactor (iter90/cluster-090-script-artifact-cache-retention):
+//   Old: Singleton resolver kept a ConcurrentDictionary<string, Lazy<...>> forever, used delimiter-concatenated keys, and cached failed Lazy values.
+//   New: Use a bounded MemoryCache keyed by a typed composite key, evict by size, and remove failed Lazy entries so transient compile failures can retry.
+public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifactResolver, IDisposable
 {
-    private readonly ConcurrentDictionary<string, Lazy<ScriptBehaviorArtifact>> _artifacts = new(StringComparer.Ordinal);
+    private const long CacheEntrySize = 1;
+    private const long DefaultMaxCachedArtifacts = 256;
+    private static readonly TimeSpan DefaultSlidingExpiration = TimeSpan.FromMinutes(30);
+
+    private readonly MemoryCache _artifacts;
+    private readonly object _cacheGate = new();
     private readonly IScriptBehaviorCompiler _compiler;
+    private readonly long _maxCachedArtifacts;
+    private readonly TimeSpan _slidingExpiration;
 
     public CachedScriptBehaviorArtifactResolver(IScriptBehaviorCompiler compiler)
+        : this(compiler, DefaultMaxCachedArtifacts, DefaultSlidingExpiration)
+    {
+    }
+
+    public CachedScriptBehaviorArtifactResolver(
+        IScriptBehaviorCompiler compiler,
+        long maxCachedArtifacts,
+        TimeSpan? slidingExpiration = null)
     {
         _compiler = compiler ?? throw new ArgumentNullException(nameof(compiler));
+        if (maxCachedArtifacts <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxCachedArtifacts), "Artifact cache size limit must be positive.");
+
+        _slidingExpiration = slidingExpiration ?? DefaultSlidingExpiration;
+        _maxCachedArtifacts = maxCachedArtifacts;
+        _artifacts = new MemoryCache(new MemoryCacheOptions
+        {
+            SizeLimit = maxCachedArtifacts,
+        });
     }
 
     public ScriptBehaviorArtifact Resolve(ScriptBehaviorArtifactRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var cacheKey = BuildCacheKey(request);
-        var lazy = _artifacts.GetOrAdd(
-            cacheKey,
-            _ => new Lazy<ScriptBehaviorArtifact>(() => CompileOrThrow(request)));
+        var cacheKey = ScriptBehaviorArtifactCacheKey.From(request);
+        var lazy = GetOrCreateLazy(cacheKey, request);
 
-        return lazy.Value;
+        try
+        {
+            return lazy.Value;
+        }
+        catch
+        {
+            RemoveFailedLazy(cacheKey, lazy);
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        _artifacts.Dispose();
+    }
+
+    private Lazy<ScriptBehaviorArtifact> GetOrCreateLazy(
+        ScriptBehaviorArtifactCacheKey cacheKey,
+        ScriptBehaviorArtifactRequest request)
+    {
+        if (_artifacts.TryGetValue(cacheKey, out Lazy<ScriptBehaviorArtifact>? existing) && existing != null)
+            return existing;
+
+        lock (_cacheGate)
+        {
+            if (_artifacts.TryGetValue(cacheKey, out existing) && existing != null)
+                return existing;
+
+            var created = new Lazy<ScriptBehaviorArtifact>(
+                () => CompileOrThrow(request),
+                LazyThreadSafetyMode.ExecutionAndPublication);
+
+            CompactWhenFull();
+            _artifacts.Set(
+                cacheKey,
+                created,
+                new MemoryCacheEntryOptions()
+                    .SetSize(CacheEntrySize)
+                    .SetSlidingExpiration(_slidingExpiration)
+                    .RegisterPostEvictionCallback(DisposeEvictedArtifact));
+
+            return created;
+        }
+    }
+
+    private void CompactWhenFull()
+    {
+        if (_artifacts.Count < _maxCachedArtifacts)
+            return;
+
+        _artifacts.Compact(1.0 / _maxCachedArtifacts);
+    }
+
+    private void RemoveFailedLazy(
+        ScriptBehaviorArtifactCacheKey cacheKey,
+        Lazy<ScriptBehaviorArtifact> failed)
+    {
+        lock (_cacheGate)
+        {
+            if (_artifacts.TryGetValue(cacheKey, out Lazy<ScriptBehaviorArtifact>? current) &&
+                ReferenceEquals(current, failed))
+            {
+                _artifacts.Remove(cacheKey);
+            }
+        }
     }
 
     private ScriptBehaviorArtifact CompileOrThrow(ScriptBehaviorArtifactRequest request)
@@ -38,15 +127,44 @@ public sealed class CachedScriptBehaviorArtifactResolver : IScriptBehaviorArtifa
         return compilation.Artifact;
     }
 
-    private static string BuildCacheKey(ScriptBehaviorArtifactRequest request)
+    private static void DisposeEvictedArtifact(object key, object? value, EvictionReason reason, object? state)
     {
-        return string.Concat(
-            request.ScriptId,
-            "|",
-            request.Revision,
-            "|",
-            request.ResolvedPackageHash,
-            "|",
-            request.Package.EntryBehaviorTypeName ?? string.Empty);
+        _ = key;
+        _ = reason;
+        _ = state;
+
+        if (value is not Lazy<ScriptBehaviorArtifact> lazy || !lazy.IsValueCreated)
+            return;
+
+        try
+        {
+            var dispose = lazy.Value.DisposeAsync();
+            if (!dispose.IsCompletedSuccessfully)
+            {
+                _ = dispose.AsTask().ContinueWith(
+                    static task => _ = task.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+        }
+        catch
+        {
+            // Eviction must not make cache mutation fail; callers already observe compile failures through Resolve.
+        }
+    }
+
+    private readonly record struct ScriptBehaviorArtifactCacheKey(
+        string ScriptId,
+        string Revision,
+        string ResolvedPackageHash,
+        string EntryBehaviorTypeName)
+    {
+        public static ScriptBehaviorArtifactCacheKey From(ScriptBehaviorArtifactRequest request) =>
+            new(
+                request.ScriptId ?? string.Empty,
+                request.Revision ?? string.Empty,
+                request.ResolvedPackageHash ?? string.Empty,
+                request.Package.EntryBehaviorTypeName ?? string.Empty);
     }
 }

--- a/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
@@ -161,6 +161,56 @@ public class ScriptArtifactCoverageTests
         compiler.CallCount.Should().Be(2);
     }
 
+    [Fact]
+    public async Task EvictedArtifact_CanBeCreatedThenAsyncDisposed_ReleasesLease()
+    {
+        var disposed = new List<string>();
+        var disposeObserved = new ManualResetEventSlim(false);
+        var compiler = new RequestEchoCompiler(
+            onDispose: request =>
+            {
+                disposed.Add(request.ScriptId);
+                disposeObserved.Set();
+            },
+            behaviorFactory: static () => new AsyncDisposableNoopBehavior());
+        using var resolver = new CachedScriptBehaviorArtifactResolver(compiler, maxCachedArtifacts: 1);
+
+        var first = resolver.Resolve(CreateRequest(scriptId: "script-1"));
+        var firstBehavior = first.CreateBehavior();
+        var firstBehaviorAsyncDisposable = firstBehavior.Should().BeAssignableTo<IAsyncDisposable>().Subject;
+        var second = resolver.Resolve(CreateRequest(scriptId: "script-2"));
+
+        second.Should().NotBeSameAs(first);
+        disposeObserved.Wait(TimeSpan.FromMilliseconds(100)).Should().BeFalse();
+        await firstBehaviorAsyncDisposable.DisposeAsync();
+        disposeObserved.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        disposed.Should().Contain("script-1");
+        compiler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task EvictedArtifact_DirectDisposeAsync_ReleasesLease_WithoutCreatingBehavior()
+    {
+        var disposed = new List<string>();
+        var disposeObserved = new ManualResetEventSlim(false);
+        var compiler = new RequestEchoCompiler(request =>
+        {
+            disposed.Add(request.ScriptId);
+            disposeObserved.Set();
+        });
+        using var resolver = new CachedScriptBehaviorArtifactResolver(compiler, maxCachedArtifacts: 1);
+
+        var first = resolver.Resolve(CreateRequest(scriptId: "script-1"));
+        var second = resolver.Resolve(CreateRequest(scriptId: "script-2"));
+
+        second.Should().NotBeSameAs(first);
+        disposeObserved.Wait(TimeSpan.FromMilliseconds(100)).Should().BeFalse();
+        await first.DisposeAsync();
+        disposeObserved.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        disposed.Should().Contain("script-1");
+        compiler.CallCount.Should().Be(2);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -272,16 +322,18 @@ public class ScriptArtifactCoverageTests
     private static ScriptBehaviorArtifact CreateArtifact(
         string scriptId,
         string revision,
-        Action? onDispose = null)
+        Action? onDispose = null,
+        Func<IScriptBehaviorBridge>? behaviorFactory = null)
     {
-        var behavior = new NoopBehavior();
+        behaviorFactory ??= static () => new NoopBehavior();
+        var behavior = behaviorFactory();
         return new ScriptBehaviorArtifact(
             scriptId,
             revision,
             "hash-1",
             behavior.Descriptor,
             behavior.Descriptor.ToContract(),
-            static () => new NoopBehavior(),
+            behaviorFactory,
             () =>
             {
                 onDispose?.Invoke();
@@ -329,7 +381,8 @@ public class ScriptArtifactCoverageTests
 
     private sealed class RequestEchoCompiler(
         Action<ScriptBehaviorCompilationRequest>? onDispose = null,
-        Action<ScriptBehaviorCompilationRequest>? onCompile = null) : IScriptBehaviorCompiler
+        Action<ScriptBehaviorCompilationRequest>? onCompile = null,
+        Func<IScriptBehaviorBridge>? behaviorFactory = null) : IScriptBehaviorCompiler
     {
         private int _callCount;
 
@@ -341,12 +394,16 @@ public class ScriptArtifactCoverageTests
             onCompile?.Invoke(request);
             return new ScriptBehaviorCompilationResult(
                 true,
-                CreateArtifact(request.ScriptId, request.Revision, () => onDispose?.Invoke(request)),
+                CreateArtifact(
+                    request.ScriptId,
+                    request.Revision,
+                    () => onDispose?.Invoke(request),
+                    behaviorFactory),
                 Array.Empty<string>());
         }
     }
 
-    private sealed class NoopBehavior : ScriptBehavior<SimpleTextState, SimpleTextReadModel>
+    private class NoopBehavior : ScriptBehavior<SimpleTextState, SimpleTextReadModel>
     {
         protected override void Configure(IScriptBehaviorBuilder<SimpleTextState, SimpleTextReadModel> builder)
         {
@@ -380,5 +437,10 @@ public class ScriptArtifactCoverageTests
             });
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class AsyncDisposableNoopBehavior : NoopBehavior, IAsyncDisposable
+    {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
@@ -47,7 +47,10 @@ public class ScriptArtifactCoverageTests
         var first = resolver.Resolve(request);
         var second = resolver.Resolve(request);
 
-        second.Should().BeSameAs(first);
+        second.ScriptId.Should().Be(first.ScriptId);
+        second.Revision.Should().Be(first.Revision);
+        first.CreateBehavior().Should().BeAssignableTo<IDisposable>().Subject.Dispose();
+        second.CreateBehavior().Should().BeAssignableTo<IDisposable>().Subject.Dispose();
         compiler.CallCount.Should().Be(1);
     }
 
@@ -74,7 +77,8 @@ public class ScriptArtifactCoverageTests
 
         var resolved = await Task.WhenAll(firstTask, secondTask);
 
-        resolved[0].Should().BeSameAs(resolved[1]);
+        resolved[0].ScriptId.Should().Be(resolved[1].ScriptId);
+        resolved[0].Revision.Should().Be(resolved[1].Revision);
         compiler.CallCount.Should().Be(1);
     }
 
@@ -133,7 +137,7 @@ public class ScriptArtifactCoverageTests
     }
 
     [Fact]
-    public void CachedResolver_ShouldEvictByConfiguredSizeLimit_AndDisposeEvictedArtifact()
+    public void CachedResolver_ShouldEvictByConfiguredSizeLimit_AndDisposeAfterReturnedBehaviorDisposes()
     {
         var disposed = new List<string>();
         var disposeObserved = new ManualResetEventSlim(false);
@@ -145,9 +149,13 @@ public class ScriptArtifactCoverageTests
         using var resolver = new CachedScriptBehaviorArtifactResolver(compiler, maxCachedArtifacts: 1);
 
         var first = resolver.Resolve(CreateRequest(scriptId: "script-1"));
+        var firstBehavior = first.CreateBehavior();
+        var firstBehaviorDisposable = firstBehavior.Should().BeAssignableTo<IDisposable>().Subject;
         var second = resolver.Resolve(CreateRequest(scriptId: "script-2"));
 
         second.Should().NotBeSameAs(first);
+        disposeObserved.Wait(TimeSpan.FromMilliseconds(100)).Should().BeFalse();
+        firstBehaviorDisposable.Dispose();
         disposeObserved.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
         disposed.Should().Contain("script-1");
         compiler.CallCount.Should().Be(2);
@@ -168,7 +176,7 @@ public class ScriptArtifactCoverageTests
     }
 
     [Fact]
-    public async Task CachedResolver_ShouldDisposeInFlightArtifact_WhenConcurrentCapacityCompactionEvictsLazy()
+    public async Task CachedResolver_ShouldKeepReturnedArtifactUsable_WhenConcurrentCapacityCompactionEvictsInFlightLazy()
     {
         var firstCompileStarted = new ManualResetEventSlim(false);
         var secondCompileStarted = new ManualResetEventSlim(false);
@@ -213,6 +221,13 @@ public class ScriptArtifactCoverageTests
             .BeEquivalentTo(["script-1", "script-2"]);
 
         resolver.Resolve(CreateRequest(scriptId: "script-3"));
+
+        var behaviors = resolved.Select(artifact => artifact.CreateBehavior()).ToArray();
+        behaviors.Should().HaveCount(2);
+        disposeObserved.Wait(TimeSpan.FromMilliseconds(100)).Should().BeFalse();
+
+        foreach (var behavior in behaviors)
+            behavior.Should().BeAssignableTo<IDisposable>().Subject.Dispose();
 
         disposeObserved.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
         lock (disposeGate)

--- a/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
@@ -153,6 +153,85 @@ public class ScriptArtifactCoverageTests
         compiler.CallCount.Should().Be(2);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void CachedResolver_ShouldRejectNonPositiveMaxCachedArtifacts(long maxCachedArtifacts)
+    {
+        var compiler = new CountingCompiler(() => CreateArtifact("script-1", "rev-1"));
+
+        Action act = () => new CachedScriptBehaviorArtifactResolver(compiler, maxCachedArtifacts);
+
+        act.Should()
+            .Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("maxCachedArtifacts");
+    }
+
+    [Fact]
+    public async Task CachedResolver_ShouldDisposeInFlightArtifact_WhenConcurrentCapacityCompactionEvictsLazy()
+    {
+        var firstCompileStarted = new ManualResetEventSlim(false);
+        var secondCompileStarted = new ManualResetEventSlim(false);
+        var compileCallCount = 0;
+        var allowCompileToReturn = new ManualResetEventSlim(false);
+        var disposed = new List<string>();
+        var disposeObserved = new CountdownEvent(2);
+        var disposeGate = new object();
+        var compiler = new RequestEchoCompiler(
+            onCompile: _ =>
+            {
+                var call = Interlocked.Increment(ref compileCallCount);
+                if (call == 1)
+                    firstCompileStarted.Set();
+                else if (call == 2)
+                    secondCompileStarted.Set();
+
+                allowCompileToReturn.Wait();
+            },
+            onDispose: request =>
+            {
+                lock (disposeGate)
+                {
+                    disposed.Add(request.ScriptId);
+                }
+
+                disposeObserved.Signal();
+            });
+        using var resolver = new CachedScriptBehaviorArtifactResolver(compiler, maxCachedArtifacts: 1);
+
+        var firstTask = ResolveOnDedicatedThread(resolver, CreateRequest(scriptId: "script-1"));
+        firstCompileStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        var secondTask = ResolveOnDedicatedThread(resolver, CreateRequest(scriptId: "script-2"));
+        secondCompileStarted.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+
+        allowCompileToReturn.Set();
+        var resolved = await Task.WhenAll(firstTask, secondTask);
+
+        resolved.Select(artifact => artifact.ScriptId)
+            .Should()
+            .BeEquivalentTo(["script-1", "script-2"]);
+
+        resolver.Resolve(CreateRequest(scriptId: "script-3"));
+
+        disposeObserved.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        lock (disposeGate)
+        {
+            disposed.Should().BeEquivalentTo(["script-1", "script-2"]);
+        }
+
+        compiler.CallCount.Should().Be(3);
+    }
+
+    private static Task<ScriptBehaviorArtifact> ResolveOnDedicatedThread(
+        CachedScriptBehaviorArtifactResolver resolver,
+        ScriptBehaviorArtifactRequest request) =>
+        Task.Factory.StartNew(
+            () => resolver.Resolve(request),
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
     private static ScriptBehaviorArtifactRequest CreateRequest() =>
         CreateRequest(
             scriptId: "script-1",
@@ -233,13 +312,18 @@ public class ScriptArtifactCoverageTests
         }
     }
 
-    private sealed class RequestEchoCompiler(Action<ScriptBehaviorCompilationRequest>? onDispose = null) : IScriptBehaviorCompiler
+    private sealed class RequestEchoCompiler(
+        Action<ScriptBehaviorCompilationRequest>? onDispose = null,
+        Action<ScriptBehaviorCompilationRequest>? onCompile = null) : IScriptBehaviorCompiler
     {
-        public int CallCount { get; private set; }
+        private int _callCount;
+
+        public int CallCount => Volatile.Read(ref _callCount);
 
         public ScriptBehaviorCompilationResult Compile(ScriptBehaviorCompilationRequest request)
         {
-            CallCount += 1;
+            Interlocked.Increment(ref _callCount);
+            onCompile?.Invoke(request);
             return new ScriptBehaviorCompilationResult(
                 true,
                 CreateArtifact(request.ScriptId, request.Revision, () => onDispose?.Invoke(request)),

--- a/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Compilation/ScriptArtifactCoverageTests.cs
@@ -91,12 +91,89 @@ public class ScriptArtifactCoverageTests
             .WithMessage("Script artifact resolution failed: compile-failed");
     }
 
+    [Fact]
+    public void CachedResolver_ShouldRetryAfterFailedCompilation()
+    {
+        var compiler = new FailOnceCompiler();
+        var resolver = new CachedScriptBehaviorArtifactResolver(compiler);
+        var request = CreateRequest();
+
+        Action first = () => resolver.Resolve(request);
+        first.Should().Throw<InvalidOperationException>();
+
+        var resolved = resolver.Resolve(request);
+
+        resolved.ScriptId.Should().Be("script-1");
+        compiler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void CachedResolver_ShouldUseTypedCompositeKey_WithoutDelimiterCollision()
+    {
+        var compiler = new RequestEchoCompiler();
+        var resolver = new CachedScriptBehaviorArtifactResolver(compiler);
+
+        var first = resolver.Resolve(CreateRequest(
+            scriptId: "script",
+            revision: "rev|hash",
+            sourceHash: "entry",
+            entryBehaviorTypeName: "type"));
+        var second = resolver.Resolve(CreateRequest(
+            scriptId: "script|rev",
+            revision: "hash",
+            sourceHash: "entry",
+            entryBehaviorTypeName: "type"));
+
+        second.Should().NotBeSameAs(first);
+        first.ScriptId.Should().Be("script");
+        first.Revision.Should().Be("rev|hash");
+        second.ScriptId.Should().Be("script|rev");
+        second.Revision.Should().Be("hash");
+        compiler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void CachedResolver_ShouldEvictByConfiguredSizeLimit_AndDisposeEvictedArtifact()
+    {
+        var disposed = new List<string>();
+        var disposeObserved = new ManualResetEventSlim(false);
+        var compiler = new RequestEchoCompiler(request =>
+        {
+            disposed.Add(request.ScriptId);
+            disposeObserved.Set();
+        });
+        using var resolver = new CachedScriptBehaviorArtifactResolver(compiler, maxCachedArtifacts: 1);
+
+        var first = resolver.Resolve(CreateRequest(scriptId: "script-1"));
+        var second = resolver.Resolve(CreateRequest(scriptId: "script-2"));
+
+        second.Should().NotBeSameAs(first);
+        disposeObserved.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        disposed.Should().Contain("script-1");
+        compiler.CallCount.Should().Be(2);
+    }
+
     private static ScriptBehaviorArtifactRequest CreateRequest() =>
+        CreateRequest(
+            scriptId: "script-1",
+            revision: "rev-1",
+            sourceHash: "hash-1",
+            entryBehaviorTypeName: string.Empty);
+
+    private static ScriptBehaviorArtifactRequest CreateRequest(
+        string scriptId,
+        string revision = "rev-1",
+        string sourceHash = "hash-1",
+        string entryBehaviorTypeName = "") =>
         new(
-            "script-1",
-            "rev-1",
-            ScriptSourcePackageSerializer.DeserializeOrWrapCSharp("public sealed class DraftBehavior {}"),
-            "hash-1");
+            scriptId,
+            revision,
+            new ScriptSourcePackage(
+                ScriptSourcePackage.CurrentFormat,
+                [new ScriptSourceFile("Behavior.cs", "public sealed class DraftBehavior {}")],
+                Array.Empty<ScriptSourceFile>(),
+                entryBehaviorTypeName),
+            sourceHash);
 
     private static ScriptBehaviorArtifact CreateArtifact(
         string scriptId,
@@ -136,6 +213,37 @@ public class ScriptArtifactCoverageTests
         {
             _ = request;
             return new ScriptBehaviorCompilationResult(false, null, ["compile-failed"]);
+        }
+    }
+
+    private sealed class FailOnceCompiler : IScriptBehaviorCompiler
+    {
+        public int CallCount { get; private set; }
+
+        public ScriptBehaviorCompilationResult Compile(ScriptBehaviorCompilationRequest request)
+        {
+            CallCount += 1;
+            if (CallCount == 1)
+                return new ScriptBehaviorCompilationResult(false, null, ["compile-failed"]);
+
+            return new ScriptBehaviorCompilationResult(
+                true,
+                CreateArtifact(request.ScriptId, request.Revision),
+                Array.Empty<string>());
+        }
+    }
+
+    private sealed class RequestEchoCompiler(Action<ScriptBehaviorCompilationRequest>? onDispose = null) : IScriptBehaviorCompiler
+    {
+        public int CallCount { get; private set; }
+
+        public ScriptBehaviorCompilationResult Compile(ScriptBehaviorCompilationRequest request)
+        {
+            CallCount += 1;
+            return new ScriptBehaviorCompilationResult(
+                true,
+                CreateArtifact(request.ScriptId, request.Revision, () => onDispose?.Invoke(request)),
+                Array.Empty<string>());
         }
     }
 


### PR DESCRIPTION
## 摘要

iter90 cluster-090-script-artifact-cache-retention(severity:low,rules:RULE-CACHE-UNBOUNDED + RULE-CACHE-KEY-COLLISION)。

3 文件(+248/-21):CachedScriptBehaviorArtifactResolver 改 bounded MemoryCache + typed composite key + size limit + failed Lazy 清理。

🤖 Auto-loop / codex-refactor-loop iter90

⟦AI:AUTO-LOOP⟧
