### PR TITLE
iter101 cluster-105: AgentRun run_id 改 typed field(删 actorId prefix parser)

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunDispatcher.cs
@@ -41,6 +41,7 @@ public sealed class AgentRunDispatcher : IChannelLlmReplyRunDispatcher
         var command = new AgentRunStartRequested
         {
             Request = request.Clone(),
+            RunId = runId.Value,
         };
         command.Request.RunId = runId.Value;
         var envelope = new EventEnvelope

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -107,8 +107,31 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             return;
         }
 
+        // Refactor (iter101/cluster-105): Old=run_id could be recovered by parsing the run actor id; New=run_id is command data.
+        if (!AgentRunId.TryParse(command.RunId, out var typedCommandRunId))
+        {
+            _logger.LogWarning(
+                "Dropping malformed agent run start command without typed run_id: runActor={RunActorId} correlation={CorrelationId}",
+                Id,
+                command.Request.CorrelationId);
+            return;
+        }
+
+        var commandRunId = typedCommandRunId.Value;
         var request = command.Request.Clone();
         ApplyTargetRefOverrides(request);
+        if (!string.IsNullOrWhiteSpace(request.RunId) &&
+            !string.Equals(request.RunId.Trim(), commandRunId, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Dropping malformed agent run start command with mismatched run_id: commandRunId={CommandRunId} requestRunId={RequestRunId} runActor={RunActorId}",
+                commandRunId,
+                request.RunId,
+                Id);
+            return;
+        }
+
+        request.RunId = commandRunId;
         if (!AgentRunId.TryParse(request.RunId, out _))
         {
             // Refactor (iter98/cluster-002): Old=missing run_id fell back to correlation/actor id; New=start commands without explicit run_id are malformed.

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunIds.cs
@@ -53,18 +53,8 @@ internal static class AgentRunActorIds
 {
     private const string ActorIdPrefix = "channel-agent-run:";
 
+    // Refactor (iter101/cluster-105):
+    //   Old pattern: callers parsed this actor id prefix to recover run_id.
+    //   New principle: actor id remains an opaque address; run_id travels in typed command/state fields.
     public static string ForRun(AgentRunId runId) => ActorIdPrefix + runId.Value;
-
-    internal static bool TryGetRunId(string? actorId, out AgentRunId runId)
-    {
-        if (!string.IsNullOrWhiteSpace(actorId) &&
-            actorId.StartsWith(ActorIdPrefix, StringComparison.Ordinal) &&
-            AgentRunId.TryParse(actorId[ActorIdPrefix.Length..], out runId))
-        {
-            return true;
-        }
-
-        runId = default;
-        return false;
-    }
 }

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -133,6 +133,10 @@ message AgentRunReplyStepState {
 // scheduler callback payloads.
 message AgentRunStartRequested {
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 1;
+  // Refactor (iter101/cluster-105):
+  //   Old pattern: derive run_id by parsing AgentRun actor id prefix.
+  //   New principle: start command carries run_id as typed data; actor id remains opaque.
+  string run_id = 2;
 }
 
 // Durable output-dispatch retry signal emitted by the callback scheduler.

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -114,6 +114,35 @@ public sealed class AgentRunGAgentTests
     }
 
     [Fact]
+    public async Task HandleStartAsync_WhenCommandRunIdMissing_ShouldRejectEvenWhenRequestRunIdExists()
+    {
+        var replyGenerator = new RecordingReplyGenerator(() => false) { ReplyText = "ignored" };
+        var runtime = CreateRunAgent(
+            new DispatchingActorRuntime(),
+            replyGenerator,
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+        var initialState = runtime.State.Clone();
+
+        await runtime.HandleStartAsync(new AgentRunStartRequested
+        {
+            RunId = string.Empty,
+            Request = new NeedsLlmReplyEvent
+            {
+                CorrelationId = "corr-missing-command-run-id",
+                RunId = "run-request",
+                TargetActorId = "actor-1",
+                RegistrationId = "reg-1",
+                Activity = BuildRelayActivity(),
+                ReplyToken = "relay-token-missing-command-run-id",
+            },
+        });
+
+        runtime.State.Should().BeEquivalentTo(initialState);
+        replyGenerator.CallCount.Should().Be(0);
+    }
+
+    [Fact]
     public async Task DispatchAsync_ShouldAcceptDuplicateStarts_ForActorOwnedAdmission()
     {
         var actorRuntime = new DispatchingActorRuntime();

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Runtime.CompilerServices;
 using Aevatar.AI.Core.Chat;
 using Aevatar.AI.Core.Tools;
 using Aevatar.AI.Abstractions.LLMProviders;
@@ -54,6 +55,7 @@ public sealed class AgentRunGAgentTests
         envelope.Runtime.Deduplication.OperationId.Should().Be("agent-run-start:run-dispatch");
         envelope.Propagation.CorrelationId.Should().Be("corr-dispatch");
         var command = envelope.Payload.Unpack<AgentRunStartRequested>();
+        command.RunId.Should().Be("run-dispatch");
         command.Request.RunId.Should().Be("run-dispatch");
         command.Request.CorrelationId.Should().Be("corr-dispatch");
         command.Request.TargetActorId.Should().Be("conversation-actor");
@@ -82,6 +84,33 @@ public sealed class AgentRunGAgentTests
             .WithMessage("*run_id*");
         dispatchPort.Dispatches.Should().BeEmpty();
         actorRuntime.Dispatches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleStartAsync_WhenCommandRunIdDiffersFromRequestRunId_ShouldReject()
+    {
+        var runtime = CreateRunAgent(
+            new DispatchingActorRuntime(),
+            new RecordingReplyGenerator(() => false) { ReplyText = "ignored" },
+            new AsyncLocalInteractiveReplyCollector(),
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions { InteractiveRepliesEnabled = true });
+
+        await runtime.HandleStartAsync(new AgentRunStartRequested
+        {
+            RunId = "run-command",
+            Request = new NeedsLlmReplyEvent
+            {
+                CorrelationId = "corr-mismatch",
+                RunId = "run-request",
+                TargetActorId = "actor-1",
+                RegistrationId = "reg-1",
+                Activity = BuildRelayActivity(),
+                ReplyToken = "relay-token-mismatch",
+            },
+        });
+
+        runtime.State.RunId.Should().BeEmpty();
+        runtime.State.Status.Should().Be(AgentRunStatus.Unspecified);
     }
 
     [Fact]
@@ -2472,6 +2501,7 @@ public sealed class AgentRunGAgentTests
         IEventPublisher? eventPublisher = null,
         IActorRuntimeCallbackScheduler? callbackScheduler = null)
     {
+        var runId = AgentRunId.New();
         var dispatchPort = actorRuntime as IActorDispatchPort ?? Substitute.For<IActorDispatchPort>();
         var generationExecutor = new RecordingReplyGenerationExecutor(
             dispatchPort,
@@ -2486,9 +2516,10 @@ public sealed class AgentRunGAgentTests
             relayOptions,
             NullLogger<AgentRunGAgent>.Instance,
             callbackScheduler);
-        SetId(agent, AgentRunActorIds.ForRun(AgentRunId.New()));
+        SetId(agent, AgentRunActorIds.ForRun(runId));
         if (actorRuntime is DispatchingActorRuntime dispatchingActorRuntime)
             dispatchingActorRuntime.Register(agent.Id, new AgentActorAdapter(agent));
+        AgentRunTestRunIds.Bind(agent, runId.Value);
         generationExecutor.Bind(agent);
         agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
             InvokeAgentTransition(agent, current, evt));
@@ -2503,15 +2534,17 @@ public sealed class AgentRunGAgentTests
         IEventPublisher? eventPublisher = null,
         IActorRuntimeCallbackScheduler? callbackScheduler = null)
     {
+        var runId = AgentRunId.New();
         var agent = new AgentRunGAgent(
             actorRuntime,
             generationExecutor,
             relayOptions,
             NullLogger<AgentRunGAgent>.Instance,
             callbackScheduler);
-        SetId(agent, AgentRunActorIds.ForRun(AgentRunId.New()));
+        SetId(agent, AgentRunActorIds.ForRun(runId));
         if (actorRuntime is DispatchingActorRuntime dispatchingActorRuntime)
             dispatchingActorRuntime.Register(agent.Id, new AgentActorAdapter(agent));
+        AgentRunTestRunIds.Bind(agent, runId.Value);
         agent.EventSourcing = new StateTransitionEventSourcing<AgentRunGAgentState>((current, evt) =>
             InvokeAgentTransition(agent, current, evt));
         agent.EventPublisher = eventPublisher ?? new DispatchingEventPublisher(actorRuntime);
@@ -3661,24 +3694,50 @@ public sealed class AgentRunGAgentTests
 
 internal static class AgentRunGAgentTestExtensions
 {
-    public static Task HandleStartAsync(this AgentRunGAgent agent, NeedsLlmReplyEvent request) =>
-        agent.HandleStartAsync(new AgentRunStartRequested
+    public static Task HandleStartAsync(this AgentRunGAgent agent, NeedsLlmReplyEvent request)
+    {
+        var normalized = WithRunId(agent, request);
+        return agent.HandleStartAsync(new AgentRunStartRequested
         {
-            Request = WithRunId(agent, request),
+            RunId = normalized.RunId,
+            Request = normalized,
         });
+    }
 
     private static NeedsLlmReplyEvent WithRunId(AgentRunGAgent agent, NeedsLlmReplyEvent request)
     {
         var clone = request.Clone();
         if (string.IsNullOrWhiteSpace(clone.RunId))
         {
-            clone.RunId = AgentRunActorIds.TryGetRunId(agent.Id, out var runId)
-                ? runId.Value
-                : "run-" + (string.IsNullOrWhiteSpace(clone.CorrelationId)
-                    ? Guid.NewGuid().ToString("N")
-                    : clone.CorrelationId.Trim());
+            // Refactor (iter101/cluster-105):
+            //   Old pattern: tests parsed AgentRun actor id prefix to recover run_id.
+            //   New principle: tests carry run_id as typed command data, matching production.
+            clone.RunId = AgentRunTestRunIds.GetOrCreate(agent);
         }
 
         return clone;
     }
+}
+
+internal static class AgentRunTestRunIds
+{
+    private static readonly ConditionalWeakTable<AgentRunGAgent, RunIdBox> RunIds = new();
+
+    public static void Bind(AgentRunGAgent agent, string runId)
+    {
+        RunIds.Remove(agent);
+        RunIds.Add(agent, new RunIdBox(runId));
+    }
+
+    public static string GetOrCreate(AgentRunGAgent agent)
+    {
+        if (RunIds.TryGetValue(agent, out var box))
+            return box.RunId;
+
+        var runId = AgentRunId.New().Value;
+        Bind(agent, runId);
+        return runId;
+    }
+
+    private sealed record RunIdBox(string RunId);
 }


### PR DESCRIPTION
## 摘要

iter101 cluster-105。`AgentRun` run id 改 typed command/state field;actor id 仍 opaque(只 address resolver 构造)。删 `AgentRunActorIds` 字符串前缀解析(违反身份与事实分离)。

## CLAUDE 违反(已修)

CLAUDE-ACTOR-ID-001「身份与事实分离:稳定 ID 只负责寻址与复用键;可变绑定必须显式建模、显式读取」

## 改动

- AgentRunDispatcher / AgentRunGAgent:run id 通过 typed field 携带
- AgentRunIds:删 prefix parser(actor id opaque)
- agent_run.proto:typed run_id field
- AgentRunGAgentTests:覆盖 typed run_id 路径

## 约束遵循

- ❌ 不引入新 actor / envelope / pipeline
- ✅ actor id opaque(身份)+ run id typed(可变绑定)

+100/-23 LOC。

⟦AI:AUTO-LOOP⟧
