### PR TITLE
iter92 cluster-092: stop emitting deprecated OwnerScope legacy fields in production write paths

### DIFF
--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -890,20 +890,14 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
 
     private async Task UpsertRegistryAsync(CancellationToken ct)
     {
-#pragma warning disable CS0612 // legacy field reads/writes during owner_scope migration
-        var legacyOwnerNyxUserId = State.OutboundConfig?.OwnerNyxUserId ?? string.Empty;
-        var legacyPlatform = ResolvePlatform(State.OutboundConfig?.Platform);
-        var ownerScope = State.OutboundConfig?.OwnerScope
-                         ?? OwnerScope.FromLegacyFields(legacyOwnerNyxUserId, legacyPlatform);
+        var ownerScope = State.OutboundConfig?.OwnerScope;
 
         var command = new UserAgentCatalogUpsertCommand
         {
             AgentId = Id,
-            Platform = legacyPlatform,
             ConversationId = State.OutboundConfig?.ConversationId ?? string.Empty,
             NyxProviderSlug = State.OutboundConfig?.NyxProviderSlug ?? string.Empty,
             NyxApiKey = State.OutboundConfig?.NyxApiKey ?? string.Empty,
-            OwnerNyxUserId = legacyOwnerNyxUserId,
             AgentType = SkillRunnerDefaults.AgentType,
             TemplateName = State.TemplateName ?? string.Empty,
             ScopeId = State.ScopeId ?? string.Empty,
@@ -915,10 +909,23 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             LarkReceiveIdFallback = State.OutboundConfig?.LarkReceiveIdFallback ?? string.Empty,
             LarkReceiveIdTypeFallback = State.OutboundConfig?.LarkReceiveIdTypeFallback ?? string.Empty,
         };
-#pragma warning restore CS0612
 
         if (ownerScope is not null)
-            command.OwnerScope = ownerScope;
+        {
+            command.OwnerScope = ownerScope.Clone();
+        }
+        else
+        {
+#pragma warning disable CS0612 // legacy field write only for pre-owner_scope state
+            var legacyOwnerNyxUserId = State.OutboundConfig?.OwnerNyxUserId ?? string.Empty;
+            var legacyPlatform = ResolvePlatform(State.OutboundConfig?.Platform);
+            command.Platform = legacyPlatform;
+            command.OwnerNyxUserId = legacyOwnerNyxUserId;
+            var legacyScope = OwnerScope.FromLegacyFields(legacyOwnerNyxUserId, legacyPlatform);
+#pragma warning restore CS0612
+            if (legacyScope is not null)
+                command.OwnerScope = legacyScope;
+        }
 
         await UserAgentCatalogStoreCommands.DispatchUpsertAsync(Services, Id, command, ct);
     }

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -910,6 +910,10 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             LarkReceiveIdTypeFallback = State.OutboundConfig?.LarkReceiveIdTypeFallback ?? string.Empty,
         };
 
+        // Refactor (iter92/cluster-092):
+        //   Old: write path simultaneously emitted deprecated `Platform`/`OwnerNyxUserId`.
+        //   New: write path emits only `OwnerScope`; legacy fields are retained only in
+        //   the no-`OwnerScope` fallback branch for backwards compatibility.
         if (ownerScope is not null)
         {
             command.OwnerScope = ownerScope.Clone();

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
@@ -33,15 +33,14 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
 
         var existing = State.Entries.FirstOrDefault(x => string.Equals(x.AgentId, command.AgentId, StringComparison.Ordinal));
         var now = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
-#pragma warning disable CS0612 // legacy fields preserved during owner_scope migration
         var entry = new UserAgentCatalogEntry
         {
             AgentId = command.AgentId.Trim(),
-            Platform = MergeNonEmpty(command.Platform, existing?.Platform),
             ConversationId = MergeNonEmpty(command.ConversationId, existing?.ConversationId),
             NyxProviderSlug = MergeNonEmpty(command.NyxProviderSlug, existing?.NyxProviderSlug),
+#pragma warning disable CS0612 // legacy credential field preserved for internal delivery compatibility
             NyxApiKey = MergeNonEmpty(command.NyxApiKey, existing?.NyxApiKey),
-            OwnerNyxUserId = MergeNonEmpty(command.OwnerNyxUserId, existing?.OwnerNyxUserId),
+#pragma warning restore CS0612
             CreatedAt = existing?.CreatedAt ?? now,
             UpdatedAt = now,
             Tombstoned = false,
@@ -56,7 +55,6 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
             LarkReceiveIdFallback = MergeNonEmpty(command.LarkReceiveIdFallback, existing?.LarkReceiveIdFallback),
             LarkReceiveIdTypeFallback = MergeNonEmpty(command.LarkReceiveIdTypeFallback, existing?.LarkReceiveIdTypeFallback),
         };
-#pragma warning restore CS0612
 
         // Issue #466 critical: copy OwnerScope from the command (or inherit existing on
         // partial upserts from older membership update paths that don't recompute scope).
@@ -65,7 +63,16 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
         // returns null for the lark surface, and `/agents` would always be empty.
         var mergedScope = command.OwnerScope ?? existing?.OwnerScope;
         if (mergedScope is not null)
+        {
             entry.OwnerScope = mergedScope.Clone();
+        }
+        else
+        {
+#pragma warning disable CS0612 // legacy fields persisted only when owner_scope is absent
+            entry.Platform = MergeNonEmpty(command.Platform, existing?.Platform);
+            entry.OwnerNyxUserId = MergeNonEmpty(command.OwnerNyxUserId, existing?.OwnerNyxUserId);
+#pragma warning restore CS0612
+        }
 
         await PersistDomainEventAsync(new UserAgentCatalogUpsertedEvent
         {

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogGAgent.cs
@@ -61,6 +61,10 @@ public sealed class UserAgentCatalogGAgent : GAgentBase<UserAgentCatalogState>
         // Without this, every catalog row would land with OwnerScope=null and
         // DocumentMatchesCaller would fall through to the legacy backfill path — which
         // returns null for the lark surface, and `/agents` would always be empty.
+        // Refactor (iter92/cluster-092):
+        //   Old: write path simultaneously emitted deprecated `Platform`/`OwnerNyxUserId`.
+        //   New: write path emits only `OwnerScope`; legacy fields are retained only in
+        //   the no-`OwnerScope` fallback branch for backwards compatibility.
         var mergedScope = command.OwnerScope ?? existing?.OwnerScope;
         if (mergedScope is not null)
         {

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -118,14 +118,8 @@ public sealed class UserAgentCatalogProjector
     {
         var document = existing?.Clone() ?? new UserAgentCatalogDocument();
         document.Id = entry.AgentId;
-#pragma warning disable CS0612 // legacy fields kept for backward read compat (issue #466 migration)
-        document.Platform = entry.Platform ?? string.Empty;
-#pragma warning restore CS0612
         document.ConversationId = entry.ConversationId ?? string.Empty;
         document.NyxProviderSlug = entry.NyxProviderSlug ?? string.Empty;
-#pragma warning disable CS0612
-        document.OwnerNyxUserId = entry.OwnerNyxUserId ?? string.Empty;
-#pragma warning restore CS0612
         document.AgentType = entry.AgentType ?? string.Empty;
         document.TemplateName = entry.TemplateName ?? string.Empty;
         document.ScopeId = entry.ScopeId ?? string.Empty;
@@ -146,6 +140,16 @@ public sealed class UserAgentCatalogProjector
         // the caller-scoped readmodel filter rather than recomputing or inferring it.
 #pragma warning disable CS0612
         var entryScope = entry.OwnerScope ?? OwnerScope.FromLegacyFields(entry.OwnerNyxUserId, entry.Platform);
+        if (entry.OwnerScope is null)
+        {
+            document.Platform = entry.Platform ?? string.Empty;
+            document.OwnerNyxUserId = entry.OwnerNyxUserId ?? string.Empty;
+        }
+        else
+        {
+            document.Platform = string.Empty;
+            document.OwnerNyxUserId = string.Empty;
+        }
 #pragma warning restore CS0612
         if (entryScope is not null)
             document.OwnerScope = entryScope;

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -139,6 +139,10 @@ public sealed class UserAgentCatalogProjector
         // is the authoritative source for ownership; the projector materializes it for
         // the caller-scoped readmodel filter rather than recomputing or inferring it.
 #pragma warning disable CS0612
+        // Refactor (iter92/cluster-092):
+        //   Old: write path simultaneously emitted deprecated `Platform`/`OwnerNyxUserId`.
+        //   New: write path emits only `OwnerScope`; legacy fields are retained only in
+        //   the no-`OwnerScope` fallback branch for backwards compatibility.
         var entryScope = entry.OwnerScope ?? OwnerScope.FromLegacyFields(entry.OwnerNyxUserId, entry.Platform);
         if (entry.OwnerScope is null)
         {

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -216,7 +216,6 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             });
         }
 
-#pragma warning disable CS0612 // legacy fields written for rollback safety during owner_scope migration
         // Refactor (iter4/cluster-009):
         //   Old pattern: Upsert mapped command-port Observed to a synchronous upserted status.
         //   New principle: Upsert ACK is accepted-only; projection freshness is observed by explicit list/get queries.
@@ -227,18 +226,15 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
             new UserAgentCatalogUpsertCommand
             {
                 AgentId = agentId.value!,
-                Platform = platform,
                 ConversationId = conversationId.value!,
                 NyxProviderSlug = nyxProviderSlug.value!,
                 // NyxApiKey intentionally not accepted as a tool argument; the LLM
                 // should never see / pass plaintext credentials. Existing credentials
                 // are preserved through the actor's MergeNonEmpty upsert policy.
                 NyxApiKey = string.Empty,
-                OwnerNyxUserId = caller.NyxUserId,
                 OwnerScope = caller.Clone(),
             },
             ct);
-#pragma warning restore CS0612
 
         return JsonSerializer.Serialize(new
         {

--- a/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.AgentCatalog/AgentDeliveryTargetTool.cs
@@ -222,6 +222,10 @@ public sealed class AgentDeliveryTargetTool : IAgentTool
         // Refactor (iter5/cluster-012):
         //   Old pattern: Upsert awaited a result object that only repeated accepted.
         //   New principle: Upsert awaits command completion; accepted status is emitted by this tool boundary.
+        // Refactor (iter92/cluster-092):
+        //   Old: write path simultaneously emitted deprecated `Platform`/`OwnerNyxUserId`.
+        //   New: write path emits only `OwnerScope`; legacy fields are retained only in
+        //   the no-`OwnerScope` fallback branch for backwards compatibility.
         await commandPort.UpsertAsync(
             new UserAgentCatalogUpsertCommand
             {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentDeliveryTargetToolTests.cs
@@ -189,7 +189,7 @@ public sealed class AgentDeliveryTargetToolTests
                 .Should().Contain("accepted")
                 .And.Contain("propagating");
 
-#pragma warning disable CS0612 // legacy fields kept on the command for rollback safety
+#pragma warning disable CS0612 // assert deprecated ownership fields are no longer emitted
             await commandPort.Received(1).UpsertAsync(
                 Arg.Is<UserAgentCatalogUpsertCommand>(c =>
                     c.AgentId == "agent-1" &&
@@ -198,7 +198,10 @@ public sealed class AgentDeliveryTargetToolTests
                     // Tool no longer accepts NyxApiKey as an argument; the credential
                     // is preserved through the actor's MergeNonEmpty upsert policy.
                     c.NyxApiKey == string.Empty &&
-                    c.OwnerNyxUserId == "user-1"),
+                    c.OwnerScope != null &&
+                    c.OwnerScope.MatchesStrictly(caller) &&
+                    c.Platform == string.Empty &&
+                    c.OwnerNyxUserId == string.Empty),
                 Arg.Any<CancellationToken>());
 #pragma warning restore CS0612
         }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -305,6 +305,51 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleInitializeAsync_WithLegacyOwnershipFields_DerivesOwnerScopeAndPreservesLegacyFields()
+    {
+        var catalogActor = Substitute.For<IActor>();
+        var runtime = Substitute.For<IActorRuntime>();
+        runtime.GetAsync(UserAgentCatalogGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(catalogActor));
+
+        var dispatch = Substitute.For<IActorDispatchPort>();
+        var captured = new List<EventEnvelope>();
+        dispatch.DispatchAsync(
+                UserAgentCatalogGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(captured.Add),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        using var provider = BuildServiceProvider(
+            new InMemoryEventStore(),
+            services =>
+            {
+                services.AddSingleton(runtime);
+                services.AddSingleton(dispatch);
+            });
+        var agent = CreateAgent("skill-runner-legacy-owner-fallback", provider);
+        await agent.ActivateAsync();
+
+        var initialize = CreateInitializeCommand();
+#pragma warning disable CS0612 // legacy fallback branch must keep backwards-compatible writes
+        initialize.OutboundConfig.OwnerNyxUserId = "legacy-user-1";
+        initialize.OutboundConfig.Platform = "nyxid";
+#pragma warning restore CS0612
+
+        await agent.HandleInitializeAsync(initialize);
+
+        captured.Should().ContainSingle();
+        captured[0].Payload.Is(UserAgentCatalogUpsertCommand.Descriptor).Should().BeTrue();
+        var command = captured[0].Payload.Unpack<UserAgentCatalogUpsertCommand>();
+        command.OwnerScope.Should().NotBeNull();
+        command.OwnerScope!.MatchesStrictly(OwnerScope.ForNyxIdNative("legacy-user-1")).Should().BeTrue();
+#pragma warning disable CS0612
+        command.Platform.Should().Be("nyxid");
+        command.OwnerNyxUserId.Should().Be("legacy-user-1");
+#pragma warning restore CS0612
+    }
+
+    [Fact]
     public async Task SendOutputAsync_ShouldUseTypedReceiveTarget_WhenLarkReceiveIdIsPopulated()
     {
         // Initialize with typed fields set (the shape AgentBuilderTool now writes for p2p flows).

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -258,6 +258,53 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleInitializeAsync_WithOwnerScope_DispatchesOwnerScopeOnlyCatalogCommand()
+    {
+        var catalogActor = Substitute.For<IActor>();
+        var runtime = Substitute.For<IActorRuntime>();
+        runtime.GetAsync(UserAgentCatalogGAgent.WellKnownId)
+            .Returns(Task.FromResult<IActor?>(catalogActor));
+
+        var dispatch = Substitute.For<IActorDispatchPort>();
+        var captured = new List<EventEnvelope>();
+        dispatch.DispatchAsync(
+                UserAgentCatalogGAgent.WellKnownId,
+                Arg.Do<EventEnvelope>(captured.Add),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        using var provider = BuildServiceProvider(
+            new InMemoryEventStore(),
+            services =>
+            {
+                services.AddSingleton(runtime);
+                services.AddSingleton(dispatch);
+            });
+        var agent = CreateAgent("skill-runner-owner-scope-only", provider);
+        await agent.ActivateAsync();
+
+        var ownerScope = OwnerScope.ForNyxIdNative("user-1");
+        var initialize = CreateInitializeCommand();
+        initialize.OutboundConfig.OwnerScope = ownerScope;
+#pragma warning disable CS0612 // stale legacy fields must not be emitted when owner_scope exists
+        initialize.OutboundConfig.Platform = "nyxid";
+        initialize.OutboundConfig.OwnerNyxUserId = "user-1";
+#pragma warning restore CS0612
+
+        await agent.HandleInitializeAsync(initialize);
+
+        captured.Should().ContainSingle();
+        captured[0].Payload.Is(UserAgentCatalogUpsertCommand.Descriptor).Should().BeTrue();
+        var command = captured[0].Payload.Unpack<UserAgentCatalogUpsertCommand>();
+        command.OwnerScope.Should().NotBeNull();
+        command.OwnerScope!.MatchesStrictly(ownerScope).Should().BeTrue();
+#pragma warning disable CS0612
+        command.Platform.Should().BeEmpty();
+        command.OwnerNyxUserId.Should().BeEmpty();
+#pragma warning restore CS0612
+    }
+
+    [Fact]
     public async Task SendOutputAsync_ShouldUseTypedReceiveTarget_WhenLarkReceiveIdIsPopulated()
     {
         // Initialize with typed fields set (the shape AgentBuilderTool now writes for p2p flows).

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogGAgentTests.cs
@@ -80,6 +80,31 @@ public sealed class UserAgentCatalogGAgentTests : IAsyncLifetime
         _agent.State.Entries.Should().ContainSingle();
         _agent.State.Entries[0].OwnerScope.Should().NotBeNull();
         _agent.State.Entries[0].OwnerScope!.MatchesStrictly(scope).Should().BeTrue();
+#pragma warning disable CS0612 // deprecated ownership fields should not be re-emitted with owner_scope
+        _agent.State.Entries[0].Platform.Should().BeEmpty();
+        _agent.State.Entries[0].OwnerNyxUserId.Should().BeEmpty();
+#pragma warning restore CS0612
+    }
+
+    [Fact]
+    public async Task HandleUpsertAsync_WithoutOwnerScope_PersistsLegacyOwnershipFields()
+    {
+        await _agent.HandleUpsertAsync(new UserAgentCatalogUpsertCommand
+        {
+            AgentId = "legacy-agent",
+            ConversationId = "oc_chat_legacy",
+#pragma warning disable CS0612 // legacy command shape remains readable/writable when owner_scope is absent
+            Platform = "nyxid",
+            OwnerNyxUserId = "legacy-user",
+#pragma warning restore CS0612
+        });
+
+        _agent.State.Entries.Should().ContainSingle();
+        _agent.State.Entries[0].OwnerScope.Should().BeNull();
+#pragma warning disable CS0612
+        _agent.State.Entries[0].Platform.Should().Be("nyxid");
+        _agent.State.Entries[0].OwnerNyxUserId.Should().Be("legacy-user");
+#pragma warning restore CS0612
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
@@ -100,6 +100,41 @@ public sealed class UserAgentCatalogProjectorTests
     }
 
     [Fact]
+    public async Task ProjectAsync_WithOwnerScope_LeavesDeprecatedOwnershipFieldsEmpty()
+    {
+        var ownerScope = OwnerScope.ForNyxIdNative("user-1");
+        var state = new UserAgentCatalogState
+        {
+            Entries =
+            {
+                new UserAgentCatalogEntry
+                {
+                    AgentId = "agent-scoped",
+                    ConversationId = "oc_chat_1",
+                    NyxProviderSlug = "api-lark-bot",
+                    AgentType = "skill_runner",
+                    OwnerScope = ownerScope,
+#pragma warning disable CS0612 // stale legacy values must not be copied when owner_scope exists
+                    Platform = "nyxid",
+                    OwnerNyxUserId = "user-1",
+#pragma warning restore CS0612
+                },
+            },
+        };
+
+        await _projector.ProjectAsync(_context, BuildCommittedEnvelope("evt-scoped", 4, state), CancellationToken.None);
+
+        _dispatcher.Upserts.Should().ContainSingle();
+        var document = _dispatcher.Upserts[0];
+        document.OwnerScope.Should().NotBeNull();
+        document.OwnerScope!.MatchesStrictly(ownerScope).Should().BeTrue();
+#pragma warning disable CS0612
+        document.Platform.Should().BeEmpty();
+        document.OwnerNyxUserId.Should().BeEmpty();
+#pragma warning restore CS0612
+    }
+
+    [Fact]
     public async Task ProjectAsync_WithSkillRunnerCommittedState_UpsertsExecutionFields()
     {
         // Refactor (iter1/cluster-001):


### PR DESCRIPTION
## Summary
audit-iter-92 cluster-092-owner-scope-deprecated-field-emission:
- `SkillRunnerGAgent`: stop setting deprecated `Platform`/`OwnerNyxUserId` on `UserAgentCatalogUpsertCommand` when `OwnerScope` is present
- `UserAgentCatalogGAgent`: persist deprecated fields only when `OwnerScope` is missing (legacy command apply path)
- `UserAgentCatalogProjector`: leave document deprecated fields empty for entries with `OwnerScope`
- `AgentDeliveryTargetTool`: LLM rebind path stops emitting deprecated command fields
- Preserve `OwnerScope.FromLegacyFields` + query-port fallback for old persisted rows
- Tests updated; legacy fallback path tests preserved

8 files: +149 / -25。

## Audit
`requires_design: false` → 直接 implement → Phase 8。

Closes #1000

⟦AI:AUTO-LOOP⟧