### PR TITLE
iter98 cluster-002: separate AgentRun id from correlation_id(local AgentRunIds codec)

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.LarkCardStreaming.cs
@@ -1471,7 +1471,8 @@ public sealed partial class ConversationGAgent
         var delivered = new LlmReplyDeliveredEvent
         {
             CorrelationId = correlationId,
-            RunId = correlationId,
+            RunId = NormalizeOptional(State.PendingLlmReplyRequests.FirstOrDefault(request =>
+                string.Equals(request.CorrelationId, correlationId, StringComparison.Ordinal))?.RunId) ?? string.Empty,
             AckedAtUnixMs = nowMs,
             ChannelMessageId = $"lark-card-stream:{cardMessageId}",
         };

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -257,6 +257,12 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         if (result.LlmReplyRequest is not null)
         {
+            if (string.IsNullOrWhiteSpace(result.LlmReplyRequest.RunId))
+            {
+                await DropNewLlmReplyWithoutRunIdAsync(result.LlmReplyRequest);
+                return;
+            }
+
             // The transient run command copy keeps reply_token + expiry + per-call credentials
             // in Metadata so the run actor can echo them back inside LlmReplyReadyEvent and
             // forward them to the LLM call; the persisted state copy must not carry any of
@@ -264,9 +270,8 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             var runCopy = result.LlmReplyRequest.Clone();
             runCopy.TargetActorId = Id;
             runCopy.TargetRef = targetRef.Clone();
-            runCopy.RunId = NormalizeOptional(runCopy.RunId) ??
-                            NormalizeOptional(runCopy.CorrelationId) ??
-                            activity.Id;
+            // Refactor (iter98/cluster-002): Old=ConversationGAgent filled run_id from correlation_id; New=producer must supply run_id before this handoff.
+            runCopy.RunId = NormalizeOptional(runCopy.RunId)!;
             ApplyRuntimeReplyToken(runCopy, runtimeContext);
             RestoreRuntimeTransportCredentials(runCopy.Activity, runtimeContext);
             var persistedCopy = runCopy.Clone();
@@ -580,6 +585,12 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             return;
         }
 
+        if (string.IsNullOrWhiteSpace(request.RunId))
+        {
+            await DropLegacyPendingLlmReplyWithoutRunIdAsync(request);
+            return;
+        }
+
         try
         {
             // Refactor (iter56/cluster-935-agent-run-actor-admission): old=dispatcher in-process admission, new=actor-owned admission with plain Task
@@ -600,6 +611,46 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
                 request.CorrelationId);
             await ScheduleDeferredLlmReplyDispatchAsync(request, DeferredLlmDispatchRetryDelay, ct);
         }
+    }
+
+    private async Task DropLegacyPendingLlmReplyWithoutRunIdAsync(NeedsLlmReplyEvent request)
+    {
+        // Refactor (iter98/cluster-002): Old=dispatcher recovered actor identity from correlation_id; New=legacy persisted requests without run_id are explicitly quarantined/dropped.
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        Logger.LogWarning(
+            "Dropping legacy pending LLM reply request without run_id; correlation remains trace-only. correlation={CorrelationId}",
+            request.CorrelationId);
+        await PersistDomainEventAsync(new ConversationContinueFailedEvent
+        {
+            CommandId = BuildLlmReplyCommandId(request.CorrelationId),
+            CorrelationId = request.CorrelationId,
+            CausationId = string.Empty,
+            Kind = FailureKind.PermanentAdapterError,
+            ErrorCode = "legacy_pending_llm_reply_missing_run_id_dropped",
+            ErrorSummary = "Legacy pending LLM reply request did not contain run_id and was dropped instead of deriving actor identity from correlation_id.",
+            NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
+            FailedAtUnixMs = nowMs,
+        });
+    }
+
+    private async Task DropNewLlmReplyWithoutRunIdAsync(NeedsLlmReplyEvent request)
+    {
+        // Refactor (iter98/cluster-002): Old=ConversationGAgent supplied implicit run_id; New=new dispatch without run_id is rejected before persistence/dispatch.
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        Logger.LogWarning(
+            "Rejecting deferred LLM reply request without run_id before persistence/dispatch. correlation={CorrelationId}",
+            request.CorrelationId);
+        await PersistDomainEventAsync(new ConversationContinueFailedEvent
+        {
+            CommandId = BuildLlmReplyCommandId(request.CorrelationId),
+            CorrelationId = request.CorrelationId,
+            CausationId = string.Empty,
+            Kind = FailureKind.PermanentAdapterError,
+            ErrorCode = "deferred_llm_reply_missing_run_id_rejected",
+            ErrorSummary = "Deferred LLM reply request must carry explicit run_id before persistence and dispatch.",
+            NotRetryable = new Google.Protobuf.WellKnownTypes.Empty(),
+            FailedAtUnixMs = nowMs,
+        });
     }
 
     [EventHandler]

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -1614,6 +1614,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             var ready = new LlmReplyReadyEvent
             {
                 CorrelationId = correlationId,
+                RunId = ResolvePendingLlmReplyRunId(correlationId) ?? string.Empty,
                 RegistrationId = sourceChunk?.RegistrationId ?? string.Empty,
                 Activity = sourceChunk?.Activity?.Clone() ?? new ChatActivity(),
                 Outbound = new MessageContent { Text = state.PendingFinalizeText },
@@ -1649,6 +1650,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             new LlmReplyReadyEvent
             {
                 CorrelationId = evt.CorrelationId,
+                RunId = ResolvePendingLlmReplyRunId(evt.CorrelationId) ?? string.Empty,
                 RegistrationId = evt.Chunk?.RegistrationId ?? string.Empty,
                 Activity = evt.Chunk?.Activity?.Clone() ?? new ChatActivity(),
                 Outbound = new MessageContent { Text = outboundText },
@@ -1671,6 +1673,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             new LlmReplyReadyEvent
             {
                 CorrelationId = evt.CorrelationId,
+                RunId = ResolvePendingLlmReplyRunId(evt.CorrelationId) ?? string.Empty,
                 RegistrationId = evt.Chunk?.RegistrationId ?? string.Empty,
                 Activity = evt.Chunk?.Activity?.Clone() ?? new ChatActivity(),
                 Outbound = new MessageContent { Text = outboundText },
@@ -2484,6 +2487,9 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         return State.PendingLlmReplyRequests.FirstOrDefault(request =>
             string.Equals(request.CorrelationId, normalizedCorrelationId, StringComparison.Ordinal));
     }
+
+    private string? ResolvePendingLlmReplyRunId(string? correlationId) =>
+        NormalizeOptional(FindPendingLlmReplyRequest(correlationId)?.RunId);
 
     private static void UpsertPendingLlmReplyRequest(
         Google.Protobuf.Collections.RepeatedField<NeedsLlmReplyEvent> field,

--- a/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/Conversation/ConversationGAgent.cs
@@ -716,7 +716,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
             var delivered = new LlmReplyDeliveredEvent
             {
                 CorrelationId = evt.CorrelationId ?? string.Empty,
-                RunId = evt.CorrelationId ?? string.Empty,
+                RunId = evt.RunId ?? string.Empty,
                 AckedAtUnixMs = nowMs,
                 ChannelMessageId = result.OutboundDelivery?.ReplyMessageId ?? string.Empty,
             };
@@ -748,7 +748,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var deliveryFailed = new LlmReplyDeliveryFailedEvent
         {
             CorrelationId = evt.CorrelationId ?? string.Empty,
-            RunId = evt.CorrelationId ?? string.Empty,
+            RunId = evt.RunId ?? string.Empty,
             FailedAtUnixMs = nowMs,
             ErrorCode = result.ErrorCode ?? string.Empty,
             ErrorMessage = result.ErrorSummary ?? string.Empty,
@@ -1713,7 +1713,7 @@ public sealed partial class ConversationGAgent : GAgentBase<ConversationGAgentSt
         var delivered = new LlmReplyDeliveredEvent
         {
             CorrelationId = evt.CorrelationId ?? string.Empty,
-            RunId = evt.CorrelationId ?? string.Empty,
+            RunId = evt.RunId ?? string.Empty,
             AckedAtUnixMs = nowMs,
             ChannelMessageId = $"nyx-relay-stream:{platformMessageId}",
         };

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -49,8 +49,9 @@ message NeedsLlmReplyEvent {
   // command copy may carry it so AgentRunGAgent can apply the route before execution.
   // Never persist to event store, projection, read model, or actor state.
   aevatar.chat_routing.v1.ChatRouteAction target_ref = 10;
-  // Stable run identity owned by AgentRunGAgent. Dispatcher adapters may use
-  // correlation_id only as a bounded fallback for older persisted requests.
+  // Stable run identity owned by AgentRunGAgent. New dispatch MUST set this
+  // explicitly before persistence and before handoff to the run dispatcher.
+  // correlation_id is trace-only and MUST NOT be used to derive actor identity.
   string run_id = 11;
   // Runtime command-only LLM control carrier. ConversationGAgent clears this on
   // the copy persisted to actor state; the run-bound command may carry it to the

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/conversation_events.proto
@@ -122,6 +122,9 @@ message LlmReplyReadyEvent {
   // NeedsLlmReplyEvent verbatim.
   string reply_token = 10;
   int64 reply_token_expires_at_unix_ms = 11;
+  // AgentRunGAgent run_id producing this reply. correlation_id remains trace-only
+  // and MUST NOT be used as actor/run identity.
+  string run_id = 12;
 }
 
 enum ConversationReplyLifecycleMode {
@@ -463,8 +466,7 @@ enum FailureKind {
 // or other side-channel signals.
 message LlmReplyDeliveredEvent {
   string correlation_id = 1;
-  // AgentRunGAgent run_id producing this reply (used to anchor delivery
-  // against a specific committed reply).
+  // AgentRunGAgent run_id producing this reply.
   string run_id = 2;
   int64 acked_at_unix_ms = 3;
   // Channel-side message id from the sink ack (e.g. Lark message_id).

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
@@ -31,8 +31,9 @@ public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
     public async Task DispatchAsync(NeedsLlmReplyEvent request, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var runId = NormalizeRunId(request);
-        var actorId = AgentRunGAgent.BuildActorId(runId);
+        // Refactor (iter98/cluster-002): Old=missing run_id could fall back to correlation_id; New=run_id is required and correlation_id is trace-only.
+        var runId = AgentRunId.Parse(request.RunId, nameof(request.RunId));
+        var actorId = AgentRunActorIds.ForRun(runId);
 
         var actor = await _actorRuntime.CreateAsync<AgentRunGAgent>(actorId, ct);
 
@@ -41,7 +42,7 @@ public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
         {
             Request = request.Clone(),
         };
-        command.Request.RunId = runId;
+        command.Request.RunId = runId.Value;
         var envelope = new EventEnvelope
         {
             Id = commandId,
@@ -51,7 +52,7 @@ public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
             Propagation = new EnvelopePropagation
             {
                 CorrelationId = string.IsNullOrWhiteSpace(request.CorrelationId)
-                    ? runId
+                    ? runId.Value
                     : request.CorrelationId.Trim(),
             },
             Runtime = new EnvelopeRuntime
@@ -70,21 +71,11 @@ public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
 
         _logger.LogInformation(
             "Accepted deferred LLM reply run for actor dispatch: runId={RunId} actorId={ActorId} commandId={CommandId} target={TargetActorId}",
-            runId,
+            runId.Value,
             actor.Id,
             commandId,
             request.TargetActorId);
     }
 
-    private static string BuildStartCommandId(string runId) => $"agent-run-start:{runId}";
-
-    private static string NormalizeRunId(NeedsLlmReplyEvent request)
-    {
-        var runId = request.RunId;
-        if (string.IsNullOrWhiteSpace(runId))
-            runId = request.CorrelationId;
-        if (string.IsNullOrWhiteSpace(runId))
-            throw new InvalidOperationException("Deferred LLM reply request requires run_id for AgentRunGAgent dispatch.");
-        return runId.Trim();
-    }
+    private static string BuildStartCommandId(AgentRunId runId) => $"agent-run-start:{runId.Value}";
 }

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -456,7 +456,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             errorCode,
             errorSummary);
 
-        await DispatchReadyEventAsync(request, replyText, outboundIntent, terminalState, errorCode, errorSummary);
+        await DispatchReadyEventAsync(request, runId, replyText, outboundIntent, terminalState, errorCode, errorSummary);
 
         // Past the point of user-visible delivery. State persistence failures and cleanup
         // scheduling failures MUST NOT propagate out — otherwise HandleStartAsync's outer
@@ -479,6 +479,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         var outbound = State.ProducedOutbound;
         await DispatchReadyEventAsync(
             request,
+            runId,
             State.ProducedReplyText ?? string.Empty,
             outbound,
             State.ProducedTerminalState,
@@ -648,6 +649,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
     private async Task DispatchReadyEventAsync(
         NeedsLlmReplyEvent request,
+        string runId,
         string replyText,
         MessageContent? outboundIntent,
         LlmReplyTerminalState terminalState,
@@ -673,6 +675,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             // entry. The actor consumes these fields and never persists them.
             ReplyToken = request.ReplyToken ?? string.Empty,
             ReplyTokenExpiresAtUnixMs = request.ReplyTokenExpiresAtUnixMs,
+            RunId = runId,
         };
         try
         {

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -24,8 +24,6 @@ namespace Aevatar.GAgents.NyxidChat;
 //   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
 public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 {
-    public const string ActorIdPrefix = "channel-agent-run:";
-
     internal const long MaxRunRequestAgeMs = 5 * 60 * 1000;
 
     /// <summary>
@@ -70,12 +68,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public static string BuildActorId(string correlationId)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
-        return ActorIdPrefix + correlationId.Trim();
-    }
-
     protected override AgentRunGAgentState TransitionState(AgentRunGAgentState current, IMessage evt) =>
         StateTransitionMatcher
             .Match(current, evt)
@@ -113,6 +105,16 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 
         var request = command.Request.Clone();
         ApplyTargetRefOverrides(request);
+        if (!AgentRunId.TryParse(request.RunId, out _))
+        {
+            // Refactor (iter98/cluster-002): Old=missing run_id fell back to correlation/actor id; New=start commands without explicit run_id are malformed.
+            _logger.LogWarning(
+                "Dropping malformed agent run start command without run_id: runActor={RunActorId} correlation={CorrelationId}",
+                Id,
+                request.CorrelationId);
+            return;
+        }
+
         var runId = ResolveRunId(request);
         var startedAtUnixMs = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
 
@@ -1205,10 +1207,8 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
     }
 
-    private string ResolveRunId(NeedsLlmReplyEvent request) =>
-        NormalizeOptional(request.RunId) ??
-        NormalizeOptional(request.CorrelationId) ??
-        Id;
+    private static string ResolveRunId(NeedsLlmReplyEvent request) =>
+        AgentRunId.Parse(request.RunId).Value;
 
     private sealed class AgentRunOutputDispatchException(string message, Exception innerException)
         : Exception(message, innerException);

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs
@@ -1,0 +1,66 @@
+namespace Aevatar.GAgents.NyxidChat;
+
+internal readonly record struct AgentRunId
+{
+    private const string Prefix = "agent-run-";
+
+    public string Value { get; }
+
+    private AgentRunId(string value)
+    {
+        Value = value;
+    }
+
+    public static AgentRunId Parse(string? value, string paramName = "runId")
+    {
+        _ = paramName;
+        var normalized = Normalize(value);
+        if (normalized is null)
+            throw new InvalidOperationException("Deferred LLM reply request requires explicit run_id for AgentRunGAgent dispatch.");
+
+        return new AgentRunId(normalized);
+    }
+
+    public static AgentRunId New() => new(Prefix + Guid.NewGuid().ToString("N"));
+
+    public static bool TryParse(string? value, out AgentRunId runId)
+    {
+        var normalized = Normalize(value);
+        if (normalized is null)
+        {
+            runId = default;
+            return false;
+        }
+
+        runId = new AgentRunId(normalized);
+        return true;
+    }
+
+    public override string ToString() => Value;
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}
+
+internal static class AgentRunActorIds
+{
+    private const string ActorIdPrefix = "channel-agent-run:";
+
+    public static string ForRun(AgentRunId runId) => ActorIdPrefix + runId.Value;
+
+    internal static bool TryGetRunId(string? actorId, out AgentRunId runId)
+    {
+        if (!string.IsNullOrWhiteSpace(actorId) &&
+            actorId.StartsWith(ActorIdPrefix, StringComparison.Ordinal) &&
+            AgentRunId.TryParse(actorId[ActorIdPrefix.Length..], out runId))
+        {
+            return true;
+        }
+
+        runId = default;
+        return false;
+    }
+}

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs
@@ -1,5 +1,8 @@
 namespace Aevatar.GAgents.NyxidChat;
 
+// Refactor (iter98/cluster-002):
+//   Old pattern: actor id 由 CorrelationId 字符串拼出(ActorIdPrefix + correlationId)
+//   New principle: run_id 是 actor id 的唯一构成;correlation_id 只用于 trace 传播
 internal readonly record struct AgentRunId
 {
     private const string Prefix = "agent-run-";
@@ -13,10 +16,11 @@ internal readonly record struct AgentRunId
 
     public static AgentRunId Parse(string? value, string paramName = "runId")
     {
-        _ = paramName;
         var normalized = Normalize(value);
         if (normalized is null)
-            throw new InvalidOperationException("Deferred LLM reply request requires explicit run_id for AgentRunGAgent dispatch.");
+            throw new ArgumentException(
+                "Deferred LLM reply request requires explicit run_id for AgentRunGAgent dispatch.",
+                paramName);
 
         return new AgentRunId(normalized);
     }

--- a/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/ChannelConversationTurnRunner.cs
@@ -1503,6 +1503,8 @@ public sealed class ChannelConversationTurnRunner : IConversationTurnRunner
         var request = new NeedsLlmReplyEvent
         {
             CorrelationId = activity.Id,
+            // Refactor (iter98/cluster-002): Old=correlation_id doubled as run identity; New=run_id is explicit before persistence/dispatch.
+            RunId = AgentRunId.New().Value,
             TargetActorId = ConversationGAgent.BuildActorId(activity.Conversation!.CanonicalKey),
             RegistrationId = registration.Id,
             Activity = requestActivity,

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -409,6 +409,44 @@ public sealed class ConversationGAgentDedupTests
     }
 
     [Fact]
+    public async Task HandleDeferredLlmReplyDispatchRequestedAsync_LegacyPendingRequestMissingRunId_DropsWithoutDispatch()
+    {
+        var dispatcher = new RecordingRunDispatcher();
+        var runner = new RecordingTurnRunner();
+        var store = new InMemoryEventStore();
+        const string agentId = "conv-legacy-pending-missing-run";
+        await AppendStateEventAsync(
+            store,
+            agentId,
+            new NeedsLlmReplyEvent
+            {
+                CorrelationId = "legacy-corr-missing-run",
+                TargetActorId = "conversation:actor",
+                RegistrationId = "reg-1",
+                Activity = CreateActivity("legacy-corr-missing-run", "conv:slack:C1"),
+                RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            },
+            version: 1);
+        var (agent, _) = CreateAgent(runner, agentId, dispatcher, store: store);
+
+        await agent.HandleDeferredLlmReplyDispatchRequestedAsync(new DeferredLlmReplyDispatchRequestedEvent
+        {
+            CorrelationId = "legacy-corr-missing-run",
+            RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        });
+
+        dispatcher.Dispatched.ShouldBeEmpty();
+        agent.State.PendingLlmReplyRequests.ShouldNotContain(req => req.CorrelationId == "legacy-corr-missing-run");
+        var failed = (await store.GetEventsAsync(agent.Id))
+            .Where(e => e.EventType.Contains(nameof(ConversationContinueFailedEvent), StringComparison.Ordinal))
+            .Select(e => ConversationContinueFailedEvent.Parser.ParseFrom(e.EventData.Value))
+            .LastOrDefault();
+        failed.ShouldNotBeNull();
+        failed!.ErrorCode.ShouldBe("legacy_pending_llm_reply_missing_run_id_dropped");
+        failed.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable);
+    }
+
+    [Fact]
     public async Task HandleNyxRelayInboundActivityAsync_WithCallbackJti_PersistsAdmissionBeforeRunner()
     {
         var observedAtMs = DateTimeOffset.UtcNow.AddSeconds(-17).ToUnixTimeMilliseconds();
@@ -760,6 +798,7 @@ public sealed class ConversationGAgentDedupTests
             Outbound = new MessageContent { Text = "reply-from-llm" },
             TerminalState = LlmReplyTerminalState.Completed,
             ReadyAtUnixMs = 43,
+            RunId = "run-act-llm-ready",
         };
 
         await agent.HandleLlmReplyReadyAsync(ready);
@@ -773,7 +812,7 @@ public sealed class ConversationGAgentDedupTests
         events.Count.ShouldBe(3);
         events.Last().EventType.ShouldContain(nameof(ConversationTurnCompletedEvent));
         events.Select(e => e.EventType).ShouldContain(s => s.Contains(nameof(LlmReplyDeliveredEvent)));
-        agent.State.LastReplyDelivery.RunId.ShouldBe("act-llm-ready");
+        agent.State.LastReplyDelivery.RunId.ShouldBe("run-act-llm-ready");
         agent.State.LastReplyDelivery.OutcomeCase.ShouldBe(ReplyDeliveryStatus.OutcomeOneofCase.Delivered);
         agent.State.LastReplyDelivery.Delivered.ChannelMessageId.ShouldBe(string.Empty);
     }
@@ -804,9 +843,10 @@ public sealed class ConversationGAgentDedupTests
             Outbound = new MessageContent { Text = "reply-from-llm" },
             TerminalState = LlmReplyTerminalState.Completed,
             ReadyAtUnixMs = 43,
+            RunId = "run-corr-delivered",
         });
 
-        agent.State.LastReplyDelivery.RunId.ShouldBe("corr-delivered");
+        agent.State.LastReplyDelivery.RunId.ShouldBe("run-corr-delivered");
         agent.State.LastReplyDelivery.OutcomeCase.ShouldBe(ReplyDeliveryStatus.OutcomeOneofCase.Delivered);
         agent.State.LastReplyDelivery.Delivered.ChannelMessageId.ShouldBe("om_delivery_ok");
         agent.State.LastReplyDelivery.Delivered.AckedAtUnixMs.ShouldBeGreaterThan(0);
@@ -833,9 +873,10 @@ public sealed class ConversationGAgentDedupTests
             Outbound = new MessageContent { Text = "reply-from-llm" },
             TerminalState = LlmReplyTerminalState.Completed,
             ReadyAtUnixMs = 43,
+            RunId = "run-corr-delivery-failed",
         });
 
-        agent.State.LastReplyDelivery.RunId.ShouldBe("corr-delivery-failed");
+        agent.State.LastReplyDelivery.RunId.ShouldBe("run-corr-delivery-failed");
         agent.State.LastReplyDelivery.OutcomeCase.ShouldBe(ReplyDeliveryStatus.OutcomeOneofCase.Failed);
         agent.State.LastReplyDelivery.Failed.ErrorCode.ShouldBe("lark_send_failed");
         agent.State.LastReplyDelivery.Failed.ErrorMessage.ShouldBe("lark rejected send");

--- a/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
+++ b/test/Aevatar.GAgents.Channel.Protocol.Tests/ConversationGAgentDedupTests.cs
@@ -261,14 +261,14 @@ public sealed class ConversationGAgentDedupTests
                 if (callCount == 1)
                     return ConversationTurnResult.TransientFailure("rate_limited", "retry later");
                 return ConversationTurnResult.LlmReplyRequested(
-                    new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                     {
                         CorrelationId = activity.Id,
                         TargetActorId = "conversation:actor",
                         RegistrationId = "reg-1",
                         Activity = activity.Clone(),
                         RequestedAtUnixMs = 7,
-                    });
+                    }));
             },
         };
         var (agent, store) = CreateAgent(runner, "conv-llm-supersedes-retry");
@@ -354,14 +354,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.Id,
                     TargetActorId = "conversation:actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = 42,
-                }),
+                })),
         };
         var (agent, store) = CreateAgent(runner, "conv-llm-request");
 
@@ -373,8 +373,39 @@ public sealed class ConversationGAgentDedupTests
         events[0].EventType.ShouldContain(nameof(NeedsLlmReplyEvent));
         var parsed = NeedsLlmReplyEvent.Parser.ParseFrom(events[0].EventData.Value);
         parsed.CorrelationId.ShouldBe("act-llm");
-        parsed.RunId.ShouldBe("act-llm");
+        parsed.RunId.ShouldBe("run-act-llm");
         parsed.Activity.Id.ShouldBe("act-llm");
+    }
+
+    [Fact]
+    public async Task HandleInboundActivityAsync_WhenDeferredReplyMissingRunId_RejectsBeforePersistenceOrDispatch()
+    {
+        var dispatcher = new RecordingRunDispatcher();
+        var runner = new RecordingTurnRunner
+        {
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                new NeedsLlmReplyEvent
+                {
+                    CorrelationId = activity.Id,
+                    TargetActorId = "conversation:actor",
+                    RegistrationId = "reg-1",
+                    Activity = activity.Clone(),
+                    RequestedAtUnixMs = 42,
+                }),
+        };
+        var (agent, store) = CreateAgent(runner, "conv-llm-missing-run", dispatcher);
+
+        await agent.HandleInboundActivityAsync(CreateActivity("act-missing-run", "conv:slack:C1"));
+
+        dispatcher.Dispatched.ShouldBeEmpty();
+        agent.State.PendingLlmReplyRequests.ShouldBeEmpty();
+        var events = await store.GetEventsAsync(agent.Id);
+        events.ShouldHaveSingleItem();
+        events[0].EventType.ShouldContain(nameof(ConversationContinueFailedEvent));
+        var failed = ConversationContinueFailedEvent.Parser.ParseFrom(events[0].EventData.Value);
+        failed.CorrelationId.ShouldBe("act-missing-run");
+        failed.ErrorCode.ShouldBe("deferred_llm_reply_missing_run_id_rejected");
+        failed.RetryPolicyCase.ShouldBe(ConversationContinueFailedEvent.RetryPolicyOneofCase.NotRetryable);
     }
 
     [Fact]
@@ -626,14 +657,15 @@ public sealed class ConversationGAgentDedupTests
 
         var llmRunner = new RecordingTurnRunner
         {
-            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(new NeedsLlmReplyEvent
+            InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
+                WithRunId(new NeedsLlmReplyEvent
             {
                 CorrelationId = activity.Id,
                 TargetActorId = "conversation:actor",
                 RegistrationId = "reg-1",
                 Activity = activity.Clone(),
                 RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            }),
+                })),
         };
         var (llmAgent, _) = CreateAgent(llmRunner, "conv-relay-llm-reap");
         var llmRelay = CreateRelayInbound("act-llm-reap", "conv:slack:C1", "api-key-1", "jti-llm");
@@ -688,14 +720,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.Id,
                     TargetActorId = "conversation:actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                }),
+                })),
         };
         var (agent, store) = CreateAgent(runner, "conv-accepted-not-committed", dispatcher);
 
@@ -873,14 +905,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.Id,
                     TargetActorId = "conversation:actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = 42,
-                }),
+                })),
         };
         var (agent, _) = CreateAgent(runner, "conv-direct-dispatch", dispatcher);
 
@@ -888,7 +920,7 @@ public sealed class ConversationGAgentDedupTests
 
         dispatcher.Dispatched.Count.ShouldBe(1);
         dispatcher.Dispatched[0].CorrelationId.ShouldBe("act-direct");
-        dispatcher.Dispatched[0].RunId.ShouldBe("act-direct");
+        dispatcher.Dispatched[0].RunId.ShouldBe("run-act-direct");
         dispatcher.Dispatched[0].TargetActorId.ShouldBe(agent.Id);
     }
 
@@ -899,14 +931,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
                     TargetActorId = "conversation:actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = 42,
-                }),
+                })),
         };
         var queryPort = StaticChatRoutePolicyQueryPort.ForSnapshot(new ChatRoutePolicySnapshot(
             ForwardToModelAction("fallback-model"),
@@ -960,7 +992,7 @@ public sealed class ConversationGAgentDedupTests
         });
 
         dispatcher.Dispatched.ShouldHaveSingleItem();
-        dispatcher.Dispatched[0].RunId.ShouldBe("corr-route");
+        dispatcher.Dispatched[0].RunId.ShouldBe("run-corr-route");
         dispatcher.Dispatched[0].TargetRef.ForwardToGagent.ActorId.ShouldBe("target-gagent-1");
         dispatcher.Dispatched[0].ReplyToken.ShouldBe("runtime-only-token");
 
@@ -983,14 +1015,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
                     TargetActorId = "conversation:actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = 42,
-                }),
+                })),
             LlmReplyResultFactory = reply => ConversationTurnResult.Sent(
                 "sent:" + reply.CorrelationId,
                 new MessageContent { Text = "ack" },
@@ -1069,14 +1101,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.Id,
                     TargetActorId = "stale-unscoped-actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                }),
+                })),
         };
         var (agent, store) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner", dispatcher);
 
@@ -1123,14 +1155,14 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.Id,
                     TargetActorId = "stale-unscoped-actor",
                     RegistrationId = "reg-1",
                     Activity = activity.Clone(),
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-                }),
+                })),
         };
         var (agent, _) = CreateAgent(runner, "channel-conversation:conv:slack:C1:scope:owner");
 
@@ -1177,7 +1209,7 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
                     TargetActorId = "conversation:actor",
@@ -1186,7 +1218,7 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     ReplyToken = sentinelReplyToken,
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
-                }),
+                })),
         };
         var (agent, store) = CreateAgent(runner, "conv-strip-token", dispatcher);
 
@@ -1227,7 +1259,7 @@ public sealed class ConversationGAgentDedupTests
         {
             InboundResultFactory = activity =>
             {
-                var request = new NeedsLlmReplyEvent
+                var request = WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
                     TargetActorId = "conversation:actor",
@@ -1236,7 +1268,7 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     ReplyToken = "relay-token-strip-cred",
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
-                };
+                });
                 request.Metadata["nyxid.sender_access_token"] = sentinelSenderToken;
                 request.Metadata["nyxid.access_token"] = sentinelOwnerToken;
                 request.Metadata["nyxid.org_token"] = sentinelOrgToken;
@@ -1292,7 +1324,7 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
                     TargetActorId = "conversation:actor",
@@ -1301,7 +1333,7 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     ReplyToken = sentinelReplyToken,
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(20).ToUnixTimeMilliseconds(),
-                }),
+                })),
         };
         var (agent, store) = CreateAgent(runner, "conv-retry-enrich", dispatcher);
 
@@ -1401,7 +1433,7 @@ public sealed class ConversationGAgentDedupTests
         var runner = new RecordingTurnRunner
         {
             InboundResultFactory = activity => ConversationTurnResult.LlmReplyRequested(
-                new NeedsLlmReplyEvent
+                WithRunId(new NeedsLlmReplyEvent
                 {
                     CorrelationId = activity.OutboundDelivery?.CorrelationId ?? activity.Id,
                     TargetActorId = "conversation:actor",
@@ -1410,7 +1442,7 @@ public sealed class ConversationGAgentDedupTests
                     RequestedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                     ReplyToken = "drop-test-token",
                     ReplyTokenExpiresAtUnixMs = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeMilliseconds(),
-                }),
+                })),
         };
         var (agent, store) = CreateAgent(runner, "conv-drop-clears", dispatcher);
 
@@ -2351,6 +2383,16 @@ public sealed class ConversationGAgentDedupTests
         Payload = new MessageContent { Text = "ping" },
         DispatchedAtUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
     };
+
+    private static NeedsLlmReplyEvent WithRunId(NeedsLlmReplyEvent request, string? runId = null)
+    {
+        request.RunId = string.IsNullOrWhiteSpace(runId)
+            ? "run-" + (string.IsNullOrWhiteSpace(request.CorrelationId)
+                ? Guid.NewGuid().ToString("N")
+                : request.CorrelationId.Trim())
+            : runId.Trim();
+        return request;
+    }
 
     private static async Task<NyxRelayTextOperationCompletedEvent> CompleteNextNyxRelayTextOperationAsync(
         ConversationGAgent agent,

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -47,7 +47,7 @@ public sealed class AgentRunGAgentTests
 
         dispatchPort.Dispatches.Should().ContainSingle();
         var (actorId, envelope) = dispatchPort.Dispatches.Single();
-        actorId.Should().Be(AgentRunGAgent.BuildActorId("run-dispatch"));
+        actorId.Should().Be(AgentRunActorIds.ForRun(AgentRunId.Parse("run-dispatch")));
         envelope.Id.Should().Be("agent-run-start:run-dispatch");
         envelope.Runtime.Deduplication.OperationId.Should().Be("agent-run-start:run-dispatch");
         envelope.Propagation.CorrelationId.Should().Be("corr-dispatch");
@@ -56,6 +56,30 @@ public sealed class AgentRunGAgentTests
         command.Request.CorrelationId.Should().Be("corr-dispatch");
         command.Request.TargetActorId.Should().Be("conversation-actor");
         command.Request.ReplyToken.Should().Be("relay-token-dispatch");
+    }
+
+    [Fact]
+    public async Task DispatchAsync_WhenRunIdMissing_ShouldRejectEvenWithCorrelationId()
+    {
+        var actorRuntime = new DispatchingActorRuntime();
+        var dispatchPort = new RecordingActorDispatchPort();
+        var dispatcher = new AgentRunDispatcher(
+            actorRuntime,
+            dispatchPort,
+            NullLogger<AgentRunDispatcher>.Instance);
+
+        var act = () => dispatcher.DispatchAsync(new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-trace-only",
+            TargetActorId = "conversation-actor",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*run_id*");
+        dispatchPort.Dispatches.Should().BeEmpty();
+        actorRuntime.Dispatches.Should().BeEmpty();
     }
 
     [Fact]
@@ -86,7 +110,7 @@ public sealed class AgentRunGAgentTests
 
         dispatchPort.Dispatches.Should().HaveCount(2);
         dispatchPort.Dispatches.Select(x => x.ActorId)
-            .Should().OnlyContain(id => id == AgentRunGAgent.BuildActorId("run-duplicate-dispatch"));
+            .Should().OnlyContain(id => id == AgentRunActorIds.ForRun(AgentRunId.Parse("run-duplicate-dispatch")));
         dispatchPort.Dispatches.Select(x => x.Envelope.Id)
             .Should().OnlyContain(id => id == "agent-run-start:run-duplicate-dispatch");
         actorRuntime.DestroyedIds.Should().BeEmpty();
@@ -148,8 +172,8 @@ public sealed class AgentRunGAgentTests
         }, CancellationToken.None);
 
         dispatchPort.Dispatches.Should().ContainSingle();
-        dispatchPort.Dispatches.Single().ActorId.Should().Be(AgentRunGAgent.BuildActorId("run-stale-dispatch"));
-        (await actorRuntime.ExistsAsync(AgentRunGAgent.BuildActorId("run-stale-dispatch"))).Should().BeTrue();
+        dispatchPort.Dispatches.Single().ActorId.Should().Be(AgentRunActorIds.ForRun(AgentRunId.Parse("run-stale-dispatch")));
+        (await actorRuntime.ExistsAsync(AgentRunActorIds.ForRun(AgentRunId.Parse("run-stale-dispatch")))).Should().BeTrue();
     }
 
     [Fact]
@@ -704,7 +728,7 @@ public sealed class AgentRunGAgentTests
         cleanup.ActorId.Should().Be(runtime.Id);
         cleanup.DueTime.Should().Be(AgentRunGAgent.TerminalCleanupDelay);
         var cleanupCommand = cleanup.TriggerEnvelope.Payload.Unpack<AgentRunCleanupRequested>();
-        cleanupCommand.RunId.Should().Be("corr-cleanup-schedule");
+        cleanupCommand.RunId.Should().Be(runtime.State.RunId);
     }
 
     [Fact]
@@ -771,7 +795,7 @@ public sealed class AgentRunGAgentTests
         });
         await runtime.HandleCleanupAsync(new AgentRunCleanupRequested
         {
-            RunId = "corr-cleanup",
+            RunId = runtime.State.RunId,
         });
 
         actorRuntime.DestroyedIds.Should().Contain(runtime.Id);
@@ -808,7 +832,7 @@ public sealed class AgentRunGAgentTests
             Activity = BuildRelayActivity(),
             ReplyToken = "relay-token-cleanup-dup",
         });
-        var cleanup = new AgentRunCleanupRequested { RunId = "corr-cleanup-dup" };
+        var cleanup = new AgentRunCleanupRequested { RunId = runtime.State.RunId };
         await runtime.HandleCleanupAsync(cleanup);
         await runtime.HandleCleanupAsync(cleanup);
 
@@ -917,7 +941,7 @@ public sealed class AgentRunGAgentTests
         await runtime.HandleStartAsync(request);
         await runtime.HandleCleanupAsync(new AgentRunCleanupRequested
         {
-            RunId = "corr-no-resched",
+            RunId = runtime.State.RunId,
         });
         var cleanupCountAfterFirst = scheduler.Timeouts
             .Count(t => t.TriggerEnvelope.Payload.Is(AgentRunCleanupRequested.Descriptor));
@@ -1155,7 +1179,7 @@ public sealed class AgentRunGAgentTests
         retry.ActorId.Should().Be(runtime.Id);
         retry.DueTime.Should().Be(AgentRunGAgent.OutputDispatchRetryDelay);
         var retryCommand = retry.TriggerEnvelope.Payload.Unpack<AgentRunOutputDispatchRetryRequested>();
-        retryCommand.RunId.Should().Be("corr-retry-ready");
+        retryCommand.RunId.Should().Be(runtime.State.RunId);
         retryCommand.CorrelationId.Should().Be("corr-retry-ready");
         retryCommand.TargetActorId.Should().Be("actor-1");
         Encoding.UTF8.GetString(retry.TriggerEnvelope.ToByteArray()).Should().NotContain("relay-token-retry-ready");
@@ -2129,7 +2153,7 @@ public sealed class AgentRunGAgentTests
             relayOptions,
             NullLogger<AgentRunGAgent>.Instance,
             callbackScheduler);
-        SetId(agent, AgentRunGAgent.BuildActorId(Guid.NewGuid().ToString("N")));
+        SetId(agent, AgentRunActorIds.ForRun(AgentRunId.New()));
         generationExecutor.Bind(agent);
         agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
             InvokeAgentTransition(agent, current, evt));
@@ -2150,7 +2174,7 @@ public sealed class AgentRunGAgentTests
             relayOptions,
             NullLogger<AgentRunGAgent>.Instance,
             callbackScheduler);
-        SetId(agent, AgentRunGAgent.BuildActorId(Guid.NewGuid().ToString("N")));
+        SetId(agent, AgentRunActorIds.ForRun(AgentRunId.New()));
         agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
             InvokeAgentTransition(agent, current, evt));
         agent.EventPublisher = eventPublisher ?? new DispatchingEventPublisher(actorRuntime);
@@ -2663,6 +2687,21 @@ internal static class AgentRunGAgentTestExtensions
     public static Task HandleStartAsync(this AgentRunGAgent agent, NeedsLlmReplyEvent request) =>
         agent.HandleStartAsync(new AgentRunStartRequested
         {
-            Request = request,
+            Request = WithRunId(agent, request),
         });
+
+    private static NeedsLlmReplyEvent WithRunId(AgentRunGAgent agent, NeedsLlmReplyEvent request)
+    {
+        var clone = request.Clone();
+        if (string.IsNullOrWhiteSpace(clone.RunId))
+        {
+            clone.RunId = AgentRunActorIds.TryGetRunId(agent.Id, out var runId)
+                ? runId.Value
+                : "run-" + (string.IsNullOrWhiteSpace(clone.CorrelationId)
+                    ? Guid.NewGuid().ToString("N")
+                    : clone.CorrelationId.Trim());
+        }
+
+        return clone;
+    }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -76,7 +76,7 @@ public sealed class AgentRunGAgentTests
             Activity = BuildRelayActivity(),
         }, CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*run_id*");
         dispatchPort.Dispatches.Should().BeEmpty();
         actorRuntime.Dispatches.Should().BeEmpty();
@@ -1636,6 +1636,7 @@ public sealed class AgentRunGAgentTests
 
         handled.Should().NotBeNull();
         var ready = handled!.Payload.Unpack<LlmReplyReadyEvent>();
+        ready.RunId.Should().Be(runtime.State.RunId);
         ready.ReplyToken.Should().Be("relay-token-echo");
         ready.ReplyTokenExpiresAtUnixMs.Should().Be(expiresAtUnixMs);
     }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelConversationTurnRunnerTests.cs
@@ -42,6 +42,8 @@ public sealed class ChannelConversationTurnRunnerTests
         result.Success.Should().BeTrue();
         result.LlmReplyRequest.Should().NotBeNull();
         result.LlmReplyRequest!.CorrelationId.Should().Be("msg-1");
+        result.LlmReplyRequest.RunId.Should().StartWith("agent-run-");
+        result.LlmReplyRequest.RunId.Should().NotBe(result.LlmReplyRequest.CorrelationId);
         result.LlmReplyRequest.TargetActorId.Should().Be("channel-conversation:lark:group:oc_group_chat_1");
         result.LlmReplyRequest.Metadata[ChannelMetadataKeys.ChatType].Should().Be("group");
         adapter.Replies.Should().BeEmpty();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayTextOperationTimeoutPayloadTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/NyxRelayTextOperationTimeoutPayloadTests.cs
@@ -39,12 +39,71 @@ public sealed class NyxRelayTextOperationTimeoutPayloadTests
         Encoding.UTF8.GetString(persistedBytes).Should().NotContain("runtime-user-access-token-secret");
     }
 
+    [Fact]
+    public async Task HandleNyxRelayTextOperationTimeoutFiredAsync_FinalCompletion_PersistsDeliveredRunIdFromPendingRequest()
+    {
+        await using var callbackHarness = await RuntimeCallbackSchedulerGrainTestHarness.StartAsync();
+        var store = new InMemoryEventStore();
+        var agent = CreateAgent("conv-nyx-final-timeout-run-id", callbackHarness.Scheduler, store);
+        var chunk = CreateStreamChunk();
+
+        agent.State.PendingLlmReplyRequests.Add(new NeedsLlmReplyEvent
+        {
+            CorrelationId = chunk.CorrelationId,
+            RunId = "run-stream-final-timeout",
+            TargetActorId = agent.Id,
+            RegistrationId = chunk.RegistrationId,
+            Activity = chunk.Activity.Clone(),
+            RequestedAtUnixMs = 10,
+        });
+        agent.State.ActiveReplyLifecycles.Add(new ConversationReplyLifecycleState
+        {
+            CorrelationId = chunk.CorrelationId,
+            Mode = ConversationReplyLifecycleMode.NyxRelayText,
+            Phase = ConversationReplyLifecyclePhase.TextStreaming,
+            PlatformMessageId = "relay-msg-1",
+            LastFlushedText = "partial text",
+            EditCount = 1,
+            NyxRelayInFlightOperation = NyxRelayTextOperationKind.Final,
+            NyxRelayInFlightSequence = 2,
+            NyxRelayOperationGeneration = 3,
+        });
+
+        await agent.HandleNyxRelayTextOperationTimeoutFiredAsync(new NyxRelayTextOperationTimeoutFiredEvent
+        {
+            CorrelationId = chunk.CorrelationId,
+            Operation = NyxRelayTextOperationKind.Final,
+            Sequence = 2,
+            OperationGeneration = 3,
+            Chunk = chunk.Clone(),
+            CurrentPlatformMessageId = "relay-msg-1",
+            CommandId = "llm-reply:corr-timeout-token",
+            FinalText = "final text",
+            LastFlushedText = "partial text",
+            EditCount = 1,
+            FiredAtUnixMs = 30,
+        });
+
+        var delivered = (await store.GetEventsAsync(agent.Id))
+            .Select(e => e.EventData)
+            .Where(e => e.Is(LlmReplyDeliveredEvent.Descriptor))
+            .Select(e => e.Unpack<LlmReplyDeliveredEvent>())
+            .OfType<LlmReplyDeliveredEvent>()
+            .Should()
+            .ContainSingle()
+            .Subject;
+        delivered.RunId.Should().Be("run-stream-final-timeout");
+        agent.State.LastReplyDelivery.RunId.Should().Be("run-stream-final-timeout");
+    }
+
     private static ConversationGAgent CreateAgent(
         string id,
-        IActorRuntimeCallbackScheduler scheduler)
+        IActorRuntimeCallbackScheduler scheduler,
+        IEventStore? store = null)
     {
+        var eventStore = store ?? new InMemoryEventStore();
         var services = new ServiceCollection()
-            .AddSingleton<IEventStore, InMemoryEventStore>()
+            .AddSingleton<IEventStore>(eventStore)
             .AddSingleton<IActorDispatchPort, NoopActorDispatchPort>()
             .AddSingleton(scheduler)
             .AddSingleton<IConversationTurnRunner, SucceedingTurnRunner>()


### PR DESCRIPTION
## 摘要

iter98 cluster-002(severity: medium,违反 CLAUDE-ID-CORRELATION-SEPARATION + CLAUDE-NAMING)。AgentRun 把追踪 ID 当成 actor 地址。

## Phase 9 r1 consensus(3/3 unanimous)

`META_JUDGE_DONE:consensus:structural:require explicit NeedsLlmReplyEvent.run_id for new dispatch; keep correlation_id trace-only; quarantine legacy fallback; rename actor-id helper to run identity`

## 改动

- **新增** `agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs`(local run identity codec,+66)
- **重构** `AgentRunDispatcher.cs`:正常 dispatch require non-blank RunId,移除 correlation_id fallback
- **重构** `AgentRunGAgent.cs`:BuildActorId 改 run-id only,不再接 correlation 字符串
- **生产方** `ChannelConversationTurnRunner.cs`:创建 NeedsLlmReplyEvent 时显式 set RunId
- **隔离** 旧 persisted 缺 RunId 路径 → explicit legacy migration/drop
- **新测试** AgentRunGAgentTests + ConversationGAgentDedupTests:缺 run_id reject / 显式 RunId
- **proto** conversation_events.proto comment 更新
- 加 Old/New 注释

## 约束遵循

- ❌ 不新增 actor / envelope / pipeline phase / ADR
- ❌ 不破坏 NyxID 外部仓库契约
- ✅ correlation_id 只用 trace 传播(EnvelopePropagation.CorrelationId)
- ✅ actor ID 字符串形状不再 dispatcher/runtime boundary 外暴露

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test AgentRun` ✅
- guards ✅

净 +268 / -74 LOC。

closes #1037

⟦AI:AUTO-LOOP⟧
