### PR TITLE
iter94 cluster-809: migrate OpenAI Realtime session.update to GA shape

### DIFF
--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/IOpenAIRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/IOpenAIRealtimeSession.cs
@@ -4,7 +4,7 @@ namespace Aevatar.Foundation.VoicePresence.OpenAI.Internal;
 
 internal interface IOpenAIRealtimeSession : IAsyncDisposable
 {
-    Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions options, CancellationToken ct);
+    Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct);
 
     Task SendInputAudioAsync(BinaryData audio, CancellationToken ct);
 

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Aevatar.Foundation.VoicePresence.Abstractions;
@@ -68,8 +69,15 @@ internal sealed class OpenAIRealtimeSession : IOpenAIRealtimeSession
         _session = session ?? throw new ArgumentNullException(nameof(session));
     }
 
-    public Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions options, CancellationToken ct) =>
-        _session.ConfigureConversationSessionAsync(options, ct);
+    public async Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(sessionUpdateEvent);
+        await _session.WebSocket.SendAsync(
+            sessionUpdateEvent.ToMemory(),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            cancellationToken: ct);
+    }
 
     public Task SendInputAudioAsync(BinaryData audio, CancellationToken ct) =>
         _session.SendInputAudioAsync(audio, ct);

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/Internal/OpenAIRealtimeSession.cs
@@ -72,6 +72,10 @@ internal sealed class OpenAIRealtimeSession : IOpenAIRealtimeSession
     public async Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(sessionUpdateEvent);
+        // Refactor (iter94/cluster-809):
+        // Old:OpenAI SDK typed beta session options.
+        // New:GA shape session.update JSON envelope per OpenAI docs
+        // (audio.input/audio.output/instructions/voice/tools fields per GA contract).
         await _session.WebSocket.SendAsync(
             sessionUpdateEvent.ToMemory(),
             WebSocketMessageType.Text,

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Aevatar.Foundation.VoicePresence.OpenAI.Internal;
 using Google.Protobuf;
@@ -110,7 +111,7 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
         ArgumentNullException.ThrowIfNull(session);
 
         _sampleRateHz = ResolveSampleRateHz(session.SampleRateHz);
-        await EnsureSession().ConfigureConversationSessionAsync(BuildConversationSessionOptions(session), ct);
+        await EnsureSession().SendSessionUpdateAsync(BuildSessionUpdateEvent(session), ct);
     }
 
     internal async Task InjectUserTextAsync(string text, CancellationToken ct)
@@ -286,19 +287,47 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
             _ => null,
         };
 
-    private RealtimeConversationSessionOptions BuildConversationSessionOptions(VoiceSessionConfig session)
+    private BinaryData BuildSessionUpdateEvent(VoiceSessionConfig session)
     {
-        var options = new RealtimeConversationSessionOptions
+        var sessionObject = new JsonObject
         {
-            Instructions = session.Instructions ?? string.Empty,
-            AudioOptions = new RealtimeConversationSessionAudioOptions
+            ["type"] = "realtime",
+            ["instructions"] = session.Instructions ?? string.Empty,
+            ["output_modalities"] = new JsonArray("audio"),
+            ["audio"] = new JsonObject
             {
-                InputAudioOptions = BuildInputAudioOptions(),
-                OutputAudioOptions = BuildOutputAudioOptions(session),
+                ["input"] = new JsonObject
+                {
+                    ["format"] = BuildPcmAudioFormat(_sampleRateHz),
+                    ["turn_detection"] = BuildTurnDetection(),
+                },
+                ["output"] = new JsonObject
+                {
+                    ["format"] = BuildPcmAudioFormat(_sampleRateHz),
+                    ["voice"] = string.IsNullOrWhiteSpace(session.Voice)
+                        ? "alloy"
+                        : session.Voice.Trim(),
+                },
             },
         };
-        options.OutputModalities.Add(RealtimeOutputModality.Audio);
 
+        var tools = BuildTools(session);
+        sessionObject["tools"] = tools;
+        if (tools.Count > 0)
+            sessionObject["tool_choice"] = "auto";
+
+        var updateEvent = new JsonObject
+        {
+            ["type"] = "session.update",
+            ["session"] = sessionObject,
+        };
+
+        return BinaryData.FromString(updateEvent.ToJsonString());
+    }
+
+    private JsonArray BuildTools(VoiceSessionConfig session)
+    {
+        var tools = new JsonArray();
         var registeredNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var definition in session.ToolDefinitions)
@@ -307,12 +336,14 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
             if (string.IsNullOrWhiteSpace(toolName) || !registeredNames.Add(toolName))
                 continue;
 
-            options.Tools.Add(new RealtimeFunctionTool(toolName)
+            tools.Add(new JsonObject
             {
-                FunctionDescription = string.IsNullOrWhiteSpace(definition.Description)
+                ["type"] = "function",
+                ["name"] = toolName,
+                ["description"] = string.IsNullOrWhiteSpace(definition.Description)
                     ? $"Aevatar tool '{toolName}'."
                     : definition.Description.Trim(),
-                FunctionParameters = BuildToolParameters(definition.ParametersSchema, toolName),
+                ["parameters"] = BuildToolParameters(definition.ParametersSchema, toolName),
             });
         }
 
@@ -322,61 +353,56 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
             if (string.IsNullOrWhiteSpace(toolName) || !registeredNames.Add(toolName))
                 continue;
 
-            options.Tools.Add(new RealtimeFunctionTool(toolName)
+            tools.Add(new JsonObject
             {
-                FunctionDescription = $"Aevatar tool '{toolName}'.",
-                FunctionParameters = PermissiveToolSchema,
+                ["type"] = "function",
+                ["name"] = toolName,
+                ["description"] = $"Aevatar tool '{toolName}'.",
+                ["parameters"] = BuildToolParameters(null, toolName),
             });
         }
 
-        if (options.Tools.Count > 0)
-            options.ToolChoice = new RealtimeToolChoice(RealtimeDefaultToolChoice.Auto);
-
-        return options;
+        return tools;
     }
 
-    private BinaryData BuildToolParameters(string? parametersSchema, string toolName)
+    private JsonNode BuildToolParameters(string? parametersSchema, string toolName)
     {
         if (string.IsNullOrWhiteSpace(parametersSchema))
-            return PermissiveToolSchema;
+            return JsonNode.Parse(PermissiveToolSchema.ToString())!;
 
         try
         {
-            using var _ = JsonDocument.Parse(parametersSchema);
-            return BinaryData.FromString(parametersSchema);
+            return JsonNode.Parse(parametersSchema)!;
         }
         catch (JsonException ex)
         {
             _logger.LogWarning(ex, "Voice tool schema for {ToolName} is invalid JSON. Falling back to permissive schema.", toolName);
-            return PermissiveToolSchema;
+            return JsonNode.Parse(PermissiveToolSchema.ToString())!;
         }
     }
 
-    private RealtimeConversationSessionInputAudioOptions BuildInputAudioOptions()
-    {
-        var options = new RealtimeConversationSessionInputAudioOptions();
-        if (_options.EnableServerVad)
-        {
-            options.TurnDetection = new RealtimeServerVadTurnDetection
-            {
-                DetectionThreshold = _options.DetectionThreshold,
-                PrefixPadding = _options.PrefixPadding,
-                SilenceDuration = _options.SilenceDuration,
-                InterruptResponseEnabled = _options.InterruptResponseOnSpeech,
-                CreateResponseEnabled = _options.AutoCreateResponse,
-            };
-        }
-
-        return options;
-    }
-
-    private static RealtimeConversationSessionOutputAudioOptions BuildOutputAudioOptions(VoiceSessionConfig session) =>
+    private static JsonObject BuildPcmAudioFormat(int sampleRateHz) =>
         new()
         {
-            Voice = string.IsNullOrWhiteSpace(session.Voice)
-                ? RealtimeVoice.Alloy
-                : new RealtimeVoice(session.Voice.Trim()),
+            ["type"] = "audio/pcm",
+            ["rate"] = sampleRateHz,
         };
+
+    private JsonNode? BuildTurnDetection()
+    {
+        if (!_options.EnableServerVad)
+            return null;
+
+        return new JsonObject
+        {
+            ["type"] = "server_vad",
+            ["threshold"] = _options.DetectionThreshold,
+            ["prefix_padding_ms"] = (int)_options.PrefixPadding.TotalMilliseconds,
+            ["silence_duration_ms"] = (int)_options.SilenceDuration.TotalMilliseconds,
+            ["interrupt_response"] = _options.InterruptResponseOnSpeech,
+            ["create_response"] = _options.AutoCreateResponse,
+        };
+    }
 
     private int ResolveSampleRateHz(int requested)
     {

--- a/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
+++ b/src/Aevatar.Foundation.VoicePresence.OpenAI/OpenAIRealtimeProvider.cs
@@ -289,6 +289,10 @@ public sealed class OpenAIRealtimeProvider : IRealtimeVoiceProvider
 
     private BinaryData BuildSessionUpdateEvent(VoiceSessionConfig session)
     {
+        // Refactor (iter94/cluster-809):
+        // Old:OpenAI SDK typed beta session options.
+        // New:GA shape session.update JSON envelope per OpenAI docs
+        // (audio.input/audio.output/instructions/voice/tools fields per GA contract).
         var sessionObject = new JsonObject
         {
             ["type"] = "realtime",

--- a/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
@@ -632,8 +632,6 @@ public class OpenAIRealtimeProviderTests
 
     private sealed class ErrorSession : IOpenAIRealtimeSession
     {
-        private readonly OpenAIRealtimeSessionEvent _unreachableEvent = new OpenAIRealtimeDisconnectedEvent("unreachable");
-
         public Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct) => Task.CompletedTask;
         public Task SendInputAudioAsync(BinaryData audio, CancellationToken ct) => Task.CompletedTask;
         public Task AddItemAsync(RealtimeItem item, CancellationToken ct) => Task.CompletedTask;
@@ -641,19 +639,15 @@ public class OpenAIRealtimeProviderTests
         public Task CancelResponseAsync(CancellationToken ct) => Task.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
-#pragma warning disable CS1998
         public async IAsyncEnumerable<OpenAIRealtimeSessionEvent> ReceiveEventsAsync(
             [EnumeratorCancellation] CancellationToken ct)
         {
-            _ = ct;
-            await Task.Yield();
-#pragma warning disable CS0162
-            if (true)
-                throw new InvalidOperationException("simulated connection error");
+            if (ct.IsCancellationRequested)
+                yield break;
 
-            yield return _unreachableEvent;
-#pragma warning restore CS0162
+            await Task.Yield();
+            ct.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("simulated connection error");
         }
-#pragma warning restore CS1998
     }
 }

--- a/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
+++ b/test/Aevatar.Foundation.VoicePresence.OpenAI.Tests/OpenAIRealtimeProviderTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Aevatar.Foundation.VoicePresence.Abstractions;
 using Aevatar.Foundation.VoicePresence.OpenAI.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -24,15 +25,46 @@ public class OpenAIRealtimeProviderTests
             ToolNames = { "door.open" },
         }, CancellationToken.None);
 
-        session.ConfiguredOptions.Count.ShouldBe(1);
-        var options = session.ConfiguredOptions.Single();
-        options.Instructions.ShouldBe("be concise");
-        options.OutputModalities.Select(x => x.ToString()).ShouldBe(["audio"]);
-        options.AudioOptions.OutputAudioOptions.Voice?.ToString().ShouldBe("alloy");
-        options.AudioOptions.InputAudioOptions.TurnDetection.ShouldNotBeNull();
-        options.Tools.Count.ShouldBe(1);
-        options.Tools[0].ShouldBeOfType<RealtimeFunctionTool>();
-        ((RealtimeFunctionTool)options.Tools[0]).FunctionName.ShouldBe("door.open");
+        session.SessionUpdateEvents.Count.ShouldBe(1);
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        var root = document.RootElement;
+        root.GetProperty("type").GetString().ShouldBe("session.update");
+        root.TryGetProperty("input_audio_format", out _).ShouldBeFalse();
+        root.TryGetProperty("output_audio_format", out _).ShouldBeFalse();
+        root.TryGetProperty("modalities", out _).ShouldBeFalse();
+
+        var configuredSession = root.GetProperty("session");
+        configuredSession.GetProperty("type").GetString().ShouldBe("realtime");
+        configuredSession.GetProperty("instructions").GetString().ShouldBe("be concise");
+        configuredSession.GetProperty("output_modalities").EnumerateArray()
+            .Select(static x => x.GetString()).ShouldBe(["audio"]);
+        configuredSession.TryGetProperty("input_audio_format", out _).ShouldBeFalse();
+        configuredSession.TryGetProperty("output_audio_format", out _).ShouldBeFalse();
+        configuredSession.TryGetProperty("modalities", out _).ShouldBeFalse();
+
+        var audio = configuredSession.GetProperty("audio");
+        var input = audio.GetProperty("input");
+        input.GetProperty("format").GetProperty("type").GetString().ShouldBe("audio/pcm");
+        input.GetProperty("format").GetProperty("rate").GetInt32().ShouldBe(24000);
+        var turnDetection = input.GetProperty("turn_detection");
+        turnDetection.GetProperty("type").GetString().ShouldBe("server_vad");
+        turnDetection.GetProperty("threshold").GetSingle().ShouldBe(0.7f);
+        turnDetection.GetProperty("prefix_padding_ms").GetInt32().ShouldBe(300);
+        turnDetection.GetProperty("silence_duration_ms").GetInt32().ShouldBe(600);
+        turnDetection.GetProperty("interrupt_response").GetBoolean().ShouldBeTrue();
+        turnDetection.GetProperty("create_response").GetBoolean().ShouldBeTrue();
+
+        var output = audio.GetProperty("output");
+        output.GetProperty("format").GetProperty("type").GetString().ShouldBe("audio/pcm");
+        output.GetProperty("format").GetProperty("rate").GetInt32().ShouldBe(24000);
+        output.GetProperty("voice").GetString().ShouldBe("alloy");
+
+        var tools = configuredSession.GetProperty("tools").EnumerateArray().ToArray();
+        tools.Length.ShouldBe(1);
+        tools[0].GetProperty("type").GetString().ShouldBe("function");
+        tools[0].GetProperty("name").GetString().ShouldBe("door.open");
+        tools[0].GetProperty("parameters").GetProperty("additionalProperties").GetBoolean().ShouldBeTrue();
+        configuredSession.GetProperty("tool_choice").GetString().ShouldBe("auto");
     }
 
     [Fact]
@@ -58,17 +90,19 @@ public class OpenAIRealtimeProviderTests
             ToolNames = { "door.open", "door.close" },
         }, CancellationToken.None);
 
-        var options = session.ConfiguredOptions.Single();
-        options.Tools.Count.ShouldBe(2);
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        var tools = document.RootElement.GetProperty("session").GetProperty("tools").EnumerateArray().ToArray();
+        tools.Length.ShouldBe(2);
 
-        var openTool = (RealtimeFunctionTool)options.Tools[0];
-        openTool.FunctionName.ShouldBe("door.open");
-        openTool.FunctionDescription.ShouldBe("open the front door");
-        openTool.FunctionParameters.ToString().ShouldContain("\"door\"");
+        var openTool = tools[0];
+        openTool.GetProperty("name").GetString().ShouldBe("door.open");
+        openTool.GetProperty("description").GetString().ShouldBe("open the front door");
+        openTool.GetProperty("parameters").GetProperty("properties").GetProperty("door")
+            .GetProperty("type").GetString().ShouldBe("string");
 
-        var closeTool = (RealtimeFunctionTool)options.Tools[1];
-        closeTool.FunctionName.ShouldBe("door.close");
-        closeTool.FunctionDescription.ShouldBe("Aevatar tool 'door.close'.");
+        var closeTool = tools[1];
+        closeTool.GetProperty("name").GetString().ShouldBe("door.close");
+        closeTool.GetProperty("description").GetString().ShouldBe("Aevatar tool 'door.close'.");
     }
 
     [Fact]
@@ -408,7 +442,7 @@ public class OpenAIRealtimeProviderTests
             SampleRateHz = 0,
         }, CancellationToken.None);
 
-        session.ConfiguredOptions.Count.ShouldBe(1);
+        session.SessionUpdateEvents.Count.ShouldBe(1);
     }
 
     [Fact]
@@ -424,7 +458,10 @@ public class OpenAIRealtimeProviderTests
             Instructions = "test",
         }, CancellationToken.None);
 
-        session.ConfiguredOptions.Single().Tools.Count.ShouldBe(0);
+        using var document = JsonDocument.Parse(session.SessionUpdateEvents.Single());
+        var configuredSession = document.RootElement.GetProperty("session");
+        configuredSession.GetProperty("tools").GetArrayLength().ShouldBe(0);
+        configuredSession.TryGetProperty("tool_choice", out _).ShouldBeFalse();
     }
 
     [Fact]
@@ -526,7 +563,7 @@ public class OpenAIRealtimeProviderTests
             _afterFirstEvent = afterFirstEvent;
         }
 
-        public List<RealtimeConversationSessionOptions> ConfiguredOptions { get; } = [];
+        public List<string> SessionUpdateEvents { get; } = [];
 
         public List<BinaryData> SentAudio { get; } = [];
 
@@ -539,10 +576,10 @@ public class OpenAIRealtimeProviderTests
         public TaskCompletionSource ReceiveCompleted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions options, CancellationToken ct)
+        public Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct)
         {
             _ = ct;
-            ConfiguredOptions.Add(options);
+            SessionUpdateEvents.Add(sessionUpdateEvent.ToString());
             return Task.CompletedTask;
         }
 
@@ -595,7 +632,9 @@ public class OpenAIRealtimeProviderTests
 
     private sealed class ErrorSession : IOpenAIRealtimeSession
     {
-        public Task ConfigureConversationSessionAsync(RealtimeConversationSessionOptions options, CancellationToken ct) => Task.CompletedTask;
+        private readonly OpenAIRealtimeSessionEvent _unreachableEvent = new OpenAIRealtimeDisconnectedEvent("unreachable");
+
+        public Task SendSessionUpdateAsync(BinaryData sessionUpdateEvent, CancellationToken ct) => Task.CompletedTask;
         public Task SendInputAudioAsync(BinaryData audio, CancellationToken ct) => Task.CompletedTask;
         public Task AddItemAsync(RealtimeItem item, CancellationToken ct) => Task.CompletedTask;
         public Task StartResponseAsync(CancellationToken ct) => Task.CompletedTask;
@@ -606,8 +645,14 @@ public class OpenAIRealtimeProviderTests
         public async IAsyncEnumerable<OpenAIRealtimeSessionEvent> ReceiveEventsAsync(
             [EnumeratorCancellation] CancellationToken ct)
         {
-            throw new InvalidOperationException("simulated connection error");
-            yield break;
+            _ = ct;
+            await Task.Yield();
+#pragma warning disable CS0162
+            if (true)
+                throw new InvalidOperationException("simulated connection error");
+
+            yield return _unreachableEvent;
+#pragma warning restore CS0162
         }
 #pragma warning restore CS1998
     }


### PR DESCRIPTION
## Summary
- `OpenAIRealtimeSession.SendSessionUpdateAsync`/`OpenAIRealtimeProvider`:session.update payload 改 GA shape(audio.input / audio.output / instructions / voice / tools 按 GA contract 组织)
- 测试覆盖 GA shape 序列化 + provider integration paths
- 解锁 ADR-0026 Stage 5(`blocker` label)

4 files: +151 / -72。

## Phase 9 consensus
`META_JUDGE_DONE:consensus:openai-realtime-session-update-ga-shape-migration`

Closes #809

⟦AI:AUTO-LOOP⟧