### PR TITLE
iter97 cluster-526: Tier 1 fail-closed ES ACL guard for AevatarOAuthClient HMAC keys at rest

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Google.Protobuf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 
 namespace Aevatar.GAgents.Channel.Identity.DependencyInjection;
 
@@ -90,6 +91,12 @@ public static class IdentityServiceCollectionExtensions
         services.TryAddSingleton<IExternalIdentityBindingQueryPort, ExternalIdentityBindingProjectionQueryPort>();
 
         // ─── Cluster-singleton OAuth client projection ───
+        // Refactor (iter97/cluster-526): Old pattern: AevatarOAuthClientDocument
+        // carries state-token HMAC bytes but ES startup did not require an
+        // explicit ACL assertion. New principle: when ChannelIdentity uses ES,
+        // AevatarOAuthClientEsAclStartupGuard fails closed unless the host
+        // declares the aevatar-oauth-clients index grant matches grain/event-store
+        // internal read access.
         services.AddProjectionMaterializationRuntimeCore<
             AevatarOAuthClientMaterializationContext,
             AevatarOAuthClientMaterializationRuntimeLease,
@@ -107,6 +114,10 @@ public static class IdentityServiceCollectionExtensions
             IProjectionDocumentMetadataProvider<AevatarOAuthClientDocument>,
             AevatarOAuthClientDocumentMetadataProvider>();
         services.TryAddSingleton<IAevatarOAuthClientProvider, AevatarOAuthClientProjectionProvider>();
+        var aclOptions = services.AddOptions<AevatarOAuthClientEsAclOptions>();
+        if (configuration is not null)
+            aclOptions.Bind(configuration.GetSection(AevatarOAuthClientEsAclOptions.SectionName));
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, AevatarOAuthClientEsAclStartupGuard>());
 
         // Endpoint filter for the operator /rebuild path — rejects unauthenticated
         // callers before model binding/DI resolution kicks in.

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientDocumentMetadataProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientDocumentMetadataProvider.cs
@@ -5,8 +5,10 @@ namespace Aevatar.GAgents.Channel.Identity;
 public sealed class AevatarOAuthClientDocumentMetadataProvider
     : IProjectionDocumentMetadataProvider<AevatarOAuthClientDocument>
 {
+    public const string IndexName = "aevatar-oauth-clients";
+
     public DocumentIndexMetadata Metadata { get; } = new(
-        IndexName: "aevatar-oauth-clients",
+        IndexName: IndexName,
         Mappings: new Dictionary<string, object?>(StringComparer.Ordinal)
         {
             ["dynamic"] = true,

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientEsAclOptions.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientEsAclOptions.cs
@@ -1,0 +1,10 @@
+namespace Aevatar.GAgents.Channel.Identity;
+
+public sealed class AevatarOAuthClientEsAclOptions
+{
+    public const string SectionName = "ChannelIdentity:OAuthClient:ElasticsearchAcl";
+
+    public bool GrantMatchesGrainEventStoreInternal { get; set; }
+
+    public string? GrantDescription { get; set; }
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientEsAclStartupGuard.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientEsAclStartupGuard.cs
@@ -1,0 +1,73 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Providers.Elasticsearch.DependencyInjection;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.GAgents.Channel.Identity;
+
+internal sealed class AevatarOAuthClientEsAclStartupGuard : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IConfiguration _configuration;
+    private readonly AevatarOAuthClientEsAclOptions _options;
+    private readonly ILogger<AevatarOAuthClientEsAclStartupGuard> _logger;
+
+    public AevatarOAuthClientEsAclStartupGuard(
+        IServiceProvider serviceProvider,
+        IConfiguration configuration,
+        IOptions<AevatarOAuthClientEsAclOptions> options,
+        ILogger<AevatarOAuthClientEsAclStartupGuard>? logger = null)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? NullLogger<AevatarOAuthClientEsAclStartupGuard>.Instance;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!ElasticsearchProjectionConfiguration.IsEnabled(_configuration, storeName: "ChannelIdentity"))
+            return Task.CompletedTask;
+
+        if (!_options.GrantMatchesGrainEventStoreInternal)
+        {
+            throw new InvalidOperationException(
+                "AevatarOAuthClient Elasticsearch projection contains state-token HMAC keys. " +
+                $"When ChannelIdentity uses Elasticsearch, set {AevatarOAuthClientEsAclOptions.SectionName}:GrantMatchesGrainEventStoreInternal=true " +
+                "only after the aevatar-oauth-clients index read grant is limited to grain/event-store internal services.");
+        }
+
+        using var scope = _serviceProvider.CreateScope();
+        var scopedProvider = scope.ServiceProvider;
+        var oauthClientProvider = scopedProvider.GetRequiredService<IAevatarOAuthClientProvider>();
+        if (oauthClientProvider.GetType() != typeof(AevatarOAuthClientProjectionProvider))
+        {
+            throw new InvalidOperationException(
+                "AevatarOAuthClient ES ACL guard requires IAevatarOAuthClientProvider to be the internal projection provider.");
+        }
+
+        _ = scopedProvider.GetRequiredService<IProjectionDocumentReader<AevatarOAuthClientDocument, string>>();
+        _ = scopedProvider.GetRequiredService<IProjectionDocumentWriter<AevatarOAuthClientDocument>>();
+        _ = scopedProvider.GetRequiredService<ICurrentStateProjectionMaterializer<AevatarOAuthClientMaterializationContext>>();
+
+        _logger.LogInformation(
+            "AevatarOAuthClient ES ACL startup guard passed. index={IndexName}",
+            AevatarOAuthClientDocumentMetadataProvider.IndexName);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+}

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs
@@ -4,11 +4,13 @@ using Aevatar.GAgents.Channel.Identity.Abstractions;
 namespace Aevatar.GAgents.Channel.Identity;
 
 /// <summary>
+/// Refactor (iter97/cluster-526): Old pattern: the OAuth client HMAC-key
+/// readmodel had no explicit ES ACL assertion at startup. New principle: this
+/// is the only provider allowed to read the HMAC-bearing document, and ES
+/// deployments must pass <see cref="AevatarOAuthClientEsAclStartupGuard"/>.
+///
 /// Reads the cluster-singleton OAuth client state from the projection
-/// document. Backs the read seam exposed by
-/// <see cref="IAevatarOAuthClientProvider"/> for callers that need
-/// <c>client_id</c> + HMAC keys (state-token codec, broker, OAuth callback,
-/// status endpoint).
+/// document. Backs the read seam exposed by <see cref="IAevatarOAuthClientProvider"/>.
 /// </summary>
 public sealed class AevatarOAuthClientProjectionProvider : IAevatarOAuthClientProvider
 {

--- a/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs
+++ b/agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs
@@ -7,9 +7,13 @@ using Aevatar.Foundation.Abstractions;
 namespace Aevatar.GAgents.Channel.Identity;
 
 /// <summary>
+/// Refactor (iter97/cluster-526): Old pattern: HMAC key projection shared the
+/// generic document-store registration without an ES access-boundary guard.
+/// New principle: projector remains the committed-state materializer, while
+/// startup/CI guards fail closed if broader query layers can reach this document.
+///
 /// Projects the cluster-singleton <see cref="AevatarOAuthClientState"/> into
-/// one <see cref="AevatarOAuthClientDocument"/>. Backs the read seam exposed
-/// by <see cref="IAevatarOAuthClientProvider"/>.
+/// one <see cref="AevatarOAuthClientDocument"/>.
 /// </summary>
 public sealed class AevatarOAuthClientProjector
     : ICurrentStateProjectionMaterializer<AevatarOAuthClientMaterializationContext>

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientEsAclStartupGuardTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/Identity/AevatarOAuthClientEsAclStartupGuardTests.cs
@@ -1,0 +1,121 @@
+using Aevatar.CQRS.Projection.Core.Abstractions;
+using Aevatar.CQRS.Projection.Stores.Abstractions;
+using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Identity;
+using Aevatar.GAgents.Channel.Identity.Abstractions;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Aevatar.GAgents.ChannelRuntime.Tests.Identity;
+
+public sealed class AevatarOAuthClientEsAclStartupGuardTests
+{
+    [Fact]
+    public async Task StartAsync_WhenElasticsearchEnabledWithoutAclAssertion_ShouldFailClosed()
+    {
+        var configuration = BuildConfiguration(esEnabled: true, aclAsserted: false);
+        await using var provider = BuildProvider(configuration);
+        var guard = ActivatorUtilities.CreateInstance<AevatarOAuthClientEsAclStartupGuard>(provider);
+
+        Func<Task> act = () => guard.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*GrantMatchesGrainEventStoreInternal=true*");
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenElasticsearchEnabledWithAclAssertion_ShouldPass()
+    {
+        var configuration = BuildConfiguration(esEnabled: true, aclAsserted: true);
+        await using var provider = BuildProvider(configuration);
+        var guard = ActivatorUtilities.CreateInstance<AevatarOAuthClientEsAclStartupGuard>(provider);
+
+        Func<Task> act = () => guard.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenElasticsearchDisabled_ShouldNotRequireAclAssertion()
+    {
+        var configuration = BuildConfiguration(esEnabled: false, aclAsserted: false);
+        await using var provider = BuildProvider(configuration);
+        var guard = ActivatorUtilities.CreateInstance<AevatarOAuthClientEsAclStartupGuard>(provider);
+
+        Func<Task> act = () => guard.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private static IConfiguration BuildConfiguration(bool esEnabled, bool aclAsserted) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Projection:Document:Providers:Elasticsearch:Enabled"] = esEnabled.ToString(),
+                ["Projection:Document:Providers:Elasticsearch:Endpoints:0"] = "http://127.0.0.1:9200",
+                [$"{AevatarOAuthClientEsAclOptions.SectionName}:GrantMatchesGrainEventStoreInternal"] = aclAsserted.ToString(),
+            })
+            .Build();
+
+    private static ServiceProvider BuildProvider(IConfiguration configuration)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(configuration);
+        services.AddOptions<AevatarOAuthClientEsAclOptions>()
+            .Bind(configuration.GetSection(AevatarOAuthClientEsAclOptions.SectionName));
+        services.AddSingleton<IAevatarOAuthClientProvider, AevatarOAuthClientProjectionProvider>();
+        services.AddSingleton<IProjectionDocumentReader<AevatarOAuthClientDocument, string>, NoOpOAuthClientDocumentReader>();
+        services.AddSingleton<IProjectionDocumentWriter<AevatarOAuthClientDocument>, NoOpOAuthClientDocumentWriter>();
+        services.AddSingleton<ICurrentStateProjectionMaterializer<AevatarOAuthClientMaterializationContext>, NoOpOAuthClientProjector>();
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class NoOpOAuthClientDocumentReader : IProjectionDocumentReader<AevatarOAuthClientDocument, string>
+    {
+        public Task<AevatarOAuthClientDocument?> GetAsync(string key, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult<AevatarOAuthClientDocument?>(null);
+        }
+
+        public Task<ProjectionDocumentQueryResult<AevatarOAuthClientDocument>> QueryAsync(
+            ProjectionDocumentQuery query,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionDocumentQueryResult<AevatarOAuthClientDocument>.Empty);
+        }
+    }
+
+    private sealed class NoOpOAuthClientDocumentWriter : IProjectionDocumentWriter<AevatarOAuthClientDocument>
+    {
+        public Task<ProjectionWriteResult> UpsertAsync(
+            AevatarOAuthClientDocument readModel,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+
+        public Task<ProjectionWriteResult> DeleteAsync(string id, CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return Task.FromResult(ProjectionWriteResult.Applied());
+        }
+    }
+
+    private sealed class NoOpOAuthClientProjector
+        : ICurrentStateProjectionMaterializer<AevatarOAuthClientMaterializationContext>
+    {
+        public ValueTask ProjectAsync(
+            AevatarOAuthClientMaterializationContext context,
+            EventEnvelope envelope,
+            CancellationToken ct = default)
+        {
+            ct.ThrowIfCancellationRequested();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -135,6 +135,9 @@ public sealed class ServiceCollectionExtensionsTests
 
         AssertProjectionActivationProviderRegistered<ChannelIdentityCommittedStateProjectionActivationPlanProvider>(
             services);
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IHostedService) &&
+            descriptor.ImplementationType == typeof(AevatarOAuthClientEsAclStartupGuard));
     }
 
     [Fact]

--- a/tools/ci/aevatar_oauth_client_es_acl_guard.sh
+++ b/tools/ci/aevatar_oauth_client_es_acl_guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+allowed_document_files_regex='^(agents/Aevatar\.GAgents\.Channel\.Identity/(DependencyInjection/IdentityServiceCollectionExtensions\.cs|Provisioning/AevatarOAuthClient(Document\.Partial|DocumentMetadataProvider|EsAclOptions|EsAclStartupGuard|ProjectionProvider|Projector)\.cs|protos/aevatar_oauth_client\.proto)|test/)'
+
+document_hits="$(
+  rg -n "AevatarOAuthClientDocument|IProjectionDocumentReader<AevatarOAuthClientDocument|IProjectionDocumentWriter<AevatarOAuthClientDocument" \
+    agents src \
+    -g '*.cs' \
+    -g '*.proto' \
+    -g '!**/bin/**' \
+    -g '!**/obj/**' \
+    | awk -F: -v allowed="${allowed_document_files_regex}" '$1 !~ allowed { print }' \
+    || true
+)"
+
+event_store_hits="$(
+  rg -l "AevatarOAuthClient" \
+    agents src \
+    -g '*.cs' \
+    -g '!**/bin/**' \
+    -g '!**/obj/**' \
+    | xargs rg -n "IEventStore|ReadEventsAsync|Replay|EventStore" \
+    | rg -v "agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientGAgent.cs:.*EventStoreOptimisticConcurrencyException" \
+    | rg -v "GrantMatchesGrainEventStoreInternal|grain/event-store internal|AevatarOAuthClient ES ACL startup guard" \
+    || true
+)"
+
+guard_registration_hits="$(
+  rg -n "AevatarOAuthClientEsAclStartupGuard|GrantMatchesGrainEventStoreInternal|Refactor \\(iter97/cluster-526\\)" \
+    agents/Aevatar.GAgents.Channel.Identity/DependencyInjection/IdentityServiceCollectionExtensions.cs \
+    agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientEsAclStartupGuard.cs \
+    agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjectionProvider.cs \
+    agents/Aevatar.GAgents.Channel.Identity/Provisioning/AevatarOAuthClientProjector.cs \
+    || true
+)"
+
+if [[ -n "${document_hits}" ]]; then
+  echo "${document_hits}"
+  echo "AevatarOAuthClientDocument carries HMAC keys. Only the projector, internal provider, metadata, startup guard, DI registration, proto, and tests may reference it."
+  exit 1
+fi
+
+if [[ -n "${event_store_hits}" ]]; then
+  echo "${event_store_hits}"
+  echo "AevatarOAuthClient HMAC-key facts must not be read from event store by query/API/projection side paths."
+  exit 1
+fi
+
+if ! grep -q "AevatarOAuthClientEsAclStartupGuard" <<<"${guard_registration_hits}" ||
+   ! grep -q "GrantMatchesGrainEventStoreInternal" <<<"${guard_registration_hits}" ||
+   ! grep -q "Refactor (iter97/cluster-526)" <<<"${guard_registration_hits}"; then
+  echo "${guard_registration_hits}"
+  echo "AevatarOAuthClient ES ACL startup guard, explicit ACL assertion, and iter97 refactor comments are required."
+  exit 1
+fi
+
+echo "AevatarOAuthClient ES ACL guard passed."

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -34,6 +34,8 @@ if [ -d "src/Aevatar.Host.Api" ] || [ -d "src/Aevatar.Host.Gateway" ]; then
   exit 1
 fi
 
+bash tools/ci/aevatar_oauth_client_es_acl_guard.sh
+
 if rg -n "Aevatar\.Host\.Api|Aevatar\.Host\.Gateway" aevatar.slnx; then
   echo "Solution must not include legacy host projects."
   exit 1


### PR DESCRIPTION
## 摘要

iter97 cluster-526(severity: medium,security boundary)。`AevatarOAuthClient` projection 存 HMAC keys at rest,需 fail-closed ACL guard 限定 ES read access 到 grain/event-store internal,不被更宽 query layer 触及。

## Phase 9 r2 consensus

`META_JUDGE_DONE:consensus:tier1-fail-closed-es-acl-guard-closes-#526:Tier 2 encrypted readmodel 后续 cluster, mandatory only before accepting broader ES read access`

## Tier 1 实施

- **新增** `AevatarOAuthClientEsAclOptions`:narrow config
- **新增** `AevatarOAuthClientEsAclStartupGuard`:fail-closed startup invariant
- **新增** `tools/ci/aevatar_oauth_client_es_acl_guard.sh`:source-level grep guard
- **注册** `tools/ci/architecture_guards.sh`:CI 入口
- **修改** `AevatarOAuthClientProjectionProvider.cs / AevatarOAuthClientProjector.cs / IdentityServiceCollectionExtensions.cs`:接入 guard
- **新测试** `AevatarOAuthClientEsAclStartupGuardTests.cs`(+121 LOC)
- 加 Old/New refactor 注释

## 约束遵循

- ❌ 不加新 actor / envelope / pipeline / ADR
- ❌ 不 redesign query/projection 层
- ✅ Tier 1 fail-closed:配置错误 / 越界访问 → 启动 fail + CI 拒绝
- ✅ Tier 2 encrypted readmodel **不在本 PR**(后续 cluster mandatory only before broader ES read)

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test` ✅
- guards ✅

净 +298 / -7 LOC。

closes #526

⟦AI:AUTO-LOOP⟧
