### PR TITLE
iter97 cluster-591: projection-core mapped current-state helper(WorkflowExecutionCurrentStateProjector 首迁移)

### DIFF
--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs
@@ -17,6 +17,9 @@ public sealed record MappedCurrentStateProjectionInput<TContext, TState>(
 /// Helper for simple actor-owned current-state projectors that map one committed state root to one read model.
 /// Complex projectors can keep implementing ICurrentStateProjectionMaterializer directly.
 /// </summary>
+// Refactor (iter97/cluster-591):
+//   Old pattern: each current-state projector hand-wrote committed-state unpack + timestamp resolution + upsert shell
+//   New principle: this helper centralizes the projection shell; subclasses only map TState -> TReadModel
 public abstract class MappedCurrentStateProjectionMaterializer<TContext, TState, TReadModel>
     : ICurrentStateProjectionMaterializer<TContext>
     where TContext : IProjectionMaterializationContext

--- a/src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs
+++ b/src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs
@@ -1,0 +1,72 @@
+using Aevatar.CQRS.Projection.Runtime.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Google.Protobuf;
+
+namespace Aevatar.CQRS.Projection.Core.Orchestration;
+
+public sealed record MappedCurrentStateProjectionInput<TContext, TState>(
+    TContext Context,
+    EventEnvelope Envelope,
+    StateEvent StateEvent,
+    TState State,
+    DateTimeOffset ObservedAt)
+    where TContext : IProjectionMaterializationContext
+    where TState : class, IMessage<TState>, new();
+
+/// <summary>
+/// Helper for simple actor-owned current-state projectors that map one committed state root to one read model.
+/// Complex projectors can keep implementing ICurrentStateProjectionMaterializer directly.
+/// </summary>
+public abstract class MappedCurrentStateProjectionMaterializer<TContext, TState, TReadModel>
+    : ICurrentStateProjectionMaterializer<TContext>
+    where TContext : IProjectionMaterializationContext
+    where TState : class, IMessage<TState>, new()
+    where TReadModel : class, IProjectionReadModel
+{
+    private readonly IProjectionWriteDispatcher<TReadModel> _writeDispatcher;
+    private readonly IProjectionClock _clock;
+
+    protected MappedCurrentStateProjectionMaterializer(
+        IProjectionWriteDispatcher<TReadModel> writeDispatcher,
+        IProjectionClock clock)
+    {
+        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+    }
+
+    public async ValueTask ProjectAsync(
+        TContext context,
+        EventEnvelope envelope,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(envelope);
+        ct.ThrowIfCancellationRequested();
+
+        if (!CommittedStateEventEnvelope.TryUnpackState<TState>(
+                envelope,
+                out _,
+                out var stateEvent,
+                out var state) ||
+            stateEvent == null ||
+            state == null)
+        {
+            return;
+        }
+
+        var input = new MappedCurrentStateProjectionInput<TContext, TState>(
+            context,
+            envelope,
+            stateEvent,
+            state,
+            CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow));
+
+        var readModel = Map(input);
+        if (readModel == null)
+            return;
+
+        await _writeDispatcher.UpsertAsync(readModel, ct);
+    }
+
+    protected abstract TReadModel? Map(MappedCurrentStateProjectionInput<TContext, TState> input);
+}

--- a/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs
@@ -5,36 +5,29 @@ using Aevatar.Workflow.Projection.ReadModels;
 namespace Aevatar.Workflow.Projection.Projectors;
 
 public sealed class WorkflowExecutionCurrentStateProjector
-    : ICurrentStateProjectionMaterializer<WorkflowExecutionMaterializationContext>
+    : MappedCurrentStateProjectionMaterializer<
+        WorkflowExecutionMaterializationContext,
+        WorkflowRunState,
+        WorkflowExecutionCurrentStateDocument>
 {
-    private readonly IProjectionWriteDispatcher<WorkflowExecutionCurrentStateDocument> _writeDispatcher;
-    private readonly IProjectionClock _clock;
-
     public WorkflowExecutionCurrentStateProjector(
         IProjectionWriteDispatcher<WorkflowExecutionCurrentStateDocument> writeDispatcher,
         IProjectionClock clock)
+        : base(writeDispatcher, clock)
     {
-        _writeDispatcher = writeDispatcher ?? throw new ArgumentNullException(nameof(writeDispatcher));
-        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
     }
 
-    public async ValueTask ProjectAsync(
-        WorkflowExecutionMaterializationContext context,
-        EventEnvelope envelope,
-        CancellationToken ct = default)
+    protected override WorkflowExecutionCurrentStateDocument Map(
+        MappedCurrentStateProjectionInput<WorkflowExecutionMaterializationContext, WorkflowRunState> input)
     {
-        if (!CommittedStateEventEnvelope.TryUnpackState<WorkflowRunState>(
-                envelope,
-                out _,
-                out var stateEvent,
-                out var state) ||
-            stateEvent == null ||
-            state == null)
-        {
-            return;
-        }
+        var context = input.Context;
+        var stateEvent = input.StateEvent;
+        var state = input.State;
 
-        var document = new WorkflowExecutionCurrentStateDocument
+        // Refactor (iter97/cluster-591): Old/New
+        //   Old: every current-state projector hand-rolled committed-state unpack, timestamp resolution, and upsert.
+        //   New: core mapped helper owns that projection shell; this projector keeps only WorkflowRunState -> read model mapping.
+        return new WorkflowExecutionCurrentStateDocument
         {
             Id = context.RootActorId,
             RootActorId = context.RootActorId,
@@ -52,10 +45,8 @@ public sealed class WorkflowExecutionCurrentStateProjector
             Success = ResolveSuccess(state.Status),
             StateVersion = stateEvent.Version,
             LastEventId = stateEvent.EventId ?? string.Empty,
-            UpdatedAt = CommittedStateEventEnvelope.ResolveTimestamp(envelope, _clock.UtcNow),
+            UpdatedAt = input.ObservedAt,
         };
-
-        await _writeDispatcher.UpsertAsync(document, ct);
     }
 
     private static bool? ResolveSuccess(string? status)

--- a/test/Aevatar.CQRS.Projection.Core.Tests/MappedCurrentStateProjectionMaterializerTests.cs
+++ b/test/Aevatar.CQRS.Projection.Core.Tests/MappedCurrentStateProjectionMaterializerTests.cs
@@ -1,0 +1,148 @@
+using Aevatar.CQRS.Projection.Core.Orchestration;
+using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.CQRS.Projection.Core.Tests;
+
+public sealed class MappedCurrentStateProjectionMaterializerTests
+{
+    [Fact]
+    public async Task ProjectAsync_ShouldMapCommittedStateRoot_AndUpsertReadModel()
+    {
+        var dispatcher = new RecordingWriteDispatcher<TestStoreReadModel>();
+        var projector = new TestMappedCurrentStateProjectionMaterializer(
+            dispatcher,
+            new FixedClock(DateTimeOffset.Parse("2026-03-17T10:00:00+00:00")));
+        var context = new TestContext
+        {
+            RootActorId = "actor-1",
+            ProjectionKind = "test-current-state",
+        };
+
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                version: 7,
+                eventId: "evt-7",
+                state: new StringValue { Value = "ready" },
+                timestamp: DateTimeOffset.Parse("2026-03-17T11:07:00+00:00")));
+
+        dispatcher.Upserts.Should().ContainSingle();
+        var readModel = dispatcher.Upserts[0];
+        readModel.Id.Should().Be("actor-1");
+        readModel.ActorId.Should().Be("actor-1");
+        readModel.StateVersion.Should().Be(7);
+        readModel.LastEventId.Should().Be("evt-7");
+        readModel.UpdatedAt.Should().Be(DateTimeOffset.Parse("2026-03-17T11:07:00+00:00"));
+        readModel.Value.Should().Be("test-current-state:ready");
+    }
+
+    [Fact]
+    public async Task ProjectAsync_ShouldIgnoreInvalidEnvelope_AndMapperCanSkip()
+    {
+        var dispatcher = new RecordingWriteDispatcher<TestStoreReadModel>();
+        var projector = new TestMappedCurrentStateProjectionMaterializer(
+            dispatcher,
+            new FixedClock(DateTimeOffset.Parse("2026-03-17T10:00:00+00:00")));
+        var context = new TestContext
+        {
+            RootActorId = "actor-1",
+            ProjectionKind = "test-current-state",
+        };
+
+        await projector.ProjectAsync(context, new EventEnvelope());
+        await projector.ProjectAsync(
+            context,
+            BuildCommittedEnvelope(
+                version: 8,
+                eventId: "evt-8",
+                state: new StringValue { Value = "skip" },
+                timestamp: DateTimeOffset.Parse("2026-03-17T11:08:00+00:00")));
+
+        dispatcher.Upserts.Should().BeEmpty();
+    }
+
+    private static EventEnvelope BuildCommittedEnvelope(
+        long version,
+        string eventId,
+        StringValue state,
+        DateTimeOffset timestamp)
+    {
+        return new EventEnvelope
+        {
+            Id = $"outer-{version}",
+            Timestamp = Timestamp.FromDateTimeOffset(timestamp),
+            Payload = Any.Pack(new CommittedStateEventPublished
+            {
+                StateEvent = new StateEvent
+                {
+                    EventId = eventId,
+                    Version = version,
+                    Timestamp = Timestamp.FromDateTimeOffset(timestamp),
+                    EventData = Any.Pack(new StringValue { Value = "event-payload" }),
+                },
+                StateRoot = Any.Pack(state),
+            }),
+        };
+    }
+
+    private sealed class TestMappedCurrentStateProjectionMaterializer
+        : MappedCurrentStateProjectionMaterializer<TestContext, StringValue, TestStoreReadModel>
+    {
+        public TestMappedCurrentStateProjectionMaterializer(
+            IProjectionWriteDispatcher<TestStoreReadModel> writeDispatcher,
+            IProjectionClock clock)
+            : base(writeDispatcher, clock)
+        {
+        }
+
+        protected override TestStoreReadModel? Map(
+            MappedCurrentStateProjectionInput<TestContext, StringValue> input)
+        {
+            if (input.State.Value == "skip")
+                return null;
+
+            return new TestStoreReadModel
+            {
+                Id = input.Context.RootActorId,
+                ActorId = input.Context.RootActorId,
+                StateVersion = input.StateEvent.Version,
+                LastEventId = input.StateEvent.EventId ?? string.Empty,
+                UpdatedAt = input.ObservedAt,
+                Value = $"{input.Context.ProjectionKind}:{input.State.Value}",
+            };
+        }
+    }
+
+    private sealed class TestContext : IProjectionMaterializationContext
+    {
+        public required string RootActorId { get; init; }
+
+        public required string ProjectionKind { get; init; }
+    }
+
+    private sealed class FixedClock : IProjectionClock
+    {
+        public FixedClock(DateTimeOffset utcNow)
+        {
+            UtcNow = utcNow;
+        }
+
+        public DateTimeOffset UtcNow { get; }
+    }
+
+    private sealed class RecordingWriteDispatcher<TReadModel> : IProjectionWriteDispatcher<TReadModel>
+        where TReadModel : class, IProjectionReadModel
+    {
+        public List<TReadModel> Upserts { get; } = [];
+
+        public Task<ProjectionWriteResult> UpsertAsync(TReadModel readModel, CancellationToken ct = default)
+        {
+            Upserts.Add(readModel);
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default) =>
+            Task.FromResult(ProjectionWriteResult.Duplicate());
+    }
+}

--- a/tools/ci/projection_state_mirror_current_state_guard.sh
+++ b/tools/ci/projection_state_mirror_current_state_guard.sh
@@ -15,6 +15,7 @@ FILES=(
   "src/Aevatar.Scripting.Projection/Projectors/ScriptNativeGraphProjector.cs"
   "src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs"
 )
+MAPPED_CURRENT_STATE_HELPER="src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs"
 
 legacy_reader_hits="$(
   rg -n "IProjectionDocumentReader<|_documentReader|IProjectionEventReducer<|_reducersByType|EventEnvelopeTimestampResolver\\.Resolve\\(" \
@@ -30,9 +31,16 @@ fi
 
 missing_committed_hits="$(
   for file in "${FILES[@]}"; do
-    if ! rg -q "CommittedStateEventEnvelope\\.(TryUnpackState<|TryGetObservedPayload\\()" "${file}"; then
-      echo "${file}"
+    if rg -q "CommittedStateEventEnvelope\\.(TryUnpackState<|TryGetObservedPayload\\()" "${file}"; then
+      continue
     fi
+
+    if rg -q "MappedCurrentStateProjectionMaterializer<" "${file}" &&
+       rg -q "CommittedStateEventEnvelope\\.TryUnpackState<" "${MAPPED_CURRENT_STATE_HELPER}"; then
+      continue
+    fi
+
+    echo "${file}"
   done
 )"
 


### PR DESCRIPTION
## 摘要

iter97 cluster-591(severity: medium,减少 current-state projection boilerplate)。在 Projection Core 加 `MappedCurrentStateProjectionMaterializer` helper folds committed-state unpack/version/timestamp/upsert。**首个迁移** `WorkflowExecutionCurrentStateProjector`。其他 projector 后续 cluster 跟进。

## Phase 9 r1 consensus(3/3 unanimous)

`META_JUDGE_DONE:consensus:projection-core-mapped-current-state-helper:migrate WorkflowExecutionCurrentStateProjector first; no new actor/envelope/pipeline phase`

## 改动

- **新增** `src/Aevatar.CQRS.Projection.Core/Orchestration/MappedCurrentStateProjectionMaterializer.cs`(+72)
- **迁移** `src/workflow/Aevatar.Workflow.Projection/Projectors/WorkflowExecutionCurrentStateProjector.cs`(净简化)
- **新测试** `MappedCurrentStateProjectionMaterializerTests.cs`(+148)
- **guard 更新** `tools/ci/projection_state_mirror_current_state_guard.sh`
- 加 Old/New 注释

## 约束遵循

- ❌ 不加新 actor / envelope / pipeline phase / ADR
- ✅ 保留 escape hatch(复杂 projector 仍可手写)
- ✅ Proof-of-concept:只迁 1 个 projector,后续 cluster 批量

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test` ✅
- `architecture_guards.sh` + `test_stability_guards.sh` ✅

净 +245 / -26 LOC。

closes #591

⟦AI:AUTO-LOOP⟧
