### PR TITLE
iter93 cluster-093: type card action workflow resume + LLM selection payloads

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardHumanInteractionPort.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/FeishuCardHumanInteractionPort.cs
@@ -141,14 +141,10 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
     /// <see cref="MessageContent"/> intent and delegating rendering to <see cref="LarkMessageComposer"/>.
     /// </summary>
     /// <remarks>
-    /// The outbound button-value payload must stay byte-compatible with the inbound card-action
-    /// parser in <see cref="Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayTransport"/>, which maps
-    /// <c>content.text.value</c> into <see cref="CardActionSubmission.Arguments"/> and
-    /// <c>content.text.form_value</c> into <see cref="CardActionSubmission.FormFields"/>. The
-    /// correlation keys (<c>actor_id</c>, <c>run_id</c>, <c>step_id</c>, <c>approved</c>) are
-    /// carried via the <c>ActionElement.Arguments</c> map and form-input names
-    /// (<c>edited_content</c>, <c>user_input</c>) are carried as action ids, so
-    /// <see cref="ChannelCardActionRouting"/> can rebuild the workflow resume command downstream.
+    /// The outbound button-value payload stays JSON-compatible with the inbound card-action parser
+    /// in <see cref="Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayTransport"/> at the Lark/Nyx
+    /// boundary, while repository-owned workflow resume semantics are authored as
+    /// <see cref="WorkflowResumeActionPayload"/>.
     /// </remarks>
     internal static string BuildCardJson(HumanInteractionRequest request) =>
         BuildCardJson(request, new LarkMessageComposer());
@@ -234,14 +230,25 @@ public sealed class FeishuCardHumanInteractionPort : IHumanInteractionPort
             Label = label,
             IsPrimary = isPrimary,
             IsDanger = isDanger,
+            WorkflowResume = BuildWorkflowResumePayload(request, approved),
         };
         button.Arguments["action_id"] = actionId;
-        button.Arguments["actor_id"] = request.ActorId;
-        button.Arguments["run_id"] = request.RunId;
-        button.Arguments["step_id"] = request.StepId;
-        if (approved.HasValue)
-            button.Arguments["approved"] = approved.Value ? "true" : "false";
         return button;
+    }
+
+    private static WorkflowResumeActionPayload BuildWorkflowResumePayload(
+        HumanInteractionRequest request,
+        bool? approved)
+    {
+        var payload = new WorkflowResumeActionPayload
+        {
+            ActorId = request.ActorId,
+            RunId = request.RunId,
+            StepId = request.StepId,
+        };
+        if (approved.HasValue)
+            payload.Approved = approved.Value;
+        return payload;
     }
 
     private static ComposeContext BuildComposeContext() => new()

--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -178,6 +178,10 @@ message ActionOption {
   string value = 2;
 }
 
+// Refactor (iter93/cluster-093):
+// Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+// New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+// extension data plus legacy callback JSON inbound compatibility.
 // Carries repository-owned workflow resume control semantics for one card action.
 message WorkflowResumeActionPayload {
   // The workflow actor that owns the suspended run.
@@ -196,6 +200,10 @@ message WorkflowResumeActionPayload {
   string feedback = 7;
 }
 
+// Refactor (iter93/cluster-093):
+// Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+// New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+// extension data plus legacy callback JSON inbound compatibility.
 // Carries repository-owned LLM selection control semantics for one card action.
 message LlmSelectionActionPayload {
   // The LLM selection action, such as selecting a service or applying a preset.

--- a/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
+++ b/agents/Aevatar.GAgents.Channel.Abstractions/protos/chat_activity.proto
@@ -178,6 +178,34 @@ message ActionOption {
   string value = 2;
 }
 
+// Carries repository-owned workflow resume control semantics for one card action.
+message WorkflowResumeActionPayload {
+  // The workflow actor that owns the suspended run.
+  string actor_id = 1;
+  // The workflow run identifier.
+  string run_id = 2;
+  // The suspended step identifier.
+  string step_id = 3;
+  // The optional approval decision when the suspension is an approval request.
+  optional bool approved = 4;
+  // The submitted user input for generic human-input suspensions.
+  string user_input = 5;
+  // The edited content submitted with an approval action.
+  string edited_content = 6;
+  // The feedback submitted with an approval or rejection action.
+  string feedback = 7;
+}
+
+// Carries repository-owned LLM selection control semantics for one card action.
+message LlmSelectionActionPayload {
+  // The LLM selection action, such as selecting a service or applying a preset.
+  string action = 1;
+  // The target LLM service identifier when selecting a service.
+  string service_id = 2;
+  // The target preset identifier when applying a preset.
+  string preset_id = 3;
+}
+
 // Declares one interactive card element.
 message ActionElement {
   // The element kind.
@@ -199,9 +227,13 @@ message ActionElement {
   // Whether the element is disabled.
   bool is_disabled = 9;
   // Additional scalar arguments forwarded verbatim to the adapter so they surface on callback.
-  // Used to carry correlation keys like workflow actor_id / run_id / step_id that the outbound
-  // side needs the inbound handler to echo back without reinterpretation.
+  // This is an open extension boundary for third-party/platform-specific scalar values. Repository-owned
+  // workflow resume and LLM selection semantics must use the typed payload fields below.
   map<string, string> arguments = 10;
+  // Repository-owned workflow resume payload for this action.
+  WorkflowResumeActionPayload workflow_resume = 11;
+  // Repository-owned LLM selection payload for this action.
+  LlmSelectionActionPayload llm_selection = 12;
 }
 
 // Declares one title-text pair rendered inside a card.
@@ -244,6 +276,10 @@ message CardActionSubmission {
   map<string, string> form_fields = 4;
   // The platform-native source message identifier for the card being acted on.
   string source_message_id = 5;
+  // Repository-owned workflow resume payload submitted by this action.
+  WorkflowResumeActionPayload workflow_resume = 6;
+  // Repository-owned LLM selection payload submitted by this action.
+  LlmSelectionActionPayload llm_selection = 7;
 }
 
 // Carries the channel-agnostic message content used for send, update, and reply operations.

--- a/agents/Aevatar.GAgents.Channel.Runtime/InboundMessage.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/InboundMessage.cs
@@ -16,5 +16,6 @@ public sealed class InboundMessage
     public string? ChatType { get; init; }
     public OutboundDeliveryContext? OutboundDelivery { get; init; }
     public TransportExtras? TransportExtras { get; init; }
+    public CardActionSubmission? CardAction { get; init; }
     public IReadOnlyDictionary<string, string> Extra { get; init; } = new Dictionary<string, string>();
 }

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
@@ -12,6 +12,10 @@ public static class ChannelCardActionRouting
         InboundMessage inbound,
         out WorkflowResumeCommand? command)
     {
+        // Refactor (iter93/cluster-093):
+        // Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+        // New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+        // extension data plus legacy callback JSON inbound compatibility.
         command = null;
         ArgumentNullException.ThrowIfNull(inbound);
 

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelCardActionRouting.cs
@@ -1,5 +1,6 @@
 using Aevatar.GAgents.Channel.Runtime;
 using Aevatar.Workflow.Application.Abstractions.Runs;
+using Aevatar.GAgents.Channel.Abstractions;
 
 namespace Aevatar.GAgents.NyxidChat;
 
@@ -17,9 +18,26 @@ public static class ChannelCardActionRouting
         if (!string.Equals(inbound.ChatType, CardActionChatType, StringComparison.Ordinal))
             return false;
 
-        if (!TryGetRequiredValue(inbound.Extra, "actor_id", out var actorId) ||
-            !TryGetRequiredValue(inbound.Extra, "run_id", out var runId) ||
-            !TryGetRequiredValue(inbound.Extra, "step_id", out var stepId))
+        var payload = inbound.CardAction?.WorkflowResume;
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (payload is not null && HasWorkflowResumeIdentity(payload))
+        {
+            CopyWorkflowResumePayload(payload, values);
+            foreach (var pair in inbound.CardAction!.FormFields)
+                values[pair.Key] = pair.Value;
+        }
+        else if (TryBuildDeprecatedWorkflowResumeValues(inbound.Extra, values))
+        {
+            // Deprecated inbound compatibility only. New producers must use WorkflowResumeActionPayload.
+        }
+        else
+        {
+            return false;
+        }
+
+        if (!TryGetRequiredValue(values, "actor_id", out var actorId) ||
+            !TryGetRequiredValue(values, "run_id", out var runId) ||
+            !TryGetRequiredValue(values, "step_id", out var stepId))
         {
             return false;
         }
@@ -32,19 +50,57 @@ public static class ChannelCardActionRouting
         if (!string.IsNullOrWhiteSpace(inbound.MessageId))
             metadata["channel.message_id"] = inbound.MessageId;
 
-        var approved = ResolveApproved(inbound.Extra);
-        var editedContent = ResolveEditedContent(inbound.Extra);
-        var feedback = ResolveFeedback(inbound.Extra, approved);
+        var approved = ResolveApproved(values);
+        var editedContent = ResolveEditedContent(values);
+        var feedback = ResolveFeedback(values, approved);
         command = new WorkflowResumeCommand(
             actorId,
             runId,
             stepId,
             NormalizeOptional(inbound.MessageId),
             approved,
-            ResolveUserInput(inbound.Extra, approved),
+            ResolveUserInput(values, approved),
             metadata,
             editedContent,
             feedback);
+        return true;
+    }
+
+    private static bool HasWorkflowResumeIdentity(WorkflowResumeActionPayload payload) =>
+        !string.IsNullOrWhiteSpace(payload.ActorId) &&
+        !string.IsNullOrWhiteSpace(payload.RunId) &&
+        !string.IsNullOrWhiteSpace(payload.StepId);
+
+    private static void CopyWorkflowResumePayload(
+        WorkflowResumeActionPayload payload,
+        IDictionary<string, string> values)
+    {
+        values["actor_id"] = payload.ActorId;
+        values["run_id"] = payload.RunId;
+        values["step_id"] = payload.StepId;
+        if (payload.HasApproved)
+            values["approved"] = payload.Approved ? "true" : "false";
+        if (!string.IsNullOrWhiteSpace(payload.UserInput))
+            values["user_input"] = payload.UserInput;
+        if (!string.IsNullOrWhiteSpace(payload.EditedContent))
+            values["edited_content"] = payload.EditedContent;
+        if (!string.IsNullOrWhiteSpace(payload.Feedback))
+            values["feedback"] = payload.Feedback;
+    }
+
+    private static bool TryBuildDeprecatedWorkflowResumeValues(
+        IReadOnlyDictionary<string, string> extra,
+        IDictionary<string, string> values)
+    {
+        if (!TryGetRequiredValue(extra, "actor_id", out _) ||
+            !TryGetRequiredValue(extra, "run_id", out _) ||
+            !TryGetRequiredValue(extra, "step_id", out _))
+        {
+            return false;
+        }
+
+        foreach (var pair in extra)
+            values[pair.Key] = pair.Value;
         return true;
     }
 

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -674,9 +674,23 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         if (cardAction is null)
             return false;
 
+        var payload = cardAction.LlmSelection;
+        if (payload is not null && !string.IsNullOrWhiteSpace(payload.Action))
+        {
+            action = payload.Action.Trim();
+            value = action switch
+            {
+                TextUserLlmOptionsRenderer.SelectServiceAction => payload.ServiceId?.Trim() ?? string.Empty,
+                TextUserLlmOptionsRenderer.ApplyPresetAction => payload.PresetId?.Trim() ?? string.Empty,
+                _ => string.Empty,
+            };
+            return true;
+        }
+
         if (!inbound.Extra.TryGetValue(TextUserLlmOptionsRenderer.LlmActionArgument, out var actionValue) ||
             string.IsNullOrWhiteSpace(actionValue))
         {
+            // Deprecated inbound compatibility only. New producers must use LlmSelectionActionPayload.
             action = cardAction.ActionId switch
             {
                 TextUserLlmOptionsRenderer.SelectServiceActionId => TextUserLlmOptionsRenderer.SelectServiceAction,
@@ -1411,7 +1425,10 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         ArgumentNullException.ThrowIfNull(activity);
 
         var extra = new Dictionary<string, string>(StringComparer.Ordinal);
-        if (activity.Type == ActivityType.CardAction && activity.Content?.CardAction is { } cardAction)
+        var cardAction = activity.Type == ActivityType.CardAction
+            ? activity.Content?.CardAction
+            : null;
+        if (cardAction is not null)
         {
             if (cardAction.Arguments.TryGetValue("agent_builder_action", out var builderAction) &&
                 !string.IsNullOrWhiteSpace(builderAction))
@@ -1442,6 +1459,7 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
             ChatType = ResolveChatType(activity.Conversation, activity.Type),
             OutboundDelivery = activity.OutboundDelivery?.Clone(),
             TransportExtras = activity.TransportExtras?.Clone(),
+            CardAction = cardAction?.Clone(),
             Extra = extra,
         };
     }

--- a/agents/Aevatar.GAgents.NyxidChat/LlmSelection/TextUserLlmOptionsRenderer.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/LlmSelection/TextUserLlmOptionsRenderer.cs
@@ -185,10 +185,10 @@ public sealed class TextUserLlmOptionsRenderer : IUserLlmOptionsRenderer<Message
         Value = option.ServiceId,
         IsPrimary = option.Allowed && string.Equals(option.Status, "ready", StringComparison.OrdinalIgnoreCase),
         IsDisabled = !option.Allowed || !string.Equals(option.Status, "ready", StringComparison.OrdinalIgnoreCase),
-        Arguments =
+        LlmSelection = new LlmSelectionActionPayload
         {
-            [LlmActionArgument] = SelectServiceAction,
-            [ServiceIdArgument] = option.ServiceId,
+            Action = SelectServiceAction,
+            ServiceId = option.ServiceId,
         },
     };
 
@@ -199,10 +199,10 @@ public sealed class TextUserLlmOptionsRenderer : IUserLlmOptionsRenderer<Message
         Label = preset.Title,
         Value = preset.Id,
         IsPrimary = true,
-        Arguments =
+        LlmSelection = new LlmSelectionActionPayload
         {
-            [LlmActionArgument] = ApplyPresetAction,
-            [PresetIdArgument] = preset.Id,
+            Action = ApplyPresetAction,
+            PresetId = preset.Id,
         },
     };
 }

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -212,6 +212,10 @@ public sealed class NyxIdRelayTransport
 
     private static void MapKnownPayloads(CardActionSubmission submission)
     {
+        // Refactor (iter93/cluster-093):
+        // Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+        // New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+        // extension data plus legacy callback JSON inbound compatibility.
         if (TryBuildWorkflowResumePayload(submission, out var workflowResume))
         {
             submission.WorkflowResume = workflowResume;

--- a/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
+++ b/agents/channels/Aevatar.GAgents.Channel.NyxIdRelay/NyxIdRelayTransport.cs
@@ -198,6 +198,8 @@ public sealed class NyxIdRelayTransport
         if (root.TryGetProperty("form_fields", out var formFieldsElement))
             CopyScalarMap(formFieldsElement, submission.FormFields);
 
+        MapKnownPayloads(submission);
+
         if (string.IsNullOrEmpty(submission.ActionId) &&
             submission.Arguments.TryGetValue("agent_builder_action", out var builderAction) &&
             !string.IsNullOrWhiteSpace(builderAction))
@@ -206,6 +208,124 @@ public sealed class NyxIdRelayTransport
         }
 
         return submission;
+    }
+
+    private static void MapKnownPayloads(CardActionSubmission submission)
+    {
+        if (TryBuildWorkflowResumePayload(submission, out var workflowResume))
+        {
+            submission.WorkflowResume = workflowResume;
+            RemoveWorkflowResumeKeys(submission);
+        }
+
+        if (TryBuildLlmSelectionPayload(submission, out var llmSelection))
+        {
+            submission.LlmSelection = llmSelection;
+            RemoveLlmSelectionKeys(submission);
+        }
+    }
+
+    private static void RemoveWorkflowResumeKeys(CardActionSubmission submission)
+    {
+        submission.Arguments.Remove("actor_id");
+        submission.Arguments.Remove("run_id");
+        submission.Arguments.Remove("step_id");
+        submission.Arguments.Remove("approved");
+    }
+
+    private static void RemoveLlmSelectionKeys(CardActionSubmission submission)
+    {
+        submission.Arguments.Remove("llm_action");
+        submission.Arguments.Remove("service_id");
+        submission.Arguments.Remove("preset_id");
+    }
+
+    private static bool TryBuildWorkflowResumePayload(
+        CardActionSubmission submission,
+        out WorkflowResumeActionPayload payload)
+    {
+        payload = new WorkflowResumeActionPayload();
+        if (!TryGetRequiredValue(submission.Arguments, "actor_id", out var actorId) ||
+            !TryGetRequiredValue(submission.Arguments, "run_id", out var runId) ||
+            !TryGetRequiredValue(submission.Arguments, "step_id", out var stepId))
+        {
+            return false;
+        }
+
+        payload.ActorId = actorId;
+        payload.RunId = runId;
+        payload.StepId = stepId;
+        if (submission.Arguments.TryGetValue("approved", out var rawApproved) &&
+            bool.TryParse(rawApproved, out var approved))
+        {
+            payload.Approved = approved;
+        }
+
+        if (submission.FormFields.TryGetValue("user_input", out var userInput))
+            payload.UserInput = userInput ?? string.Empty;
+        if (submission.FormFields.TryGetValue("edited_content", out var editedContent))
+            payload.EditedContent = editedContent ?? string.Empty;
+        if (submission.FormFields.TryGetValue("feedback", out var feedback))
+            payload.Feedback = feedback ?? string.Empty;
+
+        return true;
+    }
+
+    private static bool TryBuildLlmSelectionPayload(
+        CardActionSubmission submission,
+        out LlmSelectionActionPayload payload)
+    {
+        payload = new LlmSelectionActionPayload();
+
+        if (!submission.Arguments.TryGetValue("llm_action", out var rawAction) ||
+            string.IsNullOrWhiteSpace(rawAction))
+        {
+            rawAction = submission.ActionId switch
+            {
+                "ls" or "llm_select_service" => "select_service",
+                "lp" or "llm_apply_preset" => "apply_preset",
+                _ => string.Empty,
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(rawAction))
+            return false;
+
+        payload.Action = rawAction.Trim();
+        if (submission.Arguments.TryGetValue("service_id", out var serviceId) &&
+            !string.IsNullOrWhiteSpace(serviceId))
+        {
+            payload.ServiceId = serviceId.Trim();
+        }
+        else if (payload.Action == "select_service" && !string.IsNullOrWhiteSpace(submission.SubmittedValue))
+        {
+            payload.ServiceId = submission.SubmittedValue.Trim();
+        }
+
+        if (submission.Arguments.TryGetValue("preset_id", out var presetId) &&
+            !string.IsNullOrWhiteSpace(presetId))
+        {
+            payload.PresetId = presetId.Trim();
+        }
+        else if (payload.Action == "apply_preset" && !string.IsNullOrWhiteSpace(submission.SubmittedValue))
+        {
+            payload.PresetId = submission.SubmittedValue.Trim();
+        }
+
+        return true;
+    }
+
+    private static bool TryGetRequiredValue(
+        Google.Protobuf.Collections.MapField<string, string> values,
+        string key,
+        out string value)
+    {
+        value = string.Empty;
+        if (!values.TryGetValue(key, out var raw))
+            return false;
+
+        value = (raw ?? string.Empty).Trim();
+        return !string.IsNullOrWhiteSpace(value);
     }
 
     private static void CopyScalarMap(JsonElement element, Google.Protobuf.Collections.MapField<string, string> target)

--- a/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
@@ -356,6 +356,10 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         WorkflowResumeActionPayload? payload,
         IDictionary<string, object?> map)
     {
+        // Refactor (iter93/cluster-093):
+        // Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+        // New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+        // extension data plus legacy callback JSON inbound compatibility.
         if (payload is null)
             return;
 
@@ -379,6 +383,10 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         LlmSelectionActionPayload? payload,
         IDictionary<string, object?> map)
     {
+        // Refactor (iter93/cluster-093):
+        // Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+        // New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+        // extension data plus legacy callback JSON inbound compatibility.
         if (payload is null)
             return;
 

--- a/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Lark/LarkMessageComposer.cs
@@ -337,6 +337,8 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
             ["action_id"] = action.ActionId,
             ["value"] = action.Value,
         };
+        CopyWorkflowResumePayload(action.WorkflowResume, map);
+        CopyLlmSelectionPayload(action.LlmSelection, map);
 
         foreach (var argument in action.Arguments)
         {
@@ -348,6 +350,44 @@ public sealed class LarkMessageComposer : IMessageComposer<LarkOutboundMessage>
         }
 
         return map;
+    }
+
+    private static void CopyWorkflowResumePayload(
+        WorkflowResumeActionPayload? payload,
+        IDictionary<string, object?> map)
+    {
+        if (payload is null)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(payload.ActorId))
+            map["actor_id"] = payload.ActorId;
+        if (!string.IsNullOrWhiteSpace(payload.RunId))
+            map["run_id"] = payload.RunId;
+        if (!string.IsNullOrWhiteSpace(payload.StepId))
+            map["step_id"] = payload.StepId;
+        if (payload.HasApproved)
+            map["approved"] = payload.Approved;
+        if (!string.IsNullOrWhiteSpace(payload.UserInput))
+            map["user_input"] = payload.UserInput;
+        if (!string.IsNullOrWhiteSpace(payload.EditedContent))
+            map["edited_content"] = payload.EditedContent;
+        if (!string.IsNullOrWhiteSpace(payload.Feedback))
+            map["feedback"] = payload.Feedback;
+    }
+
+    private static void CopyLlmSelectionPayload(
+        LlmSelectionActionPayload? payload,
+        IDictionary<string, object?> map)
+    {
+        if (payload is null)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(payload.Action))
+            map["llm_action"] = payload.Action;
+        if (!string.IsNullOrWhiteSpace(payload.ServiceId))
+            map["service_id"] = payload.ServiceId;
+        if (!string.IsNullOrWhiteSpace(payload.PresetId))
+            map["preset_id"] = payload.PresetId;
     }
 
     private static object? CoerceArgumentValue(string raw)

--- a/agents/platforms/Aevatar.GAgents.Platform.Telegram/TelegramMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Telegram/TelegramMessageComposer.cs
@@ -194,12 +194,10 @@ public sealed class TelegramMessageComposer : IMessageComposer<TelegramOutboundM
         if (!string.IsNullOrWhiteSpace(submittedValue))
             payload["s"] = submittedValue;
 
-        if (action.Arguments.Count > 0)
+        var arguments = BuildCallbackArguments(action);
+        if (arguments.Count > 0)
         {
-            payload["v"] = action.Arguments.ToDictionary(
-                pair => pair.Key,
-                pair => pair.Value,
-                StringComparer.Ordinal);
+            payload["v"] = arguments;
         }
 
         callbackData = JsonSerializer.Serialize(payload);
@@ -216,11 +214,31 @@ public sealed class TelegramMessageComposer : IMessageComposer<TelegramOutboundM
         if (!string.IsNullOrWhiteSpace(submittedValue))
             return false;
 
-        if (action.Arguments.Count > 0)
+        if (arguments.Count > 0)
             return false;
 
         callbackData = actionId;
         return FitsCallbackDataLimit(callbackData);
+    }
+
+    private static Dictionary<string, string> BuildCallbackArguments(ActionElement action)
+    {
+        var arguments = action.Arguments.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value,
+            StringComparer.Ordinal);
+
+        if (action.LlmSelection is { } llmSelection)
+        {
+            if (!string.IsNullOrWhiteSpace(llmSelection.Action))
+                arguments["llm_action"] = llmSelection.Action;
+            if (!string.IsNullOrWhiteSpace(llmSelection.ServiceId))
+                arguments["service_id"] = llmSelection.ServiceId;
+            if (!string.IsNullOrWhiteSpace(llmSelection.PresetId))
+                arguments["preset_id"] = llmSelection.PresetId;
+        }
+
+        return arguments;
     }
 
     private static bool FitsCallbackDataLimit(string value) =>

--- a/agents/platforms/Aevatar.GAgents.Platform.Telegram/TelegramMessageComposer.cs
+++ b/agents/platforms/Aevatar.GAgents.Platform.Telegram/TelegramMessageComposer.cs
@@ -183,14 +183,15 @@ public sealed class TelegramMessageComposer : IMessageComposer<TelegramOutboundM
     {
         callbackData = string.Empty;
         var actionId = action.ActionId?.Trim();
-        if (string.IsNullOrWhiteSpace(actionId))
+        var hasTypedLlmAction = action.LlmSelection is { Action: { } llmAction } &&
+            !string.IsNullOrWhiteSpace(llmAction);
+        if (string.IsNullOrWhiteSpace(actionId) && !hasTypedLlmAction)
             return false;
 
         var submittedValue = action.Value?.Trim();
-        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
-        {
-            ["a"] = actionId,
-        };
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (!string.IsNullOrWhiteSpace(actionId))
+            payload["a"] = actionId;
         if (!string.IsNullOrWhiteSpace(submittedValue))
             payload["s"] = submittedValue;
 
@@ -217,12 +218,19 @@ public sealed class TelegramMessageComposer : IMessageComposer<TelegramOutboundM
         if (arguments.Count > 0)
             return false;
 
+        if (string.IsNullOrWhiteSpace(actionId))
+            return false;
+
         callbackData = actionId;
         return FitsCallbackDataLimit(callbackData);
     }
 
     private static Dictionary<string, string> BuildCallbackArguments(ActionElement action)
     {
+        // Refactor (iter93/cluster-093):
+        // Old: workflow resume + LLM selection control semantics lived in the open `arguments` map.
+        // New: repository-owned semantics use typed payloads; `arguments` is only for adapter/third-party
+        // extension data plus legacy callback JSON inbound compatibility.
         var arguments = action.Arguments.ToDictionary(
             pair => pair.Key,
             pair => pair.Value,

--- a/docs/adr/0014-interactive-reply-abstraction.md
+++ b/docs/adr/0014-interactive-reply-abstraction.md
@@ -123,15 +123,18 @@ behaviour without redeploying.
 - New abstractions (`ChannelNativeMessage`, `IChannelMessageComposerRegistry`,
   `IInteractiveReplyCollector`, `IChannelNativeMessageProducer`,
   `IInteractiveReplyDispatcher`).
-- Proto additions: `ActionElementKind.TEXT_INPUT` and `ActionElement.arguments` map
-  (carries correlation keys forwarded verbatim to the adapter so inbound parsers still
-  see them in the expected locations).
+- Proto additions: `ActionElementKind.TEXT_INPUT`, `WorkflowResumeActionPayload`,
+  `LlmSelectionActionPayload`, and the `ActionElement.arguments` extension map.
+  Workflow resume and LLM selection fields are repository-owned control semantics and
+  therefore use typed payloads on `ActionElement` / `CardActionSubmission`; `arguments`
+  is only an open adapter-extension / deprecated inbound compatibility map.
 - `NyxIdApiClient.SendChannelRelayReplyAsync` rich overload; existing text overload
   becomes a thin wrapper.
 - `LarkMessageComposer` extended to render form-wrapped cards when `TextInput` actions
   are present (emits `body.elements[].tag=form` with mixed `tag=input` + `tag=button`
-  children, merges `ActionElement.Arguments` into the button `value` object, and picks
-  the `orange` header template whenever any action is marked `is_danger`).
+  children, projects typed action payloads plus `ActionElement.Arguments` into the
+  boundary callback `value` object, and picks the `orange` header template whenever any
+  action is marked `is_danger`).
 - `LarkChannelNativeMessageProducer` wrapping the existing `LarkMessageComposer`.
 - `NyxIdRelayInteractiveReplyDispatcher` default implementation.
 - New project `Aevatar.AI.ToolProviders.Channel` with `ReplyWithInteractionTool` and

--- a/docs/canon/aevatar-channel-architecture.md
+++ b/docs/canon/aevatar-channel-architecture.md
@@ -487,6 +487,8 @@ public record MessageContent(
 
 **核心原则**：`MessageContent` 描述 "要表达什么"，不描述 "长什么样"。`IMessageComposer` 把它翻译成 channel-native 的具体 payload。
 
+**Card action typed payload rule**：workflow resume 与 LLM selection 是仓库内可控的控制语义，必须通过 `WorkflowResumeActionPayload` / `LlmSelectionActionPayload` 挂在 `ActionElement` 与 `CardActionSubmission` 上。`ActionElement.arguments` / `CardActionSubmission.Arguments` 只作为第三方或平台扩展 map，以及旧 callback JSON 的入站兼容边界；进入 `ChannelConversationTurnRunner`、`ChannelCardActionRouting` 或 LLM selection handoff 后，不得把这些字段当成权威事实源。
+
 **为什么不做 universal card schema（Adaptive Cards 路线）**：universal schema 是 Level-3 抽象——为了一致性牺牲 native 表达力。Slack Block Kit 的嵌套 / Discord Embed 的字段限制 / Lark 卡片的交互模型各自有自己最自然的表达方式，强行统一会得到"处处一致但处处不好用"的结果。我们选 Level-2：intent 层统一，表达层 native，能力缺失就显式降级。
 
 ### 5.4 `IChannelTransport` + `IChannelOutboundPort` + `IMessageComposer`

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardActionRoutingTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelCardActionRoutingTests.cs
@@ -3,13 +3,14 @@ using Aevatar.GAgents.NyxidChat;
 using Aevatar.Workflow.Application.Abstractions.Runs;
 using FluentAssertions;
 using Xunit;
+using Aevatar.GAgents.Channel.Abstractions;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
 public sealed class ChannelCardActionRoutingTests
 {
     [Fact]
-    public void TryBuildWorkflowResumeCommand_should_build_command_for_complete_card_action()
+    public void TryBuildWorkflowResumeCommand_should_build_command_for_typed_card_action()
     {
         var inbound = new InboundMessage
         {
@@ -20,13 +21,16 @@ public sealed class ChannelCardActionRoutingTests
             Text = "{}",
             MessageId = "evt_card_1",
             ChatType = "card_action",
-            Extra = new Dictionary<string, string>
+            CardAction = new CardActionSubmission
             {
-                ["actor_id"] = "run-actor-1",
-                ["run_id"] = "run-1",
-                ["step_id"] = "approval-1",
-                ["approved"] = "false",
-                ["user_input"] = "need edits",
+                WorkflowResume = new WorkflowResumeActionPayload
+                {
+                    ActorId = "run-actor-1",
+                    RunId = "run-1",
+                    StepId = "approval-1",
+                    Approved = false,
+                    UserInput = "need edits",
+                },
             },
         };
 
@@ -48,6 +52,42 @@ public sealed class ChannelCardActionRoutingTests
     }
 
     [Fact]
+    public void TryBuildWorkflowResumeCommand_should_keep_deprecated_literal_key_fallback()
+    {
+        var inbound = new InboundMessage
+        {
+            Platform = "lark",
+            ConversationId = "oc_chat_1",
+            SenderId = "ou_user_1",
+            SenderName = string.Empty,
+            Text = "{}",
+            MessageId = "evt_card_legacy_1",
+            ChatType = "card_action",
+            Extra = new Dictionary<string, string>
+            {
+                ["actor_id"] = "run-actor-1",
+                ["run_id"] = "run-1",
+                ["step_id"] = "approval-1",
+                ["approved"] = "false",
+                ["user_input"] = "need edits",
+            },
+        };
+
+        var matched = ChannelCardActionRouting.TryBuildWorkflowResumeCommand(inbound, out var command);
+
+        matched.Should().BeTrue();
+        command.Should().NotBeNull();
+        command!.ActorId.Should().Be("run-actor-1");
+        command.RunId.Should().Be("run-1");
+        command.StepId.Should().Be("approval-1");
+        command.CommandId.Should().Be("evt_card_legacy_1");
+        command.Approved.Should().BeFalse();
+        command.UserInput.Should().Be("need edits");
+        command.EditedContent.Should().BeNull();
+        command.Feedback.Should().Be("need edits");
+    }
+
+    [Fact]
     public void TryBuildWorkflowResumeCommand_should_prefer_edited_content_when_approved()
     {
         var inbound = new InboundMessage
@@ -59,14 +99,17 @@ public sealed class ChannelCardActionRoutingTests
             Text = "{}",
             MessageId = "evt_card_approved_1",
             ChatType = "card_action",
-            Extra = new Dictionary<string, string>
+            CardAction = new CardActionSubmission
             {
-                ["actor_id"] = "run-actor-1",
-                ["run_id"] = "run-1",
-                ["step_id"] = "approval-1",
-                ["approved"] = "true",
-                ["edited_content"] = "Rewritten final draft",
-                ["user_input"] = "minor note",
+                WorkflowResume = new WorkflowResumeActionPayload
+                {
+                    ActorId = "run-actor-1",
+                    RunId = "run-1",
+                    StepId = "approval-1",
+                    Approved = true,
+                    EditedContent = "Rewritten final draft",
+                    UserInput = "minor note",
+                },
             },
         };
 
@@ -92,14 +135,17 @@ public sealed class ChannelCardActionRoutingTests
             Text = "{}",
             MessageId = "evt_card_rejected_1",
             ChatType = "card_action",
-            Extra = new Dictionary<string, string>
+            CardAction = new CardActionSubmission
             {
-                ["actor_id"] = "run-actor-1",
-                ["run_id"] = "run-1",
-                ["step_id"] = "approval-1",
-                ["approved"] = "false",
-                ["edited_content"] = "Edited but not accepted",
-                ["user_input"] = "Need stronger hook",
+                WorkflowResume = new WorkflowResumeActionPayload
+                {
+                    ActorId = "run-actor-1",
+                    RunId = "run-1",
+                    StepId = "approval-1",
+                    Approved = false,
+                    EditedContent = "Edited but not accepted",
+                    UserInput = "Need stronger hook",
+                },
             },
         };
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -773,6 +773,57 @@ public sealed class ChannelConversationTurnRunnerTests
     }
 
     [Fact]
+    public async Task RunInboundAsync_ShouldApplyTypedLlmPreset_WhenPayloadCarriesPresetId()
+    {
+        var subject = new ExternalSubjectRef
+        {
+            Platform = "lark",
+            Tenant = "scope-1",
+            ExternalUserId = "ou_user_1",
+        };
+        var broker = new InMemoryCapabilityBroker();
+        broker.SeedBinding(subject, new BindingId { Value = "bnd-user-1" });
+        var option = new UserLlmOption(
+            ServiceId: "svc-openai",
+            ServiceSlug: "openai-work",
+            DisplayName: "OpenAI Work",
+            RouteValue: "/api/v1/proxy/s/openai-work",
+            DefaultModel: "gpt-5.4",
+            AvailableModels: ["gpt-5.4"],
+            Status: "ready",
+            Source: "user",
+            Allowed: true,
+            Description: null);
+        var optionsService = new StubUserLlmOptionsService(option);
+        var selectionService = new RecordingUserLlmSelectionService();
+        var services = new ServiceCollection()
+            .AddSingleton<IExternalIdentityBindingQueryPort>(broker)
+            .AddSingleton<IUserLlmOptionsService>(optionsService)
+            .AddSingleton<IUserLlmSelectionService>(selectionService)
+            .AddSingleton<IUserLlmOptionsRenderer<MessageContent>>(new TextUserLlmOptionsRenderer())
+            .BuildServiceProvider();
+        var registrationQueryPort = BuildRegistrationQueryPort();
+        var adapter = new RecordingPlatformAdapter();
+        var runner = CreateRunner(registrationQueryPort, adapter, services);
+        var activity = BuildCardActionActivity("evt-llm-preset-typed-1");
+        activity.Content.CardAction.LlmSelection = new LlmSelectionActionPayload
+        {
+            Action = TextUserLlmOptionsRenderer.ApplyPresetAction,
+            PresetId = "work-fast",
+        };
+
+        var result = await runner.RunInboundAsync(activity, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.LlmReplyRequest.Should().BeNull();
+        result.SentActivityId.Should().Be("direct-reply:evt-llm-preset-typed-1");
+        selectionService.PresetId.Should().Be("work-fast");
+        selectionService.Context?.BindingId.Value.Should().Be("bnd-user-1");
+        adapter.Replies.Should().ContainSingle();
+        adapter.Replies[0].ReplyText.Should().Contain("work-fast");
+    }
+
+    [Fact]
     public async Task RunInboundAsync_ShouldMapWorkflowResumeValidationErrors()
     {
         var registrationQueryPort = BuildRegistrationQueryPort();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -593,15 +593,17 @@ public sealed class ChannelConversationTurnRunnerTests
             .BuildServiceProvider();
         var runner = CreateRunner(registrationQueryPort, adapter, services);
 
-        var result = await runner.RunInboundAsync(
-            BuildCardActionActivity(
-                "evt-card-1",
-                ("actor_id", "actor-1"),
-                ("run_id", "run-1"),
-                ("step_id", "approval-1"),
-                ("approved", "false"),
-                ("user_input", "Need stronger hook")),
-            CancellationToken.None);
+        var activity = BuildCardActionActivity("evt-card-1");
+        activity.Content.CardAction.WorkflowResume = new WorkflowResumeActionPayload
+        {
+            ActorId = "actor-1",
+            RunId = "run-1",
+            StepId = "approval-1",
+            Approved = false,
+            UserInput = "Need stronger hook",
+        };
+
+        var result = await runner.RunInboundAsync(activity, CancellationToken.None);
 
         result.Success.Should().BeTrue();
         result.SentActivityId.Should().Be("workflow-resume:cmd-card-1");
@@ -707,10 +709,12 @@ public sealed class ChannelConversationTurnRunnerTests
         var registrationQueryPort = BuildRegistrationQueryPort();
         var adapter = new RecordingPlatformAdapter();
         var runner = CreateRunner(registrationQueryPort, adapter, services);
-        var activity = BuildCardActionActivity(
-            "evt-llm-select-1",
-            (TextUserLlmOptionsRenderer.LlmActionArgument, TextUserLlmOptionsRenderer.SelectServiceAction),
-            (TextUserLlmOptionsRenderer.ServiceIdArgument, "svc-openai"));
+        var activity = BuildCardActionActivity("evt-llm-select-1");
+        activity.Content.CardAction.LlmSelection = new LlmSelectionActionPayload
+        {
+            Action = TextUserLlmOptionsRenderer.SelectServiceAction,
+            ServiceId = "svc-openai",
+        };
 
         var result = await runner.RunInboundAsync(activity, CancellationToken.None);
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortRoundTripTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/FeishuCardHumanInteractionPortRoundTripTests.cs
@@ -4,16 +4,19 @@ using Aevatar.GAgents.Platform.Lark;
 using FluentAssertions;
 using Xunit;
 using Aevatar.GAgents.Authoring.Lark;
+using Aevatar.GAgents.Channel.NyxIdRelay;
+using System.Text;
+using Aevatar.GAgents.Channel.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
+using Aevatar.GAgents.NyxidChat;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
 /// <summary>
 /// The outbound approval card is parsed back on the inbound side by
 /// <c>NyxIdRelayTransport</c>, which normalizes the Lark callback <c>action.value</c> into the
-/// strongly typed <c>CardActionSubmission.Arguments</c> map and <c>action.form_value</c> into
-/// <c>CardActionSubmission.FormFields</c>. These tests pin that the composer output still carries
-/// the correlation keys in the exact locations the transport reads, so <c>ChannelCardActionRouting</c>
-/// can rebuild the workflow resume command end-to-end.
+/// <c>CardActionSubmission.WorkflowResume</c>. These tests pin that the composer output remains
+/// Lark/Nyx JSON-compatible at the adapter edge while internal routing consumes typed payloads.
 /// </summary>
 public sealed class FeishuCardHumanInteractionPortRoundTripTests
 {
@@ -59,6 +62,83 @@ public sealed class FeishuCardHumanInteractionPortRoundTripTests
         var rejectValue = rejectButton.GetProperty("behaviors")[0].GetProperty("value");
         rejectValue.GetProperty("actor_id").GetString().Should().Be("actor-A");
         rejectValue.GetProperty("approved").GetBoolean().Should().BeFalse();
+    }
+
+    [Fact]
+    public void Approval_card_round_trips_to_typed_workflow_resume_payload()
+    {
+        var card = FeishuCardHumanInteractionPort.BuildCardJson(new HumanInteractionRequest
+        {
+            ActorId = "actor-A",
+            RunId = "run-A",
+            StepId = "step-A",
+            SuspensionType = "human_approval",
+            Prompt = "Approve the draft",
+            Content = "draft body",
+            Options = ["approve", "reject"],
+        });
+
+        using var document = JsonDocument.Parse(card);
+        var formElements = document.RootElement
+            .GetProperty("body")
+            .GetProperty("elements")[1]
+            .GetProperty("elements");
+        var approveButton = formElements
+            .EnumerateArray()
+            .First(e => e.GetProperty("tag").GetString() == "button" &&
+                        e.GetProperty("text").GetProperty("content").GetString() == "Approve");
+        var callbackText = JsonSerializer.Serialize(new
+        {
+            value = approveButton.GetProperty("behaviors")[0].GetProperty("value"),
+            form_value = new Dictionary<string, string>
+            {
+                ["edited_content"] = "final draft",
+                ["user_input"] = "looks good",
+            },
+        });
+        var body = $$"""
+            {
+              "message_id": "msg-card-typed-1",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_chat_1", "type": "private" },
+              "sender": { "platform_id": "ou_1", "display_name": "User One" },
+              "content": {
+                "content_type": "card_action",
+                "text": {{JsonSerializer.Serialize(callbackText)}}
+              }
+            }
+            """;
+
+        var parsed = new NyxIdRelayTransport().Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        var cardAction = parsed.Activity!.Content.CardAction;
+        cardAction.WorkflowResume.ActorId.Should().Be("actor-A");
+        cardAction.WorkflowResume.RunId.Should().Be("run-A");
+        cardAction.WorkflowResume.StepId.Should().Be("step-A");
+        cardAction.WorkflowResume.Approved.Should().BeTrue();
+        cardAction.WorkflowResume.EditedContent.Should().Be("final draft");
+        cardAction.WorkflowResume.UserInput.Should().Be("looks good");
+
+        var inbound = new InboundMessage
+        {
+            Platform = "lark",
+            ConversationId = "oc_chat_1",
+            SenderId = "ou_1",
+            SenderName = "User One",
+            Text = string.Empty,
+            MessageId = "evt-card-typed-1",
+            ChatType = "card_action",
+            CardAction = cardAction,
+        };
+        ChannelCardActionRouting.TryBuildWorkflowResumeCommand(inbound, out var command).Should().BeTrue();
+        command!.ActorId.Should().Be("actor-A");
+        command.RunId.Should().Be("run-A");
+        command.StepId.Should().Be("step-A");
+        command.Approved.Should().BeTrue();
+        command.UserInput.Should().Be("final draft");
+        command.Feedback.Should().Be("looks good");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using Aevatar.GAgents.Channel.Abstractions;
 using Aevatar.GAgents.Channel.NyxIdRelay;
 using FluentAssertions;
@@ -293,6 +294,46 @@ public sealed class NyxIdRelayTransportTests
         cardAction.Arguments.Should().NotContainKey("service_id");
         cardAction.LlmSelection.Action.Should().Be("select_service");
         cardAction.LlmSelection.ServiceId.Should().Be("chrono-llm-shared");
+    }
+
+    [Theory]
+    [InlineData("lp")]
+    [InlineData("llm_apply_preset")]
+    public void Parse_ShouldMapCompactApplyPresetActionId_ToTypedLlmSelection(string actionId)
+    {
+        var cardActionText = JsonSerializer.Serialize(new
+        {
+            a = actionId,
+            s = "work-fast",
+            v = new
+            {
+                preset_id = "work-fast",
+            },
+        });
+        var body = $$"""
+            {
+              "message_id": "msg-card-compact-preset",
+              "platform": "telegram",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "123", "type": "private" },
+              "sender": { "platform_id": "456", "display_name": "User One" },
+              "content": {
+                "content_type": "card_action",
+                "text": {{JsonSerializer.Serialize(cardActionText)}}
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        var cardAction = parsed.Activity!.Content.CardAction;
+        cardAction.Should().NotBeNull();
+        cardAction!.ActionId.Should().Be(actionId);
+        cardAction.SubmittedValue.Should().Be("work-fast");
+        cardAction.Arguments.Should().NotContainKey("preset_id");
+        cardAction.LlmSelection.Action.Should().Be("apply_preset");
+        cardAction.LlmSelection.PresetId.Should().Be("work-fast");
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxIdRelayTransportTests.cs
@@ -290,8 +290,42 @@ public sealed class NyxIdRelayTransportTests
         cardAction.Should().NotBeNull();
         cardAction!.ActionId.Should().Be("llm_select_service");
         cardAction.SubmittedValue.Should().Be("chrono-llm-shared");
-        cardAction.Arguments.Should().ContainKey("service_id")
-            .WhoseValue.Should().Be("chrono-llm-shared");
+        cardAction.Arguments.Should().NotContainKey("service_id");
+        cardAction.LlmSelection.Action.Should().Be("select_service");
+        cardAction.LlmSelection.ServiceId.Should().Be("chrono-llm-shared");
+    }
+
+    [Fact]
+    public void Parse_ShouldMapKnownWorkflowCallbackFields_ToTypedPayload()
+    {
+        var body = """
+            {
+              "message_id": "msg-card-workflow",
+              "platform": "lark",
+              "agent": { "api_key_id": "api-key-1" },
+              "conversation": { "id": "conv-1", "platform_id": "oc_chat_1", "type": "private" },
+              "sender": { "platform_id": "ou_1", "display_name": "User One" },
+              "content": {
+                "content_type": "card_action",
+                "text": "{\"value\":{\"actor_id\":\"actor-1\",\"run_id\":\"run-1\",\"step_id\":\"step-1\",\"approved\":false},\"form_value\":{\"user_input\":\"needs work\"}}"
+              }
+            }
+            """;
+
+        var parsed = _transport.Parse(Encoding.UTF8.GetBytes(body));
+
+        parsed.Success.Should().BeTrue();
+        var cardAction = parsed.Activity!.Content.CardAction;
+        cardAction.Should().NotBeNull();
+        cardAction!.WorkflowResume.ActorId.Should().Be("actor-1");
+        cardAction.WorkflowResume.RunId.Should().Be("run-1");
+        cardAction.WorkflowResume.StepId.Should().Be("step-1");
+        cardAction.WorkflowResume.Approved.Should().BeFalse();
+        cardAction.WorkflowResume.UserInput.Should().Be("needs work");
+        cardAction.Arguments.Should().NotContainKey("actor_id");
+        cardAction.Arguments.Should().NotContainKey("run_id");
+        cardAction.Arguments.Should().NotContainKey("step_id");
+        cardAction.Arguments.Should().NotContainKey("approved");
     }
 
     [Fact]
@@ -341,9 +375,10 @@ public sealed class NyxIdRelayTransportTests
         parsed.Activity.Conversation.Scope.Should().Be(ConversationScope.Unspecified);
         var cardAction = parsed.Activity.Content.CardAction;
         cardAction.Should().NotBeNull();
-        cardAction!.Arguments.Should().ContainKey("actor_id").WhoseValue.Should().Be("actor-1");
-        cardAction.Arguments.Should().ContainKey("run_id").WhoseValue.Should().Be("run-1");
-        cardAction.Arguments.Should().ContainKey("step_id").WhoseValue.Should().Be("step-1");
+        cardAction!.WorkflowResume.ActorId.Should().Be("actor-1");
+        cardAction.WorkflowResume.RunId.Should().Be("run-1");
+        cardAction.WorkflowResume.StepId.Should().Be("step-1");
+        cardAction.Arguments.Should().BeEmpty();
     }
 
     [Fact]

--- a/test/Aevatar.GAgents.Platform.Telegram.Tests/TelegramMessageComposerTests.cs
+++ b/test/Aevatar.GAgents.Platform.Telegram.Tests/TelegramMessageComposerTests.cs
@@ -126,6 +126,39 @@ public sealed class TelegramMessageComposerTests : MessageComposerUnitTests<Tele
     }
 
     [Fact]
+    public void Compose_with_typed_llm_selection_projects_callback_arguments()
+    {
+        var intent = new MessageContent { Text = "Choose" };
+        intent.Actions.Add(new ActionElement
+        {
+            Kind = ActionElementKind.Button,
+            Label = "Fast",
+            LlmSelection = new LlmSelectionActionPayload
+            {
+                Action = "x",
+                ServiceId = "s",
+                PresetId = "p",
+            },
+        });
+
+        var payload = CreateComposer().Compose(intent, BuildContext());
+
+        using var document = JsonDocument.Parse(payload.ContentJson);
+        var callbackData = document.RootElement
+            .GetProperty("reply_markup")
+            .GetProperty("inline_keyboard")[0][0]
+            .GetProperty("callback_data")
+            .GetString();
+        callbackData.ShouldNotBeNull();
+        Encoding.UTF8.GetByteCount(callbackData!).ShouldBeLessThanOrEqualTo(64);
+        using var callbackDocument = JsonDocument.Parse(callbackData!);
+        var value = callbackDocument.RootElement.GetProperty("v");
+        value.GetProperty("llm_action").GetString().ShouldBe("x");
+        value.GetProperty("service_id").GetString().ShouldBe("s");
+        value.GetProperty("preset_id").GetString().ShouldBe("p");
+    }
+
+    [Fact]
     public void Compose_omits_button_when_callback_data_cannot_carry_submitted_value()
     {
         var longServiceId = new string('x', 80);


### PR DESCRIPTION
## Summary
- `chat_activity.proto`:加 `WorkflowResumeActionPayload` + `LlmSelectionActionPayload` typed sub-messages
- `arguments` map 降级 open-extension-only
- Lark / Telegram composer + FeishuCardHumanInteractionPort:emit typed payload(adapter JSON compat 在边界)
- `NyxIdRelayTransport.BuildCardActionSubmission`:known JSON → typed sub-message
- `ChannelConversationTurnRunner` + `InboundMessage.Extra`:workflow/LLM handoff typed access;literal-key 路径 deprecated inbound fallback only
- `ChannelCardActionRouting`:消费 typed `WorkflowResumeActionPayload`
- `TextUserLlmOptionsRenderer`:LLM selection 走 typed payload
- Tests:Lark card round-trip + negative

15 files: +547 / -81。

## Phase 9 consensus
`META_JUDGE_DONE:consensus:type-card-action-workflow-resume-and-llm-selection-payloads`

Closes #1004

⟦AI:AUTO-LOOP⟧