### PR TITLE
iter99 cluster-099: 删 Channel bot 注册表 fake rebuild event path

### DIFF
--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationCommittedStateProjectionActivationPlanProvider.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationCommittedStateProjectionActivationPlanProvider.cs
@@ -39,7 +39,6 @@ public sealed class ChannelBotRegistrationCommittedStateProjectionActivationPlan
     private static bool IsChannelBotRegistrationEvent(Any payload) =>
         payload.Is(ChannelBotRegisteredEvent.Descriptor) ||
         payload.Is(ChannelBotUnregisteredEvent.Descriptor) ||
-        payload.Is(ChannelBotProjectionRebuildRequestedEvent.Descriptor) ||
         payload.Is(ChannelBotTombstonesCompactedEvent.Descriptor) ||
         payload.Is(ChannelBotRegistrationRejectedEvent.Descriptor) ||
         payload.Is(ChannelBotScopeIdRepairedEvent.Descriptor);

--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationGAgent.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationGAgent.cs
@@ -26,7 +26,6 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
         StateTransitionMatcher
             .Match(current, evt)
             .On<ChannelBotRegisteredEvent>(ApplyRegistered)
-            .On<ChannelBotProjectionRebuildRequestedEvent>(static (state, _) => state)
             .On<ChannelBotRegistrationRejectedEvent>(static (state, _) => state)
             .On<ChannelBotScopeIdRepairedEvent>(ApplyScopeIdRepaired)
             .On<ChannelBotUnregisteredEvent>(ApplyUnregistered)
@@ -115,21 +114,6 @@ public sealed class ChannelBotRegistrationGAgent : GAgentBase<ChannelBotRegistra
             TombstoneStateVersion = NextCommittedVersion(),
         });
         Logger.LogInformation("Unregistered channel bot: id={Id}", cmd.RegistrationId);
-    }
-
-    [EventHandler]
-    private async Task HandleRebuildProjection(ChannelBotRebuildProjectionCommand cmd)
-    {
-        // Refactor (iter101/cluster-104): Old rebuild handler was public and callable as a direct command surface; new handler is private actor inbox protocol for startup refresh only.
-        await PersistDomainEventAsync(new ChannelBotProjectionRebuildRequestedEvent
-        {
-            Reason = cmd.Reason ?? string.Empty,
-            RequestedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-        });
-        Logger.LogInformation(
-            "Requested channel bot registration projection rebuild: actorId={ActorId}, reason={Reason}",
-            Id,
-            string.IsNullOrWhiteSpace(cmd.Reason) ? "unspecified" : cmd.Reason);
     }
 
     [EventHandler]

--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationLegacyAliases.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationLegacyAliases.cs
@@ -14,9 +14,7 @@ internal static class ChannelBotRegistrationLegacyAliases
     internal const string UnregisteredEventProto = ProtoPrefix + "ChannelBotUnregisteredEvent";
     internal const string RegisterCommandProto = ProtoPrefix + "ChannelBotRegisterCommand";
     internal const string UnregisterCommandProto = ProtoPrefix + "ChannelBotUnregisterCommand";
-    internal const string RebuildProjectionCommandProto = ProtoPrefix + "ChannelBotRebuildProjectionCommand";
     internal const string CompactTombstonesCommandProto = ProtoPrefix + "ChannelBotCompactTombstonesCommand";
-    internal const string ProjectionRebuildRequestedEventProto = ProtoPrefix + "ChannelBotProjectionRebuildRequestedEvent";
     internal const string TombstonesCompactedEventProto = ProtoPrefix + "ChannelBotTombstonesCompactedEvent";
     internal const string RegistrationRejectedEventProto = ProtoPrefix + "ChannelBotRegistrationRejectedEvent";
     internal const string ScopeIdRepairedEventProto = ProtoPrefix + "ChannelBotScopeIdRepairedEvent";
@@ -47,14 +45,8 @@ public sealed partial class ChannelBotRegisterCommand;
 [LegacyProtoFullName(ChannelBotRegistrationLegacyAliases.UnregisterCommandProto)]
 public sealed partial class ChannelBotUnregisterCommand;
 
-[LegacyProtoFullName(ChannelBotRegistrationLegacyAliases.RebuildProjectionCommandProto)]
-public sealed partial class ChannelBotRebuildProjectionCommand;
-
 [LegacyProtoFullName(ChannelBotRegistrationLegacyAliases.CompactTombstonesCommandProto)]
 public sealed partial class ChannelBotCompactTombstonesCommand;
-
-[LegacyProtoFullName(ChannelBotRegistrationLegacyAliases.ProjectionRebuildRequestedEventProto)]
-public sealed partial class ChannelBotProjectionRebuildRequestedEvent;
 
 [LegacyProtoFullName(ChannelBotRegistrationLegacyAliases.TombstonesCompactedEventProto)]
 public sealed partial class ChannelBotTombstonesCompactedEvent;

--- a/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
+++ b/agents/Aevatar.GAgents.Channel.Runtime/ChannelBotRegistrationStartupService.cs
@@ -1,6 +1,3 @@
-using Aevatar.Foundation.Abstractions;
-using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -8,36 +5,30 @@ namespace Aevatar.GAgents.Channel.Runtime;
 
 /// <summary>
 /// Activates the projection scope for the channel bot registration store
-/// at application startup, then re-emits the authoritative state root so the
-/// query-side read model can be refreshed after a restart.
+/// at application startup so the query-side read model can catch up through
+/// the committed-state projection activation path after a restart.
 ///
 /// StartAsync awaits the activation with retries so the host does not
-/// accept HTTP requests until the registration projection binder is active and
-/// the refresh command has been accepted. Request paths must not activate or
-/// prime this projection themselves.
+/// accept HTTP requests until the registration projection binder is active.
+/// Request paths must not activate or prime this projection themselves.
 /// </summary>
 internal sealed class ChannelBotRegistrationStartupService : IHostedService
 {
+    // Refactor (iter99/cluster-099): Old pattern: ChannelBotRegistrationStartupService dispatched ChannelBotRebuildProjectionCommand; actor wrote no-op ChannelBotProjectionRebuildRequestedEvent to trigger projection refresh. New principle: committed-state publication + projection activation cover cold-start refresh natively; no synthetic event needed.
     // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=public rebuild surfaces, new=internal Runtime startup helper only
-    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual projection refresh surface, new=startup-owned actor inbox dispatch
-    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=operator-triggered rebuild, new=host startup refresh after projection activation
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=manual projection refresh surface, new=host startup projection activation
+    // Refactor (iter56/cluster-933-channel-registration-rebuild-narrow): old=operator-triggered rebuild, new=activation-only startup warm-up
     private const int MaxRetries = 5;
     private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
 
     private readonly ChannelBotRegistrationProjectionBootstrapActivator _projectionActivator;
-    private readonly IActorRuntime _actorRuntime;
-    private readonly IActorHandledDispatchPort _dispatchPort;
     private readonly ILogger<ChannelBotRegistrationStartupService> _logger;
 
     public ChannelBotRegistrationStartupService(
         ChannelBotRegistrationProjectionBootstrapActivator projectionActivator,
-        IActorRuntime actorRuntime,
-        IActorHandledDispatchPort dispatchPort,
         ILogger<ChannelBotRegistrationStartupService> logger)
     {
         _projectionActivator = projectionActivator;
-        _actorRuntime = actorRuntime;
-        _dispatchPort = dispatchPort;
         _logger = logger;
     }
 
@@ -49,9 +40,8 @@ internal sealed class ChannelBotRegistrationStartupService : IHostedService
             try
             {
                 await _projectionActivator.ActivateWellKnownCatalogAsync(ct);
-                await DispatchStartupProjectionRefreshAsync(ct);
                 _logger.LogInformation(
-                    "Channel bot registration projection scope activated and rebuild dispatched for {ActorId} (attempt {Attempt})",
+                    "Channel bot registration projection scope activated for {ActorId} (attempt {Attempt})",
                     ChannelBotRegistrationGAgent.WellKnownId, attempt);
                 return;
             }
@@ -62,7 +52,7 @@ internal sealed class ChannelBotRegistrationStartupService : IHostedService
             catch (Exception ex)
             {
                 _logger.LogWarning(ex,
-                    "Failed to activate or rebuild channel bot registration projection scope (attempt {Attempt}/{MaxRetries})",
+                    "Failed to activate channel bot registration projection scope (attempt {Attempt}/{MaxRetries})",
                     attempt, MaxRetries);
 
                 if (attempt < MaxRetries)
@@ -72,41 +62,13 @@ internal sealed class ChannelBotRegistrationStartupService : IHostedService
         }
 
         // All retries exhausted — let the host start in degraded mode.
-        // Registrations may appear missing until the projection binder and
-        // authoritative refresh are re-triggered by a later host restart or
-        // operator intervention.
+        // Registrations may appear missing until the projection binder is
+        // activated by a later host restart or operator intervention.
         _logger.LogError(
-            "Channel bot registration projection activation/rebuild failed after {MaxRetries} attempts — " +
-            "registrations may not be visible until the refresh path is re-triggered",
+            "Channel bot registration projection activation failed after {MaxRetries} attempts — " +
+            "registrations may not be visible until activation is re-triggered",
             MaxRetries);
     }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
-
-    private async Task DispatchStartupProjectionRefreshAsync(CancellationToken ct)
-    {
-        // Refactor (iter101/cluster-104): Old channel registration exposed a reusable RebuildProjection helper; new rebuild signal is private to startup after projection activation.
-        _ = await _actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            ?? await _actorRuntime.CreateAsync<ChannelBotRegistrationGAgent>(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                ct);
-
-        var envelope = new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(new ChannelBotRebuildProjectionCommand
-            {
-                Reason = "startup_projection_rebuild",
-            }),
-            Route = EnvelopeRouteSemantics.CreateDirect(
-                "channel-runtime.registration-store",
-                ChannelBotRegistrationGAgent.WellKnownId),
-        };
-
-        await _dispatchPort.DispatchAndWaitHandledAsync(
-            ChannelBotRegistrationGAgent.WellKnownId,
-            envelope,
-            ct);
-    }
 }

--- a/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_bot_registration.proto
+++ b/agents/Aevatar.GAgents.Channel.Runtime/protos/channel_bot_registration.proto
@@ -60,17 +60,8 @@ message ChannelBotUnregisterCommand {
   string registration_id = 1;
 }
 
-message ChannelBotRebuildProjectionCommand {
-  string reason = 1;
-}
-
 message ChannelBotCompactTombstonesCommand {
   int64 safe_state_version = 1;
-}
-
-message ChannelBotProjectionRebuildRequestedEvent {
-  string reason = 1;
-  google.protobuf.Timestamp requested_at = 2;
 }
 
 message ChannelBotTombstonesCompactedEvent {

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStartupServiceTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStartupServiceTests.cs
@@ -1,18 +1,17 @@
 using Aevatar.CQRS.Projection.Core.Abstractions;
 using Aevatar.CQRS.Projection.Core.Orchestration;
-using Aevatar.Foundation.Abstractions;
+using Aevatar.GAgents.Channel.Runtime;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using Xunit;
-using Aevatar.GAgents.Channel.Runtime;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
 public sealed class ChannelBotRegistrationStartupServiceTests
 {
     [Fact]
-    public async Task StartAsync_ActivatesProjection_AndDispatchesRebuildCommand()
+    public async Task StartAsync_ActivatesProjection_WithoutDispatchingSyntheticRebuild()
     {
         var activationService = Substitute.For<IProjectionScopeActivationService<ChannelBotRegistrationMaterializationRuntimeLease>>();
         activationService.EnsureAsync(Arg.Any<ProjectionScopeStartRequest>(), Arg.Any<CancellationToken>())
@@ -23,22 +22,9 @@ public sealed class ChannelBotRegistrationStartupServiceTests
                     ProjectionKind = ChannelBotRegistrationProjectionBootstrapActivator.ProjectionKind,
                 })));
 
-        EventEnvelope? capturedEnvelope = null;
-        var actorRuntime = Substitute.For<IActorRuntime>();
-        var dispatchPort = Substitute.For<IActorHandledDispatchPort>();
-        actorRuntime.GetAsync(ChannelBotRegistrationGAgent.WellKnownId)
-            .Returns(Task.FromResult<IActor?>(Substitute.For<IActor>()));
-        dispatchPort.DispatchAndWaitHandledAsync(
-                ChannelBotRegistrationGAgent.WellKnownId,
-                Arg.Do<EventEnvelope>(envelope => capturedEnvelope = envelope),
-                Arg.Any<CancellationToken>())
-            .Returns(call => Task.FromResult(DispatchAdmissionFactory.Create(call.ArgAt<string>(0), call.ArgAt<EventEnvelope>(1))));
-
         var projectionActivator = new ChannelBotRegistrationProjectionBootstrapActivator(activationService);
         var startupService = new ChannelBotRegistrationStartupService(
             projectionActivator,
-            actorRuntime,
-            dispatchPort,
             NullLogger<ChannelBotRegistrationStartupService>.Instance);
 
         await startupService.StartAsync(CancellationToken.None);
@@ -49,7 +35,5 @@ public sealed class ChannelBotRegistrationStartupServiceTests
                 request.ProjectionKind == ChannelBotRegistrationProjectionBootstrapActivator.ProjectionKind &&
                 request.Mode == ProjectionRuntimeMode.DurableMaterialization),
             Arg.Any<CancellationToken>());
-        capturedEnvelope.Should().NotBeNull();
-        capturedEnvelope!.Payload.Unpack<ChannelBotRebuildProjectionCommand>().Reason.Should().Be("startup_projection_rebuild");
     }
 }

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ChannelBotRegistrationStoreTests.cs
@@ -4,12 +4,12 @@ using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Foundation.Core;
 using Aevatar.Foundation.Core.EventSourcing;
+using Aevatar.GAgents.Channel.Runtime;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Aevatar.GAgents.Channel.Runtime;
 
 namespace Aevatar.GAgents.ChannelRuntime.Tests;
 
@@ -300,39 +300,6 @@ public sealed class ChannelBotRegistrationGAgentTests : IAsyncLifetime
             ],
             _agent.EventSourcing!.CurrentVersion,
             CancellationToken.None);
-    }
-
-    [Fact]
-    public async Task RebuildProjectionInboxSignal_PersistsRefreshEvent_WithoutMutatingState()
-    {
-        await _agent.HandleRegister(new ChannelBotRegisterCommand
-        {
-            Platform = "lark",
-            NyxProviderSlug = "api-lark-bot",
-            ScopeId = "scope-1",
-            RequestedId = "reg-1",
-            NyxAgentApiKeyId = "key-1",
-        });
-
-        var beforeState = _agent.State.Clone();
-        var beforeVersion = _agent.EventSourcing!.CurrentVersion;
-
-        // Refactor (iter101/cluster-104): Rebuild is no longer a directly callable public handler; tests exercise the actor inbox path used by startup refresh.
-        await _agent.HandleEventAsync(new EventEnvelope
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Timestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
-            Payload = Any.Pack(new ChannelBotRebuildProjectionCommand
-            {
-                Reason = "test-rebuild",
-            }),
-            Route = EnvelopeRouteSemantics.CreateDirect(
-                "test",
-                ChannelBotRegistrationGAgent.WellKnownId),
-        });
-
-        _agent.EventSourcing!.CurrentVersion.Should().Be(beforeVersion + 1);
-        _agent.State.Should().BeEquivalentTo(beforeState);
     }
 
     private sealed class NoopCallbackScheduler : IActorRuntimeCallbackScheduler

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/ServiceCollectionExtensionsTests.cs
@@ -86,14 +86,6 @@ public sealed class ServiceCollectionExtensionsTests
             descriptor.ServiceType == typeof(ChannelRegistrationCommandFacade));
         services.Should().Contain(descriptor =>
             descriptor.ServiceType == typeof(ICommandDispatchService<ChannelBotRegisterCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
-        services.Should().NotContain(descriptor =>
-            descriptor.ServiceType == typeof(ICommandTargetResolver<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandStartError>));
-        services.Should().NotContain(descriptor =>
-            descriptor.ServiceType == typeof(ICommandEnvelopeFactory<ChannelBotRebuildProjectionCommand>));
-        services.Should().NotContain(descriptor =>
-            descriptor.ServiceType == typeof(ICommandDispatchPipeline<ChannelBotRebuildProjectionCommand, ChannelBotRegistrationCommandTarget, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
-        services.Should().NotContain(descriptor =>
-            descriptor.ServiceType == typeof(ICommandDispatchService<ChannelBotRebuildProjectionCommand, ChannelRegistrationCommandAcceptedReceipt, ChannelRegistrationCommandStartError>));
         registry.Get(ChannelId.From("telegram")).Should().BeOfType<Aevatar.GAgents.Platform.Telegram.TelegramMessageComposer>();
     }
 


### PR DESCRIPTION
## Summary

Phase 9 r2 consensus(reflector retry-fix narrowing):删 startup-only fake rebuild event path,不引入新 core refresh contract;activation-only startup 保留。

- **Old**:`ChannelBotRegistrationStartupService` dispatch `ChannelBotRebuildProjectionCommand` → actor 写 no-op `ChannelBotProjectionRebuildRequestedEvent` 触发 projection 刷新
- **New**:committed-state publication + projection activation 自然 cover cold-start refresh;无 synthetic event

违反 CLAUDE.md「权威状态 / ReadModel / Projection」:committed event store + actor state 是唯一真相;projection 只消费 committed 事实;无业务变化的领域事件不应作为 projection trigger。

## Scope

- 8 files changed (+16 / -145):
  - 删 `ChannelBotRegistrationStartupService` dispatch fake event(保留 activation-only startup)
  - 删 `ChannelBotRebuildProjectionCommand` 类型 + factory + dispatch pipeline
  - 删 `ChannelBotProjectionRebuildRequestedEvent` proto 类型 + legacy alias
  - 删 `ChannelBotRegistrationGAgent.HandleRebuildProjection` handler + state transition
  - 删 activation plan provider 中 fake event 路由
  - 调整测试 3 个文件,验证 activation-only 行为

## Verification

- `dotnet build aevatar.slnx --nologo`:0 errors(仅 既有 warning)
- `dotnet test ChannelRuntime.Tests`:890 passed
- `bash tools/ci/architecture_guards.sh && bash tools/ci/test_stability_guards.sh`:passed

## 历史(Phase 9 路径)

- iter99 escalate(3 选项 A/B/C 全引入新 abstraction)→ 4h timeout
- reflector r1:retry-fix with narrowing `delete startup-only fake rebuild event path without new core refresh contract`
- r2 三 solver 全 propose 同方向 → meta-judge r2 consensus
- implement codex narrow delete + 890 tests pass

closes #1043

🤖 Auto-loop / codex-refactor-loop iter99

⟦AI:AUTO-LOOP⟧