### PR TITLE
iter96 cluster-547: Studio team update/archive return 202 accepted receipt

### DIFF
--- a/docs/adr/0017-studio-team-first-class-aggregate.md
+++ b/docs/adr/0017-studio-team-first-class-aggregate.md
@@ -600,8 +600,13 @@ Team CRUD:
 - `POST   /api/scopes/{scopeId}/teams`            — create team
 - `GET    /api/scopes/{scopeId}/teams`            — list teams in scope
 - `GET    /api/scopes/{scopeId}/teams/{teamId}`   — read team
-- `PATCH  /api/scopes/{scopeId}/teams/{teamId}`   — update display name / description (Merge Patch semantics, see below)
-- `POST   /api/scopes/{scopeId}/teams/{teamId}/archive` — archive (irreversible)
+- `PATCH  /api/scopes/{scopeId}/teams/{teamId}`   — update display name / description (Merge Patch semantics, see below); returns `202 Accepted` with an accepted/no-change command receipt and `Location: /api/scopes/{scopeId}/teams/{teamId}`
+- `POST   /api/scopes/{scopeId}/teams/{teamId}/archive` — archive (irreversible); returns `202 Accepted` with an accepted command receipt and `Location: /api/scopes/{scopeId}/teams/{teamId}`
+
+Team update/archive responses are dispatch admission receipts, not
+post-dispatch read-model snapshots. Callers that need the visible team state
+must follow the `Location` resource and treat it as an eventually consistent
+read-model query.
 
 Team -> Member listing (read model query, filtered):
 

--- a/docs/adr/0017-studio-team-first-class-aggregate.md
+++ b/docs/adr/0017-studio-team-first-class-aggregate.md
@@ -600,13 +600,8 @@ Team CRUD:
 - `POST   /api/scopes/{scopeId}/teams`            — create team
 - `GET    /api/scopes/{scopeId}/teams`            — list teams in scope
 - `GET    /api/scopes/{scopeId}/teams/{teamId}`   — read team
-- `PATCH  /api/scopes/{scopeId}/teams/{teamId}`   — update display name / description (Merge Patch semantics, see below); returns `202 Accepted` with an accepted/no-change command receipt and `Location: /api/scopes/{scopeId}/teams/{teamId}`
-- `POST   /api/scopes/{scopeId}/teams/{teamId}/archive` — archive (irreversible); returns `202 Accepted` with an accepted command receipt and `Location: /api/scopes/{scopeId}/teams/{teamId}`
-
-Team update/archive responses are dispatch admission receipts, not
-post-dispatch read-model snapshots. Callers that need the visible team state
-must follow the `Location` resource and treat it as an eventually consistent
-read-model query.
+- `PATCH  /api/scopes/{scopeId}/teams/{teamId}`   — update display name / description (Merge Patch semantics, see below)
+- `POST   /api/scopes/{scopeId}/teams/{teamId}/archive` — archive (irreversible)
 
 Team -> Member listing (read model query, filtered):
 

--- a/docs/adr/0028-studio-team-accepted-receipt-semantics.md
+++ b/docs/adr/0028-studio-team-accepted-receipt-semantics.md
@@ -1,0 +1,64 @@
+---
+title: "Studio Team Accepted Receipt Semantics"
+status: accepted
+owner: eanzhao
+---
+
+# ADR-0028: Studio Team Accepted Receipt Semantics
+
+## Context
+
+ADR-0017 introduced Studio Team as a first-class aggregate and defined the
+team CRUD HTTP surface. The current architecture rules require honest ACK
+semantics: synchronous HTTP responses may only promise the stage that has
+actually completed. A dispatch admission ACK must not be presented as a
+committed write or readmodel-observed state.
+
+Before this decision, team update/archive handlers dispatched the command and
+then called `GetAsync` to read the team readmodel, returning `200 OK` plus a
+snapshot. That mixed command admission with eventually consistent query
+visibility and could imply completion that had not been observed through the
+projection pipeline.
+
+## Decision
+
+This ADR extends ADR-0017 for Studio Team update/archive HTTP response
+semantics.
+
+`PATCH /api/scopes/{scopeId}/teams/{teamId}` returns `202 Accepted` with:
+
+- a `Location: /api/scopes/{scopeId}/teams/{teamId}` header
+- an accepted/no-change command receipt body
+
+`POST /api/scopes/{scopeId}/teams/{teamId}/archive` returns `202 Accepted`
+with:
+
+- a `Location: /api/scopes/{scopeId}/teams/{teamId}` header
+- an accepted command receipt body
+
+These responses are dispatch admission receipts only. They do not mean the
+target actor has committed the command, the committed event has been projected,
+or a follow-up readmodel query will immediately observe the new state.
+
+Callers that need visible team state must follow the `Location` resource and
+treat it as an eventually consistent team query resource.
+
+## Superseded ADR-0017 Sections
+
+This ADR supersedes only the implicit ADR-0017 interpretation that team
+update/archive HTTP handlers may return post-dispatch readmodel snapshots as
+the command response.
+
+ADR-0017 remains the source of record for Studio Team aggregate ownership,
+schema, lifecycle, member/team semantics, and endpoint shape.
+
+## Consequences
+
+- `StudioTeamService.UpdateAsync` and `ArchiveAsync` return
+  `StudioTeamCommandResponse` receipts from the command port.
+- The application service does not call `GetAsync` after dispatching update or
+  archive commands.
+- Studio Team HTTP PATCH/archive endpoints return `202 Accepted` with
+  `Location` instead of `200 OK` with a snapshot.
+- Readmodel freshness remains a query concern and is not implied by the
+  synchronous command response.

--- a/src/Aevatar.CQRS.Core.Abstractions/Commands/CommandDispatchResult.cs
+++ b/src/Aevatar.CQRS.Core.Abstractions/Commands/CommandDispatchResult.cs
@@ -5,8 +5,11 @@ public sealed record CommandDispatchResult<TReceipt, TError>
     public required bool Succeeded { get; init; }
     public required TError Error { get; init; }
     public TReceipt? Receipt { get; init; }
+    public DispatchAdmission? Admission { get; init; }
 
-    public static CommandDispatchResult<TReceipt, TError> Success(TReceipt receipt)
+    public static CommandDispatchResult<TReceipt, TError> Success(
+        TReceipt receipt,
+        DispatchAdmission? admission = null)
     {
         ArgumentNullException.ThrowIfNull(receipt);
 
@@ -15,6 +18,7 @@ public sealed record CommandDispatchResult<TReceipt, TError>
             Succeeded = true,
             Error = default!,
             Receipt = receipt,
+            Admission = admission,
         };
     }
 

--- a/src/Aevatar.CQRS.Core/Commands/DefaultCommandDispatchService.cs
+++ b/src/Aevatar.CQRS.Core/Commands/DefaultCommandDispatchService.cs
@@ -22,6 +22,8 @@ public sealed class DefaultCommandDispatchService<TCommand, TTarget, TReceipt, T
         if (!dispatch.Succeeded || dispatch.Target == null)
             return CommandDispatchResult<TReceipt, TError>.Failure(dispatch.Error);
 
-        return CommandDispatchResult<TReceipt, TError>.Success(dispatch.Target.Receipt);
+        return CommandDispatchResult<TReceipt, TError>.Success(
+            dispatch.Target.Receipt,
+            dispatch.Target.Admission);
     }
 }

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamCommandPort.cs
@@ -14,7 +14,7 @@ public interface IStudioTeamCommandPort
         CreateStudioTeamRequest request,
         CancellationToken ct = default);
 
-    Task UpdateAsync(
+    Task<StudioTeamCommandResponse> UpdateAsync(
         string scopeId,
         string teamId,
         UpdateStudioTeamRequest request,
@@ -24,7 +24,7 @@ public interface IStudioTeamCommandPort
     /// Archives the team. Archive is irreversible (ADR-0017 §Locked Rule 5).
     /// Idempotent on already-archived teams.
     /// </summary>
-    Task ArchiveAsync(
+    Task<StudioTeamCommandResponse> ArchiveAsync(
         string scopeId,
         string teamId,
         CancellationToken ct = default);

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioTeamService.cs
@@ -25,13 +25,13 @@ public interface IStudioTeamService
         string teamId,
         CancellationToken ct = default);
 
-    Task<StudioTeamSummaryResponse> UpdateAsync(
+    Task<StudioTeamCommandResponse> UpdateAsync(
         string scopeId,
         string teamId,
         UpdateStudioTeamRequest request,
         CancellationToken ct = default);
 
-    Task<StudioTeamSummaryResponse> ArchiveAsync(
+    Task<StudioTeamCommandResponse> ArchiveAsync(
         string scopeId,
         string teamId,
         CancellationToken ct = default);

--- a/src/Aevatar.Studio.Application/Studio/Contracts/TeamContracts.cs
+++ b/src/Aevatar.Studio.Application/Studio/Contracts/TeamContracts.cs
@@ -34,6 +34,20 @@ public sealed record StudioTeamRosterPageRequest(
     int? PageSize = null,
     string? PageToken = null);
 
+public static class StudioTeamCommandStatusNames
+{
+    public const string Accepted = "accepted";
+    public const string NoChange = "no_change";
+}
+
+public sealed record StudioTeamCommandResponse(
+    string Status,
+    string ScopeId,
+    string TeamId,
+    string? CommandId = null,
+    string? CorrelationId = null,
+    DateTimeOffset? AckedAt = null);
+
 public sealed record CreateStudioTeamRequest(
     string DisplayName,
     string? Description = null,

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
@@ -91,6 +91,10 @@ public sealed class StudioTeamService : IStudioTeamService
                     $"description must be at most {StudioTeamInputLimits.MaxDescriptionLength} characters.");
         }
 
+        // Refactor (iter96/cluster-547):
+        //   Old: dispatch then GetAsync readmodel returned 200 OK + snapshot (pretending completion).
+        //   New: no readmodel read; 202 Accepted + Location points to stable team query resource,
+        //        body only carries accepted/no_change receipt.
         return await _commandPort.UpdateAsync(scopeId, teamId, request, ct);
     }
 
@@ -99,6 +103,10 @@ public sealed class StudioTeamService : IStudioTeamService
         string teamId,
         CancellationToken ct = default)
     {
+        // Refactor (iter96/cluster-547):
+        //   Old: dispatch then GetAsync readmodel returned 200 OK + snapshot (pretending completion).
+        //   New: no readmodel read; 202 Accepted + Location points to stable team query resource,
+        //        body only carries accepted/no_change receipt.
         return _commandPort.ArchiveAsync(scopeId, teamId, ct);
     }
 

--- a/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
+++ b/src/Aevatar.Studio.Application/Studio/Services/StudioTeamService.cs
@@ -59,7 +59,7 @@ public sealed class StudioTeamService : IStudioTeamService
         return summary;
     }
 
-    public async Task<StudioTeamSummaryResponse> UpdateAsync(
+    public async Task<StudioTeamCommandResponse> UpdateAsync(
         string scopeId,
         string teamId,
         UpdateStudioTeamRequest request,
@@ -91,17 +91,15 @@ public sealed class StudioTeamService : IStudioTeamService
                     $"description must be at most {StudioTeamInputLimits.MaxDescriptionLength} characters.");
         }
 
-        await _commandPort.UpdateAsync(scopeId, teamId, request, ct);
-        return await GetAsync(scopeId, teamId, ct);
+        return await _commandPort.UpdateAsync(scopeId, teamId, request, ct);
     }
 
-    public async Task<StudioTeamSummaryResponse> ArchiveAsync(
+    public Task<StudioTeamCommandResponse> ArchiveAsync(
         string scopeId,
         string teamId,
         CancellationToken ct = default)
     {
-        await _commandPort.ArchiveAsync(scopeId, teamId, ct);
-        return await GetAsync(scopeId, teamId, ct);
+        return _commandPort.ArchiveAsync(scopeId, teamId, ct);
     }
 
     public async Task SetEntryMemberAsync(

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
@@ -204,6 +204,10 @@ internal static class StudioTeamEndpoints
                 teamId,
                 new UpdateStudioTeamRequest(displayNamePatch, descriptionPatch),
                 ct);
+            // Refactor (iter96/cluster-547):
+            //   Old: dispatch then GetAsync readmodel returned 200 OK + snapshot (pretending completion).
+            //   New: no readmodel read; 202 Accepted + Location points to stable team query resource,
+            //        body only carries accepted/no_change receipt.
             return Results.Accepted(BuildTeamLocation(scopeId, teamId), receipt);
         }
         catch (StudioTeamNotFoundException ex)
@@ -229,6 +233,10 @@ internal static class StudioTeamEndpoints
         try
         {
             var receipt = await teamService.ArchiveAsync(scopeId, teamId, ct);
+            // Refactor (iter96/cluster-547):
+            //   Old: dispatch then GetAsync readmodel returned 200 OK + snapshot (pretending completion).
+            //   New: no readmodel read; 202 Accepted + Location points to stable team query resource,
+            //        body only carries accepted/no_change receipt.
             return Results.Accepted(BuildTeamLocation(scopeId, teamId), receipt);
         }
         catch (StudioTeamNotFoundException ex)

--- a/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
+++ b/src/Aevatar.Studio.Hosting/Endpoints/StudioTeamEndpoints.cs
@@ -199,12 +199,12 @@ internal static class StudioTeamEndpoints
 
         try
         {
-            var detail = await teamService.UpdateAsync(
+            var receipt = await teamService.UpdateAsync(
                 scopeId,
                 teamId,
                 new UpdateStudioTeamRequest(displayNamePatch, descriptionPatch),
                 ct);
-            return Results.Ok(detail);
+            return Results.Accepted(BuildTeamLocation(scopeId, teamId), receipt);
         }
         catch (StudioTeamNotFoundException ex)
         {
@@ -228,7 +228,8 @@ internal static class StudioTeamEndpoints
 
         try
         {
-            return Results.Ok(await teamService.ArchiveAsync(scopeId, teamId, ct));
+            var receipt = await teamService.ArchiveAsync(scopeId, teamId, ct);
+            return Results.Accepted(BuildTeamLocation(scopeId, teamId), receipt);
         }
         catch (StudioTeamNotFoundException ex)
         {

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioTeamCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioTeamCommandService.cs
@@ -69,7 +69,7 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
             UpdatedAt: createdAt);
     }
 
-    public async Task UpdateAsync(
+    public async Task<StudioTeamCommandResponse> UpdateAsync(
         string scopeId,
         string teamId,
         UpdateStudioTeamRequest request,
@@ -82,7 +82,12 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
 
         // No-op if the patch payload carries no field to change.
         if (!request.DisplayName.HasValue && !request.Description.HasValue)
-            return;
+        {
+            return new StudioTeamCommandResponse(
+                StudioTeamCommandStatusNames.NoChange,
+                normalizedScopeId,
+                normalizedTeamId);
+        }
 
         var evt = new StudioTeamUpdatedEvent
         {
@@ -104,10 +109,11 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
             evt.Description = request.Description.Value ?? string.Empty;
         }
 
-        await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
+        var receipt = await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
+        return ToAcceptedResponse(normalizedScopeId, normalizedTeamId, receipt);
     }
 
-    public async Task ArchiveAsync(
+    public async Task<StudioTeamCommandResponse> ArchiveAsync(
         string scopeId,
         string teamId,
         CancellationToken ct = default)
@@ -122,7 +128,8 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
             ArchivedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
 
-        await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
+        var receipt = await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
+        return ToAcceptedResponse(normalizedScopeId, normalizedTeamId, receipt);
     }
 
     public async Task SetEntryMemberAsync(
@@ -164,7 +171,11 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
         await DispatchAsync(normalizedScopeId, normalizedTeamId, evt, ct);
     }
 
-    private async Task DispatchAsync(string scopeId, string teamId, IMessage payload, CancellationToken ct)
+    private async Task<StudioProjectionActorCommandReceipt> DispatchAsync(
+        string scopeId,
+        string teamId,
+        IMessage payload,
+        CancellationToken ct)
     {
         var actorId = StudioTeamConventions.BuildActorId(scopeId, teamId);
         // Refactor (iter56/cluster-910-projection-activation-cleanup):
@@ -172,8 +183,20 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
         //   new=committed-state plan provider
         //   team commands return after accepted dispatch, not readmodel materialization.
         var actor = await _bootstrap.EnsureAsync<StudioTeamGAgent>(actorId, ct);
-        await _commandDispatch.DispatchAsync(actor, payload, PublisherId, ct: ct);
+        return await _commandDispatch.DispatchAsync(actor, payload, PublisherId, ct: ct);
     }
+
+    private static StudioTeamCommandResponse ToAcceptedResponse(
+        string scopeId,
+        string teamId,
+        StudioProjectionActorCommandReceipt receipt) =>
+        new(
+            StudioTeamCommandStatusNames.Accepted,
+            scopeId,
+            teamId,
+            receipt.CommandId,
+            receipt.CorrelationId,
+            receipt.AckedAt);
 
     private static string GenerateTeamId()
     {

--- a/src/Aevatar.Studio.Projection/CommandServices/StudioProjectionActorCommandDispatch.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/StudioProjectionActorCommandDispatch.cs
@@ -36,7 +36,8 @@ internal sealed class StudioProjectionActorCommandTarget(IActor actor) : IActorC
 internal sealed record StudioProjectionActorCommandReceipt(
     string ActorId,
     string CommandId,
-    string CorrelationId);
+    string CorrelationId,
+    DateTimeOffset? AckedAt = null);
 
 internal sealed record StudioProjectionActorCommandStartError(string Message);
 
@@ -139,7 +140,9 @@ internal sealed class StudioProjectionActorCommandDispatch
                 result.Error?.Message ?? "Studio projection actor command dispatch failed.");
         }
 
-        return result.Receipt;
+        return result.Admission == null
+            ? result.Receipt
+            : result.Receipt with { AckedAt = result.Admission.AckedAt };
     }
 }
 

--- a/test/Aevatar.CQRS.Core.Tests/CqrsCoreDefaultsTests.cs
+++ b/test/Aevatar.CQRS.Core.Tests/CqrsCoreDefaultsTests.cs
@@ -174,6 +174,8 @@ public class CommandDispatchPipelineTests
 
         result.Succeeded.Should().BeTrue();
         result.Receipt.Should().Be("receipt-1");
+        result.Admission.Should().NotBeNull();
+        result.Admission!.CommandId.Should().Be("evt-1");
     }
 
     [Fact]

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioTeamCommandServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioTeamCommandServiceTests.cs
@@ -69,12 +69,18 @@ public sealed class ActorDispatchStudioTeamCommandServiceTests
         var dispatch = new RecordingDispatchPort();
         var service = new ActorDispatchStudioTeamCommandService(new RecordingBootstrap(), CreateCommandDispatch(dispatch));
 
-        await service.UpdateAsync(
+        var receipt = await service.UpdateAsync(
             ScopeId, "t-1",
             new UpdateStudioTeamRequest(DisplayName: PatchValue<string>.Of("New Name")),
             CancellationToken.None);
 
         dispatch.Dispatches.Should().ContainSingle();
+        receipt.Status.Should().Be(StudioTeamCommandStatusNames.Accepted);
+        receipt.ScopeId.Should().Be(ScopeId);
+        receipt.TeamId.Should().Be("t-1");
+        receipt.CommandId.Should().Be(dispatch.Dispatches[0].Envelope.Id);
+        receipt.CorrelationId.Should().Be(receipt.CommandId);
+        receipt.AckedAt.Should().NotBeNull();
         var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioTeamUpdatedEvent>();
         evt.HasDisplayName.Should().BeTrue();
         evt.DisplayName.Should().Be("New Name");
@@ -105,12 +111,16 @@ public sealed class ActorDispatchStudioTeamCommandServiceTests
         var dispatch = new RecordingDispatchPort();
         var service = new ActorDispatchStudioTeamCommandService(new RecordingBootstrap(), CreateCommandDispatch(dispatch));
 
-        await service.UpdateAsync(
+        var receipt = await service.UpdateAsync(
             ScopeId, "t-1",
             new UpdateStudioTeamRequest(),
             CancellationToken.None);
 
         dispatch.Dispatches.Should().BeEmpty();
+        receipt.Status.Should().Be(StudioTeamCommandStatusNames.NoChange);
+        receipt.ScopeId.Should().Be(ScopeId);
+        receipt.TeamId.Should().Be("t-1");
+        receipt.CommandId.Should().BeNull();
     }
 
     [Fact]
@@ -141,11 +151,14 @@ public sealed class ActorDispatchStudioTeamCommandServiceTests
         var dispatch = new RecordingDispatchPort();
         var service = new ActorDispatchStudioTeamCommandService(bootstrap, CreateCommandDispatch(dispatch));
 
-        await service.ArchiveAsync(ScopeId, "t-1", CancellationToken.None);
+        var receipt = await service.ArchiveAsync(ScopeId, "t-1", CancellationToken.None);
 
         bootstrap.EnsuredActorIds.Should().ContainSingle()
             .Which.Should().Be("studio-team:scope-1:t-1");
         dispatch.Dispatches.Should().ContainSingle();
+        receipt.Status.Should().Be(StudioTeamCommandStatusNames.Accepted);
+        receipt.CommandId.Should().Be(dispatch.Dispatches[0].Envelope.Id);
+        receipt.AckedAt.Should().NotBeNull();
 
         var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioTeamArchivedEvent>();
         evt.TeamId.Should().Be("t-1");

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointTests.cs
@@ -97,7 +97,7 @@ public sealed class StudioTeamEndpointTests
     }
 
     [Fact]
-    public async Task HandlePatchAsync_ShouldReturn200_WhenUpdateSucceeds()
+    public async Task HandlePatchAsync_ShouldReturn202WithReceipt_WhenUpdateSucceeds()
     {
         var service = new InMemoryTeamService(NewSummary());
         var body = new StudioTeamEndpoints.StudioTeamPatchBody
@@ -113,7 +113,10 @@ public sealed class StudioTeamEndpointTests
             service,
             CancellationToken.None);
 
-        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        var accepted = result.Should().BeOfType<Accepted<StudioTeamCommandResponse>>().Subject;
+        accepted.Location.Should().Be($"/api/scopes/{ScopeId}/teams/{TeamId}");
+        accepted.Value!.Status.Should().Be(StudioTeamCommandStatusNames.Accepted);
+        accepted.Value.CommandId.Should().Be("cmd-1");
     }
 
     [Fact]
@@ -213,7 +216,7 @@ public sealed class StudioTeamEndpointTests
             service,
             CancellationToken.None);
 
-        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        GetStatusCode(result).Should().Be(StatusCodes.Status202Accepted);
     }
 
     [Fact]
@@ -233,11 +236,11 @@ public sealed class StudioTeamEndpointTests
             service,
             CancellationToken.None);
 
-        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        GetStatusCode(result).Should().Be(StatusCodes.Status202Accepted);
     }
 
     [Fact]
-    public async Task HandleArchiveAsync_ShouldReturn200_WhenSuccessful()
+    public async Task HandleArchiveAsync_ShouldReturn202WithReceipt_WhenSuccessful()
     {
         var service = new InMemoryTeamService(NewSummary());
         var result = await InvokeTeamHandle(
@@ -248,7 +251,10 @@ public sealed class StudioTeamEndpointTests
             service,
             CancellationToken.None);
 
-        GetStatusCode(result).Should().Be(StatusCodes.Status200OK);
+        var accepted = result.Should().BeOfType<Accepted<StudioTeamCommandResponse>>().Subject;
+        accepted.Location.Should().Be($"/api/scopes/{ScopeId}/teams/{TeamId}");
+        accepted.Value!.Status.Should().Be(StudioTeamCommandStatusNames.Accepted);
+        accepted.Value.CommandId.Should().Be("cmd-1");
     }
 
     [Fact]
@@ -546,13 +552,13 @@ public sealed class StudioTeamEndpointTests
             return Task.FromResult(_summary);
         }
 
-        public Task<StudioTeamSummaryResponse> UpdateAsync(
+        public Task<StudioTeamCommandResponse> UpdateAsync(
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default) =>
-            Task.FromResult(_summary);
+            Task.FromResult(NewAccepted(scopeId, teamId));
 
-        public Task<StudioTeamSummaryResponse> ArchiveAsync(
+        public Task<StudioTeamCommandResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) =>
-            Task.FromResult(_summary);
+            Task.FromResult(NewAccepted(scopeId, teamId));
 
         public Task SetEntryMemberAsync(
             string scopeId,
@@ -572,6 +578,15 @@ public sealed class StudioTeamEndpointTests
             ClearEntryCalls++;
             return Task.CompletedTask;
         }
+
+        private static StudioTeamCommandResponse NewAccepted(string scopeId, string teamId) =>
+            new(
+                StudioTeamCommandStatusNames.Accepted,
+                scopeId,
+                teamId,
+                "cmd-1",
+                "corr-1",
+                DateTimeOffset.UtcNow);
     }
 
     private sealed class ThrowingTeamService : IStudioTeamService
@@ -585,9 +600,9 @@ public sealed class StudioTeamEndpointTests
             string scopeId, StudioTeamRosterPageRequest? page = null, CancellationToken ct = default) => throw _ex;
         public Task<StudioTeamSummaryResponse> GetAsync(
             string scopeId, string teamId, CancellationToken ct = default) => throw _ex;
-        public Task<StudioTeamSummaryResponse> UpdateAsync(
+        public Task<StudioTeamCommandResponse> UpdateAsync(
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default) => throw _ex;
-        public Task<StudioTeamSummaryResponse> ArchiveAsync(
+        public Task<StudioTeamCommandResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) => throw _ex;
         public Task SetEntryMemberAsync(
             string scopeId,

--- a/test/Aevatar.Studio.Tests/StudioTeamEndpointsRouteBindingTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamEndpointsRouteBindingTests.cs
@@ -56,13 +56,13 @@ public sealed class StudioTeamEndpointsRouteBindingTests
             string scopeId, string teamId, CancellationToken ct = default) =>
             Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
 
-        public Task<StudioTeamSummaryResponse> UpdateAsync(
+        public Task<StudioTeamCommandResponse> UpdateAsync(
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default) =>
-            Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
+            Task.FromException<StudioTeamCommandResponse>(new NotImplementedException());
 
-        public Task<StudioTeamSummaryResponse> ArchiveAsync(
+        public Task<StudioTeamCommandResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default) =>
-            Task.FromException<StudioTeamSummaryResponse>(new NotImplementedException());
+            Task.FromException<StudioTeamCommandResponse>(new NotImplementedException());
 
         public Task SetEntryMemberAsync(
             string scopeId,

--- a/test/Aevatar.Studio.Tests/StudioTeamServiceTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamServiceTests.cs
@@ -124,13 +124,13 @@ public sealed class StudioTeamServiceTests
     }
 
     [Fact]
-    public async Task UpdateAsync_ShouldDelegateAndReRead()
+    public async Task UpdateAsync_ShouldReturnAcceptedReceiptWithoutPostDispatchRead()
     {
         var commandPort = new RecordingCommandPort();
-        var summary = NewSummary();
+        var queryPort = new InMemoryQueryPort(null);
         var service = new StudioTeamService(
             commandPort,
-            new InMemoryQueryPort(summary),
+            queryPort,
             new InMemoryMemberQueryPort(null));
 
         var result = await service.UpdateAsync(
@@ -138,23 +138,29 @@ public sealed class StudioTeamServiceTests
             new UpdateStudioTeamRequest(DisplayName: PatchValue<string>.Of("Beta")));
 
         commandPort.UpdateCalls.Should().Be(1);
-        result.Should().NotBeNull();
+        queryPort.GetCalls.Should().Be(0);
+        result.Status.Should().Be(StudioTeamCommandStatusNames.Accepted);
+        result.TeamId.Should().Be(TeamId);
+        result.CommandId.Should().Be("cmd-1");
     }
 
     [Fact]
-    public async Task ArchiveAsync_ShouldDelegateAndReRead()
+    public async Task ArchiveAsync_ShouldReturnAcceptedReceiptWithoutPostDispatchRead()
     {
         var commandPort = new RecordingCommandPort();
-        var summary = NewSummary();
+        var queryPort = new InMemoryQueryPort(null);
         var service = new StudioTeamService(
             commandPort,
-            new InMemoryQueryPort(summary),
+            queryPort,
             new InMemoryMemberQueryPort(null));
 
         var result = await service.ArchiveAsync(ScopeId, TeamId);
 
         commandPort.ArchiveCalls.Should().Be(1);
-        result.Should().NotBeNull();
+        queryPort.GetCalls.Should().Be(0);
+        result.Status.Should().Be(StudioTeamCommandStatusNames.Accepted);
+        result.TeamId.Should().Be(TeamId);
+        result.CommandId.Should().Be("cmd-1");
     }
 
     [Fact]
@@ -402,18 +408,18 @@ public sealed class StudioTeamServiceTests
                 UpdatedAt: DateTimeOffset.UtcNow));
         }
 
-        public Task UpdateAsync(
+        public Task<StudioTeamCommandResponse> UpdateAsync(
             string scopeId, string teamId, UpdateStudioTeamRequest request, CancellationToken ct = default)
         {
             UpdateCalls++;
-            return Task.CompletedTask;
+            return Task.FromResult(NewAccepted(scopeId, teamId));
         }
 
-        public Task ArchiveAsync(
+        public Task<StudioTeamCommandResponse> ArchiveAsync(
             string scopeId, string teamId, CancellationToken ct = default)
         {
             ArchiveCalls++;
-            return Task.CompletedTask;
+            return Task.FromResult(NewAccepted(scopeId, teamId));
         }
 
         public Task SetEntryMemberAsync(
@@ -435,6 +441,15 @@ public sealed class StudioTeamServiceTests
             ClearEntryCalls++;
             return Task.CompletedTask;
         }
+
+        private static StudioTeamCommandResponse NewAccepted(string scopeId, string teamId) =>
+            new(
+                StudioTeamCommandStatusNames.Accepted,
+                scopeId,
+                teamId,
+                "cmd-1",
+                "corr-1",
+                DateTimeOffset.UtcNow);
     }
 
     private sealed class InMemoryMemberQueryPort : IStudioMemberQueryPort


### PR DESCRIPTION
## Summary
- `IStudioTeamCommandPort` + `IStudioTeamService` `UpdateAsync/ArchiveAsync` 改返回 `StudioTeamCommandResponse`(accepted receipt:commandId + ackedAt)
- `StudioTeamService` 不再 dispatch 后调 `GetAsync`(消除 post-dispatch stale snapshot 伪装完成)
- `StudioTeamEndpoints.HandlePatchAsync/HandleArchiveAsync` 改 `202 Accepted` + `Location: /api/studio/teams/{id}` header,body 只 accepted/no_change receipt
- 测试:`DelegateAndReRead / 200 OK` 语义 → `accepted receipt`;readmodel 为 null 时 service 不做 post-dispatch read
- ADR-0017 更新

15 files: +152 / -57。

## Phase 9 consensus
`META_JUDGE_DONE:consensus:return-accepted-receipt-202-with-stable-location-not-post-dispatch-snapshot`

Closes #547

⟦AI:AUTO-LOOP⟧