### PR TITLE
iter94 cluster-094b: rename workflow capabilities as startup artifact with honest watermarks

### DIFF
--- a/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/DependencyInjection/ServiceCollectionExtensions.cs
@@ -115,8 +115,8 @@ public static class ServiceCollectionExtensions
             IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>,
             WorkflowCatalogCurrentStateDocumentMetadataProvider>();
         services.TryAddSingleton<
-            IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>,
-            WorkflowCapabilitiesCurrentStateDocumentMetadataProvider>();
+            IProjectionDocumentMetadataProvider<WorkflowCapabilitiesStartupArtifact>,
+            WorkflowCapabilitiesStartupArtifactMetadataProvider>();
 
         if (documentProvider.ElasticsearchEnabled)
         {
@@ -133,7 +133,7 @@ public static class ServiceCollectionExtensions
             TryAddElasticsearchDocumentProjectionStore<ResponsesAgentToolStateCurrentStateReadModel>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<UserConfigCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
             TryAddElasticsearchDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
-            TryAddElasticsearchDocumentProjectionStore<WorkflowCapabilitiesCurrentStateDocument>(services, configuration, static readModel => readModel.Id);
+            TryAddElasticsearchDocumentProjectionStore<WorkflowCapabilitiesStartupArtifact>(services, configuration, static readModel => readModel.Id);
         }
         else
         {
@@ -150,7 +150,7 @@ public static class ServiceCollectionExtensions
             TryAddInMemoryDocumentProjectionStore<ResponsesAgentToolStateCurrentStateReadModel>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<UserConfigCurrentStateDocument>(services, static readModel => readModel.Id);
             TryAddInMemoryDocumentProjectionStore<WorkflowCatalogCurrentStateDocument>(services, static readModel => readModel.Id);
-            TryAddInMemoryDocumentProjectionStore<WorkflowCapabilitiesCurrentStateDocument>(services, static readModel => readModel.Id);
+            TryAddInMemoryDocumentProjectionStore<WorkflowCapabilitiesStartupArtifact>(services, static readModel => readModel.Id);
         }
 
         return services;
@@ -173,7 +173,7 @@ public static class ServiceCollectionExtensions
                && HasProjectionDocumentReaderForProvider<ResponsesAgentToolStateCurrentStateReadModel>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<UserConfigCurrentStateDocument>(services, providerKind)
                && HasProjectionDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind)
-               && HasProjectionDocumentReaderForProvider<WorkflowCapabilitiesCurrentStateDocument>(services, providerKind);
+               && HasProjectionDocumentReaderForProvider<WorkflowCapabilitiesStartupArtifact>(services, providerKind);
     }
 
     private static bool HasAnyProjectionDocumentReader<TReadModel>(IServiceCollection services)

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowCapabilitiesModels.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Queries/WorkflowCapabilitiesModels.cs
@@ -8,7 +8,6 @@ public sealed class WorkflowCapabilitiesDocument
     public string SchemaVersion { get; set; } = "capabilities.v1";
 
     public DateTimeOffset GeneratedAtUtc { get; set; } = DateTimeOffset.UtcNow;
-    public long AuthorityStateVersion { get; set; }
     public DateTimeOffset ProjectionWatermark { get; set; }
 
     public List<WorkflowPrimitiveCapability> Primitives { get; set; } = [];

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowCapabilitiesStartupMaterializer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowCapabilitiesStartupMaterializer.cs
@@ -11,7 +11,7 @@ namespace Aevatar.Workflow.Infrastructure.Workflows;
 //   New principle: Removed dead capability flag; output describes available primitives only
 internal sealed class WorkflowCapabilitiesStartupMaterializer
 {
-    public const string DocumentId = "workflow-capabilities";
+    public const string ArtifactId = "workflow-capabilities";
 
     private static readonly IReadOnlyDictionary<string, PrimitiveMetadataDescriptor> PrimitiveDescriptors =
         new Dictionary<string, PrimitiveMetadataDescriptor>(StringComparer.OrdinalIgnoreCase)
@@ -57,11 +57,11 @@ internal sealed class WorkflowCapabilitiesStartupMaterializer
                 ]),
         };
 
-    private readonly IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument> _writeDispatcher;
+    private readonly IProjectionWriteDispatcher<WorkflowCapabilitiesStartupArtifact> _writeDispatcher;
     private readonly IEnumerable<IWorkflowModulePack> _modulePacks;
 
     public WorkflowCapabilitiesStartupMaterializer(
-        IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument> writeDispatcher,
+        IProjectionWriteDispatcher<WorkflowCapabilitiesStartupArtifact> writeDispatcher,
         IEnumerable<IWorkflowModulePack> modulePacks)
     {
         _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
@@ -75,19 +75,16 @@ internal sealed class WorkflowCapabilitiesStartupMaterializer
     {
         ct.ThrowIfCancellationRequested();
         var now = DateTimeOffset.UtcNow;
-        var document = new WorkflowCapabilitiesCurrentStateDocument
+        var artifact = new WorkflowCapabilitiesStartupArtifact
         {
-            Id = DocumentId,
-            ActorId = DocumentId,
-            StateVersion = 1,
-            LastEventId = "startup-materialization",
-            UpdatedAt = now,
+            Id = ArtifactId,
+            GeneratedAtUtc = now,
             SchemaVersion = "capabilities.v1",
             Primitives = BuildPrimitiveCapabilities(),
             Connectors = BuildConnectorCapabilities(AevatarConnectorConfig.LoadConnectors()),
         };
 
-        await _writeDispatcher.UpsertAsync(document, ct);
+        await _writeDispatcher.UpsertAsync(artifact, ct);
     }
 
     private List<WorkflowPrimitiveCapabilityReadModel> BuildPrimitiveCapabilities()

--- a/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowCapabilitiesStartupMaterializer.cs
+++ b/src/workflow/Aevatar.Workflow.Infrastructure/Workflows/WorkflowCapabilitiesStartupMaterializer.cs
@@ -71,6 +71,9 @@ internal sealed class WorkflowCapabilitiesStartupMaterializer
     // Refactor (iter46/issue-871-workflow-file-catalog-query-port):
     //   Old pattern: Workflow catalog/capabilities query port discovered files, parsed YAML, loaded connector config, and cached results in singleton process memory during query execution.
     //   New principle: WorkflowGAgent per-definition authority; query ports only read freshness-bearing readmodels; file discovery/parsing happens at startup/import time, not in query path.
+    // Refactor (iter94/cluster-094b):
+    //   Old: workflow capabilities was a current-state document with fake StateVersion = 1 and LastEventId = startup-materialization.
+    //   New: workflow capabilities is a startup artifact with honest GeneratedAtUtc and SchemaVersion watermarks, without fake authoritative version fields.
     public async Task MaterializeAsync(CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();

--- a/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowRunInsightReportDocument>, WorkflowRunInsightReportDocumentMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowActorBindingDocument>, WorkflowActorBindingDocumentMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowCatalogCurrentStateDocument>, WorkflowCatalogCurrentStateDocumentMetadataProvider>();
-        services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>, WorkflowCapabilitiesCurrentStateDocumentMetadataProvider>();
+        services.TryAddSingleton<IProjectionDocumentMetadataProvider<WorkflowCapabilitiesStartupArtifact>, WorkflowCapabilitiesStartupArtifactMetadataProvider>();
         services.TryAddSingleton<IProjectionClock, SystemProjectionClock>();
         services.TryAddSingleton<WorkflowExecutionReadModelMapper>();
         services.TryAddSingleton<WorkflowCatalogReadModelMapper>();

--- a/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCapabilitiesStartupArtifactMetadataProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCapabilitiesStartupArtifactMetadataProvider.cs
@@ -2,6 +2,9 @@ using Aevatar.Workflow.Projection.ReadModels;
 
 namespace Aevatar.Workflow.Projection.Metadata;
 
+// Refactor (iter94/cluster-094b):
+//   Old: workflow capabilities was a current-state document with fake StateVersion = 1 and LastEventId = startup-materialization.
+//   New: workflow capabilities is a startup artifact with honest GeneratedAtUtc and SchemaVersion watermarks, without fake authoritative version fields.
 public sealed class WorkflowCapabilitiesStartupArtifactMetadataProvider
     : IProjectionDocumentMetadataProvider<WorkflowCapabilitiesStartupArtifact>
 {

--- a/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCapabilitiesStartupArtifactMetadataProvider.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Metadata/WorkflowCapabilitiesStartupArtifactMetadataProvider.cs
@@ -2,11 +2,11 @@ using Aevatar.Workflow.Projection.ReadModels;
 
 namespace Aevatar.Workflow.Projection.Metadata;
 
-public sealed class WorkflowCapabilitiesCurrentStateDocumentMetadataProvider
-    : IProjectionDocumentMetadataProvider<WorkflowCapabilitiesCurrentStateDocument>
+public sealed class WorkflowCapabilitiesStartupArtifactMetadataProvider
+    : IProjectionDocumentMetadataProvider<WorkflowCapabilitiesStartupArtifact>
 {
     public DocumentIndexMetadata Metadata { get; } = new(
-        IndexName: "workflow-capabilities-current-states",
+        IndexName: "workflow-capabilities-startup-artifacts",
         Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["dynamic"] = true,

--- a/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowCatalogReadModels.Partial.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/ReadModels/WorkflowCatalogReadModels.Partial.cs
@@ -89,14 +89,22 @@ public sealed partial class WorkflowCatalogStepReadModel
 
 [ProjectionExempt(
     Category = ProjectionExemptionCategory.StartupBootstrap,
-    Reason = "Workflow capabilities are materialized by WorkflowCapabilitiesStartupMaterializer from startup module and connector capability sources.")]
-public sealed partial class WorkflowCapabilitiesCurrentStateDocument : IProjectionReadModel<WorkflowCapabilitiesCurrentStateDocument>
+    Reason = "Workflow capabilities are startup artifacts materialized by WorkflowCapabilitiesStartupMaterializer from module and connector capability sources.")]
+public sealed partial class WorkflowCapabilitiesStartupArtifact : IProjectionReadModel<WorkflowCapabilitiesStartupArtifact>
 {
-    public DateTimeOffset UpdatedAt
+    string IProjectionReadModel.ActorId => Id;
+
+    long IProjectionReadModel.StateVersion => 0;
+
+    string IProjectionReadModel.LastEventId => string.Empty;
+
+    public DateTimeOffset GeneratedAtUtc
     {
-        get => UpdatedAtUtcValue == null ? default : UpdatedAtUtcValue.ToDateTimeOffset();
-        set => UpdatedAtUtcValue = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
+        get => GeneratedAtUtcValue == null ? default : GeneratedAtUtcValue.ToDateTimeOffset();
+        set => GeneratedAtUtcValue = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
     }
+
+    public DateTimeOffset UpdatedAt => GeneratedAtUtc;
 
     public IList<WorkflowPrimitiveCapabilityReadModel> Primitives
     {

--- a/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelMapper.cs
@@ -50,7 +50,7 @@ public sealed class WorkflowCatalogReadModelMapper
         };
 
     public WorkflowCapabilitiesDocument ToCapabilitiesDocument(
-        WorkflowCapabilitiesCurrentStateDocument capabilities,
+        WorkflowCapabilitiesStartupArtifact capabilities,
         IReadOnlyList<WorkflowCatalogCurrentStateDocument> workflows)
     {
         var workflowWatermark = workflows.Count == 0
@@ -61,11 +61,8 @@ public sealed class WorkflowCatalogReadModelMapper
             SchemaVersion = string.IsNullOrWhiteSpace(capabilities.SchemaVersion)
                 ? "capabilities.v1"
                 : capabilities.SchemaVersion,
-            GeneratedAtUtc = Max(capabilities.UpdatedAt, workflowWatermark),
-            AuthorityStateVersion = workflows.Count == 0
-                ? capabilities.StateVersion
-                : Math.Max(capabilities.StateVersion, workflows.Max(workflow => workflow.StateVersion)),
-            ProjectionWatermark = Max(capabilities.UpdatedAt, workflowWatermark),
+            GeneratedAtUtc = capabilities.GeneratedAtUtc,
+            ProjectionWatermark = Max(capabilities.GeneratedAtUtc, workflowWatermark),
             Primitives = capabilities.Primitives.Select(ToPrimitiveCapability).ToList(),
             Connectors = capabilities.Connectors.Select(ToConnectorCapability).ToList(),
             Workflows = workflows

--- a/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelMapper.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelMapper.cs
@@ -6,6 +6,9 @@ namespace Aevatar.Workflow.Projection.Workflows;
 // Refactor (iter72/cluster-072-workflow-closed-world-false-capability):
 //   Old pattern: ClosedWorldBlocked flag retained as always-false compatibility field
 //   New principle: Removed dead capability flag; output describes available primitives only
+// Refactor (iter94/cluster-094b):
+//   Old: workflow capabilities was a current-state document with fake StateVersion = 1 and LastEventId = startup-materialization.
+//   New: workflow capabilities is a startup artifact with honest GeneratedAtUtc and SchemaVersion watermarks, without fake authoritative version fields.
 public sealed class WorkflowCatalogReadModelMapper
 {
     public WorkflowCatalogItem ToCatalogItem(WorkflowCatalogCurrentStateDocument document) =>

--- a/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Workflows/WorkflowCatalogReadModelQueryPort.cs
@@ -6,14 +6,14 @@ namespace Aevatar.Workflow.Projection.Workflows;
 
 public sealed class WorkflowCatalogReadModelQueryPort : IWorkflowCatalogPort, IWorkflowCapabilitiesPort
 {
-    private const string CapabilitiesDocumentId = "workflow-capabilities";
+    private const string CapabilitiesArtifactId = "workflow-capabilities";
     private readonly IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string> _catalogReader;
-    private readonly IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string> _capabilitiesReader;
+    private readonly IProjectionDocumentReader<WorkflowCapabilitiesStartupArtifact, string> _capabilitiesReader;
     private readonly WorkflowCatalogReadModelMapper _mapper;
 
     public WorkflowCatalogReadModelQueryPort(
         IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string> catalogReader,
-        IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string> capabilitiesReader,
+        IProjectionDocumentReader<WorkflowCapabilitiesStartupArtifact, string> capabilitiesReader,
         WorkflowCatalogReadModelMapper mapper)
     {
         _catalogReader = catalogReader ?? throw new ArgumentNullException(nameof(catalogReader));
@@ -50,11 +50,10 @@ public sealed class WorkflowCatalogReadModelQueryPort : IWorkflowCatalogPort, IW
 
     public async Task<WorkflowCapabilitiesDocument> GetCapabilitiesAsync(CancellationToken ct = default)
     {
-        var capabilities = await _capabilitiesReader.GetAsync(CapabilitiesDocumentId, ct)
-            ?? new WorkflowCapabilitiesCurrentStateDocument
+        var capabilities = await _capabilitiesReader.GetAsync(CapabilitiesArtifactId, ct)
+            ?? new WorkflowCapabilitiesStartupArtifact
             {
-                Id = CapabilitiesDocumentId,
-                ActorId = CapabilitiesDocumentId,
+                Id = CapabilitiesArtifactId,
                 SchemaVersion = "capabilities.v1",
             };
         return _mapper.ToCapabilitiesDocument(capabilities, await QueryCatalogDocumentsAsync(ct));

--- a/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
+++ b/src/workflow/Aevatar.Workflow.Projection/workflow_projection_transport.proto
@@ -170,12 +170,10 @@ message WorkflowCatalogEdgeReadModel {
   string label = 3;
 }
 
-message WorkflowCapabilitiesCurrentStateDocument {
+message WorkflowCapabilitiesStartupArtifact {
+  reserved 2, 3, 5;
   string id = 1;
-  int64 state_version = 2;
-  string last_event_id = 3;
-  google.protobuf.Timestamp updated_at_utc_value = 4;
-  string actor_id = 5;
+  google.protobuf.Timestamp generated_at_utc_value = 4;
   string schema_version = 6;
   repeated WorkflowPrimitiveCapabilityReadModel primitive_entries = 7;
   repeated WorkflowConnectorCapabilityReadModel connector_entries = 8;

--- a/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
+++ b/src/workflow/extensions/Aevatar.Workflow.Extensions.Hosting/WorkflowProjectionProviderServiceCollectionExtensions.cs
@@ -82,7 +82,7 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             services,
             configuration,
             static document => document.Id);
-        TryAddElasticsearchDocumentStore<WorkflowCapabilitiesCurrentStateDocument>(
+        TryAddElasticsearchDocumentStore<WorkflowCapabilitiesStartupArtifact>(
             services,
             configuration,
             static document => document.Id);
@@ -106,10 +106,10 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
             services,
             static document => document.Id,
             static document => document.UpdatedAt);
-        TryAddInMemoryDocumentStore<WorkflowCapabilitiesCurrentStateDocument>(
+        TryAddInMemoryDocumentStore<WorkflowCapabilitiesStartupArtifact>(
             services,
             static document => document.Id,
-            static document => document.UpdatedAt);
+            static document => document.GeneratedAtUtc);
     }
 
     private static bool HasAllWorkflowDocumentReaders(
@@ -120,7 +120,7 @@ public static class WorkflowProjectionProviderServiceCollectionExtensions
                && HasDocumentReaderForProvider<WorkflowRunInsightReportDocument>(services, providerKind)
                && HasDocumentReaderForProvider<WorkflowActorBindingDocument>(services, providerKind)
                && HasDocumentReaderForProvider<WorkflowCatalogCurrentStateDocument>(services, providerKind)
-               && HasDocumentReaderForProvider<WorkflowCapabilitiesCurrentStateDocument>(services, providerKind);
+               && HasDocumentReaderForProvider<WorkflowCapabilitiesStartupArtifact>(services, providerKind);
     }
 
     private static bool HasAnyDocumentReader<TDocument>(IServiceCollection services)

--- a/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/GAgentServiceHostingServiceCollectionExtensionsTests.cs
@@ -255,10 +255,10 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         app.Services.GetRequiredService<IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument>>()
             .Should()
             .NotBeNull();
-        app.Services.GetRequiredService<IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument>>()
+        app.Services.GetRequiredService<IProjectionWriteDispatcher<WorkflowCapabilitiesStartupArtifact>>()
             .Should()
             .NotBeNull();
-        var capabilitiesReader = app.Services.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string>>();
+        var capabilitiesReader = app.Services.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesStartupArtifact, string>>();
         var capabilities = await capabilitiesReader.GetAsync(
             "workflow-capabilities",
             CancellationToken.None);
@@ -336,7 +336,7 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<UserConfigCurrentStateDocument, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string>>().Should().NotBeNull();
-        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesStartupArtifact, string>>().Should().NotBeNull();
         services.Count(x => x.ServiceType == typeof(IProjectionDocumentReader<ServiceCatalogReadModel, string>)).Should().Be(1);
     }
 
@@ -388,9 +388,9 @@ public sealed class GAgentServiceHostingServiceCollectionExtensionsTests
         provider.GetRequiredService<IProjectionDocumentReader<ServiceRolloutCommandObservationReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<GAgentRunTerminalReadModel, string>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionWriteDispatcher<WorkflowCatalogCurrentStateDocument>>().Should().NotBeNull();
-        provider.GetRequiredService<IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionWriteDispatcher<WorkflowCapabilitiesStartupArtifact>>().Should().NotBeNull();
         provider.GetRequiredService<IProjectionDocumentReader<WorkflowCatalogCurrentStateDocument, string>>().Should().NotBeNull();
-        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesCurrentStateDocument, string>>().Should().NotBeNull();
+        provider.GetRequiredService<IProjectionDocumentReader<WorkflowCapabilitiesStartupArtifact, string>>().Should().NotBeNull();
     }
 
     [Fact]

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -53,15 +53,12 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
                 BuildCatalogDocument("alpha", updatedAt, sortOrder: 1),
             ],
         };
-        var capabilitiesReader = new RecordingDocumentReader<WorkflowCapabilitiesCurrentStateDocument>
+        var capabilitiesReader = new RecordingDocumentReader<WorkflowCapabilitiesStartupArtifact>
         {
-            Item = new WorkflowCapabilitiesCurrentStateDocument
+            Item = new WorkflowCapabilitiesStartupArtifact
             {
                 Id = "workflow-capabilities",
-                ActorId = "workflow-capabilities",
-                StateVersion = 3,
-                LastEventId = "startup-materialization",
-                UpdatedAt = updatedAt.AddMinutes(2),
+                GeneratedAtUtc = updatedAt.AddMinutes(2),
                 SchemaVersion = "capabilities.v1",
                 Primitives =
                 [
@@ -121,7 +118,11 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         detail.Definition.Steps[0].Children.Should().ContainSingle(child => child.Id == "child");
         detail.Edges.Should().ContainSingle(edge => edge.From == "start" && edge.To == "child" && edge.Label == "child");
         capabilities.Workflows.Should().HaveCount(2);
-        capabilities.AuthorityStateVersion.Should().Be(12);
+        typeof(WorkflowCapabilitiesDocument)
+            .GetProperty("AuthorityStateVersion")
+            .Should()
+            .BeNull();
+        capabilities.GeneratedAtUtc.Should().Be(updatedAt.AddMinutes(2));
         capabilities.ProjectionWatermark.Should().Be(updatedAt.AddMinutes(2));
         capabilities.Primitives.Should().ContainSingle(primitive =>
             primitive.Name == "assign" &&
@@ -139,7 +140,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
     public async Task WorkflowCatalogReadModelQueryPort_WhenReadModelsAreMissing_ShouldReturnHonestDefaults()
     {
         var catalogReader = new RecordingDocumentReader<WorkflowCatalogCurrentStateDocument>();
-        var capabilitiesReader = new RecordingDocumentReader<WorkflowCapabilitiesCurrentStateDocument>();
+        var capabilitiesReader = new RecordingDocumentReader<WorkflowCapabilitiesStartupArtifact>();
         var port = new WorkflowCatalogReadModelQueryPort(
             catalogReader,
             capabilitiesReader,
@@ -150,7 +151,10 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var capabilities = await port.GetCapabilitiesAsync();
 
         capabilities.SchemaVersion.Should().Be("capabilities.v1");
-        capabilities.AuthorityStateVersion.Should().Be(0);
+        typeof(WorkflowCapabilitiesDocument)
+            .GetProperty("AuthorityStateVersion")
+            .Should()
+            .BeNull();
         capabilities.ProjectionWatermark.Should().Be(default);
         capabilities.Workflows.Should().BeEmpty();
         catalogReader.GetCalls.Should().Be(1);
@@ -166,7 +170,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             [BuildCatalogDocument("alpha", updatedAt)]);
         var port = new WorkflowCatalogReadModelQueryPort(
             catalogReader,
-            new RecordingDocumentReader<WorkflowCapabilitiesCurrentStateDocument>(),
+            new RecordingDocumentReader<WorkflowCapabilitiesStartupArtifact>(),
             new WorkflowCatalogReadModelMapper());
 
         var catalogTask = port.ListWorkflowCatalogAsync();

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowInfrastructureCoverageTests.cs
@@ -377,7 +377,8 @@ public sealed class WorkflowInfrastructureCoverageTests
 
             writer.LastWritten.Should().NotBeNull();
             var document = writer.LastWritten!;
-            document.Id.Should().Be(WorkflowCapabilitiesStartupMaterializer.DocumentId);
+            document.Id.Should().Be(WorkflowCapabilitiesStartupMaterializer.ArtifactId);
+            document.GeneratedAtUtc.Should().BeAfter(DateTimeOffset.MinValue);
             var primitiveNames = document.Primitives.Select(primitive => primitive.Name).ToList();
             primitiveNames.Should().Contain("connector_call");
             primitiveNames.Should().Contain("llm_call");
@@ -420,6 +421,22 @@ public sealed class WorkflowInfrastructureCoverageTests
             .Select(field => field.FieldNumber)
             .Should().NotContain(5);
         descriptor.FindFieldByName("closed_world_blocked").Should().BeNull();
+    }
+
+    [Fact]
+    public void WorkflowCapabilitiesStartupArtifactProto_ShouldExposeOnlyArtifactWatermarks()
+    {
+        var descriptor = WorkflowCapabilitiesStartupArtifact.Descriptor;
+        var proto = descriptor.ToProto();
+
+        proto.ReservedRange.Should().Contain(range => range.Start <= 2 && range.End > 2);
+        proto.ReservedRange.Should().Contain(range => range.Start <= 3 && range.End > 3);
+        proto.ReservedRange.Should().Contain(range => range.Start <= 5 && range.End > 5);
+        descriptor.FindFieldByName("state_version").Should().BeNull();
+        descriptor.FindFieldByName("last_event_id").Should().BeNull();
+        descriptor.FindFieldByName("actor_id").Should().BeNull();
+        descriptor.FindFieldByName("generated_at_utc_value").Should().NotBeNull();
+        descriptor.FindFieldByName("schema_version").Should().NotBeNull();
     }
 
     [Fact]
@@ -496,12 +513,12 @@ public sealed class WorkflowInfrastructureCoverageTests
     }
 
     private sealed class RecordingCapabilitiesWriteDispatcher
-        : IProjectionWriteDispatcher<WorkflowCapabilitiesCurrentStateDocument>
+        : IProjectionWriteDispatcher<WorkflowCapabilitiesStartupArtifact>
     {
-        public WorkflowCapabilitiesCurrentStateDocument? LastWritten { get; private set; }
+        public WorkflowCapabilitiesStartupArtifact? LastWritten { get; private set; }
 
         public Task<ProjectionWriteResult> UpsertAsync(
-            WorkflowCapabilitiesCurrentStateDocument readModel,
+            WorkflowCapabilitiesStartupArtifact readModel,
             CancellationToken ct = default)
         {
             LastWritten = readModel;

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowStartupArtifactExemptionTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowStartupArtifactExemptionTests.cs
@@ -5,17 +5,17 @@ using FluentAssertions;
 
 namespace Aevatar.Workflow.Host.Api.Tests;
 
-public sealed class WorkflowProjectionExemptionTests
+public sealed class WorkflowStartupArtifactExemptionTests
 {
     [Fact]
-    public void WorkflowCapabilitiesCurrentStateDocument_ShouldDeclareStartupBootstrapExemption()
+    public void WorkflowCapabilitiesStartupArtifact_ShouldDeclareStartupBootstrapExemption()
     {
-        var exemption = typeof(WorkflowCapabilitiesCurrentStateDocument)
+        var exemption = typeof(WorkflowCapabilitiesStartupArtifact)
             .GetCustomAttribute<ProjectionExemptAttribute>(inherit: false);
 
         exemption.Should().NotBeNull();
         exemption!.Category.Should().Be(ProjectionExemptionCategory.StartupBootstrap);
         exemption.Reason.Should().Be(
-            "Workflow capabilities are materialized by WorkflowCapabilitiesStartupMaterializer from startup module and connector capability sources.");
+            "Workflow capabilities are startup artifacts materialized by WorkflowCapabilitiesStartupMaterializer from module and connector capability sources.");
     }
 }


### PR DESCRIPTION
## Summary
- `WorkflowCapabilitiesCurrentStateDocumentMetadataProvider` → `WorkflowCapabilitiesStartupArtifactMetadataProvider`;暴露 `generated_at` + `schema_version` 替代 fake `AuthorityStateVersion = 1`
- `workflow_projection_transport.proto`:声明 startup artifact contract;删除 `StateVersion = 1` / `LastEventId = "startup-materialization"` fake authority 字段
- `WorkflowCapabilitiesStartupMaterializer`:生成 startup artifact 不再是 `CurrentStateDocument`
- consumer 路径(query port / mapper)更新
- DI 注册 + 集成测试 同步

14 files: +89 / -70。

## Phase 9 consensus
`META_JUDGE_DONE:consensus:rename-workflow-capabilities-as-startup-artifact-with-honest-watermarks`

Closes #1007

⟦AI:AUTO-LOOP⟧