### PR TITLE
skill: 加 hard rule #9 — gh pr merge 前 CI 必须 required check 全绿

### DIFF
--- a/.claude/skills/codex-refactor-loop/SKILL.md
+++ b/.claude/skills/codex-refactor-loop/SKILL.md
@@ -2307,6 +2307,7 @@ Bash(
 6. **No `[Skip]` / disabled tests** as a way to make CI green.
 7. **No scope creep** — codex must print `SCOPE_EXTEND: <file> <reason>` before touching anything outside `scope_paths`.
 8. **All user-facing output is in 中文 by default** (per Auric 2026-05-19 "默认工作语言中文吧, 不双语了"). Every GitHub issue body, PR description, design notification, and any natural-language artifact uses 中文 as the working language. Code identifiers, file paths, log markers, CLI commands, and proto/yaml structure stay original (English). English may appear inline when quoting (a) a CLAUDE.md / AGENTS.md clause, (b) error messages, (c) test names — quote verbatim, do not translate. No mandatory parallel English section.
+9. **gh pr merge 前必须 CI 全 required check 绿**(per Auric 2026-05-25 "改一下分支保护，必须ci 绿了才能合并"). auto-refact-dev 已设 branch protection(8 required:`fast-gates` / `console-web` / `coverage-quality` / `projection-provider-e2e` / `kafka-transport-integration` / `event-sourcing-regression` / `host-composition-smoke` / `slow-test-guards`,`strict: true`,`enforce_admins: true`)。**禁止**用 `--admin` / `--bypass` flag 绕过(已不可能;enforce_admins=true)。每次 `gh pr merge` 前 controller **必须** verify:`gh pr checks <PR> --required --json bucket --jq 'all(.[]; .bucket == "pass")'` 返回 `true`,否则**等 CI 完成**(arm Monitor watch + ScheduleWakeup,不要立即重试 merge)。事故记录:2026-05-25 session 11 个 cluster PR 全在 reviewer 3/3 approve 后 squash merge,**没等 GitHub Actions CI** → trunk auto-refact-dev 5 个 integration test 挂(hotfix `ef7962d` 修)。今后此情形不可能发生(branch protection 拦)。
 
 ## 工作语言规则(默认中文)
 


### PR DESCRIPTION
## Summary
per Auric 2026-05-25 "改一下分支保护，必须ci 绿了才能合并"。

- auto-refact-dev branch protection 已设(独立 \`gh api PUT\`,本 PR 仅同步 SKILL.md 文档):
  - 8 required status checks(\`fast-gates\` / \`console-web\` / \`coverage-quality\` / \`projection-provider-e2e\` / \`kafka-transport-integration\` / \`event-sourcing-regression\` / \`host-composition-smoke\` / \`slow-test-guards\`)
  - \`strict: true\`(PR 必须 up-to-date with base)
  - \`enforce_admins: true\`(admin 不能 bypass)
- SKILL.md hard rule #9 同步:controller 每次 \`gh pr merge\` 前必须 verify \`gh pr checks <PR> --required\` 全绿

## 事故记录
本 session 11 个 cluster PR 全在 reviewer 3/3 approve 后 squash merge,**没等 GitHub Actions integration test 完成** → trunk auto-refact-dev 5 个 test 挂(hotfix \`ef7962d\` 修)。今后此情形 branch protection 拦,不可能发生。

⟦AI:AUTO-LOOP⟧