### PR TITLE
iter113 cluster-2 #1093: 删 Scripting runtime side-read + direct ScriptDefinitionSnapshot

### DIFF
--- a/src/Aevatar.Scripting.Abstractions/Behaviors/IScriptBehaviorRuntimeCapabilities.cs
+++ b/src/Aevatar.Scripting.Abstractions/Behaviors/IScriptBehaviorRuntimeCapabilities.cs
@@ -8,6 +8,9 @@ namespace Aevatar.Scripting.Abstractions.Behaviors;
 // Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
 //   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
 //   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
+// Refactor (iter113/cluster-113-scripting-runtime-definition-snapshot-side-read):
+//   Old pattern: Scripting runtime side-read scripting definition snapshot via runtime readmodel (cache + factory injection).
+//   New principle: Direct command-owned ScriptDefinitionSnapshot;delete runtime readmodel side-read/cache/factory injection;migrate script-facing API as in-scope migration risk(public API break in scope).
 public interface IScriptBehaviorRuntimeCapabilities
 {
     Task<string> AskAIAsync(string prompt, CancellationToken ct);
@@ -28,7 +31,7 @@ public interface IScriptBehaviorRuntimeCapabilities
 
     Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct);
 
-    Task<string> UpsertScriptDefinitionAsync(
+    Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(
         string scriptId,
         string scriptRevision,
         string sourceText,
@@ -40,6 +43,7 @@ public interface IScriptBehaviorRuntimeCapabilities
         string definitionActorId,
         string scriptRevision,
         string? runtimeActorId,
+        ScriptDefinitionBindingSpec definitionSnapshot,
         CancellationToken ct);
 
     Task RunScriptInstanceAsync(

--- a/src/Aevatar.Scripting.Abstractions/Behaviors/ScriptDefinitionUpsertResult.cs
+++ b/src/Aevatar.Scripting.Abstractions/Behaviors/ScriptDefinitionUpsertResult.cs
@@ -1,0 +1,10 @@
+using Aevatar.Scripting.Abstractions.Definitions;
+
+namespace Aevatar.Scripting.Abstractions.Behaviors;
+
+// Refactor (iter113/cluster-113-scripting-runtime-definition-snapshot-side-read):
+//   Old pattern: Scripting runtime side-read scripting definition snapshot via runtime readmodel (cache + factory injection).
+//   New principle: Direct command-owned ScriptDefinitionSnapshot;delete runtime readmodel side-read/cache/factory injection;migrate script-facing API as in-scope migration risk(public API break in scope).
+public sealed record ScriptDefinitionUpsertResult(
+    string ActorId,
+    ScriptDefinitionBindingSpec DefinitionSnapshot);

--- a/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilities.cs
+++ b/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilities.cs
@@ -14,6 +14,9 @@ namespace Aevatar.Scripting.Application.Runtime;
 // Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
 //   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
 //   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
+// Refactor (iter113/cluster-113-scripting-runtime-definition-snapshot-side-read):
+//   Old pattern: Scripting runtime side-read scripting definition snapshot via runtime readmodel (cache + factory injection).
+//   New principle: Direct command-owned ScriptDefinitionSnapshot;delete runtime readmodel side-read/cache/factory injection;migrate script-facing API as in-scope migration risk(public API break in scope).
 public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCapabilities
 {
     private readonly Func<IMessage, TopologyAudience, CancellationToken, Task> _publishAsync;
@@ -22,17 +25,11 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
     private readonly Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> _scheduleSelfSignalAsync;
     private readonly Func<RuntimeCallbackLease, CancellationToken, Task> _cancelCallbackAsync;
     private readonly IAICapability _aiCapability;
-    private readonly IScriptDefinitionSnapshotPort _definitionSnapshotPort;
     private readonly IScriptEvolutionProposalPort _proposalPort;
     private readonly IScriptDefinitionCommandPort _definitionCommandPort;
     private readonly IScriptRuntimeProvisioningPort _runtimeProvisioningPort;
     private readonly IScriptRuntimeCommandPort _runtimeCommandPort;
     private readonly IScriptCatalogCommandPort _catalogCommandPort;
-    // Activation-local snapshot cache for the current runtime capability instance.
-    // This cache is non-durable and only short-circuits immediate follow-up calls
-    // that already carry write-side authority facts in the same interaction.
-    private readonly Dictionary<string, ScriptDefinitionSnapshot> _activationLocalDefinitionSnapshots =
-        new(StringComparer.Ordinal);
     private readonly string _scopeId;
     private readonly string _runId;
     private readonly string _correlationId;
@@ -46,7 +43,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
         Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> scheduleSelfSignalAsync,
         Func<RuntimeCallbackLease, CancellationToken, Task> cancelCallbackAsync,
         IAICapability aiCapability,
-        IScriptDefinitionSnapshotPort definitionSnapshotPort,
         IScriptEvolutionProposalPort proposalPort,
         IScriptDefinitionCommandPort definitionCommandPort,
         IScriptRuntimeProvisioningPort runtimeProvisioningPort,
@@ -62,7 +58,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
             scheduleSelfSignalAsync,
             cancelCallbackAsync,
             aiCapability,
-            definitionSnapshotPort,
             proposalPort,
             definitionCommandPort,
             runtimeProvisioningPort,
@@ -81,7 +76,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
         Func<string, TimeSpan, IMessage, CancellationToken, Task<RuntimeCallbackLease>> scheduleSelfSignalAsync,
         Func<RuntimeCallbackLease, CancellationToken, Task> cancelCallbackAsync,
         IAICapability aiCapability,
-        IScriptDefinitionSnapshotPort definitionSnapshotPort,
         IScriptEvolutionProposalPort proposalPort,
         IScriptDefinitionCommandPort definitionCommandPort,
         IScriptRuntimeProvisioningPort runtimeProvisioningPort,
@@ -97,7 +91,6 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
         _scheduleSelfSignalAsync = scheduleSelfSignalAsync ?? throw new ArgumentNullException(nameof(scheduleSelfSignalAsync));
         _cancelCallbackAsync = cancelCallbackAsync ?? throw new ArgumentNullException(nameof(cancelCallbackAsync));
         _aiCapability = aiCapability ?? throw new ArgumentNullException(nameof(aiCapability));
-        _definitionSnapshotPort = definitionSnapshotPort ?? throw new ArgumentNullException(nameof(definitionSnapshotPort));
         _proposalPort = proposalPort ?? throw new ArgumentNullException(nameof(proposalPort));
         _definitionCommandPort = definitionCommandPort ?? throw new ArgumentNullException(nameof(definitionCommandPort));
         _runtimeProvisioningPort = runtimeProvisioningPort ?? throw new ArgumentNullException(nameof(runtimeProvisioningPort));
@@ -130,29 +123,43 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
     public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(
         ScriptEvolutionProposal proposal,
         CancellationToken ct) =>
-        ProposeAndRememberAsync(proposal, ct);
+        _proposalPort.ProposeAsync(proposal, ct);
 
-    public Task<string> UpsertScriptDefinitionAsync(
+    public async Task<Aevatar.Scripting.Abstractions.Behaviors.ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(
         string scriptId,
         string scriptRevision,
         string sourceText,
         string sourceHash,
         string? definitionActorId,
-        CancellationToken ct) =>
-        UpsertAndRememberAsync(scriptId, scriptRevision, sourceText, sourceHash, definitionActorId, ct);
+        CancellationToken ct)
+    {
+        var result = await _definitionCommandPort.UpsertDefinitionWithSnapshotAsync(
+            scriptId,
+            scriptRevision,
+            ScriptPackageSpecExtensions.CreateSingleSource(sourceText ?? string.Empty),
+            definitionActorId,
+            _scopeId,
+            ct);
+        return new Aevatar.Scripting.Abstractions.Behaviors.ScriptDefinitionUpsertResult(
+            result.ActorId,
+            result.Snapshot.ToBindingSpec());
+    }
 
     public async Task<string> SpawnScriptRuntimeAsync(
         string definitionActorId,
         string scriptRevision,
         string? runtimeActorId,
+        ScriptDefinitionBindingSpec definitionSnapshot,
         CancellationToken ct)
     {
-        var definitionSnapshot = await ResolveDefinitionSnapshotAsync(definitionActorId, scriptRevision, ct);
+        ArgumentNullException.ThrowIfNull(definitionSnapshot);
+        var snapshot = definitionSnapshot.ToSnapshot()
+            ?? throw new InvalidOperationException("Script runtime provisioning requires a definition snapshot.");
         var resolvedRuntimeActorId = await _runtimeProvisioningPort.EnsureRuntimeAsync(
             definitionActorId,
             scriptRevision,
             runtimeActorId,
-            definitionSnapshot,
+            snapshot,
             _scopeId,
             ct);
         return resolvedRuntimeActorId;
@@ -214,83 +221,4 @@ public sealed class ScriptBehaviorRuntimeCapabilities : IScriptBehaviorRuntimeCa
             _scopeId,
             ct);
 
-    private async Task<ScriptPromotionDecision> ProposeAndRememberAsync(
-        ScriptEvolutionProposal proposal,
-        CancellationToken ct)
-    {
-        var decision = await _proposalPort.ProposeAsync(proposal, ct);
-        if (decision.Accepted && decision.DefinitionSnapshot != null)
-        {
-            RememberTransientDefinitionSnapshot(
-                decision.DefinitionActorId,
-                decision.CandidateRevision,
-                decision.DefinitionSnapshot.ToSnapshot());
-        }
-
-        return decision;
-    }
-
-    private async Task<string> UpsertAndRememberAsync(
-        string scriptId,
-        string scriptRevision,
-        string sourceText,
-        string sourceHash,
-        string? definitionActorId,
-        CancellationToken ct)
-    {
-        var result = await _definitionCommandPort.UpsertDefinitionWithSnapshotAsync(
-            scriptId,
-            scriptRevision,
-            ScriptPackageSpecExtensions.CreateSingleSource(sourceText ?? string.Empty),
-            definitionActorId,
-            _scopeId,
-            ct);
-        RememberTransientDefinitionSnapshot(result.ActorId, result.Snapshot.Revision, result.Snapshot);
-        return result.ActorId;
-    }
-
-    private void RememberTransientDefinitionSnapshot(
-        string definitionActorId,
-        string scriptRevision,
-        ScriptDefinitionSnapshot? snapshot)
-    {
-        // This cache is bounded to the capability lifetime and must not be treated
-        // as cross-request or cross-node authority state.
-        if (snapshot == null || string.IsNullOrWhiteSpace(definitionActorId))
-            return;
-
-        _activationLocalDefinitionSnapshots[BuildDefinitionSnapshotKey(definitionActorId, scriptRevision)] = snapshot;
-    }
-
-    private ScriptDefinitionSnapshot? TryGetTransientDefinitionSnapshot(
-        string definitionActorId,
-        string scriptRevision)
-    {
-        _activationLocalDefinitionSnapshots.TryGetValue(
-            BuildDefinitionSnapshotKey(definitionActorId, scriptRevision),
-            out var snapshot);
-        return snapshot;
-    }
-
-    private static string BuildDefinitionSnapshotKey(
-        string definitionActorId,
-        string scriptRevision) =>
-        string.Concat(
-            definitionActorId ?? string.Empty,
-            "::",
-            string.IsNullOrWhiteSpace(scriptRevision) ? "latest" : scriptRevision);
-
-    private async Task<ScriptDefinitionSnapshot> ResolveDefinitionSnapshotAsync(
-        string definitionActorId,
-        string scriptRevision,
-        CancellationToken ct)
-    {
-        var snapshot = TryGetTransientDefinitionSnapshot(definitionActorId, scriptRevision);
-        if (snapshot != null)
-            return snapshot;
-
-        snapshot = await _definitionSnapshotPort.GetRequiredAsync(definitionActorId, scriptRevision, ct);
-        RememberTransientDefinitionSnapshot(definitionActorId, snapshot.Revision, snapshot);
-        return snapshot;
-    }
 }

--- a/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilityFactory.cs
+++ b/src/Aevatar.Scripting.Application/Runtime/ScriptBehaviorRuntimeCapabilityFactory.cs
@@ -1,7 +1,6 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Scripting.Abstractions.Behaviors;
-using Aevatar.Scripting.Abstractions.Queries;
 using Aevatar.Scripting.Core.AI;
 using Aevatar.Scripting.Core.Ports;
 using Aevatar.Scripting.Core.Runtime;
@@ -12,10 +11,12 @@ namespace Aevatar.Scripting.Application.Runtime;
 // Refactor (iter27/cluster-029-scripting-runtime-raw-actor-lifecycle):
 //   Old pattern: Scripting behavior runtime exposes raw IActorRuntime lifecycle/topology by assembly-qualified type name and caller-supplied actor ids
 //   New principle: Delete raw script-facing actor lifecycle/topology API; keep existing typed scripting ports (provisioning/command/definition/catalog/evolution)
+// Refactor (iter113/cluster-113-scripting-runtime-definition-snapshot-side-read):
+//   Old pattern: Scripting runtime side-read scripting definition snapshot via runtime readmodel (cache + factory injection).
+//   New principle: Direct command-owned ScriptDefinitionSnapshot;delete runtime readmodel side-read/cache/factory injection;migrate script-facing API as in-scope migration risk(public API break in scope).
 public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRuntimeCapabilityFactory
 {
     private readonly IAICapability _aiCapability;
-    private readonly IScriptDefinitionSnapshotPort _definitionSnapshotPort;
     private readonly IScriptEvolutionProposalPort _proposalPort;
     private readonly IScriptDefinitionCommandPort _definitionCommandPort;
     private readonly IScriptRuntimeProvisioningPort _runtimeProvisioningPort;
@@ -24,7 +25,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRunt
 
     public ScriptBehaviorRuntimeCapabilityFactory(
         IAICapability aiCapability,
-        IScriptDefinitionSnapshotPort definitionSnapshotPort,
         IScriptEvolutionProposalPort proposalPort,
         IScriptDefinitionCommandPort definitionCommandPort,
         IScriptRuntimeProvisioningPort runtimeProvisioningPort,
@@ -32,7 +32,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRunt
         IScriptCatalogCommandPort catalogCommandPort)
     {
         _aiCapability = aiCapability ?? throw new ArgumentNullException(nameof(aiCapability));
-        _definitionSnapshotPort = definitionSnapshotPort ?? throw new ArgumentNullException(nameof(definitionSnapshotPort));
         _proposalPort = proposalPort ?? throw new ArgumentNullException(nameof(proposalPort));
         _definitionCommandPort = definitionCommandPort ?? throw new ArgumentNullException(nameof(definitionCommandPort));
         _runtimeProvisioningPort = runtimeProvisioningPort ?? throw new ArgumentNullException(nameof(runtimeProvisioningPort));
@@ -60,7 +59,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactory : IScriptBehaviorRunt
             scheduleSelfSignalAsync,
             cancelCallbackAsync,
             _aiCapability,
-            _definitionSnapshotPort,
             _proposalPort,
             _definitionCommandPort,
             _runtimeProvisioningPort,

--- a/test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj
+++ b/test/Aevatar.Integration.Tests/Aevatar.Integration.Tests.csproj
@@ -47,7 +47,7 @@
               AdditionalImportDirs="..\..\src\Aevatar.Scripting.Abstractions\Protos" />
     <Protobuf Include="Protos/script_evolution_protocol.proto"
               GrpcServices="None"
-              AdditionalImportDirs="..\..\src\Aevatar.Scripting.Abstractions\Protos" />
+              AdditionalImportDirs="..\..\src\Aevatar.Scripting.Abstractions;..\..\src\Aevatar.Scripting.Abstractions\Protos" />
     <Protobuf Include="Protos/hybrid_service_upgrade_protocol.proto"
               GrpcServices="None"
               AdditionalImportDirs="..\..\src\Aevatar.Scripting.Abstractions\Protos" />

--- a/test/Aevatar.Integration.Tests/ClaimOrchestrationIntegrationTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimOrchestrationIntegrationTests.cs
@@ -152,8 +152,9 @@ public class ClaimOrchestrationIntegrationTests
 
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) => Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) => Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) => Task.FromResult(runtimeActorId ?? string.Empty);
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) => Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) => Task.CompletedTask;
         public Task PromoteRevisionAsync(string catalogActorId, string scriptId, string revision, string definitionActorId, string sourceHash, string proposalId, CancellationToken ct) => Task.CompletedTask;
         public Task RollbackRevisionAsync(string catalogActorId, string scriptId, string targetRevision, string reason, string proposalId, CancellationToken ct) => Task.CompletedTask;

--- a/test/Aevatar.Integration.Tests/ClaimScriptDocumentDrivenFlexibilityTests.cs
+++ b/test/Aevatar.Integration.Tests/ClaimScriptDocumentDrivenFlexibilityTests.cs
@@ -199,8 +199,9 @@ public class ClaimScriptDocumentDrivenFlexibilityTests
 
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) => Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) => Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) => Task.FromResult(runtimeActorId ?? string.Empty);
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) => Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) => Task.CompletedTask;
         public Task PromoteRevisionAsync(string catalogActorId, string scriptId, string revision, string definitionActorId, string sourceHash, string proposalId, CancellationToken ct) => Task.CompletedTask;
         public Task RollbackRevisionAsync(string catalogActorId, string scriptId, string targetRevision, string reason, string proposalId, CancellationToken ct) => Task.CompletedTask;

--- a/test/Aevatar.Integration.Tests/Protos/script_evolution_protocol.proto
+++ b/test/Aevatar.Integration.Tests/Protos/script_evolution_protocol.proto
@@ -6,6 +6,7 @@ option csharp_namespace = "Aevatar.Integration.Tests.Protocols";
 
 import "scripting_schema_options.proto";
 import "scripting_runtime_options.proto";
+import "script_host_messages.proto";
 
 message ScriptOnlyEvolutionState {
   option (aevatar.scripting.schema.scripting_read_model) = {
@@ -26,6 +27,7 @@ message ScriptOnlyEvolutionRequested {
   };
   string new_script_source = 1;
   string worker_v2_source = 2;
+  aevatar.scripting.ScriptDefinitionBindingSpec worker_v1_definition_snapshot = 3;
 }
 
 message ScriptOnlyEvolutionCompleted {
@@ -69,6 +71,8 @@ message MultiScriptEvolutionRequested {
   string generated_source_1 = 5;
   string generated_source_2 = 6;
   string runtime_agent_type = 7;
+  aevatar.scripting.ScriptDefinitionBindingSpec worker_a_v1_definition_snapshot = 8;
+  aevatar.scripting.ScriptDefinitionBindingSpec worker_b_v1_definition_snapshot = 9;
 }
 
 message MultiScriptEvolutionCompleted {
@@ -235,6 +239,8 @@ message OrleansClusterRequested {
   string temp_b_runtime_id = 6;
   string generated_runtime_id = 7;
   string generated_definition_actor_id = 8;
+  aevatar.scripting.ScriptDefinitionBindingSpec worker_a_definition_snapshot = 9;
+  aevatar.scripting.ScriptDefinitionBindingSpec worker_b_definition_snapshot = 10;
 }
 
 message OrleansClusterCompleted {

--- a/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionComprehensiveE2ETests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionComprehensiveE2ETests.cs
@@ -3,6 +3,7 @@ using Aevatar.Integration.Tests.Protocols;
 using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Core;
 using Aevatar.Scripting.Core.Compilation;
+using Aevatar.Scripting.Core.Ports;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +24,7 @@ public sealed class ScriptAutonomousEvolutionComprehensiveE2ETests
         const string orchestratorDefinitionActorId = "multi-orchestrator-definition";
         const string orchestratorRuntimeActorId = "multi-orchestrator-runtime";
 
-        await ScriptEvolutionIntegrationTestKit.UpsertDefinitionAsync(
+        var workerADefinition = await ScriptEvolutionIntegrationTestKit.UpsertDefinitionWithSnapshotAsync(
             provider,
             "worker-a-script",
             "rev-a-1",
@@ -34,7 +35,7 @@ public sealed class ScriptAutonomousEvolutionComprehensiveE2ETests
                 "1"),
             workerADefinitionActorId,
             CancellationToken.None);
-        await ScriptEvolutionIntegrationTestKit.UpsertDefinitionAsync(
+        var workerBDefinition = await ScriptEvolutionIntegrationTestKit.UpsertDefinitionWithSnapshotAsync(
             provider,
             "worker-b-script",
             "rev-b-1",
@@ -94,6 +95,8 @@ public sealed class ScriptAutonomousEvolutionComprehensiveE2ETests
                 "generated_round",
                 "2"),
             RuntimeAgentType = runtimeAgentType,
+            WorkerAV1DefinitionSnapshot = workerADefinition.Snapshot.ToBindingSpec(),
+            WorkerBV1DefinitionSnapshot = workerBDefinition.Snapshot.ToBindingSpec(),
         };
         await ScriptEvolutionIntegrationTestKit.ActivateAuthorityReadModelsAsync(
             provider,
@@ -180,18 +183,18 @@ public sealed class ScriptAutonomousEvolutionComprehensiveE2ETests
         catalogEntryA.RevisionHistory.Should().Contain(["rev-a-2", "rev-a-3"]);
         catalogEntryB.RevisionHistory.Should().Contain(["rev-b-2", "rev-b-3"]);
 
-        var workerADefinition = await ScriptEvolutionIntegrationTestKit.GetDefinitionSnapshotAsync(
+        var workerADefinitionV3 = await ScriptEvolutionIntegrationTestKit.GetDefinitionSnapshotAsync(
             provider,
             catalogEntryA.ActiveDefinitionActorId,
             "rev-a-3",
             CancellationToken.None);
-        var workerBDefinition = await ScriptEvolutionIntegrationTestKit.GetDefinitionSnapshotAsync(
+        var workerBDefinitionV3 = await ScriptEvolutionIntegrationTestKit.GetDefinitionSnapshotAsync(
             provider,
             catalogEntryB.ActiveDefinitionActorId,
             "rev-b-3",
             CancellationToken.None);
-        workerADefinition.Revision.Should().Be("rev-a-3");
-        workerBDefinition.Revision.Should().Be("rev-b-3");
+        workerADefinitionV3.Revision.Should().Be("rev-a-3");
+        workerBDefinitionV3.Revision.Should().Be("rev-b-3");
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionE2ETests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionE2ETests.cs
@@ -1,7 +1,9 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Integration.Tests.Protocols;
+using Aevatar.Scripting.Abstractions;
 using Aevatar.Scripting.Core;
+using Aevatar.Scripting.Core.Ports;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,7 +40,7 @@ public sealed class ScriptAutonomousEvolutionE2ETests
             "new_runtime_normalization",
             "1");
 
-        await ScriptEvolutionIntegrationTestKit.UpsertDefinitionAsync(
+        var workerDefinition = await ScriptEvolutionIntegrationTestKit.UpsertDefinitionWithSnapshotAsync(
             provider,
             scriptId: "worker-script",
             revision: "rev-worker-1",
@@ -63,6 +65,7 @@ public sealed class ScriptAutonomousEvolutionE2ETests
         {
             NewScriptSource = newRuntimeSource,
             WorkerV2Source = workerV2Source,
+            WorkerV1DefinitionSnapshot = workerDefinition.Snapshot.ToBindingSpec(),
         };
         await ScriptEvolutionIntegrationTestKit.ActivateAuthorityReadModelsAsync(
             provider,

--- a/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
+++ b/test/Aevatar.Integration.Tests/ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests.cs
@@ -126,7 +126,7 @@ public sealed class ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests
                 "orleans_generated",
                 "1");
 
-            await definitionPortNode1.UpsertDefinitionAsync(
+            var workerADefinition = await definitionPortNode1.UpsertDefinitionWithSnapshotAsync(
                 workerAScriptId,
                 "rev-a-1",
                 ScriptPackageSpecExtensions.CreateSingleSource(ScriptEvolutionIntegrationSources.BuildNormalizationBehaviorSource(
@@ -136,7 +136,7 @@ public sealed class ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests
                     "1")),
                 workerADefinitionActorId,
                 CancellationToken.None);
-            await definitionPortNode1.UpsertDefinitionAsync(
+            var workerBDefinition = await definitionPortNode1.UpsertDefinitionWithSnapshotAsync(
                 workerBScriptId,
                 "rev-b-1",
                 ScriptPackageSpecExtensions.CreateSingleSource(ScriptEvolutionIntegrationSources.BuildNormalizationBehaviorSource(
@@ -201,6 +201,8 @@ public sealed class ScriptAutonomousEvolutionOrleans3ClusterConsistencyTests
                                 TempBRuntimeId = tempBRuntimeId,
                                 GeneratedRuntimeId = generatedRuntimeId,
                                 GeneratedDefinitionActorId = generatedDefinitionActorId,
+                                WorkerADefinitionSnapshot = workerADefinition.Snapshot.ToBindingSpec(),
+                                WorkerBDefinitionSnapshot = workerBDefinition.Snapshot.ToBindingSpec(),
                             }),
                             ScriptRevision = "rev-orchestrator-1",
                             DefinitionActorId = orchestratorDefinitionActorId,

--- a/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationSources.cs
+++ b/test/Aevatar.Integration.Tests/ScriptEvolutionIntegrationSources.cs
@@ -79,6 +79,7 @@ internal static class ScriptEvolutionIntegrationSources
         using System.Text;
         using System.Threading;
         using System.Threading.Tasks;
+        using Aevatar.Scripting.Abstractions;
         using Aevatar.Integration.Tests.Protocols;
         using Aevatar.Scripting.Abstractions.Behaviors;
         using Aevatar.Scripting.Abstractions.Definitions;
@@ -107,6 +108,7 @@ internal static class ScriptEvolutionIntegrationSources
                     "worker-definition",
                     "rev-worker-1",
                     "worker-temp-" + context.RunId,
+                    input.WorkerV1DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     tempRuntimeId,
@@ -121,7 +123,7 @@ internal static class ScriptEvolutionIntegrationSources
                     "worker.temp.run",
                     ct);
 
-                var newDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var newDefinition = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "new-script",
                     "rev-new-1",
                     newScriptSource,
@@ -129,9 +131,10 @@ internal static class ScriptEvolutionIntegrationSources
                     "new-definition",
                     ct);
                 var newRuntimeId = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
-                    newDefinitionActorId,
+                    newDefinition.ActorId,
                     "rev-new-1",
                     "new-runtime-" + context.RunId,
+                    newDefinition.DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     newRuntimeId,
@@ -142,7 +145,7 @@ internal static class ScriptEvolutionIntegrationSources
                         InputText = "new",
                     }),
                     "rev-new-1",
-                    newDefinitionActorId,
+                    newDefinition.ActorId,
                     "new.runtime.run",
                     ct);
 
@@ -164,6 +167,7 @@ internal static class ScriptEvolutionIntegrationSources
                         decision.DefinitionActorId,
                         decision.CandidateRevision,
                         "worker-evolved-" + context.RunId,
+                        decision.DefinitionSnapshot ?? new ScriptDefinitionBindingSpec(),
                         ct);
                     await context.RuntimeCapabilities.RunScriptInstanceAsync(
                         evolvedRuntimeId,
@@ -186,7 +190,7 @@ internal static class ScriptEvolutionIntegrationSources
                         TempRuntimeId = tempRuntimeId,
                         NewRuntimeId = newRuntimeId,
                         EvolvedRuntimeId = evolvedRuntimeId,
-                        NewDefinitionActorId = newDefinitionActorId,
+                        NewDefinitionActorId = newDefinition.ActorId,
                         DecisionStatus = decision.Status,
                     },
                 });
@@ -207,6 +211,7 @@ internal static class ScriptEvolutionIntegrationSources
         using System.Text;
         using System.Threading;
         using System.Threading.Tasks;
+        using Aevatar.Scripting.Abstractions;
         using Aevatar.Integration.Tests.Protocols;
         using Aevatar.Scripting.Abstractions.Behaviors;
         using Aevatar.Scripting.Abstractions.Definitions;
@@ -240,6 +245,7 @@ internal static class ScriptEvolutionIntegrationSources
                     "multi-worker-a-definition",
                     "rev-a-1",
                     "temp-worker-a-" + context.RunId,
+                    input.WorkerAV1DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     tempARuntimeId,
@@ -258,6 +264,7 @@ internal static class ScriptEvolutionIntegrationSources
                     "multi-worker-b-definition",
                     "rev-b-1",
                     "temp-worker-b-" + context.RunId,
+                    input.WorkerBV1DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     tempBRuntimeId,
@@ -272,7 +279,7 @@ internal static class ScriptEvolutionIntegrationSources
                     "worker.b.temp",
                     ct);
 
-                var generatedDefinitionActorId1 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var generatedDefinition1 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "generated-script-1",
                     "rev-g-1",
                     generatedSource1,
@@ -280,9 +287,10 @@ internal static class ScriptEvolutionIntegrationSources
                     "generated-definition-1-" + context.RunId,
                     ct);
                 var generatedRuntimeId1 = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
-                    generatedDefinitionActorId1,
+                    generatedDefinition1.ActorId,
                     "rev-g-1",
                     "generated-runtime-1-" + context.RunId,
+                    generatedDefinition1.DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     generatedRuntimeId1,
@@ -293,7 +301,7 @@ internal static class ScriptEvolutionIntegrationSources
                         InputText = "generated one",
                     }),
                     "rev-g-1",
-                    generatedDefinitionActorId1,
+                    generatedDefinition1.ActorId,
                     "generated.script.1.run",
                     ct);
 
@@ -345,6 +353,7 @@ internal static class ScriptEvolutionIntegrationSources
                         decisionA3.DefinitionActorId,
                         decisionA3.CandidateRevision,
                         "worker-a-evolved-" + context.RunId,
+                        decisionA3.DefinitionSnapshot ?? new ScriptDefinitionBindingSpec(),
                         ct);
                     await context.RuntimeCapabilities.RunScriptInstanceAsync(
                         evolvedARuntimeId,
@@ -367,6 +376,7 @@ internal static class ScriptEvolutionIntegrationSources
                         decisionB3.DefinitionActorId,
                         decisionB3.CandidateRevision,
                         "worker-b-evolved-" + context.RunId,
+                        decisionB3.DefinitionSnapshot ?? new ScriptDefinitionBindingSpec(),
                         ct);
                     await context.RuntimeCapabilities.RunScriptInstanceAsync(
                         evolvedBRuntimeId,
@@ -382,7 +392,7 @@ internal static class ScriptEvolutionIntegrationSources
                         ct);
                 }
 
-                var generatedDefinitionActorId2 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var generatedDefinition2 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "generated-script-2",
                     "rev-g-2",
                     generatedSource2,
@@ -390,9 +400,10 @@ internal static class ScriptEvolutionIntegrationSources
                     "generated-definition-2-" + context.RunId,
                     ct);
                 var generatedRuntimeId2 = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
-                    generatedDefinitionActorId2,
+                    generatedDefinition2.ActorId,
                     "rev-g-2",
                     "generated-runtime-2-" + context.RunId,
+                    generatedDefinition2.DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     generatedRuntimeId2,
@@ -403,7 +414,7 @@ internal static class ScriptEvolutionIntegrationSources
                         InputText = "generated two",
                     }),
                     "rev-g-2",
-                    generatedDefinitionActorId2,
+                    generatedDefinition2.ActorId,
                     "generated.script.2.run",
                     ct);
 
@@ -441,6 +452,7 @@ internal static class ScriptEvolutionIntegrationSources
         using System.Text;
         using System.Threading;
         using System.Threading.Tasks;
+        using Aevatar.Scripting.Abstractions;
         using Aevatar.Integration.Tests.Protocols;
         using Aevatar.Scripting.Abstractions.Behaviors;
         using Aevatar.Scripting.Abstractions.Definitions;
@@ -466,7 +478,7 @@ internal static class ScriptEvolutionIntegrationSources
                 var nextV3Source = input.NextV3Source ?? string.Empty;
                 var generatedSource = input.GeneratedSource ?? string.Empty;
 
-                var generatedDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var generatedDefinition = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "self-generated-script",
                     "rev-self-generated-1",
                     generatedSource,
@@ -474,9 +486,10 @@ internal static class ScriptEvolutionIntegrationSources
                     "self-generated-definition-" + context.RunId,
                     ct);
                 var generatedRuntimeId = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
-                    generatedDefinitionActorId,
+                    generatedDefinition.ActorId,
                     "rev-self-generated-1",
                     "self-generated-runtime-" + context.RunId,
+                    generatedDefinition.DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     generatedRuntimeId,
@@ -487,7 +500,7 @@ internal static class ScriptEvolutionIntegrationSources
                         InputText = "generated",
                     }),
                     "rev-self-generated-1",
-                    generatedDefinitionActorId,
+                    generatedDefinition.ActorId,
                     "self.generated.run",
                     ct);
 
@@ -509,6 +522,7 @@ internal static class ScriptEvolutionIntegrationSources
                         decisionV2.DefinitionActorId,
                         decisionV2.CandidateRevision,
                         "self-v2-runtime-" + context.RunId,
+                        decisionV2.DefinitionSnapshot ?? new ScriptDefinitionBindingSpec(),
                         ct);
                     await context.RuntimeCapabilities.RunScriptInstanceAsync(
                         v2RuntimeId,
@@ -549,6 +563,7 @@ internal static class ScriptEvolutionIntegrationSources
         using System.Text;
         using System.Threading;
         using System.Threading.Tasks;
+        using Aevatar.Scripting.Abstractions;
         using Aevatar.Integration.Tests.Protocols;
         using Aevatar.Scripting.Abstractions.Behaviors;
         using Aevatar.Scripting.Abstractions.Definitions;
@@ -590,6 +605,7 @@ internal static class ScriptEvolutionIntegrationSources
                         decisionV3.DefinitionActorId,
                         decisionV3.CandidateRevision,
                         "self-v3-runtime-" + context.RunId,
+                        decisionV3.DefinitionSnapshot ?? new ScriptDefinitionBindingSpec(),
                         ct);
                     await context.RuntimeCapabilities.RunScriptInstanceAsync(
                         v3RuntimeId,
@@ -630,6 +646,7 @@ internal static class ScriptEvolutionIntegrationSources
         using System.Text;
         using System.Threading;
         using System.Threading.Tasks;
+        using Aevatar.Scripting.Abstractions;
         using Aevatar.Integration.Tests.Protocols;
         using Aevatar.Scripting.Abstractions.Behaviors;
         using Aevatar.Scripting.Abstractions.Definitions;
@@ -654,7 +671,7 @@ internal static class ScriptEvolutionIntegrationSources
                 var manualV1Source = input.ManualV1Source ?? string.Empty;
                 var manualV2Source = input.ManualV2Source ?? string.Empty;
 
-                var manualDefinitionActorIdV1 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var manualDefinitionV1 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "manual-catalog-script",
                     "rev-manual-1",
                     manualV1Source,
@@ -665,12 +682,12 @@ internal static class ScriptEvolutionIntegrationSources
                     "script-catalog",
                     "manual-catalog-script",
                     "rev-manual-1",
-                    manualDefinitionActorIdV1,
+                    manualDefinitionV1.ActorId,
                     ComputeHash(manualV1Source),
                     "manual-promote-v1-" + context.RunId,
                     ct);
 
-                var manualDefinitionActorIdV2 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var manualDefinitionV2 = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "manual-catalog-script",
                     "rev-manual-2",
                     manualV2Source,
@@ -681,15 +698,16 @@ internal static class ScriptEvolutionIntegrationSources
                     "script-catalog",
                     "manual-catalog-script",
                     "rev-manual-2",
-                    manualDefinitionActorIdV2,
+                    manualDefinitionV2.ActorId,
                     ComputeHash(manualV2Source),
                     "manual-promote-v2-" + context.RunId,
                     ct);
 
                 var manualRuntimeId = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
-                    manualDefinitionActorIdV2,
+                    manualDefinitionV2.ActorId,
                     "rev-manual-2",
                     "manual-catalog-runtime-" + context.RunId,
+                    manualDefinitionV2.DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     manualRuntimeId,
@@ -700,7 +718,7 @@ internal static class ScriptEvolutionIntegrationSources
                         InputText = "manual",
                     }),
                     "rev-manual-2",
-                    manualDefinitionActorIdV2,
+                    manualDefinitionV2.ActorId,
                     "manual.catalog.run",
                     ct);
 
@@ -716,8 +734,8 @@ internal static class ScriptEvolutionIntegrationSources
                 {
                     Current = new CatalogControlState
                     {
-                        ManualDefinitionActorIdV1 = manualDefinitionActorIdV1,
-                        ManualDefinitionActorIdV2 = manualDefinitionActorIdV2,
+                        ManualDefinitionActorIdV1 = manualDefinitionV1.ActorId,
+                        ManualDefinitionActorIdV2 = manualDefinitionV2.ActorId,
                         ManualRuntimeId = manualRuntimeId,
                     },
                 });
@@ -766,7 +784,7 @@ internal static class ScriptEvolutionIntegrationSources
 
                 var aiResponse = await context.RuntimeCapabilities.AskAIAsync("health-check", ct);
 
-                var publishedDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var publishedDefinition = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "interaction-published-script",
                     "rev-published-1",
                     publishSource,
@@ -781,7 +799,7 @@ internal static class ScriptEvolutionIntegrationSources
                     TopologyAudience.Children,
                     ct);
 
-                var sendToDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var sendToDefinition = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "interaction-sendto-script",
                     "rev-sendto-1",
                     sendToSource,
@@ -789,7 +807,7 @@ internal static class ScriptEvolutionIntegrationSources
                     "sendto-definition-" + context.RunId,
                     ct);
                 await context.RuntimeCapabilities.SendToAsync(
-                    sendToDefinitionActorId,
+                    sendToDefinition.ActorId,
                     new UpsertScriptDefinitionRequestedEvent
                     {
                         ScriptId = "interaction-sendto-script",
@@ -799,7 +817,7 @@ internal static class ScriptEvolutionIntegrationSources
                     },
                     ct);
 
-                var upsertDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var upsertDefinition = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     "interaction-invoke-script",
                     "rev-invoke-1",
                     invokeSource,
@@ -812,9 +830,9 @@ internal static class ScriptEvolutionIntegrationSources
                     Current = new InteractionUpsertState
                     {
                         AiResponseLength = (aiResponse ?? string.Empty).Length.ToString(),
-                        PublishedDefinitionActorId = publishedDefinitionActorId,
-                        SendtoDefinitionActorId = sendToDefinitionActorId,
-                        UpsertDefinitionActorId = upsertDefinitionActorId,
+                        PublishedDefinitionActorId = publishedDefinition.ActorId,
+                        SendtoDefinitionActorId = sendToDefinition.ActorId,
+                        UpsertDefinitionActorId = upsertDefinition.ActorId,
                     },
                 });
             }
@@ -834,6 +852,7 @@ internal static class ScriptEvolutionIntegrationSources
         using System.Text;
         using System.Threading;
         using System.Threading.Tasks;
+        using Aevatar.Scripting.Abstractions;
         using Aevatar.Integration.Tests.Protocols;
         using Aevatar.Scripting.Abstractions.Behaviors;
         using Aevatar.Scripting.Abstractions.Definitions;
@@ -868,6 +887,7 @@ internal static class ScriptEvolutionIntegrationSources
                     workerADefinitionActorId,
                     "rev-a-1",
                     tempARuntimeId,
+                    input.WorkerADefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     tempARuntimeId,
@@ -886,6 +906,7 @@ internal static class ScriptEvolutionIntegrationSources
                     workerBDefinitionActorId,
                     "rev-b-1",
                     tempBRuntimeId,
+                    input.WorkerBDefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     tempBRuntimeId,
@@ -900,17 +921,19 @@ internal static class ScriptEvolutionIntegrationSources
                     "temp.b.run",
                     ct);
 
-                generatedDefinitionActorId = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
+                var generatedDefinition = await context.RuntimeCapabilities.UpsertScriptDefinitionAsync(
                     newScriptId,
                     "rev-new-1",
                     newScriptSource,
                     ComputeHash(newScriptSource),
                     generatedDefinitionActorId,
                     ct);
+                generatedDefinitionActorId = generatedDefinition.ActorId;
                 generatedRuntimeId = await context.RuntimeCapabilities.SpawnScriptRuntimeAsync(
                     generatedDefinitionActorId,
                     "rev-new-1",
                     generatedRuntimeId,
+                    generatedDefinition.DefinitionSnapshot,
                     ct);
                 await context.RuntimeCapabilities.RunScriptInstanceAsync(
                     generatedRuntimeId,

--- a/test/Aevatar.Scripting.Core.Tests/AI/ClaimRoleIntegrationTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/AI/ClaimRoleIntegrationTests.cs
@@ -139,10 +139,10 @@ public class ClaimRoleIntegrationTests
                     CatalogActorId: "script-catalog",
                     ValidationReport: new ScriptEvolutionValidationReport(true, [])));
 
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? "definition-1");
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? "definition-1", new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
 
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? "runtime-1");
 
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Behaviors/ScriptBehaviorAbstractionsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Behaviors/ScriptBehaviorAbstractionsTests.cs
@@ -451,9 +451,9 @@ public sealed class ScriptBehaviorAbstractionsTests
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Business/ClaimScriptDecisionTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Business/ClaimScriptDecisionTests.cs
@@ -140,10 +140,10 @@ public class ClaimScriptDecisionTests
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
 
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
 
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
 
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>

--- a/test/Aevatar.Scripting.Core.Tests/Compilation/RoslynScriptExecutionEngineTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Compilation/RoslynScriptExecutionEngineTests.cs
@@ -127,9 +127,9 @@ public sealed class RoslynScriptExecutionEngineTests
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Contract/ScriptDefinitionContractsTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Contract/ScriptDefinitionContractsTests.cs
@@ -62,9 +62,9 @@ public sealed class ScriptDefinitionContractsTests
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Contract/ScriptPackageRuntimeContractTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Contract/ScriptPackageRuntimeContractTests.cs
@@ -241,9 +241,9 @@ public sealed class ScriptPackageRuntimeContractTests
         public Task CancelDurableCallbackAsync(Aevatar.Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
@@ -12,6 +12,7 @@ using Aevatar.Scripting.Core.Tests.Messages;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using CoreScriptDefinitionUpsertResult = Aevatar.Scripting.Core.Ports.ScriptDefinitionUpsertResult;
 
 namespace Aevatar.Scripting.Core.Tests.Runtime;
 
@@ -102,7 +103,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
                 CandidateSourceHash: "hash",
                 Reason: "reason"),
             CancellationToken.None);
-        var definitionActorId = await capabilities.UpsertScriptDefinitionAsync(
+        var definitionUpsert = await capabilities.UpsertScriptDefinitionAsync(
             "script-1",
             "rev-2",
             "source",
@@ -113,6 +114,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             "rev-2",
             "runtime-1",
+            definitionUpsert.DefinitionSnapshot,
             CancellationToken.None);
         await capabilities.RunScriptInstanceAsync(
             "runtime-1",
@@ -144,7 +146,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
 
         aiResponse.Should().Be("ok:hello");
         decision.Accepted.Should().BeTrue();
-        definitionActorId.Should().Be("definition-1");
+        definitionUpsert.ActorId.Should().Be("definition-1");
         runtimeActorId.Should().Be("runtime-1");
         proposalPort.LastProposal.Should().NotBeNull();
         proposalPort.LastProposal!.CandidateRevision.Should().Be("rev-2");
@@ -158,7 +160,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     [Fact]
-    public async Task ProposeScriptEvolutionAsync_ShouldRememberAcceptedSnapshot_ForLaterProvisioning()
+    public async Task SpawnScriptRuntimeAsync_ShouldUseCommandOwnedDefinitionSnapshot()
     {
         var provisioningPort = new RecordingRuntimeProvisioningPort();
         var proposalPort = new StaticProposalPort(new ScriptPromotionDecision(
@@ -199,6 +201,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             "rev-2",
             "runtime-1",
+            decision.DefinitionSnapshot!,
             CancellationToken.None);
 
         decision.Accepted.Should().BeTrue();
@@ -209,7 +212,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     [Fact]
-    public async Task ProposeScriptEvolutionAsync_ShouldNotRememberSnapshot_WhenDecisionHasNoSnapshot()
+    public async Task SpawnScriptRuntimeAsync_ShouldNotReadSnapshot_WhenDecisionHasNoSnapshot()
     {
         var provisioningPort = new RecordingRuntimeProvisioningPort();
         var proposalPort = new StaticProposalPort(new ScriptPromotionDecision(
@@ -241,6 +244,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             "rev-2",
             "runtime-1",
+            CreateDefinitionBindingSpec("rev-2"),
             CancellationToken.None);
 
         runtimeActorId.Should().Be("runtime-1");
@@ -249,9 +253,8 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     [Fact]
-    public async Task TransientDefinitionSnapshotCache_ShouldStayScopedToSingleCapabilityInstance()
+    public async Task SpawnScriptRuntimeAsync_ShouldTrustProvidedSnapshot_AcrossCapabilityInstances()
     {
-        var sharedDefinitionSnapshotPort = new CountingDefinitionSnapshotPort();
         var firstProvisioningPort = new RecordingRuntimeProvisioningPort();
         var secondProvisioningPort = new RecordingRuntimeProvisioningPort();
         var cachedSnapshot = new ScriptDefinitionSnapshot(
@@ -265,9 +268,8 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "schema-hash");
 
         var firstCapabilities = CreateCapabilities(
-            definitionSnapshotPort: sharedDefinitionSnapshotPort,
             definitionCommandPort: new StaticDefinitionCommandPort(
-                new ScriptDefinitionUpsertResult(
+                new CoreScriptDefinitionUpsertResult(
                     "definition-1",
                     cachedSnapshot,
                     new ScriptingCommandAcceptedReceipt("definition-1", "command-1", "corr-1"))),
@@ -284,33 +286,32 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             "rev-2",
             "runtime-1",
+            cachedSnapshot.ToBindingSpec(),
             CancellationToken.None);
 
-        sharedDefinitionSnapshotPort.RequestCount.Should().Be(0);
         firstProvisioningPort.EnsureCalls.Should().ContainSingle();
         firstProvisioningPort.EnsureCalls[0].DefinitionSnapshot.Revision.Should().Be("rev-2");
 
         var secondCapabilities = CreateCapabilities(
-            definitionSnapshotPort: sharedDefinitionSnapshotPort,
             runtimeProvisioningPort: secondProvisioningPort);
 
         await secondCapabilities.SpawnScriptRuntimeAsync(
             "definition-1",
             "rev-2",
             "runtime-2",
+            cachedSnapshot.ToBindingSpec(),
             CancellationToken.None);
 
-        sharedDefinitionSnapshotPort.RequestCount.Should().Be(1);
         secondProvisioningPort.EnsureCalls.Should().ContainSingle();
         secondProvisioningPort.EnsureCalls[0].DefinitionSnapshot.Revision.Should().Be("rev-2");
     }
 
     [Fact]
-    public async Task UpsertScriptDefinitionAsync_ShouldRememberSnapshot_UsingLatestKey_WhenRevisionIsBlank()
+    public async Task SpawnScriptRuntimeAsync_ShouldUseProvidedSnapshot_WhenRevisionIsBlank()
     {
         var provisioningPort = new RecordingRuntimeProvisioningPort();
         var definitionPort = new StaticDefinitionCommandPort(
-            new ScriptDefinitionUpsertResult(
+            new CoreScriptDefinitionUpsertResult(
                 "definition-1",
                 new ScriptDefinitionSnapshot(
                     "script-1",
@@ -337,6 +338,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             string.Empty,
             "runtime-1",
+            definitionPort.Result.Snapshot.ToBindingSpec(),
             CancellationToken.None);
 
         provisioningPort.EnsureCalls.Should().ContainSingle();
@@ -345,11 +347,11 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     [Fact]
-    public async Task UpsertScriptDefinitionAsync_ShouldNotRememberSnapshot_WhenDefinitionActorIdIsBlank()
+    public async Task SpawnScriptRuntimeAsync_ShouldUseProvidedProposalSnapshot_WhenDefinitionActorIdIsBlank()
     {
         var provisioningPort = new RecordingRuntimeProvisioningPort();
         var definitionPort = new StaticDefinitionCommandPort(
-            new ScriptDefinitionUpsertResult(
+            new CoreScriptDefinitionUpsertResult(
                 string.Empty,
                 new ScriptDefinitionSnapshot(
                     "script-1",
@@ -376,6 +378,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             "rev-1",
             "runtime-1",
+            definitionPort.Result.Snapshot.ToBindingSpec(),
             CancellationToken.None);
 
         runtimeActorId.Should().Be("runtime-1");
@@ -384,7 +387,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     [Fact]
-    public async Task ProposeScriptEvolutionAsync_ShouldNotRememberSnapshot_WhenDefinitionActorIdIsBlank()
+    public async Task SpawnScriptRuntimeAsync_ShouldUseProvidedSnapshot_WhenDefinitionActorIdIsBlank()
     {
         var provisioningPort = new RecordingRuntimeProvisioningPort();
         var proposalPort = new StaticProposalPort(new ScriptPromotionDecision(
@@ -422,6 +425,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             "definition-1",
             "rev-2",
             "runtime-1",
+            CreateDefinitionBindingSpec("rev-2"),
             CancellationToken.None);
 
         runtimeActorId.Should().Be("runtime-1");
@@ -460,18 +464,17 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     {
         var cases = new (string Name, Func<ScriptBehaviorRuntimeCapabilities> Create)[]
         {
-            ("publishAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", null!, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("sendToAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("publishToSelfAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, null!, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("scheduleSelfSignalAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("cancelCallbackAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), null!, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, null!, new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionSnapshotPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
-            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
+            ("publishAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", null!, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("sendToAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("publishToSelfAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, null!, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("scheduleSelfSignalAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, null!, static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("cancelCallbackAsync", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), null!, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
+            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilities("run-1", "corr-1", static (_, _, _) => Task.CompletedTask, static (_, _, _) => Task.CompletedTask, static (_, _) => Task.CompletedTask, static (callbackId, _, _, _) => Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory)), static (_, _) => Task.CompletedTask, new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
         };
 
         foreach (var testCase in cases)
@@ -483,7 +486,6 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
 
     private static ScriptBehaviorRuntimeCapabilities CreateCapabilities(
         IAICapability? aiCapability = null,
-        IScriptDefinitionSnapshotPort? definitionSnapshotPort = null,
         IScriptEvolutionProposalPort? proposalPort = null,
         IScriptDefinitionCommandPort? definitionCommandPort = null,
         IScriptRuntimeProvisioningPort? runtimeProvisioningPort = null,
@@ -505,13 +507,25 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
                 Task.FromResult(new RuntimeCallbackLease("runtime-1", callbackId, 1, RuntimeCallbackBackend.InMemory))),
             cancelCallbackAsync: cancelCallbackAsync ?? ((_, _) => Task.CompletedTask),
             aiCapability: aiCapability ?? new RecordingAICapability(),
-            definitionSnapshotPort: definitionSnapshotPort ?? new RecordingDefinitionSnapshotPort(),
             proposalPort: proposalPort ?? new RecordingProposalPort(),
             definitionCommandPort: definitionCommandPort ?? new RecordingDefinitionCommandPort(),
             runtimeProvisioningPort: runtimeProvisioningPort ?? new RecordingRuntimeProvisioningPort(),
             runtimeCommandPort: runtimeCommandPort ?? new RecordingRuntimeCommandPort(),
             catalogCommandPort: catalogCommandPort ?? new RecordingCatalogCommandPort());
     }
+
+    private static ScriptDefinitionBindingSpec CreateDefinitionBindingSpec(string revision) =>
+        new()
+        {
+            ScriptId = "script-1",
+            Revision = revision,
+            SourceHash = ScriptSources.UppercaseBehaviorHash,
+            ScriptPackage = ScriptPackageSpecExtensions.CreateSingleSource(ScriptSources.UppercaseBehavior),
+            StateTypeUrl = ScriptSources.UppercaseStateTypeUrl,
+            ReadModelTypeUrl = ScriptSources.UppercaseReadModelTypeUrl,
+            ReadModelSchemaVersion = "1",
+            ReadModelSchemaHash = "schema-hash",
+        };
 
     private sealed class RecordingAICapability : IAICapability
     {
@@ -718,7 +732,7 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             Upserts.Add((scriptId, scriptRevision, definitionActorId));
             var sourceHash = ScriptPackageModel.ComputePackageHash(scriptPackage);
             var actorId = definitionActorId ?? "definition-created";
-            return Task.FromResult(new ScriptDefinitionUpsertResult(
+            return Task.FromResult(new CoreScriptDefinitionUpsertResult(
                 actorId,
                 new ScriptDefinitionSnapshot(
                     scriptId,
@@ -733,9 +747,11 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
         }
     }
 
-    private sealed class StaticDefinitionCommandPort(ScriptDefinitionUpsertResult result) : IScriptDefinitionCommandPort
+    private sealed class StaticDefinitionCommandPort(CoreScriptDefinitionUpsertResult result) : IScriptDefinitionCommandPort
     {
-        public Task<ScriptDefinitionUpsertResult> UpsertDefinitionWithSnapshotAsync(
+        public CoreScriptDefinitionUpsertResult Result => result;
+
+        public Task<CoreScriptDefinitionUpsertResult> UpsertDefinitionWithSnapshotAsync(
             string scriptId,
             string scriptRevision,
             ScriptPackageSpec scriptPackage,

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptAgentLifecycleCapabilitiesTests.cs
@@ -434,6 +434,30 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
     }
 
     [Fact]
+    public void ScriptBehaviorRuntimeCapabilities_must_not_reintroduce_snapshot_side_read_or_cache()
+    {
+        var repoRoot = FindRepoRoot();
+        var path = Path.Combine(
+            repoRoot,
+            "src",
+            "Aevatar.Scripting.Application",
+            "Runtime",
+            "ScriptBehaviorRuntimeCapabilities.cs");
+        File.Exists(path).Should().BeTrue("source regression test needs the runtime capabilities source file: {0}", path);
+
+        var source = File.ReadAllText(path);
+        source.Should().NotContain(
+            "IScriptDefinitionSnapshotPort",
+            "deleted per iter113/cluster-2 - command directly carries typed ScriptDefinitionSnapshot");
+        source.Should().NotContain(
+            "ResolveDefinitionSnapshotAsync",
+            "side-read deleted; runtime trusts command-supplied snapshot");
+        source.Should().NotContain(
+            "IScriptDefinitionSnapshotFactory",
+            "factory injection deleted per Phase 9 r2 consensus");
+    }
+
+    [Fact]
     public async Task PromoteAndRollback_ShouldNormalizeBlankCatalogActorId()
     {
         var catalogCommandPort = new RecordingCatalogCommandPort();
@@ -512,6 +536,21 @@ public sealed class ScriptAgentLifecycleCapabilitiesTests
             runtimeProvisioningPort: runtimeProvisioningPort ?? new RecordingRuntimeProvisioningPort(),
             runtimeCommandPort: runtimeCommandPort ?? new RecordingRuntimeCommandPort(),
             catalogCommandPort: catalogCommandPort ?? new RecordingCatalogCommandPort());
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var marker = Path.Combine(dir.FullName, "aevatar.slnx");
+            if (File.Exists(marker))
+                return dir.FullName;
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Cannot locate repository root from test base directory.");
     }
 
     private static ScriptDefinitionBindingSpec CreateDefinitionBindingSpec(string revision) =>

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptBehaviorDispatcherTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptBehaviorDispatcherTests.cs
@@ -1091,9 +1091,9 @@ public sealed class ScriptBehaviorDispatcherTests
                 string.Empty,
                 string.Empty,
                 new ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeExecutionOrchestratorTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeExecutionOrchestratorTests.cs
@@ -142,9 +142,9 @@ public sealed class ScriptRuntimeExecutionOrchestratorTests
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentBranchCoverageTests.cs
@@ -584,9 +584,9 @@ public sealed class ScriptRuntimeGAgentBranchCoverageTests
         public Task CancelDurableCallbackAsync(RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision> ProposeScriptEvolutionAsync(Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new Aevatar.Scripting.Abstractions.Definitions.ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new Aevatar.Scripting.Abstractions.Definitions.ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptRuntimeGAgentReplayContractTests.cs
@@ -185,9 +185,9 @@ public class ScriptBehaviorGAgentReplayContractTests
         public Task CancelDurableCallbackAsync(Foundation.Abstractions.Runtime.Callbacks.RuntimeCallbackLease lease, CancellationToken ct) => Task.CompletedTask;
         public Task<ScriptPromotionDecision> ProposeScriptEvolutionAsync(ScriptEvolutionProposal proposal, CancellationToken ct) =>
             Task.FromResult(new ScriptPromotionDecision(false, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, new ScriptEvolutionValidationReport(false, [])));
-        public Task<string> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
-            Task.FromResult(definitionActorId ?? string.Empty);
-        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, CancellationToken ct) =>
+        public Task<ScriptDefinitionUpsertResult> UpsertScriptDefinitionAsync(string scriptId, string scriptRevision, string sourceText, string sourceHash, string? definitionActorId, CancellationToken ct) =>
+            Task.FromResult(new ScriptDefinitionUpsertResult(definitionActorId ?? string.Empty, new ScriptDefinitionBindingSpec { ScriptId = scriptId, Revision = scriptRevision, SourceHash = sourceHash }));
+        public Task<string> SpawnScriptRuntimeAsync(string definitionActorId, string scriptRevision, string? runtimeActorId, ScriptDefinitionBindingSpec definitionSnapshot, CancellationToken ct) =>
             Task.FromResult(runtimeActorId ?? string.Empty);
         public Task RunScriptInstanceAsync(string runtimeActorId, string runId, Any? inputPayload, string scriptRevision, string definitionActorId, string requestedEventType, CancellationToken ct) =>
             Task.CompletedTask;

--- a/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
+++ b/test/Aevatar.Scripting.Core.Tests/Runtime/ScriptingBranchCoverageTests.cs
@@ -22,6 +22,7 @@ using Aevatar.Scripting.Projection.ReadModels;
 using FluentAssertions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
+using CoreScriptDefinitionUpsertResult = Aevatar.Scripting.Core.Ports.ScriptDefinitionUpsertResult;
 using SystemType = System.Type;
 
 namespace Aevatar.Scripting.Core.Tests.Runtime;
@@ -429,7 +430,6 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactoryTests
         var ai = new RecordingAICapability();
         var factory = new ScriptBehaviorRuntimeCapabilityFactory(
             ai,
-            new RecordingDefinitionSnapshotPort(),
             new RecordingProposalPort(),
             new RecordingDefinitionCommandPort(),
             new RecordingRuntimeProvisioningPort(),
@@ -460,13 +460,12 @@ public sealed class ScriptBehaviorRuntimeCapabilityFactoryTests
     {
         var cases = new (string Name, Func<ScriptBehaviorRuntimeCapabilityFactory> Create)[]
         {
-            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilityFactory(null!, new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionSnapshotPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
-            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
-            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingDefinitionSnapshotPort(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
+            ("aiCapability", () => new ScriptBehaviorRuntimeCapabilityFactory(null!, new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("proposalPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), null!, new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("definitionCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingProposalPort(), null!, new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeProvisioningPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), null!, new RecordingRuntimeCommandPort(), new RecordingCatalogCommandPort())),
+            ("runtimeCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), null!, new RecordingCatalogCommandPort())),
+            ("catalogCommandPort", () => new ScriptBehaviorRuntimeCapabilityFactory(new RecordingAICapability(), new RecordingProposalPort(), new RecordingDefinitionCommandPort(), new RecordingRuntimeProvisioningPort(), new RecordingRuntimeCommandPort(), null!)),
         };
 
         foreach (var testCase in cases)
@@ -1051,7 +1050,7 @@ internal sealed class RecordingProposalPort : IScriptEvolutionProposalPort
 
 internal sealed class RecordingDefinitionCommandPort : IScriptDefinitionCommandPort
 {
-    public Task<ScriptDefinitionUpsertResult> UpsertDefinitionWithSnapshotAsync(
+    public Task<CoreScriptDefinitionUpsertResult> UpsertDefinitionWithSnapshotAsync(
         string scriptId,
         string scriptRevision,
         ScriptPackageSpec scriptPackage,
@@ -1060,7 +1059,7 @@ internal sealed class RecordingDefinitionCommandPort : IScriptDefinitionCommandP
     {
         ct.ThrowIfCancellationRequested();
         var sourceHash = ScriptPackageModel.ComputePackageHash(scriptPackage);
-        return Task.FromResult(new ScriptDefinitionUpsertResult(
+        return Task.FromResult(new CoreScriptDefinitionUpsertResult(
             definitionActorId ?? "definition-created",
             new ScriptDefinitionSnapshot(
                 scriptId,


### PR DESCRIPTION
## 摘要

iter113 cluster-2 #1093(high)。

**Old**:`ScriptBehaviorRuntimeCapabilities` 通过 side-read scripting definition snapshot via runtime readmodel(cache + factory injection)。违反「事实源唯一」+「读写分离」。

**New**:Command 直接携 typed `ScriptDefinitionSnapshot`;**删** runtime readmodel side-read / cache / factory injection;script-facing API migrated as in-scope migration risk(public API break in scope per 3/3 共识)。

- 删 `ScriptBehaviorRuntimeCapabilities` readmodel snapshot lookup + cache
- 删 `IScriptDefinitionSnapshotFactory` factory injection 整套
- 新 `ScriptDefinitionUpsertResult` 替代 path
- caller 改 command-owned snapshot
- 测试同步(24 files)

**不开** 新 actor type / envelope kind / pipeline。

## 范围

24 files / +211 / -217(净 -6,deletion-positive)。

closes #1093

🤖 Auto-loop / codex-refactor-loop iter113

⟦AI:AUTO-LOOP⟧
