### PR TITLE
iter99 cluster-100: Static service activation via IAgentKindRegistry + CreateByKindAsync

### DIFF
--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_artifact.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_artifact.proto
@@ -8,8 +8,9 @@ import "service_endpoint.proto";
 import "service_revision.proto";
 
 message StaticServiceDeploymentPlan {
-  string actor_type_name = 1;
+  string actor_type_name = 1 [deprecated = true];
   string preferred_actor_id = 2;
+  string agent_kind = 3;
 }
 
 message ScriptingServiceDeploymentPlan {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_revision.proto
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Protos/service_revision.proto
@@ -36,9 +36,10 @@ enum ServiceRevisionStatus {
 }
 
 message StaticServiceRevisionSpec {
-  string actor_type_name = 1;
+  string actor_type_name = 1 [deprecated = true];
   repeated ServiceEndpointDescriptor endpoints = 2;
   string preferred_actor_id = 3;
+  string agent_kind = 4;
 }
 
 message ScriptingServiceRevisionSpec {

--- a/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceRevisionCatalogSnapshot.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/Queries/ServiceRevisionCatalogSnapshot.cs
@@ -27,7 +27,8 @@ public sealed record ServiceRevisionImplementationSnapshot(
 
 public sealed record ServiceRevisionStaticSnapshot(
     string ActorTypeName,
-    string PreferredActorId);
+    string PreferredActorId,
+    string AgentKind = "");
 
 public sealed record ServiceRevisionScriptingSnapshot(
     string ScriptId,

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingModels.cs
@@ -24,9 +24,17 @@ public sealed record ScopeBindingGAgentEndpoint(
     string Description);
 
 public sealed record ScopeBindingGAgentSpec(
-    string ActorTypeName,
+    string AgentKind,
     IReadOnlyList<ScopeBindingGAgentEndpoint> Endpoints,
-    string? AgentKind = null);
+    string? ActorTypeName = null)
+{
+    public ScopeBindingGAgentSpec(
+        string actorTypeName,
+        IReadOnlyList<ScopeBindingGAgentEndpoint> endpoints)
+        : this(string.Empty, endpoints, actorTypeName)
+    {
+    }
+}
 
 public sealed record ScopeBindingUpsertRequest(
     string ScopeId,

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeBindings/ScopeBindingModels.cs
@@ -25,7 +25,8 @@ public sealed record ScopeBindingGAgentEndpoint(
 
 public sealed record ScopeBindingGAgentSpec(
     string ActorTypeName,
-    IReadOnlyList<ScopeBindingGAgentEndpoint> Endpoints);
+    IReadOnlyList<ScopeBindingGAgentEndpoint> Endpoints,
+    string? AgentKind = null);
 
 public sealed record ScopeBindingUpsertRequest(
     string ScopeId,

--- a/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs
+++ b/src/platform/Aevatar.GAgentService.Abstractions/ScopeGAgents/GAgentDraftRunModels.cs
@@ -32,7 +32,8 @@ public sealed record GAgentDraftRunCommand(
     string? PreferredLlmRoute = null,
     IReadOnlyDictionary<string, string>? Headers = null,
     IReadOnlyList<GAgentDraftRunInputPart>? InputParts = null,
-    bool UseCorrelationIdAsFallbackSessionId = true) : ICommandContextSeed
+    bool UseCorrelationIdAsFallbackSessionId = true,
+    string? AgentKind = null) : ICommandContextSeed
 {
     public string? CommandId => null;
 

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -7,6 +7,7 @@ using Aevatar.GAgentService.Abstractions.Services;
 using Aevatar.GAgentService.Application.Internal;
 using Aevatar.GAgentService.Application.Workflows;
 using Aevatar.GAgentService.Governance.Abstractions.Ports;
+using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Core.Ports;
 using Aevatar.Workflow.Application.Abstractions.Runs;
@@ -26,6 +27,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
     private readonly IScopeScriptQueryPort _scopeScriptQueryPort;
     private readonly IScriptDefinitionSnapshotPort _scriptDefinitionSnapshotPort;
     private readonly IWorkflowDefinitionParser _workflowDefinitionParser;
+    private readonly IAgentKindRegistry? _agentKindRegistry;
     private readonly ScopeWorkflowCapabilityOptions _options;
 
     public ScopeBindingCommandApplicationService(
@@ -36,7 +38,8 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         IScopeScriptQueryPort scopeScriptQueryPort,
         IScriptDefinitionSnapshotPort scriptDefinitionSnapshotPort,
         IWorkflowDefinitionParser workflowDefinitionParser,
-        IOptions<ScopeWorkflowCapabilityOptions> options)
+        IOptions<ScopeWorkflowCapabilityOptions> options,
+        IAgentKindRegistry? agentKindRegistry = null)
     {
         _serviceCommandPort = serviceCommandPort ?? throw new ArgumentNullException(nameof(serviceCommandPort));
         _serviceLifecycleQueryPort = serviceLifecycleQueryPort ?? throw new ArgumentNullException(nameof(serviceLifecycleQueryPort));
@@ -45,6 +48,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
         _scopeScriptQueryPort = scopeScriptQueryPort ?? throw new ArgumentNullException(nameof(scopeScriptQueryPort));
         _scriptDefinitionSnapshotPort = scriptDefinitionSnapshotPort ?? throw new ArgumentNullException(nameof(scriptDefinitionSnapshotPort));
         _workflowDefinitionParser = workflowDefinitionParser ?? throw new ArgumentNullException(nameof(workflowDefinitionParser));
+        _agentKindRegistry = agentKindRegistry;
         ArgumentNullException.ThrowIfNull(options);
         _options = options.Value ?? throw new InvalidOperationException("Scope workflow capability options are required.");
     }
@@ -449,7 +453,8 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
     {
         var gagent = request.GAgent
             ?? throw new InvalidOperationException("gagent is required for implementationKind 'gagent'.");
-        var actorTypeName = ScopeWorkflowCapabilityOptions.NormalizeRequired(gagent.ActorTypeName, nameof(gagent.ActorTypeName));
+        var agentKind = NormalizeGAgentKind(gagent);
+        var actorTypeName = NormalizeLegacyActorTypeName(gagent.ActorTypeName, agentKind);
 
         // Start with caller-supplied endpoints, then ensure a chat endpoint always exists.
         var endpointSpecs = (gagent.Endpoints ?? [])
@@ -479,7 +484,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                     StaticSpec = new StaticServiceRevisionSpec
                     {
                         ActorTypeName = actorTypeName,
-                        AgentKind = gagent.AgentKind ?? string.Empty,
+                        AgentKind = agentKind,
                     },
                 };
                 revisionSpec.StaticSpec.Endpoints.Add(endpointSpecs.Select(ToEndpointDescriptor));
@@ -496,6 +501,38 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                     GAgent: new ScopeBindingGAgentResult(
                         actorTypeName),
                     ExpectedDeploymentId: expectedDeploymentId));
+    }
+
+    private string NormalizeGAgentKind(ScopeBindingGAgentSpec gagent)
+    {
+        var agentKind = ScopeWorkflowCapabilityConventions.NormalizeOptional(gagent.AgentKind);
+        if (!string.IsNullOrWhiteSpace(agentKind))
+            return agentKind;
+
+        var actorTypeName = ScopeWorkflowCapabilityConventions.NormalizeOptional(gagent.ActorTypeName);
+        if (string.IsNullOrWhiteSpace(actorTypeName))
+            ScopeWorkflowCapabilityOptions.NormalizeRequired(string.Empty, nameof(gagent.AgentKind));
+
+        if (_agentKindRegistry != null &&
+            _agentKindRegistry.TryResolveKindByClrTypeName(actorTypeName!, out var resolvedKind))
+            return resolvedKind;
+
+        return string.Empty;
+    }
+
+    private string NormalizeLegacyActorTypeName(string? actorTypeName, string agentKind)
+    {
+        var normalizedActorTypeName = ScopeWorkflowCapabilityConventions.NormalizeOptional(actorTypeName);
+        if (!string.IsNullOrWhiteSpace(normalizedActorTypeName))
+            return normalizedActorTypeName;
+
+        if (_agentKindRegistry != null)
+        {
+            var implementation = _agentKindRegistry.Resolve(agentKind);
+            return implementation.Metadata.ImplementationClrTypeName;
+        }
+
+        return string.Empty;
     }
 
     private async Task<WorkflowYamlBundle> ParseWorkflowBundleAsync(

--- a/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Bindings/ScopeBindingCommandApplicationService.cs
@@ -287,6 +287,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                 StaticPlan = new StaticServiceDeploymentPlan
                 {
                     ActorTypeName = staticSpec.ActorTypeName,
+                    AgentKind = staticSpec.AgentKind,
                     PreferredActorId = staticSpec.PreferredActorId ?? string.Empty,
                 },
             },
@@ -478,6 +479,7 @@ public sealed class ScopeBindingCommandApplicationService : IScopeBindingCommand
                     StaticSpec = new StaticServiceRevisionSpec
                     {
                         ActorTypeName = actorTypeName,
+                        AgentKind = gagent.AgentKind ?? string.Empty,
                     },
                 };
                 revisionSpec.StaticSpec.Endpoints.Add(endpointSpecs.Select(ToEndpointDescriptor));

--- a/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
+++ b/src/platform/Aevatar.GAgentService.Application/ScopeGAgents/GAgentDraftRunInteraction.cs
@@ -213,17 +213,20 @@ internal sealed class GAgentDraftRunCommandTargetResolver
     private readonly IGAgentDraftRunProjectionPort _projectionPort;
     private readonly IGAgentRunTerminalProjectionPort _terminalProjectionPort;
     private readonly IAgentTypeVerifier? _agentTypeVerifier;
+    private readonly IAgentKindRegistry? _agentKindRegistry;
 
     public GAgentDraftRunCommandTargetResolver(
         IActorRuntime actorRuntime,
         IGAgentDraftRunProjectionPort projectionPort,
         IGAgentRunTerminalProjectionPort terminalProjectionPort,
-        IAgentTypeVerifier? agentTypeVerifier = null)
+        IAgentTypeVerifier? agentTypeVerifier = null,
+        IAgentKindRegistry? agentKindRegistry = null)
     {
         _actorRuntime = actorRuntime ?? throw new ArgumentNullException(nameof(actorRuntime));
         _projectionPort = projectionPort ?? throw new ArgumentNullException(nameof(projectionPort));
         _terminalProjectionPort = terminalProjectionPort ?? throw new ArgumentNullException(nameof(terminalProjectionPort));
         _agentTypeVerifier = agentTypeVerifier;
+        _agentKindRegistry = agentKindRegistry;
     }
 
     public async Task<CommandTargetResolution<GAgentDraftRunCommandTarget, GAgentDraftRunStartError>> ResolveAsync(
@@ -232,7 +235,9 @@ internal sealed class GAgentDraftRunCommandTargetResolver
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        var agentType = ScopeGAgentActorTypeResolver.Resolve(command.ActorTypeName);
+        var agentKind = NormalizeOptional(command.AgentKind);
+        var legacyActorTypeName = NormalizeOptional(command.ActorTypeName);
+        var agentType = ResolveExpectedType(agentKind, legacyActorTypeName);
         if (agentType is null)
         {
             return CommandTargetResolution<GAgentDraftRunCommandTarget, GAgentDraftRunStartError>.Failure(
@@ -259,16 +264,49 @@ internal sealed class GAgentDraftRunCommandTargetResolver
             }
             else
             {
-                actor = await _actorRuntime.CreateAsync(agentType, preferredActorId, ct);
+                actor = string.IsNullOrWhiteSpace(agentKind)
+                    ? await _actorRuntime.CreateAsync(agentType!, preferredActorId, ct)
+                    : await _actorRuntime.CreateByKindAsync(agentKind, preferredActorId, ct);
             }
         }
         else
         {
-            actor = await _actorRuntime.CreateAsync(agentType, null, ct);
+            actor = string.IsNullOrWhiteSpace(agentKind)
+                ? await _actorRuntime.CreateAsync(agentType!, null, ct)
+                : await _actorRuntime.CreateByKindAsync(agentKind, null, ct);
         }
 
         return CommandTargetResolution<GAgentDraftRunCommandTarget, GAgentDraftRunStartError>.Success(
-            new GAgentDraftRunCommandTarget(actor, command.ActorTypeName, _projectionPort, _terminalProjectionPort));
+            new GAgentDraftRunCommandTarget(
+                actor,
+                legacyActorTypeName ?? agentKind!,
+                _projectionPort,
+                _terminalProjectionPort));
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        var normalized = value?.Trim();
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private System.Type? ResolveExpectedType(string? agentKind, string? legacyActorTypeName)
+    {
+        if (!string.IsNullOrWhiteSpace(agentKind))
+        {
+            try
+            {
+                var implementation = _agentKindRegistry?.Resolve(agentKind);
+                if (implementation != null)
+                    return ScopeGAgentActorTypeResolver.Resolve(implementation.Metadata.ImplementationClrTypeName);
+            }
+            catch (UnknownAgentKindException)
+            {
+                return null;
+            }
+        }
+
+        return ScopeGAgentActorTypeResolver.Resolve(legacyActorTypeName ?? string.Empty);
     }
 
     private async Task<bool> MatchesExpectedTypeAsync(

--- a/src/platform/Aevatar.GAgentService.Application/Services/StaticGAgentStreamInvocationApplicationService.cs
+++ b/src/platform/Aevatar.GAgentService.Application/Services/StaticGAgentStreamInvocationApplicationService.cs
@@ -60,9 +60,11 @@ public sealed class StaticGAgentStreamInvocationApplicationService : IStaticGAge
             ct);
 
         EnsureStaticChatTarget(target, invocationRequest);
-        var actorTypeName = target.Artifact.DeploymentPlan.StaticPlan?.ActorTypeName?.Trim() ?? string.Empty;
-        if (actorTypeName.Length == 0)
-            throw new InvalidOperationException("Static GAgent service has no actor type configured.");
+        var staticPlan = target.Artifact.DeploymentPlan.StaticPlan;
+        var agentKind = staticPlan?.AgentKind?.Trim() ?? string.Empty;
+        var actorTypeName = staticPlan?.ActorTypeName?.Trim() ?? string.Empty;
+        if (agentKind.Length == 0 && actorTypeName.Length == 0)
+            throw new InvalidOperationException("Static GAgent service has no agent kind configured.");
 
         StaticGAgentStreamAcceptedReceipt? accepted = null;
 
@@ -87,7 +89,8 @@ public sealed class StaticGAgentStreamInvocationApplicationService : IStaticGAge
                 SessionId: input.SessionId,
                 Headers: headers,
                 InputParts: input.InputParts,
-                UseCorrelationIdAsFallbackSessionId: false),
+                UseCorrelationIdAsFallbackSessionId: false,
+                AgentKind: agentKind),
             emitAsync,
             OnAcceptedAsync,
             timeoutCts.Token);

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -193,7 +193,7 @@ public static class ScopeServiceEndpoints
                     request.GAgent == null
                         ? null
                         : new ScopeBindingGAgentSpec(
-                            request.GAgent.ActorTypeName,
+                            request.GAgent.AgentKind ?? string.Empty,
                             (request.GAgent.Endpoints ?? [])
                             .Select(endpoint => new ScopeBindingGAgentEndpoint(
                                 endpoint.EndpointId,
@@ -203,7 +203,7 @@ public static class ScopeServiceEndpoints
                                 endpoint.ResponseTypeUrl,
                                 endpoint.Description))
                             .ToArray(),
-                            request.GAgent.AgentKind),
+                            request.GAgent.ActorTypeName),
                     request.DisplayName,
                     request.RevisionId,
                     request.AppId,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ScopeServiceEndpoints.cs
@@ -202,7 +202,8 @@ public static class ScopeServiceEndpoints
                                 endpoint.RequestTypeUrl,
                                 endpoint.ResponseTypeUrl,
                                 endpoint.Description))
-                            .ToArray()),
+                            .ToArray(),
+                            request.GAgent.AgentKind),
                     request.DisplayName,
                     request.RevisionId,
                     request.AppId,
@@ -3256,7 +3257,8 @@ const response = await fetch("{{invokePath}}", {
 
     public sealed record ScopeBindingGAgentHttpRequest(
         string ActorTypeName,
-        IReadOnlyList<ServiceEndpoints.ServiceEndpointHttpRequest>? Endpoints);
+        IReadOnlyList<ServiceEndpoints.ServiceEndpointHttpRequest>? Endpoints,
+        string? AgentKind = null);
 
     public sealed record StreamScopeServiceHttpRequest(
         string? Prompt,

--- a/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
+++ b/src/platform/Aevatar.GAgentService.Hosting/Endpoints/ServiceEndpoints.cs
@@ -103,6 +103,7 @@ public static partial class ServiceEndpoints
                 spec.StaticSpec = new StaticServiceRevisionSpec
                 {
                     ActorTypeName = request.Static?.ActorTypeName ?? string.Empty,
+                    AgentKind = request.Static?.AgentKind ?? string.Empty,
                     PreferredActorId = request.Static?.PreferredActorId ?? string.Empty,
                     Endpoints = { (request.Static?.Endpoints ?? []).Select(ToEndpointDescriptor) },
                 };
@@ -574,7 +575,8 @@ public static partial class ServiceEndpoints
     public sealed record StaticRevisionHttpRequest(
         string ActorTypeName,
         string? PreferredActorId,
-        IReadOnlyList<ServiceEndpointHttpRequest> Endpoints);
+        IReadOnlyList<ServiceEndpointHttpRequest> Endpoints,
+        string? AgentKind = null);
 
     public sealed record ScriptingRevisionHttpRequest(
         string ScriptId,

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs
@@ -68,13 +68,20 @@ public sealed class DefaultServiceRuntimeActivator : IServiceRuntimeActivator
         string deploymentId,
         CancellationToken ct)
     {
-        var actorType = ResolveActorType(plan.ActorTypeName)
-            ?? throw new InvalidOperationException($"Static actor type '{plan.ActorTypeName}' was not found.");
+        var agentKind = plan.AgentKind?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(agentKind))
+            throw new InvalidOperationException("Static agent_kind is required.");
+
         var actorId = string.IsNullOrWhiteSpace(plan.PreferredActorId)
             ? $"gagent-service:static-runtime:{deploymentId}"
             : $"{plan.PreferredActorId}:{deploymentId}";
         if (!await _runtime.ExistsAsync(actorId))
-            _ = await _runtime.CreateAsync(actorType, actorId, ct);
+        {
+            // Refactor (issue1044/static-service-agent-kind):
+            //   Old pattern: static service activation reconstructed CLR Type from actor_type_name.
+            //   New principle: runtime owns kind-based creation through IAgentKindRegistry + CreateByKindAsync.
+            _ = await _runtime.CreateByKindAsync(agentKind, actorId, ct);
+        }
 
         return new ServiceRuntimeActivationResult(deploymentId, actorId, "active");
     }
@@ -118,31 +125,5 @@ public sealed class DefaultServiceRuntimeActivator : IServiceRuntimeActivator
             ct);
 
         return new ServiceRuntimeActivationResult(deploymentId, receipt.ActorId, "active");
-    }
-
-    private static Type? ResolveActorType(string typeName)
-    {
-        // Try direct resolution first (works for assembly-qualified names).
-        var type = Type.GetType(typeName, throwOnError: false);
-        if (type is not null)
-            return type;
-
-        // Fallback: scan all loaded assemblies by full type name.
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            if (assembly.IsDynamic) continue;
-            try
-            {
-                type = assembly.GetType(typeName);
-                if (type is not null)
-                    return type;
-            }
-            catch
-            {
-                // ignored
-            }
-        }
-
-        return null;
     }
 }

--- a/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/StaticServiceImplementationAdapter.cs
+++ b/src/platform/Aevatar.GAgentService.Infrastructure/Adapters/StaticServiceImplementationAdapter.cs
@@ -1,5 +1,4 @@
-using System.Reflection;
-using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Core.Ports;
 
@@ -7,31 +6,11 @@ namespace Aevatar.GAgentService.Infrastructure.Adapters;
 
 public sealed class StaticServiceImplementationAdapter : IServiceImplementationAdapter
 {
-    /// <summary>
-    /// Resolves a type by name, searching all loaded assemblies if <see cref="Type.GetType"/> fails.
-    /// </summary>
-    private static Type? ResolveType(string typeName)
+    private readonly IAgentKindRegistry _agentKindRegistry;
+
+    public StaticServiceImplementationAdapter(IAgentKindRegistry agentKindRegistry)
     {
-        var type = Type.GetType(typeName, throwOnError: false);
-        if (type is not null)
-            return type;
-
-        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            if (assembly.IsDynamic) continue;
-            try
-            {
-                type = assembly.GetType(typeName);
-                if (type is not null)
-                    return type;
-            }
-            catch
-            {
-                // ignored
-            }
-        }
-
-        return null;
+        _agentKindRegistry = agentKindRegistry ?? throw new ArgumentNullException(nameof(agentKindRegistry));
     }
 
     public ServiceImplementationKind ImplementationKind => ServiceImplementationKind.Static;
@@ -44,16 +23,9 @@ public sealed class StaticServiceImplementationAdapter : IServiceImplementationA
         ArgumentNullException.ThrowIfNull(request);
         var spec = request.Spec?.StaticSpec
             ?? throw new InvalidOperationException("static implementation_spec is required.");
-        if (string.IsNullOrWhiteSpace(spec.ActorTypeName))
-            throw new InvalidOperationException("static actor_type_name is required.");
+        var agentKind = ResolveAgentKind(spec);
         if (spec.Endpoints.Count == 0)
             throw new InvalidOperationException("static endpoints are required.");
-
-        var actorType = ResolveType(spec.ActorTypeName);
-        if (actorType == null)
-            throw new InvalidOperationException($"Static actor type '{spec.ActorTypeName}' was not found.");
-        if (!typeof(IAgent).IsAssignableFrom(actorType))
-            throw new InvalidOperationException($"Static actor type '{spec.ActorTypeName}' does not implement IAgent.");
 
         return Task.FromResult(new PreparedServiceRevisionArtifact
         {
@@ -65,10 +37,43 @@ public sealed class StaticServiceImplementationAdapter : IServiceImplementationA
             {
                 StaticPlan = new StaticServiceDeploymentPlan
                 {
+                    AgentKind = agentKind,
                     ActorTypeName = spec.ActorTypeName,
                     PreferredActorId = spec.PreferredActorId ?? string.Empty,
                 },
             },
         });
+    }
+
+    private string ResolveAgentKind(StaticServiceRevisionSpec spec)
+    {
+        var agentKind = spec.AgentKind?.Trim() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(agentKind))
+        {
+            _agentKindRegistry.Resolve(agentKind);
+            return agentKind;
+        }
+
+        var actorTypeName = spec.ActorTypeName?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(actorTypeName))
+            throw new InvalidOperationException("static agent_kind is required.");
+
+        var legacyClrTypeName = NormalizeLegacyClrTypeName(actorTypeName);
+        if (_agentKindRegistry.TryResolveKindByClrTypeName(legacyClrTypeName, out var translatedKind))
+            return translatedKind;
+
+        throw new InvalidOperationException(
+            $"Static legacy actor_type_name '{actorTypeName}' is not registered with IAgentKindRegistry.");
+    }
+
+    // Refactor (issue1044/static-service-agent-kind):
+    //   Old pattern: static service preparation resolved actor_type_name through CLR-name reflection.
+    //   New principle: static service activation persists agent_kind; actor_type_name only translates legacy boundary input.
+    private static string NormalizeLegacyClrTypeName(string actorTypeName)
+    {
+        var commaIndex = actorTypeName.IndexOf(',', StringComparison.Ordinal);
+        return commaIndex < 0
+            ? actorTypeName
+            : actorTypeName[..commaIndex].Trim();
     }
 }

--- a/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRevisionCatalogProjector.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Projectors/ServiceRevisionCatalogProjector.cs
@@ -78,6 +78,7 @@ public sealed class ServiceRevisionCatalogProjector
                 .OrderBy(x => x.EndpointId, StringComparer.Ordinal)
                 .ToList(),
             StaticActorTypeName = state.Spec?.StaticSpec?.ActorTypeName ?? string.Empty,
+            StaticAgentKind = state.Spec?.StaticSpec?.AgentKind ?? string.Empty,
             StaticPreferredActorId = state.Spec?.StaticSpec?.PreferredActorId ?? string.Empty,
             ScriptingScriptId = state.Spec?.ScriptingSpec?.ScriptId ?? string.Empty,
             ScriptingRevision = state.Spec?.ScriptingSpec?.Revision ?? string.Empty,

--- a/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceRevisionCatalogQueryReader.cs
+++ b/src/platform/Aevatar.GAgentService.Projection/Queries/ServiceRevisionCatalogQueryReader.cs
@@ -67,10 +67,12 @@ public sealed class ServiceRevisionCatalogQueryReader : IServiceRevisionCatalogQ
     {
         var staticSnapshot =
             !string.IsNullOrWhiteSpace(revision.StaticActorTypeName) ||
-            !string.IsNullOrWhiteSpace(revision.StaticPreferredActorId)
+            !string.IsNullOrWhiteSpace(revision.StaticPreferredActorId) ||
+            !string.IsNullOrWhiteSpace(revision.StaticAgentKind)
                 ? new ServiceRevisionStaticSnapshot(
                     revision.StaticActorTypeName ?? string.Empty,
-                    revision.StaticPreferredActorId ?? string.Empty)
+                    revision.StaticPreferredActorId ?? string.Empty,
+                    revision.StaticAgentKind ?? string.Empty)
                 : null;
 
         var scriptingSnapshot =

--- a/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
+++ b/src/platform/Aevatar.GAgentService.Projection/service_projection_read_models.proto
@@ -79,6 +79,7 @@ message ServiceRevisionEntryReadModel {
   repeated ServiceCatalogEndpointReadModel endpoint_entries = 10;
   string static_actor_type_name = 11;
   string static_preferred_actor_id = 12;
+  string static_agent_kind = 20;
   string scripting_script_id = 13;
   string scripting_revision = 14;
   string scripting_definition_actor_id = 15;

--- a/test/Aevatar.GAgentService.Tests/Application/StaticGAgentStreamInvocationApplicationServiceTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Application/StaticGAgentStreamInvocationApplicationServiceTests.cs
@@ -114,6 +114,8 @@ public sealed class StaticGAgentStreamInvocationApplicationServiceTests
         interaction.Commands.Should().ContainSingle();
         var command = interaction.Commands[0];
         command.ScopeId.Should().Be(identity.TenantId);
+        command.AgentKind.Should().Be(GAgentServiceTestKit.TestStaticServiceAgentKind);
+        command.ActorTypeName.Should().Be(typeof(TestStaticServiceAgent).AssemblyQualifiedName);
         command.Prompt.Should().Be("hello static");
         command.PreferredActorId.Should().Be("preferred-actor");
         command.SessionId.Should().Be("session-1");
@@ -236,7 +238,7 @@ public sealed class StaticGAgentStreamInvocationApplicationServiceTests
     }
 
     [Fact]
-    public async Task InvokeAsync_ShouldThrow_WhenStaticPlanHasNoActorType()
+    public async Task InvokeAsync_ShouldUseAgentKind_WhenStaticPlanHasNoActorType()
     {
         var identity = GAgentServiceTestKit.CreateIdentity();
         var interaction = new RecordingGAgentDraftRunInteractionService();
@@ -249,12 +251,36 @@ public sealed class StaticGAgentStreamInvocationApplicationServiceTests
             interaction,
             registration);
 
+        var result = await service.InvokeAsync(
+            NewRequest(identity),
+            (_, _) => ValueTask.CompletedTask);
+
+        result.Succeeded.Should().BeTrue();
+        interaction.Commands.Should().ContainSingle()
+            .Which.AgentKind.Should().Be(GAgentServiceTestKit.TestStaticServiceAgentKind);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldThrow_WhenStaticPlanHasNoAgentKindOrActorType()
+    {
+        var identity = GAgentServiceTestKit.CreateIdentity();
+        var interaction = new RecordingGAgentDraftRunInteractionService();
+        var registration = new RecordingServiceRunRegistrationPort();
+        var artifact = CreateArtifact(identity, ServiceImplementationKind.Static);
+        artifact.DeploymentPlan.StaticPlan!.AgentKind = " ";
+        artifact.DeploymentPlan.StaticPlan!.ActorTypeName = " ";
+        var service = await CreateServiceAsync(
+            identity,
+            artifact,
+            interaction,
+            registration);
+
         var act = () => service.InvokeAsync(
             NewRequest(identity),
             (_, _) => ValueTask.CompletedTask);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Static GAgent service has no actor type configured*");
+            .WithMessage("*Static GAgent service has no agent kind configured*");
         interaction.Commands.Should().BeEmpty();
         registration.Records.Should().BeEmpty();
     }

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/DefaultServiceRuntimeActivatorTests.cs
@@ -32,7 +32,10 @@ public sealed class DefaultServiceRuntimeActivatorTests
 
         result.DeploymentId.Should().Be("deployment-actor:r2");
         result.PrimaryActorId.Should().Be("static:r2:deployment-actor:r2");
-        runtime.CreateCalls.Should().ContainSingle(x => x.actorId == "static:r2:deployment-actor:r2");
+        runtime.CreateByKindCalls.Should().ContainSingle(x =>
+            x.agentKind == GAgentServiceTestKit.TestStaticServiceAgentKind &&
+            x.actorId == "static:r2:deployment-actor:r2");
+        runtime.CreateCalls.Should().BeEmpty();
     }
 
     [Fact]
@@ -290,7 +293,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
     }
 
     [Fact]
-    public async Task ActivateAsync_ShouldThrow_WhenStaticActorTypeCannotBeResolved()
+    public async Task ActivateAsync_ShouldThrow_WhenStaticAgentKindIsMissing()
     {
         var activator = new DefaultServiceRuntimeActivator(
             new RecordingActorRuntime(),
@@ -298,7 +301,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
             new RecordingScriptRuntimeProvisioningPort(),
             new RecordingWorkflowRunActorPort());
         var artifact = GAgentServiceTestKit.CreatePreparedStaticArtifact(revisionId: "r2");
-        artifact.DeploymentPlan.StaticPlan.ActorTypeName = "Missing.StaticActor, Missing.Assembly";
+        artifact.DeploymentPlan.StaticPlan.AgentKind = string.Empty;
 
         var act = () => activator.ActivateAsync(
             new ServiceRuntimeActivationRequest(
@@ -308,7 +311,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
                 "deployment-actor"));
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Missing.StaticActor, Missing.Assembly*was not found*");
+            .WithMessage("Static agent_kind is required.");
     }
 
     [Fact]
@@ -347,6 +350,7 @@ public sealed class DefaultServiceRuntimeActivatorTests
         private readonly HashSet<string> _existingWithoutActor = new(StringComparer.Ordinal);
 
         public List<(Type actorType, string actorId)> CreateCalls { get; } = [];
+        public List<(string agentKind, string actorId)> CreateByKindCalls { get; } = [];
         public List<string> DestroyCalls { get; } = [];
 
         public void MarkExisting(string actorId)
@@ -367,6 +371,15 @@ public sealed class DefaultServiceRuntimeActivatorTests
         {
             var actorId = id ?? $"created:{agentType.Name}";
             CreateCalls.Add((agentType, actorId));
+            var actor = new RecordingActor(actorId);
+            _actors[actorId] = actor;
+            return Task.FromResult<IActor>(actor);
+        }
+
+        public Task<IActor> CreateByKindAsync(string agentKind, string? id = null, CancellationToken ct = default)
+        {
+            var actorId = id ?? $"created:{agentKind}";
+            CreateByKindCalls.Add((agentKind, actorId));
             var actor = new RecordingActor(actorId);
             _actors[actorId] = actor;
             return Task.FromResult<IActor>(actor);

--- a/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
+++ b/test/Aevatar.GAgentService.Tests/Infrastructure/ServiceImplementationAdaptersTests.cs
@@ -1,4 +1,6 @@
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.TypeSystem;
+using Aevatar.Foundation.Core.TypeSystem;
 using Aevatar.GAgentService.Abstractions;
 using Aevatar.GAgentService.Infrastructure.Adapters;
 using Aevatar.GAgentService.Tests.TestSupport;
@@ -48,7 +50,7 @@ public sealed class ServiceImplementationAdaptersTests
     [Fact]
     public async Task StaticAdapter_ShouldPrepareRevisionArtifact()
     {
-        var adapter = new StaticServiceImplementationAdapter();
+        var adapter = new StaticServiceImplementationAdapter(CreateStaticAgentKindRegistry());
         var request = new PrepareServiceRevisionRequest
         {
             ServiceKey = "tenant:app:default:svc",
@@ -59,44 +61,47 @@ public sealed class ServiceImplementationAdaptersTests
 
         artifact.ImplementationKind.Should().Be(ServiceImplementationKind.Static);
         artifact.Endpoints.Should().ContainSingle(x => x.EndpointId == "run");
+        artifact.DeploymentPlan.StaticPlan.AgentKind.Should().Be(GAgentServiceTestKit.TestStaticServiceAgentKind);
         artifact.DeploymentPlan.StaticPlan.ActorTypeName.Should().Be(typeof(TestStaticServiceAgent).AssemblyQualifiedName);
         artifact.DeploymentPlan.StaticPlan.PreferredActorId.Should().Be("static:r1");
     }
 
     [Fact]
-    public async Task StaticAdapter_ShouldRejectNonAgentType()
+    public async Task StaticAdapter_ShouldTranslateLegacyActorTypeNameToAgentKind()
     {
-        var adapter = new StaticServiceImplementationAdapter();
+        var adapter = new StaticServiceImplementationAdapter(CreateStaticAgentKindRegistry());
         var request = new PrepareServiceRevisionRequest
         {
-            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(actorTypeName: typeof(string).AssemblyQualifiedName),
+            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(
+                actorTypeName: typeof(TestStaticServiceAgent).AssemblyQualifiedName,
+                agentKind: string.Empty),
         };
 
-        var act = () => adapter.PrepareRevisionAsync(request);
+        var artifact = await adapter.PrepareRevisionAsync(request);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*does not implement IAgent*");
+        artifact.DeploymentPlan.StaticPlan.AgentKind.Should().Be(GAgentServiceTestKit.TestStaticServiceAgentKind);
+        artifact.DeploymentPlan.StaticPlan.ActorTypeName.Should().Be(typeof(TestStaticServiceAgent).AssemblyQualifiedName);
     }
 
     [Fact]
-    public async Task StaticAdapter_ShouldRejectMissingActorTypeName()
+    public async Task StaticAdapter_ShouldRejectMissingAgentKind()
     {
-        var adapter = new StaticServiceImplementationAdapter();
+        var adapter = new StaticServiceImplementationAdapter(CreateStaticAgentKindRegistry());
         var request = new PrepareServiceRevisionRequest
         {
-            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(actorTypeName: string.Empty),
+            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(actorTypeName: string.Empty, agentKind: string.Empty),
         };
 
         var act = () => adapter.PrepareRevisionAsync(request);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("static actor_type_name is required.");
+            .WithMessage("static agent_kind is required.");
     }
 
     [Fact]
     public async Task StaticAdapter_ShouldRejectMissingEndpoints()
     {
-        var adapter = new StaticServiceImplementationAdapter();
+        var adapter = new StaticServiceImplementationAdapter(CreateStaticAgentKindRegistry());
         var spec = GAgentServiceTestKit.CreateStaticRevisionSpec();
         spec.StaticSpec.Endpoints.Clear();
 
@@ -110,17 +115,17 @@ public sealed class ServiceImplementationAdaptersTests
     }
 
     [Fact]
-    public async Task StaticAdapter_ShouldRejectUnknownActorType()
+    public async Task StaticAdapter_ShouldRejectUnknownAgentKind()
     {
-        var adapter = new StaticServiceImplementationAdapter();
+        var adapter = new StaticServiceImplementationAdapter(CreateStaticAgentKindRegistry());
 
         var act = () => adapter.PrepareRevisionAsync(new PrepareServiceRevisionRequest
         {
-            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(actorTypeName: "Missing.Actor, Missing.Assembly"),
+            Spec = GAgentServiceTestKit.CreateStaticRevisionSpec(agentKind: "tests.missing-static-agent"),
         });
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*was not found*");
+            .WithMessage("*tests.missing-static-agent*");
     }
 
     [Fact]
@@ -688,5 +693,12 @@ public sealed class ServiceImplementationAdaptersTests
         public Task<string?> GetParentIdAsync() => Task.FromResult<string?>(null);
 
         public Task<IReadOnlyList<string>> GetChildrenIdsAsync() => Task.FromResult<IReadOnlyList<string>>([]);
+    }
+
+    private static IAgentKindRegistry CreateStaticAgentKindRegistry()
+    {
+        var builder = new AgentKindRegistryBuilder();
+        builder.Register<TestStaticServiceAgent>();
+        return new AgentKindRegistry(builder.Build());
     }
 }

--- a/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
+++ b/test/Aevatar.GAgentService.Tests/TestSupport/GAgentServiceTestKit.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Hooks;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Foundation.Abstractions.TypeSystem;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Foundation.Runtime.Callbacks;
@@ -15,6 +16,8 @@ namespace Aevatar.GAgentService.Tests.TestSupport;
 
 internal static class GAgentServiceTestKit
 {
+    public const string TestStaticServiceAgentKind = "tests.static-service-agent";
+
     private static readonly MethodInfo SetIdMethod = typeof(GAgentBase)
         .GetMethod("SetId", BindingFlags.Instance | BindingFlags.NonPublic)
         ?? throw new InvalidOperationException("GAgentBase.SetId was not found.");
@@ -71,6 +74,7 @@ internal static class GAgentServiceTestKit
         ServiceIdentity? identity = null,
         string revisionId = "r1",
         string? actorTypeName = null,
+        string? agentKind = null,
         params ServiceEndpointDescriptor[] endpoints)
     {
         var spec = new ServiceRevisionSpec
@@ -81,6 +85,7 @@ internal static class GAgentServiceTestKit
             StaticSpec = new StaticServiceRevisionSpec
             {
                 ActorTypeName = actorTypeName ?? typeof(TestStaticServiceAgent).AssemblyQualifiedName!,
+                AgentKind = agentKind ?? TestStaticServiceAgentKind,
                 PreferredActorId = $"static:{revisionId}",
             },
         };
@@ -105,6 +110,7 @@ internal static class GAgentServiceTestKit
                 StaticPlan = new StaticServiceDeploymentPlan
                 {
                     ActorTypeName = typeof(TestStaticServiceAgent).AssemblyQualifiedName!,
+                    AgentKind = TestStaticServiceAgentKind,
                     PreferredActorId = $"static:{revisionId}",
                 },
             },
@@ -143,6 +149,7 @@ internal static class GAgentServiceTestKit
     }
 }
 
+[GAgent(GAgentServiceTestKit.TestStaticServiceAgentKind)]
 internal sealed class TestStaticServiceAgent : IAgent
 {
     public string Id { get; private set; } = Guid.NewGuid().ToString("N");

--- a/tools/ci/architecture_guards.sh
+++ b/tools/ci/architecture_guards.sh
@@ -35,6 +35,7 @@ if [ -d "src/Aevatar.Host.Api" ] || [ -d "src/Aevatar.Host.Gateway" ]; then
 fi
 
 bash tools/ci/aevatar_oauth_client_es_acl_guard.sh
+bash tools/ci/static_service_activation_guard.sh || exit $?
 
 if rg -n "Aevatar\.Host\.Api|Aevatar\.Host\.Gateway" aevatar.slnx; then
   echo "Solution must not include legacy host projects."

--- a/tools/ci/static_service_activation_guard.sh
+++ b/tools/ci/static_service_activation_guard.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+targets=(
+  "src/platform/Aevatar.GAgentService.Infrastructure/Adapters/StaticServiceImplementationAdapter.cs"
+  "src/platform/Aevatar.GAgentService.Infrastructure/Activation/DefaultServiceRuntimeActivator.cs"
+)
+
+set +e
+report="$(
+  rg -n "Type\.GetType|AppDomain\.GetAssemblies" "${targets[@]}"
+)"
+status=$?
+set -e
+
+if [[ ${status} -ne 0 && ${status} -ne 1 ]]; then
+  echo "Static service activation guard execution failed."
+  exit "${status}"
+fi
+
+if [[ -n "${report}" ]]; then
+  echo "${report}"
+  echo "Static service activation must use IAgentKindRegistry + CreateByKindAsync, not CLR reflection."
+  exit 1
+fi
+
+echo "Static service activation guard passed."


### PR DESCRIPTION
## 摘要

iter99 cluster-100。Static service activation:删 `Type.GetType` + `AppDomain.GetAssemblies` reflection,改用 `IAgentKindRegistry` + `CreateByKindAsync`。`ActorTypeName` 降级 legacy adapter translation。

## Phase 9 r1 consensus(3/3 propose unanimous)

`META_JUDGE_DONE:consensus:agent-kind-registry:reuse IAgentKindRegistry + CreateByKindAsync, deprecate ActorTypeName to legacy adapter translation only`

3 solver 完全一致 propose,无需新 core abstraction(reuse 现有 registry)。

## 改动

- **adapter** `StaticServiceImplementationAdapter.cs`:删 `ResolveType` 反射,用 `IAgentKindRegistry.Resolve`
- **activator** `DefaultServiceRuntimeActivator.cs`:用 `CreateByKindAsync` 替换 Type-based 创建
- **proto** `service_artifact.proto` / `service_revision.proto`:加 `agent_kind` field
- **projection** `ServiceRevisionCatalogProjector` / `QueryReader` / ReadModel:propagate `agent_kind`
- **binding/endpoint** ScopeBinding / Endpoints 用 agent_kind
- **CI guard** `tools/ci/static_service_activation_guard.sh`:禁 `Type.GetType` / `AppDomain.GetAssemblies` 在 activation 路径
- 测试更新 + Old/New 注释

## 约束遵循

- ❌ 不引入新 actor / envelope / pipeline / ADR / Layer
- ❌ 不破坏 scripting / workflow activation paths
- ✅ Reuse 现有 `IAgentKindRegistry`(不新 core abstraction)
- ✅ ActorTypeName 仅 boundary legacy translation

## 验证

- `dotnet build aevatar.slnx --nologo` ✅
- `dotnet test ServiceRuntime / ServiceImplementation / ScopeService` ✅
- `bash tools/ci/architecture_guards.sh` ✅
- `bash tools/ci/test_stability_guards.sh` ✅
- `bash tools/ci/static_service_activation_guard.sh` ✅

净 +156 / -92 LOC。

closes #1044

⟦AI:AUTO-LOOP⟧
