### PR TITLE
iter98 cluster-790: draft-run RunFinished typed payload(GAgentDraftRunResultPayload)

### DIFF
--- a/apps/aevatar-console-web/src/pages/runs/runEventPresentation.ts
+++ b/apps/aevatar-console-web/src/pages/runs/runEventPresentation.ts
@@ -161,6 +161,7 @@ export function extractRunFinishedOutput(events: AGUIEvent[]): string {
     (latestRunFinished as unknown as Record<string, unknown>).result,
   );
 
+  // Refactor (iter98/cluster-790): Old: missed-live fallback expected generic result keys after backend text synthesis. New: RunFinished.result is typed GAgentDraftRunResultPayload, and consumers read result.output directly.
   return (
     readOptionalRecordString(result, 'output') ||
     readOptionalRecordString(result, 'Output') ||

--- a/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/StudioBuildPanels.tsx
@@ -537,6 +537,7 @@ function extractRunFinishedOutput(result: unknown): string {
   }
 
   const record = result as Record<string, unknown>;
+  // Refactor (iter98/cluster-790): Old: UI relied on generic/fallback result shapes after backend missed-live synthesis. New: typed GAgentDraftRunResultPayload exposes result.output.
   const candidate = record.output ?? record.Output ?? record.message ?? record.text;
   return typeof candidate === 'string' ? candidate : '';
 }

--- a/apps/aevatar-console-web/src/shared/agui/runtimeEventSemantics.ts
+++ b/apps/aevatar-console-web/src/shared/agui/runtimeEventSemantics.ts
@@ -217,6 +217,7 @@ export function extractRunFinishedOutput(event: RuntimeEvent): string | null {
   }
 
   const record = asRecord(result);
+  // Refactor (iter98/cluster-790): Old: backend could synthesize missed-live text frames. New: consumer fallback reads typed GAgentDraftRunResultPayload.output from RunFinished.result.
   const candidate = readOptionalString(record, "output", "Output", "message", "text");
   return candidate || null;
 }

--- a/src/Aevatar.Presentation.AGUI/AGUISseWriter.cs
+++ b/src/Aevatar.Presentation.AGUI/AGUISseWriter.cs
@@ -21,6 +21,7 @@ public sealed class AGUISseWriter : IAsyncDisposable
     // Refactor (iter57/cluster-067-942): old per-request channel/sink removed; new active path writes CQRS/projection AGUI events to SSE.
     private static readonly TypeRegistry DefaultTypeRegistry = TypeRegistry.FromFiles(
         AGUIEvent.Descriptor.File,
+        GAgentDraftRunResultPayload.Descriptor.File,
         AnyReflection.Descriptor,
         StructReflection.Descriptor,
         WrappersReflection.Descriptor);

--- a/src/Aevatar.Presentation.AGUI/AGUISseWriter.cs
+++ b/src/Aevatar.Presentation.AGUI/AGUISseWriter.cs
@@ -19,6 +19,7 @@ namespace Aevatar.Presentation.AGUI;
 public sealed class AGUISseWriter : IAsyncDisposable
 {
     // Refactor (iter57/cluster-067-942): old per-request channel/sink removed; new active path writes CQRS/projection AGUI events to SSE.
+    // Refactor (iter98/cluster-790): Old: SSE Any registry only knew AGUI base files, so typed RunFinished.result payloads rendered opaquely. New: register GAgentDraftRunResultPayload for JSON result.output fallback.
     private static readonly TypeRegistry DefaultTypeRegistry = TypeRegistry.FromFiles(
         AGUIEvent.Descriptor.File,
         GAgentDraftRunResultPayload.Descriptor.File,

--- a/src/Aevatar.Presentation.AGUI/agui_events.proto
+++ b/src/Aevatar.Presentation.AGUI/agui_events.proto
@@ -39,6 +39,10 @@ message RunFinishedEvent {
   google.protobuf.Any result = 3;
 }
 
+message GAgentDraftRunResultPayload {
+  string output = 1;
+}
+
 message RunErrorEvent {
   string message = 1;
   google.protobuf.StringValue run_id = 2;

--- a/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardedCompletionRecorder.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Responses/ResponsesForwardedCompletionRecorder.cs
@@ -78,13 +78,23 @@ public sealed class ResponsesForwardedCompletionRecorder
             CompletedAt = Timestamp.FromDateTimeOffset(completedAt),
         };
         var toolStarts = new List<(string ToolCallId, string ToolName)>();
+        var observedLiveTextDelta = false;
+        string? runFinishedOutput = null;
 
         foreach (var evt in events)
         {
             switch (evt.EventCase)
             {
                 case AGUIEvent.EventOneofCase.TextMessageContent:
-                    completion.OutputText += evt.TextMessageContent?.Delta ?? string.Empty;
+                    var delta = evt.TextMessageContent?.Delta ?? string.Empty;
+                    if (delta.Length > 0)
+                    {
+                        observedLiveTextDelta = true;
+                        completion.OutputText += delta;
+                    }
+                    break;
+                case AGUIEvent.EventOneofCase.RunFinished:
+                    runFinishedOutput = ResolveGAgentDraftRunOutput(evt.RunFinished?.Result) ?? runFinishedOutput;
                     break;
                 case AGUIEvent.EventOneofCase.ToolCallStart:
                     if (!string.IsNullOrWhiteSpace(evt.ToolCallStart?.ToolCallId))
@@ -119,7 +129,20 @@ public sealed class ResponsesForwardedCompletionRecorder
             }
         }
 
+        // Refactor (iter98/cluster-790): Old: backend could synthesize missed-live TextMessageContent, duplicating output for clients that did observe deltas. New: consumers fallback to typed RunFinished.result.output only when no live delta was observed.
+        if (!observedLiveTextDelta && !string.IsNullOrEmpty(runFinishedOutput))
+            completion.OutputText = runFinishedOutput;
+
         return completion;
+    }
+
+    private static string? ResolveGAgentDraftRunOutput(Any? result)
+    {
+        if (result?.Is(GAgentDraftRunResultPayload.Descriptor) != true)
+            return null;
+
+        var payload = result.Unpack<GAgentDraftRunResultPayload>();
+        return payload.Output ?? string.Empty;
     }
 
     public static LlmSessionCompletion BuildFailureCompletion(

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
@@ -548,6 +548,8 @@ internal sealed class GAgentDraftRunFinalizeEmitter
                 {
                     ThreadId = receipt.ActorId,
                     RunId = receipt.CommandId,
+                    // Refactor (iter98/cluster-790): Old: terminal RunFinished carried no typed result, so consumers needed backend text-frame synthesis for missed live deltas. New: result packs GAgentDraftRunResultPayload and consumers use result.output fallback.
+                    Result = Any.Pack(new GAgentDraftRunResultPayload()),
                 },
             },
             ct).AsTask();

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/GAgentDraftRunSessionEventProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/GAgentDraftRunSessionEventProjector.cs
@@ -97,44 +97,7 @@ public sealed class GAgentDraftRunSessionEventProjector
             ? context.SessionId
             : completed.SessionId;
         var content = completed.Content ?? string.Empty;
-        if (string.IsNullOrEmpty(content) || completed.ContentEmitted)
-        {
-            return BuildTerminalEntries(context, messageId, content);
-        }
-
-        return
-        [
-            new ProjectionSessionEventEntry<AGUIEvent>(
-                context.RootActorId,
-                context.SessionId,
-                new AGUIEvent
-                {
-                    TextMessageStart = new TextMessageStartEvent
-                    {
-                        MessageId = messageId,
-                        Role = "assistant",
-                    },
-                }),
-            new ProjectionSessionEventEntry<AGUIEvent>(
-                context.RootActorId,
-                context.SessionId,
-                new AGUIEvent
-                {
-                    TextMessageContent = new TextMessageContentEvent
-                    {
-                        MessageId = messageId,
-                        Delta = content,
-                    },
-                }),
-            new ProjectionSessionEventEntry<AGUIEvent>(
-                context.RootActorId,
-                context.SessionId,
-                BuildTextMessageEnd(messageId)),
-            new ProjectionSessionEventEntry<AGUIEvent>(
-                context.RootActorId,
-                context.SessionId,
-                BuildRunFinished(context, content)),
-        ];
+        return BuildTerminalEntries(context, messageId, content);
     }
 
     private static void CompleteRunFinishedFrame(

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/GAgentDraftRunSessionEventProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/GAgentDraftRunSessionEventProjector.cs
@@ -99,7 +99,7 @@ public sealed class GAgentDraftRunSessionEventProjector
         var content = completed.Content ?? string.Empty;
         if (string.IsNullOrEmpty(content) || completed.ContentEmitted)
         {
-            return BuildTerminalEntries(context, messageId);
+            return BuildTerminalEntries(context, messageId, content);
         }
 
         return
@@ -133,7 +133,7 @@ public sealed class GAgentDraftRunSessionEventProjector
             new ProjectionSessionEventEntry<AGUIEvent>(
                 context.RootActorId,
                 context.SessionId,
-                BuildRunFinished(context)),
+                BuildRunFinished(context, content)),
         ];
     }
 
@@ -189,7 +189,8 @@ public sealed class GAgentDraftRunSessionEventProjector
 
     private static IReadOnlyList<ProjectionSessionEventEntry<AGUIEvent>> BuildTerminalEntries(
         GAgentDraftRunProjectionContext context,
-        string messageId) =>
+        string messageId,
+        string output) =>
         [
             new ProjectionSessionEventEntry<AGUIEvent>(
                 context.RootActorId,
@@ -198,7 +199,7 @@ public sealed class GAgentDraftRunSessionEventProjector
             new ProjectionSessionEventEntry<AGUIEvent>(
                 context.RootActorId,
                 context.SessionId,
-                BuildRunFinished(context)),
+                BuildRunFinished(context, output)),
         ];
 
     private static AGUIEvent BuildTextMessageEnd(string messageId) =>
@@ -210,13 +211,18 @@ public sealed class GAgentDraftRunSessionEventProjector
             },
         };
 
-    private static AGUIEvent BuildRunFinished(GAgentDraftRunProjectionContext context) =>
+    private static AGUIEvent BuildRunFinished(GAgentDraftRunProjectionContext context, string output) =>
         new()
         {
             RunFinished = new RunFinishedEvent
             {
                 ThreadId = context.RootActorId,
                 RunId = context.SessionId,
+                // Refactor (iter98/cluster-790): Old: committed completion fallback synthesized TextMessageContent when live deltas were missed. New: RunFinished.result carries typed GAgentDraftRunResultPayload and consumers read result.output without extra stream frames.
+                Result = Any.Pack(new GAgentDraftRunResultPayload
+                {
+                    Output = output ?? string.Empty,
+                }),
             },
         };
 }

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -422,7 +422,7 @@ public sealed class ScopeServiceEndpointsStreamTests
     }
 
     [Fact]
-    public async Task GAgentDraftRunSessionEventProjector_ShouldPublishContentFrames_FromCommittedTerminalSuccess_WhenContentWasNotEmitted()
+    public async Task GAgentDraftRunSessionEventProjector_ShouldPublishTypedRunFinishedResultWithoutSyntheticTextContent_WhenContentWasNotEmitted()
     {
         var sessionHub = new RecordingProjectionSessionEventHub();
         var projector = new GAgentDraftRunSessionEventProjector(sessionHub);
@@ -445,18 +445,17 @@ public sealed class ScopeServiceEndpointsStreamTests
                 correlationId: "cmd-1"),
             CancellationToken.None);
 
-        sessionHub.Published.Should().HaveCount(4);
-        sessionHub.Published[0].Event.TextMessageStart.Should().NotBeNull();
-        sessionHub.Published[0].Event.TextMessageStart!.MessageId.Should().Be("cmd-1");
-        sessionHub.Published[0].Event.TextMessageStart.Role.Should().Be("assistant");
-        sessionHub.Published[1].Event.TextMessageContent.Should().NotBeNull();
-        sessionHub.Published[1].Event.TextMessageContent!.MessageId.Should().Be("cmd-1");
-        sessionHub.Published[1].Event.TextMessageContent.Delta.Should().Be("pong");
-        sessionHub.Published[2].Event.TextMessageEnd.Should().NotBeNull();
-        sessionHub.Published[2].Event.TextMessageEnd!.MessageId.Should().Be("cmd-1");
-        sessionHub.Published[3].Event.RunFinished.Should().NotBeNull();
-        sessionHub.Published[3].Event.RunFinished!.ThreadId.Should().Be("actor-1");
-        sessionHub.Published[3].Event.RunFinished.RunId.Should().Be("cmd-1");
+        sessionHub.Published.Should().HaveCount(2);
+        sessionHub.Published.Should().NotContain(entry =>
+            entry.Event.EventCase == AGUIEvent.EventOneofCase.TextMessageStart);
+        sessionHub.Published.Should().NotContain(entry =>
+            entry.Event.EventCase == AGUIEvent.EventOneofCase.TextMessageContent);
+        sessionHub.Published[0].Event.TextMessageEnd.Should().NotBeNull();
+        sessionHub.Published[0].Event.TextMessageEnd!.MessageId.Should().Be("cmd-1");
+        sessionHub.Published[1].Event.RunFinished.Should().NotBeNull();
+        sessionHub.Published[1].Event.RunFinished!.ThreadId.Should().Be("actor-1");
+        sessionHub.Published[1].Event.RunFinished.RunId.Should().Be("cmd-1");
+        sessionHub.Published[1].Event.RunFinished.Result.Unpack<GAgentDraftRunResultPayload>().Output.Should().Be("pong");
     }
 
     [Fact]

--- a/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
+++ b/test/Aevatar.GAgentService.Integration.Tests/ScopeServiceEndpointsStreamTests.cs
@@ -678,6 +678,37 @@ public sealed class ScopeServiceEndpointsStreamTests
     }
 
     [Fact]
+    public async Task GAgentDraftRunSessionEventProjector_ShouldPublishTypedRunFinishedResultWithoutSyntheticTextContent_WhenCompletionWasAlreadyEmitted()
+    {
+        var sessionHub = new RecordingProjectionSessionEventHub();
+        var projector = new GAgentDraftRunSessionEventProjector(sessionHub);
+
+        await projector.ProjectAsync(
+            new GAgentDraftRunProjectionContext
+            {
+                RootActorId = "actor-1",
+                SessionId = "cmd-1",
+                ProjectionKind = "service-draft-run-session",
+            },
+            WrapCommittedCompletion(
+                new RoleChatSessionCompletedEvent
+                {
+                    SessionId = "cmd-1",
+                    Content = "committed final",
+                    ContentEmitted = true,
+                },
+                correlationId: "cmd-1"),
+            CancellationToken.None);
+
+        sessionHub.Published.Should().HaveCount(2);
+        sessionHub.Published.Should().NotContain(entry =>
+            entry.Event.EventCase == AGUIEvent.EventOneofCase.TextMessageContent);
+        var runFinished = sessionHub.Published[1].Event.RunFinished;
+        runFinished.Should().NotBeNull();
+        runFinished!.Result.Unpack<GAgentDraftRunResultPayload>().Output.Should().Be("committed final");
+    }
+
+    [Fact]
     public async Task GAgentDraftRunSessionEventProjector_ShouldPublishRunError_FromCommittedLlmRequestFailure()
     {
         var sessionHub = new RecordingProjectionSessionEventHub();

--- a/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/GAgentDraftRunInteractionCoverageTests.cs
@@ -458,6 +458,7 @@ public sealed class GAgentDraftRunInteractionCoverageTests
         emitted.Should().ContainSingle();
         emitted[0].RunFinished.ThreadId.Should().Be("actor-1");
         emitted[0].RunFinished.RunId.Should().Be("cmd-1");
+        emitted[0].RunFinished.Result.Unpack<GAgentDraftRunResultPayload>().Output.Should().BeEmpty();
 
         var terminalQuery = new RecordingGAgentRunTerminalQueryPort
         {

--- a/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/ResponsesCommandFacadeTests.cs
@@ -8,6 +8,7 @@ using Aevatar.GAgentService.Abstractions.Responses;
 using Aevatar.GAgentService.Application.Responses;
 using Aevatar.Presentation.AGUI;
 using FluentAssertions;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aevatar.GAgentService.Tests.Application;
@@ -350,6 +351,64 @@ public sealed class ResponsesCommandFacadeTests
             "Request timed out."));
         sessions.RecordedCompletions.Should().ContainSingle()
             .Which.FailureCode.Should().Be("request_timeout");
+    }
+
+    [Fact]
+    public void BuildCompletion_ShouldReadTypedRunFinishedOutput_WhenNoLiveDeltaWasObserved()
+    {
+        var completion = ResponsesForwardedCompletionRecorder.BuildCompletion(
+            [
+                new AGUIEvent
+                {
+                    RunFinished = new RunFinishedEvent
+                    {
+                        Result = Any.Pack(new GAgentDraftRunResultPayload
+                        {
+                            Output = "final from typed payload",
+                        }),
+                    },
+                },
+            ],
+            DateTimeOffset.UtcNow);
+
+        completion.OutputText.Should().Be("final from typed payload");
+    }
+
+    [Fact]
+    public void BuildCompletion_ShouldPreferLiveDeltaOverTypedRunFinishedOutput()
+    {
+        var completion = ResponsesForwardedCompletionRecorder.BuildCompletion(
+            [
+                new AGUIEvent
+                {
+                    TextMessageContent = new TextMessageContentEvent
+                    {
+                        MessageId = "msg-1",
+                        Delta = "live ",
+                    },
+                },
+                new AGUIEvent
+                {
+                    TextMessageContent = new TextMessageContentEvent
+                    {
+                        MessageId = "msg-1",
+                        Delta = "delta",
+                    },
+                },
+                new AGUIEvent
+                {
+                    RunFinished = new RunFinishedEvent
+                    {
+                        Result = Any.Pack(new GAgentDraftRunResultPayload
+                        {
+                            Output = "duplicate final",
+                        }),
+                    },
+                },
+            ],
+            DateTimeOffset.UtcNow);
+
+        completion.OutputText.Should().Be("live delta");
     }
 
     private static ResponsesCommandFacade CreateFacade(


### PR DESCRIPTION
## 摘要

iter98 cluster-790。draft-run EventStream:RunFinished.result 改 typed `GAgentDraftRunResultPayload`;backend 不合成 TextMessageContent;consumer 在未观察 live delta 时读 result.output fallback。

## Phase 9 r2 consensus

`META_JUDGE_DONE:consensus:typed-payload:RunFinished.result 用 typed GAgentDraftRunResultPayload;backend 不合成 TextMessageContent;consumer fallback`

## 改动

- **proto** `agui_events.proto` 加 `GAgentDraftRunResultPayload` typed message
- **emit** `AGUISseWriter` / `GAgentDraftRunInteraction` / `GAgentDraftRunSessionEventProjector` 用 typed payload
- **consumer** `ResponsesForwardedCompletionRecorder` 在未观察 live delta 时读 `result.output` fallback
- **前端** `runtimeEventSemantics` + `StudioBuildPanels` 处理 typed payload
- **测试** `ScopeServiceEndpointsStreamTests` + `ResponsesCommandFacadeTests` 覆盖
- 加 Old/New 注释

## 约束遵循

- ❌ 不加新 actor / envelope / pipeline / ADR
- ❌ 不在 backend 合成 TextMessageContent(契约层避免重复)
- ✅ 强类型 payload(CLAUDE「核心语义强类型」)
- ✅ consumer fallback(未观察 live delta)

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test DraftRun` ✅
- guards ✅

净 +136 / -6 LOC。

closes #790

⟦AI:AUTO-LOOP⟧
