### PR TITLE
iter94 cluster-094a: split UserAgentCatalogDocument readmodel by authority

### DIFF
--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -16,6 +16,7 @@ public sealed class AgentBuilderTool : IAgentTool
     //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
     //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
     private readonly IUserAgentCatalogQueryPort _queryPort;
+    private readonly ISkillRunnerExecutionQueryPort _executionQueryPort;
     private readonly INyxIdApiClientFactory _nyxClientFactory;
     private readonly ISkillRunnerCommandPort _skillRunnerPort;
     private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
@@ -27,6 +28,7 @@ public sealed class AgentBuilderTool : IAgentTool
     //   New principle: Lifecycle commands return accepted; freshness is observed by follow-up query or push event.
     public AgentBuilderTool(
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         INyxIdApiClientFactory nyxClientFactory,
         ISkillRunnerCommandPort skillRunnerPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
@@ -34,6 +36,7 @@ public sealed class AgentBuilderTool : IAgentTool
         ILogger<AgentBuilderTool>? logger = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _executionQueryPort = executionQueryPort ?? throw new ArgumentNullException(nameof(executionQueryPort));
         _nyxClientFactory = nyxClientFactory ?? throw new ArgumentNullException(nameof(nyxClientFactory));
         _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
@@ -111,28 +114,30 @@ public sealed class AgentBuilderTool : IAgentTool
         var action = args.Str("action", "list_agents");
         return action switch
         {
-            "list_agents" => await ListAgentsAsync(_queryPort, caller, ct),
-            "agent_status" => await GetAgentStatusAsync(args, _queryPort, caller, ct),
-            "run_agent" => await RunAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
-            "disable_agent" => await DisableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
-            "enable_agent" => await EnableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
-            "delete_agent" => await DeleteAgentAsync(args, _queryPort, _catalogCommandPort, _skillRunnerPort, _nyxClientFactory, token, caller, ct),
+            "list_agents" => await ListAgentsAsync(_queryPort, _executionQueryPort, caller, ct),
+            "agent_status" => await GetAgentStatusAsync(args, _queryPort, _executionQueryPort, caller, ct),
+            "run_agent" => await RunAgentAsync(args, _queryPort, _executionQueryPort, _skillRunnerPort, caller, ct),
+            "disable_agent" => await DisableAgentAsync(args, _queryPort, _executionQueryPort, _skillRunnerPort, caller, ct),
+            "enable_agent" => await EnableAgentAsync(args, _queryPort, _executionQueryPort, _skillRunnerPort, caller, ct),
+            "delete_agent" => await DeleteAgentAsync(args, _queryPort, _executionQueryPort, _catalogCommandPort, _skillRunnerPort, _nyxClientFactory, token, caller, ct),
             _ => JsonSerializer.Serialize(new { error = $"Unsupported action '{action}'" }),
         };
     }
 
     private async Task<string> ListAgentsAsync(
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         OwnerScope caller,
         CancellationToken ct)
     {
-        var agents = await QueryAgentsForCallerAsync(queryPort, caller, ct);
+        var agents = await QueryAgentsForCallerAsync(queryPort, executionQueryPort, caller, ct);
         return JsonSerializer.Serialize(new { agents, total = agents.Length });
     }
 
     private async Task<string> GetAgentStatusAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         OwnerScope caller,
         CancellationToken ct)
     {
@@ -140,7 +145,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return """{"error":"agent_id is required for agent_status"}""";
 
-        var entry = await queryPort.GetForCallerAsync(agentId.Trim(), caller, ct);
+        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" });
 
@@ -150,6 +155,7 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<string> DeleteAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
         ISkillRunnerCommandPort skillRunnerPort,
         INyxIdApiClientFactory nyxClientFactory,
@@ -161,7 +167,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return """{"error":"agent_id is required for delete_agent"}""";
 
-        var entry = await queryPort.GetForCallerAsync(agentId.Trim(), caller, ct);
+        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" });
 
@@ -196,7 +202,7 @@ public sealed class AgentBuilderTool : IAgentTool
         //   New principle: Delete awaits command completion; accepted status is emitted by this tool boundary.
         await catalogCommandPort.TombstoneAsync(entry.AgentId, ct);
 
-        var agents = await QueryAgentsForCallerAsync(queryPort, caller, ct);
+        var agents = await QueryAgentsForCallerAsync(queryPort, executionQueryPort, caller, ct);
 
         return JsonSerializer.Serialize(new
         {
@@ -213,6 +219,7 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<string> RunAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         ISkillRunnerCommandPort skillRunnerPort,
         OwnerScope caller,
         CancellationToken ct)
@@ -221,7 +228,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return """{"error":"agent_id is required for run_agent"}""";
 
-        var entry = await queryPort.GetForCallerAsync(agentId.Trim(), caller, ct);
+        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" });
 
@@ -250,11 +257,12 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<string> DisableAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         ISkillRunnerCommandPort skillRunnerPort,
         OwnerScope caller,
         CancellationToken ct)
     {
-        var entry = await RequireManagedAgentAsync(args, queryPort, caller, "disable_agent", ct);
+        var entry = await RequireManagedAgentAsync(args, queryPort, executionQueryPort, caller, "disable_agent", ct);
         if (entry.error != null)
             return entry.error;
 
@@ -274,11 +282,12 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<string> EnableAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         ISkillRunnerCommandPort skillRunnerPort,
         OwnerScope caller,
         CancellationToken ct)
     {
-        var entry = await RequireManagedAgentAsync(args, queryPort, caller, "enable_agent", ct);
+        var entry = await RequireManagedAgentAsync(args, queryPort, executionQueryPort, caller, "enable_agent", ct);
         if (entry.error != null)
             return entry.error;
 
@@ -317,11 +326,16 @@ public sealed class AgentBuilderTool : IAgentTool
 
     private async Task<object[]> QueryAgentsForCallerAsync(
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         OwnerScope caller,
         CancellationToken ct)
     {
         var entries = await queryPort.QueryByCallerAsync(caller, ct);
+        var executions = await executionQueryPort.QueryByAgentIdsAsync(
+            entries.Select(static entry => entry.AgentId).ToArray(),
+            ct);
         return entries
+            .Select(entry => MergeExecution(entry, executions.GetValueOrDefault(entry.AgentId)))
             .Select(static x => new
             {
                 agent_id = x.AgentId,
@@ -341,6 +355,7 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<(UserAgentCatalogReadModelEntry? value, string? error)> RequireManagedAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         OwnerScope caller,
         string actionName,
         CancellationToken ct)
@@ -349,7 +364,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return (null, $$"""{"error":"agent_id is required for {{actionName}}"}""");
 
-        var entry = await queryPort.GetForCallerAsync(agentId.Trim(), caller, ct);
+        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return (null, JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" }));
 
@@ -357,6 +372,63 @@ public sealed class AgentBuilderTool : IAgentTool
             return (null, JsonSerializer.Serialize(new { error = $"Agent '{entry.AgentId}' does not support {actionName}" }));
 
         return (entry, null);
+    }
+
+    private static async Task<UserAgentCatalogReadModelEntry?> QueryAgentForCallerAsync(
+        IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
+        string agentId,
+        OwnerScope caller,
+        CancellationToken ct)
+    {
+        var entry = await queryPort.GetForCallerAsync(agentId, caller, ct);
+        if (entry is null)
+            return null;
+
+        return MergeExecution(entry, await executionQueryPort.GetAsync(entry.AgentId, ct));
+    }
+
+    // Refactor (iter94/cluster-094a):
+    //   Old: UserAgentCatalogQueryPort joined catalog and runner execution readmodels, creating a stable cross-authority view inside a query port.
+    //   New: /agents and /agent-status compose catalog + SkillRunner execution rows at the AgentBuilder consumer boundary.
+    internal static UserAgentCatalogReadModelEntry MergeExecution(
+        UserAgentCatalogReadModelEntry catalog,
+        SkillRunnerExecutionDocument? execution)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+
+        if (execution is null)
+            return catalog;
+
+        return new UserAgentCatalogReadModelEntry
+        {
+            AgentId = catalog.AgentId,
+            ConversationId = catalog.ConversationId,
+            NyxProviderSlug = catalog.NyxProviderSlug,
+            AgentType = catalog.AgentType,
+            TemplateName = catalog.TemplateName,
+            ScopeId = catalog.ScopeId,
+            ApiKeyId = catalog.ApiKeyId,
+            ScheduleCron = catalog.ScheduleCron,
+            ScheduleTimezone = catalog.ScheduleTimezone,
+            Status = execution.Status ?? string.Empty,
+            LastRunAt = execution.LastRunAtUtc,
+            NextRunAt = execution.NextRunAtUtc,
+            ErrorCount = execution.ErrorCount,
+            LastError = execution.LastError ?? string.Empty,
+            CreatedAt = catalog.CreatedAt,
+            UpdatedAt = catalog.UpdatedAt,
+            Tombstoned = catalog.Tombstoned,
+            LarkReceiveId = catalog.LarkReceiveId,
+            LarkReceiveIdType = catalog.LarkReceiveIdType,
+            LarkReceiveIdFallback = catalog.LarkReceiveIdFallback,
+            LarkReceiveIdTypeFallback = catalog.LarkReceiveIdTypeFallback,
+            OwnerScope = catalog.OwnerScope,
+            CatalogAuthorityStateVersion = catalog.CatalogAuthorityStateVersion,
+            CatalogLastEventId = catalog.CatalogLastEventId,
+            RunnerAuthorityStateVersion = execution.StateVersion,
+            RunnerLastEventId = execution.LastEventId ?? string.Empty,
+        };
     }
 
     private static async Task<(bool success, string? error)> TryDispatchLifecycleAsync(

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs
@@ -116,9 +116,9 @@ public sealed class AgentBuilderTool : IAgentTool
         {
             "list_agents" => await ListAgentsAsync(_queryPort, _executionQueryPort, caller, ct),
             "agent_status" => await GetAgentStatusAsync(args, _queryPort, _executionQueryPort, caller, ct),
-            "run_agent" => await RunAgentAsync(args, _queryPort, _executionQueryPort, _skillRunnerPort, caller, ct),
-            "disable_agent" => await DisableAgentAsync(args, _queryPort, _executionQueryPort, _skillRunnerPort, caller, ct),
-            "enable_agent" => await EnableAgentAsync(args, _queryPort, _executionQueryPort, _skillRunnerPort, caller, ct),
+            "run_agent" => await RunAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
+            "disable_agent" => await DisableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
+            "enable_agent" => await EnableAgentAsync(args, _queryPort, _skillRunnerPort, caller, ct),
             "delete_agent" => await DeleteAgentAsync(args, _queryPort, _executionQueryPort, _catalogCommandPort, _skillRunnerPort, _nyxClientFactory, token, caller, ct),
             _ => JsonSerializer.Serialize(new { error = $"Unsupported action '{action}'" }),
         };
@@ -167,7 +167,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return """{"error":"agent_id is required for delete_agent"}""";
 
-        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
+        var entry = await QueryCatalogAgentForCallerAsync(queryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" });
 
@@ -219,7 +219,6 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<string> RunAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
-        ISkillRunnerExecutionQueryPort executionQueryPort,
         ISkillRunnerCommandPort skillRunnerPort,
         OwnerScope caller,
         CancellationToken ct)
@@ -228,15 +227,12 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return """{"error":"agent_id is required for run_agent"}""";
 
-        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
+        var entry = await QueryCatalogAgentForCallerAsync(queryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" });
 
         if (!SupportsManagedLifecycle(entry.AgentType))
             return JsonSerializer.Serialize(new { error = $"Agent '{entry.AgentId}' does not support run_agent" });
-
-        if (string.Equals(entry.Status, SkillRunnerDefaults.StatusDisabled, StringComparison.Ordinal))
-            return JsonSerializer.Serialize(new { error = $"Agent '{entry.AgentId}' is disabled. Enable it before running." });
 
         var revisionFeedback = NormalizeOptional(args.Str("revision_feedback"));
         var dispatch = await TryDispatchLifecycleAsync(entry, "run_agent", LifecycleAction.Run, revisionFeedback, skillRunnerPort, ct);
@@ -249,59 +245,51 @@ public sealed class AgentBuilderTool : IAgentTool
             agent_id = entry.AgentId,
             template = entry.TemplateName,
             note = revisionFeedback is null
-                ? "Manual run dispatched."
-                : "Manual run dispatched with revision feedback.",
+                ? "Manual run accepted for dispatch. Runner state decides whether execution proceeds; use /agent-status to observe the result."
+                : "Manual run accepted for dispatch with revision feedback. Runner state decides whether execution proceeds; use /agent-status to observe the result.",
         });
     }
 
     private async Task<string> DisableAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
-        ISkillRunnerExecutionQueryPort executionQueryPort,
         ISkillRunnerCommandPort skillRunnerPort,
         OwnerScope caller,
         CancellationToken ct)
     {
-        var entry = await RequireManagedAgentAsync(args, queryPort, executionQueryPort, caller, "disable_agent", ct);
+        var entry = await RequireManagedAgentAsync(args, queryPort, caller, "disable_agent", ct);
         if (entry.error != null)
             return entry.error;
-
-        if (string.Equals(entry.value!.Status, SkillRunnerDefaults.StatusDisabled, StringComparison.Ordinal))
-            return SerializeAgentStatus(entry.value, "Agent is already disabled.");
 
         // Refactor (iter1/cluster-002):
         //   Old pattern: Captured readmodel version, dispatched lifecycle, then delayed-looped for projected status.
         //   New principle: Lifecycle commands return accepted; freshness is observed by follow-up query or push event.
-        var dispatch = await TryDispatchLifecycleAsync(entry.value, "disable_agent", LifecycleAction.Disable, null, skillRunnerPort, ct);
+        var dispatch = await TryDispatchLifecycleAsync(entry.value!, "disable_agent", LifecycleAction.Disable, null, skillRunnerPort, ct);
         if (dispatch.error != null)
             return dispatch.error;
 
-        return SerializeAgentStatus(entry.value, "Disable accepted. Status update is propagating; run /agent-status to confirm the agent is paused.");
+        return SerializeAgentStatus(entry.value!, "Disable accepted. Status update is propagating; run /agent-status to confirm the agent is paused.");
     }
 
     private async Task<string> EnableAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
-        ISkillRunnerExecutionQueryPort executionQueryPort,
         ISkillRunnerCommandPort skillRunnerPort,
         OwnerScope caller,
         CancellationToken ct)
     {
-        var entry = await RequireManagedAgentAsync(args, queryPort, executionQueryPort, caller, "enable_agent", ct);
+        var entry = await RequireManagedAgentAsync(args, queryPort, caller, "enable_agent", ct);
         if (entry.error != null)
             return entry.error;
-
-        if (string.Equals(entry.value!.Status, SkillRunnerDefaults.StatusRunning, StringComparison.Ordinal))
-            return SerializeAgentStatus(entry.value, "Agent is already enabled.");
 
         // Refactor (iter1/cluster-002):
         //   Old pattern: Captured readmodel version, dispatched lifecycle, then delayed-looped for projected status.
         //   New principle: Lifecycle commands return accepted; freshness is observed by follow-up query or push event.
-        var dispatch = await TryDispatchLifecycleAsync(entry.value, "enable_agent", LifecycleAction.Enable, null, skillRunnerPort, ct);
+        var dispatch = await TryDispatchLifecycleAsync(entry.value!, "enable_agent", LifecycleAction.Enable, null, skillRunnerPort, ct);
         if (dispatch.error != null)
             return dispatch.error;
 
-        return SerializeAgentStatus(entry.value, "Enable accepted. Status update is propagating; run /agent-status to confirm the agent is running.");
+        return SerializeAgentStatus(entry.value!, "Enable accepted. Status update is propagating; run /agent-status to confirm the agent is running.");
     }
 
     private static string SerializeAgentStatus(UserAgentCatalogReadModelEntry entry, string? note = null)
@@ -355,7 +343,6 @@ public sealed class AgentBuilderTool : IAgentTool
     private async Task<(UserAgentCatalogReadModelEntry? value, string? error)> RequireManagedAgentAsync(
         BuilderArgs args,
         IUserAgentCatalogQueryPort queryPort,
-        ISkillRunnerExecutionQueryPort executionQueryPort,
         OwnerScope caller,
         string actionName,
         CancellationToken ct)
@@ -364,7 +351,7 @@ public sealed class AgentBuilderTool : IAgentTool
         if (string.IsNullOrWhiteSpace(agentId))
             return (null, $$"""{"error":"agent_id is required for {{actionName}}"}""");
 
-        var entry = await QueryAgentForCallerAsync(queryPort, executionQueryPort, agentId.Trim(), caller, ct);
+        var entry = await QueryCatalogAgentForCallerAsync(queryPort, agentId.Trim(), caller, ct);
         if (entry is null)
             return (null, JsonSerializer.Serialize(new { error = $"Agent '{agentId}' not found" }));
 
@@ -373,6 +360,13 @@ public sealed class AgentBuilderTool : IAgentTool
 
         return (entry, null);
     }
+
+    private static Task<UserAgentCatalogReadModelEntry?> QueryCatalogAgentForCallerAsync(
+        IUserAgentCatalogQueryPort queryPort,
+        string agentId,
+        OwnerScope caller,
+        CancellationToken ct) =>
+        queryPort.GetForCallerAsync(agentId, caller, ct);
 
     private static async Task<UserAgentCatalogReadModelEntry?> QueryAgentForCallerAsync(
         IUserAgentCatalogQueryPort queryPort,
@@ -391,6 +385,10 @@ public sealed class AgentBuilderTool : IAgentTool
     // Refactor (iter94/cluster-094a):
     //   Old: UserAgentCatalogQueryPort joined catalog and runner execution readmodels, creating a stable cross-authority view inside a query port.
     //   New: /agents and /agent-status compose catalog + SkillRunner execution rows at the AgentBuilder consumer boundary.
+    //   This is presentation response assembly only. It must not be reused as an
+    //   internal lifecycle command admission source or promoted into an aggregate
+    //   query contract; command admission uses catalog authority only, while runner
+    //   execution state remains runner-owned and observable through readmodels.
     internal static UserAgentCatalogReadModelEntry MergeExecution(
         UserAgentCatalogReadModelEntry catalog,
         SkillRunnerExecutionDocument? execution)

--- a/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
+++ b/agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderToolSource.cs
@@ -12,6 +12,7 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
     //   Old pattern: tool source captures root IServiceProvider; tools resolve business ports via service locator in ExecuteAsync
     //   New principle: tool source + tools constructor-inject typed contracts; no root provider lookup
     private readonly IUserAgentCatalogQueryPort _queryPort;
+    private readonly ISkillRunnerExecutionQueryPort _executionQueryPort;
     private readonly INyxIdApiClientFactory _nyxClientFactory;
     private readonly ISkillRunnerCommandPort _skillRunnerPort;
     private readonly IUserAgentCatalogCommandPort _catalogCommandPort;
@@ -20,6 +21,7 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
 
     public AgentBuilderToolSource(
         IUserAgentCatalogQueryPort queryPort,
+        ISkillRunnerExecutionQueryPort executionQueryPort,
         INyxIdApiClientFactory nyxClientFactory,
         ISkillRunnerCommandPort skillRunnerPort,
         IUserAgentCatalogCommandPort catalogCommandPort,
@@ -27,6 +29,7 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
         ILogger<AgentBuilderTool>? toolLogger = null)
     {
         _queryPort = queryPort ?? throw new ArgumentNullException(nameof(queryPort));
+        _executionQueryPort = executionQueryPort ?? throw new ArgumentNullException(nameof(executionQueryPort));
         _nyxClientFactory = nyxClientFactory ?? throw new ArgumentNullException(nameof(nyxClientFactory));
         _skillRunnerPort = skillRunnerPort ?? throw new ArgumentNullException(nameof(skillRunnerPort));
         _catalogCommandPort = catalogCommandPort ?? throw new ArgumentNullException(nameof(catalogCommandPort));
@@ -41,6 +44,7 @@ public sealed class AgentBuilderToolSource : IAgentToolSource
         [
             new AgentBuilderTool(
                 _queryPort,
+                _executionQueryPort,
                 _nyxClientFactory,
                 _skillRunnerPort,
                 _catalogCommandPort,

--- a/agents/Aevatar.GAgents.Scheduled/DependencyInjection/ScheduledServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Scheduled/DependencyInjection/ScheduledServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ public static class ScheduledServiceCollectionExtensions
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<UserAgentCatalogNyxCredentialDocument>,
             UserAgentCatalogNyxCredentialDocumentMetadataProvider>();
         services.TryAddSingleton<IUserAgentCatalogQueryPort, UserAgentCatalogQueryPort>();
+        services.TryAddSingleton<ISkillRunnerExecutionQueryPort, SkillRunnerExecutionQueryPort>();
         // Internal-only credential-bearing reader for outbound delivery (issue #466 §D).
         // Architecture rule: NEVER inject IUserAgentDeliveryTargetReader into an
         // IAgentTool implementation; LLM tools see only the caller-scoped public port

--- a/agents/Aevatar.GAgents.Scheduled/DependencyInjection/ScheduledServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Scheduled/DependencyInjection/ScheduledServiceCollectionExtensions.cs
@@ -67,9 +67,14 @@ public static class ScheduledServiceCollectionExtensions
             UserAgentCatalogProjector>();
         services.AddCurrentStateProjectionMaterializer<
             UserAgentCatalogMaterializationContext,
+            SkillRunnerExecutionProjector>();
+        services.AddCurrentStateProjectionMaterializer<
+            UserAgentCatalogMaterializationContext,
             UserAgentCatalogNyxCredentialProjector>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<UserAgentCatalogDocument>,
             UserAgentCatalogDocumentMetadataProvider>();
+        services.TryAddSingleton<IProjectionDocumentMetadataProvider<SkillRunnerExecutionDocument>,
+            SkillRunnerExecutionDocumentMetadataProvider>();
         services.TryAddSingleton<IProjectionDocumentMetadataProvider<UserAgentCatalogNyxCredentialDocument>,
             UserAgentCatalogNyxCredentialDocumentMetadataProvider>();
         services.TryAddSingleton<IUserAgentCatalogQueryPort, UserAgentCatalogQueryPort>();
@@ -103,6 +108,11 @@ public static class ScheduledServiceCollectionExtensions
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<UserAgentCatalogDocument>>().Metadata,
                 keySelector: static doc => doc.Id,
                 keyFormatter: static key => key);
+            services.AddElasticsearchDocumentProjectionStore<SkillRunnerExecutionDocument, string>(
+                optionsFactory: _ => ElasticsearchProjectionConfiguration.BindOptions(configuration!),
+                metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<SkillRunnerExecutionDocument>>().Metadata,
+                keySelector: static doc => doc.Id,
+                keyFormatter: static key => key);
             services.AddElasticsearchDocumentProjectionStore<UserAgentCatalogNyxCredentialDocument, string>(
                 optionsFactory: _ => ElasticsearchProjectionConfiguration.BindOptions(configuration!),
                 metadataFactory: sp => sp.GetRequiredService<IProjectionDocumentMetadataProvider<UserAgentCatalogNyxCredentialDocument>>().Metadata,
@@ -112,6 +122,8 @@ public static class ScheduledServiceCollectionExtensions
         else
         {
             services.AddInMemoryDocumentProjectionStore<UserAgentCatalogDocument, string>(
+                static doc => doc.Id, static key => key);
+            services.AddInMemoryDocumentProjectionStore<SkillRunnerExecutionDocument, string>(
                 static doc => doc.Id, static key => key);
             services.AddInMemoryDocumentProjectionStore<UserAgentCatalogNyxCredentialDocument, string>(
                 static doc => doc.Id, static key => key);

--- a/agents/Aevatar.GAgents.Scheduled/ISkillRunnerExecutionQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ISkillRunnerExecutionQueryPort.cs
@@ -1,0 +1,14 @@
+namespace Aevatar.GAgents.Scheduled;
+
+/// <summary>
+/// Read port for SkillRunner-owned execution read models. Callers compose these rows
+/// with catalog rows only at their own consumer boundary.
+/// </summary>
+public interface ISkillRunnerExecutionQueryPort
+{
+    Task<SkillRunnerExecutionDocument?> GetAsync(string agentId, CancellationToken ct = default);
+
+    Task<IReadOnlyDictionary<string, SkillRunnerExecutionDocument>> QueryByAgentIdsAsync(
+        IReadOnlyCollection<string> agentIds,
+        CancellationToken ct = default);
+}

--- a/agents/Aevatar.GAgents.Scheduled/ScheduledRetiredActorSpec.cs
+++ b/agents/Aevatar.GAgents.Scheduled/ScheduledRetiredActorSpec.cs
@@ -102,6 +102,9 @@ public sealed class ScheduledRetiredActorSpec : RetiredActorSpec
             .DeleteByActorAsync<UserAgentCatalogDocument>(services, actorId, ct)
             .ConfigureAwait(false);
         await RetiredActorReadModelHelpers
+            .DeleteByActorAsync<SkillRunnerExecutionDocument>(services, actorId, ct)
+            .ConfigureAwait(false);
+        await RetiredActorReadModelHelpers
             .DeleteByActorAsync<UserAgentCatalogNyxCredentialDocument>(services, actorId, ct)
             .ConfigureAwait(false);
     }

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerDefaults.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerDefaults.cs
@@ -12,6 +12,7 @@ public static class SkillRunnerDefaults
     public const string StatusRunning = "running";
     public const string StatusError = "error";
     public const string StatusDisabled = "disabled";
+    public const string RejectionReasonRunnerDisabled = "runner_disabled";
     public const string TriggerCallbackId = "skill-runner-next-fire";
     public const string RetryCallbackId = "skill-runner-retry";
     public const int MaxRetryAttempts = 1;

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionDocument.Partial.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionDocument.Partial.cs
@@ -1,0 +1,19 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed partial class SkillRunnerExecutionDocument : IProjectionReadModel<SkillRunnerExecutionDocument>
+{
+    public DateTimeOffset UpdatedAt
+    {
+        get => UpdatedAtUtc != null ? UpdatedAtUtc.ToDateTimeOffset() : default;
+        set => UpdatedAtUtc = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
+    }
+
+    public DateTimeOffset CreatedAt
+    {
+        get => CreatedAtUtc != null ? CreatedAtUtc.ToDateTimeOffset() : default;
+        set => CreatedAtUtc = Timestamp.FromDateTimeOffset(value.ToUniversalTime());
+    }
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionDocumentMetadataProvider.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionDocumentMetadataProvider.cs
@@ -1,0 +1,16 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed class SkillRunnerExecutionDocumentMetadataProvider
+    : IProjectionDocumentMetadataProvider<SkillRunnerExecutionDocument>
+{
+    public DocumentIndexMetadata Metadata { get; } = new(
+        IndexName: UserAgentCatalogStorageContracts.RunnerExecutionReadModelIndexName,
+        Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["dynamic"] = true,
+        },
+        Settings: new Dictionary<string, object?>(StringComparer.Ordinal),
+        Aliases: new Dictionary<string, object?>(StringComparer.Ordinal));
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionProjector.cs
@@ -6,6 +6,9 @@ using Aevatar.Foundation.Abstractions;
 
 namespace Aevatar.GAgents.Scheduled;
 
+// Refactor (iter94/cluster-094a):
+//   Old: runner execution fields were tempting to fold into the catalog readmodel/query port.
+//   New: SkillRunner committed state owns and materializes execution readmodel rows independently.
 public sealed class SkillRunnerExecutionProjector
     : ICurrentStateProjectionMaterializer<UserAgentCatalogMaterializationContext>
 {

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionProjector.cs
@@ -1,0 +1,107 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed class SkillRunnerExecutionProjector
+    : ICurrentStateProjectionMaterializer<UserAgentCatalogMaterializationContext>
+{
+    private readonly IProjectionWriteDispatcher<SkillRunnerExecutionDocument> _writeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    public SkillRunnerExecutionProjector(
+        IProjectionWriteDispatcher<SkillRunnerExecutionDocument> writeDispatcher,
+        IProjectionClock clock)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async ValueTask ProjectAsync(
+        UserAgentCatalogMaterializationContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!CommittedStateEventEnvelope.TryUnpackState<SkillRunnerState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out var state) ||
+            stateEvent is null ||
+            state is null ||
+            !TryResolveRunnerActorId(context, envelope, out var agentId))
+        {
+            return;
+        }
+
+        var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
+        await _writeDispatcher.UpsertAsync(
+            Materialize(agentId, state, stateEvent, updatedAt),
+            ct);
+    }
+
+    private static SkillRunnerExecutionDocument Materialize(
+        string agentId,
+        SkillRunnerState state,
+        StateEvent stateEvent,
+        DateTimeOffset updatedAt) =>
+        new()
+        {
+            Id = agentId,
+            ActorId = agentId,
+            StateVersion = stateEvent.Version,
+            LastEventId = stateEvent.EventId ?? string.Empty,
+            UpdatedAt = updatedAt,
+            CreatedAt = updatedAt,
+            TemplateName = state.TemplateName ?? string.Empty,
+            ScopeId = state.ScopeId ?? string.Empty,
+            ScheduleCron = state.ScheduleCron ?? string.Empty,
+            ScheduleTimezone = state.ScheduleTimezone ?? string.Empty,
+            Status = ResolveRunnerStatus(state),
+            LastRunAtUtc = state.LastRunAt,
+            NextRunAtUtc = state.NextRunAt,
+            ErrorCount = state.ErrorCount,
+            LastError = state.LastError ?? string.Empty,
+        };
+
+    private static bool TryResolveRunnerActorId(
+        UserAgentCatalogMaterializationContext context,
+        EventEnvelope envelope,
+        out string agentId)
+    {
+        agentId = string.Empty;
+        var rootActorId = context.RootActorId?.Trim();
+        if (!string.IsNullOrWhiteSpace(rootActorId) &&
+            !string.Equals(rootActorId, UserAgentCatalogGAgent.WellKnownId, StringComparison.Ordinal))
+        {
+            agentId = rootActorId;
+            return true;
+        }
+
+        var publisherActorId = envelope.Route?.PublisherActorId?.Trim();
+        if (string.IsNullOrWhiteSpace(publisherActorId) ||
+            string.Equals(publisherActorId, UserAgentCatalogGAgent.WellKnownId, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        agentId = publisherActorId;
+        return true;
+    }
+
+    private static string ResolveRunnerStatus(SkillRunnerState state)
+    {
+        if (!state.Enabled)
+            return SkillRunnerDefaults.StatusDisabled;
+
+        return state.ErrorCount > 0
+            ? SkillRunnerDefaults.StatusError
+            : SkillRunnerDefaults.StatusRunning;
+    }
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerExecutionQueryPort.cs
@@ -1,0 +1,65 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+
+namespace Aevatar.GAgents.Scheduled;
+
+public sealed class SkillRunnerExecutionQueryPort : ISkillRunnerExecutionQueryPort
+{
+    private readonly IProjectionDocumentReader<SkillRunnerExecutionDocument, string> _documentReader;
+
+    public SkillRunnerExecutionQueryPort(
+        IProjectionDocumentReader<SkillRunnerExecutionDocument, string> documentReader)
+    {
+        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
+    }
+
+    public async Task<SkillRunnerExecutionDocument?> GetAsync(string agentId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(agentId))
+            return null;
+
+        return await _documentReader.GetAsync(agentId.Trim(), ct);
+    }
+
+    public async Task<IReadOnlyDictionary<string, SkillRunnerExecutionDocument>> QueryByAgentIdsAsync(
+        IReadOnlyCollection<string> agentIds,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(agentIds);
+
+        var ids = agentIds
+            .Select(static id => id?.Trim())
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (ids.Length == 0)
+            return new Dictionary<string, SkillRunnerExecutionDocument>(StringComparer.Ordinal);
+
+        var result = await _documentReader.QueryAsync(
+            new ProjectionDocumentQuery
+            {
+                Take = ids.Length,
+                Filters =
+                [
+                    new ProjectionDocumentFilter
+                    {
+                        FieldPath = nameof(SkillRunnerExecutionDocument.Id),
+                        Operator = ids.Length == 1
+                            ? ProjectionDocumentFilterOperator.Eq
+                            : ProjectionDocumentFilterOperator.In,
+                        Value = ids.Length == 1
+                            ? ProjectionDocumentValue.FromString(ids[0])
+                            : ProjectionDocumentValue.FromStrings(ids),
+                    },
+                ],
+            },
+            ct);
+
+        return result.Items
+            .Where(static doc => !string.IsNullOrWhiteSpace(doc.Id))
+            .GroupBy(static doc => doc.Id, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.OrderByDescending(doc => doc.StateVersion).First(),
+                StringComparer.Ordinal);
+    }
+}

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerGAgent.cs
@@ -157,6 +157,7 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
             .On<SkillRunnerNextRunScheduledEvent>(ApplyNextRunScheduled)
             .On<SkillRunnerExecutionCompletedEvent>(ApplyCompleted)
             .On<SkillRunnerExecutionFailedEvent>(ApplyFailed)
+            .On<SkillRunnerExecutionRejectedEvent>(ApplyRejected)
             .On<SkillRunnerDisabledEvent>(ApplyDisabled)
             .On<SkillRunnerEnabledEvent>(ApplyEnabled)
             .OrCurrent();
@@ -210,6 +211,11 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         if (!State.Enabled)
         {
             Logger.LogInformation("Skill runner {ActorId} ignored trigger because it is disabled", Id);
+            await PersistDomainEventAsync(new SkillRunnerExecutionRejectedEvent
+            {
+                RejectedAt = Timestamp.FromDateTimeOffset(_clock.UtcNow),
+                Reason = SkillRunnerDefaults.RejectionReasonRunnerDisabled,
+            });
             return;
         }
 
@@ -996,6 +1002,15 @@ public sealed class SkillRunnerGAgent : AIGAgentBase<SkillRunnerState>
         var next = current.Clone();
         next.LastRunAt = evt.FailedAt;
         next.LastError = evt.Error ?? string.Empty;
+        next.ErrorCount += 1;
+        return next;
+    }
+
+    private static SkillRunnerState ApplyRejected(SkillRunnerState current, SkillRunnerExecutionRejectedEvent evt)
+    {
+        var next = current.Clone();
+        next.LastRunAt = evt.RejectedAt;
+        next.LastError = evt.Reason ?? string.Empty;
         next.ErrorCount += 1;
         return next;
     }

--- a/agents/Aevatar.GAgents.Scheduled/SkillRunnerLegacyAliases.cs
+++ b/agents/Aevatar.GAgents.Scheduled/SkillRunnerLegacyAliases.cs
@@ -15,6 +15,7 @@ internal static class SkillRunnerLegacyAliases
     internal const string NextRunScheduledEventProto = ProtoPrefix + "SkillRunnerNextRunScheduledEvent";
     internal const string CompletedEventProto = ProtoPrefix + "SkillRunnerExecutionCompletedEvent";
     internal const string FailedEventProto = ProtoPrefix + "SkillRunnerExecutionFailedEvent";
+    internal const string RejectedEventProto = ProtoPrefix + "SkillRunnerExecutionRejectedEvent";
     internal const string DisableCommandProto = ProtoPrefix + "DisableSkillRunnerCommand";
     internal const string EnableCommandProto = ProtoPrefix + "EnableSkillRunnerCommand";
     internal const string DisabledEventProto = ProtoPrefix + "SkillRunnerDisabledEvent";
@@ -47,6 +48,9 @@ public sealed partial class SkillRunnerExecutionCompletedEvent;
 
 [LegacyProtoFullName(SkillRunnerLegacyAliases.FailedEventProto)]
 public sealed partial class SkillRunnerExecutionFailedEvent;
+
+[LegacyProtoFullName(SkillRunnerLegacyAliases.RejectedEventProto)]
+public sealed partial class SkillRunnerExecutionRejectedEvent;
 
 [LegacyProtoFullName(SkillRunnerLegacyAliases.DisableCommandProto)]
 public sealed partial class DisableSkillRunnerCommand;

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogCommittedStateProjectionActivationPlanProvider.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogCommittedStateProjectionActivationPlanProvider.cs
@@ -43,6 +43,7 @@ public sealed class UserAgentCatalogCommittedStateProjectionActivationPlanProvid
         payload.Is(SkillRunnerNextRunScheduledEvent.Descriptor) ||
         payload.Is(SkillRunnerExecutionCompletedEvent.Descriptor) ||
         payload.Is(SkillRunnerExecutionFailedEvent.Descriptor) ||
+        payload.Is(SkillRunnerExecutionRejectedEvent.Descriptor) ||
         payload.Is(SkillRunnerDisabledEvent.Descriptor) ||
         payload.Is(SkillRunnerEnabledEvent.Descriptor);
 

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -7,8 +7,9 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.Scheduled;
 
-// Catalog documents are actor-scoped membership read models. Runner execution facts
-// are projected separately by SkillRunnerExecutionProjector.
+// Refactor (iter94/cluster-094a):
+//   Old: catalog projection/query surfaces could carry runner execution facts beside membership facts.
+//   New: this projector only materializes UserAgentCatalog authority membership; SkillRunner execution has its own projector/read port.
 public sealed class UserAgentCatalogProjector
     : ICurrentStateProjectionMaterializer<UserAgentCatalogMaterializationContext>
 {

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogProjector.cs
@@ -7,23 +7,19 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.GAgents.Scheduled;
 
-// Refactor (iter1/cluster-001):
-//   Old pattern: Catalog execution fields were changed by commands sent from each runner to one catalog actor.
-//   New principle: Catalog documents merge catalog-owned membership state with runner-owned committed execution state.
+// Catalog documents are actor-scoped membership read models. Runner execution facts
+// are projected separately by SkillRunnerExecutionProjector.
 public sealed class UserAgentCatalogProjector
     : ICurrentStateProjectionMaterializer<UserAgentCatalogMaterializationContext>
 {
     private readonly IProjectionWriteDispatcher<UserAgentCatalogDocument> _writeDispatcher;
-    private readonly IProjectionDocumentReader<UserAgentCatalogDocument, string> _documentReader;
     private readonly IProjectionClock _clock;
 
     public UserAgentCatalogProjector(
         IProjectionWriteDispatcher<UserAgentCatalogDocument> writeDispatcher,
-        IProjectionDocumentReader<UserAgentCatalogDocument, string> documentReader,
         IProjectionClock clock)
     {
         _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
-        _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
@@ -44,18 +40,6 @@ public sealed class UserAgentCatalogProjector
             catalogState is not null)
         {
             await ProjectCatalogMembershipAsync(catalogState, catalogStateEvent, envelope, ct);
-            return;
-        }
-
-        if (CommittedStateEventEnvelope.TryUnpackState<SkillRunnerState>(
-                envelope,
-                out _,
-                out var runnerStateEvent,
-                out var runnerState) &&
-            runnerStateEvent is not null &&
-            runnerState is not null)
-        {
-            await ProjectRunnerExecutionAsync(context, runnerState, runnerStateEvent, envelope, ct);
         }
     }
 
@@ -81,8 +65,7 @@ public sealed class UserAgentCatalogProjector
                 continue;
             }
 
-            var existing = await _documentReader.GetAsync(key, ct);
-            var document = MaterializeCatalogEntry(entry, stateEvent, updatedAt, existing);
+            var document = MaterializeCatalogEntry(entry, stateEvent, updatedAt);
             if (!string.Equals(document.Id, key, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
@@ -93,30 +76,12 @@ public sealed class UserAgentCatalogProjector
         }
     }
 
-    private async Task ProjectRunnerExecutionAsync(
-        UserAgentCatalogMaterializationContext context,
-        SkillRunnerState state,
-        StateEvent stateEvent,
-        EventEnvelope envelope,
-        CancellationToken ct)
-    {
-        if (!TryResolveRunnerActorId(context, envelope, out var agentId))
-            return;
-
-        var updatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow);
-        var existing = await _documentReader.GetAsync(agentId, ct);
-        await _writeDispatcher.UpsertAsync(
-            MaterializeRunnerExecution(agentId, state, stateEvent, updatedAt, existing),
-            ct);
-    }
-
     private static UserAgentCatalogDocument MaterializeCatalogEntry(
         UserAgentCatalogEntry entry,
         StateEvent stateEvent,
-        DateTimeOffset updatedAt,
-        UserAgentCatalogDocument? existing)
+        DateTimeOffset updatedAt)
     {
-        var document = existing?.Clone() ?? new UserAgentCatalogDocument();
+        var document = new UserAgentCatalogDocument();
         document.Id = entry.AgentId;
         document.ConversationId = entry.ConversationId ?? string.Empty;
         document.NyxProviderSlug = entry.NyxProviderSlug ?? string.Empty;
@@ -158,101 +123,8 @@ public sealed class UserAgentCatalogProjector
         if (entryScope is not null)
             document.OwnerScope = entryScope;
 
-        document.CatalogSourceVersion = stateEvent.Version;
-        document.CatalogLastEventId = stateEvent.EventId ?? string.Empty;
-        document.StateVersion = ResolveMergedStateVersion(document);
-        document.LastEventId = ResolveMergedLastEventId(document);
+        document.StateVersion = stateEvent.Version;
+        document.LastEventId = stateEvent.EventId ?? string.Empty;
         return document;
     }
-
-    private static UserAgentCatalogDocument MaterializeRunnerExecution(
-        string agentId,
-        SkillRunnerState state,
-        StateEvent stateEvent,
-        DateTimeOffset updatedAt,
-        UserAgentCatalogDocument? existing)
-    {
-        var document = existing?.Clone() ?? new UserAgentCatalogDocument
-        {
-            Id = agentId,
-            ActorId = UserAgentCatalogGAgent.WellKnownId,
-            CreatedAt = updatedAt,
-        };
-
-        document.Id = agentId;
-        document.ActorId = UserAgentCatalogGAgent.WellKnownId;
-        document.AgentType = string.IsNullOrWhiteSpace(document.AgentType)
-            ? SkillRunnerDefaults.AgentType
-            : document.AgentType;
-        document.TemplateName = CoalesceNonEmpty(document.TemplateName, state.TemplateName);
-        document.ScopeId = CoalesceNonEmpty(document.ScopeId, state.ScopeId);
-        document.ScheduleCron = CoalesceNonEmpty(document.ScheduleCron, state.ScheduleCron);
-        document.ScheduleTimezone = CoalesceNonEmpty(document.ScheduleTimezone, state.ScheduleTimezone);
-        document.Status = ResolveRunnerStatus(state);
-        document.LastRunAtUtc = state.LastRunAt;
-        document.NextRunAtUtc = state.NextRunAt;
-        document.ErrorCount = state.ErrorCount;
-        document.LastError = state.LastError ?? string.Empty;
-        document.UpdatedAt = updatedAt;
-        if (document.CreatedAt == default)
-            document.CreatedAt = updatedAt;
-        document.RunnerSourceVersion = stateEvent.Version;
-        document.RunnerLastEventId = stateEvent.EventId ?? string.Empty;
-        document.StateVersion = ResolveMergedStateVersion(document);
-        document.LastEventId = ResolveMergedLastEventId(document);
-        return document;
-    }
-
-    private static bool TryResolveRunnerActorId(
-        UserAgentCatalogMaterializationContext context,
-        EventEnvelope envelope,
-        out string agentId)
-    {
-        agentId = string.Empty;
-        var rootActorId = context.RootActorId?.Trim();
-        if (!string.IsNullOrWhiteSpace(rootActorId) &&
-            !string.Equals(rootActorId, UserAgentCatalogGAgent.WellKnownId, StringComparison.Ordinal))
-        {
-            agentId = rootActorId;
-            return true;
-        }
-
-        var publisherActorId = envelope.Route?.PublisherActorId?.Trim();
-        if (string.IsNullOrWhiteSpace(publisherActorId) ||
-            string.Equals(publisherActorId, UserAgentCatalogGAgent.WellKnownId, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        agentId = publisherActorId;
-        return true;
-    }
-
-    private static string ResolveRunnerStatus(SkillRunnerState state)
-    {
-        if (!state.Enabled)
-            return SkillRunnerDefaults.StatusDisabled;
-
-        return state.ErrorCount > 0
-            ? SkillRunnerDefaults.StatusError
-            : SkillRunnerDefaults.StatusRunning;
-    }
-
-    private static long ResolveMergedStateVersion(UserAgentCatalogDocument document) =>
-        Math.Max(0, document.CatalogSourceVersion) + Math.Max(0, document.RunnerSourceVersion);
-
-    private static string ResolveMergedLastEventId(UserAgentCatalogDocument document)
-    {
-        if (string.IsNullOrWhiteSpace(document.CatalogLastEventId))
-            return document.RunnerLastEventId ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(document.RunnerLastEventId))
-            return document.CatalogLastEventId ?? string.Empty;
-
-        return $"{document.CatalogLastEventId}:{document.RunnerLastEventId}";
-    }
-
-    private static string CoalesceNonEmpty(string? existing, string? incoming) =>
-        !string.IsNullOrWhiteSpace(existing)
-            ? existing.Trim()
-            : (incoming ?? string.Empty).Trim();
 }

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
@@ -27,14 +27,11 @@ namespace Aevatar.GAgents.Scheduled;
 public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
 {
     private readonly IProjectionDocumentReader<UserAgentCatalogDocument, string> _documentReader;
-    private readonly IProjectionDocumentReader<SkillRunnerExecutionDocument, string> _executionReader;
 
     public UserAgentCatalogQueryPort(
-        IProjectionDocumentReader<UserAgentCatalogDocument, string> documentReader,
-        IProjectionDocumentReader<SkillRunnerExecutionDocument, string> executionReader)
+        IProjectionDocumentReader<UserAgentCatalogDocument, string> documentReader)
     {
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
-        _executionReader = executionReader ?? throw new ArgumentNullException(nameof(executionReader));
     }
 
     public async Task<UserAgentCatalogReadModelEntry?> GetForCallerAsync(string agentId, OwnerScope caller, CancellationToken ct = default)
@@ -48,9 +45,7 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
         var document = await _documentReader.GetAsync(agentId, ct);
         if (document == null || document.Tombstoned) return null;
 
-        return DocumentMatchesCaller(document, caller)
-            ? ToEntry(document, await _executionReader.GetAsync(agentId, ct))
-            : null;
+        return DocumentMatchesCaller(document, caller) ? ToEntry(document) : null;
     }
 
     /// <summary>
@@ -87,12 +82,10 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             };
 
             var page = await _documentReader.QueryAsync(query, ct);
-            var executionDocuments = await LoadExecutionDocumentsAsync(page.Items, ct);
             foreach (var doc in page.Items)
             {
                 if (doc.Tombstoned) continue;
-                executionDocuments.TryGetValue(doc.Id ?? string.Empty, out var execution);
-                entries.Add(ToEntry(doc, execution));
+                entries.Add(ToEntry(doc));
                 if (entries.Count >= MaxCallerCatalogEntries)
                     return entries;
             }
@@ -183,9 +176,7 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
     /// after the credential drop). Internal callers that still need the credential go
     /// through <see cref="IUserAgentDeliveryTargetReader"/>.
     /// </summary>
-    internal static UserAgentCatalogReadModelEntry ToEntry(
-        UserAgentCatalogDocument document,
-        SkillRunnerExecutionDocument? execution = null)
+    internal static UserAgentCatalogReadModelEntry ToEntry(UserAgentCatalogDocument document)
     {
         var documentScope = document.OwnerScope ?? OwnerScope.FromLegacyFields(
 #pragma warning disable CS0612 // legacy field read for backfill only
@@ -203,11 +194,6 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             ApiKeyId = document.ApiKeyId ?? string.Empty,
             ScheduleCron = document.ScheduleCron ?? string.Empty,
             ScheduleTimezone = document.ScheduleTimezone ?? string.Empty,
-            Status = execution?.Status ?? string.Empty,
-            LastRunAt = execution?.LastRunAtUtc,
-            NextRunAt = execution?.NextRunAtUtc,
-            ErrorCount = execution?.ErrorCount ?? 0,
-            LastError = execution?.LastError ?? string.Empty,
             CreatedAt = document.CreatedAtUtc,
             UpdatedAt = document.UpdatedAtUtc,
             Tombstoned = document.Tombstoned,
@@ -218,50 +204,6 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             OwnerScope = documentScope,
             CatalogAuthorityStateVersion = document.StateVersion,
             CatalogLastEventId = document.LastEventId ?? string.Empty,
-            RunnerAuthorityStateVersion = execution?.StateVersion,
-            RunnerLastEventId = execution?.LastEventId ?? string.Empty,
         };
-    }
-
-    private async Task<IReadOnlyDictionary<string, SkillRunnerExecutionDocument>> LoadExecutionDocumentsAsync(
-        IReadOnlyList<UserAgentCatalogDocument> documents,
-        CancellationToken ct)
-    {
-        var ids = documents
-            .Where(static doc => !doc.Tombstoned)
-            .Select(static doc => doc.Id?.Trim())
-            .Where(static id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-        if (ids.Length == 0)
-            return new Dictionary<string, SkillRunnerExecutionDocument>(StringComparer.Ordinal);
-
-        var result = await _executionReader.QueryAsync(
-            new ProjectionDocumentQuery
-            {
-                Take = ids.Length,
-                Filters =
-                [
-                    new ProjectionDocumentFilter
-                    {
-                        FieldPath = nameof(SkillRunnerExecutionDocument.Id),
-                        Operator = ids.Length == 1
-                            ? ProjectionDocumentFilterOperator.Eq
-                            : ProjectionDocumentFilterOperator.In,
-                        Value = ids.Length == 1
-                            ? ProjectionDocumentValue.FromString(ids[0])
-                            : ProjectionDocumentValue.FromStrings(ids),
-                    },
-                ],
-            },
-            ct);
-
-        return result.Items
-            .Where(static doc => !string.IsNullOrWhiteSpace(doc.Id))
-            .GroupBy(static doc => doc.Id, StringComparer.Ordinal)
-            .ToDictionary(
-                static group => group.Key,
-                static group => group.OrderByDescending(doc => doc.StateVersion).First(),
-                StringComparer.Ordinal);
     }
 }

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogQueryPort.cs
@@ -27,10 +27,14 @@ namespace Aevatar.GAgents.Scheduled;
 public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
 {
     private readonly IProjectionDocumentReader<UserAgentCatalogDocument, string> _documentReader;
+    private readonly IProjectionDocumentReader<SkillRunnerExecutionDocument, string> _executionReader;
 
-    public UserAgentCatalogQueryPort(IProjectionDocumentReader<UserAgentCatalogDocument, string> documentReader)
+    public UserAgentCatalogQueryPort(
+        IProjectionDocumentReader<UserAgentCatalogDocument, string> documentReader,
+        IProjectionDocumentReader<SkillRunnerExecutionDocument, string> executionReader)
     {
         _documentReader = documentReader ?? throw new ArgumentNullException(nameof(documentReader));
+        _executionReader = executionReader ?? throw new ArgumentNullException(nameof(executionReader));
     }
 
     public async Task<UserAgentCatalogReadModelEntry?> GetForCallerAsync(string agentId, OwnerScope caller, CancellationToken ct = default)
@@ -45,7 +49,7 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
         if (document == null || document.Tombstoned) return null;
 
         return DocumentMatchesCaller(document, caller)
-            ? ToEntry(document)
+            ? ToEntry(document, await _executionReader.GetAsync(agentId, ct))
             : null;
     }
 
@@ -83,10 +87,12 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             };
 
             var page = await _documentReader.QueryAsync(query, ct);
+            var executionDocuments = await LoadExecutionDocumentsAsync(page.Items, ct);
             foreach (var doc in page.Items)
             {
                 if (doc.Tombstoned) continue;
-                entries.Add(ToEntry(doc));
+                executionDocuments.TryGetValue(doc.Id ?? string.Empty, out var execution);
+                entries.Add(ToEntry(doc, execution));
                 if (entries.Count >= MaxCallerCatalogEntries)
                     return entries;
             }
@@ -177,7 +183,9 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
     /// after the credential drop). Internal callers that still need the credential go
     /// through <see cref="IUserAgentDeliveryTargetReader"/>.
     /// </summary>
-    internal static UserAgentCatalogReadModelEntry ToEntry(UserAgentCatalogDocument document)
+    internal static UserAgentCatalogReadModelEntry ToEntry(
+        UserAgentCatalogDocument document,
+        SkillRunnerExecutionDocument? execution = null)
     {
         var documentScope = document.OwnerScope ?? OwnerScope.FromLegacyFields(
 #pragma warning disable CS0612 // legacy field read for backfill only
@@ -195,11 +203,11 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             ApiKeyId = document.ApiKeyId ?? string.Empty,
             ScheduleCron = document.ScheduleCron ?? string.Empty,
             ScheduleTimezone = document.ScheduleTimezone ?? string.Empty,
-            Status = document.Status ?? string.Empty,
-            LastRunAt = document.LastRunAtUtc,
-            NextRunAt = document.NextRunAtUtc,
-            ErrorCount = document.ErrorCount,
-            LastError = document.LastError ?? string.Empty,
+            Status = execution?.Status ?? string.Empty,
+            LastRunAt = execution?.LastRunAtUtc,
+            NextRunAt = execution?.NextRunAtUtc,
+            ErrorCount = execution?.ErrorCount ?? 0,
+            LastError = execution?.LastError ?? string.Empty,
             CreatedAt = document.CreatedAtUtc,
             UpdatedAt = document.UpdatedAtUtc,
             Tombstoned = document.Tombstoned,
@@ -208,6 +216,52 @@ public sealed class UserAgentCatalogQueryPort : IUserAgentCatalogQueryPort
             LarkReceiveIdFallback = document.LarkReceiveIdFallback ?? string.Empty,
             LarkReceiveIdTypeFallback = document.LarkReceiveIdTypeFallback ?? string.Empty,
             OwnerScope = documentScope,
+            CatalogAuthorityStateVersion = document.StateVersion,
+            CatalogLastEventId = document.LastEventId ?? string.Empty,
+            RunnerAuthorityStateVersion = execution?.StateVersion,
+            RunnerLastEventId = execution?.LastEventId ?? string.Empty,
         };
+    }
+
+    private async Task<IReadOnlyDictionary<string, SkillRunnerExecutionDocument>> LoadExecutionDocumentsAsync(
+        IReadOnlyList<UserAgentCatalogDocument> documents,
+        CancellationToken ct)
+    {
+        var ids = documents
+            .Where(static doc => !doc.Tombstoned)
+            .Select(static doc => doc.Id?.Trim())
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (ids.Length == 0)
+            return new Dictionary<string, SkillRunnerExecutionDocument>(StringComparer.Ordinal);
+
+        var result = await _executionReader.QueryAsync(
+            new ProjectionDocumentQuery
+            {
+                Take = ids.Length,
+                Filters =
+                [
+                    new ProjectionDocumentFilter
+                    {
+                        FieldPath = nameof(SkillRunnerExecutionDocument.Id),
+                        Operator = ids.Length == 1
+                            ? ProjectionDocumentFilterOperator.Eq
+                            : ProjectionDocumentFilterOperator.In,
+                        Value = ids.Length == 1
+                            ? ProjectionDocumentValue.FromString(ids[0])
+                            : ProjectionDocumentValue.FromStrings(ids),
+                    },
+                ],
+            },
+            ct);
+
+        return result.Items
+            .Where(static doc => !string.IsNullOrWhiteSpace(doc.Id))
+            .GroupBy(static doc => doc.Id, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.OrderByDescending(doc => doc.StateVersion).First(),
+                StringComparer.Ordinal);
     }
 }

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogReadModelEntry.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogReadModelEntry.cs
@@ -31,4 +31,8 @@ public sealed class UserAgentCatalogReadModelEntry
     public string LarkReceiveIdFallback { get; init; } = string.Empty;
     public string LarkReceiveIdTypeFallback { get; init; } = string.Empty;
     public OwnerScope? OwnerScope { get; init; }
+    public long CatalogAuthorityStateVersion { get; init; }
+    public string CatalogLastEventId { get; init; } = string.Empty;
+    public long? RunnerAuthorityStateVersion { get; init; }
+    public string RunnerLastEventId { get; init; } = string.Empty;
 }

--- a/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogStorageContracts.cs
+++ b/agents/Aevatar.GAgents.Scheduled/UserAgentCatalogStorageContracts.cs
@@ -7,6 +7,7 @@ internal static class UserAgentCatalogStorageContracts
     // to avoid colliding with the legacy AgentRegistry materialization scope actor type.
     public const string StoreActorId = "agent-registry-store";
     public const string ReadModelIndexName = "agent-registry";
+    public const string RunnerExecutionReadModelIndexName = "skill-runner-execution";
     public const string LegacyDurableProjectionKind = "agent-registry";
     public const string DurableProjectionKind = "user-agent-catalog-read-model";
 }

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -76,6 +76,24 @@ message SkillRunnerState {
   bool requires_nyxid_proxy_success = 21;
 }
 
+message SkillRunnerExecutionDocument {
+  string id = 1;
+  string actor_id = 2;
+  int64 state_version = 3;
+  string last_event_id = 4;
+  google.protobuf.Timestamp updated_at_utc = 5;
+  google.protobuf.Timestamp created_at_utc = 6;
+  string template_name = 7;
+  string scope_id = 8;
+  string schedule_cron = 9;
+  string schedule_timezone = 10;
+  string status = 11;
+  google.protobuf.Timestamp last_run_at_utc = 12;
+  google.protobuf.Timestamp next_run_at_utc = 13;
+  int32 error_count = 14;
+  string last_error = 15;
+}
+
 message InitializeSkillRunnerCommand {
   string skill_name = 1;
   string template_name = 2;

--- a/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/skill_runner.proto
@@ -156,6 +156,11 @@ message SkillRunnerExecutionFailedEvent {
   string error = 2;
 }
 
+message SkillRunnerExecutionRejectedEvent {
+  google.protobuf.Timestamp rejected_at = 1;
+  string reason = 2;
+}
+
 message DisableSkillRunnerCommand {
   string reason = 1;
 }

--- a/agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto
+++ b/agents/Aevatar.GAgents.Scheduled/protos/user_agent_catalog.proto
@@ -143,11 +143,8 @@ message UserAgentCatalogDocument {
   string api_key_id = 16;
   string schedule_cron = 17;
   string schedule_timezone = 18;
-  string status = 19;
-  google.protobuf.Timestamp last_run_at_utc = 20;
-  google.protobuf.Timestamp next_run_at_utc = 21;
-  int32 error_count = 22;
-  string last_error = 23;
+  reserved 19, 20, 21, 22, 23;
+  reserved "status", "last_run_at_utc", "next_run_at_utc", "error_count", "last_error";
   // Mirrors UserAgentCatalogEntry.lark_receive_id*. Required so catalog-backed
   // outbound senders (FeishuCardHumanInteractionPort) read the typed target
   // through the projection rather than re-deriving from conversation_id.
@@ -163,14 +160,8 @@ message UserAgentCatalogDocument {
   // case the caller-scoped query port lazily synthesizes owner_scope on read
   // for the nyxid surface (issue #466 migration plan).
   aevatar.OwnerScope owner_scope = 28;
-  // Source watermarks for the merged catalog read model. Catalog membership
-  // state and runner execution state are owned by different actors, so the
-  // document exposes both authority versions and derives state_version from
-  // their committed watermarks instead of inventing a local projection counter.
-  int64 catalog_source_version = 29;
-  string catalog_last_event_id = 30;
-  int64 runner_source_version = 31;
-  string runner_last_event_id = 32;
+  reserved 29, 30, 31, 32;
+  reserved "catalog_source_version", "catalog_last_event_id", "runner_source_version", "runner_last_event_id";
 }
 
 // Runtime-only Nyx credential read model for delivery-target execution paths.

--- a/docs/canon/daily-command-pipeline.md
+++ b/docs/canon/daily-command-pipeline.md
@@ -358,6 +358,8 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 
 **Projection**：`UserAgentCatalogProjector` 只消费 catalog committed state → 物化 catalog membership-only `UserAgentCatalogDocument`，`StateVersion` 来自 `UserAgentCatalogGAgent` committed version。`SkillRunnerExecutionProjector` 只消费 runner committed state → 物化 runner-owned `SkillRunnerExecutionDocument`，`StateVersion` 来自对应 `SkillRunnerGAgent` committed version。`/agents` 与 `/agent-status` 在 query/consumer 层 join 两个 readmodel，并暴露 catalog/runner 双水位，不合成单一版本。
 
+**Presentation join 约束**：`/agents` 与 `/agent-status` 的 catalog + execution join 只是对外 presentation response 装配，用于展示 caller 可见 agent 的执行快照。它不得作为内部 lifecycle command 准入事实源，不得形成可复用 aggregate query contract，也不得反向声明 catalog/execution 的统一业务状态。`run_agent` / `disable_agent` / `enable_agent` 同步准入只依赖 catalog authority（caller visible、agent exists、agent type supports managed lifecycle）；runner `Enabled/Disabled` 只在 `SkillRunnerGAgent` 自身 turn 内判定，拒绝执行时发布 runner-owned state event，再由 `/agent-status` 或 `/agents` 观察。
+
 **查询端口**：`IUserAgentCatalogQueryPort`
 - `QueryByCallerAsync(owner_scope)`：`/agents` 命令的数据源
 - `GetForCallerAsync(agentId, owner_scope)`：`/agent-status <id>` 单条查询

--- a/docs/canon/daily-command-pipeline.md
+++ b/docs/canon/daily-command-pipeline.md
@@ -226,7 +226,7 @@ try {
     PersistDomainEventAsync(SkillRunnerExecutionCompletedEvent { Output = output });
     CancelRetryLeaseAsync();
     Scheduler.ScheduleNextRunAsync(now);
-    // runner committed state is projected into UserAgentCatalogDocument
+    // runner committed state is projected into SkillRunnerExecutionDocument
 }
 catch (Exception ex) {
     if (RetryAttempt < MaxRetryAttempts /*=1*/)
@@ -234,7 +234,7 @@ catch (Exception ex) {
     PersistDomainEventAsync(SkillRunnerExecutionFailedEvent { Error = ex.Message });
     TrySendFailureAsync(ex.Message);
     Scheduler.ScheduleNextRunAsync(now);
-    // failure facts are owned by the runner and projected into the catalog document
+    // failure facts are owned by the runner and projected into the execution document
 }
 ```
 
@@ -309,7 +309,7 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 
 ### `UserAgentCatalogEntry`（well-known 注册表条目）
 - 关键字段：`agent_id`、`agent_type="skill_runner"`、`template_name="daily"`、`platform="lark"`、`conversation_id`、`scope_id`、`lark_receive_id*`
-- 不承载执行事实：`status`、`last_run_at`、`next_run_at`、`error_count`、`last_error` 由 `SkillRunnerState` 拥有，并由 `UserAgentCatalogProjector` 从 runner committed state 合并进 `UserAgentCatalogDocument`。
+- 不承载执行事实：`status`、`last_run_at`、`next_run_at`、`error_count`、`last_error` 由 `SkillRunnerState` 拥有，并由 `SkillRunnerExecutionProjector` 从 runner committed state 物化进 `SkillRunnerExecutionDocument`。
 - `nyx_api_key` / `api_key_id`：actor state 内的 catalog entry 保留这两个字段；公开 `UserAgentCatalogDocument` 不再暴露 `nyx_api_key`，运行时出站读取单独的 `UserAgentCatalogNyxCredentialDocument`。
 
 ### 命令 / 事件
@@ -356,7 +356,7 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 
 **事实源**：`SkillRunnerGAgent` actor state（每个 agent 一个 actor，拥有执行事实）+ `UserAgentCatalogGAgent`（well-known，全局唯一注册表 actor，只拥有成员集合与静态属性）
 
-**Projection**：`UserAgentCatalogProjector` 消费 catalog committed state 与 runner committed state → 合并物化到 `UserAgentCatalogDocument`。catalog membership 字段来自 `UserAgentCatalogState`；执行字段来自 `SkillRunnerState`。
+**Projection**：`UserAgentCatalogProjector` 只消费 catalog committed state → 物化 catalog membership-only `UserAgentCatalogDocument`，`StateVersion` 来自 `UserAgentCatalogGAgent` committed version。`SkillRunnerExecutionProjector` 只消费 runner committed state → 物化 runner-owned `SkillRunnerExecutionDocument`，`StateVersion` 来自对应 `SkillRunnerGAgent` committed version。`/agents` 与 `/agent-status` 在 query/consumer 层 join 两个 readmodel，并暴露 catalog/runner 双水位，不合成单一版本。
 
 **查询端口**：`IUserAgentCatalogQueryPort`
 - `QueryByCallerAsync(owner_scope)`：`/agents` 命令的数据源
@@ -364,7 +364,7 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 
 **关键不变量 / 测试关注**：
 - `UpsertRegistryAsync` 在 `HandleInitializeAsync` 末尾只注册 membership；它不写执行字段。
-- runner 执行完成、失败、启停后的 committed state 是 `/agent-status` 的执行事实来源；projection 必须从 runner state 合并 `status` / `last_run_at` / `next_run_at` / `error_count` / `last_error`。
+- runner 执行完成、失败、启停后的 committed state 是 `/agent-status` 的执行事实来源；projection 必须从 runner state 物化 `status` / `last_run_at` / `next_run_at` / `error_count` / `last_error` 到 `SkillRunnerExecutionDocument`。
 - 创建、启停、删除与手动运行命令的同步结果只承诺 accepted；readmodel 是否已经反映，需要通过后续 `/agent-status`、`/agents` 或推送事件观察。
 
 ---
@@ -450,7 +450,7 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 | ~~#437~~ ✅ | 高（数据隔离） | `/daily` binding causes cross-user data leakage（用户视角） | UserConfigGAgent scope key | **已由 [#438](https://github.com/aevatarAI/aevatar/pull/438) 修复**（composite scope `{regScope}:lark:{senderId}`）；下表 12.6 #8 / 12.8 E11 转为回归测试 |
 | ~~#436~~ ✅ | 高（同上 #437 的工程分析） | GitHub username binding shared across all Lark users（last writer wins） | 同上 | 同上 |
 | #439 | 高（语义错） | SkillRunner masks GitHub tool failures as silent "no activity" success | prompt + nyxid_proxy 工具 + runner 的"非空即成功"路径 | 强制 GitHub 接口返回 4xx/5xx，验证报告必须显式标错而不是出 `No X surfaced` |
-| #440 | 中（运维可见性） | `/agent-status` 首次执行不刷新 `Last run`/`Next run` | runner committed state → `UserAgentCatalogProjector` 合并路径 | `/daily X`（run_immediately）→ 30s 后 `/agent-status <id>` 看 `Last run` 应非 n/a |
+| #440 | 中（运维可见性） | `/agent-status` 首次执行不刷新 `Last run`/`Next run` | runner committed state → `SkillRunnerExecutionProjector` execution readmodel 路径 | `/daily X`（run_immediately）→ 30s 后 `/agent-status <id>` 看 `Last run` 应非 n/a |
 | ~~#423~~ ✅ | 中（增强 + 失败通知短板） | richer report content + progressive delivery + chunked + 失败通知旁路 | prompt（§A，#458 已合）+ streaming-edit（§B，#469 已合）+ chunked + failure-notification slug（§C，本 PR） | 已落地：`/daily` 报告流式编辑、>30K 自动分段、出站失败时优先经入站 channel-bot 投递失败通知 |
 | #398 | 高（链路断） | Lark relay callbacks never reach aevatar | NyxID 侧 callback_url 配置 / 多副本 ingress / Lark 订阅状态 | 用户发消息无任何反应，aevatar 日志只有 K8s liveness |
 
@@ -493,7 +493,7 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 - `HandleInitializeAsync`：`SkillContent` 为空 → 直接返回不持久化（仅 LogWarning）
 - `HandleInitializeAsync` 正常 → 持久化 `SkillRunnerInitializedEvent` + `Scheduler.ScheduleNextRunAsync` + `UpsertRegistryAsync`
 - `HandleTriggerAsync`：`State.Enabled=false` → 跳过
-- `HandleTriggerAsync` 成功 → `Completed` 事件 + retry lease 取消 + 下次调度；执行字段由 runner committed state 投影到 catalog document
+- `HandleTriggerAsync` 成功 → `Completed` 事件 + retry lease 取消 + 下次调度；执行字段由 runner committed state 投影到 `SkillRunnerExecutionDocument`
 - `HandleTriggerAsync` 失败：`RetryAttempt < 1` → `ScheduleRetryAsync(2)` 不发 `Failed`
 - `HandleTriggerAsync` 失败：`RetryAttempt >= 1` → 持久化 `Failed` + `TrySendFailureAsync` + 下次调度（仍按 cron）+ status=error
 - `Disable` → `Enabled=false`，下次 trigger 跳过
@@ -506,8 +506,8 @@ string failure_notification_provider_slug = 12;  // §C 旁路 proxy slug（入�
 
 应覆盖：
 - `Upsert` → entry 进 state；同 agent 再次 `Upsert` → 覆盖且不重复
-- `SkillRunnerExecutionCompletedEvent` / `SkillRunnerExecutionFailedEvent` → projector 合并 `last_run_at` / `next_run_at` / `status` / `error_count` / `last_error`
-- **#440 应加测**：membership upsert 与 runner execution committed state 在 projection 后共同体现在 `UserAgentCatalogDocument` 上。
+- `SkillRunnerExecutionCompletedEvent` / `SkillRunnerExecutionFailedEvent` → execution projector 物化 `last_run_at` / `next_run_at` / `status` / `error_count` / `last_error`
+- **#440 应加测**：membership upsert 与 runner execution committed state 分别物化到 `UserAgentCatalogDocument` / `SkillRunnerExecutionDocument`，查询层 join 后共同体现在 `/agent-status` DTO 上。
 - `Tombstone` → entry 标 `tombstoned=true`，`/agents` 列表里隐藏
 - Projector：每种事件 → readmodel 对应字段被覆盖（projector 是单调覆盖语义，不累加）
 

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -244,6 +244,150 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_AgentStatus_JoinsPerIdCatalogAndExecutionAtToolBoundary()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("skill-runner-join", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(new UserAgentCatalogReadModelEntry
+            {
+                AgentId = "skill-runner-join",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily",
+                Status = string.Empty,
+                ErrorCount = 0,
+                CatalogAuthorityStateVersion = 7,
+                CatalogLastEventId = "catalog-7",
+            }));
+
+        var executionQueryPort = Substitute.For<ISkillRunnerExecutionQueryPort>();
+        executionQueryPort.GetAsync("skill-runner-join", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SkillRunnerExecutionDocument?>(new SkillRunnerExecutionDocument
+            {
+                Id = "skill-runner-join",
+                StateVersion = 3,
+                LastEventId = "runner-3",
+                Status = SkillRunnerDefaults.StatusError,
+                ErrorCount = 2,
+                LastError = "tool failed",
+            }));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(executionQueryPort);
+        services.AddSingleton(Substitute.For<ISkillRunnerCommandPort>());
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        services.AddSingleton(callerScopeResolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""
+                {
+                  "action": "agent_status",
+                  "agent_id": "skill-runner-join"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("agent_id").GetString().Should().Be("skill-runner-join");
+            doc.RootElement.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusError);
+            doc.RootElement.GetProperty("error_count").GetInt32().Should().Be(2);
+            doc.RootElement.GetProperty("last_error").GetString().Should().Be("tool failed");
+
+            await queryPort.Received(1).GetForCallerAsync(
+                "skill-runner-join",
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+            await executionQueryPort.Received(1).GetAsync(
+                "skill-runner-join",
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ListAgents_JoinsCatalogAndExecutionAtToolBoundary()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.QueryByCallerAsync(Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<UserAgentCatalogReadModelEntry>>(
+            [
+                new UserAgentCatalogReadModelEntry
+                {
+                    AgentId = "skill-runner-list",
+                    AgentType = SkillRunnerDefaults.AgentType,
+                    TemplateName = "daily",
+                },
+            ]));
+
+        var executionQueryPort = Substitute.For<ISkillRunnerExecutionQueryPort>();
+        executionQueryPort.QueryByAgentIdsAsync(
+                Arg.Is<IReadOnlyCollection<string>>(ids => ids.Contains("skill-runner-list")),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, SkillRunnerExecutionDocument>>(
+                new Dictionary<string, SkillRunnerExecutionDocument>(StringComparer.Ordinal)
+                {
+                    ["skill-runner-list"] = new()
+                    {
+                        Id = "skill-runner-list",
+                        StateVersion = 4,
+                        LastEventId = "runner-4",
+                        Status = SkillRunnerDefaults.StatusRunning,
+                        ErrorCount = 1,
+                    },
+                }));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(executionQueryPort);
+        services.AddSingleton(Substitute.For<ISkillRunnerCommandPort>());
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        services.AddSingleton(callerScopeResolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"action":"list_agents"}""");
+
+            using var doc = JsonDocument.Parse(result);
+            var agent = doc.RootElement.GetProperty("agents").EnumerateArray().Should().ContainSingle().Subject;
+            agent.GetProperty("agent_id").GetString().Should().Be("skill-runner-list");
+            agent.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusRunning);
+            agent.GetProperty("error_count").GetInt32().Should().Be(1);
+
+            await queryPort.Received(1).QueryByCallerAsync(
+                Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+            await executionQueryPort.Received(1).QueryByAgentIdsAsync(
+                Arg.Is<IReadOnlyCollection<string>>(ids => ids.Contains("skill-runner-list")),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RunAgent_RejectsDisabledAgent()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
@@ -490,28 +634,33 @@ public sealed class AgentBuilderToolTests
     public void Constructor_Requires_Typed_Dependencies()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        var executionQueryPort = Substitute.For<ISkillRunnerExecutionQueryPort>();
         var nyxClientFactory = Substitute.For<INyxIdApiClientFactory>();
         var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
         var catalogCommandPort = Substitute.For<IUserAgentCatalogCommandPort>();
         var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
 
-        var missingQuery = () => new AgentBuilderTool(null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingNyxFactory = () => new AgentBuilderTool(queryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingSkillRunner = () => new AgentBuilderTool(queryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
-        var missingCatalogCommand = () => new AgentBuilderTool(queryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
-        var missingCallerScope = () => new AgentBuilderTool(queryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
-        var missingSourceQuery = () => new AgentBuilderToolSource(null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingSourceNyxFactory = () => new AgentBuilderToolSource(queryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
-        var missingSourceSkillRunner = () => new AgentBuilderToolSource(queryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
-        var missingSourceCatalogCommand = () => new AgentBuilderToolSource(queryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
-        var missingSourceCallerScope = () => new AgentBuilderToolSource(queryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
+        var missingQuery = () => new AgentBuilderTool(null!, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingExecutionQuery = () => new AgentBuilderTool(queryPort, null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingNyxFactory = () => new AgentBuilderTool(queryPort, executionQueryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSkillRunner = () => new AgentBuilderTool(queryPort, executionQueryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
+        var missingCatalogCommand = () => new AgentBuilderTool(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
+        var missingCallerScope = () => new AgentBuilderTool(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
+        var missingSourceQuery = () => new AgentBuilderToolSource(null!, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSourceExecutionQuery = () => new AgentBuilderToolSource(queryPort, null!, nyxClientFactory, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSourceNyxFactory = () => new AgentBuilderToolSource(queryPort, executionQueryPort, null!, skillRunnerPort, catalogCommandPort, callerScopeResolver);
+        var missingSourceSkillRunner = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, null!, catalogCommandPort, callerScopeResolver);
+        var missingSourceCatalogCommand = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, null!, callerScopeResolver);
+        var missingSourceCallerScope = () => new AgentBuilderToolSource(queryPort, executionQueryPort, nyxClientFactory, skillRunnerPort, catalogCommandPort, null!);
 
         missingQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingExecutionQuery.Should().Throw<ArgumentNullException>().WithParameterName("executionQueryPort");
         missingNyxFactory.Should().Throw<ArgumentNullException>().WithParameterName("nyxClientFactory");
         missingSkillRunner.Should().Throw<ArgumentNullException>().WithParameterName("skillRunnerPort");
         missingCatalogCommand.Should().Throw<ArgumentNullException>().WithParameterName("catalogCommandPort");
         missingCallerScope.Should().Throw<ArgumentNullException>().WithParameterName("callerScopeResolver");
         missingSourceQuery.Should().Throw<ArgumentNullException>().WithParameterName("queryPort");
+        missingSourceExecutionQuery.Should().Throw<ArgumentNullException>().WithParameterName("executionQueryPort");
         missingSourceNyxFactory.Should().Throw<ArgumentNullException>().WithParameterName("nyxClientFactory");
         missingSourceSkillRunner.Should().Throw<ArgumentNullException>().WithParameterName("skillRunnerPort");
         missingSourceCatalogCommand.Should().Throw<ArgumentNullException>().WithParameterName("catalogCommandPort");
@@ -527,6 +676,7 @@ public sealed class AgentBuilderToolTests
 
         var services = new ServiceCollection();
         services.AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>());
+        services.AddSingleton(Substitute.For<ISkillRunnerExecutionQueryPort>());
         services.AddSingleton(Substitute.For<ISkillRunnerCommandPort>());
         services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
         services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
@@ -569,6 +719,7 @@ public sealed class AgentBuilderToolTests
 
         var source = new AgentBuilderToolSource(
             queryPort,
+            Substitute.For<ISkillRunnerExecutionQueryPort>(),
             nyxClientFactory,
             skillRunnerPort,
             catalogCommandPort,
@@ -603,6 +754,7 @@ public sealed class AgentBuilderToolTests
         var provider = services.BuildServiceProvider();
         return new AgentBuilderTool(
             provider.GetRequiredService<IUserAgentCatalogQueryPort>(),
+            provider.GetService<ISkillRunnerExecutionQueryPort>() ?? Substitute.For<ISkillRunnerExecutionQueryPort>(),
             provider.GetRequiredService<INyxIdApiClientFactory>(),
             provider.GetRequiredService<ISkillRunnerCommandPort>(),
             provider.GetRequiredService<IUserAgentCatalogCommandPort>(),

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentBuilderToolTests.cs
@@ -231,6 +231,9 @@ public sealed class AgentBuilderToolTests
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
             doc.RootElement.GetProperty("agent_id").GetString().Should().Be("skill-runner-1");
+            doc.RootElement.GetProperty("note").GetString()
+                .Should().Contain("accepted for dispatch")
+                .And.Contain("/agent-status");
 
             await skillRunnerPort.Received(1).TriggerAsync(
                 "skill-runner-1",
@@ -388,7 +391,7 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_RunAgent_RejectsDisabledAgent()
+    public async Task ExecuteAsync_RunAgent_DispatchesEvenWhenPresentationStatusIsDisabled()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
         queryPort.GetForCallerAsync("skill-runner-1", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
@@ -427,10 +430,15 @@ public sealed class AgentBuilderToolTests
                 }
                 """);
 
-            result.Should().Contain("is disabled");
-            await skillRunnerPort.DidNotReceive().TriggerAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("status").GetString().Should().Be("accepted");
+            doc.RootElement.GetProperty("note").GetString()
+                .Should().Contain("accepted for dispatch")
+                .And.Contain("/agent-status");
+
+            await skillRunnerPort.Received(1).TriggerAsync(
+                "skill-runner-1",
+                "run_agent",
                 Arg.Any<CancellationToken>());
         }
         finally
@@ -506,7 +514,7 @@ public sealed class AgentBuilderToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_DisableAgent_ReturnsAlreadyDisabledWithoutDispatch()
+    public async Task ExecuteAsync_DisableAgent_DispatchesEvenWhenPresentationStatusIsDisabled()
     {
         var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
         queryPort.GetForCallerAsync("skill-runner-1", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
@@ -549,11 +557,13 @@ public sealed class AgentBuilderToolTests
 
             using var doc = JsonDocument.Parse(result);
             doc.RootElement.GetProperty("status").GetString().Should().Be(SkillRunnerDefaults.StatusDisabled);
-            doc.RootElement.GetProperty("note").GetString().Should().Contain("already disabled");
+            doc.RootElement.GetProperty("note").GetString()
+                .Should().Contain("Disable accepted")
+                .And.Contain("/agent-status");
 
-            await skillRunnerPort.DidNotReceive().DisableAsync(
-                Arg.Any<string>(),
-                Arg.Any<string>(),
+            await skillRunnerPort.Received(1).DisableAsync(
+                "skill-runner-1",
+                "disable_agent",
                 Arg.Any<CancellationToken>());
         }
         finally
@@ -622,6 +632,57 @@ public sealed class AgentBuilderToolTests
             await queryPort.DidNotReceive().GetStateVersionForCallerAsync(
                 Arg.Any<string>(),
                 Arg.Any<OwnerScope>(),
+                Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LifecycleCommands_DoNotReadExecutionStatusForAdmission()
+    {
+        var queryPort = Substitute.For<IUserAgentCatalogQueryPort>();
+        queryPort.GetForCallerAsync("skill-runner-1", Arg.Any<OwnerScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<UserAgentCatalogReadModelEntry?>(new UserAgentCatalogReadModelEntry
+            {
+                AgentId = "skill-runner-1",
+                AgentType = SkillRunnerDefaults.AgentType,
+                TemplateName = "daily",
+                Status = string.Empty,
+            }));
+
+        var executionQueryPort = Substitute.For<ISkillRunnerExecutionQueryPort>();
+        var skillRunnerPort = Substitute.For<ISkillRunnerCommandPort>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(queryPort);
+        services.AddSingleton(executionQueryPort);
+        services.AddSingleton(skillRunnerPort);
+        services.AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>());
+        services.AddSingleton<INyxIdApiClientFactory>(new TestNyxIdApiClientFactory());
+        var callerScopeResolver = Substitute.For<ICallerScopeResolver>();
+        callerScopeResolver.TryResolveAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<OwnerScope?>(OwnerScope.ForNyxIdNative("user-1")));
+        services.AddSingleton(callerScopeResolver);
+        var tool = CreateTool(services);
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            [LLMRequestMetadataKeys.NyxIdAccessToken] = "session-token",
+        };
+        try
+        {
+            await tool.ExecuteAsync("""{"action":"run_agent","agent_id":"skill-runner-1"}""");
+            await tool.ExecuteAsync("""{"action":"disable_agent","agent_id":"skill-runner-1"}""");
+            await tool.ExecuteAsync("""{"action":"enable_agent","agent_id":"skill-runner-1"}""");
+
+            await executionQueryPort.DidNotReceive().GetAsync(
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>());
+            await executionQueryPort.DidNotReceive().QueryByAgentIdsAsync(
+                Arg.Any<IReadOnlyCollection<string>>(),
                 Arg.Any<CancellationToken>());
         }
         finally

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -951,6 +951,7 @@ public sealed class ChannelConversationTurnRunnerTests
         var callerScopeResolver = new CapturingCallerScopeResolver();
         var services = new ServiceCollection()
             .AddSingleton(Substitute.For<IUserAgentCatalogQueryPort>())
+            .AddSingleton(Substitute.For<ISkillRunnerExecutionQueryPort>())
             .AddSingleton(Substitute.For<ISkillRunnerCommandPort>())
             .AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>())
             .AddSingleton<ICallerScopeResolver>(callerScopeResolver)
@@ -2522,6 +2523,7 @@ public sealed class ChannelConversationTurnRunnerTests
 
         return new ServiceCollection()
             .AddSingleton(queryPort)
+            .AddSingleton(Substitute.For<ISkillRunnerExecutionQueryPort>())
             .AddSingleton(Substitute.For<ISkillRunnerCommandPort>())
             .AddSingleton(Substitute.For<IUserAgentCatalogCommandPort>())
             .AddSingleton<ICallerScopeResolver>(callerScopeResolver)

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerExecutionQueryPortTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerExecutionQueryPortTests.cs
@@ -1,0 +1,157 @@
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.Scheduled;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class SkillRunnerExecutionQueryPortTests
+{
+    [Fact]
+    public async Task GetAsync_TrimsAgentIdBeforeReading()
+    {
+        var reader = Substitute.For<IProjectionDocumentReader<SkillRunnerExecutionDocument, string>>();
+        reader.GetAsync("runner-1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SkillRunnerExecutionDocument?>(new SkillRunnerExecutionDocument
+            {
+                Id = "runner-1",
+                StateVersion = 3,
+            }));
+
+        var port = new SkillRunnerExecutionQueryPort(reader);
+
+        var result = await port.GetAsync("  runner-1  ");
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be("runner-1");
+        await reader.Received(1).GetAsync("runner-1", Arg.Any<CancellationToken>());
+        await reader.DidNotReceive().GetAsync("  runner-1  ", Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public async Task GetAsync_BlankAgentId_ReturnsNullWithoutReading(string agentId)
+    {
+        var reader = Substitute.For<IProjectionDocumentReader<SkillRunnerExecutionDocument, string>>();
+        var port = new SkillRunnerExecutionQueryPort(reader);
+
+        var result = await port.GetAsync(agentId);
+
+        result.Should().BeNull();
+        await reader.DidNotReceiveWithAnyArgs().GetAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task QueryByAgentIdsAsync_BlankAndDuplicateIds_UsesInFilterAndKeepsHighestStateVersion()
+    {
+        ProjectionDocumentQuery? capturedQuery = null;
+        var reader = Substitute.For<IProjectionDocumentReader<SkillRunnerExecutionDocument, string>>();
+        reader.QueryAsync(
+                Arg.Do<ProjectionDocumentQuery>(query => capturedQuery = query),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>
+            {
+                Items =
+                [
+                    new SkillRunnerExecutionDocument
+                    {
+                        Id = "runner-1",
+                        StateVersion = 2,
+                        Status = "older",
+                    },
+                    new SkillRunnerExecutionDocument
+                    {
+                        Id = "runner-2",
+                        StateVersion = 4,
+                        Status = "current",
+                    },
+                    new SkillRunnerExecutionDocument
+                    {
+                        Id = "runner-1",
+                        StateVersion = 7,
+                        Status = "latest",
+                    },
+                    new SkillRunnerExecutionDocument
+                    {
+                        Id = "",
+                        StateVersion = 99,
+                    },
+                    new SkillRunnerExecutionDocument
+                    {
+                        Id = "   ",
+                        StateVersion = 100,
+                    },
+                ],
+            }));
+
+        var port = new SkillRunnerExecutionQueryPort(reader);
+
+        var result = await port.QueryByAgentIdsAsync(
+            [" runner-1 ", "", "runner-2", "runner-1", "   ", "\trunner-2\t"]);
+
+        result.Keys.Should().BeEquivalentTo(["runner-1", "runner-2"]);
+        result["runner-1"].StateVersion.Should().Be(7);
+        result["runner-1"].Status.Should().Be("latest");
+        result["runner-2"].StateVersion.Should().Be(4);
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Take.Should().Be(2);
+        capturedQuery.Filters.Should().ContainSingle();
+        var filter = capturedQuery.Filters[0];
+        filter.FieldPath.Should().Be(nameof(SkillRunnerExecutionDocument.Id));
+        filter.Operator.Should().Be(ProjectionDocumentFilterOperator.In);
+        filter.Value.Kind.Should().Be(ProjectionDocumentValueKind.StringList);
+        filter.Value.RawValue.Should().BeEquivalentTo(new[] { "runner-1", "runner-2" });
+    }
+
+    [Fact]
+    public async Task QueryByAgentIdsAsync_SingleUniqueId_UsesEqFilter()
+    {
+        ProjectionDocumentQuery? capturedQuery = null;
+        var reader = Substitute.For<IProjectionDocumentReader<SkillRunnerExecutionDocument, string>>();
+        reader.QueryAsync(
+                Arg.Do<ProjectionDocumentQuery>(query => capturedQuery = query),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>
+            {
+                Items =
+                [
+                    new SkillRunnerExecutionDocument
+                    {
+                        Id = "runner-1",
+                        StateVersion = 5,
+                    },
+                ],
+            }));
+
+        var port = new SkillRunnerExecutionQueryPort(reader);
+
+        var result = await port.QueryByAgentIdsAsync([" runner-1 ", "runner-1"]);
+
+        result.Should().ContainSingle();
+        result["runner-1"].StateVersion.Should().Be(5);
+
+        capturedQuery.Should().NotBeNull();
+        capturedQuery!.Take.Should().Be(1);
+        capturedQuery.Filters.Should().ContainSingle();
+        var filter = capturedQuery.Filters[0];
+        filter.FieldPath.Should().Be(nameof(SkillRunnerExecutionDocument.Id));
+        filter.Operator.Should().Be(ProjectionDocumentFilterOperator.Eq);
+        filter.Value.Kind.Should().Be(ProjectionDocumentValueKind.String);
+        filter.Value.RawValue.Should().Be("runner-1");
+    }
+
+    [Fact]
+    public async Task QueryByAgentIdsAsync_NoUsableIds_ReturnsEmptyWithoutQuerying()
+    {
+        var reader = Substitute.For<IProjectionDocumentReader<SkillRunnerExecutionDocument, string>>();
+        var port = new SkillRunnerExecutionQueryPort(reader);
+
+        var result = await port.QueryByAgentIdsAsync(["", "   ", "\t"]);
+
+        result.Should().BeEmpty();
+        await reader.DidNotReceiveWithAnyArgs().QueryAsync(default!, default);
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -221,6 +221,29 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task HandleTriggerAsync_WhenDisabled_PersistsRunnerOwnedRejectedEvent()
+    {
+        await _agent.HandleInitializeAsync(CreateInitializeCommand());
+        await _agent.HandleDisableAsync(new DisableSkillRunnerCommand { Reason = "test" });
+
+        await _agent.HandleTriggerAsync(new TriggerSkillRunnerExecutionCommand { Reason = "run_agent" });
+
+        var persisted = await _store.GetEventsAsync("skill-runner-test");
+        var rejected = persisted
+            .Select(x => x.EventData)
+            .Where(x => x.Is(SkillRunnerExecutionRejectedEvent.Descriptor))
+            .Select(x => x.Unpack<SkillRunnerExecutionRejectedEvent>())
+            .Should()
+            .ContainSingle()
+            .Subject;
+        rejected.Reason.Should().Be(SkillRunnerDefaults.RejectionReasonRunnerDisabled);
+
+        _agent.State.Enabled.Should().BeFalse();
+        _agent.State.LastError.Should().Be(SkillRunnerDefaults.RejectionReasonRunnerDisabled);
+        _agent.State.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task HandleInitializeAsync_ShouldDispatchCatalogCommandsThroughDispatchPort()
     {
         var catalogActor = Substitute.For<IActor>();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/SkillRunnerGAgentTests.cs
@@ -186,10 +186,9 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         persisted.Should().HaveCount(2);
 
         var runnerState = agent.State.Clone();
-        var writeDispatcher = new RecordingCatalogWriteDispatcher();
-        var projector = new UserAgentCatalogProjector(
+        var writeDispatcher = new RecordingExecutionWriteDispatcher();
+        var projector = new SkillRunnerExecutionProjector(
             writeDispatcher,
-            new EmptyCatalogDocumentReader(),
             new FixedProjectionClock(new DateTimeOffset(2026, 4, 14, 10, 0, 0, TimeSpan.Zero)));
 
         await projector.ProjectAsync(
@@ -215,9 +214,10 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         writeDispatcher.Upserts.Should().ContainSingle();
         var doc = writeDispatcher.Upserts[0];
         doc.Id.Should().Be("skill-runner-projection-regression");
+        doc.ActorId.Should().Be("skill-runner-projection-regression");
         doc.Status.Should().Be(SkillRunnerDefaults.StatusRunning);
         doc.NextRunAtUtc.Should().NotBeNull();
-        doc.RunnerSourceVersion.Should().Be(2);
+        doc.StateVersion.Should().Be(2);
     }
 
     [Fact]
@@ -1109,12 +1109,12 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
         }
     }
 
-    private sealed class RecordingCatalogWriteDispatcher : IProjectionWriteDispatcher<UserAgentCatalogDocument>
+    private sealed class RecordingExecutionWriteDispatcher : IProjectionWriteDispatcher<SkillRunnerExecutionDocument>
     {
-        public List<UserAgentCatalogDocument> Upserts { get; } = [];
+        public List<SkillRunnerExecutionDocument> Upserts { get; } = [];
 
         public Task<ProjectionWriteResult> UpsertAsync(
-            UserAgentCatalogDocument readModel,
+            SkillRunnerExecutionDocument readModel,
             CancellationToken ct = default)
         {
             Upserts.Add(readModel.Clone());
@@ -1123,17 +1123,6 @@ public sealed class SkillRunnerGAgentTests : IAsyncLifetime
 
         public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
             Task.FromResult(ProjectionWriteResult.Applied());
-    }
-
-    private sealed class EmptyCatalogDocumentReader : IProjectionDocumentReader<UserAgentCatalogDocument, string>
-    {
-        public Task<UserAgentCatalogDocument?> GetAsync(string key, CancellationToken ct = default) =>
-            Task.FromResult<UserAgentCatalogDocument?>(null);
-
-        public Task<ProjectionDocumentQueryResult<UserAgentCatalogDocument>> QueryAsync(
-            ProjectionDocumentQuery query,
-            CancellationToken ct = default) =>
-            Task.FromResult(new ProjectionDocumentQueryResult<UserAgentCatalogDocument>());
     }
 
     private sealed class FixedProjectionClock(DateTimeOffset now) : Aevatar.CQRS.Projection.Core.Abstractions.IProjectionClock

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
@@ -116,7 +116,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildDocument("agent-B", OwnerScope.ForNyxIdNative("user-B")),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var asUserA = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-A"), CancellationToken.None);
         var asUserB = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-B"), CancellationToken.None);
@@ -136,7 +136,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildDocument("agent-lark", OwnerScope.ForChannel("user-1", "lark", "bot-1", "sender-1")),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var fromCli = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-1"), CancellationToken.None);
         var fromLark = await port.QueryByCallerAsync(OwnerScope.ForChannel("user-1", "lark", "bot-1", "sender-1"), CancellationToken.None);
@@ -156,7 +156,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildDocument("bob-agent", OwnerScope.ForChannel("user-B", "lark", "bot-1", "bob")),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var asBob = await port.QueryByCallerAsync(OwnerScope.ForChannel("user-B", "lark", "bot-1", "bob"), CancellationToken.None);
 
@@ -174,7 +174,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         reader.GetAsync("alice-agent", Arg.Any<CancellationToken>())
             .Returns(BuildDocument("alice-agent", OwnerScope.ForChannel("user-A", "lark", "bot-1", "alice")));
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var asBob = await port.GetForCallerAsync(
             "alice-agent",
@@ -199,7 +199,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         doc.StateVersion = 42;
         reader.GetAsync("alice-agent", Arg.Any<CancellationToken>()).Returns(doc);
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var asAlice = await port.GetStateVersionForCallerAsync(
             "alice-agent",
@@ -236,7 +236,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildLegacyNyxidDocument("legacy-cli-agent", "user-1"),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var asUser1 = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-1"), CancellationToken.None);
 
@@ -252,7 +252,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildLegacyLarkDocument("legacy-lark-agent", "user-1"),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var asUser1Lark = await port.QueryByCallerAsync(
             OwnerScope.ForChannel("user-1", "lark", "bot-1", "sender-1"),
@@ -396,7 +396,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         reader.GetAsync("agent-1", Arg.Any<CancellationToken>())
             .Returns(BuildDocument("agent-1", OwnerScope.ForNyxIdNative("user-1")));
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
         var entry = await port.GetForCallerAsync("agent-1", OwnerScope.ForNyxIdNative("user-1"), CancellationToken.None);
 
         entry.Should().NotBeNull();
@@ -418,7 +418,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             .ToList<UserAgentCatalogDocument>();
         var reader = new RecordingDocumentReader(docs);
 
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
         var entries = await port.QueryByCallerAsync(caller, CancellationToken.None);
 
         entries.Should().HaveCount(305,
@@ -426,7 +426,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
     }
 
     [Fact]
-    public async Task QueryByCallerAsync_JoinsRunnerExecutionWithoutSyntheticStateVersion()
+    public async Task QueryByCallerAsync_ReturnsCatalogAuthorityWithoutRunnerExecutionJoin()
     {
         var caller = OwnerScope.ForNyxIdNative("user-join");
         var catalogDocument = BuildDocument("agent-join", caller);
@@ -436,31 +436,17 @@ public sealed class UnifyCallerScopeAcceptanceTests
         {
             catalogDocument,
         });
-        var executionReader = new RecordingExecutionDocumentReader(new List<SkillRunnerExecutionDocument>
-        {
-            new()
-            {
-                Id = "agent-join",
-                ActorId = "agent-join",
-                StateVersion = 2,
-                LastEventId = "runner-2",
-                Status = SkillRunnerDefaults.StatusRunning,
-                ErrorCount = 1,
-                LastError = "previous failure",
-            },
-        });
 
-        var port = new UserAgentCatalogQueryPort(reader, executionReader);
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var entry = (await port.QueryByCallerAsync(caller, CancellationToken.None)).Should().ContainSingle().Subject;
-        entry.Status.Should().Be(SkillRunnerDefaults.StatusRunning);
-        entry.ErrorCount.Should().Be(1);
-        entry.LastError.Should().Be("previous failure");
+        entry.Status.Should().BeEmpty();
+        entry.ErrorCount.Should().Be(0);
+        entry.LastError.Should().BeEmpty();
         entry.CatalogAuthorityStateVersion.Should().Be(5);
         entry.CatalogLastEventId.Should().Be("catalog-5");
-        entry.RunnerAuthorityStateVersion.Should().Be(2);
-        entry.RunnerLastEventId.Should().Be("runner-2");
-        entry.CatalogAuthorityStateVersion.Should().NotBe(7);
+        entry.RunnerAuthorityStateVersion.Should().BeNull();
+        entry.RunnerLastEventId.Should().BeEmpty();
     }
 
     // ─── Actor → projector → query integration (lark caller end-to-end) ───
@@ -520,7 +506,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         // dispatcher's last-written documents — close enough to exercise the actor →
         // projector → reader chain end-to-end without standing up the full pipeline.
         var reader = new RecordingDocumentReader(dispatcher.Upserts);
-        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
+        var port = new UserAgentCatalogQueryPort(reader);
 
         var fromAlice = await port.QueryByCallerAsync(aliceScope, CancellationToken.None);
         var fromBob = await port.QueryByCallerAsync(bobScope, CancellationToken.None);
@@ -693,56 +679,4 @@ public sealed class UnifyCallerScopeAcceptanceTests
         }
     }
 
-    private sealed class EmptyExecutionDocumentReader : IProjectionDocumentReader<SkillRunnerExecutionDocument, string>
-    {
-        public Task<SkillRunnerExecutionDocument?> GetAsync(string key, CancellationToken ct = default) =>
-            Task.FromResult<SkillRunnerExecutionDocument?>(null);
-
-        public Task<ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>> QueryAsync(
-            ProjectionDocumentQuery query,
-            CancellationToken ct = default) =>
-            Task.FromResult(new ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>());
-    }
-
-    private sealed class RecordingExecutionDocumentReader : IProjectionDocumentReader<SkillRunnerExecutionDocument, string>
-    {
-        private readonly IList<SkillRunnerExecutionDocument> _items;
-
-        public RecordingExecutionDocumentReader(IList<SkillRunnerExecutionDocument> items)
-        {
-            _items = items;
-        }
-
-        public Task<SkillRunnerExecutionDocument?> GetAsync(string key, CancellationToken ct = default)
-        {
-            var match = _items.FirstOrDefault(d => string.Equals(d.Id, key, StringComparison.Ordinal));
-            return Task.FromResult(match?.Clone());
-        }
-
-        public Task<ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>> QueryAsync(
-            ProjectionDocumentQuery query,
-            CancellationToken ct = default)
-        {
-            IEnumerable<SkillRunnerExecutionDocument> filtered = _items.Select(d => d.Clone());
-            foreach (var filter in query.Filters)
-            {
-                if (filter.FieldPath != nameof(SkillRunnerExecutionDocument.Id))
-                    continue;
-
-                filtered = filter.Operator switch
-                {
-                    ProjectionDocumentFilterOperator.Eq => filtered.Where(d =>
-                        string.Equals(d.Id, filter.Value.RawValue as string, StringComparison.Ordinal)),
-                    ProjectionDocumentFilterOperator.In when filter.Value.RawValue is string[] ids => filtered.Where(d =>
-                        ids.Contains(d.Id, StringComparer.Ordinal)),
-                    _ => filtered,
-                };
-            }
-
-            return Task.FromResult(new ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>
-            {
-                Items = filtered.Take(query.Take).ToArray(),
-            });
-        }
-    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UnifyCallerScopeAcceptanceTests.cs
@@ -116,7 +116,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildDocument("agent-B", OwnerScope.ForNyxIdNative("user-B")),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var asUserA = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-A"), CancellationToken.None);
         var asUserB = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-B"), CancellationToken.None);
@@ -136,7 +136,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildDocument("agent-lark", OwnerScope.ForChannel("user-1", "lark", "bot-1", "sender-1")),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var fromCli = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-1"), CancellationToken.None);
         var fromLark = await port.QueryByCallerAsync(OwnerScope.ForChannel("user-1", "lark", "bot-1", "sender-1"), CancellationToken.None);
@@ -156,7 +156,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildDocument("bob-agent", OwnerScope.ForChannel("user-B", "lark", "bot-1", "bob")),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var asBob = await port.QueryByCallerAsync(OwnerScope.ForChannel("user-B", "lark", "bot-1", "bob"), CancellationToken.None);
 
@@ -174,7 +174,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         reader.GetAsync("alice-agent", Arg.Any<CancellationToken>())
             .Returns(BuildDocument("alice-agent", OwnerScope.ForChannel("user-A", "lark", "bot-1", "alice")));
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var asBob = await port.GetForCallerAsync(
             "alice-agent",
@@ -199,7 +199,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         doc.StateVersion = 42;
         reader.GetAsync("alice-agent", Arg.Any<CancellationToken>()).Returns(doc);
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var asAlice = await port.GetStateVersionForCallerAsync(
             "alice-agent",
@@ -236,7 +236,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildLegacyNyxidDocument("legacy-cli-agent", "user-1"),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var asUser1 = await port.QueryByCallerAsync(OwnerScope.ForNyxIdNative("user-1"), CancellationToken.None);
 
@@ -252,7 +252,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
             BuildLegacyLarkDocument("legacy-lark-agent", "user-1"),
         });
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var asUser1Lark = await port.QueryByCallerAsync(
             OwnerScope.ForChannel("user-1", "lark", "bot-1", "sender-1"),
@@ -396,7 +396,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         reader.GetAsync("agent-1", Arg.Any<CancellationToken>())
             .Returns(BuildDocument("agent-1", OwnerScope.ForNyxIdNative("user-1")));
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
         var entry = await port.GetForCallerAsync("agent-1", OwnerScope.ForNyxIdNative("user-1"), CancellationToken.None);
 
         entry.Should().NotBeNull();
@@ -418,11 +418,49 @@ public sealed class UnifyCallerScopeAcceptanceTests
             .ToList<UserAgentCatalogDocument>();
         var reader = new RecordingDocumentReader(docs);
 
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
         var entries = await port.QueryByCallerAsync(caller, CancellationToken.None);
 
         entries.Should().HaveCount(305,
             "all owned agents are returned, not just the first 200; the port pages internally");
+    }
+
+    [Fact]
+    public async Task QueryByCallerAsync_JoinsRunnerExecutionWithoutSyntheticStateVersion()
+    {
+        var caller = OwnerScope.ForNyxIdNative("user-join");
+        var catalogDocument = BuildDocument("agent-join", caller);
+        catalogDocument.StateVersion = 5;
+        catalogDocument.LastEventId = "catalog-5";
+        var reader = new RecordingDocumentReader(new List<UserAgentCatalogDocument>
+        {
+            catalogDocument,
+        });
+        var executionReader = new RecordingExecutionDocumentReader(new List<SkillRunnerExecutionDocument>
+        {
+            new()
+            {
+                Id = "agent-join",
+                ActorId = "agent-join",
+                StateVersion = 2,
+                LastEventId = "runner-2",
+                Status = SkillRunnerDefaults.StatusRunning,
+                ErrorCount = 1,
+                LastError = "previous failure",
+            },
+        });
+
+        var port = new UserAgentCatalogQueryPort(reader, executionReader);
+
+        var entry = (await port.QueryByCallerAsync(caller, CancellationToken.None)).Should().ContainSingle().Subject;
+        entry.Status.Should().Be(SkillRunnerDefaults.StatusRunning);
+        entry.ErrorCount.Should().Be(1);
+        entry.LastError.Should().Be("previous failure");
+        entry.CatalogAuthorityStateVersion.Should().Be(5);
+        entry.CatalogLastEventId.Should().Be("catalog-5");
+        entry.RunnerAuthorityStateVersion.Should().Be(2);
+        entry.RunnerLastEventId.Should().Be("runner-2");
+        entry.CatalogAuthorityStateVersion.Should().NotBe(7);
     }
 
     // ─── Actor → projector → query integration (lark caller end-to-end) ───
@@ -441,7 +479,6 @@ public sealed class UnifyCallerScopeAcceptanceTests
         var clock = new FixedProjectionClock(new DateTimeOffset(2026, 4, 28, 10, 0, 0, TimeSpan.Zero));
         var projector = new UserAgentCatalogProjector(
             dispatcher,
-            new RecordingDocumentReader(new List<UserAgentCatalogDocument>()),
             clock);
         var context = new UserAgentCatalogMaterializationContext
         {
@@ -483,7 +520,7 @@ public sealed class UnifyCallerScopeAcceptanceTests
         // dispatcher's last-written documents — close enough to exercise the actor →
         // projector → reader chain end-to-end without standing up the full pipeline.
         var reader = new RecordingDocumentReader(dispatcher.Upserts);
-        var port = new UserAgentCatalogQueryPort(reader);
+        var port = new UserAgentCatalogQueryPort(reader, new EmptyExecutionDocumentReader());
 
         var fromAlice = await port.QueryByCallerAsync(aliceScope, CancellationToken.None);
         var fromBob = await port.QueryByCallerAsync(bobScope, CancellationToken.None);
@@ -508,7 +545,6 @@ public sealed class UnifyCallerScopeAcceptanceTests
             AgentType = "skill_runner",
             TemplateName = "daily",
             ScopeId = scope.RegistrationScopeId,
-            Status = "running",
             StateVersion = 1,
             Tombstoned = false,
             ActorId = "agent-registry-store",
@@ -527,7 +563,6 @@ public sealed class UnifyCallerScopeAcceptanceTests
             Platform = "nyxid",
             OwnerNyxUserId = nyxUserId,
             ScopeId = string.Empty,
-            Status = "running",
             StateVersion = 1,
             Tombstoned = false,
             ActorId = "agent-registry-store",
@@ -545,7 +580,6 @@ public sealed class UnifyCallerScopeAcceptanceTests
             Platform = "lark",
             OwnerNyxUserId = nyxUserId,
             ScopeId = "legacy-bot-scope",
-            Status = "running",
             StateVersion = 1,
             Tombstoned = false,
             ActorId = "agent-registry-store",
@@ -656,6 +690,59 @@ public sealed class UnifyCallerScopeAcceptanceTests
                 _ => null,
             };
             return string.Equals(actual as string, filter.Value.RawValue as string, StringComparison.Ordinal);
+        }
+    }
+
+    private sealed class EmptyExecutionDocumentReader : IProjectionDocumentReader<SkillRunnerExecutionDocument, string>
+    {
+        public Task<SkillRunnerExecutionDocument?> GetAsync(string key, CancellationToken ct = default) =>
+            Task.FromResult<SkillRunnerExecutionDocument?>(null);
+
+        public Task<ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default) =>
+            Task.FromResult(new ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>());
+    }
+
+    private sealed class RecordingExecutionDocumentReader : IProjectionDocumentReader<SkillRunnerExecutionDocument, string>
+    {
+        private readonly IList<SkillRunnerExecutionDocument> _items;
+
+        public RecordingExecutionDocumentReader(IList<SkillRunnerExecutionDocument> items)
+        {
+            _items = items;
+        }
+
+        public Task<SkillRunnerExecutionDocument?> GetAsync(string key, CancellationToken ct = default)
+        {
+            var match = _items.FirstOrDefault(d => string.Equals(d.Id, key, StringComparison.Ordinal));
+            return Task.FromResult(match?.Clone());
+        }
+
+        public Task<ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default)
+        {
+            IEnumerable<SkillRunnerExecutionDocument> filtered = _items.Select(d => d.Clone());
+            foreach (var filter in query.Filters)
+            {
+                if (filter.FieldPath != nameof(SkillRunnerExecutionDocument.Id))
+                    continue;
+
+                filtered = filter.Operator switch
+                {
+                    ProjectionDocumentFilterOperator.Eq => filtered.Where(d =>
+                        string.Equals(d.Id, filter.Value.RawValue as string, StringComparison.Ordinal)),
+                    ProjectionDocumentFilterOperator.In when filter.Value.RawValue is string[] ids => filtered.Where(d =>
+                        ids.Contains(d.Id, StringComparer.Ordinal)),
+                    _ => filtered,
+                };
+            }
+
+            return Task.FromResult(new ProjectionDocumentQueryResult<SkillRunnerExecutionDocument>
+            {
+                Items = filtered.Take(query.Take).ToArray(),
+            });
         }
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/UserAgentCatalogProjectorTests.cs
@@ -13,14 +13,13 @@ namespace Aevatar.GAgents.ChannelRuntime.Tests;
 public sealed class UserAgentCatalogProjectorTests
 {
     private readonly RecordingWriteDispatcher _dispatcher = new();
-    private readonly RecordingDocumentReader _documentReader = new();
     private readonly FixedProjectionClock _clock = new(new DateTimeOffset(2026, 4, 14, 10, 0, 0, TimeSpan.Zero));
     private readonly UserAgentCatalogProjector _projector;
     private readonly UserAgentCatalogMaterializationContext _context;
 
     public UserAgentCatalogProjectorTests()
     {
-        _projector = new UserAgentCatalogProjector(_dispatcher, _documentReader, _clock);
+        _projector = new UserAgentCatalogProjector(_dispatcher, _clock);
         _context = new UserAgentCatalogMaterializationContext
         {
             RootActorId = UserAgentCatalogGAgent.WellKnownId,
@@ -74,15 +73,8 @@ public sealed class UserAgentCatalogProjectorTests
         document.ApiKeyId.Should().Be("key-1");
         document.ScheduleCron.Should().Be("0 9 * * *");
         document.ScheduleTimezone.Should().Be("UTC");
-        document.Status.Should().BeEmpty("catalog membership projection must not synthesize runner-owned execution facts");
-        document.LastRunAtUtc.Should().BeNull();
-        document.NextRunAtUtc.Should().BeNull();
-        document.ErrorCount.Should().Be(0);
-        document.LastError.Should().BeEmpty();
         document.StateVersion.Should().Be(3);
         document.LastEventId.Should().Be("evt-agent-1");
-        document.CatalogSourceVersion.Should().Be(3);
-        document.CatalogLastEventId.Should().Be("evt-agent-1");
         document.ActorId.Should().Be("agent-registry-store");
         document.CreatedAt.Should().Be(createdAt.ToDateTimeOffset());
         document.UpdatedAt.Should().Be(_clock.UtcNow);
@@ -135,27 +127,8 @@ public sealed class UserAgentCatalogProjectorTests
     }
 
     [Fact]
-    public async Task ProjectAsync_WithSkillRunnerCommittedState_UpsertsExecutionFields()
+    public async Task ProjectAsync_WithSkillRunnerCommittedState_DoesNotWriteCatalogDocument()
     {
-        // Refactor (iter1/cluster-001):
-        //   Old pattern: execution fields were projected only after UserAgentCatalogExecutionUpdatedEvent.
-        //   New principle: runner committed state updates LastRunAt/NextRunAt/Status by agent id.
-        var existing = new UserAgentCatalogDocument
-        {
-            Id = "runner-1",
-            ActorId = UserAgentCatalogGAgent.WellKnownId,
-            AgentType = SkillRunnerDefaults.AgentType,
-            TemplateName = "daily",
-            ScopeId = "scope-1",
-            ScheduleCron = "0 9 * * *",
-            ScheduleTimezone = "UTC",
-            CatalogSourceVersion = 5,
-            CatalogLastEventId = "catalog-5",
-            StateVersion = 5,
-            LastEventId = "catalog-5",
-        };
-        _documentReader.Items["runner-1"] = existing;
-
         var state = new SkillRunnerState
         {
             TemplateName = "daily",
@@ -177,23 +150,14 @@ public sealed class UserAgentCatalogProjectorTests
             BuildSkillRunnerCommittedEnvelope("runner-event-2", 2, state),
             CancellationToken.None);
 
-        _dispatcher.Upserts.Should().ContainSingle();
-        var document = _dispatcher.Upserts[0];
-        document.Id.Should().Be("runner-1");
-        document.Status.Should().Be(SkillRunnerDefaults.StatusRunning);
-        document.LastRunAtUtc.Should().Be(state.LastRunAt);
-        document.NextRunAtUtc.Should().Be(state.NextRunAt);
-        document.ErrorCount.Should().Be(0);
-        document.RunnerSourceVersion.Should().Be(2);
-        document.RunnerLastEventId.Should().Be("runner-event-2");
-        document.CatalogSourceVersion.Should().Be(5);
-        document.StateVersion.Should().Be(7);
-        document.LastEventId.Should().Be("catalog-5:runner-event-2");
+        _dispatcher.Upserts.Should().BeEmpty("runner-owned execution state has a separate read model");
     }
 
     [Fact]
-    public async Task ProjectAsync_WithSkillRunnerFailedState_ProjectsErrorStatus()
+    public async Task SkillRunnerExecutionProjector_WithSkillRunnerFailedState_ProjectsErrorStatus()
     {
+        var dispatcher = new RecordingExecutionWriteDispatcher();
+        var projector = new SkillRunnerExecutionProjector(dispatcher, _clock);
         var state = new SkillRunnerState
         {
             Enabled = true,
@@ -202,7 +166,7 @@ public sealed class UserAgentCatalogProjectorTests
             LastError = "tool failed",
         };
 
-        await _projector.ProjectAsync(
+        await projector.ProjectAsync(
             new UserAgentCatalogMaterializationContext
             {
                 RootActorId = "runner-failed",
@@ -211,11 +175,14 @@ public sealed class UserAgentCatalogProjectorTests
             BuildSkillRunnerCommittedEnvelope("runner-event-4", 4, state),
             CancellationToken.None);
 
-        var document = _dispatcher.Upserts.Should().ContainSingle().Subject;
+        var document = dispatcher.Upserts.Should().ContainSingle().Subject;
+        document.Id.Should().Be("runner-failed");
+        document.ActorId.Should().Be("runner-failed");
         document.Status.Should().Be(SkillRunnerDefaults.StatusError);
         document.LastError.Should().Be("tool failed");
         document.ErrorCount.Should().Be(2);
-        document.RunnerSourceVersion.Should().Be(4);
+        document.StateVersion.Should().Be(4);
+        document.LastEventId.Should().Be("runner-event-4");
     }
 
     [Fact]
@@ -426,22 +393,6 @@ public sealed class UserAgentCatalogProjectorTests
         }
     }
 
-    private sealed class RecordingDocumentReader : IProjectionDocumentReader<UserAgentCatalogDocument, string>
-    {
-        public Dictionary<string, UserAgentCatalogDocument> Items { get; } = new(StringComparer.Ordinal);
-
-        public Task<UserAgentCatalogDocument?> GetAsync(string key, CancellationToken ct = default)
-        {
-            Items.TryGetValue(key, out var document);
-            return Task.FromResult(document?.Clone());
-        }
-
-        public Task<ProjectionDocumentQueryResult<UserAgentCatalogDocument>> QueryAsync(
-            ProjectionDocumentQuery query,
-            CancellationToken ct = default) =>
-            Task.FromResult(new ProjectionDocumentQueryResult<UserAgentCatalogDocument>());
-    }
-
     private sealed class RecordingCredentialWriteDispatcher : IProjectionWriteDispatcher<UserAgentCatalogNyxCredentialDocument>
     {
         public List<UserAgentCatalogNyxCredentialDocument> Upserts { get; } = [];
@@ -463,6 +414,23 @@ public sealed class UserAgentCatalogProjectorTests
             Deletes.Add(id);
             return Task.FromResult(ProjectionWriteResult.Applied());
         }
+    }
+
+    private sealed class RecordingExecutionWriteDispatcher : IProjectionWriteDispatcher<SkillRunnerExecutionDocument>
+    {
+        public List<SkillRunnerExecutionDocument> Upserts { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(
+            SkillRunnerExecutionDocument readModel,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            Upserts.Add(readModel.Clone());
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
+            Task.FromResult(ProjectionWriteResult.Applied());
     }
 
     private sealed class FixedProjectionClock(DateTimeOffset now) : IProjectionClock

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -205,6 +205,64 @@ if rg -n "IGAgentActorStore|ActorBackedGAgentActorStore" src agents; then
   exit 1
 fi
 
+# Refactor (PR #1010 r3):
+#   Old pattern: /run-agent, /disable-agent, and /enable-agent used runner execution
+#   readmodel Status as a cross-authority business admission view.
+#   New principle: lifecycle command admission is catalog-only. Runner Enabled/Disabled
+#   is authoritative inside SkillRunnerGAgent's own turn and is later observed via readmodel.
+python3 - <<'PY'
+from pathlib import Path
+import sys
+
+path = Path("agents/Aevatar.GAgents.Authoring.Lark/AgentBuilderTool.cs")
+text = path.read_text()
+methods = [
+    "RunAgentAsync",
+    "DisableAgentAsync",
+    "EnableAgentAsync",
+    "RequireManagedAgentAsync",
+]
+forbidden = [
+    "executionQueryPort",
+    "_executionQueryPort",
+    "QueryAgentForCallerAsync",
+    "MergeExecution",
+    "StatusDisabled",
+    "StatusRunning",
+]
+
+def method_body(source: str, name: str) -> str:
+    marker = name + "("
+    start = source.find(marker)
+    if start < 0:
+        raise RuntimeError(f"method not found: {name}")
+    open_brace = source.find("{", start)
+    if open_brace < 0:
+        raise RuntimeError(f"method body not found: {name}")
+    depth = 0
+    for index in range(open_brace, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace:index + 1]
+    raise RuntimeError(f"method body unterminated: {name}")
+
+violations = []
+for method in methods:
+    body = method_body(text, method)
+    for token in forbidden:
+        if token in body:
+            violations.append(f"{path}:{method}: forbidden lifecycle admission token `{token}`")
+
+if violations:
+    print("\n".join(violations))
+    print("Scheduled-agent lifecycle command admission must stay catalog-only; execution Status belongs to runner-owned observation.")
+    sys.exit(1)
+PY
+
 # Refactor (iter92/cluster-645):
 #   Old pattern: no guard blocked new production consumers from depending on StreamingProxy.
 #   New principle: this guard prevents new consumers, wrappers, or re-maps; direct model streaming goes through /v1/responses.


### PR DESCRIPTION
## Summary
- 删 `UserAgentCatalogDocument` synthetic `StateVersion = catalogVersion + runnerVersion`
- catalog readmodel only ← catalogVersion(authoritative):`UserAgentCatalogReadModelEntry` + `UserAgentCatalogProjector` + `UserAgentCatalogQueryPort`
- execution readmodel 拆出:`SkillRunnerExecutionDocument.Partial` + `SkillRunnerExecutionProjector` + `SkillRunnerExecutionDocumentMetadataProvider` ← runnerVersion(authoritative)
- DI 注册新 projection + retired-actor spec
- proto 拆 contract;docs/canon daily-command-pipeline 记录新 topology
- consumer-side join 在 query 调用方处理;不引入 aggregate actor

15 files: +400 / -259。

## Phase 9 r2 consensus
`META_JUDGE_DONE:consensus:mechanical-split-user-agent-catalog-readmodel-by-authority`

Closes #1006

⟦AI:AUTO-LOOP⟧