### PR TITLE
iter96 cluster-529: enable classified OCC retry runtime by default

### DIFF
--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionDispatchAggregateException.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionDispatchAggregateException.cs
@@ -5,6 +5,9 @@ namespace Aevatar.CQRS.Projection.Core.Orchestration;
 /// </summary>
 public sealed class ProjectionDispatchAggregateException : Exception
 {
+    // Refactor (iter96/cluster-529):
+    //   Old pattern: aggregate exception 只保留首个 inner exception,非首个 OCC 失败不被 classifier 识别
+    //   New principle: aggregate failure 中所有 inner exceptions 都参与 classification,non-first OCC 也能被识别并重试
     public ProjectionDispatchAggregateException(
         IReadOnlyList<ProjectionDispatchFailure> failures)
         : base(BuildMessage(failures), BuildInnerException(failures))

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionDispatchAggregateException.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/ProjectionDispatchAggregateException.cs
@@ -7,7 +7,7 @@ public sealed class ProjectionDispatchAggregateException : Exception
 {
     public ProjectionDispatchAggregateException(
         IReadOnlyList<ProjectionDispatchFailure> failures)
-        : base(BuildMessage(failures), failures.Count > 0 ? failures[0].Exception : null)
+        : base(BuildMessage(failures), BuildInnerException(failures))
     {
         Failures = failures.ToArray();
     }
@@ -22,6 +22,14 @@ public sealed class ProjectionDispatchAggregateException : Exception
         var projectorList = string.Join(", ", failures.Select(x => $"{x.ProjectorName}#{x.ProjectorOrder}"));
         return $"Projection dispatch failed for {failures.Count} projector(s): {projectorList}.";
     }
+
+    private static Exception? BuildInnerException(IReadOnlyList<ProjectionDispatchFailure> failures) =>
+        failures.Count switch
+        {
+            0 => null,
+            1 => failures[0].Exception,
+            _ => new AggregateException(failures.Select(static failure => failure.Exception)),
+        };
 }
 
 /// <summary>

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeEnvelopeRetryPolicy.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeEnvelopeRetryPolicy.cs
@@ -34,6 +34,9 @@ internal sealed class RuntimeEnvelopeRetryPolicy
 
     internal static RuntimeEnvelopeRetryPolicy FromValues(string? maxAttemptsRaw, string? retryDelayRaw)
     {
+        // Refactor (iter96/cluster-529):
+        //   Old pattern: AEVATAR_RUNTIME_AUTO_RETRY_MAX_ATTEMPTS 未配置 → 默认关闭重试;显式配置后重试所有异常
+        //   New principle: 默认开启 OCC-classified retry(仅重试 EventStoreOptimisticConcurrencyException);显式配置 max attempts 仍保留通用重试语义
         var maxAttemptsConfigured = int.TryParse(maxAttemptsRaw, out var configuredMaxAttempts);
         var maxAttempts = maxAttemptsConfigured ? configuredMaxAttempts : DefaultMaxAttempts;
         var retryDelayMs = ParseOrDefault(retryDelayRaw, defaultValue: DefaultRetryDelayMs);

--- a/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeEnvelopeRetryPolicy.cs
+++ b/src/Aevatar.Foundation.Runtime.Implementations.Orleans/Grains/RuntimeEnvelopeRetryPolicy.cs
@@ -1,20 +1,29 @@
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Runtime.Deduplication;
 
 namespace Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
 
 internal sealed class RuntimeEnvelopeRetryPolicy
 {
-    private RuntimeEnvelopeRetryPolicy(int maxAttempts, int retryDelayMs)
+    private const int DefaultMaxAttempts = 3;
+    private const int DefaultRetryDelayMs = 1000;
+
+    private RuntimeEnvelopeRetryPolicy(
+        int maxAttempts,
+        int retryDelayMs,
+        bool retryOnlyRecoverableConcurrencyFailures)
     {
         MaxAttempts = maxAttempts;
         RetryDelayMs = retryDelayMs;
+        RetryOnlyRecoverableConcurrencyFailures = retryOnlyRecoverableConcurrencyFailures;
     }
 
     public int MaxAttempts { get; }
     public int RetryDelayMs { get; }
     public bool Enabled => MaxAttempts > 0;
+    public bool RetryOnlyRecoverableConcurrencyFailures { get; }
 
-    public static RuntimeEnvelopeRetryPolicy Disabled { get; } = new(0, 0);
+    public static RuntimeEnvelopeRetryPolicy Disabled { get; } = new(0, 0, true);
 
     public static RuntimeEnvelopeRetryPolicy FromEnvironment()
     {
@@ -25,14 +34,20 @@ internal sealed class RuntimeEnvelopeRetryPolicy
 
     internal static RuntimeEnvelopeRetryPolicy FromValues(string? maxAttemptsRaw, string? retryDelayRaw)
     {
-        var maxAttempts = ParseOrDefault(maxAttemptsRaw, defaultValue: 0);
-        var retryDelayMs = ParseOrDefault(retryDelayRaw, defaultValue: 1000);
+        var maxAttemptsConfigured = int.TryParse(maxAttemptsRaw, out var configuredMaxAttempts);
+        var maxAttempts = maxAttemptsConfigured ? configuredMaxAttempts : DefaultMaxAttempts;
+        var retryDelayMs = ParseOrDefault(retryDelayRaw, defaultValue: DefaultRetryDelayMs);
         if (maxAttempts < 0)
             maxAttempts = 0;
         if (retryDelayMs < 0)
             retryDelayMs = 0;
 
-        return maxAttempts == 0 ? Disabled : new RuntimeEnvelopeRetryPolicy(maxAttempts, retryDelayMs);
+        return maxAttempts == 0
+            ? Disabled
+            : new RuntimeEnvelopeRetryPolicy(
+                maxAttempts,
+                retryDelayMs,
+                retryOnlyRecoverableConcurrencyFailures: !maxAttemptsConfigured);
     }
 
     public bool TryBuildRetryEnvelope(
@@ -42,7 +57,9 @@ internal sealed class RuntimeEnvelopeRetryPolicy
         out int nextAttempt)
     {
         nextAttempt = GetAttempt(originalEnvelope) + 1;
-        if (!Enabled || nextAttempt > MaxAttempts)
+        if (!Enabled ||
+            nextAttempt > MaxAttempts ||
+            !ShouldRetry(exception))
         {
             retryEnvelope = null!;
             return false;
@@ -56,6 +73,22 @@ internal sealed class RuntimeEnvelopeRetryPolicy
         if (!string.IsNullOrWhiteSpace(originEventId))
             retry.OriginEventId = originEventId;
         return true;
+    }
+
+    private bool ShouldRetry(Exception exception) =>
+        !RetryOnlyRecoverableConcurrencyFailures || ContainsRecoverableConcurrencyFailure(exception);
+
+    private static bool ContainsRecoverableConcurrencyFailure(Exception exception)
+    {
+        return exception switch
+        {
+            EventStoreOptimisticConcurrencyException => true,
+            AggregateException aggregate =>
+                aggregate.InnerExceptions.Any(ContainsRecoverableConcurrencyFailure),
+            _ when exception.InnerException is not null =>
+                ContainsRecoverableConcurrencyFailure(exception.InnerException),
+            _ => false,
+        };
     }
 
     private static int GetAttempt(EventEnvelope envelope)

--- a/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionObservationFailurePolicyTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/ProjectionObservationFailurePolicyTests.cs
@@ -29,6 +29,26 @@ public sealed class ProjectionObservationFailurePolicyTests
     }
 
     [Fact]
+    public void ShouldPropagate_ShouldReturnTrue_ForProjectionDispatchAggregateContainingNonFirstOptimisticConcurrencyException()
+    {
+        var aggregate = new ProjectionDispatchAggregateException(
+        [
+            new ProjectionDispatchFailure(
+                "projector-a",
+                1,
+                new InvalidOperationException("deterministic")),
+            new ProjectionDispatchFailure(
+                "projector-b",
+                2,
+                new EventStoreOptimisticConcurrencyException("actor-2", 7, 8)),
+        ]);
+
+        ProjectionObservationFailurePolicy.ShouldPropagate(aggregate).Should().BeTrue();
+        ProjectionObservationFailurePolicy.ContainsOcc(aggregate).Should().BeTrue();
+        aggregate.InnerException.Should().BeOfType<AggregateException>();
+    }
+
+    [Fact]
     public void ShouldPropagate_ShouldReturnFalse_ForDeterministicProjectionFailure()
     {
         var aggregate = new ProjectionDispatchAggregateException(

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDirectDispatchFailurePropagationTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDirectDispatchFailurePropagationTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Runtime.Deduplication;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.DependencyInjection;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
@@ -43,6 +44,44 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
 
             var dispatchPort = host.Services.GetRequiredService<IActorDispatchPort>();
             var envelope = CreateEnvelope("always-fail-no-retry");
+
+            await dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
+            await RetryAwareDirectDispatchAgent.WaitForAttemptAsync(envelope.Id, TimeSpan.FromSeconds(20));
+            await logProbe.WaitForRuntimeHandlingFailureAsync(TimeSpan.FromSeconds(20));
+            RetryAwareDirectDispatchAgent.GetAttemptCount(envelope.Id).Should().Be(1);
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ShouldNotRetryNonOccFailure_WhenRuntimeRetryUsesDefaultClassifier()
+    {
+        RetryAwareDirectDispatchAgent.Reset();
+        var actorId = $"actor-{Guid.NewGuid():N}";
+        var siloPort = ReserveTcpPort();
+        var gatewayPort = ReserveTcpPort();
+        var logProbe = new RuntimeRetryLogProbe();
+
+        using var envScope = new EnvironmentVariableScope(new Dictionary<string, string?>
+        {
+            ["AEVATAR_RUNTIME_AUTO_RETRY_MAX_ATTEMPTS"] = null,
+            ["AEVATAR_RUNTIME_AUTO_RETRY_DELAY_MS"] = "50",
+            ["AEVATAR_TEST_NODE_VERSION_TAG"] = "new",
+            ["AEVATAR_TEST_FAIL_EVENT_TYPE_URLS"] = string.Empty,
+        });
+
+        var host = await StartSiloHostAsync(siloPort, gatewayPort, logProbe);
+
+        try
+        {
+            await InitializeAgentAsync(host, actorId);
+
+            var dispatchPort = host.Services.GetRequiredService<IActorDispatchPort>();
+            var envelope = CreateEnvelope("always-fail-non-occ-default");
 
             await dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
             await RetryAwareDirectDispatchAgent.WaitForAttemptAsync(envelope.Id, TimeSpan.FromSeconds(20));
@@ -129,6 +168,47 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
 
             await dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
             await logProbe.WaitForRuntimeRetryScheduledAsync(TimeSpan.FromSeconds(20));
+        }
+        finally
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task DispatchAsync_ShouldRetryOccFailure_WhenRuntimeRetryUsesDefaultClassifier()
+    {
+        RetryAwareDirectDispatchAgent.Reset();
+        var actorId = $"actor-{Guid.NewGuid():N}";
+        var siloPort = ReserveTcpPort();
+        var gatewayPort = ReserveTcpPort();
+        var logProbe = new RuntimeRetryLogProbe();
+
+        using var envScope = new EnvironmentVariableScope(new Dictionary<string, string?>
+        {
+            ["AEVATAR_RUNTIME_AUTO_RETRY_MAX_ATTEMPTS"] = null,
+            ["AEVATAR_RUNTIME_AUTO_RETRY_DELAY_MS"] = "50",
+            ["AEVATAR_TEST_NODE_VERSION_TAG"] = "new",
+            ["AEVATAR_TEST_FAIL_EVENT_TYPE_URLS"] = string.Empty,
+        });
+
+        var host = await StartSiloHostAsync(siloPort, gatewayPort, logProbe);
+
+        try
+        {
+            await InitializeAgentAsync(host, actorId);
+
+            var dispatchPort = host.Services.GetRequiredService<IActorDispatchPort>();
+            var envelope = CreateEnvelope("occ-fail-once-then-succeed");
+
+            await dispatchPort.DispatchAsync(actorId, envelope, CancellationToken.None);
+            await logProbe.WaitForRuntimeRetryScheduledAsync(TimeSpan.FromSeconds(20));
+            var successfulEnvelope =
+                await RetryAwareDirectDispatchAgent.WaitForSuccessAsync(envelope.Id, TimeSpan.FromSeconds(20));
+
+            RuntimeEnvelopeDeduplication.GetAttempt(successfulEnvelope).Should().Be(1);
+            RetryAwareDirectDispatchAgent.GetAttemptCount(envelope.Id).Should().Be(2);
         }
         finally
         {
@@ -355,6 +435,9 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
             if (payload == "always-fail-no-retry")
                 throw new InvalidOperationException("always-fail-no-retry");
 
+            if (payload == "always-fail-non-occ-default")
+                throw new InvalidOperationException("always-fail-non-occ-default");
+
             if (payload == "always-fail-retry-exhausted")
                 throw new InvalidOperationException("always-fail-retry-exhausted");
 
@@ -362,6 +445,15 @@ public sealed class OrleansDirectDispatchFailurePropagationTests
                 RuntimeEnvelopeDeduplication.GetAttempt(envelope) == 0)
             {
                 throw new InvalidOperationException("fail-once-before-retry");
+            }
+
+            if (payload == "occ-fail-once-then-succeed" &&
+                RuntimeEnvelopeDeduplication.GetAttempt(envelope) == 0)
+            {
+                throw new EventStoreOptimisticConcurrencyException(
+                    envelope.Id,
+                    expectedVersion: 1,
+                    actualVersion: 2);
             }
 
             lock (SyncLock)

--- a/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDistributedCoverageTests.cs
+++ b/test/Aevatar.Foundation.Runtime.Hosting.Tests/OrleansDistributedCoverageTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Streaming;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Actors;
 using Aevatar.Foundation.Runtime.Implementations.Orleans.Grains;
@@ -42,15 +43,10 @@ public sealed class OrleansDistributedCoverageTests
     }
 
     [Fact]
-    public void RuntimeEnvelopeRetryPolicy_ShouldBuildRetryEnvelope_WhenAttemptWithinLimit()
+    public void RuntimeEnvelopeRetryPolicy_ShouldBuildRetryEnvelope_ForExplicitPolicy_WhenAttemptWithinLimit()
     {
         var policy = RuntimeEnvelopeRetryPolicy.FromValues("2", "10");
-        var envelope = new EventEnvelope
-        {
-            Id = "evt-1",
-            Payload = Google.Protobuf.WellKnownTypes.Any.Pack(new Google.Protobuf.WellKnownTypes.StringValue { Value = "payload" }),
-            Route = EnvelopeRouteSemantics.CreateTopologyPublication(string.Empty, TopologyAudience.Children),
-        };
+        var envelope = CreateRetryPolicyEnvelope("evt-1");
 
         var built = policy.TryBuildRetryEnvelope(
             envelope,
@@ -70,12 +66,7 @@ public sealed class OrleansDistributedCoverageTests
     public void RuntimeEnvelopeRetryPolicy_ShouldKeepRootOriginEventIdAcrossRetries()
     {
         var policy = RuntimeEnvelopeRetryPolicy.FromValues("2", "10");
-        var envelope = new EventEnvelope
-        {
-            Id = "evt-retry-2",
-            Payload = Google.Protobuf.WellKnownTypes.Any.Pack(new Google.Protobuf.WellKnownTypes.StringValue { Value = "payload" }),
-            Route = EnvelopeRouteSemantics.CreateTopologyPublication(string.Empty, TopologyAudience.Children),
-        };
+        var envelope = CreateRetryPolicyEnvelope("evt-retry-2");
         envelope.Runtime = new EnvelopeRuntime
         {
             Retry = new EnvelopeRetryContext
@@ -98,12 +89,100 @@ public sealed class OrleansDistributedCoverageTests
     }
 
     [Fact]
-    public void RuntimeEnvelopeRetryPolicy_ShouldBeDisabledByDefault_WhenEnvironmentNotConfigured()
+    public void RuntimeEnvelopeRetryPolicy_ShouldRetryOccByDefault_WhenEnvironmentNotConfigured()
     {
         var policy = RuntimeEnvelopeRetryPolicy.FromValues(null, null);
+        var envelope = CreateRetryPolicyEnvelope("evt-default-occ");
 
-        policy.Enabled.Should().BeFalse();
-        policy.MaxAttempts.Should().Be(0);
+        policy.Enabled.Should().BeTrue();
+        policy.MaxAttempts.Should().Be(3);
+        policy.RetryDelayMs.Should().Be(1000);
+        policy.RetryOnlyRecoverableConcurrencyFailures.Should().BeTrue();
+
+        var built = policy.TryBuildRetryEnvelope(
+            envelope,
+            new EventStoreOptimisticConcurrencyException("actor-1", expectedVersion: 4, actualVersion: 5),
+            out var retryEnvelope,
+            out var nextAttempt);
+
+        built.Should().BeTrue();
+        nextAttempt.Should().Be(1);
+        retryEnvelope.Runtime!.Retry!.Attempt.Should().Be(1);
+        retryEnvelope.Runtime.Retry.LastErrorType.Should().Be(nameof(EventStoreOptimisticConcurrencyException));
+    }
+
+    [Fact]
+    public void RuntimeEnvelopeRetryPolicy_ShouldRetryWrappedOccByDefault_WhenEnvironmentNotConfigured()
+    {
+        var policy = RuntimeEnvelopeRetryPolicy.FromValues(null, null);
+        var envelope = CreateRetryPolicyEnvelope("evt-default-wrapped-occ");
+
+        var built = policy.TryBuildRetryEnvelope(
+            envelope,
+            new InvalidOperationException(
+                "wrapped",
+                new EventStoreOptimisticConcurrencyException("actor-1", expectedVersion: 4, actualVersion: 5)),
+            out var retryEnvelope,
+            out var nextAttempt);
+
+        built.Should().BeTrue();
+        nextAttempt.Should().Be(1);
+        retryEnvelope.Runtime!.Retry!.Attempt.Should().Be(1);
+    }
+
+    [Fact]
+    public void RuntimeEnvelopeRetryPolicy_ShouldNotRetryNonOccByDefault_WhenEnvironmentNotConfigured()
+    {
+        var policy = RuntimeEnvelopeRetryPolicy.FromValues(null, null);
+        var envelope = CreateRetryPolicyEnvelope("evt-default-non-occ");
+
+        var built = policy.TryBuildRetryEnvelope(
+            envelope,
+            new InvalidOperationException("boom"),
+            out _,
+            out var nextAttempt);
+
+        policy.Enabled.Should().BeTrue();
+        policy.RetryOnlyRecoverableConcurrencyFailures.Should().BeTrue();
+        built.Should().BeFalse();
+        nextAttempt.Should().Be(1);
+    }
+
+    [Fact]
+    public void RuntimeEnvelopeRetryPolicy_ShouldRetryNonOcc_WhenAttemptsExplicitlyConfigured()
+    {
+        var policy = RuntimeEnvelopeRetryPolicy.FromValues("2", null);
+        var envelope = CreateRetryPolicyEnvelope("evt-explicit-non-occ");
+
+        var built = policy.TryBuildRetryEnvelope(
+            envelope,
+            new InvalidOperationException("boom"),
+            out var retryEnvelope,
+            out var nextAttempt);
+
+        policy.RetryOnlyRecoverableConcurrencyFailures.Should().BeFalse();
+        built.Should().BeTrue();
+        nextAttempt.Should().Be(1);
+        retryEnvelope.Runtime!.Retry!.Attempt.Should().Be(1);
+    }
+
+    [Fact]
+    public void RuntimeEnvelopeRetryPolicy_ShouldKeepDefaultClassifier_WhenAttemptsConfigurationIsInvalid()
+    {
+        var policy = RuntimeEnvelopeRetryPolicy.FromValues("not-a-number", null);
+        var envelope = CreateRetryPolicyEnvelope("evt-invalid-config-non-occ");
+
+        var built = policy.TryBuildRetryEnvelope(
+            envelope,
+            new InvalidOperationException("boom"),
+            out _,
+            out var nextAttempt);
+
+        policy.Enabled.Should().BeTrue();
+        policy.MaxAttempts.Should().Be(3);
+        policy.RetryOnlyRecoverableConcurrencyFailures.Should().BeTrue();
+        built.Should().BeFalse();
+        nextAttempt.Should().Be(1);
     }
 
     [Fact]
@@ -114,6 +193,7 @@ public sealed class OrleansDistributedCoverageTests
         policy.Enabled.Should().BeTrue();
         policy.MaxAttempts.Should().Be(2);
         policy.RetryDelayMs.Should().Be(1000);
+        policy.RetryOnlyRecoverableConcurrencyFailures.Should().BeFalse();
     }
 
     [Fact]
@@ -143,6 +223,14 @@ public sealed class OrleansDistributedCoverageTests
         built.Should().BeFalse();
         nextAttempt.Should().Be(2);
     }
+
+    private static EventEnvelope CreateRetryPolicyEnvelope(string id) =>
+        new()
+        {
+            Id = id,
+            Payload = Google.Protobuf.WellKnownTypes.Any.Pack(new Google.Protobuf.WellKnownTypes.StringValue { Value = "payload" }),
+            Route = EnvelopeRouteSemantics.CreateTopologyPublication(string.Empty, TopologyAudience.Children),
+        };
 
     [Fact]
     public async Task OrleansActorTypeProbe_ShouldResolveAndNormalizeTypeName()

--- a/tools/ci/distributed_mixed_version_smoke.sh
+++ b/tools/ci/distributed_mixed_version_smoke.sh
@@ -114,6 +114,11 @@ start_node() {
   local version_tag="$7"
   local fail_event_type_urls="$8"
   local log_file="${log_dir}/node${node}.log"
+  local retry_max_attempts="${AEVATAR_RUNTIME_AUTO_RETRY_MAX_ATTEMPTS:-}"
+
+  if [[ -n "${fail_event_type_urls}" && -z "${retry_max_attempts}" ]]; then
+    retry_max_attempts=3
+  fi
 
   (
     ASPNETCORE_ENVIRONMENT=Distributed \
@@ -144,6 +149,7 @@ start_node() {
     Projection__Graph__Providers__InMemory__Enabled=false \
     AEVATAR_TEST_NODE_VERSION_TAG="${version_tag}" \
     AEVATAR_TEST_FAIL_EVENT_TYPE_URLS="${fail_event_type_urls}" \
+    AEVATAR_RUNTIME_AUTO_RETRY_MAX_ATTEMPTS="${retry_max_attempts}" \
     dotnet "${app_dll}" >"${log_file}" 2>&1
   ) &
 


### PR DESCRIPTION
## Summary
- `RuntimeEnvelopeRetryPolicy`默认开启,但仅按 OCC concurrency exception 分类重试
- NPE / argument / domain rule 等不重试
- `ProjectionDispatchAggregateException` 配合 projection scope "drop pending and re-execute" 协同
- 测试覆盖 OCC retry + 非 OCC 不重试 + projection scope 不冲突
- distributed_mixed_version_smoke guard 调整

6 files: +270 / -23。

## Phase 9 consensus
`META_JUDGE_DONE:consensus:enable-classified-occ-retry-runtime-by-default`

Closes #529

⟦AI:AUTO-LOOP⟧