### PR TITLE
iter97 cluster-098: typed bounded executor port 取代会话 actor Task.Run 业务 IO

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -400,14 +400,27 @@ public sealed partial class ConversationGAgent
         ConversationTurnRuntimeContext runtimeContext)
     {
         var runner = ResolveCardRunner();
-        _ = Task.Run(() => ExecuteLarkCardCreateOperationAsync(
-            runner,
-            evt.Clone(),
-            correlationId,
-            streamingElementId,
-            sequence,
-            generation,
-            runtimeContext));
+        var executor = ResolveBusinessIoExecutor();
+        var workItemId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Create, sequence, generation);
+        // Refactor (iter97/cluster-098): Old pattern: raw Task.Run launched CardKit create IO from the actor turn.
+        // New principle: actor has already recorded in-flight intent/timeout; bounded executor owns the business IO and returns via existing completion event.
+        _ = executor.SubmitAsync(
+            new LongRunningBusinessIoWorkItem(
+                workItemId,
+                Id,
+                "lark-card-create",
+                correlationId,
+                StreamingFailureUpdateTimeout,
+                ct => ExecuteLarkCardCreateOperationAsync(
+                    runner,
+                    evt.Clone(),
+                    correlationId,
+                    streamingElementId,
+                    sequence,
+                    generation,
+                    runtimeContext,
+                    ct)),
+            CancellationToken.None);
     }
 
     private async Task ExecuteLarkCardCreateOperationAsync(
@@ -417,7 +430,8 @@ public sealed partial class ConversationGAgent
         string streamingElementId,
         long sequence,
         long generation,
-        ConversationTurnRuntimeContext runtimeContext)
+        ConversationTurnRuntimeContext runtimeContext,
+        CancellationToken ct)
     {
         LarkCardOperationCompletedEvent signal;
         try
@@ -426,7 +440,7 @@ public sealed partial class ConversationGAgent
                     chunk,
                     streamingElementId,
                     runtimeContext,
-                    CancellationToken.None)
+                    ct)
                 .ConfigureAwait(false);
             signal = new LarkCardOperationCompletedEvent
             {
@@ -471,15 +485,30 @@ public sealed partial class ConversationGAgent
         ConversationTurnRuntimeContext runtimeContext)
     {
         var runner = ResolveCardRunner();
-        _ = Task.Run(() => ExecuteLarkCardStreamOperationAsync(
-            runner,
-            evt.Clone(),
-            correlationId,
-            state.CardId ?? string.Empty,
-            state.StreamingElementId,
-            sequence,
-            generation,
-            runtimeContext));
+        var executor = ResolveBusinessIoExecutor();
+        var cardId = state.CardId ?? string.Empty;
+        var streamingElementId = state.StreamingElementId;
+        var workItemId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Stream, sequence, generation);
+        // Refactor (iter97/cluster-098): Old pattern: raw Task.Run launched CardKit stream IO from the actor turn.
+        // New principle: actor has already recorded in-flight intent/timeout; bounded executor owns the business IO and returns via existing completion event.
+        _ = executor.SubmitAsync(
+            new LongRunningBusinessIoWorkItem(
+                workItemId,
+                Id,
+                "lark-card-stream",
+                correlationId,
+                StreamingFailureUpdateTimeout,
+                ct => ExecuteLarkCardStreamOperationAsync(
+                    runner,
+                    evt.Clone(),
+                    correlationId,
+                    cardId,
+                    streamingElementId,
+                    sequence,
+                    generation,
+                    runtimeContext,
+                    ct)),
+            CancellationToken.None);
     }
 
     private async Task ExecuteLarkCardStreamOperationAsync(
@@ -490,7 +519,8 @@ public sealed partial class ConversationGAgent
         string streamingElementId,
         long sequence,
         long generation,
-        ConversationTurnRuntimeContext runtimeContext)
+        ConversationTurnRuntimeContext runtimeContext,
+        CancellationToken ct)
     {
         LarkCardOperationCompletedEvent signal;
         try
@@ -501,7 +531,7 @@ public sealed partial class ConversationGAgent
                     streamingElementId,
                     sequence,
                     runtimeContext,
-                    CancellationToken.None)
+                    ct)
                 .ConfigureAwait(false);
             signal = new LarkCardOperationCompletedEvent
             {
@@ -553,20 +583,37 @@ public sealed partial class ConversationGAgent
         ConversationTurnRuntimeContext runtimeContext)
     {
         var runner = ResolveCardRunner();
-        _ = Task.Run(() => ExecuteLarkCardFinalizeOperationAsync(
-            runner,
-            activityForToken.Clone(),
-            correlationId,
-            commandId,
-            state.CardId ?? string.Empty,
-            state.CardMessageId ?? string.Empty,
-            state.StreamingElementId,
-            finalText,
-            state.LastFlushedText,
-            finalDiffers,
-            sequence,
-            generation,
-            runtimeContext));
+        var executor = ResolveBusinessIoExecutor();
+        var cardId = state.CardId ?? string.Empty;
+        var cardMessageId = state.CardMessageId ?? string.Empty;
+        var streamingElementId = state.StreamingElementId;
+        var lastFlushedText = state.LastFlushedText;
+        var workItemId = BuildLarkCardOperationId(correlationId, LarkCardOperationPhase.Finalize, sequence, generation);
+        // Refactor (iter97/cluster-098): Old pattern: raw Task.Run launched CardKit finalize IO from the actor turn.
+        // New principle: actor has already recorded in-flight intent/timeout; bounded executor owns the business IO and returns via existing completion event.
+        _ = executor.SubmitAsync(
+            new LongRunningBusinessIoWorkItem(
+                workItemId,
+                Id,
+                "lark-card-finalize",
+                correlationId,
+                StreamingFailureUpdateTimeout,
+                ct => ExecuteLarkCardFinalizeOperationAsync(
+                    runner,
+                    activityForToken.Clone(),
+                    correlationId,
+                    commandId,
+                    cardId,
+                    cardMessageId,
+                    streamingElementId,
+                    finalText,
+                    lastFlushedText,
+                    finalDiffers,
+                    sequence,
+                    generation,
+                    runtimeContext,
+                    ct)),
+            CancellationToken.None);
     }
 
     private async Task ExecuteLarkCardFinalizeOperationAsync(
@@ -582,7 +629,8 @@ public sealed partial class ConversationGAgent
         bool finalDiffers,
         long sequence,
         long generation,
-        ConversationTurnRuntimeContext runtimeContext)
+        ConversationTurnRuntimeContext runtimeContext,
+        CancellationToken ct)
     {
         LarkCardOperationCompletedEvent signal;
         try
@@ -595,7 +643,7 @@ public sealed partial class ConversationGAgent
                     finalDiffers,
                     sequence,
                     runtimeContext,
-                    CancellationToken.None)
+                    ct)
                 .ConfigureAwait(false);
             signal = new LarkCardOperationCompletedEvent
             {

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -1151,19 +1151,32 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         ConversationTurnRuntimeContext runtimeContext)
     {
         var runner = ResolveRunner();
-        _ = Task.Run(() => ExecuteNyxRelayTextOperationAsync(
-            runner,
-            operation,
-            chunk.Clone(),
-            correlationId,
-            currentPlatformMessageId,
-            commandId,
-            finalText,
-            lastFlushedText,
-            editCount,
-            sequence,
-            generation,
-            runtimeContext));
+        var executor = ResolveBusinessIoExecutor();
+        var workItemId = BuildNyxRelayTextOperationId(correlationId, operation, sequence, generation);
+        // Refactor (iter97/cluster-098): Old pattern: raw Task.Run launched Nyx relay text IO from the actor turn.
+        // New principle: actor has already recorded in-flight intent/timeout; bounded executor owns the business IO and returns via existing completion event.
+        _ = executor.SubmitAsync(
+            new LongRunningBusinessIoWorkItem(
+                workItemId,
+                Id,
+                $"nyx-relay-text-{operation}",
+                correlationId,
+                StreamingFailureUpdateTimeout,
+                ct => ExecuteNyxRelayTextOperationAsync(
+                    runner,
+                    operation,
+                    chunk.Clone(),
+                    correlationId,
+                    currentPlatformMessageId,
+                    commandId,
+                    finalText,
+                    lastFlushedText,
+                    editCount,
+                    sequence,
+                    generation,
+                    runtimeContext,
+                    ct)),
+            CancellationToken.None);
     }
 
     private async Task ExecuteNyxRelayTextOperationAsync(
@@ -1178,17 +1191,17 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         int editCount,
         long sequence,
         long generation,
-        ConversationTurnRuntimeContext runtimeContext)
+        ConversationTurnRuntimeContext runtimeContext,
+        CancellationToken ct)
     {
         NyxRelayTextOperationCompletedEvent signal;
         try
         {
-            using var cts = new CancellationTokenSource(StreamingFailureUpdateTimeout);
             var result = await runner.RunStreamChunkAsync(
                     chunk,
                     currentPlatformMessageId,
                     runtimeContext,
-                    cts.Token)
+                    ct)
                 .ConfigureAwait(false);
             signal = new NyxRelayTextOperationCompletedEvent
             {
@@ -1909,6 +1922,9 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
 
     private IConversationTurnRunner ResolveRunner() =>
         Services.GetService<IConversationTurnRunner>() ?? new NullConversationTurnRunner();
+
+    private ILongRunningBusinessIoExecutor ResolveBusinessIoExecutor() =>
+        Services.GetRequiredService<ILongRunningBusinessIoExecutor>();
 
     private ConversationTurnRuntimeContext BuildNyxRelayRuntimeContext(
         string? correlationId,

--- a/agents/Aevatar.GAgents.Channel.Runtime/DependencyInjection/ChannelRuntimeServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/DependencyInjection/ChannelRuntimeServiceCollectionExtensions.cs
@@ -53,6 +53,8 @@ public static class ChannelRuntimeServiceCollectionExtensions
         services.TryAddSingleton<TracingMiddleware>();
         services.TryAddSingleton<IConversationTurnRunner, NullConversationTurnRunner>();
         services.TryAddSingleton<IConversationCardTurnRunner, NullConversationCardTurnRunner>();
+        services.AddOptions<LongRunningBusinessIoExecutorOptions>();
+        services.TryAddSingleton<ILongRunningBusinessIoExecutor, LongRunningBusinessIoExecutor>();
 
         // ─── Tombstone compaction options + materialized watermark ───
         services.AddOptions<ChannelRuntimeTombstoneCompactionOptions>();

--- a/agents/Aevatar.GAgents.Channel.Runtime/ILongRunningBusinessIoExecutor.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ILongRunningBusinessIoExecutor.cs
@@ -1,0 +1,182 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Threading.Channels;
+
+namespace Aevatar.GAgents.Channel.Runtime;
+
+/// <summary>
+/// Runtime-owned bounded executor for business IO that must continue after an actor turn records intent.
+/// </summary>
+public interface ILongRunningBusinessIoExecutor
+{
+    Task SubmitAsync(LongRunningBusinessIoWorkItem workItem, CancellationToken ct);
+}
+
+public sealed record LongRunningBusinessIoWorkItem(
+    string WorkItemId,
+    string OwnerActorId,
+    string OperationName,
+    string CorrelationId,
+    TimeSpan Timeout,
+    Func<CancellationToken, Task> ExecuteAsync);
+
+public sealed class LongRunningBusinessIoExecutorOptions
+{
+    public int MaxConcurrency { get; set; } = 8;
+
+    public int QueueCapacity { get; set; } = 256;
+
+    public TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromMinutes(5);
+}
+
+// Refactor (iter97/cluster-098): Old pattern: actor code launched raw Task.Run business IO from the actor turn.
+// New principle: actor records intent + timeout, then submits typed bounded work to this runtime-owned executor.
+public sealed class LongRunningBusinessIoExecutor :
+    ILongRunningBusinessIoExecutor,
+    IDisposable,
+    IAsyncDisposable
+{
+    private readonly Channel<LongRunningBusinessIoWorkItem> _queue;
+    private readonly CancellationTokenSource _stopping = new();
+    private readonly Task[] _workers;
+    private readonly LongRunningBusinessIoExecutorOptions _options;
+    private readonly ILogger<LongRunningBusinessIoExecutor> _logger;
+    private bool _disposed;
+
+    public LongRunningBusinessIoExecutor(
+        IOptions<LongRunningBusinessIoExecutorOptions>? options,
+        ILogger<LongRunningBusinessIoExecutor> logger)
+    {
+        _options = options?.Value ?? new LongRunningBusinessIoExecutorOptions();
+        if (_options.MaxConcurrency <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options), "MaxConcurrency must be positive.");
+        if (_options.QueueCapacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options), "QueueCapacity must be positive.");
+
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _queue = global::System.Threading.Channels.Channel.CreateBounded<LongRunningBusinessIoWorkItem>(
+            new BoundedChannelOptions(_options.QueueCapacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = _options.MaxConcurrency == 1,
+                SingleWriter = false,
+            });
+        _workers = Enumerable
+            .Range(0, _options.MaxConcurrency)
+            .Select(index => Task.Factory.StartNew(
+                static state => ((LongRunningBusinessIoExecutor)state!).WorkerLoopAsync(),
+                this,
+                CancellationToken.None,
+                TaskCreationOptions.DenyChildAttach,
+                TaskScheduler.Default).Unwrap())
+            .ToArray();
+    }
+
+    public async Task SubmitAsync(LongRunningBusinessIoWorkItem workItem, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+        ThrowIfInvalid(workItem);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        await _queue.Writer.WriteAsync(workItem, ct).ConfigureAwait(false);
+        _logger.LogDebug(
+            "Accepted long-running business IO work: owner={OwnerActorId}, operation={OperationName}, correlation={CorrelationId}, workItem={WorkItemId}",
+            workItem.OwnerActorId,
+            workItem.OperationName,
+            workItem.CorrelationId,
+            workItem.WorkItemId);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _queue.Writer.TryComplete();
+        _stopping.Cancel();
+        _stopping.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _queue.Writer.TryComplete();
+        await _stopping.CancelAsync().ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(_workers).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        _stopping.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task WorkerLoopAsync()
+    {
+        try
+        {
+            await foreach (var workItem in _queue.Reader.ReadAllAsync(_stopping.Token).ConfigureAwait(false))
+            {
+                await ExecuteWorkItemAsync(workItem).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task ExecuteWorkItemAsync(LongRunningBusinessIoWorkItem workItem)
+    {
+        var timeout = workItem.Timeout > TimeSpan.Zero
+            ? workItem.Timeout
+            : _options.DefaultTimeout;
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_stopping.Token);
+        if (timeout > TimeSpan.Zero)
+            timeoutCts.CancelAfter(timeout);
+
+        try
+        {
+            await workItem.ExecuteAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested && !_stopping.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                ex,
+                "Long-running business IO work timed out: owner={OwnerActorId}, operation={OperationName}, correlation={CorrelationId}, workItem={WorkItemId}, timeout={Timeout}",
+                workItem.OwnerActorId,
+                workItem.OperationName,
+                workItem.CorrelationId,
+                workItem.WorkItemId,
+                timeout);
+        }
+        catch (OperationCanceledException) when (_stopping.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Long-running business IO work failed without producing its typed completion: owner={OwnerActorId}, operation={OperationName}, correlation={CorrelationId}, workItem={WorkItemId}",
+                workItem.OwnerActorId,
+                workItem.OperationName,
+                workItem.CorrelationId,
+                workItem.WorkItemId);
+        }
+    }
+
+    private static void ThrowIfInvalid(LongRunningBusinessIoWorkItem workItem)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workItem.WorkItemId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workItem.OwnerActorId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workItem.OperationName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(workItem.CorrelationId);
+        ArgumentNullException.ThrowIfNull(workItem.ExecuteAsync);
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -16,6 +16,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
     private const string PublisherActorId = "agent-run-reply-generation-executor";
     private readonly IActorDispatchPort _actorDispatchPort;
     private readonly IActorHandledDispatchPort? _actorHandledDispatchPort;
+    private readonly ILongRunningBusinessIoExecutor _businessIoExecutor;
     private readonly IConversationReplyGenerator _replyGenerator;
     private readonly IInteractiveReplyCollector? _interactiveReplyCollector;
     private readonly Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? _relayOptions;
@@ -26,6 +27,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
 
     public AgentRunReplyGenerationExecutor(
         IActorDispatchPort actorDispatchPort,
+        ILongRunningBusinessIoExecutor businessIoExecutor,
         IConversationReplyGenerator replyGenerator,
         IInteractiveReplyCollector? interactiveReplyCollector,
         Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions? relayOptions,
@@ -36,6 +38,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         IActorHandledDispatchPort? actorHandledDispatchPort = null)
     {
         _actorDispatchPort = actorDispatchPort ?? throw new ArgumentNullException(nameof(actorDispatchPort));
+        _businessIoExecutor = businessIoExecutor ?? throw new ArgumentNullException(nameof(businessIoExecutor));
         _replyGenerator = replyGenerator ?? throw new ArgumentNullException(nameof(replyGenerator));
         _interactiveReplyCollector = interactiveReplyCollector;
         _relayOptions = relayOptions;
@@ -51,15 +54,26 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         ArgumentNullException.ThrowIfNull(request);
         ct.ThrowIfCancellationRequested();
         var workItem = request with { Request = request.Request.Clone() };
-        _ = Task.Run(() => ExecuteAndReportAsync(workItem), CancellationToken.None);
-        return Task.CompletedTask;
+        // Refactor (iter97/cluster-098): Old pattern: raw Task.Run launched deferred LLM reply business IO from the run actor path.
+        // New principle: actor has recorded generation intent/timeout; bounded executor owns LLM IO and returns via existing completion/failure events.
+        return _businessIoExecutor.SubmitAsync(
+            new LongRunningBusinessIoWorkItem(
+                BuildWorkItemId(workItem),
+                workItem.RunActorId,
+                "agent-run-reply-generation",
+                workItem.Request.CorrelationId,
+                ResolveFallbackTimeout(),
+                executorCt => ExecuteAndReportAsync(workItem, executorCt)),
+            ct);
     }
 
-    private async Task ExecuteAndReportAsync(AgentRunReplyGenerationExecutionRequest workItem)
+    private async Task ExecuteAndReportAsync(
+        AgentRunReplyGenerationExecutionRequest workItem,
+        CancellationToken ct)
     {
         try
         {
-            var completed = await ExecuteAsync(workItem).ConfigureAwait(false);
+            var completed = await ExecuteAsync(workItem, ct).ConfigureAwait(false);
             await DispatchToRunActorAsync(workItem.RunActorId, completed, CancellationToken.None)
                 .ConfigureAwait(false);
         }
@@ -98,7 +112,8 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
     }
 
     internal async Task<AgentRunReplyGenerationCompleted> ExecuteAsync(
-        AgentRunReplyGenerationExecutionRequest workItem)
+        AgentRunReplyGenerationExecutionRequest workItem,
+        CancellationToken ct = default)
     {
         var request = workItem.Request.Clone();
         string replyText;
@@ -110,8 +125,9 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         var streamingState = TryBuildStreamingReplyState(streamingSink);
 
         ReplyGenerationContext generationContext;
-        using (var metadataCts = new CancellationTokenSource(AgentRunGAgent.MetadataBuildBudget))
+        using (var metadataCts = CancellationTokenSource.CreateLinkedTokenSource(ct))
         {
+            metadataCts.CancelAfter(AgentRunGAgent.MetadataBuildBudget);
             try
             {
                 generationContext = await BuildGenerationContextAsync(request, metadataCts.Token)
@@ -137,9 +153,9 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         }
 
         var fallbackTimeout = ResolveFallbackTimeout();
-        using var timeoutCts = fallbackTimeout > TimeSpan.Zero
-            ? new CancellationTokenSource(fallbackTimeout)
-            : new CancellationTokenSource();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        if (fallbackTimeout > TimeSpan.Zero)
+            timeoutCts.CancelAfter(fallbackTimeout);
 
         try
         {
@@ -235,6 +251,9 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
 
         return BuildCompleted(workItem, request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
     }
+
+    private static string BuildWorkItemId(AgentRunReplyGenerationExecutionRequest workItem) =>
+        $"{workItem.RunId}:{workItem.Request.CorrelationId}:{workItem.Attempt}";
 
     private AgentRunReplyGenerationCompleted BuildCompleted(
         AgentRunReplyGenerationExecutionRequest workItem,

--- a/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ServiceCollectionExtensions.cs
@@ -41,6 +41,8 @@ public static class ServiceCollectionExtensions
 
         services.AddCqrsCore();
         services.AddHttpClient();
+        services.AddOptions<LongRunningBusinessIoExecutorOptions>();
+        services.TryAddSingleton<ILongRunningBusinessIoExecutor, LongRunningBusinessIoExecutor>();
         services.TryAddSingleton(provider => BindRelayOptions(configuration));
         services.TryAddSingleton<Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions>(
             provider => provider.GetRequiredService<NyxIdRelayOptions>());

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -2250,6 +2250,8 @@ public sealed class ConversationGAgentDedupTests
         services.AddSingleton<IActorRuntimeCallbackScheduler, RecordingCallbackScheduler>();
         services.AddSingleton<EventSourcingRuntimeOptions>();
         services.AddSingleton<IConversationTurnRunner>(runner);
+        // Refactor (iter97/cluster-098): test fixture must register ILongRunningBusinessIoExecutor
+        services.AddSingleton<ILongRunningBusinessIoExecutor, ImmediateBusinessIoExecutor>();
         if (cardRunner is not null)
             services.AddSingleton(cardRunner);
         if (dispatcher is not null)
@@ -3343,5 +3345,11 @@ public sealed class ConversationGAgentDedupTests
                 ?? ConversationCardFinalizeResult.Succeeded();
             return Task.FromResult(result);
         }
+    }
+
+    private sealed class ImmediateBusinessIoExecutor : ILongRunningBusinessIoExecutor
+    {
+        public Task SubmitAsync(LongRunningBusinessIoWorkItem workItem, CancellationToken ct) =>
+            workItem.ExecuteAsync(ct);
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -2318,6 +2318,7 @@ public sealed class AgentRunGAgentTests
         {
             _inner = new AgentRunReplyGenerationExecutor(
                 dispatchPort,
+                new ImmediateBusinessIoExecutor(),
                 replyGenerator,
                 collector,
                 relayOptions,
@@ -2343,6 +2344,12 @@ public sealed class AgentRunGAgentTests
             var agent = _agent ?? throw new InvalidOperationException("AgentRunGAgent test executor was not bound.");
             await agent.HandleReplyGenerationCompletedAsync(completed);
         }
+    }
+
+    private sealed class ImmediateBusinessIoExecutor : ILongRunningBusinessIoExecutor
+    {
+        public Task SubmitAsync(LongRunningBusinessIoWorkItem workItem, CancellationToken ct) =>
+            workItem.ExecuteAsync(ct);
     }
 
     private sealed class ThrowingActorDispatchPort : IActorDispatchPort

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LarkCardOperationSignalTests.cs
@@ -217,6 +217,7 @@ public sealed class LarkCardOperationSignalTests
             .AddSingleton(dispatch)
             .AddSingleton(cardRunner)
             .AddSingleton(callbackScheduler ?? new NoopCallbackScheduler())
+            .AddSingleton<ILongRunningBusinessIoExecutor, ImmediateBusinessIoExecutor>()
             .AddSingleton<EventSourcingRuntimeOptions>()
             .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
             .BuildServiceProvider();
@@ -521,5 +522,11 @@ public sealed class LarkCardOperationSignalTests
             EventEnvelopePublishOptions? options = null)
             where TEvent : IMessage =>
             Task.CompletedTask;
+    }
+
+    private sealed class ImmediateBusinessIoExecutor : ILongRunningBusinessIoExecutor
+    {
+        public Task SubmitAsync(LongRunningBusinessIoWorkItem workItem, CancellationToken ct) =>
+            workItem.ExecuteAsync(ct);
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/LongRunningBusinessIoExecutorTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/LongRunningBusinessIoExecutorTests.cs
@@ -1,0 +1,145 @@
+using Aevatar.GAgents.Channel.Runtime;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests;
+
+public sealed class LongRunningBusinessIoExecutorTests
+{
+    [Fact]
+    public async Task SubmitAsync_RespectsConfiguredConcurrencyLimit()
+    {
+        await using var executor = CreateExecutor(maxConcurrency: 2, queueCapacity: 8);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstTwoStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var running = 0;
+        var maxObserved = 0;
+
+        var tasks = Enumerable.Range(0, 4)
+            .Select(index => executor.SubmitAsync(
+                WorkItem($"work-{index}", async _ =>
+                {
+                    var current = Interlocked.Increment(ref running);
+                    UpdateMax(ref maxObserved, current);
+                    if (current == 2)
+                        firstTwoStarted.TrySetResult();
+                    await gate.Task.ConfigureAwait(false);
+                    Interlocked.Decrement(ref running);
+                }),
+                CancellationToken.None))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+        await firstTwoStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        maxObserved.Should().Be(2);
+        running.Should().Be(2);
+        gate.SetResult();
+    }
+
+    [Fact]
+    public async Task SubmitAsync_HonorsSubmitCancellation_WhenQueueIsFull()
+    {
+        await using var executor = CreateExecutor(maxConcurrency: 1, queueCapacity: 1);
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await executor.SubmitAsync(WorkItem("running", _ => gate.Task), CancellationToken.None);
+        await executor.SubmitAsync(WorkItem("queued", _ => Task.CompletedTask), CancellationToken.None);
+
+        using var submitCts = new CancellationTokenSource();
+        await submitCts.CancelAsync();
+
+        var act = () => executor.SubmitAsync(WorkItem("cancelled", _ => Task.CompletedTask), submitCts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        gate.SetResult();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancelsWork_WhenTimeoutExpires()
+    {
+        await using var executor = CreateExecutor(maxConcurrency: 1, queueCapacity: 4);
+        var cancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await executor.SubmitAsync(
+            WorkItem(
+                "timeout",
+                ct =>
+                {
+                    var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    ct.Register(static state =>
+                    {
+                        var (observed, blocked) = ((TaskCompletionSource Observed, TaskCompletionSource Blocked))state!;
+                        observed.SetResult();
+                        blocked.SetCanceled();
+                    }, (cancellationObserved, pending));
+                    return pending.Task;
+                },
+                timeout: TimeSpan.FromMilliseconds(50)),
+            CancellationToken.None);
+
+        await cancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PreservesTypedOwnershipAndCorrelationContract()
+    {
+        await using var executor = CreateExecutor(maxConcurrency: 1, queueCapacity: 4);
+        var observed = new TaskCompletionSource<(string OwnerActorId, string OperationName, string CorrelationId)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var item = new LongRunningBusinessIoWorkItem(
+            "work-corr-1",
+            "actor-1",
+            "lark-card-create",
+            "corr-1",
+            TimeSpan.FromSeconds(5),
+            _ =>
+            {
+                observed.SetResult(("actor-1", "lark-card-create", "corr-1"));
+                return Task.CompletedTask;
+            });
+
+        await executor.SubmitAsync(item, CancellationToken.None);
+
+        var result = await observed.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        result.OwnerActorId.Should().Be(item.OwnerActorId);
+        result.OperationName.Should().Be(item.OperationName);
+        result.CorrelationId.Should().Be(item.CorrelationId);
+    }
+
+    private static LongRunningBusinessIoExecutor CreateExecutor(int maxConcurrency, int queueCapacity) =>
+        new(
+            Options.Create(new LongRunningBusinessIoExecutorOptions
+            {
+                MaxConcurrency = maxConcurrency,
+                QueueCapacity = queueCapacity,
+                DefaultTimeout = TimeSpan.FromSeconds(10),
+            }),
+            NullLogger<LongRunningBusinessIoExecutor>.Instance);
+
+    private static LongRunningBusinessIoWorkItem WorkItem(
+        string id,
+        Func<CancellationToken, Task> executeAsync,
+        TimeSpan? timeout = null) =>
+        new(
+            id,
+            "owner-1",
+            "operation-1",
+            $"corr-{id}",
+            timeout ?? TimeSpan.FromSeconds(10),
+            executeAsync);
+
+    private static void UpdateMax(ref int target, int value)
+    {
+        while (true)
+        {
+            var current = Volatile.Read(ref target);
+            if (value <= current)
+                return;
+            if (Interlocked.CompareExchange(ref target, value, current) == current)
+                return;
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayTextOperationTimeoutPayloadTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayTextOperationTimeoutPayloadTests.cs
@@ -48,6 +48,7 @@ public sealed class NyxRelayTextOperationTimeoutPayloadTests
             .AddSingleton<IActorDispatchPort, NoopActorDispatchPort>()
             .AddSingleton(scheduler)
             .AddSingleton<IConversationTurnRunner, SucceedingTurnRunner>()
+            .AddSingleton<ILongRunningBusinessIoExecutor, ImmediateBusinessIoExecutor>()
             .AddSingleton<EventSourcingRuntimeOptions>()
             .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
             .BuildServiceProvider();
@@ -283,5 +284,11 @@ public sealed class NyxRelayTextOperationTimeoutPayloadTests
             stream.RemoveAll(x => x.Version <= toVersion);
             return Task.FromResult((long)(before - stream.Count));
         }
+    }
+
+    private sealed class ImmediateBusinessIoExecutor : ILongRunningBusinessIoExecutor
+    {
+        public Task SubmitAsync(LongRunningBusinessIoWorkItem workItem, CancellationToken ct) =>
+            workItem.ExecuteAsync(ct);
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -52,6 +52,9 @@ public sealed class ServiceCollectionExtensionsTests
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IChannelBotRegistrationRuntimeQueryPort));
         services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ILongRunningBusinessIoExecutor) &&
+            descriptor.ImplementationType == typeof(LongRunningBusinessIoExecutor));
+        services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(IChannelBotRegistrationQueryByNyxIdentityPort));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(INyxIdRelayScopeResolver));


### PR DESCRIPTION
## 摘要

iter97 cluster-098(severity: high,违反 `RULE-ACTOR-CALLBACK-SIGNAL`)。会话 actor 用后台 Task.Run 执行业务 IO,后台任务无正式运行所有者,业务推进一部分落在 actor turn 之外。改成 typed bounded executor port,actor 只保留 intent+timeout+continuation reconciliation。

## Phase 9 r1 consensus(3/3 unanimous)

`META_JUDGE_DONE:consensus:structural:typed-bounded-executor-port-replaces-raw-actor-taskrun-business-io-while-actors-keep-intent-timeout-completion-reconciliation`

## 改动

- **新增** `ILongRunningBusinessIoExecutor`(narrow contract:ownership/cancellation/timeout/correlation)
- **改造** 3 处 Task.Run:
  - `ConversationGAgent.LarkCardStreaming.cs:403, :474, :556` card create/stream/finalize
  - `ConversationGAgent.cs:1154` Nyx relay text
  - `AgentRunReplyGenerationExecutor.cs:54` deferred LLM reply
- **Actor turn 简化**:只 record intent + schedule timeout + 消费 continuation event
- **新测试** `LongRunningBusinessIoExecutorTests.cs` 145 LOC(并发/cancellation/timeout/correlation)
- 加 Old/New refactor 注释

## 约束遵循

- ❌ 不加新 actor
- ❌ 不加新 envelope
- ❌ 不加新 pipeline phase
- ❌ 不加 ADR
- ✅ 保留 current continuation event shape

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test Conversation` + NyxidChat ✅
- `architecture_guards.sh` + `test_stability_guards.sh` ✅

净 +500 / -62 LOC。

closes #1032

⟦AI:AUTO-LOOP⟧
