### PR TITLE
iter90 cluster-090: console-web 共享 service-resource query keys + 跨 alias invalidation

### DIFF
--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -38,6 +38,10 @@ import { servicesApi } from "@/shared/api/servicesApi";
 import { formatDateTime } from "@/shared/datetime/dateTime";
 import { history } from "@/shared/navigation/history";
 import { buildPlatformDeploymentsHref } from "@/shared/navigation/platformRoutes";
+import {
+  invalidateServiceResourceQueries,
+  serviceResourceQueryKeys,
+} from "@/shared/query/serviceResourceQueryKeys";
 import { resolveStudioScopeContext } from "@/shared/scope/context";
 import { studioApi } from "@/shared/studio/api";
 import type {
@@ -885,38 +889,38 @@ const DeploymentsPage: React.FC = () => {
 
   const servicesQuery = useQuery({
     queryFn: () => servicesApi.listServices(query),
-    queryKey: ["deployments", "services", query],
+    queryKey: serviceResourceQueryKeys.list(query),
   });
 
   const serviceDetailQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
     queryFn: () => servicesApi.getService(selectedServiceId, query),
-    queryKey: ["deployments", "service", query, selectedServiceId],
+    queryKey: serviceResourceQueryKeys.detail(query, selectedServiceId),
   });
   const revisionsQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
     queryFn: () => servicesApi.getRevisions(selectedServiceId, query),
-    queryKey: ["deployments", "revisions", query, selectedServiceId],
+    queryKey: serviceResourceQueryKeys.revisions(query, selectedServiceId),
   });
   const deploymentsQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
     queryFn: () => servicesApi.getDeployments(selectedServiceId, query),
-    queryKey: ["deployments", "catalog", query, selectedServiceId],
+    queryKey: serviceResourceQueryKeys.deployments(query, selectedServiceId),
   });
   const servingQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
     queryFn: () => servicesApi.getServingSet(selectedServiceId, query),
-    queryKey: ["deployments", "serving", query, selectedServiceId],
+    queryKey: serviceResourceQueryKeys.serving(query, selectedServiceId),
   });
   const rolloutQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
     queryFn: () => servicesApi.getRollout(selectedServiceId, query),
-    queryKey: ["deployments", "rollout", query, selectedServiceId],
+    queryKey: serviceResourceQueryKeys.rollout(query, selectedServiceId),
   });
   const trafficQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
     queryFn: () => servicesApi.getTraffic(selectedServiceId, query),
-    queryKey: ["deployments", "traffic", query, selectedServiceId],
+    queryKey: serviceResourceQueryKeys.traffic(query, selectedServiceId),
   });
 
   const selectedService = useMemo(
@@ -1179,15 +1183,7 @@ const DeploymentsPage: React.FC = () => {
   );
 
   const invalidateDetailQueries = useCallback(async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ["deployments", "service"] }),
-      queryClient.invalidateQueries({ queryKey: ["deployments", "revisions"] }),
-      queryClient.invalidateQueries({ queryKey: ["deployments", "catalog"] }),
-      queryClient.invalidateQueries({ queryKey: ["deployments", "serving"] }),
-      queryClient.invalidateQueries({ queryKey: ["deployments", "rollout"] }),
-      queryClient.invalidateQueries({ queryKey: ["deployments", "traffic"] }),
-      queryClient.invalidateQueries({ queryKey: ["deployments", "services"] }),
-    ]);
+    await invalidateServiceResourceQueries(queryClient);
   }, [queryClient]);
 
   const openDrawer = useCallback((tab: DeploymentDrawerTab) => {

--- a/apps/aevatar-console-web/src/pages/services/index.tsx
+++ b/apps/aevatar-console-web/src/pages/services/index.tsx
@@ -25,6 +25,7 @@ import {
   buildPlatformDeploymentsHref,
   buildPlatformGovernanceHref,
 } from "@/shared/navigation/platformRoutes";
+import { serviceResourceQueryKeys } from "@/shared/query/serviceResourceQueryKeys";
 import { buildRuntimeExplorerHref } from "@/shared/navigation/runtimeRoutes";
 import { resolveStudioScopeContext } from "@/shared/scope/context";
 import { studioApi } from "@/shared/studio/api";
@@ -488,27 +489,27 @@ const ServicesPage: React.FC = () => {
   }, [draft, resolvedScope?.scopeId]);
 
   const servicesQuery = useQuery({
-    queryKey: ["services", query],
+    queryKey: serviceResourceQueryKeys.list(query),
     queryFn: () => servicesApi.listServices(query),
   });
   const selectedServiceQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
-    queryKey: ["services", "detail", selectedServiceId, query],
+    queryKey: serviceResourceQueryKeys.detail(query, selectedServiceId),
     queryFn: () => servicesApi.getService(selectedServiceId, query),
   });
   const revisionsQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
-    queryKey: ["services", "revisions", selectedServiceId, query],
+    queryKey: serviceResourceQueryKeys.revisions(query, selectedServiceId),
     queryFn: () => servicesApi.getRevisions(selectedServiceId, query),
   });
   const deploymentsQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
-    queryKey: ["services", "deployments", selectedServiceId, query],
+    queryKey: serviceResourceQueryKeys.deployments(query, selectedServiceId),
     queryFn: () => servicesApi.getDeployments(selectedServiceId, query),
   });
   const trafficQuery = useQuery({
     enabled: selectedServiceId.trim().length > 0,
-    queryKey: ["services", "traffic", selectedServiceId, query],
+    queryKey: serviceResourceQueryKeys.traffic(query, selectedServiceId),
     queryFn: () => servicesApi.getTraffic(selectedServiceId, query),
   });
 

--- a/apps/aevatar-console-web/src/shared/query/serviceResourceQueryKeys.test.ts
+++ b/apps/aevatar-console-web/src/shared/query/serviceResourceQueryKeys.test.ts
@@ -1,0 +1,65 @@
+import {
+  invalidateServiceResourceQueries,
+  isServiceResourceQueryKeyAlias,
+  serviceResourceQueryKeys,
+} from "./serviceResourceQueryKeys";
+
+const query = {
+  appId: "app-1",
+  namespace: "default",
+  take: 200,
+  tenantId: "tenant-1",
+};
+
+describe("serviceResourceQueryKeys", () => {
+  it("uses one shared service-resource namespace for catalog and deployment resources", () => {
+    expect(serviceResourceQueryKeys.list(query)).toEqual([
+      "service-resources",
+      "list",
+      query,
+    ]);
+    expect(serviceResourceQueryKeys.deployments(query, "svc-1")).toEqual([
+      "service-resources",
+      "deployments",
+      query,
+      "svc-1",
+    ]);
+  });
+
+  it("matches the shared keys and previous page-scoped aliases for invalidation", () => {
+    expect(
+      isServiceResourceQueryKeyAlias(serviceResourceQueryKeys.detail(query, "svc-1")),
+    ).toBe(true);
+    expect(isServiceResourceQueryKeyAlias(["services", query])).toBe(true);
+    expect(
+      isServiceResourceQueryKeyAlias(["services", "detail", "svc-1", query]),
+    ).toBe(true);
+    expect(
+      isServiceResourceQueryKeyAlias(["deployments", "catalog", query, "svc-1"]),
+    ).toBe(true);
+    expect(isServiceResourceQueryKeyAlias(["services", "auth-session"])).toBe(
+      false,
+    );
+    expect(isServiceResourceQueryKeyAlias(["deployments", "auth-session"])).toBe(
+      false,
+    );
+  });
+
+  it("invalidates every matched alias through one helper", async () => {
+    const invalidateQueries = jest.fn();
+
+    await invalidateServiceResourceQueries({ invalidateQueries });
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+    const [filters] = invalidateQueries.mock.calls[0];
+    expect(filters.predicate({ queryKey: serviceResourceQueryKeys.list(query) })).toBe(
+      true,
+    );
+    expect(filters.predicate({ queryKey: ["deployments", "traffic", query, "svc-1"] })).toBe(
+      true,
+    );
+    expect(filters.predicate({ queryKey: ["chat", "services", "tenant-1"] })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/aevatar-console-web/src/shared/query/serviceResourceQueryKeys.ts
+++ b/apps/aevatar-console-web/src/shared/query/serviceResourceQueryKeys.ts
@@ -1,0 +1,58 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+import type { ServiceIdentityQuery } from "@/shared/models/services";
+
+const serviceResourceRoot = "service-resources";
+
+const legacyDeploymentResourceKeys = new Set([
+  "catalog",
+  "revisions",
+  "rollout",
+  "service",
+  "services",
+  "serving",
+  "traffic",
+]);
+
+export const serviceResourceQueryKeys = {
+  all: [serviceResourceRoot] as const,
+  deployments: (query: ServiceIdentityQuery, serviceId: string) =>
+    [serviceResourceRoot, "deployments", query, serviceId] as const,
+  detail: (query: ServiceIdentityQuery, serviceId: string) =>
+    [serviceResourceRoot, "detail", query, serviceId] as const,
+  list: (query: ServiceIdentityQuery) =>
+    [serviceResourceRoot, "list", query] as const,
+  revisions: (query: ServiceIdentityQuery, serviceId: string) =>
+    [serviceResourceRoot, "revisions", query, serviceId] as const,
+  rollout: (query: ServiceIdentityQuery, serviceId: string) =>
+    [serviceResourceRoot, "rollout", query, serviceId] as const,
+  serving: (query: ServiceIdentityQuery, serviceId: string) =>
+    [serviceResourceRoot, "serving", query, serviceId] as const,
+  traffic: (query: ServiceIdentityQuery, serviceId: string) =>
+    [serviceResourceRoot, "traffic", query, serviceId] as const,
+};
+
+export function isServiceResourceQueryKeyAlias(queryKey: QueryKey): boolean {
+  const [resource, alias] = queryKey;
+
+  if (resource === serviceResourceRoot) {
+    return true;
+  }
+
+  if (resource === "deployments" && typeof alias === "string") {
+    return legacyDeploymentResourceKeys.has(alias);
+  }
+
+  if (resource !== "services") {
+    return false;
+  }
+
+  return alias !== "auth-session";
+}
+
+export async function invalidateServiceResourceQueries(
+  queryClient: Pick<QueryClient, "invalidateQueries">,
+): Promise<void> {
+  await queryClient.invalidateQueries({
+    predicate: ({ queryKey }) => isServiceResourceQueryKeyAlias(queryKey),
+  });
+}

--- a/apps/aevatar-console-web/src/shared/query/serviceResourceQueryKeys.ts
+++ b/apps/aevatar-console-web/src/shared/query/serviceResourceQueryKeys.ts
@@ -13,8 +13,14 @@ const legacyDeploymentResourceKeys = new Set([
   "traffic",
 ]);
 
+// Refactor (iter90/cluster-090-console-service-cache-invalidation):
+// Old: service catalog and deployment pages owned separate query-key roots, so
+// mutation invalidation could refresh one page while leaving sibling resource
+// views stale.
+// New: shared service-resource query keys plus one alias matcher invalidate both
+// the unified keys and legacy page-scoped aliases without touching auth-session
+// cache entries.
 export const serviceResourceQueryKeys = {
-  all: [serviceResourceRoot] as const,
   deployments: (query: ServiceIdentityQuery, serviceId: string) =>
     [serviceResourceRoot, "deployments", query, serviceId] as const,
   detail: (query: ServiceIdentityQuery, serviceId: string) =>


### PR DESCRIPTION
## 摘要

iter90 cluster-090-console-service-cache-invalidation(severity:low,rule:RULE-CACHE-STALE-READ)。

console-web 改:
- 新 `serviceResourceQueryKeys.ts`(共享 service-resource key 命名空间 + invalidation helper)
- Deployments / services pages 改用 shared keys → 写后跨 catalog/detail/revision/deployment/traffic alias 全 invalidate

🤖 Auto-loop / codex-refactor-loop iter90

⟦AI:AUTO-LOOP⟧
