### PR TITLE
iter110 cluster-2 #1085: executor IO-only + AgentRunGAgent 应用 typed step result

### DIFF
--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -22,6 +22,9 @@ namespace Aevatar.GAgents.NyxidChat;
 // Refactor (iter73/cluster-073-durable-callback-runtime-credentials):
 //   Old pattern: durable callback envelope clones full command/chunk payload, may embed transient runtime credentials (reply_token)
 //   New principle: callback payload carries only stable IDs + actor-owned lease keys; actor reconciles from current actor state on fire
+// Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+//   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+//   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
 public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
 {
     internal const long MaxRunRequestAgeMs = 5 * 60 * 1000;
@@ -456,7 +459,6 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             Attempt = attempt,
             StepIndex = generationContext.NextStepIndex,
             Request = request.Clone(),
-            StepState = generationContext.Clone(),
         }, TopologyAudience.Self, CancellationToken.None);
     }
 
@@ -552,7 +554,7 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         return next;
     }
 
-    private bool IsCurrentStepContinuation(string runId, string correlationId, int attempt, int stepIndex)
+    private bool IsCurrentStepRequest(string runId, string correlationId, int attempt, int stepIndex)
     {
         if (!IsCurrentGenerationContinuation(runId, correlationId, attempt))
             return false;
@@ -561,7 +563,19 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         if (currentStep is null)
             return stepIndex <= 1;
 
-        return stepIndex == currentStep.NextStepIndex || stepIndex == currentStep.NextStepIndex + 1;
+        return stepIndex == currentStep.NextStepIndex;
+    }
+
+    private bool IsCurrentStepResult(string runId, string correlationId, int attempt, int stepIndex)
+    {
+        if (!IsCurrentGenerationContinuation(runId, correlationId, attempt))
+            return false;
+
+        var currentStep = State.GenerationStep;
+        if (currentStep is null)
+            return false;
+
+        return stepIndex == currentStep.NextStepIndex + 1;
     }
 
     private static NeedsLlmReplyEvent BuildStepRequest(AgentRunNextLlmStepRequestedEvent command) =>
@@ -583,25 +597,31 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
     [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
     public async Task HandleNextLlmStepAsync(AgentRunNextLlmStepRequestedEvent command)
     {
+        // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+        //   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+        //   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
         ArgumentNullException.ThrowIfNull(command);
-        if (!IsCurrentStepContinuation(command.RunId, command.CorrelationId, command.Attempt, command.StepIndex))
+        var hasResult = command.LlmStepResult is not null;
+        if (hasResult)
+        {
+            if (!IsCurrentStepResult(command.RunId, command.CorrelationId, command.Attempt, command.StepIndex))
+                return;
+
+            await PersistStepStateAsync(ApplyLlmStepResult(State.GenerationStep!, command.LlmStepResult!, command.StepIndex));
+        }
+        else if (!IsCurrentStepRequest(command.RunId, command.CorrelationId, command.Attempt, command.StepIndex))
+        {
             return;
-
-        var isCompletedLlmStep = State.GenerationStep is not null &&
-                                 command.StepState is not null &&
-                                 command.StepIndex == State.GenerationStep.NextStepIndex + 1;
-
-        if (command.StepState is not null)
-            await PersistStepStateAsync(command.StepState);
+        }
 
         var request = command.Request?.Clone() ?? BuildStepRequest(command);
         ApplyTargetRefOverrides(request);
 
-        var stepState = command.StepState ?? State.GenerationStep;
+        var stepState = State.GenerationStep;
         if (stepState is null)
             return;
 
-        if (ShouldCompleteAfterLlmStep(stepState, isCompletedLlmStep))
+        if (ShouldCompleteAfterLlmStep(stepState, hasResult))
         {
             await CompletePerStepReplyAsync(request, stepState);
             return;
@@ -622,16 +642,26 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
     [EventHandler(AllowSelfHandling = true, OnlySelfHandling = true)]
     public async Task HandleNextToolStepAsync(AgentRunNextToolStepRequestedEvent command)
     {
+        // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+        //   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+        //   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
         ArgumentNullException.ThrowIfNull(command);
-        if (!IsCurrentStepContinuation(command.RunId, command.CorrelationId, command.Attempt, command.StepIndex))
-            return;
+        var hasResult = command.ToolStepResult is not null;
+        if (hasResult)
+        {
+            if (!IsCurrentStepResult(command.RunId, command.CorrelationId, command.Attempt, command.StepIndex))
+                return;
 
-        if (command.StepState is not null)
-            await PersistStepStateAsync(command.StepState);
+            await PersistStepStateAsync(ApplyToolStepResult(State.GenerationStep!, command.ToolStepResult!, command.StepIndex));
+        }
+        else if (!IsCurrentStepRequest(command.RunId, command.CorrelationId, command.Attempt, command.StepIndex))
+        {
+            return;
+        }
 
         var request = command.Request?.Clone() ?? BuildStepRequest(command);
         ApplyTargetRefOverrides(request);
-        var stepState = command.StepState ?? State.GenerationStep;
+        var stepState = State.GenerationStep;
         if (stepState is null)
             return;
 
@@ -639,6 +669,68 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
             stepState = await AdvanceToFinalNoToolsStepAsync(stepState);
 
         await DispatchLlmStepExecutorAsync(request, stepState);
+    }
+
+    private static AgentRunReplyStepState ApplyLlmStepResult(
+        AgentRunReplyStepState current,
+        AgentRunLlmStepResult result,
+        int completedStepIndex)
+    {
+        var next = current.Clone();
+        next.NextStepIndex = completedStepIndex;
+        next.AccumulatedText = result.AccumulatedText ?? string.Empty;
+        AddUsage(next, result.Usage);
+        if (result.OutboundIntent is not null)
+            next.OutboundIntent = result.OutboundIntent.Clone();
+        if (!string.IsNullOrEmpty(result.FinishReason))
+            next.LastFinishReason = result.FinishReason;
+        if (result.HasStreamedTextContent)
+            next.HasStreamedTextContent = true;
+
+        next.PendingToolCalls.Clear();
+        if (result.ToolCalls.Count > 0)
+            next.PendingToolCalls.AddRange(result.ToolCalls.Select(call => call.Clone()));
+
+        if (!string.IsNullOrEmpty(result.Content) ||
+            !string.IsNullOrEmpty(result.ReasoningContent) ||
+            result.ToolCalls.Count > 0)
+        {
+            var message = new AgentRunChatMessage
+            {
+                Role = "assistant",
+                Content = result.Content ?? string.Empty,
+                ReasoningContent = result.ReasoningContent ?? string.Empty,
+            };
+            message.ToolCalls.AddRange(result.ToolCalls.Select(call => call.Clone()));
+            next.Messages.Add(message);
+        }
+
+        return next;
+    }
+
+    private static AgentRunReplyStepState ApplyToolStepResult(
+        AgentRunReplyStepState current,
+        AgentRunToolStepResult result,
+        int completedStepIndex)
+    {
+        var next = current.Clone();
+        next.NextStepIndex = completedStepIndex;
+        next.PendingToolCalls.Clear();
+        next.Messages.AddRange(result.ResultMessages.Select(message => message.Clone()));
+        if (result.AdvanceRound)
+            next.Round++;
+        return next;
+    }
+
+    private static void AddUsage(AgentRunReplyStepState state, AgentRunReplyTokenUsage? usage)
+    {
+        if (usage is null)
+            return;
+
+        state.AggregatedUsage ??= new AgentRunReplyTokenUsage();
+        state.AggregatedUsage.PromptTokens += usage.PromptTokens;
+        state.AggregatedUsage.CompletionTokens += usage.CompletionTokens;
+        state.AggregatedUsage.TotalTokens += usage.TotalTokens;
     }
 
     /// <summary>

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunGAgent.cs
@@ -671,6 +671,9 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         await DispatchLlmStepExecutorAsync(request, stepState);
     }
 
+    // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+    //   Old pattern: AgentRunReplyGenerationExecutor cloned/mutated AgentRunReplyStepState and the actor persisted that full state.
+    //   New principle: Executor returns typed IO facts; actor applies deterministic step-state transition inside event handling.
     private static AgentRunReplyStepState ApplyLlmStepResult(
         AgentRunReplyStepState current,
         AgentRunLlmStepResult result,
@@ -708,6 +711,9 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         return next;
     }
 
+    // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+    //   Old pattern: AgentRunReplyGenerationExecutor cloned/mutated AgentRunReplyStepState and the actor persisted that full state.
+    //   New principle: Executor returns typed IO facts; actor applies deterministic step-state transition inside event handling.
     private static AgentRunReplyStepState ApplyToolStepResult(
         AgentRunReplyStepState current,
         AgentRunToolStepResult result,
@@ -722,6 +728,9 @@ public sealed class AgentRunGAgent : GAgentBase<AgentRunGAgentState>
         return next;
     }
 
+    // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+    //   Old pattern: AgentRunReplyGenerationExecutor cloned/mutated AgentRunReplyStepState and the actor persisted that full state.
+    //   New principle: Executor returns typed IO facts; actor applies deterministic step-state transition inside event handling.
     private static void AddUsage(AgentRunReplyStepState state, AgentRunReplyTokenUsage? usage)
     {
         if (usage is null)

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyGenerationExecutor.cs
@@ -15,6 +15,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.GAgents.NyxidChat;
 
+// Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+//   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+//   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
 public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationExecutorPort
 {
     private const string PublisherActorId = "agent-run-reply-generation-executor";
@@ -108,7 +111,6 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         var workItem = request with
         {
             Request = request.Request.Clone(),
-            StepState = request.StepState.Clone(),
         };
         // Refactor (iter99/cluster-596-phase-e): Old pattern: executor owned the whole multi-round LLM/tool loop.
         // New principle: AgentRunGAgent owns per-step continuation; executor performs exactly one LLM IO step.
@@ -130,7 +132,6 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         var workItem = request with
         {
             Request = request.Request.Clone(),
-            StepState = request.StepState.Clone(),
         };
         // Refactor (iter99/cluster-596-phase-e): Old pattern: tool execution stayed inside ChatRuntime's multi-round loop.
         // New principle: a typed self-message asks for one tool IO step, then actor reconciles the result.
@@ -181,6 +182,9 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         AgentRunReplyStepExecutionRequest workItem,
         CancellationToken ct)
     {
+        // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+        //   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+        //   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
         var request = workItem.Request.Clone();
         using TurnStreamingReplySink? streamingSink = TryBuildStreamingSink(request, request.TargetActorId);
         var streamingState = TryBuildStreamingReplyState(streamingSink);
@@ -220,17 +224,6 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         if (streamingState is not null)
             await streamingState.FinalizeAsync(output.ToString(), ct).ConfigureAwait(false);
 
-        var nextState = workItem.StepState.Clone();
-        nextState.NextStepIndex = workItem.StepIndex + 1;
-        nextState.AccumulatedText = output.ToString();
-        AddUsage(nextState, llmResult.Usage);
-        if (TryTakeOutboundIntent(generator) is { } outboundIntent)
-            nextState.OutboundIntent = outboundIntent.Clone();
-        if (!string.IsNullOrEmpty(llmResult.FinishReason))
-            nextState.LastFinishReason = llmResult.FinishReason;
-        if (!string.IsNullOrEmpty(llmResult.Content))
-            nextState.HasStreamedTextContent = true;
-
         var effectiveContent = llmResult.Content;
         var effectiveToolCalls = llmResult.ToolCalls;
         if (effectiveToolCalls is not { Count: > 0 } && !workItem.StepState.FinalNoToolsStep && effectiveContent is not null)
@@ -243,22 +236,20 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             }
         }
 
-        nextState.PendingToolCalls.Clear();
-        if (effectiveToolCalls is { Count: > 0 })
-            nextState.PendingToolCalls.AddRange(effectiveToolCalls.Select(AgentRunReplyStepMappers.ToProto));
-
-        if (!string.IsNullOrEmpty(effectiveContent) ||
-            !string.IsNullOrEmpty(llmResult.ReasoningContent) ||
-            effectiveToolCalls is { Count: > 0 })
+        var result = new AgentRunLlmStepResult
         {
-            nextState.Messages.Add(AgentRunReplyStepMappers.ToProto(new ChatMessage
-            {
-                Role = "assistant",
-                Content = effectiveContent,
-                ReasoningContent = llmResult.ReasoningContent,
-                ToolCalls = effectiveToolCalls,
-            }));
-        }
+            AccumulatedText = output.ToString(),
+            Content = effectiveContent ?? string.Empty,
+            ReasoningContent = llmResult.ReasoningContent ?? string.Empty,
+            FinishReason = llmResult.FinishReason ?? string.Empty,
+            HasStreamedTextContent = !string.IsNullOrEmpty(llmResult.Content),
+        };
+        if (AgentRunReplyStepMappers.ToProto(llmResult.Usage) is { } usage)
+            result.Usage = usage;
+        if (TryTakeOutboundIntent(generator) is { } outboundIntent)
+            result.OutboundIntent = outboundIntent.Clone();
+        if (effectiveToolCalls is { Count: > 0 })
+            result.ToolCalls.AddRange(effectiveToolCalls.Select(AgentRunReplyStepMappers.ToProto));
 
         return new AgentRunNextLlmStepRequestedEvent
         {
@@ -268,7 +259,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             Attempt = workItem.Attempt,
             StepIndex = workItem.StepIndex + 1,
             Request = request.Clone(),
-            StepState = nextState,
+            LlmStepResult = result,
         };
     }
 
@@ -276,6 +267,9 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         AgentRunReplyStepExecutionRequest workItem,
         CancellationToken ct)
     {
+        // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+        //   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+        //   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
         var request = workItem.Request.Clone();
         var generator = RequireStepGenerator();
         var plan = await generator.BuildStepPlanAsync(
@@ -289,16 +283,15 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
         var results = await plan.StepExecutor.ExecuteToolStepAsync(toolCalls, plan.Metadata, plan.ToolContext, ct)
             .ConfigureAwait(false);
 
-        var nextState = workItem.StepState.Clone();
-        nextState.NextStepIndex = workItem.StepIndex + 1;
-        nextState.PendingToolCalls.Clear();
-        foreach (var result in results)
+        var toolStepResult = new AgentRunToolStepResult
         {
-            nextState.Messages.Add(AgentRunReplyStepMappers.ToProto(
-                ToolCallLoop.BuildToolResultMessage(result.CallId, result.Result)));
+            AdvanceRound = true,
+        };
+        foreach (var toolResult in results)
+        {
+            toolStepResult.ResultMessages.Add(AgentRunReplyStepMappers.ToProto(
+                ToolCallLoop.BuildToolResultMessage(toolResult.CallId, toolResult.Result)));
         }
-
-        nextState.Round++;
 
         return new AgentRunNextToolStepRequestedEvent
         {
@@ -308,7 +301,7 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
             Attempt = workItem.Attempt,
             StepIndex = workItem.StepIndex + 1,
             Request = request.Clone(),
-            StepState = nextState,
+            ToolStepResult = toolStepResult,
         };
     }
 
@@ -374,16 +367,6 @@ public sealed class AgentRunReplyGenerationExecutor : IAgentRunReplyGenerationEx
                 workItem.RunId,
                 workItem.RunActorId);
         }
-    }
-
-    private static void AddUsage(AgentRunReplyStepState state, TokenUsage? usage)
-    {
-        if (usage is null)
-            return;
-        state.AggregatedUsage ??= new AgentRunReplyTokenUsage();
-        state.AggregatedUsage.PromptTokens += usage.PromptTokens;
-        state.AggregatedUsage.CompletionTokens += usage.CompletionTokens;
-        state.AggregatedUsage.TotalTokens += usage.TotalTokens;
     }
 
     private async Task DispatchToRunActorAsync<TCommand>(

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyStepMappers.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyStepMappers.cs
@@ -74,6 +74,17 @@ internal static class AgentRunReplyStepMappers
     public static AgentToolExecutionContext ToolContextFromProto(AgentRunReplyStepState state) =>
         AgentToolExecutionContextMapper.FromPayload(state.ToolContext);
 
+    // Refactor helper, no behavior change: keep executor/actor result payload conversion narrow.
+    public static AgentRunReplyTokenUsage? ToProto(TokenUsage? source) =>
+        source is null
+            ? null
+            : new AgentRunReplyTokenUsage
+            {
+                PromptTokens = source.PromptTokens,
+                CompletionTokens = source.CompletionTokens,
+                TotalTokens = source.TotalTokens,
+            };
+
     private static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyStepMappers.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/AgentRunReplyStepMappers.cs
@@ -7,6 +7,9 @@ namespace Aevatar.GAgents.NyxidChat;
 
 internal static class AgentRunReplyStepMappers
 {
+    // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+    //   Old pattern: AgentRunReplyGenerationExecutor cloned/mutated AgentRunReplyStepState and the actor persisted that full state.
+    //   New principle: Executor returns typed IO facts; actor applies deterministic step-state transition inside event handling.
     public static AgentRunChatMessage ToProto(ChatMessage source)
     {
         ArgumentNullException.ThrowIfNull(source);

--- a/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
+++ b/agents/Aevatar.GAgents.NyxidChat/IAgentRunReplyGenerationExecutorPort.cs
@@ -6,6 +6,9 @@ public interface IAgentRunReplyGenerationExecutorPort
 {
     Task<AgentRunReplyStepState> BuildInitialStepStateAsync(AgentRunReplyGenerationExecutionRequest request, CancellationToken ct);
 
+    // Refactor (iter110/cluster-110-agent-run-executor-authoritative-step-state):
+    //   Old pattern: AgentRunReplyGenerationExecutor performs LLM/tool IO and constructs the authoritative next AgentRunReplyStepState outside the run actor.
+    //   New principle: Executor returns typed IO facts only; AgentRunGAgent applies deterministic step-state transition and persists state inside actor event handling.
     Task ExecuteLlmStepAsync(AgentRunReplyStepExecutionRequest request, CancellationToken ct);
 
     Task ExecuteToolStepAsync(AgentRunReplyStepExecutionRequest request, CancellationToken ct);

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -127,6 +127,27 @@ message AgentRunReplyStepState {
   aevatar.gagents.channel.abstractions.MessageContent outbound_intent = 20;
 }
 
+// Typed LLM IO facts returned by the executor. The run actor reconciles these
+// facts with its current AgentRunReplyStepState before persisting the next
+// waterline.
+message AgentRunLlmStepResult {
+  string accumulated_text = 1;
+  string content = 2;
+  string reasoning_content = 3;
+  repeated AgentRunToolCall tool_calls = 4;
+  AgentRunReplyTokenUsage usage = 5;
+  string finish_reason = 6;
+  aevatar.gagents.channel.abstractions.MessageContent outbound_intent = 7;
+  bool has_streamed_text_content = 8;
+}
+
+// Typed tool IO facts returned by the executor. The run actor owns round
+// advancement and message/state persistence.
+message AgentRunToolStepResult {
+  repeated AgentRunChatMessage result_messages = 1;
+  bool advance_round = 2;
+}
+
 // Transient command for the run actor. The nested NeedsLlmReplyEvent may carry
 // a short-lived relay reply_token; AgentRunGAgent must never persist that
 // credential into AgentRunGAgentState, AgentRun*Event facts, or durable
@@ -223,7 +244,7 @@ message AgentRunNextLlmStepRequestedEvent {
   int32 attempt = 4;
   int32 step_index = 5;
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 6;
-  AgentRunReplyStepState step_state = 7;
+  AgentRunLlmStepResult llm_step_result = 7;
 }
 
 // Typed self-message: request the next single tool IO step. The nested request
@@ -235,7 +256,7 @@ message AgentRunNextToolStepRequestedEvent {
   int32 attempt = 4;
   int32 step_index = 5;
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 6;
-  AgentRunReplyStepState step_state = 7;
+  AgentRunToolStepResult tool_step_result = 7;
 }
 
 // Transient command for executor failures that did not produce a normal reply

--- a/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
+++ b/agents/Aevatar.GAgents.NyxidChat/protos/agent_run.proto
@@ -244,7 +244,9 @@ message AgentRunNextLlmStepRequestedEvent {
   int32 attempt = 4;
   int32 step_index = 5;
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 6;
-  AgentRunLlmStepResult llm_step_result = 7;
+  reserved 7;
+  reserved "step_state";
+  AgentRunLlmStepResult llm_step_result = 8;
 }
 
 // Typed self-message: request the next single tool IO step. The nested request
@@ -256,7 +258,9 @@ message AgentRunNextToolStepRequestedEvent {
   int32 attempt = 4;
   int32 step_index = 5;
   aevatar.gagents.channel.runtime.NeedsLlmReplyEvent request = 6;
-  AgentRunToolStepResult tool_step_result = 7;
+  reserved 7;
+  reserved "step_state";
+  AgentRunToolStepResult tool_step_result = 8;
 }
 
 // Transient command for executor failures that did not produce a normal reply

--- a/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
+++ b/test/Aevatar.GAgents.ChannelRuntime.Tests/AgentRunGAgentTests.cs
@@ -629,10 +629,156 @@ public sealed class AgentRunGAgentTests
             Attempt = 1,
             StepIndex = 2,
             Request = request.Clone(),
-            StepState = NewStepState(request, nextStepIndex: 2, pendingTool: true),
+            LlmStepResult = new AgentRunLlmStepResult
+            {
+                ToolCalls =
+                {
+                    new AgentRunToolCall { Id = "tool-call-1", Name = "lookup", ArgumentsJson = "{}" },
+                },
+            },
         });
 
         generationExecutor.ToolSteps.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task HandleNextLlmStepAsync_WhenTypedResultIdentityIsStale_ShouldIgnoreBeforePersisting()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var generationExecutor = new RecordingStepGenerationExecutor();
+        var runtime = CreateRunAgentWithExecutor(
+            actorRuntime,
+            generationExecutor,
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            eventPublisher: new DispatchingEventPublisher(actorRuntime) { DeliverSelf = false });
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-stale-typed-result",
+            RunId = "run-stale-typed-result",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-stale-typed-result",
+        };
+
+        await runtime.HandleStartAsync(request);
+        var before = runtime.State.GenerationStep!.Clone();
+
+        await runtime.HandleNextLlmStepAsync(new AgentRunNextLlmStepRequestedEvent
+        {
+            RunId = request.RunId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            Attempt = 2,
+            StepIndex = 2,
+            Request = request.Clone(),
+            LlmStepResult = new AgentRunLlmStepResult { AccumulatedText = "stale reply" },
+        });
+
+        runtime.State.GenerationStep.Should().BeEquivalentTo(before);
+        runtime.State.ProducedReplyText.Should().BeEmpty();
+        generationExecutor.ToolSteps.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleNextLlmAndToolStepAsync_ShouldReconcileTypedResultsInsideActor()
+    {
+        var actor = Substitute.For<IActor>();
+        actor.Id.Returns("actor-1");
+        var actorRuntime = new DispatchingActorRuntime(("actor-1", actor));
+        var generationExecutor = new RecordingStepGenerationExecutor();
+        var runtime = CreateRunAgentWithExecutor(
+            actorRuntime,
+            generationExecutor,
+            new Aevatar.GAgents.Channel.NyxIdRelay.NyxIdRelayOptions
+            {
+                InteractiveRepliesEnabled = true,
+                StreamingRepliesEnabled = false,
+            },
+            eventPublisher: new DispatchingEventPublisher(actorRuntime) { DeliverSelf = false });
+        var request = new NeedsLlmReplyEvent
+        {
+            CorrelationId = "corr-typed-reconcile",
+            RunId = "run-typed-reconcile",
+            TargetActorId = "actor-1",
+            RegistrationId = "reg-1",
+            Activity = BuildRelayActivity(),
+            ReplyToken = "relay-token-typed-reconcile",
+        };
+
+        await runtime.HandleStartAsync(request);
+        await runtime.HandleNextLlmStepAsync(new AgentRunNextLlmStepRequestedEvent
+        {
+            RunId = request.RunId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            Attempt = 1,
+            StepIndex = 2,
+            Request = request.Clone(),
+            LlmStepResult = new AgentRunLlmStepResult
+            {
+                AccumulatedText = "partial",
+                Content = "call lookup",
+                FinishReason = "tool_calls",
+                Usage = new AgentRunReplyTokenUsage
+                {
+                    PromptTokens = 1,
+                    CompletionTokens = 2,
+                    TotalTokens = 3,
+                },
+                ToolCalls =
+                {
+                    new AgentRunToolCall { Id = "tool-call-typed", Name = "lookup", ArgumentsJson = "{}" },
+                },
+            },
+        });
+
+        runtime.State.GenerationStep!.NextStepIndex.Should().Be(2);
+        runtime.State.GenerationStep.PendingToolCalls.Should().ContainSingle(t => t.Id == "tool-call-typed");
+        runtime.State.GenerationStep.Messages.Should().Contain(message =>
+            message.Role == "assistant" &&
+            message.Content == "call lookup" &&
+            message.ToolCalls.Any(tool => tool.Id == "tool-call-typed"));
+        runtime.State.GenerationStep.AggregatedUsage!.TotalTokens.Should().Be(3);
+        generationExecutor.ToolSteps.Should().ContainSingle();
+
+        await runtime.HandleNextToolStepAsync(new AgentRunNextToolStepRequestedEvent
+        {
+            RunId = request.RunId,
+            CorrelationId = request.CorrelationId,
+            TargetActorId = request.TargetActorId,
+            Attempt = 1,
+            StepIndex = 3,
+            Request = request.Clone(),
+            ToolStepResult = new AgentRunToolStepResult
+            {
+                AdvanceRound = true,
+                ResultMessages =
+                {
+                    new AgentRunChatMessage
+                    {
+                        Role = "tool",
+                        ToolCallId = "tool-call-typed",
+                        Content = """{"result":"ok"}""",
+                    },
+                },
+            },
+        });
+
+        runtime.State.GenerationStep!.NextStepIndex.Should().Be(3);
+        runtime.State.GenerationStep.Round.Should().Be(1);
+        runtime.State.GenerationStep.PendingToolCalls.Should().BeEmpty();
+        runtime.State.GenerationStep.Messages.Should().Contain(message =>
+            message.Role == "tool" &&
+            message.ToolCallId == "tool-call-typed" &&
+            message.Content == """{"result":"ok"}""");
+        generationExecutor.LlmSteps.Should().ContainSingle(step => step.StepIndex == 3);
     }
 
     [Fact]
@@ -688,15 +834,9 @@ public sealed class AgentRunGAgentTests
             Attempt = generationExecutor.InitialSteps.Single().Attempt,
             Request = generationExecutor.InitialSteps.Single().Request.Clone(),
             StepIndex = 2,
-            StepState = new AgentRunReplyStepState
+            LlmStepResult = new AgentRunLlmStepResult
             {
-                RunId = "run-generation-timeout-race",
-                CorrelationId = "corr-generation-timeout-race",
-                TargetActorId = "actor-1",
-                Attempt = generationExecutor.InitialSteps.Single().Attempt,
-                NextStepIndex = 2,
                 AccumulatedText = "late executor reply",
-                MaxToolRounds = 40,
             },
         });
 
@@ -2823,7 +2963,7 @@ public sealed class AgentRunGAgentTests
                 Attempt = request.Attempt,
                 StepIndex = request.StepIndex + 1,
                 Request = request.Request.Clone(),
-                StepState = request.StepState.Clone(),
+                LlmStepResult = new AgentRunLlmStepResult(),
             });
 
         public Task<AgentRunNextToolStepRequestedEvent> BuildToolStepContinuationAsync(
@@ -2837,7 +2977,7 @@ public sealed class AgentRunGAgentTests
                 Attempt = request.Attempt,
                 StepIndex = request.StepIndex + 1,
                 Request = request.Request.Clone(),
-                StepState = request.StepState.Clone(),
+                ToolStepResult = new AgentRunToolStepResult { AdvanceRound = true },
             });
     }
 
@@ -2887,7 +3027,7 @@ public sealed class AgentRunGAgentTests
                 Attempt = request.Attempt,
                 StepIndex = request.StepIndex + 1,
                 Request = request.Request.Clone(),
-                StepState = request.StepState.Clone(),
+                LlmStepResult = new AgentRunLlmStepResult(),
             });
 
         public virtual Task<AgentRunNextToolStepRequestedEvent> BuildToolStepContinuationAsync(
@@ -2901,7 +3041,7 @@ public sealed class AgentRunGAgentTests
                 Attempt = request.Attempt,
                 StepIndex = request.StepIndex + 1,
                 Request = request.Request.Clone(),
-                StepState = request.StepState.Clone(),
+                ToolStepResult = new AgentRunToolStepResult { AdvanceRound = true },
             });
     }
 
@@ -2915,21 +3055,11 @@ public sealed class AgentRunGAgentTests
         {
             await base.ExecuteLlmStepAsync(request, ct);
             var agent = _agent ?? throw new InvalidOperationException("AgentRunGAgent test executor was not bound.");
-            var nextState = request.StepState.Clone();
-            nextState.NextStepIndex = request.StepIndex + 1;
-            nextState.PendingToolCalls.Clear();
+            var result = new AgentRunLlmStepResult();
 
             if (LlmSteps.Count == 1)
             {
-                nextState.Messages.Add(new AgentRunChatMessage
-                {
-                    Role = "assistant",
-                    ToolCalls =
-                    {
-                        new AgentRunToolCall { Id = "tool-call-1", Name = "lookup", ArgumentsJson = "{}" },
-                    },
-                });
-                nextState.PendingToolCalls.Add(new AgentRunToolCall
+                result.ToolCalls.Add(new AgentRunToolCall
                 {
                     Id = "tool-call-1",
                     Name = "lookup",
@@ -2938,12 +3068,8 @@ public sealed class AgentRunGAgentTests
             }
             else
             {
-                nextState.AccumulatedText = "final answer after tool";
-                nextState.Messages.Add(new AgentRunChatMessage
-                {
-                    Role = "assistant",
-                    Content = "final answer after tool",
-                });
+                result.AccumulatedText = "final answer after tool";
+                result.Content = "final answer after tool";
             }
 
             await agent.HandleNextLlmStepAsync(new AgentRunNextLlmStepRequestedEvent
@@ -2954,7 +3080,7 @@ public sealed class AgentRunGAgentTests
                 Attempt = request.Attempt,
                 StepIndex = request.StepIndex + 1,
                 Request = request.Request.Clone(),
-                StepState = nextState,
+                LlmStepResult = result,
             });
         }
 
@@ -2962,16 +3088,6 @@ public sealed class AgentRunGAgentTests
         {
             await base.ExecuteToolStepAsync(request, ct);
             var agent = _agent ?? throw new InvalidOperationException("AgentRunGAgent test executor was not bound.");
-            var nextState = request.StepState.Clone();
-            nextState.NextStepIndex = request.StepIndex + 1;
-            nextState.Round++;
-            nextState.PendingToolCalls.Clear();
-            nextState.Messages.Add(new AgentRunChatMessage
-            {
-                Role = "tool",
-                ToolCallId = "tool-call-1",
-                Content = """{"result":"tool-ok"}""",
-            });
 
             await agent.HandleNextToolStepAsync(new AgentRunNextToolStepRequestedEvent
             {
@@ -2981,7 +3097,19 @@ public sealed class AgentRunGAgentTests
                 Attempt = request.Attempt,
                 StepIndex = request.StepIndex + 1,
                 Request = request.Request.Clone(),
-                StepState = nextState,
+                ToolStepResult = new AgentRunToolStepResult
+                {
+                    AdvanceRound = true,
+                    ResultMessages =
+                    {
+                        new AgentRunChatMessage
+                        {
+                            Role = "tool",
+                            ToolCallId = "tool-call-1",
+                            Content = """{"result":"tool-ok"}""",
+                        },
+                    },
+                },
             });
         }
     }


### PR DESCRIPTION
## 摘要

iter110 cluster-2 #1085(high,CLAUDE-FACT-SOURCE-READMODEL / CLAUDE-ACTOR-EXECUTION-EVENTIZED)。

**Old**:`AgentRunReplyGenerationExecutor` 执行 LLM/tool IO **+ 构造权威的下一份 `AgentRunReplyStepState`**;`AgentRunGAgent` 直接持久化 executor 传来的 full state。违反「单一权威拥有者」+「单线程事实源」+「业务推进内聚」。

**New**:`Executor` IO-only(返 typed facts);`AgentRunGAgent` 在 actor turn 内 deterministic step-state transition + 持久化。

- proto `step_state` → typed `llm_step_result` / `tool_step_result`
- Executor 删 `StepState.Clone()` mutation;只填 typed facts(streamed text/tool calls/usage/finish reason 等)
- Actor handler 内 validate continuation identity + 推导下一 state + 持久化
- 加 stale/mismatched + reconcile 行为测试

**不开** 新 actor type / 新 envelope kind / 新 pipeline(reflector-style minimal narrowing,无 rule exception)。

## 范围

6 files / +348 / -110。

closes #1085

🤖 Auto-loop / codex-refactor-loop iter110

⟦AI:AUTO-LOOP⟧
