### PR TITLE
iter97 cluster-598: scope_workflows_upsert/list/get LLM tools

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Binding/BindingAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/BindingAgentToolSource.cs
@@ -21,6 +21,8 @@ public sealed class BindingAgentToolSource : IAgentToolSource
     private readonly IScopeBindingQueryAdapter? _queryAdapter;
     private readonly IScopeBindingUnbindAdapter? _unbindAdapter;
     private readonly IWorkflowDefinitionCommandAdapter? _definitionAdapter;
+    private readonly IScopeWorkflowCommandPort? _scopeWorkflowCommandPort;
+    private readonly IScopeWorkflowQueryPort? _scopeWorkflowQueryPort;
     private readonly ILogger _logger;
 
     public BindingAgentToolSource(
@@ -29,6 +31,8 @@ public sealed class BindingAgentToolSource : IAgentToolSource
         IScopeBindingQueryAdapter? queryAdapter = null,
         IScopeBindingUnbindAdapter? unbindAdapter = null,
         IWorkflowDefinitionCommandAdapter? definitionAdapter = null,
+        IScopeWorkflowCommandPort? scopeWorkflowCommandPort = null,
+        IScopeWorkflowQueryPort? scopeWorkflowQueryPort = null,
         ILogger<BindingAgentToolSource>? logger = null)
     {
         _options = options;
@@ -36,12 +40,15 @@ public sealed class BindingAgentToolSource : IAgentToolSource
         _queryAdapter = queryAdapter;
         _unbindAdapter = unbindAdapter;
         _definitionAdapter = definitionAdapter;
+        _scopeWorkflowCommandPort = scopeWorkflowCommandPort;
+        _scopeWorkflowQueryPort = scopeWorkflowQueryPort;
         _logger = logger ?? NullLogger<BindingAgentToolSource>.Instance;
     }
 
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
-        if (_commandPort == null && _queryAdapter == null)
+        if (_commandPort == null && _queryAdapter == null &&
+            _scopeWorkflowCommandPort == null && _scopeWorkflowQueryPort == null)
         {
             _logger.LogDebug("Binding adapter implementations not registered, skipping binding tools");
             return Task.FromResult<IReadOnlyList<IAgentTool>>([]);
@@ -63,6 +70,18 @@ public sealed class BindingAgentToolSource : IAgentToolSource
         // Unbind (requires unbind adapter)
         if (_unbindAdapter != null)
             tools.Add(new BindingUnbindTool(_unbindAdapter));
+
+        // Refactor (iter97/cluster-598): Old/New
+        //   Old pattern: Ornn skill recipes could not reach typed scope workflow ports through LLM tools.
+        //   New principle: expose thin scope_workflows_* adapters without changing binding_* generic service tools.
+        if (_scopeWorkflowCommandPort != null)
+            tools.Add(new ScopeWorkflowsUpsertTool(_scopeWorkflowCommandPort));
+
+        if (_scopeWorkflowQueryPort != null)
+        {
+            tools.Add(new ScopeWorkflowsListTool(_scopeWorkflowQueryPort, _options));
+            tools.Add(new ScopeWorkflowsGetTool(_scopeWorkflowQueryPort));
+        }
 
         _logger.LogInformation("Binding tools registered ({Count} tools)", tools.Count);
         return Task.FromResult<IReadOnlyList<IAgentTool>>(tools);

--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsGetTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsGetTool.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions.Ports;
+
+namespace Aevatar.AI.ToolProviders.Binding.Tools;
+
+/// <summary>
+/// Get a workflow summary from the current scope.
+/// Delegates to IScopeWorkflowQueryPort.GetByWorkflowIdAsync.
+/// </summary>
+public sealed class ScopeWorkflowsGetTool : IAgentTool
+{
+    private readonly IScopeWorkflowQueryPort _queryPort;
+
+    public ScopeWorkflowsGetTool(IScopeWorkflowQueryPort queryPort)
+    {
+        _queryPort = queryPort;
+    }
+
+    public string Name => "scope_workflows_get";
+
+    public string Description =>
+        "Get one workflow from the current scope by workflow_id. " +
+        "Returns the typed workflow summary without executing the workflow.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "properties": {
+            "workflow_id": {
+              "type": "string",
+              "description": "Stable workflow ID inside the current scope"
+            }
+          },
+          "required": ["workflow_id"]
+        }
+        """;
+
+    public bool IsReadOnly => true;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        try
+        {
+            var args = ToolArgs.Parse(argumentsJson);
+            if (args.ParseError != null)
+                return JsonDefaults.Error(args.ParseError);
+
+            var workflowId = args.Str("workflow_id");
+            if (string.IsNullOrWhiteSpace(workflowId))
+                return JsonDefaults.Error("'workflow_id' is required");
+
+            var scopeId = AgentToolRequestContext.ScopeId;
+            if (string.IsNullOrWhiteSpace(scopeId))
+                return JsonDefaults.Error("scope_id not available in request context");
+
+            // Refactor (iter97/cluster-598): Old/New
+            //   Old pattern: LLM callers had no workflow-id specific adapter over scope workflow queries.
+            //   New principle: keep get semantics on the typed query port and return an honest not-found result.
+            var workflow = await _queryPort.GetByWorkflowIdAsync(scopeId.Trim(), workflowId.Trim(), ct);
+            if (workflow is null)
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    available = false,
+                    scope_id = scopeId.Trim(),
+                    workflow_id = workflowId.Trim(),
+                    error = $"Workflow '{workflowId.Trim()}' was not found in scope '{scopeId.Trim()}'.",
+                }, JsonDefaults.SnakeCase);
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                available = true,
+                scope_id = scopeId.Trim(),
+                workflow,
+            }, JsonDefaults.SnakeCase);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            return JsonDefaults.Error($"Workflow get failed: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsListTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsListTool.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions.Ports;
+
+namespace Aevatar.AI.ToolProviders.Binding.Tools;
+
+/// <summary>
+/// List workflows in the current scope.
+/// Delegates to IScopeWorkflowQueryPort.ListAsync.
+/// </summary>
+public sealed class ScopeWorkflowsListTool : IAgentTool
+{
+    private readonly IScopeWorkflowQueryPort _queryPort;
+    private readonly BindingToolOptions _options;
+
+    public ScopeWorkflowsListTool(IScopeWorkflowQueryPort queryPort, BindingToolOptions options)
+    {
+        _queryPort = queryPort;
+        _options = options;
+    }
+
+    public string Name => "scope_workflows_list";
+
+    public string Description =>
+        "List workflows published in the current scope. " +
+        "Returns typed workflow IDs and actor/readmodel data for Ornn skill coordination.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "properties": {
+            "max_results": {
+              "type": "integer",
+              "description": "Maximum workflows to return"
+            }
+          }
+        }
+        """;
+
+    public bool IsReadOnly => true;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        try
+        {
+            var args = ToolArgs.Parse(argumentsJson);
+            if (args.ParseError != null)
+                return JsonDefaults.Error(args.ParseError);
+
+            var scopeId = AgentToolRequestContext.ScopeId;
+            if (string.IsNullOrWhiteSpace(scopeId))
+                return JsonDefaults.Error("scope_id not available in request context");
+
+            // Refactor (iter97/cluster-598): Old/New
+            //   Old pattern: LLM callers had to use generic binding views to infer workflow state.
+            //   New principle: this query tool reads the existing typed scope workflow readmodel port directly.
+            var workflows = await _queryPort.ListAsync(scopeId.Trim(), ct);
+            var maxResults = args.Int("max_results", _options.MaxListResults);
+            maxResults = Math.Clamp(maxResults, 1, _options.MaxListResults);
+            var limited = workflows.Take(maxResults).ToArray();
+
+            return JsonSerializer.Serialize(new
+            {
+                scope_id = scopeId.Trim(),
+                count = limited.Length,
+                total = workflows.Count,
+                workflows = limited,
+            }, JsonDefaults.SnakeCase);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            return JsonDefaults.Error($"Workflow list failed: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsUpsertTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/ScopeWorkflowsUpsertTool.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.GAgentService.Abstractions;
+using Aevatar.GAgentService.Abstractions.Ports;
+
+namespace Aevatar.AI.ToolProviders.Binding.Tools;
+
+/// <summary>
+/// Upsert a scope workflow from an Ornn skill recipe.
+/// Delegates to IScopeWorkflowCommandPort.UpsertAsync.
+/// </summary>
+public sealed class ScopeWorkflowsUpsertTool : IAgentTool
+{
+    private readonly IScopeWorkflowCommandPort _commandPort;
+
+    public ScopeWorkflowsUpsertTool(IScopeWorkflowCommandPort commandPort)
+    {
+        _commandPort = commandPort;
+    }
+
+    public string Name => "scope_workflows_upsert";
+
+    public string Description =>
+        "Create or update a workflow in the current scope. " +
+        "Use this after an Ornn skill has produced the workflow recipe YAML; this tool only persists it.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "properties": {
+            "workflow_id": {
+              "type": "string",
+              "description": "Stable workflow ID inside the current scope"
+            },
+            "workflow_yaml": {
+              "type": "string",
+              "description": "Workflow YAML produced by an Ornn skill recipe"
+            },
+            "workflow_name": {
+              "type": "string",
+              "description": "Optional workflow name recorded with the workflow"
+            },
+            "display_name": {
+              "type": "string",
+              "description": "Optional display name for humans"
+            },
+            "inline_workflow_yamls": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "Optional named inline workflow YAMLs referenced by workflow_yaml"
+            },
+            "revision_id": {
+              "type": "string",
+              "description": "Optional caller-supplied revision ID"
+            }
+          },
+          "required": ["workflow_id", "workflow_yaml"]
+        }
+        """;
+
+    public ToolApprovalMode ApprovalMode => ToolApprovalMode.AlwaysRequire;
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        try
+        {
+            var args = ToolArgs.Parse(argumentsJson);
+            if (args.ParseError != null)
+                return JsonDefaults.Error(args.ParseError);
+
+            var scopeId = AgentToolRequestContext.ScopeId;
+            if (string.IsNullOrWhiteSpace(scopeId))
+                return JsonDefaults.Error("scope_id not available in request context");
+
+            var workflowId = args.Str("workflow_id");
+            if (string.IsNullOrWhiteSpace(workflowId))
+                return JsonDefaults.Error("'workflow_id' is required");
+
+            var workflowYaml = args.Str("workflow_yaml");
+            if (string.IsNullOrWhiteSpace(workflowYaml))
+                return JsonDefaults.Error("'workflow_yaml' is required");
+
+            var inlineWorkflowYamls = args.StrDictionary("inline_workflow_yamls");
+            if (inlineWorkflowYamls is null && args.Has("inline_workflow_yamls"))
+                return JsonDefaults.Error("'inline_workflow_yamls' must be an object whose values are strings");
+
+            // Refactor (iter97/cluster-598): Old/New
+            //   Old pattern: Ornn-facing workflow recipes had no direct LLM adapter over the scope workflow ports.
+            //   New principle: recipes stay owned by Ornn skills; this tool is a thin typed adapter over IScopeWorkflowCommandPort.
+            var result = await _commandPort.UpsertAsync(new ScopeWorkflowUpsertRequest(
+                scopeId.Trim(),
+                workflowId.Trim(),
+                workflowYaml,
+                args.Str("workflow_name"),
+                args.Str("display_name"),
+                inlineWorkflowYamls,
+                args.Str("revision_id")), ct);
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                workflow = result.Workflow,
+                revision_id = result.RevisionId,
+                definition_actor_id_prefix = result.DefinitionActorIdPrefix,
+                expected_actor_id = result.ExpectedActorId,
+            }, JsonDefaults.SnakeCase);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            return JsonDefaults.Error($"Workflow upsert failed: {ex.GetType().Name}");
+        }
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Binding/Tools/ToolArgs.cs
+++ b/src/Aevatar.AI.ToolProviders.Binding/Tools/ToolArgs.cs
@@ -16,6 +16,8 @@ internal sealed class ToolArgs
     /// <summary>Parse error message, if the input JSON was malformed.</summary>
     public string? ParseError => _parseError;
 
+    public bool Has(string name) => _props.ContainsKey(name);
+
     public static ToolArgs Parse(string? json)
     {
         if (string.IsNullOrWhiteSpace(json))
@@ -73,5 +75,25 @@ internal sealed class ToolArgs
             .Where(e => e.ValueKind == JsonValueKind.String)
             .Select(e => e.GetString()!)
             .ToArray();
+    }
+
+    public IReadOnlyDictionary<string, string>? StrDictionary(string name)
+    {
+        if (!_props.TryGetValue(name, out var el))
+            return null;
+
+        if (el.ValueKind != JsonValueKind.Object)
+            return null;
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var prop in el.EnumerateObject())
+        {
+            if (prop.Value.ValueKind != JsonValueKind.String)
+                return null;
+
+            result[prop.Name] = prop.Value.GetString() ?? string.Empty;
+        }
+
+        return result;
     }
 }

--- a/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Binding.Tests/BindingToolsTests.cs
@@ -171,6 +171,292 @@ public class BindingToolsTests
 
     #endregion
 
+    #region ScopeWorkflows tools
+
+    [Fact]
+    public async Task ScopeWorkflowsUpsertTool_CallsCommandPort()
+    {
+        ScopeWorkflowUpsertRequest? captured = null;
+        var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
+            captureRequest: r => captured = r));
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync(
+                """
+                {
+                  "workflow_id":"daily-digest",
+                  "workflow_yaml":"name: daily-digest\nsteps: []\n",
+                  "workflow_name":"daily_digest",
+                  "display_name":"Daily Digest",
+                  "inline_workflow_yamls": { "child": "name: child\nsteps: []\n" },
+                  "revision_id":"rev-input"
+                }
+                """);
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("success").GetBoolean().Should().BeTrue();
+            doc.RootElement.GetProperty("workflow").GetProperty("workflow_id").GetString().Should().Be("daily-digest");
+            doc.RootElement.GetProperty("revision_id").GetString().Should().Be("rev-result");
+
+            captured.Should().NotBeNull();
+            captured!.ScopeId.Should().Be("scope-workflows");
+            captured.WorkflowId.Should().Be("daily-digest");
+            captured.WorkflowYaml.Should().Contain("daily-digest");
+            captured.WorkflowName.Should().Be("daily_digest");
+            captured.DisplayName.Should().Be("Daily Digest");
+            captured.InlineWorkflowYamls.Should().ContainKey("child");
+            captured.RevisionId.Should().Be("rev-input");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsUpsertTool_ValidatesTypedParameters()
+    {
+        var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var missingWorkflowId = await tool.ExecuteAsync("""{"workflow_yaml":"name: wf"}""");
+            ReadError(missingWorkflowId).Should().Be("'workflow_id' is required");
+
+            var missingYaml = await tool.ExecuteAsync("""{"workflow_id":"wf"}""");
+            ReadError(missingYaml).Should().Be("'workflow_yaml' is required");
+
+            var invalidInlineMap = await tool.ExecuteAsync(
+                """{"workflow_id":"wf","workflow_yaml":"name: wf","inline_workflow_yamls":{"child":42}}""");
+            invalidInlineMap.Should().Contain("inline_workflow_yamls");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsUpsertTool_ReturnsErrorOnCommandFailure()
+    {
+        var tool = new ScopeWorkflowsUpsertTool(new StubScopeWorkflowCommandPort(
+            exception: new InvalidOperationException("bad request")));
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"workflow_id":"wf","workflow_yaml":"name: wf"}""");
+
+            result.Should().Contain("Workflow upsert failed");
+            result.Should().Contain("InvalidOperationException");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsListTool_ReturnsWorkflows()
+    {
+        var workflows = new[]
+        {
+            BuildWorkflowSummary("scope-workflows", "wf-1"),
+            BuildWorkflowSummary("scope-workflows", "wf-2"),
+        };
+        var tool = new ScopeWorkflowsListTool(
+            new StubScopeWorkflowQueryPort(listResult: workflows),
+            new BindingToolOptions { MaxListResults = 1 });
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"max_results":2}""");
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("scope_id").GetString().Should().Be("scope-workflows");
+            doc.RootElement.GetProperty("count").GetInt32().Should().Be(1);
+            doc.RootElement.GetProperty("total").GetInt32().Should().Be(2);
+            doc.RootElement.GetProperty("workflows")[0].GetProperty("workflow_id").GetString().Should().Be("wf-1");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsListTool_ValidatesScopeContext()
+    {
+        var tool = new ScopeWorkflowsListTool(
+            new StubScopeWorkflowQueryPort(),
+            new BindingToolOptions());
+
+        AgentToolRequestContext.CurrentMetadata = null;
+
+        var result = await tool.ExecuteAsync("{}");
+
+        result.Should().Contain("scope_id not available");
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsListTool_ReturnsErrorOnQueryFailure()
+    {
+        var tool = new ScopeWorkflowsListTool(
+            new StubScopeWorkflowQueryPort(exception: new InvalidOperationException("query failed")),
+            new BindingToolOptions());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("{}");
+
+            result.Should().Contain("Workflow list failed");
+            result.Should().Contain("InvalidOperationException");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsGetTool_ReturnsWorkflow()
+    {
+        var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
+            getResult: BuildWorkflowSummary("scope-workflows", "wf-1")));
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"workflow_id":"wf-1"}""");
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("available").GetBoolean().Should().BeTrue();
+            doc.RootElement.GetProperty("scope_id").GetString().Should().Be("scope-workflows");
+            doc.RootElement.GetProperty("workflow").GetProperty("workflow_id").GetString().Should().Be("wf-1");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsGetTool_ValidatesWorkflowId()
+    {
+        var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort());
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("{}");
+
+            ReadError(result).Should().Be("'workflow_id' is required");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsGetTool_ReturnsUnavailableWhenWorkflowMissing()
+    {
+        var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(getResult: null));
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"workflow_id":"missing"}""");
+
+            using var doc = JsonDocument.Parse(result);
+            doc.RootElement.GetProperty("available").GetBoolean().Should().BeFalse();
+            doc.RootElement.GetProperty("workflow_id").GetString().Should().Be("missing");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task ScopeWorkflowsGetTool_ReturnsErrorOnQueryFailure()
+    {
+        var tool = new ScopeWorkflowsGetTool(new StubScopeWorkflowQueryPort(
+            exception: new InvalidOperationException("query failed")));
+
+        AgentToolRequestContext.CurrentMetadata = new Dictionary<string, string>
+        {
+            ["scope_id"] = "scope-workflows"
+        };
+
+        try
+        {
+            var result = await tool.ExecuteAsync("""{"workflow_id":"wf-1"}""");
+
+            result.Should().Contain("Workflow get failed");
+            result.Should().Contain("InvalidOperationException");
+        }
+        finally
+        {
+            AgentToolRequestContext.CurrentMetadata = null;
+        }
+    }
+
+    [Fact]
+    public async Task BindingAgentToolSource_RegistersScopeWorkflowToolsConditionally()
+    {
+        var source = new BindingAgentToolSource(
+            new BindingToolOptions(),
+            scopeWorkflowCommandPort: new StubScopeWorkflowCommandPort(),
+            scopeWorkflowQueryPort: new StubScopeWorkflowQueryPort());
+
+        var tools = await source.DiscoverToolsAsync();
+
+        tools.Should().HaveCount(3);
+        tools.Should().Contain(t => t is ScopeWorkflowsUpsertTool);
+        tools.Should().Contain(t => t is ScopeWorkflowsListTool);
+        tools.Should().Contain(t => t is ScopeWorkflowsGetTool);
+    }
+
+    #endregion
+
     #region BindingUnbindTool
 
     [Fact]
@@ -295,6 +581,99 @@ public class BindingToolsTests
 
         public Task<ScopeBindingUnbindResult> UnbindAsync(string scopeId, string serviceId, CancellationToken ct = default) =>
             Task.FromResult(_result);
+    }
+
+    private sealed class StubScopeWorkflowCommandPort : IScopeWorkflowCommandPort
+    {
+        private readonly Action<ScopeWorkflowUpsertRequest>? _captureRequest;
+        private readonly Exception? _exception;
+
+        public StubScopeWorkflowCommandPort(
+            Action<ScopeWorkflowUpsertRequest>? captureRequest = null,
+            Exception? exception = null)
+        {
+            _captureRequest = captureRequest;
+            _exception = exception;
+        }
+
+        public Task<ScopeWorkflowUpsertResult> UpsertAsync(
+            ScopeWorkflowUpsertRequest request,
+            CancellationToken ct = default)
+        {
+            if (_exception is not null)
+                throw _exception;
+
+            _captureRequest?.Invoke(request);
+            var workflow = BuildWorkflowSummary(request.ScopeId, request.WorkflowId);
+            return Task.FromResult(new ScopeWorkflowUpsertResult(
+                workflow,
+                "rev-result",
+                "definition-prefix",
+                "expected-actor"));
+        }
+    }
+
+    private sealed class StubScopeWorkflowQueryPort : IScopeWorkflowQueryPort
+    {
+        private readonly IReadOnlyList<ScopeWorkflowSummary> _listResult;
+        private readonly ScopeWorkflowSummary? _getResult;
+        private readonly Exception? _exception;
+
+        public StubScopeWorkflowQueryPort(
+            IReadOnlyList<ScopeWorkflowSummary>? listResult = null,
+            ScopeWorkflowSummary? getResult = null,
+            Exception? exception = null)
+        {
+            _listResult = listResult ?? [];
+            _getResult = getResult;
+            _exception = exception;
+        }
+
+        public Task<IReadOnlyList<ScopeWorkflowSummary>> ListAsync(string scopeId, CancellationToken ct = default)
+        {
+            if (_exception is not null)
+                throw _exception;
+
+            return Task.FromResult(_listResult);
+        }
+
+        public Task<ScopeWorkflowSummary?> GetByWorkflowIdAsync(
+            string scopeId,
+            string workflowId,
+            CancellationToken ct = default)
+        {
+            if (_exception is not null)
+                throw _exception;
+
+            return Task.FromResult(_getResult);
+        }
+
+        public Task<ScopeWorkflowSummary?> GetByActorIdAsync(
+            string scopeId,
+            string actorId,
+            CancellationToken ct = default) =>
+            Task.FromResult<ScopeWorkflowSummary?>(null);
+    }
+
+    private static ScopeWorkflowSummary BuildWorkflowSummary(
+        string scopeId,
+        string workflowId) =>
+        new(
+            scopeId,
+            workflowId,
+            $"Display {workflowId}",
+            $"service-key-{workflowId}",
+            $"workflow-name-{workflowId}",
+            $"actor-{workflowId}",
+            "rev-active",
+            "deployment-1",
+            "active",
+            DateTimeOffset.Parse("2026-05-25T00:00:00Z"));
+
+    private static string? ReadError(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("error").GetString();
     }
 
     #endregion


### PR DESCRIPTION
## 摘要

iter97 cluster-598。加 3 个 LLM tools(`scope_workflows_upsert`/`list`/`get`)作为现有 `IScopeWorkflow*Port` 的 thin adapters。Ornn skills 拥有 scheduled-agent recipes。

## Phase 9 r2 consensus

`META_JUDGE_DONE:consensus:scope-workflows-tools:add scope_workflows_upsert/list/get as thin adapters over existing scope workflow ports; Ornn skills own recipes`

## 改动

- **新增** 3 tools `ScopeWorkflowsUpsertTool.cs` / `ScopeWorkflowsListTool.cs` / `ScopeWorkflowsGetTool.cs`(+275)
- **注册** `BindingAgentToolSource.cs`
- **proto** `ToolArgs.cs` 加 typed args
- **新测试** `BindingToolsTests.cs`(+379)
- 加 Old/New 注释

## 约束遵循

- ❌ 不加新 actor / envelope / pipeline / ADR
- ❌ 不恢复 agent_builder 模板
- ❌ 不暴露 retired WorkflowAgentGAgent lifecycle
- ✅ binding_* tools 保持 generic service binding 不动
- ✅ invoke_service 只负责安装后执行

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test BindingTools` ✅
- guards ✅

净 +696 / -1 LOC。

closes #598

⟦AI:AUTO-LOOP⟧
