### PR TITLE
iter96 cluster-544: durable team roster fanout via actor-event-driven contract

### DIFF
--- a/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
+++ b/agents/Aevatar.GAgents.StudioMember/StudioMemberGAgent.cs
@@ -239,9 +239,8 @@ public sealed class StudioMemberGAgent : GAgentBase<StudioMemberState>, IProject
     ///
     /// from_team_id must agree with the current state.team_id — this guards
     /// against stale or hand-crafted events committing against a roster the
-    /// member no longer claims to be on. The destination TeamGAgents are
-    /// dispatched the same event by the application command port and apply
-    /// idempotent set operations to their own roster.
+    /// member no longer claims to be on. Durable TeamGAgent fanout is driven
+    /// by this committed event through the projection materialization actor.
     /// </summary>
     [EventHandler(EndpointName = "reassignTeam")]
     public async Task HandleReassigned(StudioMemberReassignedEvent evt)

--- a/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
+++ b/agents/Aevatar.GAgents.StudioMember/studio_member_messages.proto
@@ -328,8 +328,9 @@ message StudioMemberBindingTerminalAcknowledged {
 }
 
 // Single reassignment event covers assign / unassign / move (ADR-0017).
-// Both source and destination StudioTeamGAgents apply idempotent set
-// operations against this event.
+// A durable committed-state consumer dispatches this committed event to the
+// source and destination StudioTeamGAgents. Each TeamGAgent applies
+// idempotent set operations against this event.
 //
 // from_team_id and to_team_id are `optional` so absence carries the
 // "unassigned" intent; empty-string sentinels are not used.

--- a/agents/Aevatar.GAgents.StudioTeam/StudioTeamGAgent.cs
+++ b/agents/Aevatar.GAgents.StudioTeam/StudioTeamGAgent.cs
@@ -17,11 +17,11 @@ namespace Aevatar.GAgents.StudioTeam;
 /// (<see cref="StudioTeamCreatedEvent"/>, <see cref="StudioTeamUpdatedEvent"/>,
 /// <see cref="StudioTeamArchivedEvent"/>) and one cross-actor signal
 /// (<see cref="StudioMemberReassignedEvent"/>) emitted by
-/// <see cref="StudioMemberGAgent"/>. The application command port is
-/// responsible for delivering reassign events to both source and destination
-/// TeamGAgents; this actor applies idempotent set operations on
-/// <c>member_ids</c> and persists a <see cref="StudioTeamMemberRosterChangedEvent"/>
-/// reflecting the resulting effect (ADDED / REMOVED / NOOP).
+/// <see cref="StudioMemberGAgent"/> and delivered by the durable committed
+/// state materialization path. This actor applies idempotent set operations
+/// on <c>member_ids</c> and persists a
+/// <see cref="StudioTeamMemberRosterChangedEvent"/> reflecting the resulting
+/// effect (ADDED / REMOVED / NOOP).
 ///
 /// Lifecycle is monotonic: <c>ACTIVE -> ARCHIVED</c>. Archive is irreversible
 /// and is a metadata signal only — it does <em>not</em> reject member

--- a/agents/Aevatar.GAgents.StudioTeam/studio_team_messages.proto
+++ b/agents/Aevatar.GAgents.StudioTeam/studio_team_messages.proto
@@ -20,7 +20,8 @@ enum StudioTeamLifecycleStage {
 //   studio-team:{scopeId}:{teamId}
 //
 // member_ids is the persisted roster (set semantics) — mutated only via
-// idempotent set operations on committed StudioMemberReassignedEvent.
+// idempotent set operations on committed StudioMemberReassignedEvent
+// delivered by the durable committed-state materialization path.
 // member_count is a derived projection of member_ids.size() and is written
 // alongside on each StudioTeamMemberRosterChangedEvent commit.
 message StudioTeamState {

--- a/docs/adr/0017-studio-team-first-class-aggregate.md
+++ b/docs/adr/0017-studio-team-first-class-aggregate.md
@@ -121,8 +121,10 @@ Rationale:
   (e.g. team-scoped permissions) and avoids re-litigating the count protocol
   later.
 - For reassignment, `StudioMemberGAgent` emits a single
-  `StudioMemberReassignedEvent { from_team_id, to_team_id }`. Both source and
-  destination TeamGAgents subscribe to member events and apply set operations:
+  `StudioMemberReassignedEvent { from_team_id, to_team_id }`. The durable
+  Studio materialization projection consumes the committed member event and
+  dispatches it into the affected TeamGAgent inboxes, where they apply set
+  operations:
   - `from = "T1"` matches → T1 removes the member_id (idempotent: no-op if absent)
   - `to = "T2"` matches → T2 adds the member_id (idempotent: no-op if present)
   - Pure assignment (`from_team_id` absent) is the same protocol with `from` absent.
@@ -330,10 +332,12 @@ Concretely:
 - "Member create with initial team": when `POST /api/scopes/{scopeId}/members`
   carries a non-empty `teamId`, the application service validates that the team
   exists (read-model check), then the command port dispatches two events
-  sequentially — `StudioMemberCreatedEvent` first (no team field), then
+  sequentially to `StudioMemberGAgent` only — `StudioMemberCreatedEvent` first
+  (no team field), then
   `StudioMemberReassignedEvent { from_team_id absent, to_team_id = T }`.
-  Member-side event ordering is guaranteed; TeamGAgent observes the
-  reassignment asynchronously (eventually consistent).
+  Member-side event ordering is guaranteed; Team roster fanout happens
+  asynchronously from the committed reassignment fact through the durable
+  projection materializer.
   `StudioMemberCreatedEvent` is **not** extended with a `team_id` field.
 - The Team read model has no fact that is not authoritative in `StudioTeamGAgent`.
 
@@ -489,8 +493,9 @@ existing):
 // string is rejected at the application layer (see ADR-0017 §Q6).
 optional string team_id = 50;
 
-// Single reassignment event covers assign / unassign / move. Both source and
-// destination TeamGAgents subscribe and apply idempotent set operations.
+// Single reassignment event covers assign / unassign / move. The durable
+// materializer dispatches committed events to source and destination
+// TeamGAgents, which apply idempotent set operations.
 // from_team_id and to_team_id are `optional` so "unassigned" is presence=false
 // rather than empty-string sentinel — proto3 cannot distinguish unset string
 // from "" otherwise (see ADR-0017 §Q6 layered handling).
@@ -518,7 +523,7 @@ message StudioMemberReassignedEvent {
 
 > **Note on first-time assignment via member create.** When `POST /api/scopes/{scopeId}/members`
 > is invoked with a non-empty `teamId`, the application command port dispatches
-> two events sequentially to `StudioMemberGAgent`:
+> two events sequentially to `StudioMemberGAgent` only:
 >
 > 1. `StudioMemberCreatedEvent` (no `team_id` field — created event keeps a
 >    single responsibility), then
@@ -526,13 +531,13 @@ message StudioMemberReassignedEvent {
 >
 > The two events are dispatched sequentially by the application command port.
 > Member-side event ordering is guaranteed (Created lands before Reassigned),
-> but TeamGAgent observes the reassignment asynchronously — there is a brief
-> eventually-consistent window where the member exists but the Team's roster
-> has not yet materialized the addition. This is normal projection lag.
-> TeamGAgent only
-> subscribes to `StudioMemberReassignedEvent`; `StudioMemberCreatedEvent`
-> never feeds the team pipeline. This keeps the event vocabulary minimal and
-> avoids extending `StudioMemberCreatedEvent` with a `team_id` field. See
+> but Team roster fanout is driven later by the durable Studio materialization
+> projection after it observes the committed reassignment fact. The materializer
+> sends the same typed event into the affected TeamGAgent inboxes with stable
+> command and deduplication IDs, so committed-event replay retries failed
+> fanout instead of silently dropping it. `StudioMemberCreatedEvent` never
+> feeds the team pipeline. This keeps the event vocabulary minimal and avoids
+> extending `StudioMemberCreatedEvent` with a `team_id` field. See
 > §Locked Rule 4 and §Cutover Order step 3.
 
 ### Read model
@@ -627,9 +632,10 @@ would otherwise need its own consistency contract.
 - Frontend no longer infers teams from unrelated scope assets.
 - Member contract remains the primary object per ADR-0016; team is an
   optional grouping that composes on top.
-- A small amount of cross-actor projection work is added: TeamGAgent must
-  subscribe to committed member events. This is the standard projection
-  pipeline pattern, not a new mechanism.
+- A small amount of cross-actor projection work is added: the Studio
+  materialization projection consumes committed member reassignment events and
+  dispatches them into affected TeamGAgent inboxes. This is the standard
+  projection pipeline pattern, not a new mechanism.
 - TeamGAgent state grows linearly with team size because the full `member_ids`
   roster is persisted (required for idempotent event processing). v1 caps
   expected size at < 10,000 members per team; very large groupings need a
@@ -652,14 +658,16 @@ would otherwise need its own consistency contract.
    `to_team_id`). Reject empty-string `team_id` at the application layer.
    `StudioMemberCreatedEvent` is **not** extended with a `team_id` field.
 4. Wire the application command port so that `POST /members` with a non-empty
-   `teamId` dispatches two events sequentially — first
-   `StudioMemberCreatedEvent`, then `StudioMemberReassignedEvent
+   `teamId` dispatches two events sequentially to `StudioMemberGAgent` only —
+   first `StudioMemberCreatedEvent`, then `StudioMemberReassignedEvent
    { from_team_id absent, to_team_id = T }`. Member-side ordering is
    guaranteed; team roster update is eventually consistent.
-5. Wire `StudioTeamGAgent` to subscribe to committed
-   `StudioMemberReassignedEvent` and apply idempotent set operations to
-   `member_ids`, emitting `StudioTeamMemberRosterChangedEvent` with the
-   correct `effect` (ADDED / REMOVED / NOOP).
+5. Wire the Studio materialization projection to consume committed
+   `StudioMemberReassignedEvent` facts and dispatch them into affected
+   `StudioTeamGAgent` inboxes with stable command / deduplication IDs. Each
+   TeamGAgent applies idempotent set operations to `member_ids`, emitting
+   `StudioTeamMemberRosterChangedEvent` with the correct `effect`
+   (ADDED / REMOVED / NOOP).
 6. Add `StudioTeamCurrentStateDocument` read model and the standard projector.
 7. Extend member endpoints (`POST` / `PATCH`) to accept `teamId` per the Merge
    Patch table in §HTTP endpoints. The application DTO must carry a

--- a/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberCommandPort.cs
+++ b/src/Aevatar.Studio.Application/Studio/Abstractions/IStudioMemberCommandPort.cs
@@ -49,10 +49,10 @@ public interface IStudioMemberCommandPort
     /// assign passes <c>fromTeamId == null</c>; pure unassign passes
     /// <c>toTeamId == null</c>; move passes both.
     ///
-    /// The implementation dispatches the same <c>StudioMemberReassignedEvent</c>
-    /// to the member actor and to the affected TeamGAgents (source and / or
-    /// destination), where each TeamGAgent applies an idempotent set
-    /// operation against its persisted roster.
+    /// The implementation dispatches <c>StudioMemberReassignedEvent</c> only
+    /// to the member actor. A durable committed-state consumer fans the
+    /// committed event out to affected TeamGAgents, where each TeamGAgent
+    /// applies an idempotent set operation against its persisted roster.
     /// </summary>
     Task ReassignTeamAsync(
         string scopeId,

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
@@ -19,7 +19,6 @@ namespace Aevatar.Studio.Projection.CommandServices;
 internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCommandPort
 {
     private const string MemberPublisherId = "aevatar.studio.projection.studio-member";
-    private const string TeamPublisherId = "aevatar.studio.projection.studio-team";
     private const string BindingRunPublisherId = "aevatar.studio.projection.studio-member-binding-run";
 
     private readonly IStudioActorBootstrap _bootstrap;
@@ -73,11 +72,11 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
 
         // Two-event create-with-team protocol (ADR-0017 §Locked Rule 3).
         // When the request carries a non-empty teamId, dispatch a
-        // Reassigned event after the Created event. The two dispatches
-        // are sequential — not atomic within one actor turn — so there
-        // is a brief window where the member exists without a team
-        // assignment. The team's roster update is eventually consistent:
-        // idempotent set ops ensure duplicates/retries collapse to NOOP.
+        // Reassigned event after the Created event to the member actor only.
+        // The durable projection materializer later fans the committed
+        // reassignment fact out to the Team actor inbox. That keeps command
+        // ACK semantics honest and lets projection replay recover roster
+        // fanout without this command service driving team roster updates.
         if (!string.IsNullOrEmpty(request.TeamId))
         {
             var initialTeamId = StudioTeamConventions.NormalizeTeamId(request.TeamId);
@@ -165,37 +164,13 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
         if (toTeamIdNormalized != null)
             evt.ToTeamId = toTeamIdNormalized;
 
-        // Step 1: dispatch the authority change to the member actor.
-        // MemberGAgent owns the team_id fact and rejects events whose
-        // from_team_id disagrees with the member's current state.
+        // Dispatch only the authority change to the member actor. Durable
+        // Team roster fanout is driven from the committed member event by
+        // the Studio materialization projection scope, not by this command
+        // service. That keeps the command ACK honest: member reassignment was
+        // accepted for dispatch, while Team roster visibility is recovered
+        // from committed facts and projection watermarks.
         await DispatchAsync(normalizedScopeId, normalizedMemberId, evt, ct);
-
-        // Step 2: fan out the same event to the affected TeamGAgents.
-        // Each team applies an idempotent set operation to its roster —
-        // duplicate deliveries collapse to NOOP by construction. Cross-
-        // actor consistency relies on the idempotency, not on transactional
-        // delivery: a re-run of this method (e.g. retry after a transient
-        // failure) lands on a NOOP for already-applied sides.
-        if (fromTeamIdNormalized != null)
-        {
-            await DispatchToTeamAsync(normalizedScopeId, fromTeamIdNormalized, evt, ct);
-        }
-        if (toTeamIdNormalized != null)
-        {
-            await DispatchToTeamAsync(normalizedScopeId, toTeamIdNormalized, evt, ct);
-        }
-    }
-
-    private async Task DispatchToTeamAsync(
-        string scopeId, string teamId, IMessage payload, CancellationToken ct)
-    {
-        var actorId = StudioTeamConventions.BuildActorId(scopeId, teamId);
-        // Refactor (iter56/cluster-910-projection-activation-cleanup):
-        //   old=command-path pre-dispatch activation
-        //   new=committed-state plan provider
-        //   team fanout provisions only the receiving actor.
-        var actor = await _bootstrap.EnsureAsync<StudioTeamGAgent>(actorId, ct);
-        await _commandDispatch.DispatchAsync(actor, payload, TeamPublisherId, ct);
     }
 
     public async Task UpdateImplementationAsync(
@@ -250,7 +225,7 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
             RequestedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
 
-        await _commandDispatch.DispatchAsync(actor, payload, BindingRunPublisherId, ct);
+        await _commandDispatch.DispatchAsync(actor, payload, BindingRunPublisherId, ct: ct);
     }
 
     private static StudioMemberImplementationRef BuildImplementationRefMessage(
@@ -368,7 +343,7 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
         //   new=committed-state plan provider
         //   member commands only provision actor and dispatch accepted work.
         var actor = await _bootstrap.EnsureAsync<StudioMemberGAgent>(actorId, ct);
-        await _commandDispatch.DispatchAsync(actor, payload, MemberPublisherId, ct);
+        await _commandDispatch.DispatchAsync(actor, payload, MemberPublisherId, ct: ct);
     }
 
     private static string GenerateMemberId()

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioMemberCommandService.cs
@@ -151,6 +151,9 @@ internal sealed class ActorDispatchStudioMemberCommandService : IStudioMemberCom
         string? toTeamIdNormalized,
         CancellationToken ct)
     {
+        // Refactor (iter96/cluster-544):
+        //   Old: command service dispatch 后顺序 fanout 到 team service(不可靠,无 durable)
+        //   New: committed state event -> StudioTeamRosterFanoutMaterializer 投递 team actor inbox(durable + actor retry)
         var reassignedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
 
         var evt = new StudioMemberReassignedEvent

--- a/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioTeamCommandService.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/ActorDispatchStudioTeamCommandService.cs
@@ -172,7 +172,7 @@ internal sealed class ActorDispatchStudioTeamCommandService : IStudioTeamCommand
         //   new=committed-state plan provider
         //   team commands return after accepted dispatch, not readmodel materialization.
         var actor = await _bootstrap.EnsureAsync<StudioTeamGAgent>(actorId, ct);
-        await _commandDispatch.DispatchAsync(actor, payload, PublisherId, ct);
+        await _commandDispatch.DispatchAsync(actor, payload, PublisherId, ct: ct);
     }
 
     private static string GenerateTeamId()

--- a/src/Aevatar.Studio.Projection/CommandServices/StudioProjectionActorCommandDispatch.cs
+++ b/src/Aevatar.Studio.Projection/CommandServices/StudioProjectionActorCommandDispatch.cs
@@ -64,18 +64,27 @@ internal sealed class StudioProjectionActorCommandTargetResolver
 internal sealed class StudioProjectionActorCommandEnvelopeFactory
     : ICommandEnvelopeFactory<StudioProjectionActorCommand>
 {
+    internal const string DeduplicationOperationIdHeader = "aevatar-deduplication-operation-id";
+
     public EventEnvelope CreateEnvelope(StudioProjectionActorCommand command, CommandContext context)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(context);
 
-        return new EventEnvelope
+        var envelope = new EventEnvelope
         {
             Id = context.CommandId,
             Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
             Payload = Any.Pack(command.Payload),
             Route = EnvelopeRouteSemantics.CreateDirect(command.PublisherId, context.TargetId),
         };
+        if (context.Headers.TryGetValue(DeduplicationOperationIdHeader, out var deduplicationOperationId) &&
+            !string.IsNullOrWhiteSpace(deduplicationOperationId))
+        {
+            envelope.EnsureRuntime().EnsureDeduplication().OperationId = deduplicationOperationId;
+        }
+
+        return envelope;
     }
 }
 
@@ -108,10 +117,21 @@ internal sealed class StudioProjectionActorCommandDispatch
         IActor actor,
         IMessage payload,
         string publisherId,
+        string? commandId = null,
+        string? correlationId = null,
+        string? deduplicationOperationId = null,
         CancellationToken ct = default)
     {
+        var headers = string.IsNullOrWhiteSpace(deduplicationOperationId)
+            ? null
+            : new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [StudioProjectionActorCommandEnvelopeFactory.DeduplicationOperationIdHeader] =
+                    deduplicationOperationId,
+            };
+
         var result = await _dispatchService.DispatchAsync(
-            new StudioProjectionActorCommand(actor, payload, publisherId),
+            new StudioProjectionActorCommand(actor, payload, publisherId, commandId, correlationId, headers),
             ct);
         if (!result.Succeeded || result.Receipt is null)
         {

--- a/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.Studio.Projection/DependencyInjection/ServiceCollectionExtensions.cs
@@ -100,6 +100,10 @@ public static class ServiceCollectionExtensions
 
         services.AddCurrentStateProjectionMaterializer<
             StudioMaterializationContext,
+            StudioTeamRosterFanoutMaterializer>();
+
+        services.AddCurrentStateProjectionMaterializer<
+            StudioMaterializationContext,
             StudioTeamCurrentStateProjector>();
 
         services.AddCurrentStateProjectionMaterializer<

--- a/src/Aevatar.Studio.Projection/Projectors/StudioTeamRosterFanoutMaterializer.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioTeamRosterFanoutMaterializer.cs
@@ -1,0 +1,84 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.StudioMember;
+using Aevatar.GAgents.StudioTeam;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Orchestration;
+using Google.Protobuf;
+
+namespace Aevatar.Studio.Projection.Projectors;
+
+/// <summary>
+/// Durable fanout from committed StudioMember reassignment facts to the
+/// affected StudioTeam actors. The enclosing projection scope owns the
+/// source-event watermark and retained failure envelopes; Team actor inbox
+/// retry owns per-target handler retry.
+/// </summary>
+internal sealed class StudioTeamRosterFanoutMaterializer
+    : ICurrentStateProjectionMaterializer<StudioMaterializationContext>
+{
+    private const string PublisherId = "aevatar.studio.projection.team-roster-fanout";
+
+    private readonly IStudioActorBootstrap _bootstrap;
+    private readonly StudioProjectionActorCommandDispatch _commandDispatch;
+
+    public StudioTeamRosterFanoutMaterializer(
+        IStudioActorBootstrap bootstrap,
+        StudioProjectionActorCommandDispatch commandDispatch)
+    {
+        _bootstrap = bootstrap ?? throw new ArgumentNullException(nameof(bootstrap));
+        _commandDispatch = commandDispatch ?? throw new ArgumentNullException(nameof(commandDispatch));
+    }
+
+    public async ValueTask ProjectAsync(
+        StudioMaterializationContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (!CommittedStateEventEnvelope.TryUnpack(envelope, out var published) ||
+            published?.StateEvent?.EventData == null ||
+            !published.StateEvent.EventData.Is(StudioMemberReassignedEvent.Descriptor))
+        {
+            return;
+        }
+
+        var evt = published.StateEvent.EventData.Unpack<StudioMemberReassignedEvent>();
+        if (evt.HasFromTeamId)
+            await DispatchToTeamAsync(evt.ScopeId, evt.FromTeamId, evt, ct).ConfigureAwait(false);
+        if (evt.HasToTeamId)
+            await DispatchToTeamAsync(evt.ScopeId, evt.ToTeamId, evt, ct).ConfigureAwait(false);
+    }
+
+    private async Task DispatchToTeamAsync(
+        string scopeId,
+        string teamId,
+        IMessage payload,
+        CancellationToken ct)
+    {
+        var actorId = StudioTeamConventions.BuildActorId(scopeId, teamId);
+        var actor = await _bootstrap.EnsureAsync<StudioTeamGAgent>(actorId, ct).ConfigureAwait(false);
+        await _commandDispatch.DispatchAsync(
+            actor,
+            payload,
+            PublisherId,
+            commandId: BuildFanoutCommandId(actorId, payload),
+            deduplicationOperationId: BuildFanoutDeduplicationId(actorId, payload),
+            ct: ct).ConfigureAwait(false);
+    }
+
+    private static string BuildFanoutCommandId(string actorId, IMessage payload)
+    {
+        var eventHash = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(payload.ToByteArray()))
+            .ToLowerInvariant();
+        return $"{PublisherId}:{actorId}:{eventHash}";
+    }
+
+    private static string BuildFanoutDeduplicationId(string actorId, IMessage payload) =>
+        BuildFanoutCommandId(actorId, payload);
+}

--- a/src/Aevatar.Studio.Projection/Projectors/StudioTeamRosterFanoutMaterializer.cs
+++ b/src/Aevatar.Studio.Projection/Projectors/StudioTeamRosterFanoutMaterializer.cs
@@ -15,6 +15,9 @@ namespace Aevatar.Studio.Projection.Projectors;
 /// affected StudioTeam actors. The enclosing projection scope owns the
 /// source-event watermark and retained failure envelopes; Team actor inbox
 /// retry owns per-target handler retry.
+/// Refactor (iter96/cluster-544):
+///   Old: command service dispatch 后顺序 fanout 到 team service(不可靠,无 durable)
+///   New: committed state event -> StudioTeamRosterFanoutMaterializer 投递 team actor inbox(durable + actor retry)
 /// </summary>
 internal sealed class StudioTeamRosterFanoutMaterializer
     : ICurrentStateProjectionMaterializer<StudioMaterializationContext>

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberReassignTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberReassignTests.cs
@@ -15,7 +15,7 @@ public sealed class ActorDispatchStudioMemberReassignTests
     private const string ScopeId = "scope-1";
 
     [Fact]
-    public async Task CreateAsync_WithTeamId_ShouldDispatchCreatedThenReassigned()
+    public async Task CreateAsync_WithTeamId_ShouldDispatchCreatedThenMemberReassignedOnly()
     {
         var bootstrap = new RecordingBootstrap();
         var dispatch = new RecordingDispatchPort();
@@ -32,7 +32,7 @@ public sealed class ActorDispatchStudioMemberReassignTests
 
         summary.TeamId.Should().Be("t-1");
 
-        dispatch.Dispatches.Should().HaveCount(3);
+        dispatch.Dispatches.Should().HaveCount(2);
 
         dispatch.Dispatches[0].Envelope.Payload.Is(StudioMemberCreatedEvent.Descriptor).Should().BeTrue();
         var created = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioMemberCreatedEvent>();
@@ -43,8 +43,7 @@ public sealed class ActorDispatchStudioMemberReassignTests
         reassigned.HasFromTeamId.Should().BeFalse();
         reassigned.ToTeamId.Should().Be("t-1");
 
-        dispatch.Dispatches[2].Envelope.Payload.Is(StudioMemberReassignedEvent.Descriptor).Should().BeTrue();
-        dispatch.Dispatches[2].ActorId.Should().StartWith("studio-team:");
+        dispatch.Dispatches.Should().OnlyContain(x => x.ActorId.StartsWith("studio-member:", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -68,7 +67,7 @@ public sealed class ActorDispatchStudioMemberReassignTests
     }
 
     [Fact]
-    public async Task ReassignTeamAsync_ShouldDispatchToMemberAndTeams()
+    public async Task ReassignTeamAsync_ShouldDispatchToMemberOnly()
     {
         var bootstrap = new RecordingBootstrap();
         var dispatch = new RecordingDispatchPort();
@@ -80,19 +79,16 @@ public sealed class ActorDispatchStudioMemberReassignTests
             toTeamId: "t-new",
             CancellationToken.None);
 
-        dispatch.Dispatches.Should().HaveCount(3);
+        dispatch.Dispatches.Should().ContainSingle();
 
         dispatch.Dispatches[0].ActorId.Should().Be("studio-member:scope-1:m-1");
         var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioMemberReassignedEvent>();
         evt.FromTeamId.Should().Be("t-old");
         evt.ToTeamId.Should().Be("t-new");
-
-        dispatch.Dispatches[1].ActorId.Should().Be("studio-team:scope-1:t-old");
-        dispatch.Dispatches[2].ActorId.Should().Be("studio-team:scope-1:t-new");
     }
 
     [Fact]
-    public async Task ReassignTeamAsync_PureAssign_ShouldDispatchToMemberAndDestTeam()
+    public async Task ReassignTeamAsync_PureAssign_ShouldDispatchToMemberOnly()
     {
         var dispatch = new RecordingDispatchPort();
         var service = new ActorDispatchStudioMemberCommandService(new RecordingBootstrap(), CreateCommandDispatch(dispatch));
@@ -103,9 +99,8 @@ public sealed class ActorDispatchStudioMemberReassignTests
             toTeamId: "t-new",
             CancellationToken.None);
 
-        dispatch.Dispatches.Should().HaveCount(2);
+        dispatch.Dispatches.Should().ContainSingle();
         dispatch.Dispatches[0].ActorId.Should().Be("studio-member:scope-1:m-1");
-        dispatch.Dispatches[1].ActorId.Should().Be("studio-team:scope-1:t-new");
 
         var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioMemberReassignedEvent>();
         evt.HasFromTeamId.Should().BeFalse();
@@ -113,7 +108,7 @@ public sealed class ActorDispatchStudioMemberReassignTests
     }
 
     [Fact]
-    public async Task ReassignTeamAsync_PureUnassign_ShouldDispatchToMemberAndSourceTeam()
+    public async Task ReassignTeamAsync_PureUnassign_ShouldDispatchToMemberOnly()
     {
         var dispatch = new RecordingDispatchPort();
         var service = new ActorDispatchStudioMemberCommandService(new RecordingBootstrap(), CreateCommandDispatch(dispatch));
@@ -124,9 +119,8 @@ public sealed class ActorDispatchStudioMemberReassignTests
             toTeamId: null,
             CancellationToken.None);
 
-        dispatch.Dispatches.Should().HaveCount(2);
+        dispatch.Dispatches.Should().ContainSingle();
         dispatch.Dispatches[0].ActorId.Should().Be("studio-member:scope-1:m-1");
-        dispatch.Dispatches[1].ActorId.Should().Be("studio-team:scope-1:t-old");
 
         var evt = dispatch.Dispatches[0].Envelope.Payload.Unpack<StudioMemberReassignedEvent>();
         evt.FromTeamId.Should().Be("t-old");

--- a/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberReassignTests.cs
+++ b/test/Aevatar.Studio.Tests/ActorDispatchStudioMemberReassignTests.cs
@@ -128,26 +128,26 @@ public sealed class ActorDispatchStudioMemberReassignTests
     }
 
     [Fact]
-    public void ReassignTeamAsync_BothNull_ShouldReject()
+    public async Task ReassignTeamAsync_BothNull_ShouldReject()
     {
         var service = new ActorDispatchStudioMemberCommandService(new RecordingBootstrap(), CreateCommandDispatch(new RecordingDispatchPort()));
 
         var act = () => service.ReassignTeamAsync(
             ScopeId, "m-1", fromTeamId: null, toTeamId: null);
 
-        act.Should().ThrowAsync<InvalidOperationException>()
+        await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*at least one*");
     }
 
     [Fact]
-    public void ReassignTeamAsync_BothEqual_ShouldReject()
+    public async Task ReassignTeamAsync_BothEqual_ShouldReject()
     {
         var service = new ActorDispatchStudioMemberCommandService(new RecordingBootstrap(), CreateCommandDispatch(new RecordingDispatchPort()));
 
         var act = () => service.ReassignTeamAsync(
             ScopeId, "m-1", fromTeamId: "t-same", toTeamId: "t-same");
 
-        act.Should().ThrowAsync<InvalidOperationException>()
+        await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*must differ*");
     }
 

--- a/test/Aevatar.Studio.Tests/StudioTeamRosterFanoutMaterializerTests.cs
+++ b/test/Aevatar.Studio.Tests/StudioTeamRosterFanoutMaterializerTests.cs
@@ -1,0 +1,243 @@
+using Aevatar.CQRS.Core.Commands;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.StudioMember;
+using Aevatar.Studio.Application.Studio.Abstractions;
+using Aevatar.Studio.Projection.CommandServices;
+using Aevatar.Studio.Projection.Orchestration;
+using Aevatar.Studio.Projection.Projectors;
+using FluentAssertions;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Studio.Tests;
+
+public sealed class StudioTeamRosterFanoutMaterializerTests
+{
+    private const string RootActorId = "studio-member:scope-1:m-1";
+
+    [Fact]
+    public async Task ProjectAsync_ShouldDispatchCommittedReassignmentToAffectedTeamActors()
+    {
+        var bootstrap = new RecordingBootstrap();
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioTeamRosterFanoutMaterializer(
+            bootstrap,
+            CreateCommandDispatch(dispatch));
+
+        var reassigned = new StudioMemberReassignedEvent
+        {
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            FromTeamId = "t-old",
+            ToTeamId = "t-new",
+            ReassignedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+        };
+
+        await materializer.ProjectAsync(NewContext(), WrapCommitted(reassigned, version: 7, eventId: "evt-7"));
+
+        bootstrap.EnsuredActorIds.Should().Equal(
+            "studio-team:scope-1:t-old",
+            "studio-team:scope-1:t-new");
+        dispatch.Dispatches.Should().HaveCount(2);
+        dispatch.Dispatches.Select(x => x.ActorId).Should().Equal(
+            "studio-team:scope-1:t-old",
+            "studio-team:scope-1:t-new");
+        dispatch.Dispatches.Should().OnlyContain(x =>
+            x.Envelope.Payload.Is(StudioMemberReassignedEvent.Descriptor));
+        dispatch.Dispatches.Select(x => x.Envelope.Id).Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldUseStableCommandId_ForCommittedEventReplay()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioTeamRosterFanoutMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatch));
+        var envelope = WrapCommitted(new StudioMemberReassignedEvent
+        {
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            ToTeamId = "t-new",
+            ReassignedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+        }, version: 8, eventId: "evt-8");
+
+        await materializer.ProjectAsync(NewContext(), envelope);
+        await materializer.ProjectAsync(NewContext(), envelope.Clone());
+
+        dispatch.Dispatches.Should().HaveCount(2);
+        dispatch.Dispatches[0].ActorId.Should().Be("studio-team:scope-1:t-new");
+        dispatch.Dispatches[1].ActorId.Should().Be("studio-team:scope-1:t-new");
+        dispatch.Dispatches[1].Envelope.Id.Should().Be(dispatch.Dispatches[0].Envelope.Id);
+        dispatch.Dispatches[1].Envelope.Runtime?.Deduplication?.OperationId
+            .Should().Be(dispatch.Dispatches[0].Envelope.Runtime?.Deduplication?.OperationId);
+        dispatch.Dispatches[0].Envelope.Runtime?.Deduplication?.OperationId
+            .Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldPropagateDispatchFailure_ForProjectionRetry()
+    {
+        var materializer = new StudioTeamRosterFanoutMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(new ThrowingDispatchPort()));
+        var envelope = WrapCommitted(new StudioMemberReassignedEvent
+        {
+            ScopeId = "scope-1",
+            MemberId = "m-1",
+            ToTeamId = "t-new",
+            ReassignedAtUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-25T00:00:00Z")),
+        }, version: 9, eventId: "evt-9");
+
+        await FluentActions
+            .Awaiting(() => materializer.ProjectAsync(NewContext(), envelope).AsTask())
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("dispatch failed");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldNoOp_WhenCommittedEventIsNotReassignment()
+    {
+        var dispatch = new RecordingDispatchPort();
+        var materializer = new StudioTeamRosterFanoutMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(dispatch));
+
+        await materializer.ProjectAsync(
+            NewContext(),
+            WrapCommitted(new StudioMemberCreatedEvent { MemberId = "m-1" }, version: 1, eventId: "evt-1"));
+
+        dispatch.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldRejectNullArguments()
+    {
+        var materializer = new StudioTeamRosterFanoutMaterializer(
+            new RecordingBootstrap(),
+            CreateCommandDispatch(new RecordingDispatchPort()));
+
+        await FluentActions
+            .Awaiting(() => materializer.ProjectAsync(null!, new EventEnvelope()).AsTask())
+            .Should().ThrowAsync<ArgumentNullException>();
+        await FluentActions
+            .Awaiting(() => materializer.ProjectAsync(NewContext(), null!).AsTask())
+            .Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNullDependencies()
+    {
+        var dispatch = CreateCommandDispatch(new RecordingDispatchPort());
+
+        FluentActions
+            .Invoking(() => new StudioTeamRosterFanoutMaterializer(null!, dispatch))
+            .Should().Throw<ArgumentNullException>();
+        FluentActions
+            .Invoking(() => new StudioTeamRosterFanoutMaterializer(new RecordingBootstrap(), null!))
+            .Should().Throw<ArgumentNullException>();
+    }
+
+    private static StudioMaterializationContext NewContext() => new()
+    {
+        RootActorId = RootActorId,
+        ProjectionKind = "studio-member",
+    };
+
+    private static EventEnvelope WrapCommitted(
+        IMessage payload,
+        long version,
+        string eventId) =>
+        new()
+        {
+            Id = eventId,
+            Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+            Route = EnvelopeRouteSemantics.CreateObserverPublication(RootActorId),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = version,
+                    EventData = Any.Pack(payload),
+                    Timestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+                    AgentId = RootActorId,
+                },
+                StateRoot = Any.Pack(new StudioMemberState
+                {
+                    ScopeId = "scope-1",
+                    MemberId = "m-1",
+                }),
+            }),
+        };
+
+    private sealed class RecordingBootstrap : IStudioActorBootstrap
+    {
+        public List<string> EnsuredActorIds { get; } = [];
+
+        public Task<IActor> EnsureAsync<TAgent>(string actorId, CancellationToken ct = default)
+            where TAgent : IAgent, IProjectedActor
+        {
+            EnsuredActorIds.Add(actorId);
+            return Task.FromResult<IActor>(new StubActor(actorId));
+        }
+    }
+
+    private sealed class StubActor(string id) : IActor
+    {
+        public string Id { get; } = id;
+        public IAgent Agent => throw new NotSupportedException();
+        public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task HandleEventAsync(EventEnvelope envelope, CancellationToken ct = default) =>
+            Task.CompletedTask;
+        public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
+        public Task<IReadOnlyList<string>> GetChildrenIdsAsync() =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private sealed class RecordingDispatchPort : IActorDispatchPort
+    {
+        public List<DispatchedCommand> Dispatches { get; } = [];
+
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default)
+        {
+            Dispatches.Add(new DispatchedCommand(actorId, envelope));
+            return Task.FromResult(DispatchAdmissionFactory.Create(actorId, envelope));
+        }
+
+        public sealed record DispatchedCommand(string ActorId, EventEnvelope Envelope);
+    }
+
+    private sealed class ThrowingDispatchPort : IActorDispatchPort
+    {
+        public Task<DispatchAdmission> DispatchAsync(
+            string actorId,
+            EventEnvelope envelope,
+            CancellationToken ct = default) =>
+            throw new InvalidOperationException("dispatch failed");
+    }
+
+    private static StudioProjectionActorCommandDispatch CreateCommandDispatch(IActorDispatchPort dispatchPort)
+    {
+        var service = new Aevatar.CQRS.Core.Commands.DefaultCommandDispatchService<
+            StudioProjectionActorCommand,
+            StudioProjectionActorCommandTarget,
+            StudioProjectionActorCommandReceipt,
+            StudioProjectionActorCommandStartError>(
+            new Aevatar.CQRS.Core.Commands.DefaultCommandDispatchPipeline<
+                StudioProjectionActorCommand,
+                StudioProjectionActorCommandTarget,
+                StudioProjectionActorCommandReceipt,
+                StudioProjectionActorCommandStartError>(
+                new StudioProjectionActorCommandTargetResolver(),
+                new DefaultCommandContextPolicy(),
+                new StudioProjectionActorCommandEnvelopeFactory(),
+                new Aevatar.CQRS.Core.Commands.ActorCommandTargetDispatcher<StudioProjectionActorCommandTarget>(dispatchPort),
+                new StudioProjectionActorCommandReceiptFactory()));
+        return new StudioProjectionActorCommandDispatch(service);
+    }
+}


### PR DESCRIPTION
## Summary
- 删除 member 提交后 command-service 顺序 fanout(不可靠)
- StudioMember commit `PublishMemberStateChange` event,StudioTeam actor 订阅消费(durable + actor inbox 自动 retry)
- 新 `StudioTeamRosterFanoutMaterializer` projector
- Fanout 失败不 silent drop
- ADR-0017 update

12 files。

## Phase 9 consensus
`META_JUDGE_DONE:consensus:make-team-roster-fanout-durable-via-actor-event-driven-contract`

Closes #544

⟦AI:AUTO-LOOP⟧