### PR TITLE
Improve frontend team member flow

### DIFF
--- a/apps/aevatar-console-web/config/proxy.ts
+++ b/apps/aevatar-console-web/config/proxy.ts
@@ -62,6 +62,12 @@ const studioScopeProxyEntries = {
     buildProxyTarget(apiTarget),
   '^/api/scopes/[^/]+/teams(?:/.*)?$':
     buildProxyTarget(studioApiTarget),
+  '^/api/scopes/[^/]+/members$':
+    buildProxyTarget(studioApiTarget),
+  '^/api/scopes/[^/]+/members/[^/]+$':
+    buildProxyTarget(studioApiTarget),
+  '^/api/scopes/[^/]+/members/[^/]+/(?:binding(?:/.*)?|binding-runs(?:/.*)?|endpoints/[^/]+/contract)$':
+    buildProxyTarget(studioApiTarget),
   '^/api/scopes/[^/]+/scripts/draft-run$':
     buildProxyTarget(studioApiTarget),
   '^/api/scripts/validate$': buildProxyTarget(studioApiTarget),

--- a/apps/aevatar-console-web/src/global.less
+++ b/apps/aevatar-console-web/src/global.less
@@ -348,6 +348,19 @@ body.aevatar-studio-host
   padding-top: 0;
 }
 
+@media (max-width: 720px) {
+  .teams-home-roster-row {
+    align-items: stretch !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .teams-home-roster-row-actions,
+  .teams-home-roster-row-actions .ant-space-item,
+  .teams-home-roster-row-actions .ant-btn {
+    width: 100%;
+  }
+}
+
 canvas {
   display: block;
 }

--- a/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.test.tsx
@@ -312,6 +312,28 @@ describe("DeploymentsPage", () => {
     expect(screen.queryByText("发布摘要")).toBeNull();
   });
 
+  it("warns when scope edits have not been loaded yet", async () => {
+    renderDeploymentsPage();
+
+    expect(await screen.findByText("Trade Agent")).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText("命名空间"), {
+      target: {
+        value: "cn.changed",
+      },
+    });
+
+    expect(await screen.findByText("范围已编辑但尚未加载")).toBeInTheDocument();
+    expect(screen.getByText("显示上次加载范围")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "加载范围变更" })).toBeInTheDocument();
+    expect(screen.getByText("Trade Agent")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /重\s*置/ }));
+
+    expect(await screen.findByText("已加载范围已锁定")).toBeInTheDocument();
+    expect(screen.getByText("显示已加载范围")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "加载发布列表" })).toBeInTheDocument();
+  });
+
   it("renders the selected service workbench from URL context", async () => {
     renderDeploymentsPage(
       "/deployments?tenantId=scope-1&appId=trade-app&namespace=cn.market&serviceId=trade-agent",

--- a/apps/aevatar-console-web/src/pages/Deployments/index.tsx
+++ b/apps/aevatar-console-web/src/pages/Deployments/index.tsx
@@ -78,7 +78,6 @@ import {
 import ConsoleMenuPageShell from "@/shared/ui/ConsoleMenuPageShell";
 import {
   cardStackStyle,
-  codeBlockStyle,
   summaryFieldLabelStyle,
   summaryMetricValueStyle,
 } from "@/shared/ui/proComponents";
@@ -168,6 +167,29 @@ function buildScopePreview(
   namespace: string,
 ): string {
   return `${truncateMiddle(tenantId)}/${appId}/${namespace}`;
+}
+
+function formatDeploymentScopeLabel(query: ServiceIdentityQuery): string {
+  const segments = [
+    query.tenantId?.trim() || "未设置团队",
+    query.appId?.trim() || "未设置应用",
+    query.namespace?.trim() || "未设置命名空间",
+  ];
+  const resultWindow = query.take && query.take > 0 ? query.take : 200;
+
+  return `${segments.join(" / ")} · ${resultWindow} 条`;
+}
+
+function isSameDeploymentScope(
+  left: ServiceIdentityQuery,
+  right: ServiceIdentityQuery,
+): boolean {
+  return (
+    (left.tenantId?.trim() ?? "") === (right.tenantId?.trim() ?? "") &&
+    (left.appId?.trim() ?? "") === (right.appId?.trim() ?? "") &&
+    (left.namespace?.trim() ?? "") === (right.namespace?.trim() ?? "") &&
+    (left.take ?? 200) === (right.take ?? 200)
+  );
 }
 
 const CompactIdentifierText: React.FC<{
@@ -490,12 +512,20 @@ const DetailFieldCard: React.FC<{
 
 const DeploymentsScopeCard: React.FC<{
   draft: ServiceQueryDraft;
+  draftScopeLabel: string;
+  isDirty: boolean;
+  isLoading?: boolean;
+  loadedScopeLabel: string;
   onChange: (draft: ServiceQueryDraft) => void;
   onLoad: () => void;
   onReset: () => void;
   scopeLabel: string;
 }> = ({
   draft,
+  draftScopeLabel,
+  isDirty,
+  isLoading = false,
+  loadedScopeLabel,
   onChange,
   onLoad,
   onReset,
@@ -626,6 +656,22 @@ const DeploymentsScopeCard: React.FC<{
 
     </div>
 
+    {isDirty ? (
+      <Alert
+        description={`当前服务指标和列表仍来自已加载范围：${loadedScopeLabel}。草稿范围是：${draftScopeLabel}。`}
+        message="范围已编辑但尚未加载"
+        showIcon
+        type="warning"
+      />
+    ) : (
+      <Alert
+        description={`下方服务指标和列表基于这个已加载范围：${loadedScopeLabel}。`}
+        message="已加载范围已锁定"
+        showIcon
+        type="info"
+      />
+    )}
+
     <div
       style={{
         alignItems: "center",
@@ -673,8 +719,13 @@ const DeploymentsScopeCard: React.FC<{
         <Button size="small" onClick={onReset}>
           重置
         </Button>
-        <Button size="small" type="primary" onClick={onLoad}>
-          加载发布列表
+        <Button
+          loading={isLoading}
+          size="small"
+          type="primary"
+          onClick={onLoad}
+        >
+          {isDirty ? "加载范围变更" : "加载发布列表"}
         </Button>
       </Space>
     </div>
@@ -1130,6 +1181,21 @@ const DeploymentsPage: React.FC = () => {
       ) ?? null
     );
   }, [deploymentsQuery.data?.deployments, inspectorState]);
+
+  const draftScopeLabel = useMemo(
+    () => formatDeploymentScopeLabel(trimServiceQuery(draft)),
+    [draft],
+  );
+
+  const loadedScopeLabel = useMemo(
+    () => formatDeploymentScopeLabel(query),
+    [query],
+  );
+
+  const isScopeDirty = useMemo(
+    () => !isSameDeploymentScope(trimServiceQuery(draft), query),
+    [draft, query],
+  );
 
   const currentScopeLabel = useMemo(() => {
     const segments = [
@@ -1591,22 +1657,31 @@ const DeploymentsPage: React.FC = () => {
   }, []);
 
   const handleReset = useCallback(() => {
-    const nextDraft = resolvedScope?.scopeId?.trim()
+    const nextDraft = isScopeDirty
       ? {
-          ...readServiceQueryDraft(""),
-          appId: defaultScopeServiceAppId,
-          namespace: defaultScopeServiceNamespace,
-          tenantId: resolvedScope.scopeId.trim(),
+          appId: query.appId?.trim() ?? "",
+          namespace: query.namespace?.trim() ?? "",
+          take: query.take && query.take > 0 ? query.take : 200,
+          tenantId: query.tenantId?.trim() ?? "",
         }
-      : readServiceQueryDraft("");
+      : resolvedScope?.scopeId?.trim()
+        ? {
+            ...readServiceQueryDraft(""),
+            appId: defaultScopeServiceAppId,
+            namespace: defaultScopeServiceNamespace,
+            tenantId: resolvedScope.scopeId.trim(),
+          }
+        : readServiceQueryDraft("");
     setDraft(nextDraft);
-    setQuery(trimServiceQuery(nextDraft));
+    if (!isScopeDirty) {
+      setQuery(trimServiceQuery(nextDraft));
+    }
     setSelectedServiceId("");
     setSelectedDeploymentId("");
     setCandidateRevisionId("");
     setDrawerReason("");
     setView("catalog");
-  }, [resolvedScope?.scopeId]);
+  }, [isScopeDirty, query, resolvedScope?.scopeId]);
 
   const drawerSubtitle = selectedService
     ? `${selectedService.tenantId}/${selectedService.appId}/${selectedService.namespace}`
@@ -1631,6 +1706,10 @@ const DeploymentsPage: React.FC = () => {
 
         <DeploymentsScopeCard
           draft={draft}
+          draftScopeLabel={draftScopeLabel}
+          isDirty={isScopeDirty}
+          isLoading={servicesQuery.isFetching}
+          loadedScopeLabel={loadedScopeLabel}
           onChange={handleDraftChange}
           onLoad={() => setQuery(trimServiceQuery(draft))}
           onReset={handleReset}
@@ -1703,6 +1782,14 @@ const DeploymentsPage: React.FC = () => {
               <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
                 扫描 serving、deployment 和入口规模，再进入某个服务的发布详情。
               </Typography.Text>
+              <Space wrap size={[8, 8]}>
+                <Tag color={isScopeDirty ? "gold" : "blue"}>
+                  {isScopeDirty ? "显示上次加载范围" : "显示已加载范围"}
+                </Tag>
+                <Typography.Text style={{ color: surfaceToken.colorTextSecondary }}>
+                  {loadedScopeLabel}
+                </Typography.Text>
+              </Space>
             </Space>
           </div>
 

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx
@@ -533,6 +533,10 @@ describe('StudioMemberBindPanel', () => {
     });
     expect(runtimeRunsApi.streamChat).not.toHaveBeenCalled();
     expect(await screen.findByText(/Smoke test passed in \d+ms/)).toBeTruthy();
+    expect(screen.getByText('Run run-1')).toBeTruthy();
+    expect(
+      screen.queryByText('The current Studio draft accepted the request.'),
+    ).toBeNull();
     expect(screen.getByText('Second node final output.')).toBeTruthy();
     expect(
       screen.getByText(
@@ -542,6 +546,77 @@ describe('StudioMemberBindPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue to Invoke' }));
     expect(handleContinueToInvoke).toHaveBeenCalledWith('default', 'chat');
+  });
+
+  it('describes non-chat smoke test success as a completed contract response', async () => {
+    (runtimeRunsApi.invokeEndpoint as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+    });
+
+    renderWithQueryClient(
+      React.createElement(StudioMemberBindPanel, {
+        authSession: {
+          enabled: true,
+          authenticated: true,
+          name: 'Abigail Deng',
+          scopeId: 'scope-1',
+          scopeSource: 'nyxid',
+        },
+        memberId: 'default',
+        scopeId: 'scope-1',
+        preferredServiceId: 'default',
+        services: [
+          {
+            serviceKey: 'scope-1:default:workspace-demo',
+            tenantId: 'scope-1',
+            appId: 'default',
+            namespace: 'default',
+            serviceId: 'default',
+            displayName: 'workspace-demo',
+            defaultServingRevisionId: 'rev-2',
+            activeServingRevisionId: 'rev-2',
+            deploymentId: 'dep-2',
+            primaryActorId: 'actor-default',
+            deploymentStatus: 'Active',
+            endpoints: [
+              {
+                endpointId: 'submit',
+                displayName: 'Submit',
+                kind: 'command',
+                requestTypeUrl: 'type.googleapis.com/example.Submit',
+                responseTypeUrl: 'type.googleapis.com/example.SubmitResult',
+                description: 'Submit a request.',
+              },
+            ],
+            policyIds: [],
+            updatedAt: '2026-03-26T08:00:00Z',
+          },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Send smoke test' }));
+    });
+
+    await waitFor(() => {
+      expect(runtimeRunsApi.invokeEndpoint).toHaveBeenCalledWith(
+        'scope-1',
+        expect.objectContaining({
+          endpointId: 'submit',
+        }),
+        expect.objectContaining({
+          serviceId: 'default',
+        }),
+      );
+    });
+    expect(await screen.findByText(/Smoke test passed in \d+ms/)).toBeTruthy();
+    expect(
+      screen.getByText('The selected contract returned without an error.'),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText('The selected contract accepted the request.'),
+    ).toBeNull();
   });
 
   it('blocks continuing to Invoke when the published service has no endpoints', async () => {

--- a/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/components/bind/StudioMemberBindPanel.tsx
@@ -1416,8 +1416,8 @@ const StudioMemberBindPanel: React.FC<StudioMemberBindPanelProps> = ({
                     smokeTestResult.runId
                       ? `Run ${smokeTestResult.runId}`
                       : runsCurrentWorkflowDraft
-                        ? 'The current Studio draft accepted the request.'
-                        : 'The selected contract accepted the request.'
+                        ? 'The current Studio draft completed without an error.'
+                        : 'The selected contract returned without an error.'
                   }
                   type="success"
                 />

--- a/apps/aevatar-console-web/src/pages/studio/index.test.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.test.tsx
@@ -3998,7 +3998,9 @@ describe("StudioPage", () => {
         "workspace-demo"
       );
     });
-    expect(message.success).toHaveBeenCalledWith("Team entry member updated.");
+    expect(message.info).toHaveBeenCalledWith(
+      "Team entry 变更已提交，正在等待同步确认。",
+    );
   });
 
   it("marks the selected Studio member when it is already the Team entry", async () => {
@@ -4498,6 +4500,53 @@ describe("StudioPage", () => {
     });
   });
 
+  it("opens a routed GAgent member on the GAgent Build surface without requiring a gagents tab hint", async () => {
+    (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
+      ...defaultStudioAppContext,
+      scopeId: "scope-1",
+      scopeResolved: true,
+    });
+    mockStudioMembers = [
+      {
+        memberId: "orders-worker",
+        scopeId: "scope-1",
+        displayName: "Orders Worker",
+        description: "Team entry GAgent member",
+        implementationKind: "gagent",
+        lifecycleStage: "bind_ready",
+        publishedServiceId: "member-orders-worker",
+        lastBoundRevisionId: "rev-gagent-1",
+        teamId: "t-alpha",
+        createdAt: "2026-04-27T08:10:00Z",
+        updatedAt: "2026-04-27T08:15:00Z",
+      },
+      ...mockStudioMembers,
+    ];
+
+    renderStudioPage(
+      "/studio?scopeId=scope-1&teamId=t-alpha&member=member%3Aorders-worker&step=build&tab=studio",
+    );
+
+    expect(await screen.findByTestId("studio-gagent-build-panel")).toBeTruthy();
+    expect(screen.queryByTestId("studio-workflow-build-panel")).toBeNull();
+    expect(screen.getByTestId("studio-context-title")).toHaveTextContent(
+      "Orders Worker",
+    );
+    expect(screen.getByRole("button", { name: /^GAgent/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Continue to Bind" })).toBeEnabled();
+
+    await waitFor(() => {
+      const searchParams = new URLSearchParams(window.location.search);
+      expect(searchParams.get("member")).toBe("member:orders-worker");
+      expect(searchParams.get("tab")).toBe("gagents");
+      expect(searchParams.get("step")).toBe("build");
+      expect(searchParams.get("focus")).toBeNull();
+    });
+  });
+
   it("binds an unbound GAgent member from Build and keeps the member route", async () => {
     (studioApi.getAppContext as jest.Mock).mockResolvedValueOnce({
       ...defaultStudioAppContext,
@@ -4666,11 +4715,9 @@ describe("StudioPage", () => {
     });
 
     const confirmConfig = (Modal.confirm as jest.Mock).mock.calls[0]?.[0];
-    await expect(
-      act(async () => {
-        await confirmConfig.onOk();
-      }),
-    ).resolves.toBeUndefined();
+    await act(async () => {
+      await expect(confirmConfig.onOk()).resolves.toBeUndefined();
+    });
 
     expect(message.error).not.toHaveBeenCalled();
     await waitFor(() => {
@@ -5063,8 +5110,8 @@ describe("StudioPage", () => {
       "workspace-demo",
     );
     expect(new URLSearchParams(window.location.search).get("testTeam")).toBe("1");
-    expect(message.success).toHaveBeenCalledWith(
-      "Team entry member update accepted.",
+    expect(message.info).toHaveBeenCalledWith(
+      "Team entry 变更已提交，正在等待同步确认。",
     );
     expect(message.warning).not.toHaveBeenCalled();
   });

--- a/apps/aevatar-console-web/src/pages/studio/index.tsx
+++ b/apps/aevatar-console-web/src/pages/studio/index.tsx
@@ -6853,11 +6853,18 @@ const StudioPage: React.FC = () => {
       publishedScopeMembers,
       studioScopeMembers,
     );
-    if (
-      normalizeStudioMemberBindingImplementationKind(
-        memberSummary?.implementationKind,
-      ) !== 'script'
-    ) {
+    const implementationKind = normalizeStudioMemberBindingImplementationKind(
+      memberSummary?.implementationKind,
+    );
+    if (implementationKind === 'gagent') {
+      setSelectedWorkflowId('');
+      setSelectedScriptId('');
+      setTemplateWorkflow('');
+      setBuildSurface('gagent');
+      return;
+    }
+
+    if (implementationKind !== 'script') {
       return;
     }
 
@@ -7257,7 +7264,7 @@ const StudioPage: React.FC = () => {
           testTeam: options?.test && entryVisible,
           teamId: candidate.teamId,
         });
-        void message.success('Team entry member update accepted.');
+        void message.info('Team entry 变更已提交，正在等待同步确认。');
         if (options?.test) {
           if (!entryVisible) {
             void message.warning(
@@ -7283,7 +7290,7 @@ const StudioPage: React.FC = () => {
     ],
   );
   useEffect(() => {
-    if (studioSurface !== 'build' || buildSurface !== 'editor') {
+    if (studioSurface !== 'build') {
       return;
     }
 
@@ -7293,6 +7300,30 @@ const StudioPage: React.FC = () => {
         workbenchStudioMember?.implementationKind ||
         workbenchPublishedServiceRevision?.implementationKind,
     );
+    if (implementationKind === 'gagent') {
+      const actorTypeName =
+        trimOptional(
+          workbenchStudioMemberDetailQuery.data?.implementationRef?.actorTypeName,
+        ) ||
+        trimOptional(workbenchPublishedServiceRevision?.staticActorTypeName);
+      if (actorTypeName) {
+        setSelectedGAgentTypeName((current) =>
+          trimOptional(current) === actorTypeName ? current : actorTypeName,
+        );
+      }
+      if (buildSurface !== 'gagent') {
+        setSelectedWorkflowId('');
+        setSelectedScriptId('');
+        setTemplateWorkflow('');
+        setBuildSurface('gagent');
+      }
+      return;
+    }
+
+    if (buildSurface !== 'editor') {
+      return;
+    }
+
     if (implementationKind !== 'script') {
       return;
     }
@@ -7322,9 +7353,11 @@ const StudioPage: React.FC = () => {
     studioSurface,
     workbenchPublishedServiceRevision?.implementationKind,
     workbenchPublishedServiceRevision?.scriptId,
+    workbenchPublishedServiceRevision?.staticActorTypeName,
     workbenchStudioMember?.displayName,
     workbenchStudioMember?.implementationKind,
     workbenchStudioMember?.publishedServiceId,
+    workbenchStudioMemberDetailQuery.data?.implementationRef?.actorTypeName,
     workbenchStudioMemberDetailQuery.data?.implementationRef?.implementationKind,
     workbenchStudioMemberDetailQuery.data?.implementationRef?.scriptId,
   ]);
@@ -8214,7 +8247,7 @@ const StudioPage: React.FC = () => {
           queryKey: ['teams', 'roster', resolvedStudioScopeId],
         }),
       ]);
-      void message.success('Team entry member updated.');
+      void message.info('Team entry 变更已提交，正在等待同步确认。');
     } catch (error) {
       void message.error(
         error instanceof Error

--- a/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamDetailChrome.tsx
@@ -76,7 +76,7 @@ export const TeamActionRail: React.FC<TeamActionRailProps> = ({
   onOpenTeamTest,
   testTeamDisabled = false,
   testTeamHint,
-  testTeamLabel = "Test Team",
+  testTeamLabel = "测试团队",
 }) => {
   const archiveMenuItems =
     archiveTeamActionLabel && onArchiveTeam
@@ -126,11 +126,11 @@ export const TeamActionRail: React.FC<TeamActionRailProps> = ({
         >
           <span title={archiveTeamDisabled ? archiveTeamHint : undefined}>
             <Button
-              aria-label="Team more actions"
+              aria-label="团队更多操作"
               disabled={archiveTeamDisabled}
               icon={<MoreOutlined />}
               style={{ ...topActionButtonStyle, paddingInline: 14 }}
-              title="More actions"
+              title="更多操作"
             />
           </span>
         </Dropdown>

--- a/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/components/TeamTestPanel.tsx
@@ -108,17 +108,34 @@ function resolveTestStatusPill(
 function formatStatusLabel(status: TeamTestStatus): string {
   switch (status) {
     case "setting-entry":
-      return "Setting entry";
+      return "正在设置入口";
     case "running":
-      return "Running";
+      return "测试中";
     case "success":
-      return "Completed";
+      return "已完成";
     case "error":
-      return "Failed";
+      return "失败";
     case "stopped":
-      return "Stopped";
+      return "已停止";
     default:
-      return "Ready";
+      return "待测试";
+  }
+}
+
+function formatLifecycleLabelForTeamTest(label: string): string {
+  switch (label.trim().toLowerCase()) {
+    case "created":
+      return "已创建";
+    case "build ready":
+    case "build_ready":
+      return "可绑定";
+    case "bind ready":
+    case "bind_ready":
+      return "可调用";
+    case "unknown":
+      return "状态未知";
+    default:
+      return label || "状态未知";
   }
 }
 
@@ -179,7 +196,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
       return (
         <AevatarInspectorEmpty
           compact
-          title="正在检查 Team entry"
+          title="正在检查入口成员"
           description="成员清单同步完成后即可选择入口成员。"
         />
       );
@@ -209,7 +226,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               onClick={handleNavigate(createMemberHref)}
               type="primary"
             >
-              Create first member
+              创建第一个成员
             </Button>
           ) : null}
         </div>
@@ -223,7 +240,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
             showIcon
             type="warning"
             message="还没有可作为入口的成员"
-            description="成员需要完成 Build / Bind，进入 Bind ready 后才能执行 Team Test。"
+            description="成员需要完成 Build / Bind，并进入可调用状态后才能测试 Team。"
           />
         ) : null}
         {rosterRows.map((row) => (
@@ -254,7 +271,11 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               <FactLine monospace rows={1} secondary text={row.memberId} />
             </div>
             <Space size={6} style={{ flex: "1 1 150px" }} wrap>
-              <DetailPill compact style={row.lifecycleStyle} text={row.lifecycleLabel} />
+              <DetailPill
+                compact
+                style={row.lifecycleStyle}
+                text={formatLifecycleLabelForTeamTest(row.lifecycleLabel)}
+              />
               {row.canInvokeAsEntry ? (
                 <DetailPill
                   compact
@@ -263,7 +284,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
                     border: `1px solid ${token.colorSuccessBorder}`,
                     color: token.colorSuccess,
                   }}
-                  text="Ready"
+                  text="可测试"
                 />
               ) : null}
             </Space>
@@ -280,10 +301,10 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
                   loading={entryActionBusyMemberId === row.memberId}
                   onClick={() => onSetEntryAndTest(row.memberId)}
                   size="small"
-                  title={!hasPrompt ? "Enter a prompt before testing." : undefined}
+                  title={!hasPrompt ? "请先输入测试问题。" : undefined}
                   type="primary"
                 >
-                  Set as entry and test
+                  设为入口并测试
                 </Button>
               ) : (
                 <Button
@@ -292,7 +313,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
                   onClick={handleNavigate(row.buildStudioHref)}
                   size="small"
                 >
-                  Build / Bind first
+                  先 Build / Bind
                 </Button>
               )}
             </Space>
@@ -308,7 +329,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <Space align="center" size={8} wrap>
             <WarningOutlined style={{ color: token.colorWarning }} />
-            <Typography.Text strong>No entry member selected</Typography.Text>
+            <Typography.Text strong>未选择入口成员</Typography.Text>
           </Space>
           {renderEntrySelection()}
         </div>
@@ -320,7 +341,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <Space align="center" size={8} wrap>
             <WarningOutlined style={{ color: token.colorWarning }} />
-            <Typography.Text strong>Entry member is not in this Team roster</Typography.Text>
+            <Typography.Text strong>入口成员不在当前 Team 成员清单中</Typography.Text>
             <CompactFactValue value={normalizedEntryMemberId} />
           </Space>
           {renderEntrySelection()}
@@ -356,13 +377,23 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               }}
             />
             <Typography.Text strong>
-              {entryMember?.name || "Entry member"}
+              {entryMember?.name || "入口成员"}
             </Typography.Text>
             {entryMember ? (
-              <DetailPill compact style={entryMember.lifecycleStyle} text={entryMember.lifecycleLabel} />
+              <DetailPill
+                compact
+                style={entryMember.lifecycleStyle}
+                text={formatLifecycleLabelForTeamTest(entryMember.lifecycleLabel)}
+              />
             ) : null}
           </Space>
-          <FactLine monospace secondary text={normalizedEntryMemberId} />
+          <CompactFactValue
+            color={token.colorTextSecondary}
+            head={8}
+            strong={false}
+            tail={6}
+            value={normalizedEntryMemberId}
+          />
         </div>
         <div
           style={{
@@ -374,7 +405,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
           }}
         >
           <Typography.Text style={{ fontSize: 12 }} type="secondary">
-            Service
+            服务
           </Typography.Text>
           <CompactFactValue value={entryMember?.serviceId || "--"} />
         </div>
@@ -385,7 +416,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               onClick={handleNavigate(entryMember.editStudioHref)}
               size="small"
             >
-              Edit in Studio
+              在 Studio 编辑
             </Button>
           ) : null}
           {onClearEntry ? (
@@ -399,7 +430,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               onClick={onClearEntry}
               size="small"
             >
-              Clear entry
+              清除入口成员
             </Button>
           ) : null}
         </Space>
@@ -433,7 +464,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
           <Space align="center" size={8} wrap>
             <PlayCircleOutlined style={{ color: token.colorPrimary }} />
             <Typography.Text strong style={{ fontSize: 16 }}>
-              Test Team
+              测试团队
             </Typography.Text>
             <DetailPill
               compact
@@ -442,7 +473,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
             />
           </Space>
           <Typography.Text style={{ fontSize: 13 }} type="secondary">
-            通过 Team entry member 发起一次真实 Team invoke。
+            通过入口成员发起一次真实 Team 调用。
           </Typography.Text>
         </div>
         {lastResult ? (
@@ -456,7 +487,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
             }}
           >
             <Typography.Text style={{ fontSize: 12 }} type="secondary">
-              Last test · {lastResult.finishedAtLabel}
+              上次测试 · {lastResult.finishedAtLabel}
             </Typography.Text>
             <Space size={6} wrap>
               <DetailPill
@@ -510,7 +541,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
         }}
       >
         <Input.TextArea
-          aria-label="Team test prompt"
+          aria-label="测试问题"
           autoSize={{ minRows: 3, maxRows: 8 }}
           disabled={disabled || isRunning || isSettingEntry}
           onChange={(event) => onPromptChange(event.target.value)}
@@ -527,7 +558,7 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               onClick={onStop}
               type="primary"
             >
-              Stop
+              停止
             </Button>
           ) : (
             <Button
@@ -538,12 +569,12 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
               onClick={onTest}
               type="primary"
             >
-              Test Team
+              开始测试
             </Button>
           )}
           {error?.actionLabel === "Retry" && !isRunning ? (
             <Button block disabled={!canTest} onClick={onTest}>
-              Retry
+              重试
             </Button>
           ) : null}
         </Space>
@@ -570,10 +601,16 @@ const TeamTestPanel: React.FC<TeamTestPanelProps> = ({
             padding: "10px 14px",
           }}
         >
-          <span>Transcript</span>
+          <span>测试记录</span>
           <Space size={6}>
             <LinkOutlined />
-            <span style={{ fontFamily: factValueFontFamily }}>{teamId}</span>
+            <CompactFactValue
+              color={token.colorTextSecondary}
+              head={8}
+              strong={false}
+              tail={6}
+              value={teamId}
+            />
           </Space>
         </div>
         <Typography.Paragraph

--- a/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.test.tsx
@@ -6,7 +6,6 @@ import { scopeRuntimeApi } from "@/shared/api/scopeRuntimeApi";
 import { runtimeActorsApi } from "@/shared/api/runtimeActorsApi";
 import { runtimeGAgentApi } from "@/shared/api/runtimeGAgentApi";
 import { runtimeRunsApi } from "@/shared/api/runtimeRunsApi";
-import { history } from "@/shared/navigation/history";
 import { studioApi } from "@/shared/studio/api";
 import {
   createTestQueryClient,
@@ -15,8 +14,8 @@ import {
 import TeamDetailPage from "./detail";
 
 async function openTeamTestDialog() {
-  fireEvent.click(await screen.findByRole("button", { name: "Test Team" }));
-  await screen.findByLabelText("Team test prompt");
+  fireEvent.click(await screen.findByRole("button", { name: "测试团队" }));
+  await screen.findByLabelText("测试问题");
   return screen.getByTestId("team-test-modal-body");
 }
 
@@ -878,7 +877,7 @@ describe("TeamDetailPage", () => {
     const currentPostureHeading = screen.getByText("当前态势");
     const compositionHeading = screen.getByText("团队构成");
     const configurationHeading = screen.getByText("配置明细");
-    expect(screen.getByRole("button", { name: "Test Team" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "测试团队" })).toBeTruthy();
     expect(currentPostureHeading).toBeTruthy();
     expect(compositionHeading).toBeTruthy();
     expect(configurationHeading).toBeTruthy();
@@ -898,8 +897,8 @@ describe("TeamDetailPage", () => {
     expect(screen.queryByText("运行摘要")).toBeNull();
     expect(screen.queryByText("连接器引用")).toBeNull();
     expect(screen.queryByText("服务能力")).toBeNull();
-    expect(await screen.findByRole("button", { name: "Edit Team" })).toBeEnabled();
-    expect(await screen.findByRole("button", { name: "Team more actions" })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: "编辑团队" })).toBeEnabled();
+    expect(await screen.findByRole("button", { name: "团队更多操作" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "服务映射" })).toBeNull();
     expect(screen.queryByRole("button", { name: "高级编辑" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Archive Team" })).toBeNull();
@@ -1034,7 +1033,7 @@ describe("TeamDetailPage", () => {
     ).toBeNull();
   });
 
-  it("shows full raw identifiers inside overview configuration details", async () => {
+  it("keeps long raw identifiers compact inside overview configuration details", async () => {
     const longRevisionId =
       "rev-20260414154556-4d89bc2a3bf347f8b3bde41d716964f3";
 
@@ -1055,13 +1054,14 @@ describe("TeamDetailPage", () => {
 
     await screen.findByText("配置明细");
 
-    expect(await screen.findByText(`revisionId: ${longRevisionId}`)).toBeTruthy();
+    expect(await screen.findByText("revisionId: rev-20260414…716964f3")).toBeTruthy();
+    expect(screen.queryByText(`revisionId: ${longRevisionId}`)).toBeNull();
   });
 
   it("returns to the teams list when clicking the breadcrumb teams link", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("link", { name: "Teams" }));
 
     await waitFor(() => {
@@ -1073,7 +1073,7 @@ describe("TeamDetailPage", () => {
   it("returns to the teams list when clicking the breadcrumb aevatar link", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("link", { name: "Aevatar" }));
 
     await waitFor(() => {
@@ -1085,7 +1085,7 @@ describe("TeamDetailPage", () => {
   it("switches tabs inside the detail page", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
 
     expect(await screen.findByText("Team Alpha Operator")).toBeTruthy();
@@ -1136,13 +1136,13 @@ describe("TeamDetailPage", () => {
   it("shows a readable team members view", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
 
     expect(await screen.findByText("Team Alpha Operator")).toBeTruthy();
     expect(screen.getByText("负责处理升级工单")).toBeTruthy();
     expect(screen.getByText("member-team-alpha")).toBeTruthy();
-    expect(screen.getByText("Entry member")).toBeTruthy();
+    expect(screen.getByText("入口成员")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Edit in Studio" })).toBeTruthy();
     expect(screen.getByRole("link", { name: "Build" })).toBeTruthy();
     expect(screen.queryByRole("link", { name: "Test member" })).toBeNull();
@@ -1155,16 +1155,18 @@ describe("TeamDetailPage", () => {
   it("shows the configured Team entry member without treating it as the service target", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    expect(await screen.findByText(/入口成员/)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getAllByText("入口成员").length).toBeGreaterThan(0);
+    });
     await waitFor(() => {
       expect(screen.getAllByText("Team Alpha Operator").length).toBeGreaterThan(0);
     });
-    expect(screen.getByText("Team invoke routes through this member.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Clear entry" })).toBeEnabled();
+    expect(screen.getByText("调用这支 Team 时会先路由到这个成员。")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "清除入口成员" })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
 
-    expect(await screen.findByText("Entry member")).toBeTruthy();
+    expect(await screen.findByText("入口成员")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Set entry" })).toBeNull();
     expect(screen.getByText("alph...vice")).toBeTruthy();
   });
@@ -1193,7 +1195,7 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
     expect(await screen.findByText("Team Beta Operator")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Set entry" }));
@@ -1205,7 +1207,9 @@ describe("TeamDetailPage", () => {
         "member-team-beta",
       );
     });
-    expect(message.success).toHaveBeenCalledWith("Team entry member update accepted.");
+    expect(message.info).toHaveBeenCalledWith(
+      "Team entry 变更已提交，正在等待同步确认。",
+    );
     await waitFor(() => {
       expect(studioApi.getTeam).toHaveBeenCalledTimes(2);
       expect(studioApi.listTeamMembers).toHaveBeenCalledTimes(2);
@@ -1215,7 +1219,7 @@ describe("TeamDetailPage", () => {
   it("clears the Team entry member from the overview", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    fireEvent.click(await screen.findByRole("button", { name: "Clear entry" }));
+    fireEvent.click(await screen.findByRole("button", { name: "清除入口成员" }));
 
     await waitFor(() => {
       expect(studioApi.clearTeamEntryMember).toHaveBeenCalledWith(
@@ -1223,7 +1227,9 @@ describe("TeamDetailPage", () => {
         "t-alpha",
       );
     });
-    expect(message.success).toHaveBeenCalledWith("Team entry member clear accepted.");
+    expect(message.info).toHaveBeenCalledWith(
+      "Team entry 清除已提交，正在等待同步确认。",
+    );
     await waitFor(() => {
       expect(studioApi.getTeam).toHaveBeenCalledTimes(2);
       expect(studioApi.listTeamMembers).toHaveBeenCalledTimes(2);
@@ -1234,10 +1240,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Can this Team handle refunds?" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Test Team" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
 
     await waitFor(() => {
       expect(runtimeRunsApi.streamTeamChat).toHaveBeenCalledWith(
@@ -1254,7 +1260,7 @@ describe("TeamDetailPage", () => {
       );
     });
     expect(await screen.findByText("Team response")).toBeTruthy();
-    expect(await screen.findByText(/Last test/)).toBeTruthy();
+    expect(await screen.findByText(/上次测试/)).toBeTruthy();
   });
 
   it("auto-opens Team Test from the Team Detail route intent", async () => {
@@ -1263,7 +1269,7 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     expect(await screen.findByTestId("team-test-modal-body")).toBeTruthy();
-    expect(screen.getByLabelText("Team test prompt")).toBeTruthy();
+    expect(screen.getByLabelText("测试问题")).toBeTruthy();
   });
 
   it("does not treat bind-ready members without a published service as Team entry candidates", async () => {
@@ -1285,10 +1291,10 @@ describe("TeamDetailPage", () => {
     expect(unpublishedRow).toBeTruthy();
     expect(
       within(unpublishedRow as HTMLElement).queryByRole("button", {
-        name: "Set as entry and test",
+        name: "设为入口并测试",
       }),
     ).toBeNull();
-    expect(within(dialog).getByRole("link", { name: "Build / Bind first" }))
+    expect(within(dialog).getByRole("link", { name: "先 Build / Bind" }))
       .toHaveAttribute("href", expect.stringContaining("member-unpublished"));
   });
 
@@ -1311,10 +1317,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Route this customer question" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Set as entry and test" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "设为入口并测试" }));
 
     await waitFor(() => {
       expect(studioApi.setTeamEntryMember).toHaveBeenCalledWith(
@@ -1359,10 +1365,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Route after projection catches up" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Set as entry and test" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "设为入口并测试" }));
 
     await waitFor(() => {
       expect(studioApi.getTeam).toHaveBeenCalledTimes(4);
@@ -1387,15 +1393,15 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Route before projection catches up" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Set as entry and test" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "设为入口并测试" }));
 
     expect(await screen.findByText("Team entry 正在同步")).toBeTruthy();
     expect(
       screen.getAllByText(
-        "Team entry 已被后端受理，但读模型还没有确认新入口成员。请稍后重试 Test Team。",
+        "Team entry 已被后端受理，但读模型还没有确认新入口成员。请稍后重试测试团队。",
       ).length,
     ).toBeGreaterThan(0);
     expect(runtimeRunsApi.streamTeamChat).not.toHaveBeenCalled();
@@ -1411,10 +1417,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Try unsupported backend" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Test Team" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
 
     expect(await screen.findByText("后端暂不支持 Team Test")).toBeTruthy();
     expect(
@@ -1432,10 +1438,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Try missing entry" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Test Team" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
 
     expect(await screen.findByText("未设置入口成员")).toBeTruthy();
     expect(
@@ -1458,10 +1464,10 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     const dialog = await openTeamTestDialog();
-    fireEvent.change(within(dialog).getByLabelText("Team test prompt"), {
+    fireEvent.change(within(dialog).getByLabelText("测试问题"), {
       target: { value: "Try missing team" },
     });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Test Team" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "开始测试" }));
 
     expect(await screen.findByText("Team 不存在")).toBeTruthy();
     expect(
@@ -1475,7 +1481,7 @@ describe("TeamDetailPage", () => {
   it("routes member build actions into Studio with Team context", async () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
     fireEvent.click(await screen.findByRole("link", { name: "Build" }));
 
@@ -1500,9 +1506,9 @@ describe("TeamDetailPage", () => {
 
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
-    await screen.findByRole("button", { name: "Edit Team" });
+    await screen.findByRole("button", { name: "编辑团队" });
     fireEvent.click(screen.getByRole("button", { name: "团队成员" }));
-    fireEvent.click(await screen.findByRole("link", { name: "Create first member" }));
+    fireEvent.click(await screen.findByRole("link", { name: "创建第一个成员" }));
 
     expect(window.location.pathname).toBe("/studio");
     const params = new URLSearchParams(window.location.search);
@@ -1591,6 +1597,7 @@ describe("TeamDetailPage", () => {
         name: "Alpha Support Team",
       }),
     ).toBeTruthy();
+    expect(screen.getByText("已启用")).toBeTruthy();
     expect((await screen.findAllByText("Team summary")).length).toBeGreaterThan(0);
     expect(screen.getAllByText("3 个成员").length).toBeGreaterThan(0);
     expect(screen.getAllByText("来自 Team 更新时间").length).toBeGreaterThan(0);
@@ -1618,17 +1625,17 @@ describe("TeamDetailPage", () => {
       level: 1,
       name: "Alpha Support Team",
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit Team" }));
+    fireEvent.click(screen.getByRole("button", { name: "编辑团队" }));
 
-    const nameInput = await screen.findByLabelText("Edit team name");
+    const nameInput = await screen.findByLabelText("编辑团队名称");
     expect(nameInput).toHaveValue("Alpha Support Team");
     fireEvent.change(nameInput, {
       target: { value: " Alpha Ops Team " },
     });
-    fireEvent.change(screen.getByLabelText("Edit team description"), {
+    fireEvent.change(screen.getByLabelText("编辑团队说明"), {
       target: { value: "   " },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save Team" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存团队" }));
 
     await waitFor(() => {
       expect(studioApi.updateTeam).toHaveBeenCalledWith({
@@ -1657,12 +1664,12 @@ describe("TeamDetailPage", () => {
       level: 1,
       name: "Alpha Support Team",
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit Team" }));
-    fireEvent.change(await screen.findByLabelText("Edit team name"), {
+    fireEvent.click(screen.getByRole("button", { name: "编辑团队" }));
+    fireEvent.change(await screen.findByLabelText("编辑团队名称"), {
       target: { value: "   " },
     });
 
-    expect(screen.getByRole("button", { name: "Save Team" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "保存团队" })).toBeDisabled();
     expect(studioApi.updateTeam).not.toHaveBeenCalled();
   });
 
@@ -1682,18 +1689,18 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     expect((await screen.findAllByRole("heading", { name: "Alpha Support Team" })).length).toBeGreaterThan(0);
-    fireEvent.click(await screen.findByRole("button", { name: "Team more actions" }));
+    fireEvent.click(await screen.findByRole("button", { name: "团队更多操作" }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Archive Team" }));
-    expect(await screen.findByText("Archive this Team?")).toBeTruthy();
+    expect(await screen.findByText("归档这支团队？")).toBeTruthy();
     expect(
       screen.getByText(
-        "This marks the Team as archived and de-emphasizes it in the active roster. You can still edit its configuration and view its history.",
+        "归档后，这支 Team 会从活跃 roster 中降权显示，但你仍然可以继续编辑配置并查看历史。",
       ),
     ).toBeTruthy();
     fireEvent.click(
-      within(screen.getByRole("dialog", { name: "Archive this Team?" })).getByRole(
+      within(screen.getByRole("dialog", { name: "归档这支团队？" })).getByRole(
         "button",
-        { name: "Archive Team" },
+        { name: "归档团队" },
       ),
     );
 
@@ -1701,8 +1708,8 @@ describe("TeamDetailPage", () => {
       expect(studioApi.archiveTeam).toHaveBeenCalledWith("scope-1", "t-alpha");
     });
     expect(message.success).toHaveBeenCalledWith("Team archived.");
-    expect(screen.getByRole("button", { name: "Edit Team" })).toBeEnabled();
-    expect(screen.queryByRole("button", { name: "Team more actions" })).toBeNull();
+    expect(screen.getByRole("button", { name: "编辑团队" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "团队更多操作" })).toBeNull();
     expect(screen.queryByRole("menuitem", { name: "Archive Team" })).toBeNull();
   });
 
@@ -1720,8 +1727,8 @@ describe("TeamDetailPage", () => {
     renderWithQueryClient(React.createElement(TeamDetailPage));
 
     expect((await screen.findAllByRole("heading", { name: "Alpha Support Team" })).length).toBeGreaterThan(0);
-    expect(screen.getByRole("button", { name: "Edit Team" })).toBeEnabled();
-    expect(screen.queryByRole("button", { name: "Team more actions" })).toBeNull();
+    expect(screen.getByRole("button", { name: "编辑团队" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "团队更多操作" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Archive Team" })).toBeNull();
   });
 

--- a/apps/aevatar-console-web/src/pages/teams/detail.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/detail.tsx
@@ -23,7 +23,6 @@ import {
 import { isStudioApiStatus, studioApi } from "@/shared/studio/api";
 import {
   formatStudioMemberLifecycleStage,
-  formatStudioTeamLifecycleStage,
 } from "@/shared/studio/models";
 import type { StudioTeamSummary } from "@/shared/studio/models";
 import { AevatarCompactText } from "@/shared/ui/compactText";
@@ -143,6 +142,15 @@ function compactId(value: string | null | undefined): string {
     : compacted;
 }
 
+function compactOptionalId(value: string | null | undefined): string {
+  const normalized = trimText(value);
+  if (!normalized || normalized === "--") {
+    return "--";
+  }
+
+  return compactId(normalized);
+}
+
 function formatTeamTabLabel(tab: TeamDetailTab): string {
   switch (tab) {
     case "members":
@@ -198,8 +206,24 @@ function formatFriendlyStatus(value: string | null | undefined): string {
   }
 }
 
-function formatCompositionKind(kind: string): string {
+function formatTeamLifecycleLabel(value: string | null | undefined): string {
+  switch (normalizeStatus(value)) {
+    case "active":
+      return "已启用";
+    case "archived":
+      return "已归档";
+    case "unknown":
+      return "状态未知";
+    default:
+      return trimText(value) || "状态未知";
+  }
+}
+
+function formatCompositionKind(kind: string | null | undefined): string {
   switch (normalizeStatus(kind)) {
+    case "":
+    case "unknown":
+      return "暂未识别";
     case "workflow role":
       return "角色";
     case "workflow":
@@ -651,7 +675,7 @@ const TeamDetailPage: React.FC = () => {
   const teamTitle = teamHeading.title;
   const teamLifecycleStatus = trimText(teamSummaryQuery.data?.lifecycleStage);
   const teamLifecycleLabel = teamSummaryQuery.data
-    ? formatStudioTeamLifecycleStage(teamSummaryQuery.data.lifecycleStage)
+    ? formatTeamLifecycleLabel(teamSummaryQuery.data.lifecycleStage)
     : "";
   const teamSummaryDescription = trimText(teamSummaryQuery.data?.description);
   const teamMetaScopeId = teamHeading.metaScopeId || (selectedTeamId ? scopeId : "");
@@ -804,7 +828,7 @@ const TeamDetailPage: React.FC = () => {
   const currentRunStatus = trimText(lens.currentRun?.completionStatus) || "--";
   const currentRunFriendly = activeRunId
     ? formatFriendlyStatus(currentRunStatus)
-    : "暂无运行";
+    : "暂无可见运行";
   const currentServiceFriendly =
     currentServiceDisplayName !== "--"
       ? currentServiceDisplayName
@@ -823,9 +847,9 @@ const TeamDetailPage: React.FC = () => {
       : "版本待确认";
   const currentRunPillText = activeRunId
     ? `运行 · ${currentRunFriendly}`
-    : "暂无近期运行";
+    : "暂无近期可见运行";
   const currentServiceCardCaption = runtimeServiceId
-    ? `serviceId · ${runtimeServiceId}`
+    ? `serviceId · ${compactOptionalId(runtimeServiceId)}`
     : currentServiceKey !== "--" && currentServiceKey !== currentServiceFriendly
       ? `serviceKey · ${compactId(currentServiceKey)}`
       : "当前还没有更多服务标识";
@@ -836,10 +860,10 @@ const TeamDetailPage: React.FC = () => {
       : "当前还没有更多服务标识";
   const currentRunCardCaption = activeRunId
     ? `runId · ${compactId(activeRunId)}`
-    : "当前还没有可见 run";
+    : "当前还没有同步到可见运行";
   const currentRunCardTooltip = activeRunId
     ? `runId · ${activeRunId}`
-    : "当前还没有可见 run";
+    : "当前还没有同步到可见运行";
   const workflowNameValue =
     trimText(activeWorkflowSummary?.workflowName) ||
     trimText(lens.activeRevision?.workflowName) ||
@@ -857,16 +881,18 @@ const TeamDetailPage: React.FC = () => {
           currentServiceFriendly !== "--"
             ? `当前会落到 ${currentServiceFriendly}`
             : "当前还没有匹配到主服务入口",
-        value: formatCompositionKind(lens.activeRevision?.implementationKind || "runtime"),
+        value: formatCompositionKind(lens.activeRevision?.implementationKind),
       },
       {
         label: "主服务入口",
-        note: `serviceId: ${runtimeServiceId || "--"} · serviceKey: ${currentServiceKey}`,
+        note: `serviceId: ${compactOptionalId(runtimeServiceId)} · serviceKey: ${compactOptionalId(currentServiceKey)}`,
+        noteTooltip: `serviceId: ${runtimeServiceId || "--"} · serviceKey: ${currentServiceKey}`,
         value: currentServiceFriendly,
       },
       {
         label: "版本标识",
-        note: `revisionId: ${currentRevisionId}`,
+        note: `revisionId: ${compactOptionalId(currentRevisionId)}`,
+        noteTooltip: `revisionId: ${currentRevisionId}`,
         value: currentVersionFriendly,
       },
     ],
@@ -888,7 +914,7 @@ const TeamDetailPage: React.FC = () => {
         key: row.key,
         kind: row.implementationKind,
         name: row.name,
-        summary: row.description || `服务入口 ${row.serviceId}`,
+        summary: row.description || `服务入口 ${compactOptionalId(row.serviceId)}`,
       }));
     }
 
@@ -975,7 +1001,7 @@ const TeamDetailPage: React.FC = () => {
     ],
   );
 
-  const editTeamActionLabel = "Edit Team";
+  const editTeamActionLabel = "编辑团队";
   const canEditSelectedTeam = Boolean(teamSummaryQuery.data && selectedTeamId);
   const editTeamHint = selectedTeamId
     ? "Team summary 读取完成后才能编辑。"
@@ -1235,7 +1261,7 @@ const TeamDetailPage: React.FC = () => {
             updatedTeam,
           );
         }
-        void message.success("Team entry member update accepted.");
+        void message.info("Team entry 变更已提交，正在等待同步确认。");
         await refreshTeamAuthority();
         if (options?.test) {
           const entryVisible = await waitForTeamEntryVisibility(normalizedMemberId);
@@ -1243,7 +1269,7 @@ const TeamDetailPage: React.FC = () => {
             const errorDescription: TeamTestErrorDescription = {
               actionLabel: "Retry",
               description:
-                "Team entry 已被后端受理，但读模型还没有确认新入口成员。请稍后重试 Test Team。",
+                "Team entry 已被后端受理，但读模型还没有确认新入口成员。请稍后重试测试团队。",
               kind: "entry_syncing",
               title: "Team entry 正在同步",
             };
@@ -1299,7 +1325,7 @@ const TeamDetailPage: React.FC = () => {
           updatedTeam,
         );
       }
-      void message.success("Team entry member clear accepted.");
+      void message.info("Team entry 清除已提交，正在等待同步确认。");
       await refreshTeamAuthority();
       setTeamTestStatus("idle");
     } catch (error) {
@@ -1434,11 +1460,12 @@ const TeamDetailPage: React.FC = () => {
           editTeamHint={editTeamHint}
           editTeamLabel={editTeamActionLabel}
           onArchiveTeam={openTeamArchive}
-          onOpenTeamEditor={openTeamEditor}
-          onOpenTeamTest={openTeamTestModal}
-          testTeamDisabled={isTeamArchived}
-          testTeamHint="归档后的 Team 不能继续发起测试。"
-        />
+        onOpenTeamEditor={openTeamEditor}
+        onOpenTeamTest={openTeamTestModal}
+        testTeamDisabled={isTeamArchived}
+        testTeamHint="归档后的 Team 不能继续发起测试。"
+        testTeamLabel="测试团队"
+      />
       }
       activeTab={activeTab}
       activeTabLabel={formatTeamTabLabel(activeTab)}
@@ -1468,7 +1495,7 @@ const TeamDetailPage: React.FC = () => {
         footer={null}
         onCancel={closeTeamTestModal}
         open={teamTestModalOpen}
-        title="Test Team"
+        title="测试团队"
         width={960}
         styles={{
           body: {
@@ -1483,26 +1510,26 @@ const TeamDetailPage: React.FC = () => {
       <Modal
         confirmLoading={teamEditorSaving}
         okButtonProps={{ disabled: !teamEditorName.trim() }}
-        okText="Save Team"
+        okText="保存团队"
         onCancel={closeTeamEditor}
         onOk={() => void saveTeamEditor()}
         open={teamEditorOpen}
-        title="Edit Team"
+        title="编辑团队"
       >
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            <Typography.Text strong>Team name</Typography.Text>
+            <Typography.Text strong>团队名称</Typography.Text>
             <Input
-              aria-label="Edit team name"
+              aria-label="编辑团队名称"
               disabled={teamEditorSaving}
               onChange={(event) => setTeamEditorName(event.target.value)}
               value={teamEditorName}
             />
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            <Typography.Text strong>Description</Typography.Text>
+            <Typography.Text strong>团队说明</Typography.Text>
             <Input.TextArea
-              aria-label="Edit team description"
+              aria-label="编辑团队说明"
               autoSize={{ minRows: 3, maxRows: 5 }}
               disabled={teamEditorSaving}
               onChange={(event) => setTeamEditorDescription(event.target.value)}
@@ -1510,23 +1537,21 @@ const TeamDetailPage: React.FC = () => {
             />
           </div>
           <Typography.Text type="secondary">
-            This updates the Team summary. Archived Teams can still be edited
-            and maintained.
+            这里更新的是 Team summary。即使团队已归档，仍然可以继续编辑和维护。
           </Typography.Text>
         </div>
       </Modal>
       <Modal
         confirmLoading={teamArchiving}
-        okText="Archive Team"
+        okText="归档团队"
         okButtonProps={{ danger: true }}
         onCancel={closeTeamArchive}
         onOk={() => void confirmTeamArchive()}
         open={teamArchiveOpen}
-        title="Archive this Team?"
+        title="归档这支团队？"
       >
         <Typography.Text>
-          This marks the Team as archived and de-emphasizes it in the active
-          roster. You can still edit its configuration and view its history.
+          归档后，这支 Team 会从活跃 roster 中降权显示，但你仍然可以继续编辑配置并查看历史。
         </Typography.Text>
       </Modal>
     </TeamDetailShell>

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -381,6 +381,48 @@ describe("TeamsHomePage", () => {
     );
   });
 
+  it("keeps the list view primary action near the Team summary instead of after every fact block", async () => {
+    const teams = Array.from({ length: 7 }, (_, index) => ({
+      ...defaultTeams[0],
+      teamId: `t-list-${index + 1}`,
+      displayName: `列表团队 ${index + 1}`,
+      memberCount: 1,
+      updatedAt: `2026-05-0${Math.min(index + 1, 9)}T10:02:00Z`,
+    }));
+    const members = Array.from({ length: 7 }, (_, index) => ({
+      ...defaultMembers[0],
+      memberId: `member-list-${index + 1}`,
+      displayName: `列表成员 ${index + 1}`,
+      publishedServiceId: `service-list-${index + 1}`,
+      teamId: `t-list-${index + 1}`,
+    }));
+    const services = Array.from({ length: 7 }, (_, index) => ({
+      ...defaultServices[0],
+      serviceId: `service-list-${index + 1}`,
+      displayName: `列表服务 ${index + 1}`,
+    }));
+
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams,
+      nextPageToken: null,
+    });
+    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      members,
+      nextPageToken: null,
+    });
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValueOnce(services);
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByRole("list", { name: "团队紧凑视图" })).toBeTruthy();
+    const article = screen
+      .getByRole("heading", { level: 4, name: "列表团队 1" })
+      .closest("article");
+    expect(article?.firstElementChild?.textContent).toContain("查看团队");
+  });
+
   it("opens the bound member detail handoff from the primary action", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -161,8 +161,13 @@ describe("TeamsHomePage", () => {
     expect(screen.getByText("Aevatar / Teams")).toBeTruthy();
     expect(screen.getByText("我的 AI 团队")).toBeTruthy();
     expect(screen.queryByText("当前工作空间")).toBeNull();
-    expect(screen.getByText("AI Team")).toBeTruthy();
+    expect(screen.getByText("AI Team 总数")).toBeTruthy();
+    expect(screen.getByText("待处理 Team")).toBeTruthy();
+    expect(screen.getByText("运行稳定")).toBeTruthy();
     expect(screen.getByText("团队列表")).toBeTruthy();
+    expect(
+      screen.getByText("按 Team 聚合成员与最近运行信号，优先处理异常或待关注项。"),
+    ).toBeTruthy();
     expect(screen.queryByText("运行正常")).toBeNull();
     expect(screen.queryByText("需要处理")).toBeNull();
     expect(screen.getByRole("button", { name: "组建新团队" })).toBeTruthy();
@@ -213,7 +218,7 @@ describe("TeamsHomePage", () => {
     ).toBeNull();
   });
 
-  it("explains unresolved runtime status without exposing internal signal wording", async () => {
+  it("loads every bound member run summary without showing a synthetic sync warning", async () => {
     const members = Array.from({ length: 13 }, (_, index) => ({
       ...defaultMembers[0],
       memberId: `member-${index + 1}`,
@@ -229,15 +234,151 @@ describe("TeamsHomePage", () => {
 
     renderWithQueryClient(React.createElement(TeamsHomePage));
 
-    expect(await screen.findByText("部分 Team 的运行状态仍在同步")).toBeTruthy();
-    expect(screen.getAllByText("状态同步中").length).toBeGreaterThan(0);
     expect(
-      screen.getByText(
-        "成员已绑定，首页暂未同步到最近运行状态；打开团队可查看完整上下文。",
-      ),
+      await screen.findByText("成员已绑定服务，最近还没有运行记录。"),
     ).toBeTruthy();
+    await waitFor(() => {
+      expect(scopeRuntimeApi.listMemberRuns).toHaveBeenCalledTimes(13);
+    });
+    expect(screen.queryByText("部分 Team 的运行状态仍在同步")).toBeNull();
+    expect(screen.queryByText("状态同步中")).toBeNull();
+    expect(
+      screen.queryByText(/首页暂未同步到最近运行状态/),
+    ).toBeNull();
     expect(screen.queryByText(/绑定事实/)).toBeNull();
-    expect(screen.queryByText(/运行信号/)).toBeNull();
+    expect(screen.queryByText(/帮助你快速判断是否需要处理/)).toBeNull();
+  });
+
+  it("keeps long member and service summaries compact while preserving full text in titles", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [
+        {
+          teamId: "t-long",
+          scopeId: "scope-a",
+          displayName: "超长展示团队",
+          description: "需要压缩展示",
+          lifecycleStage: "active",
+          memberCount: 3,
+          createdAt: "2026-05-01T09:10:00Z",
+          updatedAt: "2026-05-01T10:10:00Z",
+        },
+      ],
+      nextPageToken: null,
+    });
+    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      members: [
+        {
+          ...defaultMembers[0],
+          memberId: "member-long-1",
+          displayName: "gagent-2 / member-m-d168d2df4f434004993f4ed475534497",
+          publishedServiceId: "service-long-1",
+          teamId: "t-long",
+        },
+        {
+          ...defaultMembers[0],
+          memberId: "member-long-2",
+          displayName: "另一个非常长的成员名字用于完整悬停展示",
+          publishedServiceId: "service-long-2",
+          teamId: "t-long",
+        },
+        {
+          ...defaultMembers[0],
+          memberId: "member-long-3",
+          displayName: "第三个成员",
+          publishedServiceId: "service-long-3",
+          teamId: "t-long",
+        },
+      ],
+      nextPageToken: null,
+    });
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValueOnce([
+      {
+        ...defaultServices[0],
+        serviceId: "service-long-1",
+        displayName: "gagent-2 / member-m-d168d2df4f434004993f4ed475534497",
+      },
+      {
+        ...defaultServices[0],
+        serviceId: "service-long-2",
+        displayName: "另一个非常长的服务名用于验证 hover 全量展示",
+      },
+      {
+        ...defaultServices[0],
+        serviceId: "service-long-3",
+        displayName: "第三个服务",
+      },
+    ]);
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByRole("heading", { level: 3, name: "超长展示团队" })).toBeTruthy();
+    expect(screen.getByText(/等 3 个成员/).closest("[title]")).toHaveAttribute(
+      "title",
+      expect.stringContaining("另一个非常长的成员名字用于完整悬停展示"),
+    );
+    expect(
+      screen.getByText("关联服务").previousElementSibling,
+    ).toHaveAttribute(
+      "title",
+      expect.stringContaining("另一个非常长的服务名用于验证 hover 全量展示"),
+    );
+    expect(screen.getByText("Team 标识：t-long").closest("[title]")).toHaveAttribute(
+      "title",
+      "t-long",
+    );
+  });
+
+  it("keeps long Team titles compact while preserving the full title in a tooltip", async () => {
+    (studioApi.listTeams as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      teams: [
+        {
+          teamId: "t-wide",
+          scopeId: "scope-a",
+          displayName:
+            "这是一个非常长的 Team 名称，用来验证首页标题不会把整张卡片撑到失控",
+          description: "需要保持稳定层级",
+          lifecycleStage: "active",
+          memberCount: 1,
+          createdAt: "2026-05-01T09:10:00Z",
+          updatedAt: "2026-05-01T10:10:00Z",
+        },
+      ],
+      nextPageToken: null,
+    });
+    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      members: [
+        {
+          ...defaultMembers[0],
+          memberId: "member-wide",
+          displayName: "标题验证成员",
+          publishedServiceId: "service-wide",
+          teamId: "t-wide",
+        },
+      ],
+      nextPageToken: null,
+    });
+    (scopeRuntimeApi.listServices as jest.Mock).mockResolvedValueOnce([
+      {
+        ...defaultServices[0],
+        serviceId: "service-wide",
+        displayName: "标题验证服务",
+      },
+    ]);
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    const heading = await screen.findByRole("heading", {
+      level: 3,
+      name: "这是一个非常长的 Team 名称，用来验证首页标题不会把整张卡片撑到失控",
+    });
+    expect(heading.parentElement).toHaveAttribute(
+      "title",
+      "这是一个非常长的 Team 名称，用来验证首页标题不会把整张卡片撑到失控",
+    );
   });
 
   it("opens the bound member detail handoff from the primary action", async () => {

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -397,7 +397,7 @@ describe("TeamsHomePage", () => {
     expect(params.get("runId")).toBe("run-latest");
   });
 
-  it("falls back to the locally stored auth scope when the live session lookup fails", async () => {
+  it("does not load roster data from a locally restored scope when server auth fails", async () => {
     window.history.replaceState({}, "", "/teams");
     persistAuthSession({
       tokens: {
@@ -424,6 +424,12 @@ describe("TeamsHomePage", () => {
         "登录状态暂时不可用，请刷新后重试。 已使用本地登录信息继续加载团队。",
       ),
     ).toBeTruthy();
+    expect(studioApi.listTeams).not.toHaveBeenCalled();
+    expect(studioApi.listMembers).not.toHaveBeenCalled();
+    expect(scopeRuntimeApi.listServices).not.toHaveBeenCalled();
+    expect(screen.queryByText("部分团队信号暂时不可见")).toBeNull();
+    expect(screen.queryByText("团队列表暂时无法加载。")).toBeNull();
+    expect(screen.queryByText("AI Team 总数")).toBeNull();
 
     await waitFor(() => {
       expect(new URLSearchParams(window.location.search).get("scopeId")).toBe("scope-a");

--- a/apps/aevatar-console-web/src/pages/teams/home.test.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.test.tsx
@@ -213,6 +213,33 @@ describe("TeamsHomePage", () => {
     ).toBeNull();
   });
 
+  it("explains unresolved runtime status without exposing internal signal wording", async () => {
+    const members = Array.from({ length: 13 }, (_, index) => ({
+      ...defaultMembers[0],
+      memberId: `member-${index + 1}`,
+      displayName: `成员 ${index + 1}`,
+      publishedServiceId: `service-${index + 1}`,
+      teamId: "t-support",
+    }));
+    (studioApi.listMembers as jest.Mock).mockResolvedValueOnce({
+      scopeId: "scope-a",
+      members,
+      nextPageToken: null,
+    });
+
+    renderWithQueryClient(React.createElement(TeamsHomePage));
+
+    expect(await screen.findByText("部分 Team 的运行状态仍在同步")).toBeTruthy();
+    expect(screen.getAllByText("状态同步中").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(
+        "成员已绑定，首页暂未同步到最近运行状态；打开团队可查看完整上下文。",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/绑定事实/)).toBeNull();
+    expect(screen.queryByText(/运行信号/)).toBeNull();
+  });
+
   it("opens the bound member detail handoff from the primary action", async () => {
     renderWithQueryClient(React.createElement(TeamsHomePage));
 

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -138,7 +138,7 @@ function formatOperationalStatusLabel(
     case "no-recent-runs":
       return "待运行";
     case "runtime-unresolved":
-      return "待确认";
+      return "同步中";
     default:
       return "未知";
   }
@@ -158,6 +158,8 @@ function formatAttentionLabel(attention: WorkflowOperationalAttention): string {
       return "待绑定";
     case "no-recent-runs":
       return "待运行";
+    case "runtime-unresolved":
+      return "状态同步中";
     default:
       return "待确认";
   }
@@ -276,13 +278,6 @@ function isFailedRun(run: ScopeServiceRunSummary | null | undefined): boolean {
   );
 }
 
-function stopEvent<T extends (...args: any[]) => void>(handler: T): T {
-  return ((event: React.MouseEvent<HTMLElement>) => {
-    event.stopPropagation();
-    handler();
-  }) as T;
-}
-
 const SummaryStatCard: React.FC<{
   readonly accent?: boolean;
   readonly label: string;
@@ -398,7 +393,9 @@ function groupMembersByTeamId(
     }
   });
 
-  result.forEach((teamMembers) => teamMembers.sort(compareMembers));
+  result.forEach((teamMembers) => {
+    teamMembers.sort(compareMembers);
+  });
   return result;
 }
 
@@ -479,7 +476,7 @@ function buildMemberRosterPreview(input: {
 
   if (runtimeUnavailable) {
     attention = "runtime-unresolved";
-    attentionDetail = "当前成员已经存在绑定事实，但本页暂时没有拿到它的运行信号。";
+    attentionDetail = "成员已绑定，首页暂未同步到最近运行状态；打开团队可查看完整上下文。";
   } else if (latestRun && isFailedRun(latestRun)) {
     attention = "failed";
     attentionDetail =
@@ -626,28 +623,18 @@ const TeamRosterCard: React.FC<{
   const { token } = theme.useToken();
 
   return (
-    <div
-      onClick={() => history.push(preview.detailHref)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          history.push(preview.detailHref);
-        }
-      }}
-      role="button"
+    <article
       style={{
         background: token.colorBgContainer,
         border: `1px solid ${token.colorBorderSecondary}`,
         borderRadius: 24,
         boxShadow: token.boxShadowTertiary,
-        cursor: "pointer",
         display: "flex",
         flexDirection: "column",
         gap: 14,
         minWidth: 0,
         padding: 18,
       }}
-      tabIndex={0}
     >
       <div
         style={{
@@ -742,14 +729,14 @@ const TeamRosterCard: React.FC<{
 
       <Space wrap>
         <Button
-          onClick={stopEvent(() => history.push(preview.detailHref))}
+          onClick={() => history.push(preview.detailHref)}
           size="large"
           type="primary"
         >
           查看团队
         </Button>
       </Space>
-    </div>
+    </article>
   );
 };
 
@@ -759,29 +746,20 @@ const TeamRosterRow: React.FC<{
   const { token } = theme.useToken();
 
   return (
-    <div
-      onClick={() => history.push(preview.detailHref)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          history.push(preview.detailHref);
-        }
-      }}
-      role="button"
+    <article
+      className="teams-home-roster-row"
       style={{
         alignItems: "center",
         background: token.colorBgContainer,
         border: `1px solid ${token.colorBorderSecondary}`,
         borderRadius: 20,
         boxShadow: token.boxShadowTertiary,
-        cursor: "pointer",
-    display: "grid",
-    gap: 16,
-    gridTemplateColumns: "minmax(0, 1.8fr) repeat(4, minmax(88px, 120px)) auto",
+        display: "grid",
+        gap: 16,
+        gridTemplateColumns: "minmax(0, 1.8fr) repeat(4, minmax(88px, 120px)) auto",
         minWidth: 0,
         padding: 16,
       }}
-      tabIndex={0}
     >
       <div style={{ minWidth: 0 }}>
         <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
@@ -841,15 +819,12 @@ const TeamRosterRow: React.FC<{
       <TeamFact label="成员" value={preview.memberPreviewLabel} />
       <TeamFact label="服务" value={preview.serviceLabel} />
 
-      <Space wrap>
-        <Button
-          onClick={stopEvent(() => history.push(preview.detailHref))}
-          type="primary"
-        >
+      <Space className="teams-home-roster-row-actions" wrap>
+        <Button onClick={() => history.push(preview.detailHref)} type="primary">
           查看团队
         </Button>
       </Space>
-    </div>
+    </article>
   );
 };
 
@@ -1044,6 +1019,13 @@ const TeamsHomePage: React.FC = () => {
       studioTeams,
     ],
   );
+  const unresolvedRuntimeTeamCount = React.useMemo(
+    () =>
+      teamPreviews.filter(
+        (preview) => preview.attention === "runtime-unresolved",
+      ).length,
+    [teamPreviews],
+  );
   const visibleTeamCount = teamPreviews.length;
   const resolvedRosterView =
     manualRosterView ??
@@ -1212,32 +1194,50 @@ const TeamsHomePage: React.FC = () => {
                     </Space.Compact>
                   ) : null}
                 </div>
+                {unresolvedRuntimeTeamCount > 0 ? (
+                  <Alert
+                    description={`有 ${unresolvedRuntimeTeamCount} 个 Team 已完成成员绑定，但首页暂未同步到最近运行状态。它们不一定需要处理；打开团队详情可以查看成员、服务和运行上下文。`}
+                    message="部分 Team 的运行状态仍在同步"
+                    showIcon
+                    type="info"
+                  />
+                ) : null}
                 {useCompactRoster ? (
-                  <div
+                  <ul
                     aria-label="团队紧凑视图"
                     style={{
                       display: "flex",
                       flexDirection: "column",
                       gap: 14,
+                      listStyle: "none",
+                      margin: 0,
+                      padding: 0,
                     }}
                   >
                     {teamPreviews.map((preview) => (
-                      <TeamRosterRow key={preview.teamId} preview={preview} />
+                      <li key={preview.teamId}>
+                        <TeamRosterRow preview={preview} />
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 ) : (
-                  <div
+                  <ul
                     aria-label="团队卡片视图"
                     style={{
                       display: "grid",
                       gap: 16,
                       gridTemplateColumns: "repeat(auto-fit, minmax(340px, 1fr))",
+                      listStyle: "none",
+                      margin: 0,
+                      padding: 0,
                     }}
                   >
                     {teamPreviews.map((preview) => (
-                      <TeamRosterCard key={preview.teamId} preview={preview} />
+                      <li key={preview.teamId}>
+                        <TeamRosterCard preview={preview} />
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 )}
               </>
             ) : (

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -878,6 +878,10 @@ const TeamsHomePage: React.FC = () => {
     () => resolveStudioScopeContext(authSessionQuery.data) ?? locallyResolvedScope,
     [authSessionQuery.data, locallyResolvedScope],
   );
+  const serverResolvedScope = React.useMemo(
+    () => resolveStudioScopeContext(authSessionQuery.data),
+    [authSessionQuery.data],
+  );
   const authSessionIssue = React.useMemo(() => {
     if (!authSessionQuery.isError) {
       return "";
@@ -900,6 +904,8 @@ const TeamsHomePage: React.FC = () => {
   }, [resolvedScope?.scopeId]);
 
   const scopeId = routeScopeId || resolvedScope?.scopeId?.trim() || "";
+  const queryScopeId =
+    serverResolvedScope?.scopeId?.trim() === scopeId ? scopeId : "";
 
   React.useEffect(() => {
     if (!scopeId) {
@@ -917,22 +923,22 @@ const TeamsHomePage: React.FC = () => {
   }, [scopeId]);
 
   const membersQuery = useQuery({
-    enabled: scopeId.length > 0,
-    queryKey: ["teams", "members", scopeId],
-    queryFn: () => studioApi.listMembers(scopeId),
+    enabled: queryScopeId.length > 0,
+    queryKey: ["teams", "members", queryScopeId],
+    queryFn: () => studioApi.listMembers(queryScopeId),
     retry: false,
   });
   const teamsQuery = useQuery({
-    enabled: scopeId.length > 0,
-    queryKey: ["teams", "roster", scopeId],
-    queryFn: () => studioApi.listTeams(scopeId),
+    enabled: queryScopeId.length > 0,
+    queryKey: ["teams", "roster", queryScopeId],
+    queryFn: () => studioApi.listTeams(queryScopeId),
     retry: false,
   });
   const servicesQuery = useQuery({
-    enabled: scopeId.length > 0,
-    queryKey: ["teams", "services", scopeId],
+    enabled: queryScopeId.length > 0,
+    queryKey: ["teams", "services", queryScopeId],
     queryFn: () =>
-      scopeRuntimeApi.listServices(scopeId, {
+      scopeRuntimeApi.listServices(queryScopeId, {
         appId: scopeServiceAppId,
       }),
     retry: false,
@@ -975,10 +981,10 @@ const TeamsHomePage: React.FC = () => {
   );
   const memberRunQueries = useQueries({
     queries: runtimeTrackableMembers.map((member) => ({
-      enabled: scopeId.length > 0 && membersQuery.isSuccess,
-      queryKey: ["teams", "member-runs", scopeId, member.memberId],
+      enabled: queryScopeId.length > 0 && membersQuery.isSuccess,
+      queryKey: ["teams", "member-runs", queryScopeId, member.memberId],
       queryFn: () =>
-        scopeRuntimeApi.listMemberRuns(scopeId, member.memberId, {
+        scopeRuntimeApi.listMemberRuns(queryScopeId, member.memberId, {
           take: 12,
         }),
       retry: false,
@@ -1008,6 +1014,7 @@ const TeamsHomePage: React.FC = () => {
     [
       membersByTeamId,
       runsByMemberId,
+      queryScopeId,
       scopeId,
       servicesQuery.data,
       studioTeams,

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -37,10 +37,7 @@ import {
   buildScopeHref,
   readScopeQueryDraft,
 } from "../scopes/components/scopeQuery";
-import {
-  WORKFLOW_RUNTIME_GUARDRAIL,
-  type WorkflowOperationalAttention,
-} from "./workflowOperationalUnits";
+import type { WorkflowOperationalAttention } from "./workflowOperationalUnits";
 import {
   clearSyncedPendingTeamRosterSummaries,
   mergePendingTeamRosterSummaries,
@@ -49,8 +46,13 @@ import {
 const scopeServiceAppId = "default";
 const compactTeamRosterThreshold = 6;
 
+type TeamOperationalAttention = Exclude<
+  WorkflowOperationalAttention,
+  "runtime-unresolved"
+>;
+
 type MemberRosterPreview = {
-  readonly attention: WorkflowOperationalAttention;
+  readonly attention: TeamOperationalAttention;
   readonly attentionDetail: string;
   readonly latestRun: ScopeServiceRunSummary | null;
   readonly memberId: string;
@@ -61,12 +63,14 @@ type MemberRosterPreview = {
 };
 
 type TeamRosterPreview = {
-  readonly attention: WorkflowOperationalAttention;
+  readonly attention: TeamOperationalAttention;
   readonly attentionDetail: string;
   readonly detailHref: string;
   readonly latestRun: ScopeServiceRunSummary | null;
   readonly memberPreviewLabel: string;
+  readonly memberPreviewTooltip?: string;
   readonly serviceLabel: string;
+  readonly serviceTooltip?: string;
   readonly team: StudioTeamSummary;
   readonly teamId: string;
   readonly title: string;
@@ -117,7 +121,7 @@ function formatRunStatusLabel(status: string | null | undefined): string {
 
 function formatOperationalStatusLabel(
   status: string | null | undefined,
-  attention: WorkflowOperationalAttention,
+  attention: TeamOperationalAttention,
 ): string {
   const normalizedStatus = trimOptional(status);
   if (normalizedStatus) {
@@ -137,14 +141,12 @@ function formatOperationalStatusLabel(
       return "待绑定";
     case "no-recent-runs":
       return "待运行";
-    case "runtime-unresolved":
-      return "同步中";
     default:
       return "未知";
   }
 }
 
-function formatAttentionLabel(attention: WorkflowOperationalAttention): string {
+function formatAttentionLabel(attention: TeamOperationalAttention): string {
   switch (attention) {
     case "failed":
       return "待处理";
@@ -158,8 +160,6 @@ function formatAttentionLabel(attention: WorkflowOperationalAttention): string {
       return "待绑定";
     case "no-recent-runs":
       return "待运行";
-    case "runtime-unresolved":
-      return "状态同步中";
     default:
       return "待确认";
   }
@@ -167,7 +167,7 @@ function formatAttentionLabel(attention: WorkflowOperationalAttention): string {
 
 function resolveAttentionPillStyle(
   token: ReturnType<typeof theme.useToken>["token"],
-  attention: WorkflowOperationalAttention,
+  attention: TeamOperationalAttention,
 ): React.CSSProperties {
   switch (attention) {
     case "healthy":
@@ -321,33 +321,75 @@ const SummaryStatCard: React.FC<{
   );
 };
 
-const TeamFact: React.FC<{
-  readonly label: string;
-  readonly value: React.ReactNode;
-}> = ({ label, value }) => (
+const TeamTitle: React.FC<{
+  readonly level: 3 | 4;
+  readonly title: string;
+}> = ({ level, title }) => (
   <div
     style={{
-      display: "flex",
-      flexDirection: "column",
-      gap: 4,
       minWidth: 0,
     }}
+    title={title}
   >
-    <Typography.Text
-      strong
+    <Typography.Title
+      level={level}
       style={{
-        fontSize: 16,
         margin: 0,
-        overflowWrap: "anywhere",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
       }}
     >
-      {value}
-    </Typography.Text>
-    <Typography.Text style={{ fontSize: 13 }} type="secondary">
-      {label}
-    </Typography.Text>
+      {title}
+    </Typography.Title>
   </div>
 );
+
+const TeamFact: React.FC<{
+  readonly label: string;
+  readonly tooltip?: string;
+  readonly value: React.ReactNode;
+}> = ({ label, tooltip, value }) => {
+  const { token } = theme.useToken();
+  const renderedValue = (
+    <span
+      style={{
+        color: token.colorText,
+        display: "block",
+        fontSize: 16,
+        fontWeight: 600,
+        margin: 0,
+        minWidth: 0,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      }}
+      title={typeof value === "string" ? tooltip || value : undefined}
+    >
+      {value}
+    </span>
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        minWidth: 0,
+      }}
+    >
+      {typeof value === "string" && (tooltip || value) ? (
+        <Tooltip title={tooltip || value}>{renderedValue}</Tooltip>
+      ) : (
+        renderedValue
+      )}
+      <Typography.Text style={{ fontSize: 13 }} type="secondary">
+        {label}
+      </Typography.Text>
+    </div>
+  );
+};
 
 function compareMembers(
   left: StudioMemberSummary,
@@ -415,32 +457,9 @@ function resolveMemberPreviewService(input: {
   );
 }
 
-function resolveRuntimeUnavailable(input: {
-  readonly memberId: string;
-  readonly runtimeAvailableByMemberId?: ReadonlySet<string>;
-  readonly runtimeGuardrailedMemberIds?: ReadonlySet<string>;
-}): boolean {
-  const memberId = trimOptional(input.memberId);
-  if (!memberId) {
-    return false;
-  }
-
-  if (input.runtimeGuardrailedMemberIds?.has(memberId)) {
-    return true;
-  }
-
-  if (!input.runtimeAvailableByMemberId) {
-    return false;
-  }
-
-  return !input.runtimeAvailableByMemberId.has(memberId);
-}
-
 function buildMemberRosterPreview(input: {
-  readonly guardrailedMemberIds?: ReadonlySet<string>;
   readonly member: StudioMemberSummary;
   readonly runsByMemberId: Readonly<Record<string, readonly ScopeServiceRunSummary[]>>;
-  readonly runtimeAvailableByMemberId?: ReadonlySet<string>;
   readonly scopeId: string;
   readonly services: readonly ServiceCatalogSnapshot[];
   readonly teamId?: string | null;
@@ -453,31 +472,17 @@ function buildMemberRosterPreview(input: {
   const serviceId =
     trimOptional(input.member.publishedServiceId) ||
     trimOptional(matchedService?.serviceId);
-  const runtimeRelevant = Boolean(
-    serviceId || trimOptional(input.member.lastBoundRevisionId),
-  );
-  const runtimeUnavailable =
-    runtimeRelevant &&
-    resolveRuntimeUnavailable({
-      memberId,
-      runtimeAvailableByMemberId: input.runtimeAvailableByMemberId,
-      runtimeGuardrailedMemberIds: input.guardrailedMemberIds,
-    });
-  const runs =
-    memberId && !runtimeUnavailable ? input.runsByMemberId[memberId] ?? [] : [];
+  const runs = memberId ? input.runsByMemberId[memberId] ?? [] : [];
   const latestRun = runs.slice().sort(compareRuns)[0] ?? null;
   const serviceLabel =
     pickMeaningfulLabel(trimOptional(matchedService?.displayName), serviceId) ||
     (trimOptional(input.member.lastBoundRevisionId) ? "已绑定待确认" : "未绑定");
   const title = pickMeaningfulLabel(input.member.displayName, input.member.memberId) || "未命名成员";
 
-  let attention: WorkflowOperationalAttention = "draft";
+  let attention: TeamOperationalAttention = "draft";
   let attentionDetail = `当前成员还处于 ${formatStudioMemberLifecycleStage(input.member.lifecycleStage)} 阶段。`;
 
-  if (runtimeUnavailable) {
-    attention = "runtime-unresolved";
-    attentionDetail = "成员已绑定，首页暂未同步到最近运行状态；打开团队可查看完整上下文。";
-  } else if (latestRun && isFailedRun(latestRun)) {
+  if (latestRun && isFailedRun(latestRun)) {
     attention = "failed";
     attentionDetail =
       trimOptional(latestRun.lastError) || "最近一次成员运行处于异常状态。";
@@ -490,7 +495,7 @@ function buildMemberRosterPreview(input: {
     attentionDetail = "最近一次成员运行正常，可继续进入详情查看。";
   } else if (serviceId || matchedService) {
     attention = "no-recent-runs";
-    attentionDetail = "当前成员已经形成绑定，但还没有可见的运行信号。";
+    attentionDetail = "成员已绑定服务，最近还没有运行记录。";
   } else if (
     trimOptional(input.member.lastBoundRevisionId) ||
     input.member.lifecycleStage === "bind_ready"
@@ -516,20 +521,16 @@ function buildMemberRosterPreview(input: {
 }
 
 function buildTeamRosterPreview(input: {
-  readonly guardrailedMemberIds?: ReadonlySet<string>;
   readonly members: readonly StudioMemberSummary[];
   readonly runsByMemberId: Readonly<Record<string, readonly ScopeServiceRunSummary[]>>;
-  readonly runtimeAvailableByMemberId?: ReadonlySet<string>;
   readonly scopeId: string;
   readonly services: readonly ServiceCatalogSnapshot[];
   readonly team: StudioTeamSummary;
 }): TeamRosterPreview {
   const memberPreviews = input.members.map((member) =>
     buildMemberRosterPreview({
-      guardrailedMemberIds: input.guardrailedMemberIds,
       member,
       runsByMemberId: input.runsByMemberId,
-      runtimeAvailableByMemberId: input.runtimeAvailableByMemberId,
       scopeId: input.scopeId,
       services: input.services,
       teamId: input.team.teamId,
@@ -541,14 +542,13 @@ function buildTeamRosterPreview(input: {
       .map((preview) => preview.latestRun)
       .filter((run): run is ScopeServiceRunSummary => Boolean(run))
       .sort(compareRuns)[0] ?? null;
-  const statusRank: Record<WorkflowOperationalAttention, number> = {
+  const statusRank: Record<TeamOperationalAttention, number> = {
     failed: 0,
     waiting: 1,
-    "runtime-unresolved": 2,
-    "no-bound-service": 3,
-    "no-recent-runs": 4,
-    draft: 5,
-    healthy: 6,
+    "no-bound-service": 2,
+    "no-recent-runs": 3,
+    draft: 4,
+    healthy: 5,
   };
   const mostImportantMemberPreview = memberPreviews
     .slice()
@@ -576,6 +576,16 @@ function buildTeamRosterPreview(input: {
     .map((preview) => preview.serviceLabel)
     .filter((label) => label && label !== "未绑定");
   const uniqueServiceLabels = Array.from(new Set(serviceLabels));
+  const memberPreviewTooltip =
+    sortedMembers.length > 0
+      ? sortedMembers
+          .map((member) =>
+            pickMeaningfulLabel(member.displayName, member.memberId) || "未命名成员",
+          )
+          .join(" / ")
+      : undefined;
+  const serviceTooltip =
+    uniqueServiceLabels.length > 0 ? uniqueServiceLabels.join(" / ") : undefined;
   const primaryMemberPreview =
     memberPreviews.find((preview) => preview.serviceId) ?? memberPreviews[0] ?? null;
   const detailHref = buildTeamDetailHref({
@@ -586,7 +596,7 @@ function buildTeamRosterPreview(input: {
     teamId: input.team.teamId,
   });
 
-  let attention: WorkflowOperationalAttention =
+  let attention: TeamOperationalAttention =
     mostImportantMemberPreview?.attention ?? "draft";
   let attentionDetail = "这个 Team 已经存在后端事实，但还没有分配成员。";
   if (input.team.lifecycleStage === "archived") {
@@ -602,10 +612,12 @@ function buildTeamRosterPreview(input: {
     detailHref,
     latestRun,
     memberPreviewLabel,
+    memberPreviewTooltip,
     serviceLabel:
       uniqueServiceLabels.length > 0
         ? uniqueServiceLabels.slice(0, 2).join(" / ")
         : "暂无绑定服务",
+    serviceTooltip,
     team: input.team,
     teamId: input.team.teamId,
     title: pickMeaningfulLabel(input.team.displayName, input.team.teamId) || "未命名 Team",
@@ -645,16 +657,9 @@ const TeamRosterCard: React.FC<{
         }}
       >
         <div style={{ minWidth: 0 }}>
-          <Typography.Title
-            level={3}
-            style={{
-              fontSize: 22,
-              margin: 0,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {preview.title}
-          </Typography.Title>
+          <div style={{ fontSize: 22 }}>
+            <TeamTitle level={3} title={preview.title} />
+          </div>
           <Typography.Paragraph
             ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
             style={{
@@ -684,8 +689,11 @@ const TeamRosterCard: React.FC<{
       </div>
 
       <Typography.Text
+        title={preview.teamId}
+        ellipsis={{ tooltip: preview.teamId }}
         style={{
           color: token.colorTextSecondary,
+          display: "block",
           fontSize: 13,
         }}
       >
@@ -723,8 +731,16 @@ const TeamRosterCard: React.FC<{
           paddingTop: 14,
         }}
       >
-        <TeamFact label="Team 成员" value={preview.memberPreviewLabel} />
-        <TeamFact label="关联服务" value={preview.serviceLabel} />
+        <TeamFact
+          label="Team 成员"
+          tooltip={preview.memberPreviewTooltip}
+          value={preview.memberPreviewLabel}
+        />
+        <TeamFact
+          label="关联服务"
+          tooltip={preview.serviceTooltip}
+          value={preview.serviceLabel}
+        />
       </div>
 
       <Space wrap>
@@ -763,15 +779,9 @@ const TeamRosterRow: React.FC<{
     >
       <div style={{ minWidth: 0 }}>
         <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
-          <Typography.Title
-            level={4}
-            style={{
-              margin: 0,
-              overflowWrap: "anywhere",
-            }}
-          >
-            {preview.title}
-          </Typography.Title>
+          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+            <TeamTitle level={4} title={preview.title} />
+          </div>
           <span
             style={{
               ...resolveAttentionPillStyle(token, preview.attention),
@@ -799,8 +809,11 @@ const TeamRosterRow: React.FC<{
           {preview.attentionDetail}
         </Typography.Paragraph>
         <Typography.Text
+          title={preview.teamId}
+          ellipsis={{ tooltip: preview.teamId }}
           style={{
             color: token.colorTextSecondary,
+            display: "block",
             fontSize: 13,
           }}
         >
@@ -816,8 +829,16 @@ const TeamRosterRow: React.FC<{
         )}
       />
       <TeamFact label="更新" value={formatShortTime(preview.updatedAt)} />
-      <TeamFact label="成员" value={preview.memberPreviewLabel} />
-      <TeamFact label="服务" value={preview.serviceLabel} />
+      <TeamFact
+        label="成员"
+        tooltip={preview.memberPreviewTooltip}
+        value={preview.memberPreviewLabel}
+      />
+      <TeamFact
+        label="服务"
+        tooltip={preview.serviceTooltip}
+        value={preview.serviceLabel}
+      />
 
       <Space className="teams-home-roster-row-actions" wrap>
         <Button onClick={() => history.push(preview.detailHref)} type="primary">
@@ -952,22 +973,8 @@ const TeamsHomePage: React.FC = () => {
       ),
     [studioMembers],
   );
-  const runtimeSampleMembers = React.useMemo(
-    () => runtimeTrackableMembers.slice(0, WORKFLOW_RUNTIME_GUARDRAIL),
-    [runtimeTrackableMembers],
-  );
-  const guardrailedMemberIds = React.useMemo(
-    () =>
-      new Set(
-        runtimeTrackableMembers
-          .slice(WORKFLOW_RUNTIME_GUARDRAIL)
-          .map((member) => trimOptional(member.memberId))
-          .filter(Boolean),
-      ),
-    [runtimeTrackableMembers],
-  );
   const memberRunQueries = useQueries({
-    queries: runtimeSampleMembers.map((member) => ({
+    queries: runtimeTrackableMembers.map((member) => ({
       enabled: scopeId.length > 0 && membersQuery.isSuccess,
       queryKey: ["teams", "member-runs", scopeId, member.memberId],
       queryFn: () =>
@@ -977,56 +984,42 @@ const TeamsHomePage: React.FC = () => {
       retry: false,
     })),
   });
-  const runtimeAvailableByMemberId = React.useMemo(() => {
-    const available = new Set<string>();
-    memberRunQueries.forEach((query, index) => {
-      if (query.isSuccess) {
-        available.add(trimOptional(runtimeSampleMembers[index]?.memberId));
-      }
-    });
-    return available;
-  }, [memberRunQueries, runtimeSampleMembers]);
   const runsByMemberId = React.useMemo(
     () =>
       Object.fromEntries(
-        runtimeSampleMembers.map((member, index) => [
+        runtimeTrackableMembers.map((member, index) => [
           trimOptional(member.memberId),
           memberRunQueries[index]?.data?.runs ?? [],
         ]),
-      ) as Record<string, readonly any[]>,
-    [memberRunQueries, runtimeSampleMembers],
+      ) as Record<string, readonly ScopeServiceRunSummary[]>,
+    [memberRunQueries, runtimeTrackableMembers],
   );
   const teamPreviews = React.useMemo(
     () =>
       studioTeams.map((team) =>
         buildTeamRosterPreview({
-          guardrailedMemberIds,
           members: membersByTeamId.get(team.teamId) ?? [],
           runsByMemberId,
-          runtimeAvailableByMemberId,
           scopeId,
           services: servicesQuery.data ?? [],
           team,
         }),
       ),
     [
-      guardrailedMemberIds,
       membersByTeamId,
       runsByMemberId,
-      runtimeAvailableByMemberId,
       scopeId,
       servicesQuery.data,
       studioTeams,
     ],
   );
-  const unresolvedRuntimeTeamCount = React.useMemo(
-    () =>
-      teamPreviews.filter(
-        (preview) => preview.attention === "runtime-unresolved",
-      ).length,
-    [teamPreviews],
-  );
   const visibleTeamCount = teamPreviews.length;
+  const actionableTeamCount = teamPreviews.filter(
+    (preview) => preview.attention !== "healthy",
+  ).length;
+  const healthyTeamCount = teamPreviews.filter(
+    (preview) => preview.attention === "healthy",
+  ).length;
   const resolvedRosterView =
     manualRosterView ??
     (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
@@ -1130,7 +1123,9 @@ const TeamsHomePage: React.FC = () => {
                 gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
               }}
             >
-              <SummaryStatCard accent label="AI Team" value={visibleTeamCount} />
+              <SummaryStatCard accent label="AI Team 总数" value={visibleTeamCount} />
+              <SummaryStatCard label="待处理 Team" value={actionableTeamCount} />
+              <SummaryStatCard label="运行稳定" value={healthyTeamCount} />
             </div>
 
             {teamsQuery.isLoading ? (
@@ -1168,7 +1163,7 @@ const TeamsHomePage: React.FC = () => {
                       团队列表
                     </Typography.Title>
                     <Typography.Text type="secondary">
-                      当前账号下已经创建的 AI Team；成员和运行状态用于帮助你快速判断是否需要处理。
+                      按 Team 聚合成员与最近运行信号，优先处理异常或待关注项。
                     </Typography.Text>
                   </div>
                   {visibleTeamCount > 1 ? (
@@ -1194,14 +1189,6 @@ const TeamsHomePage: React.FC = () => {
                     </Space.Compact>
                   ) : null}
                 </div>
-                {unresolvedRuntimeTeamCount > 0 ? (
-                  <Alert
-                    description={`有 ${unresolvedRuntimeTeamCount} 个 Team 已完成成员绑定，但首页暂未同步到最近运行状态。它们不一定需要处理；打开团队详情可以查看成员、服务和运行上下文。`}
-                    message="部分 Team 的运行状态仍在同步"
-                    showIcon
-                    type="info"
-                  />
-                ) : null}
                 {useCompactRoster ? (
                   <ul
                     aria-label="团队紧凑视图"

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -906,6 +906,7 @@ const TeamsHomePage: React.FC = () => {
   const scopeId = routeScopeId || resolvedScope?.scopeId?.trim() || "";
   const queryScopeId =
     serverResolvedScope?.scopeId?.trim() === scopeId ? scopeId : "";
+  const canLoadRoster = queryScopeId.length > 0;
 
   React.useEffect(() => {
     if (!scopeId) {
@@ -923,19 +924,19 @@ const TeamsHomePage: React.FC = () => {
   }, [scopeId]);
 
   const membersQuery = useQuery({
-    enabled: queryScopeId.length > 0,
+    enabled: canLoadRoster,
     queryKey: ["teams", "members", queryScopeId],
     queryFn: () => studioApi.listMembers(queryScopeId),
     retry: false,
   });
   const teamsQuery = useQuery({
-    enabled: queryScopeId.length > 0,
+    enabled: canLoadRoster,
     queryKey: ["teams", "roster", queryScopeId],
     queryFn: () => studioApi.listTeams(queryScopeId),
     retry: false,
   });
   const servicesQuery = useQuery({
-    enabled: queryScopeId.length > 0,
+    enabled: canLoadRoster,
     queryKey: ["teams", "services", queryScopeId],
     queryFn: () =>
       scopeRuntimeApi.listServices(queryScopeId, {
@@ -981,7 +982,7 @@ const TeamsHomePage: React.FC = () => {
   );
   const memberRunQueries = useQueries({
     queries: runtimeTrackableMembers.map((member) => ({
-      enabled: queryScopeId.length > 0 && membersQuery.isSuccess,
+      enabled: canLoadRoster && membersQuery.isSuccess,
       queryKey: ["teams", "member-runs", queryScopeId, member.memberId],
       queryFn: () =>
         scopeRuntimeApi.listMemberRuns(queryScopeId, member.memberId, {
@@ -1032,7 +1033,7 @@ const TeamsHomePage: React.FC = () => {
     (visibleTeamCount >= compactTeamRosterThreshold ? "list" : "cards");
   const useCompactRoster = resolvedRosterView === "list";
   const emptyRosterHint =
-    scopeId.length > 0
+    canLoadRoster
       ? "当前账号还没有创建任何 Team。创建后，这里会展示你的 AI 团队列表。"
       : "当前登录状态还没有解析出可用的团队范围，请刷新后重试。";
   const partialIssues = [
@@ -1095,7 +1096,7 @@ const TeamsHomePage: React.FC = () => {
           />
         ) : null}
 
-        {partialIssues.length > 0 ? (
+        {canLoadRoster && partialIssues.length > 0 ? (
           <Alert
             description={partialIssues.join(" ")}
             showIcon
@@ -1121,7 +1122,7 @@ const TeamsHomePage: React.FC = () => {
           />
         ) : null}
 
-        {scopeId ? (
+        {canLoadRoster ? (
           <>
             <div
               style={{

--- a/apps/aevatar-console-web/src/pages/teams/home.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/home.tsx
@@ -765,86 +765,106 @@ const TeamRosterRow: React.FC<{
     <article
       className="teams-home-roster-row"
       style={{
-        alignItems: "center",
         background: token.colorBgContainer,
         border: `1px solid ${token.colorBorderSecondary}`,
         borderRadius: 20,
         boxShadow: token.boxShadowTertiary,
-        display: "grid",
-        gap: 16,
-        gridTemplateColumns: "minmax(0, 1.8fr) repeat(4, minmax(88px, 120px)) auto",
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
         minWidth: 0,
         padding: 16,
       }}
     >
-      <div style={{ minWidth: 0 }}>
-        <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
-          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
-            <TeamTitle level={4} title={preview.title} />
-          </div>
-          <span
+      <div
+        style={{
+          alignItems: "flex-start",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 12,
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ flex: "1 1 280px", minWidth: 0 }}>
+          <Space size={[8, 8]} wrap style={{ marginBottom: 6 }}>
+            <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+              <TeamTitle level={4} title={preview.title} />
+            </div>
+            <span
+              style={{
+                ...resolveAttentionPillStyle(token, preview.attention),
+                borderRadius: 999,
+                display: "inline-flex",
+                fontSize: 12,
+                fontWeight: 600,
+                lineHeight: 1,
+                padding: "7px 10px",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {formatAttentionLabel(preview.attention)}
+            </span>
+          </Space>
+          <Typography.Paragraph
+            ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
             style={{
-              ...resolveAttentionPillStyle(token, preview.attention),
-              borderRadius: 999,
-              display: "inline-flex",
-              fontSize: 12,
-              fontWeight: 600,
-              lineHeight: 1,
-              padding: "7px 10px",
-              whiteSpace: "nowrap",
+              color: token.colorTextSecondary,
+              fontSize: 13,
+              marginBottom: 0,
+              marginTop: 0,
             }}
           >
-            {formatAttentionLabel(preview.attention)}
-          </span>
+            {preview.attentionDetail}
+          </Typography.Paragraph>
+          <Typography.Text
+            title={preview.teamId}
+            ellipsis={{ tooltip: preview.teamId }}
+            style={{
+              color: token.colorTextSecondary,
+              display: "block",
+              fontSize: 13,
+              marginTop: 4,
+            }}
+          >
+            Team 标识：{preview.teamId}
+          </Typography.Text>
+        </div>
+
+        <Space className="teams-home-roster-row-actions" wrap>
+          <Button onClick={() => history.push(preview.detailHref)} type="primary">
+            查看团队
+          </Button>
         </Space>
-        <Typography.Paragraph
-          ellipsis={{ rows: 1, tooltip: preview.attentionDetail }}
-          style={{
-            color: token.colorTextSecondary,
-            fontSize: 13,
-            marginBottom: 0,
-            marginTop: 0,
-          }}
-        >
-          {preview.attentionDetail}
-        </Typography.Paragraph>
-        <Typography.Text
-          title={preview.teamId}
-          ellipsis={{ tooltip: preview.teamId }}
-          style={{
-            color: token.colorTextSecondary,
-            display: "block",
-            fontSize: 13,
-          }}
-        >
-          Team 标识：{preview.teamId}
-        </Typography.Text>
       </div>
 
-      <TeamFact
-        label="状态"
-        value={formatOperationalStatusLabel(
-          preview.latestRun?.completionStatus,
-          preview.attention,
-        )}
-      />
-      <TeamFact label="更新" value={formatShortTime(preview.updatedAt)} />
-      <TeamFact
-        label="成员"
-        tooltip={preview.memberPreviewTooltip}
-        value={preview.memberPreviewLabel}
-      />
-      <TeamFact
-        label="服务"
-        tooltip={preview.serviceTooltip}
-        value={preview.serviceLabel}
-      />
-
-      <Space className="teams-home-roster-row-actions" wrap>
-        <Button onClick={() => history.push(preview.detailHref)} type="primary">
-          查看团队
-        </Button>
-      </Space>
+      <div
+        style={{
+          borderTop: `1px solid ${token.colorBorderSecondary}`,
+          display: "grid",
+          gap: 14,
+          gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+          paddingTop: 14,
+        }}
+      >
+        <TeamFact
+          label="状态"
+          value={formatOperationalStatusLabel(
+            preview.latestRun?.completionStatus,
+            preview.attention,
+          )}
+        />
+        <TeamFact label="更新" value={formatShortTime(preview.updatedAt)} />
+        <TeamFact
+          label="成员"
+          tooltip={preview.memberPreviewTooltip}
+          value={preview.memberPreviewLabel}
+        />
+        <TeamFact
+          label="服务"
+          tooltip={preview.serviceTooltip}
+          value={preview.serviceLabel}
+        />
+      </div>
     </article>
   );
 };

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamMembersTab.tsx
@@ -193,7 +193,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                               border: `1px solid ${token.colorSuccessBorder}`,
                               color: token.colorSuccess,
                             }}
-                            text="Entry member"
+                            text="入口成员"
                           />
                         ) : null}
                       </div>
@@ -232,7 +232,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                           onClick={onClearEntry}
                           size="small"
                         >
-                          Clear entry
+                          清除入口成员
                         </Button>
                       ) : row.canInvokeAsEntry && onSetEntry ? (
                         <Button
@@ -283,7 +283,7 @@ const TeamMembersTab: React.FC<TeamMembersTabProps> = ({
                   onClick={handleNavigate(createMemberHref)}
                   type="primary"
                 >
-                  Create first member
+                  创建第一个成员
                 </Button>
               </div>
             ) : null}

--- a/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
+++ b/apps/aevatar-console-web/src/pages/teams/tabs/TeamOverviewTab.tsx
@@ -18,6 +18,7 @@ type OverviewCompositionRow = {
 type OverviewConfigurationRow = {
   readonly label: string;
   readonly note: string;
+  readonly noteTooltip?: string;
   readonly value: string;
 };
 
@@ -150,8 +151,8 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
             value={entryMemberLabel || entryMemberId || "未配置"}
             caption={
               hasEntryMember
-                ? "Team invoke routes through this member."
-                : "Set an entry member before invoking this team."
+                ? "调用这支 Team 时会先路由到这个成员。"
+                : "测试或调用前，请先设置一个入口成员。"
             }
           />
         </div>
@@ -162,7 +163,7 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
               onClick={onClearEntryMember}
               size="small"
             >
-              Clear entry
+              清除入口成员
             </Button>
           </div>
         ) : null}
@@ -234,7 +235,12 @@ const TeamOverviewTab: React.FC<TeamOverviewTabProps> = ({
                   </Typography.Text>
                   <div style={{ display: "flex", flexDirection: "column", gap: 4, minWidth: 0 }}>
                     <Typography.Text strong>{row.value}</Typography.Text>
-                    <FactLine rows={2} secondary text={row.note} />
+                    <FactLine
+                      rows={2}
+                      secondary
+                      text={row.note}
+                      tooltipText={row.noteTooltip}
+                    />
                   </div>
                 </div>
               ))}

--- a/apps/aevatar-console-web/src/shared/config/proxyConfig.test.ts
+++ b/apps/aevatar-console-web/src/shared/config/proxyConfig.test.ts
@@ -128,6 +128,33 @@ describe('proxy config', () => {
       changeOrigin: true,
       ws: true,
     });
+    expect(resolveProxyEntry(devProxy, '/api/scopes/scope-1/members')).toEqual({
+      target: 'http://127.0.0.1:5180',
+      changeOrigin: true,
+      ws: true,
+    });
+    expect(resolveProxyEntry(devProxy, '/api/scopes/scope-1/members/m-alpha')).toEqual({
+      target: 'http://127.0.0.1:5180',
+      changeOrigin: true,
+      ws: true,
+    });
+    expect(
+      resolveProxyEntry(devProxy, '/api/scopes/scope-1/members/m-alpha/binding'),
+    ).toEqual({
+      target: 'http://127.0.0.1:5180',
+      changeOrigin: true,
+      ws: true,
+    });
+    expect(
+      resolveProxyEntry(
+        devProxy,
+        '/api/scopes/scope-1/members/m-alpha/endpoints/chat/contract',
+      ),
+    ).toEqual({
+      target: 'http://127.0.0.1:5180',
+      changeOrigin: true,
+      ws: true,
+    });
     expect(
       resolveProxyEntry(devProxy, '/api/scopes/scope-1/teams/t-alpha/archive'),
     ).toEqual({

--- a/apps/aevatar-console-web/tests/setupTests.jsx
+++ b/apps/aevatar-console-web/tests/setupTests.jsx
@@ -2,6 +2,9 @@
 
 defaultConfig.hashed = false;
 
+// React 19 expects the test environment to opt into act-aware updates.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
 const localStorageState = new Map();
 
 const localStorageMock = {
@@ -113,6 +116,7 @@ if (typeof window !== 'undefined') {
 }
 const ignoredConsoleErrors = [
   'Warning: An update to %s inside a test was not wrapped in act(...)',
+  'The current testing environment is not configured to support act(...)',
   'Warning: [antd: Space] `direction` is deprecated. Please use `orientation` instead.',
   'Warning: [antd: List] The `List` component is deprecated. And will be removed in next major version.',
   'Warning: [antd: Alert] `message` is deprecated. Please use `title` instead.',


### PR DESCRIPTION
## Summary
- Improve the frontend Team and Studio member flow so async accepted states are presented honestly instead of as completed success.
- Keep Studio Build aligned to the selected member implementation, including routed GAgent members opening the GAgent Build surface with actor type restored.
- Tighten Team member/home/detail surfaces for clearer readiness, next actions, and responsive presentation.

## Scope
- Frontend-only changes under `apps/aevatar-console-web/`.
- No backend, proto, docs, tools, or .NET project changes included.

## Verification
- `pnpm --dir apps/aevatar-console-web tsc`
- `pnpm --dir apps/aevatar-console-web jest --runTestsByPath src/pages/studio/index.test.tsx src/pages/studio/components/bind/StudioMemberBindPanel.test.tsx src/pages/teams/detail.test.tsx src/pages/teams/home.test.tsx src/pages/Deployments/index.test.tsx --runInBand`
- `git diff --check -- apps/aevatar-console-web`
- `bash tools/ci/test_stability_guards.sh`

## Runtime Check
- Frontend dev server started locally at `http://localhost:5173`.
- Dev proxy confirmed targeting `https://aevatar-console-backend-api.aevatar.ai/` for `/api/*` routes.