### PR TITLE
iter115 cluster-3 #1098: 收紧 WorkflowExecutionRuntimeContext + typed actor state

### DIFF
--- a/src/Aevatar.Foundation.Core/Properties/InternalVisibility.cs
+++ b/src/Aevatar.Foundation.Core/Properties/InternalVisibility.cs
@@ -10,3 +10,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Aevatar.Foundation.Runtime.Implementations.Orleans")]
 [assembly: InternalsVisibleTo("Aevatar.Foundation.Core.Tests")]
 [assembly: InternalsVisibleTo("Aevatar.Foundation.Runtime.Hosting.Tests")]
+[assembly: InternalsVisibleTo("Aevatar.Integration.Tests")]

--- a/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
+++ b/src/workflow/Aevatar.Workflow.Abstractions/workflow_execution_messages.proto
@@ -29,7 +29,31 @@ message WorkflowRunExecutionStartedEvent
   string input = 3;
   string definition_actor_id = 4;
   string scope_id = 5;
+  WorkflowRunExecutionContextDelta execution_context_delta = 6;
 }
+message WorkflowRunExecutionContextDelta
+{
+  WorkflowRunLlmExecutionContextDelta llm = 1;
+  WorkflowRunConnectorExecutionContextDelta connector = 2;
+  bool clear_llm = 3;
+  bool clear_connector = 4;
+}
+message WorkflowRunLlmExecutionContextDelta
+{
+  string nyxid_access_token = 1;
+  string model_override = 2;
+  string nyxid_route_preference = 3;
+}
+message WorkflowRunConnectorExecutionContextDelta
+{
+  string http_authorization = 1;
+}
+message WorkflowRunExecutionContextUpdatedEvent
+{
+  string run_id = 1;
+  WorkflowRunExecutionContextDelta execution_context_delta = 2;
+}
+message WorkflowRunExecutionContextClearedEvent { string run_id = 1; }
 message WorkflowCommandObservedEvent { string command_id = 1; }
 message WorkflowExecutionStateUpsertedEvent
 {

--- a/src/workflow/Aevatar.Workflow.Core/Execution/ConnectorAuthorizationRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/ConnectorAuthorizationRuntimeContextAccess.cs
@@ -15,30 +15,49 @@ internal static class ConnectorAuthorizationRuntimeContextAccess
     //                `http.authorization` string key.
     //   New principle: authorization writes update the typed connector section
     //                  of WorkflowExecutionRuntimeContext.
-    public static void SetAuthorization(
+    public static Task SetAuthorizationAsync(
         IWorkflowExecutionStateHost stateHost,
-        string? authorization)
+        string? authorization,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
         if (string.IsNullOrWhiteSpace(authorization))
         {
-            stateHost.ExecutionContextState.Connector = null;
-            return;
+            return stateHost.UpdateExecutionContextAsync(
+                new WorkflowRunExecutionContextDelta
+                {
+                    ClearConnector = true,
+                },
+                ct);
         }
 
-        WorkflowRunExecutionContextStateAccess
-            .EnsureConnector(stateHost.ExecutionContextState)
-            .HttpAuthorization = authorization.Trim();
+        return stateHost.UpdateExecutionContextAsync(
+            new WorkflowRunExecutionContextDelta
+            {
+                ClearConnector = true,
+                Connector = new WorkflowRunConnectorExecutionContextDelta
+                {
+                    HttpAuthorization = authorization.Trim(),
+                },
+            },
+            ct);
     }
 
     // Refactor (iter16/cluster-031):
     //   Old pattern: clearing authorization removed a value from the generic
     //                execution item bag by string key.
     //   New principle: clearing authorization nulls the typed connector field.
-    public static void RemoveAuthorization(IWorkflowExecutionStateHost stateHost)
+    public static Task RemoveAuthorizationAsync(
+        IWorkflowExecutionStateHost stateHost,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.ExecutionContextState.Connector = null;
+        return stateHost.UpdateExecutionContextAsync(
+            new WorkflowRunExecutionContextDelta
+            {
+                ClearConnector = true,
+            },
+            ct);
     }
 
     // Refactor (iter16/cluster-031):

--- a/src/workflow/Aevatar.Workflow.Core/Execution/ConnectorAuthorizationRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/ConnectorAuthorizationRuntimeContextAccess.cs
@@ -20,8 +20,15 @@ internal static class ConnectorAuthorizationRuntimeContextAccess
         string? authorization)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.RuntimeContext.Connector.Authorization =
-            string.IsNullOrWhiteSpace(authorization) ? null : authorization.Trim();
+        if (string.IsNullOrWhiteSpace(authorization))
+        {
+            stateHost.ExecutionContextState.Connector = null;
+            return;
+        }
+
+        WorkflowRunExecutionContextStateAccess
+            .EnsureConnector(stateHost.ExecutionContextState)
+            .HttpAuthorization = authorization.Trim();
     }
 
     // Refactor (iter16/cluster-031):
@@ -31,7 +38,7 @@ internal static class ConnectorAuthorizationRuntimeContextAccess
     public static void RemoveAuthorization(IWorkflowExecutionStateHost stateHost)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.RuntimeContext.Connector.Authorization = null;
+        stateHost.ExecutionContextState.Connector = null;
     }
 
     // Refactor (iter16/cluster-031):
@@ -45,14 +52,6 @@ internal static class ConnectorAuthorizationRuntimeContextAccess
     {
         ArgumentNullException.ThrowIfNull(ctx);
 
-        if (ctx is IWorkflowExecutionRuntimeContextAccessor runtimeAccessor &&
-            !string.IsNullOrWhiteSpace(runtimeAccessor.RuntimeContext.Connector.Authorization))
-        {
-            authorization = runtimeAccessor.RuntimeContext.Connector.Authorization.Trim();
-            return true;
-        }
-
-        authorization = string.Empty;
-        return false;
+        return WorkflowRunExecutionContextStateAccess.TryGetConnectorAuthorization(ctx, out authorization);
     }
 }

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -2,16 +2,18 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aevatar.Workflow.Core.Execution;
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: WorkflowRunGAgent kept Dictionary<string, object?> _executionItems
-//                bag for request metadata, LLM overrides, authorization, secure values
-//   New principle: typed non-durable actor-owned WorkflowExecutionRuntimeContext;
-//                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
+// Refactor (iter115/cluster-3):
+//   Old pattern: WorkflowRunGAgent exposed only a process-local runtime context,
+//                so durable control/security facts could not survive replay.
+//   New principle: execution facades keep their names but read/write typed
+//                  WorkflowRunState execution context owned by the actor.
 internal interface IWorkflowExecutionStateHost
 {
     string RunId { get; }
 
     WorkflowExecutionRuntimeContext RuntimeContext { get; }
+
+    WorkflowRunExecutionContextState ExecutionContextState { get; }
 
     Any? GetExecutionState(string scopeKey);
 
@@ -25,4 +27,9 @@ internal interface IWorkflowExecutionStateHost
     Task ClearExecutionStateAsync(
         string scopeKey,
         CancellationToken ct = default);
+}
+
+internal interface IWorkflowExecutionStateHostAccessor
+{
+    IWorkflowExecutionStateHost StateHost { get; }
 }

--- a/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/IWorkflowExecutionStateHost.cs
@@ -13,7 +13,13 @@ internal interface IWorkflowExecutionStateHost
 
     WorkflowExecutionRuntimeContext RuntimeContext { get; }
 
-    WorkflowRunExecutionContextState ExecutionContextState { get; }
+    WorkflowRunExecutionContextState ExecutionContextSnapshot { get; }
+
+    Task UpdateExecutionContextAsync(
+        WorkflowRunExecutionContextDelta delta,
+        CancellationToken ct = default);
+
+    Task ClearExecutionContextAsync(CancellationToken ct = default);
 
     Any? GetExecutionState(string scopeKey);
 

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionContextAdapter.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionContextAdapter.cs
@@ -6,12 +6,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Workflow.Core.Execution;
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: WorkflowRunGAgent kept Dictionary<string, object?> _executionItems
-//                bag for request metadata, LLM overrides, authorization, secure values
-//   New principle: typed non-durable actor-owned WorkflowExecutionRuntimeContext;
-//                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
-internal sealed class WorkflowExecutionContextAdapter : IWorkflowExecutionContext, IWorkflowExecutionRuntimeContextAccessor
+// Refactor (iter115/cluster-3):
+//   Old pattern: module contexts could only access process-local runtime context facts.
+//   New principle: module contexts expose the actor state host so facades can resolve
+//                  typed execution context state without query/replay side reads.
+internal sealed class WorkflowExecutionContextAdapter :
+    IWorkflowExecutionContext,
+    IWorkflowExecutionRuntimeContextAccessor,
+    IWorkflowExecutionStateHostAccessor
 {
     private readonly IEventHandlerContext _inner;
     private readonly IWorkflowExecutionStateHost _stateHost;
@@ -31,6 +33,8 @@ internal sealed class WorkflowExecutionContextAdapter : IWorkflowExecutionContex
     public string RunId => _stateHost.RunId;
 
     public WorkflowExecutionRuntimeContext RuntimeContext => _stateHost.RuntimeContext;
+
+    public IWorkflowExecutionStateHost StateHost => _stateHost;
 
     public IServiceProvider Services => _inner.Services;
 

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowExecutionRuntimeContext.cs
@@ -1,7 +1,5 @@
 using Aevatar.AI.Abstractions.LLMProviders;
-using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions.Connectors;
-using Aevatar.Workflow.Core.Primitives;
 
 namespace Aevatar.Workflow.Core.Execution;
 
@@ -15,33 +13,19 @@ internal interface IWorkflowExecutionRuntimeContextAccessor
     WorkflowExecutionRuntimeContext RuntimeContext { get; }
 }
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: WorkflowRunGAgent kept Dictionary<string, object?> _executionItems
-//                bag for request metadata, LLM overrides, authorization, secure values
-//   New principle: typed non-durable actor-owned WorkflowExecutionRuntimeContext;
-//                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
+// Refactor (iter115/cluster-3):
+//   Old pattern: durable LLM, connector authorization, and secure captured values
+//                were held as authority inside per-process runtime context fields.
+//   New principle: runtime context only carries same-turn passthrough metadata; durable
+//                  control and security facts live in typed actor state.
 internal sealed class WorkflowExecutionRuntimeContext
 {
-    public WorkflowLlmRuntimeOverrides LlmOverrides { get; } = new();
-
-    public WorkflowConnectorRuntimeContext Connector { get; } = new();
-
     public WorkflowRequestPassthroughMetadata RequestPassthroughMetadata { get; } = new();
 
-    public CapturedSecureInputs CapturedSecureInputs { get; } = new();
-
-    public void Clear()
-    {
-        LlmOverrides.Clear();
-        Connector.Clear();
-        RequestPassthroughMetadata.Clear();
-        CapturedSecureInputs.Clear();
-    }
+    public void Clear() => RequestPassthroughMetadata.Clear();
 
     public void ApplyRequestMetadata(IReadOnlyDictionary<string, string>? metadata)
     {
-        LlmOverrides.Clear();
-        Connector.Clear();
         RequestPassthroughMetadata.Clear();
 
         if (metadata == null || metadata.Count == 0)
@@ -54,77 +38,29 @@ internal sealed class WorkflowExecutionRuntimeContext
             if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(value))
                 continue;
 
-            // Refactor (iter56/cluster-917-workflow-llm-control-metadata): old=Headers/Metadata bag for control fields, new=typed ChatRequestEvent.Telegram
-
-            if (string.Equals(key, ConnectorRequest.HttpAuthorizationMetadataKey, StringComparison.Ordinal))
-            {
-                Connector.Authorization = value;
-                continue;
-            }
-
             RequestPassthroughMetadata.Set(key, value);
         }
-    }
-
-    public void ApplyToolContext(AgentToolExecutionContext? context)
-    {
-        LlmOverrides.Clear();
-
-        if (context == null)
-            return;
-
-        LlmOverrides.NyxIdAccessToken = Normalize(context.Credentials.NyxIdAccessToken);
-        LlmOverrides.ModelOverride = Normalize(context.Routing.ModelOverride);
-        LlmOverrides.NyxIdRoutePreference = Normalize(context.Routing.NyxIdRoutePreference);
     }
 
     private static string Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
 }
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: LLM request overrides were stored as string-key entries in the
-//                generic workflow execution item bag.
-//   New principle: LLM override values live in a typed runtime section owned by
-//                  the run actor.
-internal sealed class WorkflowLlmRuntimeOverrides
-{
-    public string? NyxIdAccessToken { get; set; }
-
-    public string? ModelOverride { get; set; }
-
-    public string? NyxIdRoutePreference { get; set; }
-
-    public void Clear()
-    {
-        NyxIdAccessToken = null;
-        ModelOverride = null;
-        NyxIdRoutePreference = null;
-    }
-}
-
-// Refactor (iter16/cluster-031):
-//   Old pattern: connector authorization used the generic item bag key
-//                `http.authorization`.
-//   New principle: connector runtime inputs live in a typed connector section
-//                  owned by the run actor.
-internal sealed class WorkflowConnectorRuntimeContext
-{
-    public string? Authorization { get; set; }
-
-    public void Clear()
-    {
-        Authorization = null;
-    }
-}
-
-// Refactor (iter16/cluster-031):
-//   Old pattern: request metadata was copied wholesale into generic runtime
-//                items, mixing control values with passthrough values.
-//   New principle: only filtered passthrough metadata remains in this typed
-//                  runtime section after control values are promoted.
+// Refactor (iter115/cluster-3):
+//   Old pattern: request metadata was copied wholesale into runtime context,
+//                allowing control/security fields to flow back as passthrough.
+//   New principle: runtime passthrough is same-turn only and rejects known
+//                  durable control/security keys.
 internal sealed class WorkflowRequestPassthroughMetadata
 {
+    private static readonly HashSet<string> BlockedKeys =
+    [
+        ConnectorRequest.HttpAuthorizationMetadataKey,
+        LLMRequestMetadataKeys.NyxIdAccessToken,
+        LLMRequestMetadataKeys.ModelOverride,
+        LLMRequestMetadataKeys.NyxIdRoutePreference,
+    ];
+
     private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
 
     public IReadOnlyDictionary<string, string> Values => _values;
@@ -133,89 +69,17 @@ internal sealed class WorkflowRequestPassthroughMetadata
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
         ArgumentException.ThrowIfNullOrWhiteSpace(value);
-        _values[key.Trim()] = value.Trim();
-    }
 
-    public void Clear() => _values.Clear();
-}
-
-// Refactor (iter16/cluster-031):
-//   Old pattern: captured secure input values were held in the generic item bag
-//                under string-composed keys.
-//   New principle: captured secure values live in a typed non-durable runtime
-//                  section owned by the run actor.
-internal sealed class CapturedSecureInputs
-{
-    private readonly Dictionary<CapturedSecureInputKey, string> _values = new();
-
-    public IReadOnlyDictionary<CapturedSecureInputKey, string> Values => _values;
-
-    public void Set(string? runId, string? variable, string? value)
-    {
-        if (!TryCreateKey(runId, variable, out var key))
+        var normalizedKey = key.Trim();
+        if (IsBlockedKey(normalizedKey))
             return;
 
-        _values[key] = value ?? string.Empty;
-    }
-
-    public bool TryGet(string? runId, string? variable, out string value)
-    {
-        if (TryCreateKey(runId, variable, out var key) &&
-            _values.TryGetValue(key, out value!))
-        {
-            return true;
-        }
-
-        value = string.Empty;
-        return false;
-    }
-
-    public bool Remove(string? runId, string? variable)
-    {
-        if (!TryCreateKey(runId, variable, out var key))
-            return false;
-
-        return _values.Remove(key);
-    }
-
-    public void RemoveRun(string? runId)
-    {
-        var normalizedRunId = WorkflowRunIdNormalizer.Normalize(runId);
-        if (string.IsNullOrWhiteSpace(normalizedRunId))
-            return;
-
-        foreach (var key in _values.Keys.Where(x => x.RunId == normalizedRunId).ToList())
-        {
-            _values.Remove(key);
-        }
+        _values[normalizedKey] = value.Trim();
     }
 
     public void Clear() => _values.Clear();
 
-    private static bool TryCreateKey(
-        string? runId,
-        string? variable,
-        out CapturedSecureInputKey key)
-    {
-        var normalizedRunId = WorkflowRunIdNormalizer.Normalize(runId);
-        var normalizedVariable = string.IsNullOrWhiteSpace(variable) ? string.Empty : variable.Trim();
-        if (string.IsNullOrWhiteSpace(normalizedRunId) ||
-            string.IsNullOrWhiteSpace(normalizedVariable))
-        {
-            key = default;
-            return false;
-        }
-
-        key = new CapturedSecureInputKey(normalizedRunId, normalizedVariable);
-        return true;
-    }
+    public static bool IsBlockedKey(string? key) =>
+        !string.IsNullOrWhiteSpace(key) &&
+        BlockedKeys.Contains(key.Trim());
 }
-
-// Refactor (iter16/cluster-031):
-//   Old pattern: captured secure input values used string-composed keys such as
-//                "{runId}::{variable}" inside the generic execution item bag.
-//   New principle: secure input capture uses a typed key in the actor-owned
-//                  non-durable runtime context.
-internal readonly record struct CapturedSecureInputKey(
-    string RunId,
-    string Variable);

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
@@ -20,6 +20,7 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
         IReadOnlyDictionary<string, string>? metadata)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
+        WorkflowRunExecutionContextStateAccess.ApplyRequestMetadata(stateHost, metadata);
         stateHost.RuntimeContext.ApplyRequestMetadata(metadata);
     }
 
@@ -28,7 +29,7 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
         AgentToolExecutionContext? toolContext)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.RuntimeContext.ApplyToolContext(toolContext);
+        WorkflowRunExecutionContextStateAccess.ApplyToolContext(stateHost, toolContext);
     }
 
     // Refactor (iter16/cluster-031):
@@ -39,6 +40,7 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
     public static void RemoveRequestMetadata(IWorkflowExecutionStateHost stateHost)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
+        WorkflowRunExecutionContextStateAccess.Clear(stateHost);
         stateHost.RuntimeContext.ApplyRequestMetadata(null);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRequestMetadataRuntimeContextAccess.cs
@@ -15,21 +15,23 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
     //                under `workflow.request.metadata` in the item bag.
     //   New principle: request metadata writes promote known control keys into
     //                  typed runtime sections and keep only passthrough values.
-    public static void SetRequestMetadata(
+    public static async Task SetRequestMetadataAsync(
         IWorkflowExecutionStateHost stateHost,
-        IReadOnlyDictionary<string, string>? metadata)
+        IReadOnlyDictionary<string, string>? metadata,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        WorkflowRunExecutionContextStateAccess.ApplyRequestMetadata(stateHost, metadata);
+        await WorkflowRunExecutionContextStateAccess.ApplyRequestMetadataAsync(stateHost, metadata, ct);
         stateHost.RuntimeContext.ApplyRequestMetadata(metadata);
     }
 
-    public static void SetToolContext(
+    public static Task SetToolContextAsync(
         IWorkflowExecutionStateHost stateHost,
-        AgentToolExecutionContext? toolContext)
+        AgentToolExecutionContext? toolContext,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        WorkflowRunExecutionContextStateAccess.ApplyToolContext(stateHost, toolContext);
+        return WorkflowRunExecutionContextStateAccess.ApplyToolContextAsync(stateHost, toolContext, ct);
     }
 
     // Refactor (iter16/cluster-031):
@@ -37,10 +39,12 @@ internal static class WorkflowRequestMetadataRuntimeContextAccess
     //                `workflow.request.metadata` item.
     //   New principle: request metadata cleanup clears the typed LLM,
     //                  connector, and passthrough runtime sections.
-    public static void RemoveRequestMetadata(IWorkflowExecutionStateHost stateHost)
+    public static async Task RemoveRequestMetadataAsync(
+        IWorkflowExecutionStateHost stateHost,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        WorkflowRunExecutionContextStateAccess.Clear(stateHost);
+        await WorkflowRunExecutionContextStateAccess.ClearAsync(stateHost, ct);
         stateHost.RuntimeContext.ApplyRequestMetadata(null);
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
@@ -32,6 +32,20 @@ internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePu
             }
         }
 
+        if (context.Published.StateEvent?.EventData?.Is(WorkflowRunExecutionStartedEvent.Descriptor) == true)
+        {
+            var startedEvent = context.Published.StateEvent.EventData.Unpack<WorkflowRunExecutionStartedEvent>();
+            RedactExecutionContextDelta(startedEvent.ExecutionContextDelta);
+            context.Published.StateEvent.EventData = Any.Pack(startedEvent);
+        }
+
+        if (context.Published.StateEvent?.EventData?.Is(WorkflowRunExecutionContextUpdatedEvent.Descriptor) == true)
+        {
+            var updateEvent = context.Published.StateEvent.EventData.Unpack<WorkflowRunExecutionContextUpdatedEvent>();
+            RedactExecutionContextDelta(updateEvent.ExecutionContextDelta);
+            context.Published.StateEvent.EventData = Any.Pack(updateEvent);
+        }
+
         var state = context.Published.StateRoot.Unpack<WorkflowRunState>() ?? new WorkflowRunState();
         state.ExecutionContext = WorkflowRunExecutionContextStateAccess.RedactedClone(state.ExecutionContext);
         RedactSecureInputExecutionState(state);
@@ -58,5 +72,16 @@ internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePu
         foreach (var captured in redacted.Captured.Values)
             captured.Value = string.Empty;
         return redacted;
+    }
+
+    private static void RedactExecutionContextDelta(WorkflowRunExecutionContextDelta? delta)
+    {
+        if (delta == null)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(delta.Llm?.NyxidAccessToken))
+            delta.Llm.NyxidAccessToken = string.Empty;
+        if (!string.IsNullOrWhiteSpace(delta.Connector?.HttpAuthorization))
+            delta.Connector.HttpAuthorization = string.Empty;
     }
 }

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunCommittedStateRedactionHook.cs
@@ -1,0 +1,62 @@
+using Aevatar.Foundation.Core.EventSourcing;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aevatar.Workflow.Core.Execution;
+
+// Refactor (iter115/cluster-3):
+//   Old pattern: raw security/control state could become observable through
+//                committed WorkflowRunState state_root publication.
+//   New principle: actor state remains typed, while the observation envelope
+//                  gets a redacted clone before projection/AGUI fanout.
+internal sealed class WorkflowRunCommittedStateRedactionHook : ICommittedStatePublicationHook
+{
+    public Task BeforePublishAsync(CommittedStatePublicationContext context, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ct.ThrowIfCancellationRequested();
+
+        if (context.ActorType != typeof(WorkflowRunGAgent) ||
+            context.Published.StateRoot?.Is(WorkflowRunState.Descriptor) != true)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (context.Published.StateEvent?.EventData?.Is(WorkflowExecutionStateUpsertedEvent.Descriptor) == true)
+        {
+            var stateEvent = context.Published.StateEvent.EventData.Unpack<WorkflowExecutionStateUpsertedEvent>();
+            if (stateEvent.State?.Is(SecureInputModuleState.Descriptor) == true)
+            {
+                var secureState = stateEvent.State.Unpack<SecureInputModuleState>() ?? new SecureInputModuleState();
+                stateEvent.State = Any.Pack(RedactSecureInputState(secureState));
+                context.Published.StateEvent.EventData = Any.Pack(stateEvent);
+            }
+        }
+
+        var state = context.Published.StateRoot.Unpack<WorkflowRunState>() ?? new WorkflowRunState();
+        state.ExecutionContext = WorkflowRunExecutionContextStateAccess.RedactedClone(state.ExecutionContext);
+        RedactSecureInputExecutionState(state);
+
+        context.Published.StateRoot = Any.Pack(state);
+        return Task.CompletedTask;
+    }
+
+    private static void RedactSecureInputExecutionState(WorkflowRunState state)
+    {
+        foreach (var pair in state.ExecutionStates.ToList())
+        {
+            if (!pair.Value.Is(SecureInputModuleState.Descriptor))
+                continue;
+
+            var secureState = pair.Value.Unpack<SecureInputModuleState>() ?? new SecureInputModuleState();
+            state.ExecutionStates[pair.Key] = Any.Pack(RedactSecureInputState(secureState));
+        }
+    }
+
+    private static SecureInputModuleState RedactSecureInputState(SecureInputModuleState source)
+    {
+        var redacted = source.Clone();
+        foreach (var captured in redacted.Captured.Values)
+            captured.Value = string.Empty;
+        return redacted;
+    }
+}

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -12,36 +12,47 @@ internal static class WorkflowRunExecutionContextStateAccess
     public static WorkflowRunExecutionContextState Get(IWorkflowExecutionStateHost stateHost)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        return stateHost.ExecutionContextState;
+        return stateHost.ExecutionContextSnapshot;
     }
 
     public static WorkflowRunExecutionContextState Get(IWorkflowExecutionContext ctx)
     {
         ArgumentNullException.ThrowIfNull(ctx);
         if (ctx is IWorkflowExecutionStateHost stateHost)
-            return stateHost.ExecutionContextState;
+            return stateHost.ExecutionContextSnapshot;
         if (ctx is IWorkflowExecutionStateHostAccessor stateHostAccessor)
-            return stateHostAccessor.StateHost.ExecutionContextState;
+            return stateHostAccessor.StateHost.ExecutionContextSnapshot;
 
         return new WorkflowRunExecutionContextState();
     }
 
-    public static void Clear(IWorkflowExecutionStateHost stateHost)
+    public static Task ClearAsync(
+        IWorkflowExecutionStateHost stateHost,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.ExecutionContextState.Llm = null;
-        stateHost.ExecutionContextState.Connector = null;
+        return stateHost.ClearExecutionContextAsync(ct);
     }
 
-    public static void ApplyRequestMetadata(
+    public static Task ApplyRequestMetadataAsync(
         IWorkflowExecutionStateHost stateHost,
-        IReadOnlyDictionary<string, string>? metadata)
+        IReadOnlyDictionary<string, string>? metadata,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.ExecutionContextState.Connector = null;
+        var delta = BuildRequestMetadataDelta(metadata);
+        return stateHost.UpdateExecutionContextAsync(delta, ct);
+    }
 
+    public static WorkflowRunExecutionContextDelta BuildRequestMetadataDelta(
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        var delta = new WorkflowRunExecutionContextDelta
+        {
+            ClearConnector = true,
+        };
         if (metadata == null || metadata.Count == 0)
-            return;
+            return delta;
 
         foreach (var pair in metadata)
         {
@@ -52,33 +63,52 @@ internal static class WorkflowRunExecutionContextStateAccess
 
             if (string.Equals(key, ConnectorRequest.HttpAuthorizationMetadataKey, StringComparison.Ordinal))
             {
-                EnsureConnector(stateHost.ExecutionContextState).HttpAuthorization = value;
+                delta.Connector = new WorkflowRunConnectorExecutionContextDelta
+                {
+                    HttpAuthorization = value,
+                };
                 continue;
             }
         }
+
+        return delta;
     }
 
-    public static void ApplyToolContext(
+    public static Task ApplyToolContextAsync(
         IWorkflowExecutionStateHost stateHost,
-        AgentToolExecutionContext? toolContext)
+        AgentToolExecutionContext? toolContext,
+        CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(stateHost);
-        stateHost.ExecutionContextState.Llm = null;
+        var delta = BuildToolContextDelta(toolContext);
+        return stateHost.UpdateExecutionContextAsync(delta, ct);
+    }
 
+    public static WorkflowRunExecutionContextDelta BuildToolContextDelta(AgentToolExecutionContext? toolContext)
+    {
+        var delta = new WorkflowRunExecutionContextDelta
+        {
+            ClearLlm = true,
+        };
         if (toolContext == null)
-            return;
+            return delta;
 
-        var llm = EnsureLlm(stateHost.ExecutionContextState);
-        llm.NyxidAccessToken = Normalize(toolContext.Credentials.NyxIdAccessToken);
-        llm.ModelOverride = Normalize(toolContext.Routing.ModelOverride);
-        llm.NyxidRoutePreference = Normalize(toolContext.Routing.NyxIdRoutePreference);
+        var llm = new WorkflowRunLlmExecutionContextDelta
+        {
+            NyxidAccessToken = Normalize(toolContext.Credentials.NyxIdAccessToken),
+            ModelOverride = Normalize(toolContext.Routing.ModelOverride),
+            NyxidRoutePreference = Normalize(toolContext.Routing.NyxIdRoutePreference),
+        };
 
         if (string.IsNullOrWhiteSpace(llm.NyxidAccessToken) &&
             string.IsNullOrWhiteSpace(llm.ModelOverride) &&
             string.IsNullOrWhiteSpace(llm.NyxidRoutePreference))
         {
-            stateHost.ExecutionContextState.Llm = null;
+            return delta;
         }
+
+        delta.Llm = llm;
+        return delta;
     }
 
     public static bool TryGetConnectorAuthorization(
@@ -104,18 +134,6 @@ internal static class WorkflowRunExecutionContextStateAccess
         return !string.IsNullOrWhiteSpace(llm.NyxidAccessToken) ||
                !string.IsNullOrWhiteSpace(llm.ModelOverride) ||
                !string.IsNullOrWhiteSpace(llm.NyxidRoutePreference);
-    }
-
-    public static WorkflowLlmExecutionContextState EnsureLlm(WorkflowRunExecutionContextState state)
-    {
-        state.Llm ??= new WorkflowLlmExecutionContextState();
-        return state.Llm;
-    }
-
-    public static WorkflowConnectorExecutionContextState EnsureConnector(WorkflowRunExecutionContextState state)
-    {
-        state.Connector ??= new WorkflowConnectorExecutionContextState();
-        return state.Connector;
     }
 
     public static WorkflowRunExecutionContextState RedactedClone(WorkflowRunExecutionContextState? source)

--- a/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Execution/WorkflowRunExecutionContextStateAccess.cs
@@ -1,0 +1,133 @@
+using Aevatar.Workflow.Core.Primitives;
+
+namespace Aevatar.Workflow.Core.Execution;
+
+// Refactor (iter115/cluster-3):
+//   Old pattern: request-scoped LLM and connector control facts lived in
+//                WorkflowExecutionRuntimeContext and disappeared on replay.
+//   New principle: durable control/security facts are typed actor state under
+//                  WorkflowRunState.ExecutionContext.
+internal static class WorkflowRunExecutionContextStateAccess
+{
+    public static WorkflowRunExecutionContextState Get(IWorkflowExecutionStateHost stateHost)
+    {
+        ArgumentNullException.ThrowIfNull(stateHost);
+        return stateHost.ExecutionContextState;
+    }
+
+    public static WorkflowRunExecutionContextState Get(IWorkflowExecutionContext ctx)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        if (ctx is IWorkflowExecutionStateHost stateHost)
+            return stateHost.ExecutionContextState;
+        if (ctx is IWorkflowExecutionStateHostAccessor stateHostAccessor)
+            return stateHostAccessor.StateHost.ExecutionContextState;
+
+        return new WorkflowRunExecutionContextState();
+    }
+
+    public static void Clear(IWorkflowExecutionStateHost stateHost)
+    {
+        ArgumentNullException.ThrowIfNull(stateHost);
+        stateHost.ExecutionContextState.Llm = null;
+        stateHost.ExecutionContextState.Connector = null;
+    }
+
+    public static void ApplyRequestMetadata(
+        IWorkflowExecutionStateHost stateHost,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        ArgumentNullException.ThrowIfNull(stateHost);
+        stateHost.ExecutionContextState.Connector = null;
+
+        if (metadata == null || metadata.Count == 0)
+            return;
+
+        foreach (var pair in metadata)
+        {
+            var key = Normalize(pair.Key);
+            var value = Normalize(pair.Value);
+            if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(value))
+                continue;
+
+            if (string.Equals(key, ConnectorRequest.HttpAuthorizationMetadataKey, StringComparison.Ordinal))
+            {
+                EnsureConnector(stateHost.ExecutionContextState).HttpAuthorization = value;
+                continue;
+            }
+        }
+    }
+
+    public static void ApplyToolContext(
+        IWorkflowExecutionStateHost stateHost,
+        AgentToolExecutionContext? toolContext)
+    {
+        ArgumentNullException.ThrowIfNull(stateHost);
+        stateHost.ExecutionContextState.Llm = null;
+
+        if (toolContext == null)
+            return;
+
+        var llm = EnsureLlm(stateHost.ExecutionContextState);
+        llm.NyxidAccessToken = Normalize(toolContext.Credentials.NyxIdAccessToken);
+        llm.ModelOverride = Normalize(toolContext.Routing.ModelOverride);
+        llm.NyxidRoutePreference = Normalize(toolContext.Routing.NyxIdRoutePreference);
+
+        if (string.IsNullOrWhiteSpace(llm.NyxidAccessToken) &&
+            string.IsNullOrWhiteSpace(llm.ModelOverride) &&
+            string.IsNullOrWhiteSpace(llm.NyxidRoutePreference))
+        {
+            stateHost.ExecutionContextState.Llm = null;
+        }
+    }
+
+    public static bool TryGetConnectorAuthorization(
+        IWorkflowExecutionContext ctx,
+        out string authorization)
+    {
+        var connector = Get(ctx).Connector;
+        if (!string.IsNullOrWhiteSpace(connector?.HttpAuthorization))
+        {
+            authorization = connector.HttpAuthorization.Trim();
+            return true;
+        }
+
+        authorization = string.Empty;
+        return false;
+    }
+
+    public static bool TryGetLlm(
+        IWorkflowExecutionContext ctx,
+        out WorkflowLlmExecutionContextState llm)
+    {
+        llm = Get(ctx).Llm ?? new WorkflowLlmExecutionContextState();
+        return !string.IsNullOrWhiteSpace(llm.NyxidAccessToken) ||
+               !string.IsNullOrWhiteSpace(llm.ModelOverride) ||
+               !string.IsNullOrWhiteSpace(llm.NyxidRoutePreference);
+    }
+
+    public static WorkflowLlmExecutionContextState EnsureLlm(WorkflowRunExecutionContextState state)
+    {
+        state.Llm ??= new WorkflowLlmExecutionContextState();
+        return state.Llm;
+    }
+
+    public static WorkflowConnectorExecutionContextState EnsureConnector(WorkflowRunExecutionContextState state)
+    {
+        state.Connector ??= new WorkflowConnectorExecutionContextState();
+        return state.Connector;
+    }
+
+    public static WorkflowRunExecutionContextState RedactedClone(WorkflowRunExecutionContextState? source)
+    {
+        var clone = source?.Clone() ?? new WorkflowRunExecutionContextState();
+        if (!string.IsNullOrWhiteSpace(clone.Llm?.NyxidAccessToken))
+            clone.Llm.NyxidAccessToken = string.Empty;
+        if (!string.IsNullOrWhiteSpace(clone.Connector?.HttpAuthorization))
+            clone.Connector.HttpAuthorization = string.Empty;
+        return clone;
+    }
+
+    private static string Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim();
+}

--- a/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/ConnectorCallModule.cs
@@ -48,14 +48,22 @@ public sealed partial class ConnectorCallModule : IEventModule<IWorkflowExecutio
             var captured = envelope.Payload.Unpack<SecureValueCapturedEvent>();
             if (!string.IsNullOrWhiteSpace(captured.Variable) && !string.IsNullOrEmpty(captured.Value))
             {
-                SecureInputRuntimeContextAccess.SetCapturedValue(ctx, captured.RunId, captured.Variable, captured.Value);
+                await SecureInputRuntimeContextAccess.SetCapturedValueAsync(
+                    ctx,
+                    captured.RunId,
+                    captured.Variable,
+                    captured.Value,
+                    ct);
             }
             return;
         }
 
         if (envelope.Payload.Is(WorkflowCompletedEvent.Descriptor))
         {
-            SecureInputRuntimeContextAccess.RemoveRun(ctx, envelope.Payload.Unpack<WorkflowCompletedEvent>().RunId);
+            await SecureInputRuntimeContextAccess.RemoveRunAsync(
+                ctx,
+                envelope.Payload.Unpack<WorkflowCompletedEvent>().RunId,
+                ct);
             return;
         }
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/LLMCallModule.cs
@@ -333,32 +333,22 @@ public sealed class LLMCallModule : IEventModule<IWorkflowExecutionContext>
         return true;
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: WorkflowRunGAgent kept Dictionary<string, object?> _executionItems
-    //                bag for request metadata, LLM overrides, authorization, secure values
-    //   New principle: typed non-durable actor-owned WorkflowExecutionRuntimeContext;
-    //                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
+    // Refactor (iter115/cluster-3):
+    //   Old pattern: LLM control values were recovered from process-local runtime context.
+    //   New principle: LLM control values are typed actor state and survive actor replay.
     private static void ApplyTypedLlmControl(
         IWorkflowExecutionContext ctx,
         ChatRequestEvent chatRequest)
     {
-        if (ctx is not IWorkflowExecutionRuntimeContextAccessor runtimeAccessor)
+        if (!WorkflowRunExecutionContextStateAccess.TryGetLlm(ctx, out var llm))
             return;
-
-        var overrides = runtimeAccessor.RuntimeContext.LlmOverrides;
-        if (string.IsNullOrWhiteSpace(overrides.NyxIdAccessToken) &&
-            string.IsNullOrWhiteSpace(overrides.ModelOverride) &&
-            string.IsNullOrWhiteSpace(overrides.NyxIdRoutePreference))
-        {
-            return;
-        }
 
         chatRequest.LlmControl = new LLMControlContext(
-            NyxIdAccessToken: Normalize(overrides.NyxIdAccessToken),
+            NyxIdAccessToken: Normalize(llm.NyxidAccessToken),
             NyxIdOrgToken: null,
             SenderNyxIdAccessToken: null,
-            ModelOverride: Normalize(overrides.ModelOverride),
-            NyxIdRoutePreference: Normalize(overrides.NyxIdRoutePreference),
+            ModelOverride: Normalize(llm.ModelOverride),
+            NyxIdRoutePreference: Normalize(llm.NyxidRoutePreference),
             MaxToolRoundsOverride: null,
             UserMemoryPrompt: null).ToPayload();
     }

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputModule.cs
@@ -9,7 +9,7 @@ namespace Aevatar.Workflow.Core.Modules;
 /// <summary>
 /// Secure human input module. Suspends the workflow, captures a secret value,
 /// and only emits a redacted completion output while keeping the raw value in
-/// the actor-owned typed workflow runtime context instead of durable event payload/state.
+/// typed actor state instead of observable event payload.
 /// </summary>
 public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
 {
@@ -37,7 +37,6 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
             var workflowCompleted = payload.Unpack<WorkflowCompletedEvent>();
             var state = SecureInputStateAccess.Load(ctx);
             SecureInputStateAccess.RemoveRun(state, workflowCompleted.RunId);
-            SecureInputRuntimeContextAccess.RemoveRun(ctx, workflowCompleted.RunId);
             await SecureInputStateAccess.SaveAsync(state, ctx, ct);
             return;
         }
@@ -82,7 +81,7 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
                 MaskedOutput = requestMaskedOutput,
             };
             await SecureInputStateAccess.SaveAsync(state, ctx, ct);
-            SecureInputRuntimeContextAccess.RemoveCapturedValue(ctx, runId, requestVariableName);
+            await SecureInputRuntimeContextAccess.RemoveCapturedValueAsync(ctx, runId, requestVariableName, ct);
 
             ctx.Logger.LogInformation(
                 "SecureInput: run={RunId} step={StepId} suspended, variable={Variable}, timeout={Timeout}s",
@@ -126,7 +125,7 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
         {
             stateForResume.Pending.Remove(pendingKey);
             await SecureInputStateAccess.SaveAsync(stateForResume, ctx, ct);
-            SecureInputRuntimeContextAccess.RemoveCapturedValue(ctx, pending.RunId, variableName);
+            await SecureInputRuntimeContextAccess.RemoveCapturedValueAsync(ctx, pending.RunId, variableName, ct);
 
             ctx.Logger.LogWarning(
                 "SecureInput: run={RunId} step={StepId} timed out or cancelled",
@@ -148,7 +147,7 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
         {
             stateForResume.Pending.Remove(pendingKey);
             await SecureInputStateAccess.SaveAsync(stateForResume, ctx, ct);
-            SecureInputRuntimeContextAccess.RemoveCapturedValue(ctx, pending.RunId, variableName);
+            await SecureInputRuntimeContextAccess.RemoveCapturedValueAsync(ctx, pending.RunId, variableName, ct);
 
             ctx.Logger.LogWarning(
                 "SecureInput: run={RunId} step={StepId} rejected empty secure value",
@@ -172,7 +171,7 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
             userInput.Length);
 
         stateForResume.Pending.Remove(pendingKey);
-        SecureInputRuntimeContextAccess.SetCapturedValue(ctx, pending.RunId, variableName, userInput);
+        SecureInputStateAccess.SetCaptured(stateForResume, pending.RunId, variableName, userInput);
         await SecureInputStateAccess.SaveAsync(stateForResume, ctx, ct);
 
         await ctx.PublishAsync(new SecureValueCapturedEvent
@@ -180,7 +179,7 @@ public sealed class SecureInputModule : IEventModule<IWorkflowExecutionContext>
             RunId = pending.RunId,
             StepId = pending.StepId,
             Variable = variableName,
-            // Keep payload redacted. Raw value remains in the typed runtime context.
+            // Keep payload redacted. Raw value remains in typed actor state.
             Value = string.Empty,
         }, TopologyAudience.Self, ct);
 

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputRuntimeContextAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputRuntimeContextAccess.cs
@@ -1,35 +1,25 @@
-using Aevatar.Workflow.Abstractions.Execution;
-using Aevatar.Workflow.Core.Execution;
-
 namespace Aevatar.Workflow.Core.Modules;
 
-// Refactor (iter16/cluster-031):
-//   Old pattern: captured secure input values used string-composed keys in the
-//                generic execution item bag.
-//   New principle: captured secure values use typed run/variable keys in the
-//                  actor-owned WorkflowExecutionRuntimeContext.
+// Refactor (iter115/cluster-3):
+//   Old pattern: captured secure input values used a process-local runtime
+//                dictionary as the authority.
+//   New principle: the compatibility facade reads and writes typed secure input
+//                  module state owned by the workflow actor.
 internal static class SecureInputRuntimeContextAccess
 {
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: secure input capture wrote raw values into generic
-    //                execution items using string-composed keys.
-    //   New principle: secure input capture writes to typed non-durable
-    //                  CapturedSecureInputs in the runtime context.
-    public static void SetCapturedValue(
+    public static Task SetCapturedValueAsync(
         IWorkflowExecutionContext ctx,
         string? runId,
         string? variable,
-        string? value)
+        string? value,
+        CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(ctx);
-        GetRuntimeContext(ctx).CapturedSecureInputs.Set(runId, variable, value);
+        var state = SecureInputStateAccess.Load(ctx);
+        SecureInputStateAccess.SetCaptured(state, runId, variable, value);
+        return SecureInputStateAccess.SaveAsync(state, ctx, ct);
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: connector modules looked up captured secure values through
-    //                the generic item accessor.
-    //   New principle: connector modules read captured values through typed
-    //                  run/variable keys in the runtime context.
     public static bool TryGetCapturedValue(
         IWorkflowExecutionContext ctx,
         string? runId,
@@ -37,54 +27,35 @@ internal static class SecureInputRuntimeContextAccess
         out string value)
     {
         ArgumentNullException.ThrowIfNull(ctx);
-        if (ctx is not IWorkflowExecutionRuntimeContextAccessor runtimeAccessor)
-        {
-            value = string.Empty;
-            return false;
-        }
-
-        return runtimeAccessor.RuntimeContext.CapturedSecureInputs.TryGet(runId, variable, out value);
+        return SecureInputStateAccess.TryGetCaptured(
+            SecureInputStateAccess.Load(ctx),
+            runId,
+            variable,
+            out value);
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: clearing one secure value removed a string-composed item
-    //                key from the generic item bag.
-    //   New principle: clearing one secure value removes its typed run/variable
-    //                  key from CapturedSecureInputs.
-    public static bool RemoveCapturedValue(
+    public static async Task<bool> RemoveCapturedValueAsync(
         IWorkflowExecutionContext ctx,
         string? runId,
-        string? variable)
+        string? variable,
+        CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(ctx);
-        if (ctx is not IWorkflowExecutionRuntimeContextAccessor runtimeAccessor)
-            return false;
-
-        return runtimeAccessor.RuntimeContext.CapturedSecureInputs.Remove(runId, variable);
+        var state = SecureInputStateAccess.Load(ctx);
+        var removed = SecureInputStateAccess.RemoveCaptured(state, runId, variable);
+        if (removed)
+            await SecureInputStateAccess.SaveAsync(state, ctx, ct);
+        return removed;
     }
 
-    // Refactor (iter16/cluster-031):
-    //   Old pattern: run cleanup scanned string-composed secure item keys in
-    //                the generic item bag.
-    //   New principle: run cleanup removes typed CapturedSecureInputKey entries
-    //                  owned by the completed run.
-    public static void RemoveRun(
+    public static Task RemoveRunAsync(
         IWorkflowExecutionContext ctx,
-        string? runId)
+        string? runId,
+        CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(ctx);
-        if (ctx is not IWorkflowExecutionRuntimeContextAccessor runtimeAccessor)
-            return;
-
-        runtimeAccessor.RuntimeContext.CapturedSecureInputs.RemoveRun(runId);
-    }
-
-    private static WorkflowExecutionRuntimeContext GetRuntimeContext(IWorkflowExecutionContext ctx)
-    {
-        if (ctx is IWorkflowExecutionRuntimeContextAccessor runtimeAccessor)
-            return runtimeAccessor.RuntimeContext;
-
-        throw new InvalidOperationException(
-            $"Workflow execution context `{ctx.GetType().FullName}` does not support actor-owned runtime context.");
+        var state = SecureInputStateAccess.Load(ctx);
+        SecureInputStateAccess.RemoveRun(state, runId);
+        return SecureInputStateAccess.SaveAsync(state, ctx, ct);
     }
 }

--- a/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputStateAccess.cs
+++ b/src/workflow/Aevatar.Workflow.Core/Modules/SecureInputStateAccess.cs
@@ -24,6 +24,59 @@ internal static class SecureInputStateAccess
         {
             state.Pending.Remove(pendingKey);
         }
+
+        foreach (var capturedKey in state.Captured
+                     .Where(x => string.Equals(x.Value.RunId, normalizedRunId, StringComparison.Ordinal))
+                     .Select(x => x.Key)
+                     .ToList())
+        {
+            state.Captured.Remove(capturedKey);
+        }
+    }
+
+    public static void SetCaptured(
+        SecureInputModuleState state,
+        string? runId,
+        string? variable,
+        string? value)
+    {
+        if (!TryBuildCapturedKey(runId, variable, out var key, out var normalizedRunId, out var normalizedVariable))
+            return;
+
+        state.Captured[key] = new CapturedSecureInputState
+        {
+            RunId = normalizedRunId,
+            VariableName = normalizedVariable,
+            Value = value ?? string.Empty,
+        };
+    }
+
+    public static bool TryGetCaptured(
+        SecureInputModuleState state,
+        string? runId,
+        string? variable,
+        out string value)
+    {
+        if (TryBuildCapturedKey(runId, variable, out var key, out _, out _) &&
+            state.Captured.TryGetValue(key, out var captured))
+        {
+            value = captured.Value ?? string.Empty;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    public static bool RemoveCaptured(
+        SecureInputModuleState state,
+        string? runId,
+        string? variable)
+    {
+        if (!TryBuildCapturedKey(runId, variable, out var key, out _, out _))
+            return false;
+
+        return state.Captured.Remove(key);
     }
 
     public static Task SaveAsync(
@@ -31,8 +84,7 @@ internal static class SecureInputStateAccess
         IWorkflowExecutionContext ctx,
         CancellationToken ct)
     {
-        state.Captured.Clear();
-        if (state.Pending.Count == 0)
+        if (state.Pending.Count == 0 && state.Captured.Count == 0)
             return WorkflowExecutionStateAccess.ClearAsync(ctx, ModuleStateKey, ct);
 
         return WorkflowExecutionStateAccess.SaveAsync(ctx, ModuleStateKey, state, ct);
@@ -40,4 +92,24 @@ internal static class SecureInputStateAccess
 
     public static string BuildPendingKey(string runId, string? stepId) =>
         $"{WorkflowRunIdNormalizer.Normalize(runId)}::{stepId ?? string.Empty}";
+
+    private static bool TryBuildCapturedKey(
+        string? runId,
+        string? variable,
+        out string key,
+        out string normalizedRunId,
+        out string normalizedVariable)
+    {
+        normalizedRunId = WorkflowRunIdNormalizer.Normalize(runId);
+        normalizedVariable = string.IsNullOrWhiteSpace(variable) ? string.Empty : variable.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedRunId) ||
+            string.IsNullOrWhiteSpace(normalizedVariable))
+        {
+            key = string.Empty;
+            return false;
+        }
+
+        key = $"{normalizedRunId}::{normalizedVariable}";
+        return true;
+    }
 }

--- a/src/workflow/Aevatar.Workflow.Core/README.md
+++ b/src/workflow/Aevatar.Workflow.Core/README.md
@@ -19,7 +19,7 @@
   - 安装 workflow modules
   - 创建 run-scoped `RoleGAgent` 子 actor
   - 处理 `ChatRequestEvent`、`ReplaceWorkflowDefinitionAndExecuteEvent`、`WorkflowCompletedEvent`
-  - 通过 event sourcing 持久化 run lifecycle 与 `ExecutionStates`
+  - 通过 event sourcing 持久化 run lifecycle、`ExecutionStates` 与 typed execution context
 - `SubWorkflowOrchestrator`
   - 管理 `workflow_call` 的子 run 创建、绑定、完成与对账
 
@@ -31,6 +31,7 @@
 - `WorkflowYaml / WorkflowName / InlineWorkflowYamls`
 - `RunId / Status / Input / FinalOutput / FinalError`
 - `ExecutionStates`
+- `ExecutionContext`（LLM control、connector authorization 等 typed request control facts）
 - 子工作流 binding / invocation 关系
 
 模块运行态通过 `IWorkflowExecutionContext.LoadState/SaveState/ClearState` 读写 `WorkflowRunState.ExecutionStates`。这意味着：
@@ -38,6 +39,12 @@
 - 模块状态跟随 run actor replay
 - callback fired 事件能在 actor 内完成对账
 - 不再依赖模块私有 `Dictionary/HashSet`
+
+request metadata 与 tool context 中的 control/security 字段不直接改写 `WorkflowRunState.ExecutionContext`。
+`WorkflowRunExecutionStartedEvent` 携带启动时的 `execution_context_delta`；后续更新走
+`WorkflowRunExecutionContextUpdatedEvent`，显式清理走 `WorkflowRunExecutionContextClearedEvent`。
+`IWorkflowExecutionStateHost.ExecutionContextSnapshot` 只暴露只读快照，写路径必须经 `PersistDomainEventAsync`
+进入 `TransitionState` reducer。committed observation 发布前会清空 token / authorization 等 raw secret 字段。
 
 // Refactor (iter89/cluster-089-workflow-module-clock-state):
 //   Old: modules read process wall clock for cache TTL, signal buffer eviction,

--- a/src/workflow/Aevatar.Workflow.Core/ServiceCollectionExtensions.cs
+++ b/src/workflow/Aevatar.Workflow.Core/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using Aevatar.Workflow.Core.Connectors;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.EventModules;
+using Aevatar.Foundation.Core.EventSourcing;
 using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core.Execution;
 using Aevatar.Workflow.Core.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -25,6 +27,9 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IConnectorRegistry, ConfiguredConnectorRegistry>();
         services.TryAddSingleton<IWorkflowConnectorResolver, RegistryBackedWorkflowConnectorResolver>();
         services.TryAddSingleton<WorkflowStepTargetAgentResolver>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            ICommittedStatePublicationHook,
+            WorkflowRunCommittedStateRedactionHook>());
         return services;
     }
 

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -111,14 +111,34 @@ public sealed class WorkflowRunGAgent
 
     WorkflowExecutionRuntimeContext IWorkflowExecutionStateHost.RuntimeContext => _runtimeContext;
 
-    WorkflowRunExecutionContextState IWorkflowExecutionStateHost.ExecutionContextState
+    // Refactor (iter115/cluster-3): Old pattern: callers received the mutable
+    // State.ExecutionContext object and could bypass PersistDomainEventAsync.
+    // New principle: callers only receive a snapshot; writes enter the event log
+    // through WorkflowRunExecutionContextUpdatedEvent/ClearedEvent reducers.
+    WorkflowRunExecutionContextState IWorkflowExecutionStateHost.ExecutionContextSnapshot =>
+        State.ExecutionContext?.Clone() ?? new WorkflowRunExecutionContextState();
+
+    Task IWorkflowExecutionStateHost.UpdateExecutionContextAsync(
+        WorkflowRunExecutionContextDelta delta,
+        CancellationToken ct)
     {
-        get
-        {
-            State.ExecutionContext ??= new WorkflowRunExecutionContextState();
-            return State.ExecutionContext;
-        }
+        ArgumentNullException.ThrowIfNull(delta);
+        return PersistDomainEventAsync(
+            new WorkflowRunExecutionContextUpdatedEvent
+            {
+                RunId = RunId,
+                ExecutionContextDelta = delta,
+            },
+            ct);
     }
+
+    Task IWorkflowExecutionStateHost.ClearExecutionContextAsync(CancellationToken ct) =>
+        PersistDomainEventAsync(
+            new WorkflowRunExecutionContextClearedEvent
+            {
+                RunId = RunId,
+            },
+            ct);
 
     public Any? GetExecutionState(string scopeKey)
     {
@@ -241,16 +261,18 @@ public sealed class WorkflowRunGAgent
                 CancellationToken.None);
         }
 
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(this, request.Metadata);
+        var metadataDelta = WorkflowRunExecutionContextStateAccess.BuildRequestMetadataDelta(request.Metadata);
+        _runtimeContext.ApplyRequestMetadata(request.Metadata);
         var llmControl = LLMControlContextMapper.FromPayload(request.LlmControl);
         var toolContext = llmControl.ToToolContext(AgentToolExecutionContextMapper.FromPayload(request.ToolContext));
-        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(this, toolContext);
+        var toolContextDelta = WorkflowRunExecutionContextStateAccess.BuildToolContextDelta(toolContext);
 
         await EnsureAgentTreeAsync();
 
         var runId = string.IsNullOrWhiteSpace(State.RunId)
             ? WorkflowRunIdNormalizer.Normalize(Id)
             : WorkflowRunIdNormalizer.Normalize(State.RunId);
+        var executionContextDelta = MergeExecutionContextDeltas(metadataDelta, toolContextDelta);
         await PersistDomainEventAsync(new WorkflowRunExecutionStartedEvent
         {
             RunId = runId,
@@ -258,6 +280,7 @@ public sealed class WorkflowRunGAgent
             Input = request.Prompt ?? string.Empty,
             DefinitionActorId = State.DefinitionActorId ?? string.Empty,
             ScopeId = ResolveScopeId(request.ScopeId, State.ScopeId),
+            ExecutionContextDelta = executionContextDelta,
         });
 
         await PublishAsync(new StartWorkflowEvent
@@ -696,6 +719,8 @@ public sealed class WorkflowRunGAgent
             .On<BindWorkflowRunDefinitionEvent>(ApplyBindWorkflowRunDefinition)
             .On<WorkflowCommandObservedEvent>(ApplyWorkflowCommandObserved)
             .On<WorkflowRunExecutionStartedEvent>(ApplyWorkflowRunExecutionStarted)
+            .On<WorkflowRunExecutionContextUpdatedEvent>(ApplyWorkflowRunExecutionContextUpdated)
+            .On<WorkflowRunExecutionContextClearedEvent>(ApplyWorkflowRunExecutionContextCleared)
             .On<WorkflowExecutionStateUpsertedEvent>(ApplyWorkflowExecutionStateUpserted)
             .On<WorkflowExecutionStateClearedEvent>(ApplyWorkflowExecutionStateCleared)
             .On<WorkflowStoppedEvent>(ApplyWorkflowStopped)
@@ -768,11 +793,81 @@ public sealed class WorkflowRunGAgent
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
         next.ExecutionContext ??= new WorkflowRunExecutionContextState();
+        ApplyExecutionContextDelta(next.ExecutionContext, evt.ExecutionContextDelta);
         if (string.IsNullOrWhiteSpace(next.DefinitionActorId) && !string.IsNullOrWhiteSpace(evt.DefinitionActorId))
             next.DefinitionActorId = evt.DefinitionActorId.Trim();
         if (string.IsNullOrWhiteSpace(next.ScopeId) && !string.IsNullOrWhiteSpace(evt.ScopeId))
             next.ScopeId = evt.ScopeId.Trim();
         return next;
+    }
+
+    private static WorkflowRunState ApplyWorkflowRunExecutionContextUpdated(
+        WorkflowRunState current,
+        WorkflowRunExecutionContextUpdatedEvent evt)
+    {
+        var next = current.Clone();
+        next.ExecutionContext ??= new WorkflowRunExecutionContextState();
+        ApplyExecutionContextDelta(next.ExecutionContext, evt.ExecutionContextDelta);
+        return next;
+    }
+
+    private static WorkflowRunState ApplyWorkflowRunExecutionContextCleared(
+        WorkflowRunState current,
+        WorkflowRunExecutionContextClearedEvent _)
+    {
+        var next = current.Clone();
+        next.ExecutionContext = new WorkflowRunExecutionContextState();
+        return next;
+    }
+
+    private static WorkflowRunExecutionContextDelta MergeExecutionContextDeltas(
+        params WorkflowRunExecutionContextDelta[] deltas)
+    {
+        var merged = new WorkflowRunExecutionContextDelta();
+        foreach (var delta in deltas)
+        {
+            if (delta.ClearLlm)
+                merged.ClearLlm = true;
+            if (delta.ClearConnector)
+                merged.ClearConnector = true;
+            if (delta.Llm != null)
+                merged.Llm = delta.Llm.Clone();
+            if (delta.Connector != null)
+                merged.Connector = delta.Connector.Clone();
+        }
+
+        return merged;
+    }
+
+    private static void ApplyExecutionContextDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta? delta)
+    {
+        if (delta == null)
+            return;
+
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken?.Trim() ?? string.Empty,
+                ModelOverride = delta.Llm.ModelOverride?.Trim() ?? string.Empty,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference?.Trim() ?? string.Empty,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization?.Trim() ?? string.Empty,
+            };
+        }
     }
 
     private static WorkflowRunState ApplyWorkflowCommandObserved(WorkflowRunState current, WorkflowCommandObservedEvent evt)

--- a/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
+++ b/src/workflow/Aevatar.Workflow.Core/WorkflowRunGAgent.cs
@@ -22,11 +22,11 @@ namespace Aevatar.Workflow.Core;
     "Maintainability",
     "CA1506:Avoid excessive class coupling",
     Justification = "WorkflowRunGAgent is the run-scoped orchestration boundary and intentionally coordinates workflow execution dependencies.")]
-// Refactor (iter16/cluster-031):
-//   Old pattern: WorkflowRunGAgent kept Dictionary<string, object?> _executionItems
-//                bag for request metadata, LLM overrides, authorization, secure values
-//   New principle: typed non-durable actor-owned WorkflowExecutionRuntimeContext;
-//                  runtime-only values stay non-durable, with no proto/state migration in this cluster.
+// Refactor (iter115/cluster-3):
+//   Old pattern: WorkflowRunGAgent kept durable control/security facts in
+//                process-local runtime context.
+//   New principle: durable control/security facts live in typed WorkflowRunState;
+//                  runtime context carries only same-turn passthrough metadata.
 // Refactor (iter78/cluster-078-workflow-subrun-lifecycle-handoff):
 //   Old pattern: create/link/bind/start child before persisting invocation → orphan on crash
 //   New principle (narrow): persist PendingSubWorkflowInvocation before child side-effects; 4 phases idempotent by invocation_id + child_actor_id
@@ -110,6 +110,15 @@ public sealed class WorkflowRunGAgent
         : State.RunId;
 
     WorkflowExecutionRuntimeContext IWorkflowExecutionStateHost.RuntimeContext => _runtimeContext;
+
+    WorkflowRunExecutionContextState IWorkflowExecutionStateHost.ExecutionContextState
+    {
+        get
+        {
+            State.ExecutionContext ??= new WorkflowRunExecutionContextState();
+            return State.ExecutionContext;
+        }
+    }
 
     public Any? GetExecutionState(string scopeKey)
     {
@@ -722,6 +731,7 @@ public sealed class WorkflowRunGAgent
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
         next.ExecutionStates.Clear();
+        next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.SubWorkflowBindings.Clear();
         next.PendingSubWorkflowDefinitionResolutions.Clear();
         next.PendingSubWorkflowDefinitionResolutionIndexByInvocationId.Clear();
@@ -757,6 +767,7 @@ public sealed class WorkflowRunGAgent
         next.Status = RunningStatus;
         next.FinalOutput = string.Empty;
         next.FinalError = string.Empty;
+        next.ExecutionContext ??= new WorkflowRunExecutionContextState();
         if (string.IsNullOrWhiteSpace(next.DefinitionActorId) && !string.IsNullOrWhiteSpace(evt.DefinitionActorId))
             next.DefinitionActorId = evt.DefinitionActorId.Trim();
         if (string.IsNullOrWhiteSpace(next.ScopeId) && !string.IsNullOrWhiteSpace(evt.ScopeId))
@@ -801,6 +812,7 @@ public sealed class WorkflowRunGAgent
         if (!string.IsNullOrWhiteSpace(evt.Reason))
             next.FinalError = evt.Reason;
         next.ExecutionStates.Clear();
+        next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.PendingSubWorkflowDefinitionResolutions.Clear();
         next.PendingSubWorkflowDefinitionResolutionIndexByInvocationId.Clear();
         next.PendingSubWorkflowInvocations.Clear();
@@ -815,6 +827,7 @@ public sealed class WorkflowRunGAgent
         next.Status = evt.Success ? CompletedStatus : FailedStatus;
         next.FinalOutput = evt.Output ?? string.Empty;
         next.FinalError = evt.Error ?? string.Empty;
+        next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.PendingSubWorkflowDefinitionResolutions.Clear();
         next.PendingSubWorkflowDefinitionResolutionIndexByInvocationId.Clear();
         return next;
@@ -828,6 +841,7 @@ public sealed class WorkflowRunGAgent
         if (!string.IsNullOrWhiteSpace(evt.Reason))
             next.FinalError = evt.Reason;
         next.ExecutionStates.Clear();
+        next.ExecutionContext = new WorkflowRunExecutionContextState();
         next.PendingSubWorkflowDefinitionResolutions.Clear();
         next.PendingSubWorkflowDefinitionResolutionIndexByInvocationId.Clear();
         next.PendingSubWorkflowInvocations.Clear();

--- a/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
+++ b/src/workflow/Aevatar.Workflow.Core/workflow_state.proto
@@ -140,6 +140,25 @@ message WorkflowRunState
   string scope_id = 18;
   repeated PendingSubWorkflowDefinitionResolution pending_sub_workflow_definition_resolutions = 19;
   map<string, int32> pending_sub_workflow_definition_resolution_index_by_invocation_id = 20;
+  WorkflowRunExecutionContextState execution_context = 21;
+}
+
+message WorkflowRunExecutionContextState
+{
+  WorkflowLlmExecutionContextState llm = 1;
+  WorkflowConnectorExecutionContextState connector = 2;
+}
+
+message WorkflowLlmExecutionContextState
+{
+  string nyxid_access_token = 1;
+  string model_override = 2;
+  string nyxid_route_preference = 3;
+}
+
+message WorkflowConnectorExecutionContextState
+{
+  string http_authorization = 1;
 }
 
 enum WorkflowRuntimeCallbackBackendState

--- a/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
@@ -3,6 +3,7 @@ using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
 using Aevatar.Workflow.Abstractions.Execution;
+using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Core.Execution;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -10,7 +11,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Aevatar.Integration.Tests;
 
-internal sealed class TestEventHandlerContext : IEventHandlerContext, IWorkflowExecutionContext, IWorkflowExecutionRuntimeContextAccessor
+internal sealed class TestEventHandlerContext :
+    IEventHandlerContext,
+    IWorkflowExecutionContext,
+    IWorkflowExecutionRuntimeContextAccessor,
+    IWorkflowExecutionStateHostAccessor
 {
     private readonly Dictionary<string, long> _generations = new(StringComparer.Ordinal);
 
@@ -37,6 +42,10 @@ internal sealed class TestEventHandlerContext : IEventHandlerContext, IWorkflowE
     public WorkflowExecutionRuntimeContext RuntimeContext => Agent is IWorkflowExecutionStateHost host
         ? host.RuntimeContext
         : _fallbackRuntimeContext;
+
+    public IWorkflowExecutionStateHost StateHost => Agent is IWorkflowExecutionStateHost host
+        ? host
+        : throw new InvalidOperationException("Workflow execution state host is required.");
 
     private readonly WorkflowExecutionRuntimeContext _fallbackRuntimeContext = new();
     private TimeSpan? _nextElapsedTime;
@@ -271,6 +280,8 @@ internal sealed class TestAgent(string id, string? runId = null) : IAgent, IWork
 
     public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
+    public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+
     public Any? GetExecutionState(string scopeKey) =>
         _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 
@@ -317,6 +328,8 @@ internal sealed class TestWorkflowRunAgent(string id, string runId) : IAgent, IW
     public string RunId { get; } = runId;
 
     public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+
+    public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
     public Any? GetExecutionState(string scopeKey) =>
         _executionStates.TryGetValue(scopeKey, out var state) ? state : null;

--- a/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
+++ b/test/Aevatar.Integration.Tests/TestDoubles/TestEventHandlerContext.cs
@@ -282,6 +282,21 @@ internal sealed class TestAgent(string id, string? runId = null) : IAgent, IWork
 
     public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+    public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+    public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+    {
+        WorkflowExecutionContextTestState.ApplyDelta(ExecutionContextState, delta);
+        return Task.CompletedTask;
+    }
+
+    public Task ClearExecutionContextAsync(CancellationToken ct = default)
+    {
+        ExecutionContextState.Llm = null;
+        ExecutionContextState.Connector = null;
+        return Task.CompletedTask;
+    }
+
     public Any? GetExecutionState(string scopeKey) =>
         _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 
@@ -331,6 +346,21 @@ internal sealed class TestWorkflowRunAgent(string id, string runId) : IAgent, IW
 
     public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+    public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+    public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+    {
+        WorkflowExecutionContextTestState.ApplyDelta(ExecutionContextState, delta);
+        return Task.CompletedTask;
+    }
+
+    public Task ClearExecutionContextAsync(CancellationToken ct = default)
+    {
+        ExecutionContextState.Llm = null;
+        ExecutionContextState.Connector = null;
+        return Task.CompletedTask;
+    }
+
     public Any? GetExecutionState(string scopeKey) =>
         _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 
@@ -366,4 +396,34 @@ internal sealed class TestWorkflowRunAgent(string id, string runId) : IAgent, IW
     public Task ActivateAsync(CancellationToken ct = default) => Task.CompletedTask;
 
     public Task DeactivateAsync(CancellationToken ct = default) => Task.CompletedTask;
+}
+
+internal static class WorkflowExecutionContextTestState
+{
+    public static void ApplyDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta delta)
+    {
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken,
+                ModelOverride = delta.Llm.ModelOverride,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization,
+            };
+        }
+    }
 }

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -1998,13 +1998,13 @@ public sealed class WorkflowAdditionalModulesCoverageTests
     {
         var module = new LLMCallModule();
         var ctx = CreateContext();
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             (IWorkflowExecutionStateHost)ctx.Agent,
             new Dictionary<string, string>
             {
                 ["trace-id"] = " trace-abc ",
             });
-        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetToolContextAsync(
             (IWorkflowExecutionStateHost)ctx.Agent,
             AgentToolExecutionContext.Empty with
             {
@@ -2043,7 +2043,7 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         var connector = new RecordingConnector("runtime-auth");
         var module = new ConnectorCallModule(new FixedWorkflowConnectorResolver(connector));
         var ctx = CreateContext();
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             (IWorkflowExecutionStateHost)ctx.Agent,
             new Dictionary<string, string>
             {

--- a/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowAdditionalModulesCoverageTests.cs
@@ -1274,11 +1274,8 @@ public sealed class WorkflowAdditionalModulesCoverageTests
 
         var resumedState = resumedCtx.LoadState<SecureInputModuleState>(SecureInputStateAccess.ModuleStateKey);
         resumedState.Pending.Should().BeEmpty();
-        resumedState.Captured.Should().BeEmpty();
-        agent.RuntimeContext.CapturedSecureInputs.Values.Should().Contain(
-            new KeyValuePair<CapturedSecureInputKey, string>(
-                new CapturedSecureInputKey("run-secure", "api_key"),
-                "top-secret-value"));
+        resumedState.Captured.Should().ContainKey("run-secure::api_key");
+        resumedState.Captured["run-secure::api_key"].Value.Should().Be("top-secret-value");
 
         await resumedModule.HandleAsync(
             Envelope(new WorkflowCompletedEvent
@@ -1289,7 +1286,6 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             CancellationToken.None);
 
         agent.GetExecutionState(SecureInputStateAccess.ModuleStateKey).Should().BeNull();
-        agent.RuntimeContext.CapturedSecureInputs.Values.Should().BeEmpty();
     }
 
     [Fact]
@@ -1326,10 +1322,8 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             ctx,
             CancellationToken.None);
 
-        agent.RuntimeContext.CapturedSecureInputs.Values.Should().Contain(
-            new KeyValuePair<CapturedSecureInputKey, string>(
-                new CapturedSecureInputKey("run-secure-recapture", "api_key"),
-                "old-secret"));
+        var capturedState = ctx.LoadState<SecureInputModuleState>(SecureInputStateAccess.ModuleStateKey);
+        capturedState.Captured["run-secure-recapture::api_key"].Value.Should().Be("old-secret");
         ctx.Published.Clear();
 
         await module.HandleAsync(
@@ -1346,7 +1340,8 @@ public sealed class WorkflowAdditionalModulesCoverageTests
             ctx,
             CancellationToken.None);
 
-        agent.RuntimeContext.CapturedSecureInputs.Values.Should().BeEmpty();
+        ctx.LoadState<SecureInputModuleState>(SecureInputStateAccess.ModuleStateKey)
+            .Captured.Should().NotContainKey("run-secure-recapture::api_key");
         ctx.Published.Clear();
 
         await module.HandleAsync(
@@ -1362,7 +1357,8 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         var failed = ctx.Published.Select(x => x.evt).OfType<StepCompletedEvent>().Single();
         failed.Success.Should().BeFalse();
         failed.Error.Should().Contain("timed out");
-        agent.RuntimeContext.CapturedSecureInputs.Values.Should().BeEmpty();
+        ctx.LoadState<SecureInputModuleState>(SecureInputStateAccess.ModuleStateKey)
+            .Captured.Should().NotContainKey("run-secure-recapture::api_key");
     }
 
     [Fact]
@@ -2074,6 +2070,42 @@ public sealed class WorkflowAdditionalModulesCoverageTests
         connector.LastRequest!.Metadata.Should().Contain(
             ConnectorRequest.HttpAuthorizationMetadataKey,
             "Bearer token-123");
+    }
+
+    [Fact]
+    public async Task ConnectorCallModule_ShouldResolveCapturedSecureValueAfterFreshRuntimeContext()
+    {
+        var connector = new RecordingConnector("secure-state");
+        var module = new ConnectorCallModule(new FixedWorkflowConnectorResolver(connector));
+        var services = new ServiceCollection().AddAevatarWorkflow().BuildServiceProvider();
+        var agent = new TestAgent("workflow-secure-state-agent", "run-secure-state");
+        var captureCtx = new TestEventHandlerContext(services, agent, NullLogger.Instance);
+
+        await SecureInputRuntimeContextAccess.SetCapturedValueAsync(
+            captureCtx,
+            "run-secure-state",
+            "api_key",
+            "sk-state",
+            CancellationToken.None);
+
+        var callCtx = new TestEventHandlerContext(services, agent, NullLogger.Instance);
+        await module.HandleAsync(
+            Envelope(new StepRequestEvent
+            {
+                StepId = "connector-secure-state",
+                StepType = "secure_connector_call",
+                RunId = "run-secure-state",
+                Parameters =
+                {
+                    ["connector"] = "secure-state",
+                    ["stdin_template"] = """{"apiKey":"[[secure:api_key]]"}""",
+                },
+            }),
+            callCtx,
+            CancellationToken.None);
+
+        connector.LastRequest.Should().NotBeNull();
+        connector.LastRequest!.Payload.Should().Be("""{"apiKey":"sk-state"}""");
     }
 
     [Fact]

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -1,6 +1,9 @@
 using Aevatar.AI.Abstractions;
 using Aevatar.AI.Abstractions.Agents;
+using Aevatar.AI.Abstractions.LLMProviders;
+using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
+using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Persistence;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
@@ -14,6 +17,7 @@ using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core;
 using Aevatar.Workflow.Core.Composition;
 using Aevatar.Workflow.Core.Execution;
+using Aevatar.Workflow.Core.Modules;
 using Aevatar.Workflow.Core.Primitives;
 using FluentAssertions;
 using Google.Protobuf;
@@ -443,6 +447,92 @@ public class WorkflowGAgentCoverageTests
 
         publisher.Published.Select(x => x.evt).OfType<TextMessageEndEvent>()
             .Should().ContainSingle(x => x.Content == "done");
+    }
+
+    [Fact]
+    public async Task WorkflowRunGAgent_CommittedObservation_ShouldRedactExecutionContextAndCapturedSecrets()
+    {
+        var eventStore = new InMemoryEventStore();
+        var publisher = new RecordingEventPublisher();
+        var agent = CreateRunAgent(eventStore: eventStore);
+        SetAgentId(agent, "workflow-run-redaction");
+        agent.EventPublisher = publisher;
+        agent.CommittedStateEventPublisher = publisher;
+
+        await agent.ActivateAsync();
+        await agent.BindWorkflowRunDefinitionAsync(
+            "definition-1",
+            BuildValidWorkflowYaml("role_a", "RoleA"),
+            "wf_redaction",
+            runId: "run-redaction");
+
+        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+            agent,
+            new Dictionary<string, string>
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
+            });
+        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(
+            agent,
+            AgentToolExecutionContext.Empty with
+            {
+                Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "token" },
+                Routing = LLMRequestRoutingContext.Empty with
+                {
+                    ModelOverride = "model",
+                    NyxIdRoutePreference = "route",
+                },
+            });
+
+        await agent.UpsertExecutionStateAsync("scope-a", Any.Pack(new StringValue { Value = "state-a" }));
+        await agent.UpsertExecutionStateAsync(
+            SecureInputStateAccess.ModuleStateKey,
+            Any.Pack(new SecureInputModuleState
+            {
+                Captured =
+                {
+                    ["run-redaction::api_key"] = new CapturedSecureInputState
+                    {
+                        RunId = "run-redaction",
+                        VariableName = "api_key",
+                        Value = "sk-secret",
+                    },
+                },
+            }));
+
+        agent.State.ExecutionContext.Llm!.NyxidAccessToken.Should().Be("token");
+        agent.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
+        agent.State.ExecutionStates[SecureInputStateAccess.ModuleStateKey]
+            .Unpack<SecureInputModuleState>()
+            .Captured["run-redaction::api_key"]
+            .Value.Should().Be("sk-secret");
+
+        var observedState = publisher.Published
+            .Select(x => x.evt)
+            .OfType<CommittedStateEventPublished>()
+            .Last()
+            .StateRoot
+            .Unpack<WorkflowRunState>();
+
+        observedState.ExecutionContext.Llm!.NyxidAccessToken.Should().BeEmpty();
+        observedState.ExecutionContext.Llm.ModelOverride.Should().Be("model");
+        observedState.ExecutionContext.Llm.NyxidRoutePreference.Should().Be("route");
+        observedState.ExecutionContext.Connector!.HttpAuthorization.Should().BeEmpty();
+        observedState.ExecutionStates[SecureInputStateAccess.ModuleStateKey]
+            .Unpack<SecureInputModuleState>()
+            .Captured["run-redaction::api_key"]
+            .Value.Should().BeEmpty();
+
+        var observedEvent = publisher.Published
+            .Select(x => x.evt)
+            .OfType<CommittedStateEventPublished>()
+            .Last()
+            .StateEvent
+            .EventData
+            .Unpack<WorkflowExecutionStateUpsertedEvent>();
+        observedEvent.State.Unpack<SecureInputModuleState>()
+            .Captured["run-redaction::api_key"]
+            .Value.Should().BeEmpty();
     }
 
     [Fact]
@@ -1511,7 +1601,8 @@ public class WorkflowGAgentCoverageTests
             .AddSingleton<IActorRuntimeCallbackScheduler>(sp =>
                 sp.GetRequiredService<InMemoryActorRuntimeCallbackScheduler>())
             .AddSingleton<EventSourcingRuntimeOptions>()
-            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>));
+            .AddTransient(typeof(IEventSourcingBehaviorFactory<>), typeof(DefaultEventSourcingBehaviorFactory<>))
+            .AddAevatarWorkflow();
 
         if (workflowResolver != null)
             services.AddSingleton(workflowResolver);
@@ -1569,24 +1660,26 @@ public class WorkflowGAgentCoverageTests
 
     private static void SeedRuntimeContext(WorkflowRunGAgent agent)
     {
-        var runtimeContext = ((IWorkflowExecutionStateHost)agent).RuntimeContext;
-        runtimeContext.LlmOverrides.NyxIdAccessToken = "token";
-        runtimeContext.LlmOverrides.ModelOverride = "model";
-        runtimeContext.LlmOverrides.NyxIdRoutePreference = "route";
-        runtimeContext.Connector.Authorization = "Bearer secret";
-        runtimeContext.RequestPassthroughMetadata.Set("trace-id", "abc");
-        runtimeContext.CapturedSecureInputs.Set(agent.RunId, "api_key", "secret");
+        var host = (IWorkflowExecutionStateHost)agent;
+        host.ExecutionContextState.Llm = new WorkflowLlmExecutionContextState
+        {
+            NyxidAccessToken = "token",
+            ModelOverride = "model",
+            NyxidRoutePreference = "route",
+        };
+        host.ExecutionContextState.Connector = new WorkflowConnectorExecutionContextState
+        {
+            HttpAuthorization = "Bearer secret",
+        };
+        host.RuntimeContext.RequestPassthroughMetadata.Set("trace-id", "abc");
     }
 
     private static void AssertRuntimeContextCleared(WorkflowRunGAgent agent)
     {
-        var runtimeContext = ((IWorkflowExecutionStateHost)agent).RuntimeContext;
-        runtimeContext.LlmOverrides.NyxIdAccessToken.Should().BeNull();
-        runtimeContext.LlmOverrides.ModelOverride.Should().BeNull();
-        runtimeContext.LlmOverrides.NyxIdRoutePreference.Should().BeNull();
-        runtimeContext.Connector.Authorization.Should().BeNull();
-        runtimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
-        runtimeContext.CapturedSecureInputs.Values.Should().BeEmpty();
+        var host = (IWorkflowExecutionStateHost)agent;
+        host.ExecutionContextState.Llm.Should().BeNull();
+        host.ExecutionContextState.Connector.Should().BeNull();
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
     }
 
     private static string BuildValidWorkflowYaml(
@@ -1634,7 +1727,7 @@ public class WorkflowGAgentCoverageTests
                """;
     }
 
-    private sealed class RecordingEventPublisher : IEventPublisher
+    private sealed class RecordingEventPublisher : IEventPublisher, ICommittedStateEventPublisher
     {
         public List<(IMessage evt, TopologyAudience direction)> Published { get; } = [];
         public List<(string targetActorId, IMessage evt)> Sent { get; } = [];
@@ -1674,6 +1767,20 @@ public class WorkflowGAgentCoverageTests
             CancellationToken ct = default,
             EventEnvelope? sourceEnvelope = null,
             EventEnvelopePublishOptions? options = null)
+        {
+            _ = audience;
+            _ = sourceEnvelope;
+            _ = options;
+            Published.Add((evt, TopologyAudience.Self));
+            return Task.CompletedTask;
+        }
+
+        Task ICommittedStateEventPublisher.PublishAsync(
+            CommittedStateEventPublished evt,
+            ObserverAudience audience,
+            CancellationToken ct,
+            EventEnvelope? sourceEnvelope,
+            EventEnvelopePublishOptions? options)
         {
             _ = audience;
             _ = sourceEnvelope;

--- a/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
+++ b/test/Aevatar.Integration.Tests/WorkflowGAgentCoverageTests.cs
@@ -332,7 +332,7 @@ public class WorkflowGAgentCoverageTests
         await agent.HandleChatRequest(new ChatRequestEvent { Prompt = "first", SessionId = "s1" });
         var oldChildActorId = runtime.CreatedActors.Single().Id;
         await agent.UpsertExecutionStateAsync("scope-a", Any.Pack(new StringValue { Value = "state-a" }));
-        SeedRuntimeContext(agent);
+        await SeedRuntimeContextAsync(agent);
         await agent.HandleWorkflowCompleted(new WorkflowCompletedEvent
         {
             WorkflowName = "wf_valid",
@@ -340,7 +340,7 @@ public class WorkflowGAgentCoverageTests
             Success = true,
             Output = "done-a",
         });
-        SeedRuntimeContext(agent);
+        await SeedRuntimeContextAsync(agent);
         runtime.ThrowOnGetAsyncActorId = agent.Id;
 
         await agent.BindWorkflowRunDefinitionAsync(
@@ -421,7 +421,7 @@ public class WorkflowGAgentCoverageTests
             BuildValidWorkflowYaml("role_a", "RoleA"),
             "wf_replay",
             runId: "run-replay");
-        SeedRuntimeContext(agent1);
+        await SeedRuntimeContextAsync(agent1);
         await agent1.HandleWorkflowCompleted(new WorkflowCompletedEvent
         {
             WorkflowName = "wf_replay",
@@ -450,6 +450,57 @@ public class WorkflowGAgentCoverageTests
     }
 
     [Fact]
+    public async Task WorkflowRunGAgent_ReplayContract_ShouldRestoreExecutionContextAfterChatStart()
+    {
+        var eventStore = new InMemoryEventStore();
+        var runtime = new RecordingActorRuntime();
+        var agent1 = CreateRunAgent(runtime: runtime, eventStore: eventStore);
+        SetAgentId(agent1, "workflow-run-context-replay");
+
+        await agent1.ActivateAsync();
+        await agent1.BindWorkflowRunDefinitionAsync(
+            "definition-1",
+            BuildValidWorkflowYaml("role_a", "RoleA"),
+            "wf_context_replay",
+            runId: "run-context-replay");
+
+        await agent1.HandleChatRequest(new ChatRequestEvent
+        {
+            Prompt = "hello",
+            SessionId = "s1",
+            Metadata =
+            {
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = " Bearer secret ",
+                ["trace-id"] = " trace-abc ",
+            },
+            LlmControl = new LLMControlContext(
+                NyxIdAccessToken: " token-123 ",
+                NyxIdOrgToken: null,
+                SenderNyxIdAccessToken: null,
+                ModelOverride: " model-main ",
+                NyxIdRoutePreference: " route-fast ",
+                MaxToolRoundsOverride: null,
+                UserMemoryPrompt: null).ToPayload(),
+        });
+
+        agent1.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
+        agent1.State.ExecutionContext.Llm!.NyxidAccessToken.Should().Be("token-123");
+        await agent1.DeactivateAsync();
+
+        var persisted = await eventStore.GetEventsAsync(agent1.Id);
+        persisted.Should().ContainSingle(x => x.EventType.Contains(nameof(WorkflowRunExecutionStartedEvent), StringComparison.Ordinal));
+
+        var agent2 = CreateRunAgent(runtime: runtime, eventStore: eventStore);
+        SetAgentId(agent2, "workflow-run-context-replay");
+        await agent2.ActivateAsync();
+
+        agent2.State.ExecutionContext.Connector!.HttpAuthorization.Should().Be("Bearer secret");
+        agent2.State.ExecutionContext.Llm!.NyxidAccessToken.Should().Be("token-123");
+        agent2.State.ExecutionContext.Llm.ModelOverride.Should().Be("model-main");
+        agent2.State.ExecutionContext.Llm.NyxidRoutePreference.Should().Be("route-fast");
+    }
+
+    [Fact]
     public async Task WorkflowRunGAgent_CommittedObservation_ShouldRedactExecutionContextAndCapturedSecrets()
     {
         var eventStore = new InMemoryEventStore();
@@ -466,13 +517,13 @@ public class WorkflowGAgentCoverageTests
             "wf_redaction",
             runId: "run-redaction");
 
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             agent,
             new Dictionary<string, string>
             {
                 [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
             });
-        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetToolContextAsync(
             agent,
             AgentToolExecutionContext.Empty with
             {
@@ -533,6 +584,19 @@ public class WorkflowGAgentCoverageTests
         observedEvent.State.Unpack<SecureInputModuleState>()
             .Captured["run-redaction::api_key"]
             .Value.Should().BeEmpty();
+
+        var observedContextEvent = publisher.Published
+            .Select(x => x.evt)
+            .OfType<CommittedStateEventPublished>()
+            .Select(x => x.StateEvent.EventData)
+            .Where(x => x.Is(WorkflowRunExecutionContextUpdatedEvent.Descriptor))
+            .Select(x => x.Unpack<WorkflowRunExecutionContextUpdatedEvent>())
+            .ToList();
+        observedContextEvent.Should().HaveCount(2);
+        observedContextEvent[0].ExecutionContextDelta.Connector!.HttpAuthorization.Should().BeEmpty();
+        observedContextEvent[1].ExecutionContextDelta.Llm!.NyxidAccessToken.Should().BeEmpty();
+        observedContextEvent[1].ExecutionContextDelta.Llm.ModelOverride.Should().Be("model");
+        observedContextEvent[1].ExecutionContextDelta.Llm.NyxidRoutePreference.Should().Be("route");
     }
 
     [Fact]
@@ -1239,7 +1303,7 @@ public class WorkflowGAgentCoverageTests
             runId: "run-stop");
         await agent.HandleChatRequest(new ChatRequestEvent { Prompt = "hello", SessionId = "s1" });
         await agent.UpsertExecutionStateAsync("scope-a", Any.Pack(new StringValue { Value = "state-a" }));
-        SeedRuntimeContext(agent);
+        await SeedRuntimeContextAsync(agent);
 
         var roleActorId = runtime.CreatedActors.Single().Id;
 
@@ -1281,7 +1345,7 @@ public class WorkflowGAgentCoverageTests
             runId: "run-stop-async");
         await agent.HandleChatRequest(new ChatRequestEvent { Prompt = "hello", SessionId = "s1" });
         await agent.UpsertExecutionStateAsync("scope-a", Any.Pack(new StringValue { Value = "state-a" }));
-        SeedRuntimeContext(agent);
+        await SeedRuntimeContextAsync(agent);
 
         var roleActorId = runtime.CreatedActors.Single().Id;
 
@@ -1658,27 +1722,33 @@ public class WorkflowGAgentCoverageTests
         setIdMethod!.Invoke(agent, [agentId]);
     }
 
-    private static void SeedRuntimeContext(WorkflowRunGAgent agent)
+    private static async Task SeedRuntimeContextAsync(WorkflowRunGAgent agent)
     {
         var host = (IWorkflowExecutionStateHost)agent;
-        host.ExecutionContextState.Llm = new WorkflowLlmExecutionContextState
-        {
-            NyxidAccessToken = "token",
-            ModelOverride = "model",
-            NyxidRoutePreference = "route",
-        };
-        host.ExecutionContextState.Connector = new WorkflowConnectorExecutionContextState
-        {
-            HttpAuthorization = "Bearer secret",
-        };
+        await host.UpdateExecutionContextAsync(
+            new WorkflowRunExecutionContextDelta
+            {
+                ClearLlm = true,
+                ClearConnector = true,
+                Llm = new WorkflowRunLlmExecutionContextDelta
+                {
+                    NyxidAccessToken = "token",
+                    ModelOverride = "model",
+                    NyxidRoutePreference = "route",
+                },
+                Connector = new WorkflowRunConnectorExecutionContextDelta
+                {
+                    HttpAuthorization = "Bearer secret",
+                },
+            });
         host.RuntimeContext.RequestPassthroughMetadata.Set("trace-id", "abc");
     }
 
     private static void AssertRuntimeContextCleared(WorkflowRunGAgent agent)
     {
         var host = (IWorkflowExecutionStateHost)agent;
-        host.ExecutionContextState.Llm.Should().BeNull();
-        host.ExecutionContextState.Connector.Should().BeNull();
+        host.ExecutionContextSnapshot.Llm.Should().BeNull();
+        host.ExecutionContextSnapshot.Connector.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -391,6 +391,8 @@ public sealed class IdempotentStepExecutionTests
 
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+
         public Dictionary<string, Any> States { get; } = new(StringComparer.Ordinal);
 
         public Any? GetExecutionState(string scopeKey) =>

--- a/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/IdempotentStepExecutionTests.cs
@@ -393,6 +393,21 @@ public sealed class IdempotentStepExecutionTests
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+        public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+        {
+            ApplyDelta(ExecutionContextState, delta);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ExecutionContextState.Llm = null;
+            ExecutionContextState.Connector = null;
+            return Task.CompletedTask;
+        }
+
         public Dictionary<string, Any> States { get; } = new(StringComparer.Ordinal);
 
         public Any? GetExecutionState(string scopeKey) =>
@@ -429,6 +444,33 @@ public sealed class IdempotentStepExecutionTests
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(System.Type serviceType) => null;
+    }
+
+    private static void ApplyDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta delta)
+    {
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken,
+                ModelOverride = delta.Llm.ModelOverride,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization,
+            };
+        }
     }
 
     internal record RecordedCallback(string CallbackId, TimeSpan DueTime, Any Event, EventEnvelopePublishOptions? Options);

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -1,6 +1,7 @@
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.EventModules;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Core.Execution;
 using FluentAssertions;
 using Google.Protobuf;
@@ -282,6 +283,21 @@ public sealed class WorkflowExecutionContextAdapterTests
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+        public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+        {
+            ApplyDelta(ExecutionContextState, delta);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ExecutionContextState.Llm = null;
+            ExecutionContextState.Connector = null;
+            return Task.CompletedTask;
+        }
+
         public Dictionary<string, Any> States { get; } = new(StringComparer.Ordinal);
 
         public Any? GetExecutionState(string scopeKey) =>
@@ -324,6 +340,33 @@ public sealed class WorkflowExecutionContextAdapterTests
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(global::System.Type serviceType) => null;
+    }
+
+    private static void ApplyDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta delta)
+    {
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken,
+                ModelOverride = delta.Llm.ModelOverride,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization,
+            };
+        }
     }
 
     private sealed class SingleServiceProvider(global::System.Type serviceType, object service) : IServiceProvider

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionContextAdapterTests.cs
@@ -30,12 +30,12 @@ public sealed class WorkflowExecutionContextAdapterTests
     public void RuntimeContext_ShouldExposeStateHostRuntimeContext()
     {
         var host = new RecordingStateHost();
-        host.RuntimeContext.LlmOverrides.ModelOverride = "model-x";
+        host.RuntimeContext.RequestPassthroughMetadata.Set("trace-id", "abc");
 
         var adapter = WorkflowExecutionContextAdapter.Create(new RecordingEventHandlerContext(), host);
 
         adapter.RuntimeContext.Should().BeSameAs(host.RuntimeContext);
-        adapter.RuntimeContext.LlmOverrides.ModelOverride.Should().Be("model-x");
+        adapter.RuntimeContext.RequestPassthroughMetadata.Values["trace-id"].Should().Be("abc");
     }
 
     [Fact]
@@ -279,6 +279,8 @@ public sealed class WorkflowExecutionContextAdapterTests
         public string RunId { get; set; } = "run-1";
 
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
         public Dictionary<string, Any> States { get; } = new(StringComparer.Ordinal);
 

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextSourceRegressionTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextSourceRegressionTests.cs
@@ -32,6 +32,66 @@ public sealed class WorkflowExecutionRuntimeContextSourceRegressionTests
         source.Should().NotContain("_executionItems");
     }
 
+    [Fact]
+    public void WorkflowExecutionRuntimeContext_ShouldNotReintroduceDurableControlOrSecurityAuthority()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var path = Path.Combine(
+            repositoryRoot,
+            "src",
+            "workflow",
+            "Aevatar.Workflow.Core",
+            "Execution",
+            "WorkflowExecutionRuntimeContext.cs");
+
+        var source = StripComments(File.ReadAllText(path));
+
+        source.Should().NotContain("CapturedSecureInputs");
+        source.Should().NotContain("Dictionary<CapturedSecureInputKey, string>");
+        source.Should().NotContain("LlmOverrides");
+        source.Should().NotContain("WorkflowLlmRuntimeOverrides");
+        source.Should().NotContain("WorkflowConnectorRuntimeContext");
+        source.Should().NotContain("public string? Authorization");
+    }
+
+    [Fact]
+    public void SecureInputStateAccess_ShouldNotClearCapturedUnconditionally()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var path = Path.Combine(
+            repositoryRoot,
+            "src",
+            "workflow",
+            "Aevatar.Workflow.Core",
+            "Modules",
+            "SecureInputStateAccess.cs");
+
+        var source = StripComments(File.ReadAllText(path));
+
+        source.Should().NotContain("state.Captured.Clear()");
+    }
+
+    [Fact]
+    public void WorkflowCoreSources_ShouldNotPreserveOldRuntimeOnlyNoMigrationComment()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var files = Directory
+            .EnumerateFiles(
+                Path.Combine(repositoryRoot, "src", "workflow", "Aevatar.Workflow.Core"),
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => !IsGeneratedFile(path))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        var source = string.Join(
+            Environment.NewLine,
+            files.Select(path => File.ReadAllText(path)));
+
+        source.Should().NotContain("runtime-only values stay non-durable");
+        source.Should().NotContain("no proto/state migration");
+    }
+
     private static string FindRepositoryRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -16,7 +16,7 @@ namespace Aevatar.Workflow.Core.Tests.Execution;
 public sealed class WorkflowExecutionRuntimeContextTests
 {
     [Fact]
-    public void SetRequestMetadata_ShouldKeepLlmControlAsPassthroughOnly()
+    public void SetRequestMetadata_ShouldPromoteControlValuesToTypedState_AndGuardPassthrough()
     {
         var host = new RecordingStateHost();
 
@@ -33,21 +33,18 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 ["empty"] = " ",
             });
 
-        host.RuntimeContext.LlmOverrides.NyxIdAccessToken.Should().BeNull();
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().BeNull();
-        host.RuntimeContext.LlmOverrides.NyxIdRoutePreference.Should().BeNull();
-        host.RuntimeContext.Connector.Authorization.Should().Be("Bearer secret");
-        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().ContainKeys(
-            "trace-id",
-            LLMRequestMetadataKeys.NyxIdAccessToken,
-            LLMRequestMetadataKeys.ModelOverride,
-            LLMRequestMetadataKeys.NyxIdRoutePreference);
+        host.ExecutionContextState.Connector!.HttpAuthorization.Should().Be("Bearer secret");
+        host.ExecutionContextState.Llm.Should().BeNull();
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().ContainKey("trace-id");
         host.RuntimeContext.RequestPassthroughMetadata.Values["trace-id"].Should().Be("abc");
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(LLMRequestMetadataKeys.ModelOverride);
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdRoutePreference);
     }
 
     [Fact]
-    public void SetToolContext_ShouldPromoteLlmRuntimeValuesFromTypedContext()
+    public void SetToolContext_ShouldPromoteLlmValuesToTypedState()
     {
         var host = new RecordingStateHost();
 
@@ -66,41 +63,13 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 },
             });
 
-        host.RuntimeContext.LlmOverrides.NyxIdAccessToken.Should().Be("token");
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().Be("model");
-        host.RuntimeContext.LlmOverrides.NyxIdRoutePreference.Should().Be("route");
+        host.ExecutionContextState.Llm!.NyxidAccessToken.Should().Be("token");
+        host.ExecutionContextState.Llm.ModelOverride.Should().Be("model");
+        host.ExecutionContextState.Llm.NyxidRoutePreference.Should().Be("route");
     }
 
     [Fact]
-    public void SetRequestMetadata_ShouldClearRuntimeValuesWhenMetadataIsNullEmptyOrInvalid()
-    {
-        var host = new RecordingStateHost();
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
-            host,
-            new Dictionary<string, string>
-            {
-                ["trace-id"] = "abc",
-                [LLMRequestMetadataKeys.ModelOverride] = "model",
-            });
-
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(host, null);
-
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().BeNull();
-        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
-
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
-            host,
-            new Dictionary<string, string>
-            {
-                [" "] = " ",
-            });
-
-        host.RuntimeContext.LlmOverrides.ModelOverride.Should().BeNull();
-        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void RemoveRequestMetadata_ShouldValidateAndClearRuntimeContext()
+    public void SetRequestMetadata_ShouldClearTypedConnectorAndPassthroughWhenMetadataIsNullEmptyOrInvalid()
     {
         var host = new RecordingStateHost();
         WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
@@ -111,9 +80,44 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
             });
 
+        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(host, null);
+
+        host.ExecutionContextState.Connector.Should().BeNull();
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
+
+        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+            host,
+            new Dictionary<string, string>
+            {
+                [" "] = " ",
+            });
+
+        host.ExecutionContextState.Connector.Should().BeNull();
+        host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoveRequestMetadata_ShouldValidateAndClearTypedExecutionContext()
+    {
+        var host = new RecordingStateHost();
+        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+            host,
+            new Dictionary<string, string>
+            {
+                ["trace-id"] = "abc",
+                [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
+            });
+        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(
+            host,
+            AgentToolExecutionContext.Empty with
+            {
+                Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "token" },
+            });
+
         WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadata(host);
 
-        host.RuntimeContext.Connector.Authorization.Should().BeNull();
+        host.ExecutionContextState.Llm.Should().BeNull();
+        host.ExecutionContextState.Connector.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
 
         FluentActions.Invoking(() => WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadata(null!))
@@ -122,22 +126,22 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void ConnectorAuthorizationRuntimeAccess_ShouldTrimSetAndClearAuthorization()
+    public void ConnectorAuthorizationRuntimeAccess_ShouldTrimSetAndClearTypedState()
     {
         var host = new RecordingStateHost();
 
         ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(host, " Bearer secret ");
 
-        host.RuntimeContext.Connector.Authorization.Should().Be("Bearer secret");
+        host.ExecutionContextState.Connector!.HttpAuthorization.Should().Be("Bearer secret");
 
         ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(host, " ");
 
-        host.RuntimeContext.Connector.Authorization.Should().BeNull();
+        host.ExecutionContextState.Connector.Should().BeNull();
 
         ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(host, "Bearer secret");
         ConnectorAuthorizationRuntimeContextAccess.RemoveAuthorization(host);
 
-        host.RuntimeContext.Connector.Authorization.Should().BeNull();
+        host.ExecutionContextState.Connector.Should().BeNull();
         FluentActions.Invoking(() => ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(null!, "secret"))
             .Should()
             .Throw<ArgumentNullException>();
@@ -147,17 +151,20 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void ConnectorAuthorizationRuntimeAccess_ShouldReadOnlyFromRuntimeAccessor()
+    public void ConnectorAuthorizationRuntimeAccess_ShouldReadFromTypedStateHost()
     {
         var context = new RecordingWorkflowExecutionContext();
-        context.RuntimeContext.Connector.Authorization = " Bearer secret ";
+        context.ExecutionContextState.Connector = new WorkflowConnectorExecutionContextState
+        {
+            HttpAuthorization = " Bearer secret ",
+        };
 
         ConnectorAuthorizationRuntimeContextAccess.TryGetAuthorization(context, out var authorization)
             .Should()
             .BeTrue();
         authorization.Should().Be("Bearer secret");
 
-        context.RuntimeContext.Connector.Authorization = " ";
+        context.ExecutionContextState.Connector.HttpAuthorization = " ";
         ConnectorAuthorizationRuntimeContextAccess.TryGetAuthorization(context, out authorization)
             .Should()
             .BeFalse();
@@ -202,10 +209,10 @@ public sealed class WorkflowExecutionRuntimeContextTests
 
         var copied = WorkflowRequestMetadataRuntimeContextAccess.CopyRequestMetadata(context, target);
 
-        copied.Should().Be(2);
-        target.Should().HaveCount(2);
+        copied.Should().Be(1);
+        target.Should().HaveCount(1);
         target["trace-id"].Should().Be("abc");
-        target.Should().ContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
+        target.Should().NotContainKey(LLMRequestMetadataKeys.NyxIdAccessToken);
         target.Should().NotContainKey(ConnectorRequest.HttpAuthorizationMetadataKey);
     }
 
@@ -227,49 +234,133 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void SecureInputRuntimeAccess_ShouldStoreRemoveAndClearTypedCapturedValues()
+    public async Task SecureInputRuntimeAccess_ShouldStoreRemoveAndClearTypedCapturedValues()
     {
         var context = new RecordingWorkflowExecutionContext();
 
-        SecureInputRuntimeContextAccess.SetCapturedValue(context, " run-1 ", " api_key ", "secret");
+        await SecureInputRuntimeContextAccess.SetCapturedValueAsync(
+            context,
+            " run-1 ",
+            " api_key ",
+            "secret",
+            CancellationToken.None);
 
         SecureInputRuntimeContextAccess.TryGetCapturedValue(context, "run-1", "api_key", out var value)
             .Should()
             .BeTrue();
         value.Should().Be("secret");
-        context.RuntimeContext.CapturedSecureInputs.Values.Should().ContainKey(new CapturedSecureInputKey("run-1", "api_key"));
+        context.SecureInputState.Captured.Should().ContainKey("run-1::api_key");
 
-        SecureInputRuntimeContextAccess.RemoveCapturedValue(context, "run-1", "api_key").Should().BeTrue();
+        (await SecureInputRuntimeContextAccess.RemoveCapturedValueAsync(
+            context,
+            "run-1",
+            "api_key",
+            CancellationToken.None)).Should().BeTrue();
         SecureInputRuntimeContextAccess.TryGetCapturedValue(context, "run-1", "api_key", out _)
             .Should()
             .BeFalse();
 
-        SecureInputRuntimeContextAccess.SetCapturedValue(context, "run-1", "api_key", "secret");
-        SecureInputRuntimeContextAccess.SetCapturedValue(context, "run-2", "api_key", "other");
-        SecureInputRuntimeContextAccess.RemoveRun(context, "run-1");
+        await SecureInputRuntimeContextAccess.SetCapturedValueAsync(context, "run-1", "api_key", "secret", CancellationToken.None);
+        await SecureInputRuntimeContextAccess.SetCapturedValueAsync(context, "run-2", "api_key", "other", CancellationToken.None);
+        await SecureInputRuntimeContextAccess.RemoveRunAsync(context, "run-1", CancellationToken.None);
 
-        context.RuntimeContext.CapturedSecureInputs.Values.Should().NotContainKey(new CapturedSecureInputKey("run-1", "api_key"));
-        context.RuntimeContext.CapturedSecureInputs.Values.Should().ContainKey(new CapturedSecureInputKey("run-2", "api_key"));
+        context.SecureInputState.Captured.Should().NotContainKey("run-1::api_key");
+        context.SecureInputState.Captured.Should().ContainKey("run-2::api_key");
     }
 
     private sealed class RecordingStateHost : IWorkflowExecutionStateHost
     {
+        private readonly Dictionary<string, Any> _states = new(StringComparer.Ordinal);
+
         public string RunId => "run-1";
 
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
-        public Any? GetExecutionState(string scopeKey) => null;
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
-        public IReadOnlyList<KeyValuePair<string, Any>> GetExecutionStates() => [];
+        public Any? GetExecutionState(string scopeKey) =>
+            _states.TryGetValue(scopeKey, out var state) ? state : null;
 
-        public Task UpsertExecutionStateAsync(string scopeKey, Any state, CancellationToken ct = default) => Task.CompletedTask;
+        public IReadOnlyList<KeyValuePair<string, Any>> GetExecutionStates() => _states.ToList();
 
-        public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default) => Task.CompletedTask;
+        public Task UpsertExecutionStateAsync(string scopeKey, Any state, CancellationToken ct = default)
+        {
+            _states[scopeKey] = state;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default)
+        {
+            _states.Remove(scopeKey);
+            return Task.CompletedTask;
+        }
     }
 
-    private sealed class RecordingWorkflowExecutionContext : ContextWithoutRuntimeAccessor, IWorkflowExecutionRuntimeContextAccessor
+    private sealed class RecordingWorkflowExecutionContext :
+        ContextWithoutRuntimeAccessor,
+        IWorkflowExecutionRuntimeContextAccessor,
+        IWorkflowExecutionStateHost
     {
+        private readonly Dictionary<string, Any> _states = new(StringComparer.Ordinal);
+
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
+
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+
+        public SecureInputModuleState SecureInputState =>
+            _states.TryGetValue(SecureInputStateAccess.ModuleStateKey, out var state) &&
+            state.Is(SecureInputModuleState.Descriptor)
+                ? state.Unpack<SecureInputModuleState>()
+                : new SecureInputModuleState();
+
+        public override TState LoadState<TState>(string scopeKey)
+        {
+            if (_states.TryGetValue(scopeKey, out var state) &&
+                state.Is(new TState().Descriptor))
+            {
+                return state.Unpack<TState>() ?? new TState();
+            }
+
+            return new TState();
+        }
+
+        public override IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
+        {
+            return _states
+                .Where(x => string.IsNullOrEmpty(scopeKeyPrefix) || x.Key.StartsWith(scopeKeyPrefix, StringComparison.Ordinal))
+                .Where(x => x.Value.Is(new TState().Descriptor))
+                .Select(x => new KeyValuePair<string, TState>(x.Key, x.Value.Unpack<TState>() ?? new TState()))
+                .ToList();
+        }
+
+        public override Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
+        {
+            _states[scopeKey] = Any.Pack(state);
+            return Task.CompletedTask;
+        }
+
+        public override Task ClearStateAsync(string scopeKey, CancellationToken ct = default)
+        {
+            _states.Remove(scopeKey);
+            return Task.CompletedTask;
+        }
+
+        public Any? GetExecutionState(string scopeKey) =>
+            _states.TryGetValue(scopeKey, out var state) ? state : null;
+
+        public IReadOnlyList<KeyValuePair<string, Any>> GetExecutionStates() => _states.ToList();
+
+        public Task UpsertExecutionStateAsync(string scopeKey, Any state, CancellationToken ct = default)
+        {
+            _states[scopeKey] = state;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionStateAsync(string scopeKey, CancellationToken ct = default)
+        {
+            _states.Remove(scopeKey);
+            return Task.CompletedTask;
+        }
     }
 
     private class ContextWithoutRuntimeAccessor : IWorkflowExecutionContext
@@ -288,16 +379,16 @@ public sealed class WorkflowExecutionRuntimeContextTests
 
         public string RunId => "run-1";
 
-        public TState LoadState<TState>(string scopeKey)
+        public virtual TState LoadState<TState>(string scopeKey)
             where TState : class, IMessage<TState>, new() => new();
 
-        public IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
+        public virtual IReadOnlyList<KeyValuePair<string, TState>> LoadStates<TState>(string scopeKeyPrefix = "")
             where TState : class, IMessage<TState>, new() => [];
 
-        public Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
+        public virtual Task SaveStateAsync<TState>(string scopeKey, TState state, CancellationToken ct = default)
             where TState : class, IMessage<TState> => Task.CompletedTask;
 
-        public Task ClearStateAsync(string scopeKey, CancellationToken ct = default) => Task.CompletedTask;
+        public virtual Task ClearStateAsync(string scopeKey, CancellationToken ct = default) => Task.CompletedTask;
 
         public Task<RuntimeCallbackLease> ScheduleSelfDurableTimeoutAsync(
             string callbackId,

--- a/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Execution/WorkflowExecutionRuntimeContextTests.cs
@@ -3,6 +3,7 @@ using Aevatar.AI.Abstractions.ToolProviders;
 using Aevatar.Foundation.Abstractions;
 using Aevatar.Foundation.Abstractions.Connectors;
 using Aevatar.Foundation.Abstractions.Runtime.Callbacks;
+using Aevatar.Workflow.Abstractions;
 using Aevatar.Workflow.Abstractions.Execution;
 using Aevatar.Workflow.Core.Execution;
 using Aevatar.Workflow.Core.Modules;
@@ -16,11 +17,11 @@ namespace Aevatar.Workflow.Core.Tests.Execution;
 public sealed class WorkflowExecutionRuntimeContextTests
 {
     [Fact]
-    public void SetRequestMetadata_ShouldPromoteControlValuesToTypedState_AndGuardPassthrough()
+    public async Task SetRequestMetadata_ShouldPromoteControlValuesToTypedState_AndGuardPassthrough()
     {
         var host = new RecordingStateHost();
 
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
             {
@@ -44,11 +45,11 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void SetToolContext_ShouldPromoteLlmValuesToTypedState()
+    public async Task SetToolContext_ShouldPromoteLlmValuesToTypedState()
     {
         var host = new RecordingStateHost();
 
-        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetToolContextAsync(
             host,
             AgentToolExecutionContext.Empty with
             {
@@ -69,10 +70,10 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void SetRequestMetadata_ShouldClearTypedConnectorAndPassthroughWhenMetadataIsNullEmptyOrInvalid()
+    public async Task SetRequestMetadata_ShouldClearTypedConnectorAndPassthroughWhenMetadataIsNullEmptyOrInvalid()
     {
         var host = new RecordingStateHost();
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
             {
@@ -80,12 +81,12 @@ public sealed class WorkflowExecutionRuntimeContextTests
                 [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
             });
 
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(host, null);
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(host, null);
 
         host.ExecutionContextState.Connector.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
 
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
             {
@@ -97,57 +98,57 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void RemoveRequestMetadata_ShouldValidateAndClearTypedExecutionContext()
+    public async Task RemoveRequestMetadata_ShouldValidateAndClearTypedExecutionContext()
     {
         var host = new RecordingStateHost();
-        WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(
             host,
             new Dictionary<string, string>
             {
                 ["trace-id"] = "abc",
                 [ConnectorRequest.HttpAuthorizationMetadataKey] = "Bearer secret",
             });
-        WorkflowRequestMetadataRuntimeContextAccess.SetToolContext(
+        await WorkflowRequestMetadataRuntimeContextAccess.SetToolContextAsync(
             host,
             AgentToolExecutionContext.Empty with
             {
                 Credentials = AgentToolCredentials.Empty with { NyxIdAccessToken = "token" },
             });
 
-        WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadata(host);
+        await WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadataAsync(host);
 
         host.ExecutionContextState.Llm.Should().BeNull();
         host.ExecutionContextState.Connector.Should().BeNull();
         host.RuntimeContext.RequestPassthroughMetadata.Values.Should().BeEmpty();
 
-        FluentActions.Invoking(() => WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadata(null!))
+        await FluentActions.Awaiting(() => WorkflowRequestMetadataRuntimeContextAccess.RemoveRequestMetadataAsync(null!))
             .Should()
-            .Throw<ArgumentNullException>();
+            .ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
-    public void ConnectorAuthorizationRuntimeAccess_ShouldTrimSetAndClearTypedState()
+    public async Task ConnectorAuthorizationRuntimeAccess_ShouldTrimSetAndClearTypedState()
     {
         var host = new RecordingStateHost();
 
-        ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(host, " Bearer secret ");
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(host, " Bearer secret ");
 
         host.ExecutionContextState.Connector!.HttpAuthorization.Should().Be("Bearer secret");
 
-        ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(host, " ");
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(host, " ");
 
         host.ExecutionContextState.Connector.Should().BeNull();
 
-        ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(host, "Bearer secret");
-        ConnectorAuthorizationRuntimeContextAccess.RemoveAuthorization(host);
+        await ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(host, "Bearer secret");
+        await ConnectorAuthorizationRuntimeContextAccess.RemoveAuthorizationAsync(host);
 
         host.ExecutionContextState.Connector.Should().BeNull();
-        FluentActions.Invoking(() => ConnectorAuthorizationRuntimeContextAccess.SetAuthorization(null!, "secret"))
+        await FluentActions.Awaiting(() => ConnectorAuthorizationRuntimeContextAccess.SetAuthorizationAsync(null!, "secret"))
             .Should()
-            .Throw<ArgumentNullException>();
-        FluentActions.Invoking(() => ConnectorAuthorizationRuntimeContextAccess.RemoveAuthorization(null!))
+            .ThrowAsync<ArgumentNullException>();
+        await FluentActions.Awaiting(() => ConnectorAuthorizationRuntimeContextAccess.RemoveAuthorizationAsync(null!))
             .Should()
-            .Throw<ArgumentNullException>();
+            .ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -217,7 +218,7 @@ public sealed class WorkflowExecutionRuntimeContextTests
     }
 
     [Fact]
-    public void CopyRequestMetadata_ShouldValidateArguments()
+    public async Task CopyRequestMetadata_ShouldValidateArguments()
     {
         var context = new RecordingWorkflowExecutionContext();
         var target = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -228,9 +229,9 @@ public sealed class WorkflowExecutionRuntimeContextTests
         FluentActions.Invoking(() => WorkflowRequestMetadataRuntimeContextAccess.CopyRequestMetadata(context, null!))
             .Should()
             .Throw<ArgumentNullException>();
-        FluentActions.Invoking(() => WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadata(null!, target))
+        await FluentActions.Awaiting(() => WorkflowRequestMetadataRuntimeContextAccess.SetRequestMetadataAsync(null!, target))
             .Should()
-            .Throw<ArgumentNullException>();
+            .ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
@@ -278,6 +279,23 @@ public sealed class WorkflowExecutionRuntimeContextTests
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+        public Task UpdateExecutionContextAsync(
+            WorkflowRunExecutionContextDelta delta,
+            CancellationToken ct = default)
+        {
+            ApplyDelta(ExecutionContextState, delta);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ExecutionContextState.Llm = null;
+            ExecutionContextState.Connector = null;
+            return Task.CompletedTask;
+        }
+
         public Any? GetExecutionState(string scopeKey) =>
             _states.TryGetValue(scopeKey, out var state) ? state : null;
 
@@ -306,6 +324,8 @@ public sealed class WorkflowExecutionRuntimeContextTests
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
 
         public SecureInputModuleState SecureInputState =>
             _states.TryGetValue(SecureInputStateAccess.ModuleStateKey, out var state) &&
@@ -360,6 +380,48 @@ public sealed class WorkflowExecutionRuntimeContextTests
         {
             _states.Remove(scopeKey);
             return Task.CompletedTask;
+        }
+
+        public Task UpdateExecutionContextAsync(
+            WorkflowRunExecutionContextDelta delta,
+            CancellationToken ct = default)
+        {
+            ApplyDelta(ExecutionContextState, delta);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ExecutionContextState.Llm = null;
+            ExecutionContextState.Connector = null;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static void ApplyDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta delta)
+    {
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken,
+                ModelOverride = delta.Llm.ModelOverride,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization,
+            };
         }
     }
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -1419,6 +1419,21 @@ public class RuntimeCallbackEventizationTests
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+        public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+        {
+            ApplyDelta(ExecutionContextState, delta);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ExecutionContextState.Llm = null;
+            ExecutionContextState.Connector = null;
+            return Task.CompletedTask;
+        }
+
         public Any? GetExecutionState(string scopeKey) =>
             _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 
@@ -1454,6 +1469,33 @@ public class RuntimeCallbackEventizationTests
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(System.Type serviceType) => null;
+    }
+
+    private static void ApplyDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta delta)
+    {
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken,
+                ModelOverride = delta.Llm.ModelOverride,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization,
+            };
+        }
     }
 
     private sealed record ScheduledCallback(

--- a/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/RuntimeCallbackEventizationTests.cs
@@ -1417,6 +1417,8 @@ public class RuntimeCallbackEventizationTests
 
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+
         public Any? GetExecutionState(string scopeKey) =>
             _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -193,6 +193,8 @@ public class WorkflowLoopModuleExpressionEvaluationTests
 
         public WorkflowExecutionRuntimeContext RuntimeContext { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
+
         public Any? GetExecutionState(string scopeKey) =>
             _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 

--- a/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
+++ b/test/Aevatar.Workflow.Core.Tests/Modules/WorkflowLoopModuleExpressionEvaluationTests.cs
@@ -195,6 +195,21 @@ public class WorkflowLoopModuleExpressionEvaluationTests
 
         public WorkflowRunExecutionContextState ExecutionContextState { get; } = new();
 
+        public WorkflowRunExecutionContextState ExecutionContextSnapshot => ExecutionContextState.Clone();
+
+        public Task UpdateExecutionContextAsync(WorkflowRunExecutionContextDelta delta, CancellationToken ct = default)
+        {
+            ApplyDelta(ExecutionContextState, delta);
+            return Task.CompletedTask;
+        }
+
+        public Task ClearExecutionContextAsync(CancellationToken ct = default)
+        {
+            ExecutionContextState.Llm = null;
+            ExecutionContextState.Connector = null;
+            return Task.CompletedTask;
+        }
+
         public Any? GetExecutionState(string scopeKey) =>
             _executionStates.TryGetValue(scopeKey, out var state) ? state : null;
 
@@ -230,5 +245,32 @@ public class WorkflowLoopModuleExpressionEvaluationTests
     private sealed class NullServiceProvider : IServiceProvider
     {
         public object? GetService(System.Type serviceType) => null;
+    }
+
+    private static void ApplyDelta(
+        WorkflowRunExecutionContextState state,
+        WorkflowRunExecutionContextDelta delta)
+    {
+        if (delta.ClearLlm)
+            state.Llm = null;
+        if (delta.ClearConnector)
+            state.Connector = null;
+        if (delta.Llm != null)
+        {
+            state.Llm = new WorkflowLlmExecutionContextState
+            {
+                NyxidAccessToken = delta.Llm.NyxidAccessToken,
+                ModelOverride = delta.Llm.ModelOverride,
+                NyxidRoutePreference = delta.Llm.NyxidRoutePreference,
+            };
+        }
+
+        if (delta.Connector != null)
+        {
+            state.Connector = new WorkflowConnectorExecutionContextState
+            {
+                HttpAuthorization = delta.Connector.HttpAuthorization,
+            };
+        }
     }
 }


### PR DESCRIPTION
## 摘要

iter115 cluster-3(high,事实源唯一 + 强类型 + 中间层禁映射)。

- **Old**:`WorkflowExecutionRuntimeContext` 持有 `CapturedSecureInputs` / connector authorization / LLM overrides 等控制 / 安全语义事实,用非持久 `Dictionary<string,string>` 兜底。
- **New**:control / security facts 全部建模为 typed actor state(`WorkflowRunExecutionContextState` 等),写 actor reducer;runtime context 只留 same-turn transient passthrough + guard 防权威 key 回流。

违反:CLAUDE.md「事实源唯一」+「核心语义强类型」+「禁止中间层维护 ID → 上下文/事实状态的进程内映射」。

## 范围

25 文件 +817/-356。新增:
- typed proto state `WorkflowRunExecutionContextState` + module access facade
- `WorkflowRunCommittedStateRedactionHook`:state mirror 不泄漏 raw secret
- source-regression test 禁止 `WorkflowExecutionRuntimeContext.cs` 重新引入权威字段
- behavioral test 验 secure resume / connector auth / LLM routing / cleanup

closes #1098

📢 cc:@loning @eanzhao

⟦AI:AUTO-LOOP⟧
