### PR TITLE
iter105 cluster-3 #1073: graph-only workflow_artifact_query + 删 actor_inspect graph

### DIFF
--- a/src/Aevatar.AI.ToolProviders.Workflow/ServiceCollectionExtensions.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/ServiceCollectionExtensions.cs
@@ -8,9 +8,12 @@ namespace Aevatar.AI.ToolProviders.Workflow;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers workflow inspection tools (workflow_status, actor_inspect, event_query).
+    /// Registers workflow inspection tools (workflow_status, workflow_artifact_query, actor_inspect, event_query).
     /// Requires IWorkflowExecutionQueryApplicationService to be registered.
     /// </summary>
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public static IServiceCollection AddWorkflowTools(
         this IServiceCollection services,
         Action<WorkflowToolOptions>? configure = null)

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/ActorInspectTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/ActorInspectTool.cs
@@ -23,10 +23,13 @@ public sealed class ActorInspectTool : IAgentTool
 
     public string Name => "actor_inspect";
 
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public string Description =>
         "Inspect actor state via the projection readmodel. " +
         "Shows actor snapshots (status, output, step counts), " +
-        "graph relationships, and registered agents. " +
+        "and registered agents. " +
         "All data is from committed projections, not live actor internals.";
 
     public string ParametersSchema => """
@@ -35,16 +38,12 @@ public sealed class ActorInspectTool : IAgentTool
           "properties": {
             "action": {
               "type": "string",
-              "enum": ["snapshot", "list", "graph", "agents"],
-              "description": "Action: 'snapshot' (default) actor state, 'list' all actors, 'graph' relationships, 'agents' registered agents"
+              "enum": ["snapshot", "list", "agents"],
+              "description": "Action: 'snapshot' (default) actor state, 'list' all actors, 'agents' registered agents"
             },
             "actor_id": {
               "type": "string",
-              "description": "Actor ID (required for 'snapshot' and 'graph')"
-            },
-            "graph_depth": {
-              "type": "integer",
-              "description": "Graph traversal depth (default: 2, max: 5)"
+              "description": "Actor ID (required for 'snapshot')"
             },
             "take": {
               "type": "integer",
@@ -75,8 +74,8 @@ public sealed class ActorInspectTool : IAgentTool
             return action switch
             {
                 "list" or "agents" => await ListAgentsAsync(ct),
-                "graph" => await GetGraphAsync(args, ct),
-                _ => await GetSnapshotAsync(args, ct),
+                "snapshot" => await GetSnapshotAsync(args, ct),
+                _ => JsonSerializer.Serialize(new { error = $"Unsupported actor_inspect action '{action}'" }),
             };
         }
         catch (OperationCanceledException) { throw; }
@@ -109,37 +108,6 @@ public sealed class ActorInspectTool : IAgentTool
                 total = snapshot.TotalSteps, requested = snapshot.RequestedSteps,
                 completed = snapshot.CompletedSteps, role_replies = snapshot.RoleReplyCount,
             },
-        }, s_json);
-    }
-
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: the graph action exposed workflow run graph data as an actor current-state graph query.
-    //   New principle: workflow history/report/graph are workflow-run artifacts or exports, not current-state readmodels.
-    private async Task<string> GetGraphAsync(ToolArgs args, CancellationToken ct)
-    {
-        var actorId = args.Str("actor_id");
-        if (string.IsNullOrWhiteSpace(actorId))
-            return """{"error":"'actor_id' is required for 'graph' action"}""";
-
-        var depth = Math.Clamp(args.Int("graph_depth") ?? _options.MaxGraphDepth, 1, 5);
-        var take = Math.Clamp(args.Int("take") ?? 200, 1, 500);
-
-        var subgraph = await _queryService.GetWorkflowRunGraphExportSubgraphAsync(actorId, depth, take, ct: ct);
-
-        return JsonSerializer.Serialize(new
-        {
-            root = subgraph.RootNodeId,
-            nodes = subgraph.Nodes.Select(n => new
-            {
-                id = n.NodeId, type = n.NodeType, updated_at = n.UpdatedAt,
-                properties = n.Properties.Count > 0 ? n.Properties : null,
-            }).ToArray(),
-            edges = subgraph.Edges.Select(e => new
-            {
-                from = e.FromNodeId, to = e.ToNodeId, type = e.EdgeType,
-                properties = e.Properties.Count > 0 ? e.Properties : null,
-            }).ToArray(),
-            node_count = subgraph.Nodes.Count, edge_count = subgraph.Edges.Count,
         }, s_json);
     }
 

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/EventQueryTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/EventQueryTool.cs
@@ -23,6 +23,9 @@ public sealed class EventQueryTool : IAgentTool
 
     public string Name => "event_query";
 
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public string Description =>
         "Query committed events for a workflow run. " +
         "Shows the chronological timeline of execution: " +
@@ -30,9 +33,9 @@ public sealed class EventQueryTool : IAgentTool
         "Optionally filter by stage or event type. " +
         "Use 'edges' action to see workflow run graph export edges.";
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: event_query required actor_id for workflow history and graph lookups.
-    //   New principle: workflow_run_id is the artifact/export identity, while actor_id is a deprecated compatibility alias.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public string ParametersSchema => """
         {
           "type": "object",
@@ -45,10 +48,6 @@ public sealed class EventQueryTool : IAgentTool
             "workflow_run_id": {
               "type": "string",
               "description": "Workflow run ID to query"
-            },
-            "actor_id": {
-              "type": "string",
-              "description": "Deprecated alias for workflow_run_id"
             },
             "stage_filter": {
               "type": "string",
@@ -68,10 +67,7 @@ public sealed class EventQueryTool : IAgentTool
               "description": "Max events to return (default: 50, max: 200)"
             }
           },
-          "anyOf": [
-            { "required": ["workflow_run_id"] },
-            { "required": ["actor_id"] }
-          ]
+          "required": ["workflow_run_id"]
         }
         """;
 
@@ -88,7 +84,7 @@ public sealed class EventQueryTool : IAgentTool
         try
         {
             var args = ToolArgs.Parse(argumentsJson);
-            var workflowRunId = GetWorkflowRunId(args);
+            var workflowRunId = args.Str("workflow_run_id");
             if (string.IsNullOrWhiteSpace(workflowRunId))
                 return """{"error":"'workflow_run_id' is required"}""";
 
@@ -106,9 +102,9 @@ public sealed class EventQueryTool : IAgentTool
         }
     }
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: event_query exposed workflow timeline as an actor timeline readmodel query keyed by actor_id.
-    //   New principle: timeline data is a workflow-run timeline export artifact; actor_id remains only as a deprecated caller alias.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     private async Task<string> GetTimelineAsync(string workflowRunId, ToolArgs args, CancellationToken ct)
     {
         var take = Math.Clamp(args.Int("take") ?? _options.MaxTimelineItems, 1, 200);
@@ -138,9 +134,9 @@ public sealed class EventQueryTool : IAgentTool
         }, s_json);
     }
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: event_query exposed graph edges as an actor graph readmodel query keyed by actor_id.
-    //   New principle: graph edges are workflow-run graph export artifact data; actor_id remains only as a deprecated caller alias.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     private async Task<string> GetEdgesAsync(string workflowRunId, ToolArgs args, CancellationToken ct)
     {
         var take = Math.Clamp(args.Int("take") ?? 200, 1, 500);
@@ -170,12 +166,6 @@ public sealed class EventQueryTool : IAgentTool
 
     private static string? NullIfEmpty(string? s) =>
         string.IsNullOrWhiteSpace(s) ? null : s;
-
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow tool calls treated actor_id as the artifact query identity.
-    //   New principle: workflow_run_id is the artifact identity; actor_id is accepted only for transitional tool compatibility.
-    private static string GetWorkflowRunId(ToolArgs args) =>
-        args.Str("workflow_run_id") ?? args.Str("actor_id") ?? string.Empty;
 
     private static Dictionary<string, string> TruncateData(IDictionary<string, string> data) =>
         data.ToDictionary(kv => kv.Key, kv => kv.Value.Length > 200 ? kv.Value[..200] + "..." : kv.Value);

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowArtifactQueryTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowArtifactQueryTool.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Aevatar.AI.Abstractions.ToolProviders;
+using Aevatar.Workflow.Application.Abstractions.Queries;
+
+namespace Aevatar.AI.ToolProviders.Workflow.Tools;
+
+/// <summary>
+/// Queries workflow artifact/export surfaces on the existing workflow execution facade.
+/// </summary>
+public sealed class WorkflowArtifactQueryTool : IAgentTool
+{
+    private readonly IWorkflowExecutionQueryApplicationService _queryService;
+    private readonly WorkflowToolOptions _options;
+
+    public WorkflowArtifactQueryTool(
+        IWorkflowExecutionQueryApplicationService queryService,
+        WorkflowToolOptions options)
+    {
+        _queryService = queryService;
+        _options = options;
+    }
+
+    public string Name => "workflow_artifact_query";
+
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
+    public string Description =>
+        "Query workflow-run graph artifact exports. " +
+        "Use action='subgraph' with workflow_run_id to return the workflow graph subgraph artifact.";
+
+    public string ParametersSchema => """
+        {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": ["subgraph"],
+              "description": "Action: 'subgraph' returns the workflow-run graph subgraph artifact"
+            },
+            "workflow_run_id": {
+              "type": "string",
+              "description": "Workflow run ID to query"
+            },
+            "graph_depth": {
+              "type": "integer",
+              "description": "Graph traversal depth (default: 2, max: 5)"
+            },
+            "take": {
+              "type": "integer",
+              "description": "Max graph items to return (default: 200, max: 500)"
+            }
+          },
+          "required": ["workflow_run_id"]
+        }
+        """;
+
+    public bool IsReadOnly => true;
+
+    private static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = false,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+
+    public async Task<string> ExecuteAsync(string argumentsJson, CancellationToken ct = default)
+    {
+        try
+        {
+            var args = ToolArgs.Parse(argumentsJson);
+            var action = args.Str("action", "subgraph");
+            if (!string.Equals(action, "subgraph", StringComparison.Ordinal))
+                return """{"error":"workflow_artifact_query only supports action='subgraph'"}""";
+
+            var workflowRunId = args.Str("workflow_run_id");
+            if (string.IsNullOrWhiteSpace(workflowRunId))
+                return """{"error":"'workflow_run_id' is required"}""";
+
+            return await GetSubgraphAsync(workflowRunId, args, ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
+    private async Task<string> GetSubgraphAsync(string workflowRunId, ToolArgs args, CancellationToken ct)
+    {
+        var depth = Math.Clamp(args.Int("graph_depth") ?? _options.MaxGraphDepth, 1, 5);
+        var take = Math.Clamp(args.Int("take") ?? 200, 1, 500);
+        var subgraph = await _queryService.GetWorkflowRunGraphExportSubgraphAsync(workflowRunId, depth, take, ct: ct);
+
+        return JsonSerializer.Serialize(new
+        {
+            workflow_run_id = workflowRunId,
+            artifact = "graph_subgraph",
+            subgraph = new
+            {
+                root = subgraph.RootNodeId,
+                nodes = subgraph.Nodes.Select(n => new
+                {
+                    id = n.NodeId, type = n.NodeType, updated_at = n.UpdatedAt,
+                    properties = n.Properties.Count > 0 ? n.Properties : null,
+                }).ToArray(),
+                edges = subgraph.Edges.Select(e => new
+                {
+                    from = e.FromNodeId, to = e.ToNodeId, type = e.EdgeType,
+                    properties = e.Properties.Count > 0 ? e.Properties : null,
+                }).ToArray(),
+                node_count = subgraph.Nodes.Count,
+                edge_count = subgraph.Edges.Count,
+            },
+        }, s_json);
+    }
+}

--- a/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowStatusTool.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/Tools/WorkflowStatusTool.cs
@@ -23,15 +23,18 @@ public sealed class WorkflowStatusTool : IAgentTool
 
     public string Name => "workflow_status";
 
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public string Description =>
         "Query the status of a workflow execution. " +
         "Shows completion status, steps, role replies, and timeline events. " +
         "Use 'list' action to see available workflows, 'catalog' for definitions, " +
         "or provide a workflow_run_id to get a specific run's status.";
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow_status described run report/timeline lookups as actor_id-driven actor queries.
-    //   New principle: report and timeline are workflow-run artifacts/exports, with actor_id accepted only as a deprecated alias.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public string ParametersSchema => """
         {
           "type": "object",
@@ -44,10 +47,6 @@ public sealed class WorkflowStatusTool : IAgentTool
             "workflow_run_id": {
               "type": "string",
               "description": "Workflow run ID (required for 'status' and 'timeline')"
-            },
-            "actor_id": {
-              "type": "string",
-              "description": "Deprecated alias for workflow_run_id"
             },
             "workflow_name": {
               "type": "string",
@@ -128,12 +127,12 @@ public sealed class WorkflowStatusTool : IAgentTool
         }, s_json);
     }
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow_status read execution reports through an actor report readmodel query keyed by actor_id.
-    //   New principle: execution reports are workflow-run report artifacts; actor_id remains only as a deprecated caller alias.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     private async Task<string> GetStatusAsync(ToolArgs args, CancellationToken ct)
     {
-        var workflowRunId = GetWorkflowRunId(args);
+        var workflowRunId = args.Str("workflow_run_id");
         if (string.IsNullOrWhiteSpace(workflowRunId))
             return """{"error":"'workflow_run_id' is required for 'status' action. Use action='list' to find available workflows."}""";
 
@@ -165,12 +164,12 @@ public sealed class WorkflowStatusTool : IAgentTool
         }, s_json);
     }
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow_status exposed timeline data through an actor timeline readmodel query keyed by actor_id.
-    //   New principle: timeline data is a workflow-run timeline export artifact; actor_id remains only as a deprecated caller alias.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     private async Task<string> GetTimelineAsync(ToolArgs args, CancellationToken ct)
     {
-        var workflowRunId = GetWorkflowRunId(args);
+        var workflowRunId = args.Str("workflow_run_id");
         if (string.IsNullOrWhiteSpace(workflowRunId))
             return """{"error":"'workflow_run_id' is required for 'timeline' action"}""";
 
@@ -194,9 +193,4 @@ public sealed class WorkflowStatusTool : IAgentTool
     private static string? Truncate(string? s, int max) =>
         string.IsNullOrWhiteSpace(s) ? null : s.Length <= max ? s : s[..max] + "...";
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow tool calls treated actor_id as the artifact query identity.
-    //   New principle: workflow_run_id is the artifact identity; actor_id is accepted only for transitional tool compatibility.
-    private static string GetWorkflowRunId(ToolArgs args) =>
-        args.Str("workflow_run_id") ?? args.Str("actor_id") ?? string.Empty;
 }

--- a/src/Aevatar.AI.ToolProviders.Workflow/WorkflowAgentToolSource.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/WorkflowAgentToolSource.cs
@@ -30,11 +30,15 @@ public sealed class WorkflowAgentToolSource : IAgentToolSource
         _logger = logger ?? NullLogger<WorkflowAgentToolSource>.Instance;
     }
 
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public Task<IReadOnlyList<IAgentTool>> DiscoverToolsAsync(CancellationToken ct = default)
     {
         var tools = new List<IAgentTool>
         {
             new WorkflowStatusTool(_queryService, _options),
+            new WorkflowArtifactQueryTool(_queryService, _options),
             new ActorInspectTool(_queryService, _options),
             new EventQueryTool(_queryService, _options),
         };

--- a/src/Aevatar.AI.ToolProviders.Workflow/WorkflowToolOptions.cs
+++ b/src/Aevatar.AI.ToolProviders.Workflow/WorkflowToolOptions.cs
@@ -9,7 +9,7 @@ public sealed class WorkflowToolOptions
     /// <summary>Maximum number of actor snapshots to list (default: 100).</summary>
     public int MaxActorSnapshots { get; set; } = 100;
 
-    /// <summary>Maximum graph traversal depth for actor_inspect subgraph queries (default: 2).</summary>
+    /// <summary>Maximum graph traversal depth for workflow_artifact_query subgraph queries (default: 2).</summary>
     public int MaxGraphDepth { get; set; } = 2;
 
     /// <summary>Maximum YAML content size in characters for create/update operations (default: 100,000).</summary>

--- a/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionArtifactQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Application.Abstractions/Projections/IWorkflowExecutionArtifactQueryPort.cs
@@ -4,12 +4,11 @@ namespace Aevatar.Workflow.Application.Abstractions.Projections;
 
 public interface IWorkflowExecutionArtifactQueryPort
 {
-    bool EnableActorQueryEndpoints { get; }
+    bool WorkflowArtifactQueryEnabled { get; }
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow history / report / graph are treated as current-state readmodels (current-state query path enriches actor snapshots by reading report artifacts; duplicate WorkflowRunTimelineDocument and WorkflowRunGraphArtifactDocument shells copy WorkflowRunInsightReportDocument; public application/query/tool/HTTP surfaces expose them as actor current-state queries instead of workflow-run artifacts)
-    //   New principle: Workflow history / report / graph are workflow-run artifacts (or aggregate-owned views), NOT actor current-state readmodels: keep existing WorkflowRunInsightReportDocument adapter/name workflow-local as the single report artifact source; delete duplicate WorkflowRunTimelineDocument / WorkflowRunGraphArtifactDocument shells (timeline derived from report artifact, graph materialization derived from report artifact); stop current-state query paths from reading report/history artifacts to enrich actor snapshots; rename public application/query/tool/HTTP surfaces so report/timeline/graph are explicit workflow-run artifact / export, not current-state readmodel surfaces; WorkflowExecutionCurrentStateDocument remains the only workflow actor-scoped current-state readmodel; NO CLAUDE.md change, NO new core abstraction, NO generic CQRS Projection artifact storage seam, NO new actor type
-    //   New pattern: workflow history/report/graph are artifacts or aggregate-owned views, not current-state readmodels.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(
         string workflowRunId,
         CancellationToken ct = default);

--- a/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
+++ b/src/workflow/Aevatar.Workflow.Application/Queries/WorkflowExecutionQueryApplicationService.cs
@@ -28,10 +28,9 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
 
     public bool ActorQueryEnabled => _currentStateQueryPort.EnableActorQueryEndpoints;
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow history / report / graph are treated as current-state readmodels (current-state query path enriches actor snapshots by reading report artifacts; duplicate WorkflowRunTimelineDocument and WorkflowRunGraphArtifactDocument shells copy WorkflowRunInsightReportDocument; public application/query/tool/HTTP surfaces expose them as actor current-state queries instead of workflow-run artifacts)
-    //   New principle: Workflow history / report / graph are workflow-run artifacts (or aggregate-owned views), NOT actor current-state readmodels: keep existing WorkflowRunInsightReportDocument adapter/name workflow-local as the single report artifact source; delete duplicate WorkflowRunTimelineDocument / WorkflowRunGraphArtifactDocument shells (timeline derived from report artifact, graph materialization derived from report artifact); stop current-state query paths from reading report/history artifacts to enrich actor snapshots; rename public application/query/tool/HTTP surfaces so report/timeline/graph are explicit workflow-run artifact / export, not current-state readmodel surfaces; WorkflowExecutionCurrentStateDocument remains the only workflow actor-scoped current-state readmodel; NO CLAUDE.md change, NO new core abstraction, NO generic CQRS Projection artifact storage seam, NO new actor type
-    //   New pattern: workflow history/report/graph are artifacts or aggregate-owned views, not current-state readmodels.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
 
     public async Task<IReadOnlyList<WorkflowAgentSummary>> ListAgentsAsync(CancellationToken ct = default)
     {
@@ -76,7 +75,7 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
 
     public async Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(string workflowRunId, CancellationToken ct = default)
     {
-        if (!_artifactQueryPort.EnableActorQueryEndpoints)
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled)
             return null;
 
         return await _artifactQueryPort.GetWorkflowRunReportArtifactAsync(workflowRunId, ct);
@@ -87,7 +86,7 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
         int take = 200,
         CancellationToken ct = default)
     {
-        if (!_artifactQueryPort.EnableActorQueryEndpoints)
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled)
             return [];
 
         return await _artifactQueryPort.ListWorkflowRunTimelineExportAsync(workflowRunId, take, ct);
@@ -99,7 +98,7 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
         WorkflowRunGraphExportQueryOptions? options = null,
         CancellationToken ct = default)
     {
-        if (!_artifactQueryPort.EnableActorQueryEndpoints || string.IsNullOrWhiteSpace(workflowRunId))
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
             return [];
 
         return await _artifactQueryPort.GetWorkflowRunGraphExportEdgesAsync(workflowRunId, take, options, ct);
@@ -112,7 +111,7 @@ public sealed class WorkflowExecutionQueryApplicationService : IWorkflowExecutio
         WorkflowRunGraphExportQueryOptions? options = null,
         CancellationToken ct = default)
     {
-        if (!_artifactQueryPort.EnableActorQueryEndpoints || string.IsNullOrWhiteSpace(workflowRunId))
+        if (!_artifactQueryPort.WorkflowArtifactQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
             return new WorkflowRunGraphExportSubgraph
             {
                 RootNodeId = workflowRunId ?? string.Empty,

--- a/src/workflow/Aevatar.Workflow.Projection/Configuration/WorkflowExecutionProjectionOptions.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Configuration/WorkflowExecutionProjectionOptions.cs
@@ -19,11 +19,15 @@ public sealed class WorkflowExecutionProjectionOptions
     /// </summary>
     public bool EnableActorQueryEndpoints { get; set; } = true;
 
-    public bool EnableRunQueryEndpoints
-    {
-        get => EnableActorQueryEndpoints;
-        set => EnableActorQueryEndpoints = value;
-    }
+    /// <summary>
+    /// Exposes workflow artifact/export query endpoints.
+    /// </summary>
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
+    public bool WorkflowArtifactQueryEnabled { get; set; } = true;
+
+    bool IProjectionRuntimeOptions.EnableRunQueryEndpoints => WorkflowArtifactQueryEnabled;
 
     /// <summary>
     /// Writes run report documents/export outputs (json/html).

--- a/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionArtifactQueryPort.cs
+++ b/src/workflow/Aevatar.Workflow.Projection/Orchestration/WorkflowExecutionArtifactQueryPort.cs
@@ -10,12 +10,11 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
     private readonly IProjectionDocumentReader<WorkflowRunInsightReportDocument, string> _reportReader;
     private readonly IProjectionGraphStore _graphStore;
     private readonly WorkflowExecutionReadModelMapper _mapper;
-    private readonly bool _enableActorQueryEndpoints;
+    private readonly bool _workflowArtifactQueryEnabled;
 
-    // Refactor (iter29/cluster-029-workflow-history-artifact):
-    //   Old pattern: workflow history / report / graph are treated as current-state readmodels (current-state query path enriches actor snapshots by reading report artifacts; duplicate WorkflowRunTimelineDocument and WorkflowRunGraphArtifactDocument shells copy WorkflowRunInsightReportDocument; public application/query/tool/HTTP surfaces expose them as actor current-state queries instead of workflow-run artifacts)
-    //   New principle: Workflow history / report / graph are workflow-run artifacts (or aggregate-owned views), NOT actor current-state readmodels: keep existing WorkflowRunInsightReportDocument adapter/name workflow-local as the single report artifact source; delete duplicate WorkflowRunTimelineDocument / WorkflowRunGraphArtifactDocument shells (timeline derived from report artifact, graph materialization derived from report artifact); stop current-state query paths from reading report/history artifacts to enrich actor snapshots; rename public application/query/tool/HTTP surfaces so report/timeline/graph are explicit workflow-run artifact / export, not current-state readmodel surfaces; WorkflowExecutionCurrentStateDocument remains the only workflow actor-scoped current-state readmodel; NO CLAUDE.md change, NO new core abstraction, NO generic CQRS Projection artifact storage seam, NO new actor type
-    //   New pattern: workflow history/report/graph are artifacts or aggregate-owned views, not current-state readmodels.
+    // Refactor (iter105/cluster-105-workflow-artifact-query-still-actor-shaped):
+    //   Old pattern: Workflow artifact/report/graph query surfaces still sit under actor inspection and actor-query enablement, even after documents were renamed as artifacts/exports.
+    //   New principle: Workflow artifacts have an explicit artifact/export query surface separate from actor current-state query and tool names — graph-only workflow_artifact_query tool on existing execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate away from actor query.
     public WorkflowExecutionArtifactQueryPort(
         IProjectionDocumentReader<WorkflowRunInsightReportDocument, string> reportReader,
         WorkflowExecutionReadModelMapper mapper,
@@ -25,16 +24,16 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
         _reportReader = reportReader ?? throw new ArgumentNullException(nameof(reportReader));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         _graphStore = graphStore ?? throw new ArgumentNullException(nameof(graphStore));
-        _enableActorQueryEndpoints = options == null || (options.Enabled && options.EnableActorQueryEndpoints);
+        _workflowArtifactQueryEnabled = options == null || (options.Enabled && options.WorkflowArtifactQueryEnabled);
     }
 
-    public bool EnableActorQueryEndpoints => _enableActorQueryEndpoints;
+    public bool WorkflowArtifactQueryEnabled => _workflowArtifactQueryEnabled;
 
     public async Task<WorkflowRunReport?> GetWorkflowRunReportArtifactAsync(
         string workflowRunId,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints || string.IsNullOrWhiteSpace(workflowRunId))
+        if (!_workflowArtifactQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
             return null;
 
         var report = await _reportReader.GetAsync(workflowRunId, ct);
@@ -46,7 +45,7 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
         int take = 200,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints || string.IsNullOrWhiteSpace(workflowRunId))
+        if (!_workflowArtifactQueryEnabled || string.IsNullOrWhiteSpace(workflowRunId))
             return [];
 
         var boundedTake = Math.Clamp(take, 1, 1000);
@@ -67,7 +66,7 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
         WorkflowRunGraphExportQueryOptions? options = null,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints)
+        if (!_workflowArtifactQueryEnabled)
             return [];
 
         var workflowRunIdValue = workflowRunId?.Trim() ?? "";
@@ -97,7 +96,7 @@ public sealed class WorkflowExecutionArtifactQueryPort : IWorkflowExecutionArtif
         WorkflowRunGraphExportQueryOptions? options = null,
         CancellationToken ct = default)
     {
-        if (!_enableActorQueryEndpoints)
+        if (!_workflowArtifactQueryEnabled)
             return new WorkflowRunGraphExportSubgraph
             {
                 RootNodeId = workflowRunId ?? string.Empty,

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowDefinitionToolsTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowDefinitionToolsTests.cs
@@ -158,8 +158,9 @@ public class WorkflowDefinitionToolsTests
         var source = new WorkflowAgentToolSource(null!, options, definitionCommand: adapter);
         var tools = await source.DiscoverToolsAsync();
 
-        // 3 base tools (status, actor_inspect, event_query) + 4 def tools (list, read, create, update) = 7
-        tools.Should().HaveCount(7);
+        // 4 base tools (status, workflow_artifact_query, actor_inspect, event_query) + 4 def tools (list, read, create, update) = 8
+        tools.Should().HaveCount(8);
+        tools.Should().Contain(t => t is WorkflowArtifactQueryTool);
         tools.Should().Contain(t => t is WorkflowListDefsTool);
         tools.Should().Contain(t => t is WorkflowReadDefTool);
         tools.Should().Contain(t => t is WorkflowCreateDefTool);
@@ -174,8 +175,9 @@ public class WorkflowDefinitionToolsTests
         var source = new WorkflowAgentToolSource(null!, options);
         var tools = await source.DiscoverToolsAsync();
 
-        // Only the 3 base tools
-        tools.Should().HaveCount(3);
+        // Only the 4 base tools
+        tools.Should().HaveCount(4);
+        tools.Should().Contain(t => t is WorkflowArtifactQueryTool);
         tools.Should().NotContain(t => t is WorkflowListDefsTool);
         tools.Should().NotContain(t => t is WorkflowCreateDefTool);
     }

--- a/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
+++ b/test/Aevatar.AI.ToolProviders.Workflow.Tests/WorkflowRunToolContractTests.cs
@@ -34,7 +34,7 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task EventQueryTool_Timeline_ShouldAcceptDeprecatedActorIdAlias()
+    public async Task EventQueryTool_Timeline_ShouldRejectActorIdAlias()
     {
         var query = new RecordingWorkflowExecutionQueryService
         {
@@ -44,9 +44,8 @@ public sealed class WorkflowRunToolContractTests
 
         var result = await tool.ExecuteAsync("""{"actor_id":"legacy-run"}""");
 
-        using var document = JsonDocument.Parse(result);
-        document.RootElement.GetProperty("workflow_run_id").GetString().Should().Be("legacy-run");
-        query.Calls.Should().Equal("ListWorkflowRunTimelineExport:legacy-run:50");
+        result.Should().Contain("'workflow_run_id' is required");
+        query.Calls.Should().BeEmpty();
     }
 
     [Fact]
@@ -79,7 +78,7 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task EventQueryTool_WhenWorkflowRunIdMissing_ShouldReturnNewErrorAndSchemaAllowAlias()
+    public async Task EventQueryTool_WhenWorkflowRunIdMissing_ShouldReturnNewErrorAndSchemaRequireWorkflowRunId()
     {
         var query = new RecordingWorkflowExecutionQueryService();
         var tool = new EventQueryTool(query, new WorkflowToolOptions());
@@ -87,9 +86,9 @@ public sealed class WorkflowRunToolContractTests
         var result = await tool.ExecuteAsync("{}");
 
         result.Should().Contain("'workflow_run_id' is required");
-        tool.ParametersSchema.Should().Contain("\"anyOf\"");
+        tool.ParametersSchema.Should().Contain("\"required\": [\"workflow_run_id\"]");
         tool.ParametersSchema.Should().Contain("\"workflow_run_id\"");
-        tool.ParametersSchema.Should().Contain("\"actor_id\"");
+        tool.ParametersSchema.Should().NotContain("\"actor_id\"");
         query.Calls.Should().BeEmpty();
     }
 
@@ -139,20 +138,20 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task WorkflowStatusTool_Status_ShouldAcceptDeprecatedActorIdAliasAndReportMissingArtifact()
+    public async Task WorkflowStatusTool_Status_ShouldRejectActorIdAlias()
     {
         var query = new RecordingWorkflowExecutionQueryService();
         var tool = new WorkflowStatusTool(query, new WorkflowToolOptions());
 
         var result = await tool.ExecuteAsync("""{"actor_id":"legacy-run"}""");
 
-        using var document = JsonDocument.Parse(result);
-        document.RootElement.GetProperty("error").GetString().Should().Be("No workflow run found for 'legacy-run'");
-        query.Calls.Should().Equal("GetWorkflowRunReportArtifact:legacy-run");
+        result.Should().Contain("'workflow_run_id' is required for 'status' action");
+        tool.ParametersSchema.Should().NotContain("\"actor_id\"");
+        query.Calls.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task WorkflowStatusTool_Timeline_ShouldAcceptWorkflowRunIdAndAlias()
+    public async Task WorkflowStatusTool_Timeline_ShouldRequireWorkflowRunId()
     {
         var query = new RecordingWorkflowExecutionQueryService
         {
@@ -167,11 +166,8 @@ public sealed class WorkflowRunToolContractTests
         workflowRunDocument.RootElement.GetProperty("workflow_run_id").GetString().Should().Be("run-1");
         workflowRunDocument.RootElement.GetProperty("events")[0].GetProperty("step_id").GetString().Should().Be("step-1");
 
-        using var aliasDocument = JsonDocument.Parse(aliasResult);
-        aliasDocument.RootElement.GetProperty("workflow_run_id").GetString().Should().Be("legacy-run");
-        query.Calls.Should().Equal(
-            "ListWorkflowRunTimelineExport:run-1:4",
-            "ListWorkflowRunTimelineExport:legacy-run:6");
+        aliasResult.Should().Contain("'workflow_run_id' is required for 'timeline' action");
+        query.Calls.Should().Equal("ListWorkflowRunTimelineExport:run-1:4");
     }
 
     [Fact]
@@ -246,7 +242,22 @@ public sealed class WorkflowRunToolContractTests
     }
 
     [Fact]
-    public async Task ActorInspectTool_Graph_ShouldUseWorkflowRunGraphExportSubgraph()
+    public async Task ActorInspectTool_Graph_ShouldNotExposeWorkflowArtifactSubgraph()
+    {
+        var query = new RecordingWorkflowExecutionQueryService();
+        var tool = new ActorInspectTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
+
+        var result = await tool.ExecuteAsync("""{"action":"graph","actor_id":"run-1","graph_depth":4,"take":11}""");
+
+        using var document = JsonDocument.Parse(result);
+        document.RootElement.GetProperty("error").GetString().Should().Be("Unsupported actor_inspect action 'graph'");
+        tool.ParametersSchema.Should().NotContain("\"graph\"");
+        tool.ParametersSchema.Should().NotContain("\"graph_depth\"");
+        query.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WorkflowArtifactQueryTool_Subgraph_ShouldUseWorkflowRunGraphExportSubgraph()
     {
         var query = new RecordingWorkflowExecutionQueryService
         {
@@ -273,17 +284,34 @@ public sealed class WorkflowRunToolContractTests
                 },
             },
         };
-        var tool = new ActorInspectTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
+        var tool = new WorkflowArtifactQueryTool(query, new WorkflowToolOptions { MaxGraphDepth = 2 });
 
-        var result = await tool.ExecuteAsync("""{"action":"graph","actor_id":"run-1","graph_depth":4,"take":11}""");
+        var result = await tool.ExecuteAsync("""{"action":"subgraph","workflow_run_id":"run-1","graph_depth":4,"take":11}""");
 
         using var document = JsonDocument.Parse(result);
         var root = document.RootElement;
-        root.GetProperty("root").GetString().Should().Be("run-1");
-        root.GetProperty("node_count").GetInt32().Should().Be(1);
-        root.GetProperty("edge_count").GetInt32().Should().Be(1);
-        root.GetProperty("edges")[0].GetProperty("to").GetString().Should().Be("child-1");
+        root.GetProperty("workflow_run_id").GetString().Should().Be("run-1");
+        root.GetProperty("artifact").GetString().Should().Be("graph_subgraph");
+        root.GetProperty("subgraph").GetProperty("root").GetString().Should().Be("run-1");
+        root.GetProperty("subgraph").GetProperty("node_count").GetInt32().Should().Be(1);
+        root.GetProperty("subgraph").GetProperty("edge_count").GetInt32().Should().Be(1);
+        root.GetProperty("subgraph").GetProperty("edges")[0].GetProperty("to").GetString().Should().Be("child-1");
+        tool.ParametersSchema.Should().NotContain("\"actor_id\"");
         query.Calls.Should().Equal("GetWorkflowRunGraphExportSubgraph:run-1:4:11");
+    }
+
+    [Fact]
+    public async Task WorkflowArtifactQueryTool_ShouldRejectActorIdAliasAndNonSubgraphActions()
+    {
+        var query = new RecordingWorkflowExecutionQueryService();
+        var tool = new WorkflowArtifactQueryTool(query, new WorkflowToolOptions());
+
+        var aliasResult = await tool.ExecuteAsync("""{"actor_id":"legacy-run"}""");
+        var wrongActionResult = await tool.ExecuteAsync("""{"action":"edges","workflow_run_id":"run-1"}""");
+
+        aliasResult.Should().Contain("'workflow_run_id' is required");
+        wrongActionResult.Should().Contain("only supports action='subgraph'");
+        query.Calls.Should().BeEmpty();
     }
 
     private static WorkflowRunTimelineExportItem CreateTimelineItem(string stage, string eventType, string stepId)

--- a/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
+++ b/test/Aevatar.Workflow.Application.Tests/WorkflowExecutionQueryApplicationServiceTests.cs
@@ -14,7 +14,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     {
         var calls = new List<string>();
         var currentStatePort = new FakeCurrentStateQueryPort(calls) { EnableActorQueryEndpoints = false };
-        var artifactPort = new FakeArtifactQueryPort(calls) { EnableActorQueryEndpoints = false };
+        var artifactPort = new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = false };
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog(["direct", "auto"]),
             currentStatePort,
@@ -38,7 +38,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
     {
         var calls = new List<string>();
         var currentStatePort = new FakeCurrentStateQueryPort(calls) { EnableActorQueryEndpoints = true };
-        var artifactPort = new FakeArtifactQueryPort(calls) { EnableActorQueryEndpoints = true };
+        var artifactPort = new FakeArtifactQueryPort(calls) { WorkflowArtifactQueryEnabled = true };
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog([]),
             currentStatePort,
@@ -91,7 +91,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
         };
         var artifactPort = new FakeArtifactQueryPort(calls)
         {
-            EnableActorQueryEndpoints = true,
+            WorkflowArtifactQueryEnabled = true,
             Timeline = timeline,
             Edges = edges,
             Subgraph = subgraph,
@@ -133,7 +133,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
         var service = new WorkflowExecutionQueryApplicationService(
             new StaticWorkflowDefinitionCatalog([]),
             new FakeCurrentStateQueryPort([]) { EnableActorQueryEndpoints = false },
-            new FakeArtifactQueryPort([]) { EnableActorQueryEndpoints = false },
+            new FakeArtifactQueryPort([]) { WorkflowArtifactQueryEnabled = false },
             new StaticWorkflowCatalogPort(),
             new StaticWorkflowCapabilitiesPort());
         using var cts = new CancellationTokenSource();
@@ -326,7 +326,7 @@ public sealed class WorkflowExecutionQueryApplicationServiceTests
 
     private sealed class FakeArtifactQueryPort(List<string> calls) : IWorkflowExecutionArtifactQueryPort
     {
-        public bool EnableActorQueryEndpoints { get; set; }
+        public bool WorkflowArtifactQueryEnabled { get; set; }
         public WorkflowRunReport? Report { get; init; }
         public IReadOnlyList<WorkflowRunTimelineExportItem> Timeline { get; init; } = [];
         public IReadOnlyList<WorkflowRunGraphExportEdge> Edges { get; init; } = [];

--- a/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
+++ b/test/Aevatar.Workflow.Host.Api.Tests/WorkflowExecutionQueryPortsCoverageTests.cs
@@ -217,11 +217,11 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
     {
         var harness = CreateHarness(new WorkflowExecutionProjectionOptions
         {
-            Enabled = false,
-            EnableActorQueryEndpoints = true,
+            Enabled = true,
+            WorkflowArtifactQueryEnabled = false,
         });
 
-        harness.ArtifactPort.EnableActorQueryEndpoints.Should().BeFalse();
+        harness.ArtifactPort.WorkflowArtifactQueryEnabled.Should().BeFalse();
         (await harness.ArtifactPort.GetWorkflowRunGraphExportEdgesAsync("actor-1")).Should().BeEmpty();
         (await harness.ArtifactPort.GetWorkflowRunGraphExportSubgraphAsync("actor-1")).RootNodeId.Should().Be("actor-1");
         harness.CurrentStateReader.GetCalls.Should().Be(0);
@@ -236,7 +236,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var harness = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = true,
-            EnableActorQueryEndpoints = true,
+            WorkflowArtifactQueryEnabled = true,
         });
 
         (await harness.ArtifactPort.GetWorkflowRunGraphExportEdgesAsync("   ")).Should().BeEmpty();
@@ -256,7 +256,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var harness = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = true,
-            EnableActorQueryEndpoints = true,
+            WorkflowArtifactQueryEnabled = true,
         });
 
         var subgraph = await harness.ArtifactPort.GetWorkflowRunGraphExportSubgraphAsync(null!);
@@ -351,7 +351,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             new WorkflowExecutionProjectionOptions
             {
                 Enabled = true,
-                EnableActorQueryEndpoints = true,
+                WorkflowArtifactQueryEnabled = true,
             },
             reportReader: new RecordingDocumentReader<WorkflowRunInsightReportDocument>
             {
@@ -401,7 +401,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var disabled = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = false,
-            EnableActorQueryEndpoints = true,
+            WorkflowArtifactQueryEnabled = true,
         });
         (await disabled.ArtifactPort.ListWorkflowRunTimelineExportAsync("actor-1")).Should().BeEmpty();
         disabled.ReportReader.GetCalls.Should().Be(0);
@@ -409,7 +409,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var enabled = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = true,
-            EnableActorQueryEndpoints = true,
+            WorkflowArtifactQueryEnabled = true,
         });
         (await enabled.ArtifactPort.ListWorkflowRunTimelineExportAsync("   ")).Should().BeEmpty();
         (await enabled.ArtifactPort.ListWorkflowRunTimelineExportAsync("actor-404")).Should().BeEmpty();
@@ -424,7 +424,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
             new WorkflowExecutionProjectionOptions
             {
                 Enabled = true,
-                EnableActorQueryEndpoints = true,
+                WorkflowArtifactQueryEnabled = true,
             },
             graphStore: new RecordingProjectionGraphStore
             {
@@ -496,7 +496,7 @@ public sealed class WorkflowExecutionQueryPortsCoverageTests
         var harness = CreateHarness(new WorkflowExecutionProjectionOptions
         {
             Enabled = true,
-            EnableActorQueryEndpoints = true,
+            WorkflowArtifactQueryEnabled = true,
         });
 
         var options = new WorkflowRunGraphExportQueryOptions


### PR DESCRIPTION
## 摘要

iter105 cluster-3 #1073(medium,CLAUDE-READMODEL-01 / CLAUDE-CQRS-01)。

**Old**:workflow artifact / report / graph 查询面仍挂在 actor inspection / actor-query 路径下,虽然文档已经改名为 artifact/export。

**New**:**graph-only workflow_artifact_query tool on existing workflow execution facade**;删 actor_inspect graph wrapper + workflow artifact actor_id aliases(仅 tool surfaces);重命名 artifact gate 为 artifact 语义。

- 加 `WorkflowArtifactQueryTool`(graph-only,挂 existing workflow execution facade,**不开** unified application service — reject as shallow forwarding)
- 删 `ActorInspectTool` graph wrapper + workflow artifact actor_id aliases(仅 tool surfaces;HTTP/SDK + actor current-state query path 不动)
- 重命名 `WorkflowToolOptions` artifact gate 字段(与 actor query 语义区分)
- 调整 `IWorkflowExecutionArtifactQueryPort` / `WorkflowExecutionQueryApplicationService` / `WorkflowExecutionArtifactQueryPort` 让 graph-only 路径走 typed facade
- 测试同步更新

违反:CLAUDE.md「读写分离 / 读模型按需创建 / 单一权威拥有者」相关条款。

## 范围

15 files / +268 / -159。无新 actor type。无 unified service。

## Phase 9 共识链路(5 round 收敛)

- r1 三 propose(scope 分歧:replacement tool 必要性 + alias scope)
- r1 judge `converge:round-2`
- r2 三 propose(alias scope 3/3 共识,graph surface 仍分歧)
- r2 judge `converge:round-3`
- r3 三 propose(tool 3/3 共识,facade design 仍分歧 2:1)
- r3 judge `converge:round-4`
- r4 lock-in(structural 选 unified,minimal/delete 选 graph-only)
- r4 judge `converge:round-5`
- r5 lock-in **3/3 propose graph-only existing facade + reject unified**
- r5 judge `consensus:minimal:graph-only workflow_artifact_query on existing workflow execution facade; delete actor-shaped graph wrapper and aliases; rename artifact gate`

详细:#1073 ✅ 共识卡片

closes #1073

🤖 Auto-loop / codex-refactor-loop iter105

⟦AI:AUTO-LOOP⟧
